### PR TITLE
Update query database

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
@@ -17,7 +17,7 @@ import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 
 object JoernScanConfig {
-  val defaultDbVersion: String = "0.0.107"
+  val defaultDbVersion: String = "0.0.108"
 }
 
 case class JoernScanConfig(src: String = "",


### PR DESCRIPTION
The old query database accidentally included ghidra2cpg, causing exceptions to be thrown after running `joern-scan --update`