### PR TITLE
Rewrite JoernParse to use mechanisms in codepropertygraph to generate…

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -1,96 +1,116 @@
 package io.shiftleft.joern
 
-import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
+import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.console.{FrontendConfig, InstallConfig}
+import io.shiftleft.console.cpgcreation.{cpgGeneratorForLanguage, guessLanguage}
 import io.shiftleft.joern.plume.PlumeCpgGenerator
 
-import scala.util.control.NonFatal
-
 object JoernParse extends App {
+
+  class InvalidLanguageError extends Error
+
+  // Special string used to separate joern-parse opts from frontend-specific opts
+  val ARGS_DELIMITER = "--frontend-args"
   val DEFAULT_CPG_OUT_FILE = "cpg.bin"
 
-  parseConfig.foreach { config =>
-    try {
-      generateCpg(config)
-    } catch {
-      case NonFatal(ex) =>
-        println("Error: Failed to generate/enhance CPG.", ex)
+  val (parserArgs, frontendArgs) = splitArgs()
+  val installConfig = new InstallConfig()
+
+  run() match {
+    case Right(msg) => println(msg)
+
+    case Left(errMsg) => println(s"ERROR: $errMsg")
+  }
+
+  def run(): Either[String, String] = {
+    for {
+      config <- parseConfig(parserArgs)
+      language <- getLanguage(config)
+      _ <- generateCpg(config, language)
+      _ <- enhanceCpg(config, language)
+    } yield "Operation success"
+  }
+
+  def splitArgs(): (List[String], List[String]) = {
+    println(s"Args to split: ${args.toList}")
+    args.indexOf(ARGS_DELIMITER) match {
+      case -1 => (args.toList, Nil)
+
+      case splitIdx =>
+        val (parseOpts, frontendOpts) = args.toList.splitAt(splitIdx)
+        (parseOpts, frontendOpts.tail) // Take the tail to ignore the delimiter
     }
   }
 
-  def generateCpg(config: ParserConfig): Unit = {
-    if (!config.enhanceOnly) {
-      config.language match {
-        case "c" =>
-          createCpgFromCSourceCode(config)
-        case "java" =>
-          PlumeCpgGenerator.createCpgForJava(config)
-        case _ =>
-          println(s"Error: Language ${config.language} not recognized")
-          return
+  def getLanguage(config: ParserConfig): Either[String, String] = {
+    if (config.language.isEmpty) {
+      val inputPath = config.inputPath
+      guessLanguage(inputPath) match {
+        case Some(guess) => Right(guess)
+
+        case None => Left(
+          s"Could not guess language from input path $inputPath. Please specify a language using the --language option."
+        )
+      }
+    } else {
+      Right(config.language)
+    }
+  }
+
+  def generateCpg(config: ParserConfig, language: String): Either[String, String] = {
+    if (config.enhanceOnly) {
+      Right("No generation required")
+    } else if (language == "java") {
+      PlumeCpgGenerator.createCpgForJava(config)
+    } else {
+      val generator = cpgGeneratorForLanguage(language, FrontendConfig(), installConfig.rootPath.path, frontendArgs).get
+      generator.generate(config.inputPath, outputPath = config.outputCpgFile, namespaces = config.namespaces) match {
+        case Some(cmd) => Right(cmd)
+
+        case None => Left(s"Could not generate CPG with language = $language and input = ${config.inputPath}")
       }
     }
-
-    if (config.enhance && config.language != "java") {
-      Cpg2Scpg.run(config.outputCpgFile, config.dataFlow).close()
-    }
-
   }
 
-  private def createCpgFromCSourceCode(config: ParserConfig): Unit = {
-    val fuzzyc = new FuzzyC2Cpg()
-    if (config.preprocessorConfig.usePreprocessor) {
-      fuzzyc.runWithPreprocessorAndOutput(
-        config.inputPaths,
-        config.cFrontendConfig.sourceFileExtensions,
-        config.preprocessorConfig.includeFiles,
-        config.preprocessorConfig.includePaths,
-        config.preprocessorConfig.defines,
-        config.preprocessorConfig.undefines,
-        config.preprocessorConfig.preprocessorExecutable
-      )
-    } else {
-      fuzzyc
-        .runAndOutput(config.inputPaths, config.cFrontendConfig.sourceFileExtensions, Some(config.outputCpgFile))
-        .close()
+  def enhanceCpg(config: ParserConfig, language: String): Either[String, String] = {
+    try {
+      if (config.enhance && language != "java") {
+        Cpg2Scpg.run(config.outputCpgFile, config.dataFlow).close()
+      }
+      Right("Enhance successful")
+    } catch {
+      case err: Throwable => Left(err.getMessage)
     }
   }
 
-  case class ParserConfig(inputPaths: Set[String] = Set.empty,
+  case class ParserConfig(inputPath: String = "",
                           outputCpgFile: String = DEFAULT_CPG_OUT_FILE,
+                          namespaces: List[String] = List.empty,
                           enhance: Boolean = true,
                           dataFlow: Boolean = true,
                           enhanceOnly: Boolean = false,
-                          language: String = "c",
-                          cFrontendConfig: CFrontendConfig = CFrontendConfig(),
-                          preprocessorConfig: PreprocessorConfig = PreprocessorConfig())
+                          language: String = "c")
 
-  case class CFrontendConfig(sourceFileExtensions: Set[String] = Set(".c", ".cc", ".cpp", ".h", ".hpp"))
-
-  case class PreprocessorConfig(preprocessorExecutable: String = "./bin/fuzzyppcli",
-                                verbose: Boolean = true,
-                                includeFiles: Set[String] = Set.empty,
-                                includePaths: Set[String] = Set.empty,
-                                defines: Set[String] = Set.empty,
-                                undefines: Set[String] = Set.empty) {
-    val usePreprocessor: Boolean =
-      includeFiles.nonEmpty || includePaths.nonEmpty || defines.nonEmpty || undefines.nonEmpty
-  }
-
-  def parseConfig: Option[ParserConfig] =
+  def parseConfig(parserArgs: List[String]): Either[String, ParserConfig] =
     new scopt.OptionParser[ParserConfig]("joern-parse") {
-
-      arg[String]("input-files")
-        .unbounded()
-        .text("directories containing: C/C++ source | Java classes | a Java archive (JAR/WAR)")
-        .action((x, c) => c.copy(inputPaths = c.inputPaths + x))
-
-      opt[String]("language")
-        .text("source language: [c|java]. Default: c")
-        .action((x, c) => c.copy(language = x))
+      arg[String]("input")
+        .required()
+        .text("source file or directory containing source files")
+        .action((x, c) => c.copy(inputPath = x))
 
       opt[String]("out")
         .text("output filename")
         .action((x, c) => c.copy(outputCpgFile = x))
+
+      opt[String]("language")
+        .optional()
+        .text("source language")
+        .action((x, c) => c.copy(language = x))
+
+      opt[String]("namespaces")
+        .optional()
+        .text("namespaces to include: comma separated string")
+        .action((x, c) => c.copy(namespaces = x.split(",").map(_.strip).toList))
 
       note("Enhancement stage")
 
@@ -104,42 +124,16 @@ object JoernParse extends App {
         .text("do not perform data flow analysis in enhancement stage")
         .action((x, c) => c.copy(dataFlow = false))
 
-      note("Options for C/C++")
-
-      opt[String]("source-file-ext")
-        .unbounded()
-        .text("source file extensions to include when gathering source files. Defaults are .c, .cc, .cpp, .h and .hpp")
-        .action((pat, cfg) =>
-          cfg.copy(cFrontendConfig =
-            cfg.cFrontendConfig.copy(sourceFileExtensions = cfg.cFrontendConfig.sourceFileExtensions + pat)))
-      opt[String]("include")
-        .unbounded()
-        .text("header include files")
-        .action((incl, cfg) =>
-          cfg.copy(preprocessorConfig =
-            cfg.preprocessorConfig.copy(includeFiles = cfg.preprocessorConfig.includeFiles + incl)))
-      opt[String]('I', "")
-        .unbounded()
-        .text("header include paths")
-        .action((incl, cfg) =>
-          cfg.copy(preprocessorConfig =
-            cfg.preprocessorConfig.copy(includePaths = cfg.preprocessorConfig.includePaths + incl)))
-      opt[String]('D', "define")
-        .unbounded()
-        .text("define a name")
-        .action((d, cfg) =>
-          cfg.copy(preprocessorConfig = cfg.preprocessorConfig.copy(defines = cfg.preprocessorConfig.defines + d)))
-      opt[String]('U', "undefine")
-        .unbounded()
-        .text("undefine a name")
-        .action((u, cfg) =>
-          cfg.copy(preprocessorConfig = cfg.preprocessorConfig.copy(defines = cfg.preprocessorConfig.undefines + u)))
-      opt[String]("preprocessor-executable")
-        .text("path to the preprocessor executable")
-        .action((s, cfg) => cfg.copy(preprocessorConfig = cfg.preprocessorConfig.copy(preprocessorExecutable = s)))
-
       note("Misc")
       help("help").text("display this help message")
-    }.parse(args, ParserConfig())
+
+      note(s"Args specified after the $ARGS_DELIMITER separator will be passed to the front-end verbatim")
+    }.parse(parserArgs, ParserConfig()) match {
+      case Some(config) => Right(config)
+
+      case None =>
+        println(s"args: $parserArgs")
+        Left("Could not parse command line options")
+    }
 
 }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -47,9 +47,10 @@ object JoernParse extends App {
       guessLanguage(inputPath) match {
         case Some(guess) => Right(guess)
 
-        case None => Left(
-          s"Could not guess language from input path $inputPath. Please specify a language using the --language option."
-        )
+        case None =>
+          Left(
+            s"Could not guess language from input path $inputPath. Please specify a language using the --language option."
+          )
       }
     } else {
       Right(config.language)
@@ -62,7 +63,8 @@ object JoernParse extends App {
     } else if (language == "java") {
       PlumeCpgGenerator.createCpgForJava(config)
     } else {
-      val generator = cpgGeneratorForLanguage(language.toUpperCase, FrontendConfig(), installConfig.rootPath.path, frontendArgs).get
+      val generator =
+        cpgGeneratorForLanguage(language.toUpperCase, FrontendConfig(), installConfig.rootPath.path, frontendArgs).get
       generator.generate(config.inputPath, outputPath = config.outputCpgFile, namespaces = config.namespaces) match {
         case Some(cmd) => Right(cmd)
 

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -7,8 +7,6 @@ import io.shiftleft.joern.plume.PlumeCpgGenerator
 
 object JoernParse extends App {
 
-  class InvalidLanguageError extends Error
-
   // Special string used to separate joern-parse opts from frontend-specific opts
   val ARGS_DELIMITER = "--frontend-args"
   val DEFAULT_CPG_OUT_FILE = "cpg.bin"
@@ -19,7 +17,9 @@ object JoernParse extends App {
   run() match {
     case Right(msg) => println(msg)
 
-    case Left(errMsg) => println(s"ERROR: $errMsg")
+    case Left(errMsg) =>
+      println(s"PARSE FAILED: $errMsg")
+      System.exit(1)
   }
 
   def run(): Either[String, String] = {
@@ -32,7 +32,6 @@ object JoernParse extends App {
   }
 
   def splitArgs(): (List[String], List[String]) = {
-    println(s"Args to split: ${args.toList}")
     args.indexOf(ARGS_DELIMITER) match {
       case -1 => (args.toList, Nil)
 
@@ -132,7 +131,6 @@ object JoernParse extends App {
       case Some(config) => Right(config)
 
       case None =>
-        println(s"args: $parserArgs")
         Left("Could not parse command line options")
     }
 

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -63,7 +63,7 @@ object JoernParse extends App {
     } else if (language == "java") {
       PlumeCpgGenerator.createCpgForJava(config)
     } else {
-      val generator = cpgGeneratorForLanguage(language, FrontendConfig(), installConfig.rootPath.path, frontendArgs).get
+      val generator = cpgGeneratorForLanguage(language.toUpperCase, FrontendConfig(), installConfig.rootPath.path, frontendArgs).get
       generator.generate(config.inputPath, outputPath = config.outputCpgFile, namespaces = config.namespaces) match {
         case Some(cmd) => Right(cmd)
 

--- a/joern-cli/src/main/scala/io/shiftleft/joern/plume/PlumeCpgGenerator.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/plume/PlumeCpgGenerator.scala
@@ -30,7 +30,7 @@ object PlumeCpgGenerator {
       extractor.load(new java.io.File(inputPath))
       extractor.project()
     } match {
-      case Success(_)   => Right("Java CPG Generation Success")
+      case Success(_) => Right("Java CPG Generation Success")
       case Failure(exc) => {
         exc.printStackTrace()
         Left(exc.getMessage)

--- a/joern-cli/src/main/scala/io/shiftleft/joern/plume/PlumeCpgGenerator.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/plume/PlumeCpgGenerator.scala
@@ -9,27 +9,19 @@ import scala.util.{Failure, Success, Try, Using}
 
 object PlumeCpgGenerator {
 
-  def createCpgForJava(config: JoernParse.ParserConfig): Unit = {
-    val (existing, nonExisting) = config.inputPaths.partition(inputPath => File(inputPath).exists)
-    nonExisting.foreach(inputPath => println(s"Error: $inputPath does not exist"))
-    if (existing.isEmpty) { Try { throw new RuntimeException("Not valid input paths for CPG generation") } }
-
-    try {
-      existing.foreach { inputPath =>
-        val inFile = File(inputPath)
-        if (inFile.isDirectory || inFile.isRegularFile) {
-          createCpgForInputPath(inputPath, config)
-        } else {
-          Try { throw new RuntimeException(s"$inputPath is neither a file nor a directory") }
-        }
-      }
-    } catch {
-      case exc: Exception =>
-        exc.printStackTrace()
+  def createCpgForJava(config: JoernParse.ParserConfig): Either[String, String] = {
+    val inputPath = config.inputPath
+    val inFile = File(inputPath)
+    if (!inFile.exists) {
+      Left(s"$inputPath does not exist")
+    } else if (!inFile.isDirectory || inFile.isRegularFile) {
+      Left(s"$inputPath is neither a file nor a directory")
+    } else {
+      createCpgForInputPath(inputPath, config)
     }
   }
 
-  private def createCpgForInputPath(inputPath: String, config: JoernParse.ParserConfig): Unit = {
+  private def createCpgForInputPath(inputPath: String, config: JoernParse.ParserConfig): Either[String, String] = {
     println(s"Creating CPG for: $inputPath")
     Using(DriverFactory.invoke(GraphDatabase.OVERFLOWDB).asInstanceOf[OverflowDbDriver]) { driver =>
       deleteIfExists(config.outputCpgFile)
@@ -38,8 +30,11 @@ object PlumeCpgGenerator {
       extractor.load(new java.io.File(inputPath))
       extractor.project()
     } match {
-      case Success(_)   =>
-      case Failure(exc) => throw exc
+      case Success(_)   => Right("Java CPG Generation Success")
+      case Failure(exc) => {
+        exc.printStackTrace()
+        Left(exc.getMessage)
+      }
     }
   }
 


### PR DESCRIPTION
# Notes 
This is a WIP PR for the joern-parse refactor (or rewrite). The point of the PR is to get feedback about the general approach.

* These changes are not backwards compatible with the old Joern parse...
* ... although it still works as before for Java so as not to break codepropertygraph
* Uses the same methods for finding a CPG generator and generating the CPG as `importCode`, so behaviour should be consistent with Joern.
* Only supports a singe input file/directory, as opposed to multiple before (in the case of Java the output would just be overwritten for every file in any case)
* In theory, one can specify `joern-parse` args and frontend args separately, so `joern-parse` would not have to be updated as front-ends are added. 
# Outstanding issues
* ~Separating `joern-parse` args from `frontend args`~ This is now done with the `--frontend-args` option.
* ~`cpgGeneratorForLanguage` is not returning the generators, possibly due to the path.~ This was due to a case mismatch, so input is now converted to uppercase.