### PR TITLE
change packaging: download frontends as binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           ./schema-extender/test.sh
           cd -
       - run: sbt ciReleaseTagNextVersion createDistribution
-      - run: sha512sum ./joern-cli.zip > ./joern-cli.zip.sha512
+      - run: sha512sum target/joern-cli.zip > target/joern-cli.zip.sha512
       - name: Export ENV vars
         run:
           echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
@@ -53,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./joern-cli.zip
+          asset_path: target/joern-cli.zip
           asset_name: joern-cli.zip
           asset_content_type: application/zip
       - name: Upload joern-cli.zip.sha512
@@ -62,6 +62,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./joern-cli.zip.sha512
+          asset_path: target/joern-cli.zip.sha512
           asset_name: joern-cli.zip.sha512
           asset_content_type: text/plain

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 ThisBuild /Test /fork := true
-val cpgVersion = "1.3.293"
+val cpgVersion = "1.3.298"
 val ghidra2cpgVersion = "0.0.24"
 val js2cpgVersion = "0.2.2"
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 ThisBuild /Test /fork := true
-val cpgVersion = "1.3.299"
-val ghidra2cpgVersion = "0.0.24"
+val cpgVersion = "1.3.302"
+val ghidra2cpgVersion = "0.0.25"
 val js2cpgVersion = "0.2.3"
 
 ThisBuild / resolvers ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 ThisBuild /Test /fork := true
-val cpgVersion = "1.3.298"
+val cpgVersion = "1.3.299"
 val ghidra2cpgVersion = "0.0.24"
