### PR TITLE
Jimple2Cpg Upgrade: Improved Resource Handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val cpgVersion = "1.3.379"
 val ghidra2cpgVersion = "0.0.41"
 val js2cpgVersion = "0.2.18"
 val javasrc2cpgVersion = "0.0.12"
-val jimple2cpgVersion = "0.0.6"
+val jimple2cpgVersion = "0.0.7"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,


### PR DESCRIPTION
As soon as an AST is built from a `SootClass` it is released from the `Scene` instead of right at the end of processing the whole CPG.