### PR TITLE
Bump JRE version from 8 to 11 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # dependencies
-RUN apk update && apk upgrade && apk add --no-cache openjdk8-jre-base python3 git curl gnupg bash nss ncurses
+RUN apk update && apk upgrade && apk add --no-cache openjdk11-jre python3 git curl gnupg bash nss ncurses
 RUN ln -sf python3 /usr/bin/python
 
 # sbt


### PR DESCRIPTION
# Problem
I got a `java.lang.UnsupportedClassVersionError` when I tried to use the image built by the Dockerfile.
Docker build command: `docker build -t joern .`
Docker run command: `docker run -it -v$PWD:/share --name joern_worker joern bash`
Error log running inside the Docker container: [error-log.txt](https://github.com/joernio/joern/files/7228722/error-log.txt).
# Solution
My solution was to bump the JRE version from 8 to 11 in the Docker container. My development machine runs Windows so I'm trying to use Joern in Docker. Bumped Java version following this guidance: https://www.baeldung.com/java-lang-unsupportedclassversion and seeing that the CI action runs JDK 11 (https://github.com/joernio/joern/blob/master/.github/workflows/pr.yml#L11).

I hope this is helpful!