### PR TITLE
fix ghidra2cpg

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -45,6 +45,7 @@ Universal/mappings ++= NativePackagerHelper.contentOf((fuzzyc2cpg/stage).value).
 }
 
 lazy val ghidra2cpg = project.in(file("frontends/ghidra2cpg")).enablePlugins(JavaAppPackaging).settings(
+  name := "ghidra2cpg-frontend",
   libraryDependencies += "io.joern" %% "ghidra2cpg" % Versions.ghidra2cpg,
   Compile/mainClass := Some("io.joern.ghidra2cpg.Main"),
 )


### PR DESCRIPTION
context: changing the organization in this build resulted in a
cyclic dependency on "io.joern::ghidra2cpg" which shadowed the actual
dependency we wanted from https://github.com/joernio/ghidra2cpg/

That'll be simplified shortly, since we'll integrate ghidra2cpg into
this build