### PR TITLE
revert last revert and fix tasty reader issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ enablePlugins(GitVersioning)
 
 name := "joern"
 organization := "io.shiftleft"
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.6"
 ThisBuild /Test /fork := true
-val cpgVersion = "1.3.191"
+val cpgVersion = "1.3.198"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ enablePlugins(GitVersioning)
 
 name := "joern"
 organization := "io.shiftleft"
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.5"
 ThisBuild /Test /fork := true
 val cpgVersion = "1.3.198"
 

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -15,7 +15,6 @@ libraryDependencies ++= Seq(
   "io.github.plume-oss"    % "plume" % "0.5.11" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",
-  "com.lihaoyi" %% "ammonite" % "2.3.8-4-88785969" cross CrossVersion.full,
   "com.github.scopt" %% "scopt" % "3.7.1",
   "com.github.pathikrit" %% "better-files" % "3.9.1",
   "io.circe" %% "circe-generic" % "0.12.2",
@@ -23,7 +22,6 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3" % Runtime,
   "org.scalatest" %% "scalatest" % "3.1.1" % Test,
 )
-
 
 enablePlugins(JavaAppPackaging)
 scriptClasspath := Seq("*") //wildcard import from staged `lib` dir, for simplicity and also to avoid `line too long` error on windows

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
@@ -10,11 +10,12 @@ import org.json4s.native.Serialization
 import better.files._
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.joern.Scan.{allTag, defaultTag}
+import io.shiftleft.semanticcpg.language.{DefaultNodeExtensionFinder, NodeExtensionFinder}
 
 import scala.reflect.runtime.universe._
 
 object JoernScanConfig {
-  val defaultDbVersion: String = "0.0.89"
+  val defaultDbVersion: String = "0.0.92"
 }
 
 case class JoernScanConfig(src: String = "",
@@ -168,6 +169,7 @@ class ScanOptions(var maxCallDepth: Int, var names: Array[String], var tags: Arr
     extends LayerCreatorOptions {}
 
 class Scan(options: ScanOptions)(implicit engineContext: EngineContext) extends LayerCreator {
+  implicit val finder: NodeExtensionFinder = DefaultNodeExtensionFinder
 
   override val overlayName: String = Scan.overlayName
   override val description: String = Scan.description

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.1
+sbt.version=1.5.4


### PR DESCRIPTION
reverts last revert, and downgrades scala to 2.13.

until https://github.com/com-lihaoyi/Ammonite/issues/1182 is fixed, or 
we find a way to specify that scalac option to ammonite.Main
