### PR TITLE
Switch to legacy String.trim and switch to JDK11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
       - uses: actions/cache@v2
         with:
           path: |

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -111,7 +111,7 @@ object JoernParse extends App {
       opt[String]("namespaces")
         .optional()
         .text("namespaces to include: comma separated string")
-        .action((x, c) => c.copy(namespaces = x.split(",").map(_.strip).toList))
+        .action((x, c) => c.copy(namespaces = x.split(",").map(_.trim).toList))
 
       note("Enhancement stage")
 


### PR DESCRIPTION
# Notes
https://github.com/joernio/joern/runs/3493692134 was failing due to a mismatch between the JDK version used for the PR and release actions. Either one of the included changes should fix it, but I'm including both since switching to `trim` shouldn't have a significant impact on joern-parse functions.

__With these changes, Joern will build for Java 11. If this is an issue, we can add an option to build for Java 8 instead__