### PR TITLE
Add a list-languages option to joern-scan and joern-parse

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -1,7 +1,11 @@
 package io.shiftleft.joern
 
+import better.files.File
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.console.{FrontendConfig, InstallConfig}
 import io.shiftleft.console.cpgcreation.{cpgGeneratorForLanguage, guessLanguage}
+
+import scala.jdk.CollectionConverters._
 
 object JoernParse extends App {
 
@@ -21,12 +25,19 @@ object JoernParse extends App {
   }
 
   def run(): Either[String, String] = {
-    for {
-      config <- parseConfig(parserArgs)
-      language <- getLanguage(config)
-      _ <- generateCpg(config, language)
-      _ <- enhanceCpg(config)
-    } yield "Operation success"
+    parseConfig(parserArgs) match {
+      case Right(config) =>
+        if (config.listLanguages) {
+          Right(buildLanguageList())
+        } else for {
+          _ <- checkInputPath(config)
+          language <- getLanguage(config)
+          _ <- generateCpg(config, language)
+          _ <- enhanceCpg(config)
+        } yield "Operation success"
+
+      case Left(err) => Left(err)
+    }
   }
 
   def splitArgs(): (List[String], List[String]) = {
@@ -37,6 +48,21 @@ object JoernParse extends App {
         val (parseOpts, frontendOpts) = args.toList.splitAt(splitIdx)
         (parseOpts, frontendOpts.tail) // Take the tail to ignore the delimiter
     }
+  }
+
+  def checkInputPath(config: ParserConfig): Either[String, Unit] = {
+    if (config.inputPath == "" || !File(config.inputPath).exists) {
+      Left("Invalid input path provided")
+    } else {
+      Right(())
+    }
+  }
+
+  def buildLanguageList(): String = {
+    val s = new StringBuilder()
+    s ++= "Available languages (case insensitive):\n"
+    s ++= Languages.ALL.asScala.map(lang => s"- ${lang.toLowerCase}").mkString("\n")
+    s.toString()
   }
 
   def getLanguage(config: ParserConfig): Either[String, String] = {
@@ -85,12 +111,13 @@ object JoernParse extends App {
                           enhance: Boolean = true,
                           dataFlow: Boolean = true,
                           enhanceOnly: Boolean = false,
-                          language: String = "c")
+                          language: String = "",
+                          listLanguages: Boolean = false)
 
   def parseConfig(parserArgs: List[String]): Either[String, ParserConfig] =
     new scopt.OptionParser[ParserConfig]("joern-parse") {
       arg[String]("input")
-        .required()
+        .optional()
         .text("source file or directory containing source files")
         .action((x, c) => c.copy(inputPath = x))
 
@@ -99,12 +126,14 @@ object JoernParse extends App {
         .action((x, c) => c.copy(outputCpgFile = x))
 
       opt[String]("language")
-        .optional()
         .text("source language")
         .action((x, c) => c.copy(language = x))
 
+      opt[Unit]("list-languages")
+        .text("list available language options")
+        .action((_, c) => c.copy(listLanguages = true))
+
       opt[String]("namespaces")
-        .optional()
         .text("namespaces to include: comma separated string")
         .action((x, c) => c.copy(namespaces = x.split(",").map(_.trim).toList))
 

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -53,7 +53,7 @@ object JoernParse extends App {
 
   def checkInputPath(config: ParserConfig): Either[String, Unit] = {
     if (config.inputPath == "" || !File(config.inputPath).exists) {
-      Left("Invalid input path provided")
+      Left("Input path does not exist at `" + config.inputPath  + "`, exiting.")
     } else {
       Right(())
     }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -29,12 +29,13 @@ object JoernParse extends App {
       case Right(config) =>
         if (config.listLanguages) {
           Right(buildLanguageList())
-        } else for {
-          _ <- checkInputPath(config)
-          language <- getLanguage(config)
-          _ <- generateCpg(config, language)
-          _ <- enhanceCpg(config)
-        } yield "Operation success"
+        } else
+          for {
+            _ <- checkInputPath(config)
+            language <- getLanguage(config)
+            _ <- generateCpg(config, language)
+            _ <- enhanceCpg(config)
+          } yield "Operation success"
 
       case Left(err) => Left(err)
     }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -53,7 +53,7 @@ object JoernParse extends App {
 
   def checkInputPath(config: ParserConfig): Either[String, Unit] = {
     if (config.inputPath == "" || !File(config.inputPath).exists) {
-      Left("Input path does not exist at `" + config.inputPath  + "`, exiting.")
+      Left("Input path does not exist at `" + config.inputPath + "`, exiting.")
     } else {
       Right(())
     }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
@@ -8,10 +8,12 @@ import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, Layer
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.Serialization
 import better.files._
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.joern.Scan.{allTag, defaultTag, getQueriesFromQueryDb}
 import io.shiftleft.semanticcpg.language.{DefaultNodeExtensionFinder, NodeExtensionFinder}
 
+import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 
 object JoernScanConfig {
@@ -28,7 +30,8 @@ case class JoernScanConfig(src: String = "",
                            maxCallDepth: Int = 2,
                            names: String = "",
                            tags: String = "",
-                           language: Option[String] = None)
+                           language: Option[String] = None,
+                           listLanguages: Boolean = false)
 
 object JoernScan extends App with BridgeBase {
 
@@ -81,6 +84,10 @@ object JoernScan extends App with BridgeBase {
       opt[String]("language")
         .action((x, c) => c.copy(language = Some(x)))
         .text("Source language")
+
+      opt[Unit]("list-languages")
+        .action((_, c) => c.copy(listLanguages = true))
+        .text("List available language options")
     }
   }.parse(args, JoernScanConfig())
 
@@ -93,6 +100,8 @@ object JoernScan extends App with BridgeBase {
       dumpQueries()
     } else if (config.listQueryNames) {
       println(queryNames().sorted.mkString("\n"))
+    } else if (config.listLanguages) {
+      println(Languages.ALL.asScala.mkString("\n"))
     } else if (config.updateQueryDb) {
       updateQueryDatabase(config.queryDbVersion)
     } else {

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
@@ -101,7 +101,10 @@ object JoernScan extends App with BridgeBase {
     } else if (config.listQueryNames) {
       println(queryNames().sorted.mkString("\n"))
     } else if (config.listLanguages) {
-      println(Languages.ALL.asScala.mkString("\n"))
+      val s = new StringBuilder()
+      s ++= "Available languages (case insensitive):\n"
+      s ++= Languages.ALL.asScala.map(lang => s"- ${lang.toLowerCase}").mkString("\n")
+      println(s.toString())
     } else if (config.updateQueryDb) {
       updateQueryDatabase(config.queryDbVersion)
     } else {


### PR DESCRIPTION
# Notes
Adds a `list-languages` option to list available languages with `joern-scan` and `joern-parse`, for example
```
❯ ./joern-scan --list-languages
Available languages (case insensitive):
- golang
- fuzzy_test_lang
- csharp
- java
- php
- c
- kotlin
- ghidra
- javascript
- python
- llvm
- newc
- javasrc
```