### PR TITLE
Add a separate C front-end version to decouple front-end and codepropertygraph staging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ ThisBuild / scalaVersion := "2.13.5"
 ThisBuild /Test /fork := true
 val cpgVersion = "1.3.305"
 val c2cpgVersion = "1.3.305"
+val fuzzyc2cpgVersion = "1.3.305"
 val ghidra2cpgVersion = "0.0.25"
 val js2cpgVersion = "0.2.3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 ThisBuild /Test /fork := true
 val cpgVersion = "1.3.305"
-val cFrontendVersion = "1.3.305"
+val c2cpgVersion = "1.3.305"
 val ghidra2cpgVersion = "0.0.25"
 val js2cpgVersion = "0.2.3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,8 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 ThisBuild /Test /fork := true
-val cpgVersion = "1.3.304"
+val cpgVersion = "1.3.305"
+val cFrontendVersion = "1.3.305"
 val ghidra2cpgVersion = "0.0.25"
 val js2cpgVersion = "0.2.3"
 

--- a/project/Frontends.scala
+++ b/project/Frontends.scala
@@ -1,9 +1,9 @@
 
 object Frontends {
 
-  def c2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/c2cpg.zip"
+  def c2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cFrontend}/c2cpg.zip"
 
-  def fuzzyc2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cpg}/fuzzy2cpg.zip"
+  def fuzzyc2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cFrontend}/fuzzy2cpg.zip"
 
   def js2cpgUrl = s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v${Versions.js2cpg}/js2cpg.zip"
 

--- a/project/Frontends.scala
+++ b/project/Frontends.scala
@@ -1,9 +1,9 @@
 
 object Frontends {
 
-  def c2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cFrontend}/c2cpg.zip"
+  def c2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.c2cpg}/c2cpg.zip"
 
-  def fuzzyc2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.cFrontend}/fuzzy2cpg.zip"
+  def fuzzyc2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.c2cpg}/fuzzy2cpg.zip"
 
   def js2cpgUrl = s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v${Versions.js2cpg}/js2cpg.zip"
 

--- a/project/Frontends.scala
+++ b/project/Frontends.scala
@@ -3,7 +3,7 @@ object Frontends {
 
   def c2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.c2cpg}/c2cpg.zip"
 
-  def fuzzyc2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.c2cpg}/fuzzy2cpg.zip"
+  def fuzzyc2cpgUrl = s"https://github.com/ShiftLeftSecurity/codepropertygraph/releases/download/v${Versions.fuzzyc2cpg}/fuzzy2cpg.zip"
 
   def js2cpgUrl = s"https://github.com/ShiftLeftSecurity/js2cpg/releases/download/v${Versions.js2cpg}/js2cpg.zip"
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -4,6 +4,7 @@ object Versions {
   val ghidra2cpg = parseVersion("ghidra2cpgVersion")
   val js2cpg = parseVersion("js2cpgVersion")
   val c2cpg = parseVersion("c2cpgVersion")
+  val fuzzyc2cpg = parseVersion("fuzzyc2cpgVersion")
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,7 +3,7 @@ object Versions {
   val cpg = parseVersion("cpgVersion")
   val ghidra2cpg = parseVersion("ghidra2cpgVersion")
   val js2cpg = parseVersion("js2cpgVersion")
-  val cFrontend = parseVersion("cFrontendVersion")
+  val c2cpg = parseVersion("c2cpgVersion")
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,6 +3,7 @@ object Versions {
   val cpg = parseVersion("cpgVersion")
   val ghidra2cpg = parseVersion("ghidra2cpgVersion")
   val js2cpg = parseVersion("js2cpgVersion")
+  val cFrontend = parseVersion("cFrontendVersion")
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r


### PR DESCRIPTION
# Notes
This is a convenience follow-up to https://github.com/joernio/joern/pull/583 and decouples the version used to fetch `c2cpg` and `fuzzyc2cpg` from the `codepropertygraph` version. This lets you test local `codepropertygraph` changes without having to use local `c2cpg` and `fuzzyc2cpg` distributions, provided no changes to the front-ends need to be tested as well (a common case).

# Testing
`sbt clean stage test`, followed by 

```
❯ ./c2cpg.sh
Error: Missing argument input-dirs
Try --help for more information.
``` 




