### PR TITLE
Add js2cpg to Joern

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ ThisBuild / scalaVersion := "2.13.5"
 ThisBuild /Test /fork := true
 val cpgVersion = "1.3.287"
 val ghidra2cpgVersion = "0.0.24"
+val js2cpgVersion = "0.2.2"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
   "io.shiftleft" %% "c2cpg" % Versions.cpgVersion,
+  "io.shiftleft" %% "js2cpg" % Versions.js2cpg,
   "io.github.plume-oss"    % "plume" % "0.5.12" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Js2Cpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Js2Cpg.scala
@@ -1,0 +1,7 @@
+package io.shiftleft.joern
+
+import io.shiftleft.js2cpg.core.Js2CpgMain
+
+object Js2Cpg extends App {
+  Js2CpgMain.main(args)
+}

--- a/joern-cli/src/universal/js2cpg.sh
+++ b/joern-cli/src/universal/js2cpg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+
+SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
+SCRIPT="$SCRIPT_ABS_DIR"/bin/js-2-cpg
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@"

--- a/js2cpg.sh
+++ b/js2cpg.sh
@@ -1,0 +1,1 @@
+joern-cli/target/universal/stage/js2cpg.sh

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,6 +2,7 @@
 object Versions {
   val cpgVersion = parseVersion("cpgVersion")
   val ghidra2cpg = parseVersion("ghidra2cpgVersion")
+  val js2cpg = parseVersion("js2cpgVersion")
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r


### PR DESCRIPTION
# Notes
These changes add `js2cpg.sh` to the Joern repo, allowing users to both generate the cpg from javascript code by calling `./js2cpg <SRC_DIR>` from the root directory, as well as in Joern through `importCode.javascript("src_dir")

# Testing
`sbt clean test`, as well as manual tests creating the cpg both by calling `js2cpg.sh` and through Joern. I didn't test whether this specifically works when installing joern via `joern-install.sh`, but I did verify that `c2cpg` is successfully installed by this, and the approach followed here mimics that one almost exactly.