-val js2cpgVersion = "0.2.2"
+val js2cpgVersion = "0.2.3"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,6 @@ createDistribution := {
   val distributionZip = new ZipFile(distributionFile)
 
   distributionZip.addFile((joerncli/Universal/packageBin).value, withName("joern-cli.zip"))
-  distributionZip.addFile((ghidra2cpg/Universal/packageBin).value, withName("ghidra2cpg.zip"))
   distributionZip.addFile(Frontends.downloadC2CpgZip, withName("c2cpg.zip"))
   distributionZip.addFile(Frontends.downloadFuzzyc2CpgZip, withName("fuzzyc2cpg.zip"))
   distributionZip.addFile(Frontends.downloadJs2CpgZip, withName("js2cpg.zip"))

--- a/build.sbt
+++ b/build.sbt
@@ -37,9 +37,15 @@ createDistribution := {
 
   distributionZip.addFile((joerncli/Universal/packageBin).value, withName("joern-cli.zip"))
   distributionZip.addFile((ghidra2cpg/Universal/packageBin).value, withName("ghidra2cpg.zip"))
-  distributionZip.addFile(SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v$js2cpgVersion/js2cpg.zip"))
-  distributionZip.addFile(SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v$cpgVersion/fuzzy2cpg.zip"))
-  distributionZip.addFile(SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v$cpgVersion/c2cpg.zip"))
+  distributionZip.addFile(
+    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v$js2cpgVersion/js2cpg.zip"),
+    withName("js2cpg.zip"))
+  distributionZip.addFile(
+    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v$cpgVersion/fuzzy2cpg.zip"),
+    withName("fuzzyc2cpg.zip"))
+  distributionZip.addFile(
+    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v$cpgVersion/c2cpg.zip"),
+    withName("c2cpg.zip"))
 
   println(s"created distribution - resulting files: $distributionFile")
   distributionFile

--- a/build.sbt
+++ b/build.sbt
@@ -29,33 +29,28 @@ lazy val joerncli = Projects.joerncli
 lazy val ghidra2cpg = Projects.ghidra2cpg
 
 lazy val createDistribution = taskKey[File]("Create a complete Joern distribution")
+import net.lingala.zip4j._
+import net.lingala.zip4j.model.ZipParameters
 createDistribution := {
-  import net.lingala.zip4j._
-
   val distributionFile = file("target/joern-cli.zip")
   val distributionZip = new ZipFile(distributionFile)
 
   distributionZip.addFile((joerncli/Universal/packageBin).value, withName("joern-cli.zip"))
   distributionZip.addFile((ghidra2cpg/Universal/packageBin).value, withName("ghidra2cpg.zip"))
-  distributionZip.addFile(
-    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v$js2cpgVersion/js2cpg.zip"),
-    withName("js2cpg.zip"))
-  distributionZip.addFile(
-    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v$cpgVersion/fuzzy2cpg.zip"),
-    withName("fuzzyc2cpg.zip"))
-  distributionZip.addFile(
-    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v$cpgVersion/c2cpg.zip"),
-    withName("c2cpg.zip"))
+  distributionZip.addFile(Frontends.downloadC2CpgZip, withName("c2cpg.zip"))
+  distributionZip.addFile(Frontends.downloadFuzzyc2CpgZip, withName("fuzzyc2cpg.zip"))
+  distributionZip.addFile(Frontends.downloadJs2CpgZip, withName("js2cpg.zip"))
 
   println(s"created distribution - resulting files: $distributionFile")
   distributionFile
 }
 
-import net.lingala.zip4j.model.ZipParameters
 def withName(name: String): ZipParameters = {
   val zipParams = new ZipParameters
   zipParams.setFileNameInZip(name)
   zipParams
 }
+
+
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 ThisBuild /Test /fork := true
-val cpgVersion = "1.3.287"
+val cpgVersion = "1.3.293"
 val ghidra2cpgVersion = "0.0.24"
 val js2cpgVersion = "0.2.2"
 

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -60,7 +60,9 @@ Universal/mappings ++= downloadFuzzyPreprocessor.value.map { fuzzyppdir =>
 lazy val cpgVersionFile = taskKey[File]("persist cpg version in file (e.g. for schema-extender)")
 cpgVersionFile := {
   val ret = target.value / "cpg-version"
-  better.files.File(ret.getPath).writeText(Versions.cpgVersion)
+  better.files.File(ret.getPath)
+    .createIfNotExists(createParents = true)
+    .writeText(Versions.cpgVersion)
   ret
 }
 Universal/mappings += cpgVersionFile.value -> "schema-extender/cpg-version"

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -5,12 +5,12 @@ organization := "io.shiftleft"
 name := "joern-cli"
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "codepropertygraph" % Versions.cpgVersion,
-  "io.shiftleft" %% "semanticcpg" % Versions.cpgVersion,
-  "io.shiftleft" %% "console" % Versions.cpgVersion,
-  "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
-  "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
-  "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion, // only needed for joern-parse - TODO MP consider to remove?
+  "io.shiftleft" %% "codepropertygraph" % Versions.cpg,
+  "io.shiftleft" %% "semanticcpg" % Versions.cpg,
+  "io.shiftleft" %% "console" % Versions.cpg,
+  "io.shiftleft" %% "console" % Versions.cpg % Test classifier "tests",
+  "io.shiftleft" %% "dataflowengineoss" % Versions.cpg,
+  "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpg, // only needed for joern-parse - TODO MP consider to remove?
   "io.github.plume-oss"    % "plume" % "0.5.12" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",
@@ -34,7 +34,7 @@ downloadFuzzyPreprocessor := {
   val log = streams.value.log
   val ppFilename = "fuzzyppcli.zip"
   val ppUrl = new URL(
-    s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpgVersion}/$ppFilename")
+    s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/$ppFilename")
   val ppOutputDir = file("fuzzyppcli")
 
   log.info(s"trying to download fuzzypp from $ppUrl")
@@ -62,7 +62,7 @@ cpgVersionFile := {
   val ret = target.value / "cpg-version"
   better.files.File(ret.getPath)
     .createIfNotExists(createParents = true)
-    .writeText(Versions.cpgVersion)
+    .writeText(Versions.cpg)
   ret
 }
 Universal/mappings += cpgVersionFile.value -> "schema-extender/cpg-version"
@@ -129,7 +129,22 @@ generateScaladocs := {
   out
 }
 
-import sbt.Path.directory
-Universal/packageBin/mappings ++= directory(new File("joern-cli/src/main/resources/scripts"))
+Universal/packageBin/mappings ++= sbt.Path.directory(new File("joern-cli/src/main/resources/scripts"))
+
+Universal/mappings ++= {
+  import net.lingala.zip4j.ZipFile
+  val frontendsDirRoot = s"target/cpg-${Versions.cpg}/"
+  val frontendsDir = s"$frontendsDirRoot/frontends"
+
+  new ZipFile(Frontends.downloadC2CpgZip).extractAll(s"$frontendsDir/c2cpg")
+  new ZipFile(Frontends.downloadFuzzyc2CpgZip).extractAll(s"$frontendsDir/fuzzyc2cpg")
+  new ZipFile(Frontends.downloadJs2CpgZip).extractAll(s"$frontendsDir/js2cpg")
+
+  NativePackagerHelper.contentOf(frontendsDirRoot)
+}
+
+Universal/mappings ++= NativePackagerHelper.contentOf((Projects.ghidra2cpg/stage).value).map {
+  case (file, str) => (file, s"frontends/ghidra2cpg/$str")
+}
 
 maintainer := "fabs@shiftleft.io"

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -10,6 +10,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion,
   "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
+  "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion, // only needed for joern-parse - TODO MP consider to remove?
   "io.github.plume-oss"    % "plume" % "0.5.12" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -10,9 +10,6 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion,
   "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
-  "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
-  "io.shiftleft" %% "c2cpg" % Versions.cpgVersion,
-  "io.shiftleft" %% "js2cpg" % Versions.js2cpg,
   "io.github.plume-oss"    % "plume" % "0.5.12" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",

--- a/joern-cli/src/main/scala/io/shiftleft/joern/C2Cpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/C2Cpg.scala
@@ -1,7 +1,0 @@
-package io.shiftleft.joern
-
-import io.shiftleft.c2cpg.C2Cpg
-
-object C2cpg extends App {
-  C2Cpg.main(args)
-}

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Fuzzyc2cpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Fuzzyc2cpg.scala
@@ -1,7 +1,0 @@
-package io.shiftleft.joern
-
-import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
-
-object Fuzzyc2cpg extends App {
-  FuzzyC2Cpg.main(args)
-}

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.joern
 
-import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
 import io.shiftleft.joern.plume.PlumeCpgGenerator
 
 import scala.util.control.NonFatal

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.joern
 
+import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
 import io.shiftleft.joern.plume.PlumeCpgGenerator
 
 import scala.util.control.NonFatal

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Js2Cpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Js2Cpg.scala
@@ -1,7 +1,0 @@
-package io.shiftleft.joern
-
-import io.shiftleft.js2cpg.core.Js2CpgMain
-
-object Js2Cpg extends App {
-  Js2CpgMain.main(args)
-}

--- a/joern-cli/src/universal/c2cpg.sh
+++ b/joern-cli/src/universal/c2cpg.sh
@@ -7,7 +7,7 @@ else
 fi
 
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/../frontends/c2cpg/bin/c2cpg
+SCRIPT="$SCRIPT_ABS_DIR"/frontends/c2cpg/bin/c2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/c2cpg.sh
+++ b/joern-cli/src/universal/c2cpg.sh
@@ -7,7 +7,7 @@ else
 fi
 
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/../c2cpg/bin/c2cpg
+SCRIPT="$SCRIPT_ABS_DIR"/../frontends/c2cpg/bin/c2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/c2cpg.sh
+++ b/joern-cli/src/universal/c2cpg.sh
@@ -7,7 +7,7 @@ else
 fi
 
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/bin/c-2-cpg
+SCRIPT="$SCRIPT_ABS_DIR"/../c2cpg/bin/c2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/fuzzyc2cpg.sh
+++ b/joern-cli/src/universal/fuzzyc2cpg.sh
@@ -6,7 +6,7 @@ else
     SCRIPT_ABS_PATH=$(readlink -f "$0")
 fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/../frontends/fuzzyc2cpg/bin/fuzzyc2cpg
+SCRIPT="$SCRIPT_ABS_DIR"/frontends/fuzzyc2cpg/bin/fuzzyc2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/fuzzyc2cpg.sh
+++ b/joern-cli/src/universal/fuzzyc2cpg.sh
@@ -6,7 +6,7 @@ else
     SCRIPT_ABS_PATH=$(readlink -f "$0")
 fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/bin/fuzzyc-2-cpg
+SCRIPT="$SCRIPT_ABS_DIR"/../fuzzyc2cpg/bin/fuzzyc2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/fuzzyc2cpg.sh
+++ b/joern-cli/src/universal/fuzzyc2cpg.sh
@@ -6,7 +6,7 @@ else
     SCRIPT_ABS_PATH=$(readlink -f "$0")
 fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/../fuzzyc2cpg/bin/fuzzyc2cpg
+SCRIPT="$SCRIPT_ABS_DIR"/../frontends/fuzzyc2cpg/bin/fuzzyc2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/ghidra2cpg
+++ b/joern-cli/src/universal/ghidra2cpg
@@ -6,7 +6,7 @@ else
     SCRIPT_ABS_PATH=$(readlink -f "$0")
 fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/../ghidra2cpg/bin/ghidra2cpg
+SCRIPT="$SCRIPT_ABS_DIR"/../frontends/ghidra2cpg/bin/ghidra2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/ghidra2cpg
+++ b/joern-cli/src/universal/ghidra2cpg
@@ -6,7 +6,7 @@ else
     SCRIPT_ABS_PATH=$(readlink -f "$0")
 fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/../frontends/ghidra2cpg/bin/ghidra2cpg
+SCRIPT="$SCRIPT_ABS_DIR"/frontends/ghidra2cpg/bin/ghidra2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/js2cpg.sh
+++ b/joern-cli/src/universal/js2cpg.sh
@@ -7,7 +7,7 @@ else
 fi
 
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/../frontends/js2cpg/bin/js2cpg
+SCRIPT="$SCRIPT_ABS_DIR"/frontends/js2cpg/bin/js2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/js2cpg.sh
+++ b/joern-cli/src/universal/js2cpg.sh
@@ -7,7 +7,7 @@ else
 fi
 
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/../js2cpg/bin/js2cpg
+SCRIPT="$SCRIPT_ABS_DIR"/../frontends/js2cpg/bin/js2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-cli/src/universal/js2cpg.sh
+++ b/joern-cli/src/universal/js2cpg.sh
@@ -7,7 +7,7 @@ else
 fi
 
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
-SCRIPT="$SCRIPT_ABS_DIR"/bin/js-2-cpg
+SCRIPT="$SCRIPT_ABS_DIR"/../js2cpg/bin/js2cpg
 
 if [ ! -f "$SCRIPT" ]; then
     echo "Unable to find $SCRIPT, have you created the distribution?"

--- a/joern-install.sh
+++ b/joern-install.sh
@@ -164,7 +164,7 @@ rm "$SCRIPT_ABS_DIR"/joern-cli.zip
 
 cd "$JOERN_INSTALL_DIR"
 unzip -qo joern-cli.zip
-FRONTENDS_DIR="$JOERN_INSTALL_DIR/frontends"
+FRONTENDS_DIR="$JOERN_INSTALL_DIR/joern-cli/frontends"
 mkdir -p "$FRONTENDS_DIR"
 unzip -qo c2cpg.zip -d "$FRONTENDS_DIR/c2cpg"
 unzip -qo fuzzyc2cpg.zip -d "$FRONTENDS_DIR/fuzzyc2cpg"

--- a/joern-install.sh
+++ b/joern-install.sh
@@ -166,8 +166,10 @@ cd "$JOERN_INSTALL_DIR"
 unzip -qo joern-cli.zip
 unzip -qo c2cpg.zip -d c2cpg
 unzip -qo fuzzyc2cpg.zip -d fuzzyc2cpg
-unzip -qo ghidra2cpg.zip -d ghidra2cpg
 unzip -qo js2cpg.zip -d js2cpg
+unzip -qo ghidra2cpg.zip -d ghidra2cpg
+# remove ghidra root directory which includes version
+mv ghidra2cpg/ghidra2cpg-*/bin ghidra2cpg/ghidra2cpg-*/lib ghidra2cpg
 rm joern-cli.zip c2cpg.zip fuzzyc2cpg.zip ghidra2cpg.zip js2cpg.zip
 cd -
 

--- a/joern-install.sh
+++ b/joern-install.sh
@@ -164,12 +164,14 @@ rm "$SCRIPT_ABS_DIR"/joern-cli.zip
 
 cd "$JOERN_INSTALL_DIR"
 unzip -qo joern-cli.zip
-unzip -qo c2cpg.zip -d c2cpg
-unzip -qo fuzzyc2cpg.zip -d fuzzyc2cpg
-unzip -qo js2cpg.zip -d js2cpg
-unzip -qo ghidra2cpg.zip -d ghidra2cpg
+FRONTENDS_DIR="$JOERN_INSTALL_DIR/frontends"
+mkdir -p "$FRONTENDS_DIR"
+unzip -qo c2cpg.zip -d "$FRONTENDS_DIR/c2cpg"
+unzip -qo fuzzyc2cpg.zip -d "$FRONTENDS_DIR/fuzzyc2cpg"
+unzip -qo js2cpg.zip -d "$FRONTENDS_DIR/js2cpg"
+unzip -qo ghidra2cpg.zip -d "$FRONTENDS_DIR/ghidra2cpg"
 # remove ghidra root directory which includes version
-mv ghidra2cpg/ghidra2cpg-*/bin ghidra2cpg/ghidra2cpg-*/lib ghidra2cpg
+mv $FRONTENDS_DIR/ghidra2cpg/ghidra2cpg-*/* "$FRONTENDS_DIR/ghidra2cpg"
 rm joern-cli.zip c2cpg.zip fuzzyc2cpg.zip ghidra2cpg.zip js2cpg.zip
 cd -
 

--- a/joern-install.sh
+++ b/joern-install.sh
@@ -162,6 +162,16 @@ fi
 unzip -qo -d "$JOERN_INSTALL_DIR" "$SCRIPT_ABS_DIR"/joern-cli.zip
 rm "$SCRIPT_ABS_DIR"/joern-cli.zip
 
+cd "$JOERN_INSTALL_DIR"
+unzip -qo joern-cli.zip
+unzip -qo c2cpg.zip -d c2cpg
+unzip -qo fuzzyc2cpg.zip -d fuzzyc2cpg
+unzip -qo ghidra2cpg.zip -d ghidra2cpg
+unzip -qo js2cpg.zip -d js2cpg
+rm joern-cli.zip c2cpg.zip fuzzyc2cpg.zip ghidra2cpg.zip js2cpg.zip
+cd -
+
+
 if [ $INTERACTIVE = false ] && [ "$(whoami)" != "root" ]; then
   echo "==============================================================="
   echo "WARNING: you are NOT root and you are running non-interactively"

--- a/joern-install.sh
+++ b/joern-install.sh
@@ -169,10 +169,7 @@ mkdir -p "$FRONTENDS_DIR"
 unzip -qo c2cpg.zip -d "$FRONTENDS_DIR/c2cpg"
 unzip -qo fuzzyc2cpg.zip -d "$FRONTENDS_DIR/fuzzyc2cpg"
 unzip -qo js2cpg.zip -d "$FRONTENDS_DIR/js2cpg"
-unzip -qo ghidra2cpg.zip -d "$FRONTENDS_DIR/ghidra2cpg"
-# remove ghidra root directory which includes version
-mv $FRONTENDS_DIR/ghidra2cpg/ghidra2cpg-*/* "$FRONTENDS_DIR/ghidra2cpg"
-rm joern-cli.zip c2cpg.zip fuzzyc2cpg.zip ghidra2cpg.zip js2cpg.zip
+rm joern-cli.zip c2cpg.zip fuzzyc2cpg.zip js2cpg.zip
 cd -
 
 

--- a/project/Frontends.scala
+++ b/project/Frontends.scala
@@ -1,0 +1,13 @@
+
+object Frontends {
+
+  def downloadC2CpgZip =
+    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/c2cpg.zip")
+
+  def downloadFuzzyc2CpgZip =
+    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/fuzzy2cpg.zip")
+
+  def downloadJs2CpgZip =
+    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v${Versions.js2cpg}/js2cpg.zip")
+
+}

--- a/project/SimpleCache.scala
+++ b/project/SimpleCache.scala
@@ -1,0 +1,25 @@
+import sbt.{IO,URL}
+import java.io.File
+import java.net.URLEncoder
+
+object SimpleCache {
+  val LocalCacheDir = ".local"
+
+  /** download given url if not yet present in cache, then add to cache
+    * warning: only use for immutable artifacts, i.e. do not use for snapshot artifacts that may change 
+    */
+  def downloadMaybe(url: String): File = {
+    val urlEncoded = URLEncoder.encode(url, "UTF-8")
+    val localFile = new File(s"$LocalCacheDir/$urlEncoded")
+
+    if (!localFile.exists) {
+      println(s"downloading $url")
+      sbt.io.Using.urlInputStream(new URL(url)) { inputStream =>
+        IO.transfer(inputStream, localFile)
+      }
+    }
+
+    localFile
+  }
+
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,7 +1,8 @@
 /* reads version declarations from /build.sbt so that we can declare them in one place */
 object Versions {
-  val cpgVersion = parseVersion("cpgVersion")
+  val cpg = parseVersion("cpgVersion")
   val ghidra2cpg = parseVersion("ghidra2cpgVersion")
+  val js2cpg = parseVersion("js2cpgVersion")
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,7 +2,6 @@
 object Versions {
   val cpgVersion = parseVersion("cpgVersion")
   val ghidra2cpg = parseVersion("ghidra2cpgVersion")
-  val js2cpg = parseVersion("js2cpgVersion")
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r


### PR DESCRIPTION
* also: upgrade cpg

### reasons to invoke frontends via shell command rather than jvm dependency
* smaller classpath
  * sbt/idea/... work faster
  * joern/ocular start faster
* no hidden memory leaks (as observed with fuzzyc2cpg)
* less complexity in classpath
* no issues with jre versions
* only a matter of time until we have version clashes between frontends