### PR TITLE
Default to latest release when updating querydb

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
@@ -15,7 +15,7 @@ import io.shiftleft.semanticcpg.language.{DefaultNodeExtensionFinder, NodeExtens
 import scala.reflect.runtime.universe._
 
 object JoernScanConfig {
-  val defaultDbVersion: String = "0.0.97"
+  val defaultDbVersion: String = "latest"
 }
 
 case class JoernScanConfig(src: String = "",


### PR DESCRIPTION
# Notes
Default to using the latest query-database release when running `joern-scan --updatedb`. This means we wouldn't have to update this version manually. 

__Alternative approach:__ We could also have the default version not be the latest one, but in that case we should move the default version into build.sbt so that it's harder to miss.

# Testing
```
❯ ./joern-scan --updatedb
Downloading default query bundle from: https://github.com/joernio/query-database/releases/latest/download/querydb.zip
Wrote: 34671576 bytes to /tmp/joern-scan16544845908678208747/querydb.zip
Removing current version of query database
Adding updated version of query database
```