### PR TITLE
Make sure `dataflowOss` is added to `metaData.overlays`

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -19,7 +19,7 @@ object Cpg2Scpg {
     new Scpg().run(context)
     if (dataFlow) {
       val options = new OssDataFlowOptions()
-      new OssDataFlow(options).create(context)
+      new OssDataFlow(options).run(context)
     }
     cpg
   }


### PR DESCRIPTION
Fix a bug in `joern-parse` where `dataflowOss` wasn't added to `metaData.overlays`.