### PR TITLE
Plume Empty ODB Fix

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -70,7 +70,7 @@ Universal/mappings ++= NativePackagerHelper.contentOf((javasrc2cpg/stage).value)
 
 lazy val plume = project.in(file("frontends/plume")).enablePlugins(JavaAppPackaging).settings(
   libraryDependencies ++= Seq(
-    "io.github.plume-oss" % "plume" % "0.5.13",
+    "io.github.plume-oss" % "plume" % "0.5.14",
     "com.github.scopt" %% "scopt" % "4.0.1"),
   Compile/mainClass := Some("io.joern.plume.Main"),
 )

--- a/joern-cli/frontends/plume/src/main/scala/io/joern/plume/Main.scala
+++ b/joern-cli/frontends/plume/src/main/scala/io/joern/plume/Main.scala
@@ -26,12 +26,13 @@ object Main extends App {
   OParser.parse(parser, args, Config()) match {
     case Some(Config(input, output)) =>
       println(s"invoking Plume on $input, writing results to $output")
-      val driver = DriverFactory.invoke(GraphDatabase.OVERFLOWDB).asInstanceOf[OverflowDbDriver]
-      deleteIfExists(output)
-      driver.storageLocation(output)
-      val extractor = new Extractor(driver)
-      extractor.load(new java.io.File(input))
-      extractor.project(true)
+      Using.resource(DriverFactory.invoke(GraphDatabase.OVERFLOWDB).asInstanceOf[OverflowDbDriver]) { driver =>
+        deleteIfExists(output)
+        driver.storageLocation(output)
+        val extractor = new Extractor(driver)
+        extractor.load(new java.io.File(input))
+        extractor.project(true)
+      }
     case _ =>
     // arguments are bad, error message will have been displayed
   }


### PR DESCRIPTION
- Plume upgraded to 0.5.14
- OverflowDBDriver `close()` called via `Using.resources` to write results