### PR TITLE
Bump jimple2cpg Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val cpgVersion = "1.3.372"
 val ghidra2cpgVersion = "0.0.41"
 val js2cpgVersion = "0.2.18"
 val javasrc2cpgVersion = "0.0.12"
-val jimple2cpgVersion = "0.0.5"
+val jimple2cpgVersion = "0.0.6"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,


### PR DESCRIPTION
# Changelist

## Jimple2Cpg
- Bump CPG to 1.3.373
- Added slf4j dependency to resolve logger warnings
- Added type hierarchy
- Added dispatch type for definitions