### PR TITLE
Reverting to previous CPG version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 ThisBuild /Test /fork := true
-val cpgVersion = "1.3.372"
+val cpgVersion = "1.3.369"
 val ghidra2cpgVersion = "0.0.41"
 val js2cpgVersion = "0.2.18"
 val javasrc2cpgVersion = "0.0.12"


### PR DESCRIPTION
Going back to CPG 1.3.369 due to a crash in `c2cpg`