### PR TITLE
Add javasrc2cpg support and clean up repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ ThisBuild /Test /fork := true
 val cpgVersion = "1.3.316"
 val ghidra2cpgVersion = "0.0.27"
 val js2cpgVersion = "0.2.3"
+val javasrc2cpgVersion = "0.0.5"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/c2cpg.sh
+++ b/c2cpg.sh
@@ -1,1 +1,0 @@
-./joern-cli/target/universal/stage/c2cpg.sh

--- a/fuzzyc2cpg.sh
+++ b/fuzzyc2cpg.sh
@@ -1,1 +1,0 @@
-./joern-cli/target/universal/stage/fuzzyc2cpg.sh

--- a/ghidra2cpg
+++ b/ghidra2cpg
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-joern-cli/frontends/ghidra2cpg/target/universal/stage/bin/ghidra2cpg -J-Dlog4j.configurationFile=config/log4j-ghidra.xml "$@"

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -60,6 +60,14 @@ Universal/mappings ++= NativePackagerHelper.contentOf((js2cpg/stage).value).map 
   case (file, name) => file -> s"frontends/js2cpg/$name"
 }
 
+lazy val javasrc2cpg = project.in(file("frontends/javasrc2cpg")).enablePlugins(JavaAppPackaging).settings(
+    libraryDependencies += "io.joern" %% "javasrc2cpg" % Versions.javasrc2cpg,
+    Compile/mainClass := Some("io.joern.javasrc2cpg.Main"),
+)
+Universal/mappings ++= NativePackagerHelper.contentOf((javasrc2cpg/stage).value).map {
+  case (file, name) => (file, s"frontends/javasrc2cpg/$name")
+}
+
 lazy val plume = project.in(file("frontends/plume")).enablePlugins(JavaAppPackaging).settings(
   libraryDependencies ++= Seq(
     "io.github.plume-oss" % "plume" % "0.5.13",

--- a/joern-cli/src/universal/javasrc2cpg
+++ b/joern-cli/src/universal/javasrc2cpg
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
+SCRIPT="$SCRIPT_ABS_DIR"/frontends/javasrc2cpg/bin/javasrc2cpg
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@"

--- a/js2cpg.sh
+++ b/js2cpg.sh
@@ -1,1 +1,0 @@
-joern-cli/target/universal/stage/js2cpg.sh

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,6 +3,7 @@ object Versions {
   val cpg = parseVersion("cpgVersion")
   val ghidra2cpg = parseVersion("ghidra2cpgVersion")
   val js2cpg = parseVersion("js2cpgVersion")
+  val javasrc2cpg = parseVersion("javasrc2cpgVersion")
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r


### PR DESCRIPTION
# Notes
* Remove front-end scripts from repo root. Specific front-ends can now be invoked through joern-parse
* Add `javasrc2cpg` support to Joern. __NOTE: The front-end itself seems broken at the moment, but having it available in Joern would help with testing__
# Testing
`sbt clean stage` followed by manual tests to verify that the front-ends are still working as expected.