### PR TITLE
Upgrade to Plume 0.5.12

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
-  "io.github.plume-oss"    % "plume" % "0.5.11" exclude("io.github.plume-oss", "cpgconv"),
+  "io.github.plume-oss"    % "plume" % "0.5.12" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",
   "com.github.scopt" %% "scopt" % "3.7.1",


### PR DESCRIPTION
- Plume now defaults to constructing call graph using Spark (Andersen-style pointer analysis) instead of simple CHA
- Call graph is now much more precise and may result in fewer unrealisable paths during data-flow analysis but this may give a slower initial build and use more memory during CPG build
- All methods are now correctly set as possible entry points