### PR TITLE
don't error (only warn) when staging fails

### DIFF
--- a/project/Frontends.scala
+++ b/project/Frontends.scala
@@ -1,13 +1,13 @@
 
 object Frontends {
 
-  def downloadC2CpgZip =
-    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/c2cpg.zip")
+  def c2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/c2cpg.zip"
 
-  def downloadFuzzyc2CpgZip =
-    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/fuzzy2cpg.zip")
+  def fuzzyc2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/fuzzy2cpg.zip"
 
-  def downloadJs2CpgZip =
-    SimpleCache.downloadMaybe(s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v${Versions.js2cpg}/js2cpg.zip")
+  def js2cpgUrl = s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v${Versions.js2cpg}/js2cpg.zip"
 
+  def downloadC2CpgZip = SimpleCache.downloadMaybe(c2cpgUrl)
+  def downloadFuzzyc2CpgZip = SimpleCache.downloadMaybe(fuzzyc2cpgUrl)
+  def downloadJs2CpgZip = SimpleCache.downloadMaybe(js2cpgUrl)
 }


### PR DESCRIPTION
Common scenario: using a locally published codepropertygraph.
Prior to this, the build would fail on `stage` because none of the
frontends would download.
Now it only prints a warning.