### PR TITLE
rework/improve heuristics for language/frontend detection

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -16,27 +16,25 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     * For a given input path, try to guess a suitable generator and return it
     * */
   def forCodeAt(inputPath: String): Option[CpgGenerator] = {
-    guessLanguage(inputPath)
-      .flatMap { l =>
-        report("Using generator for language: " + l)
-        cpgGeneratorForLanguage(l, config.frontend, config.install.rootPath.path, args = Nil)
-      }
+    guessLanguage(inputPath).flatMap { language =>
+      report(s"Using generator for language: $language and frontend=${config.frontend}")
+      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil)
+    }
   }
 
   /**
     * For a language, return the generator
     * */
   def forLanguage(language: String): Option[CpgGenerator] = {
-    Some(language)
+    Option(language)
       .filter(languageIsKnown)
-      .flatMap(
-        lang =>
-          cpgGeneratorForLanguage(
-            lang,
-            config.frontend,
-            config.install.rootPath.path,
-            args = Nil
-        ))
+      .flatMap { lang =>
+        cpgGeneratorForLanguage(
+          lang,
+          config.frontend,
+          config.install.rootPath.path,
+          args = Nil)
+      }
   }
 
   def languageIsKnown(language: String): Boolean = {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -29,11 +29,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     Option(language)
       .filter(languageIsKnown)
       .flatMap { lang =>
-        cpgGeneratorForLanguage(
-          lang,
-          config.frontend,
-          config.install.rootPath.path,
-          args = Nil)
+        cpgGeneratorForLanguage(lang, config.frontend, config.install.rootPath.path, args = Nil)
       }
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -54,7 +54,9 @@ package object cpgcreation {
         if (fileNames.exists(f =>
               f.endsWith(".go") || Set("Gopkg.lock", "Gopkg.toml", "go.mod", "go.sum").contains(f))) {
           Some(Languages.GOLANG)
-        } else if (fileNames.exists(f => f.endsWith(".java") || f.endsWith(".class"))) {
+        } else if (fileNames.exists(f => f.endsWith(".java"))) {
+          Some(Languages.JAVASRC)
+        } else if (fileNames.exists(f => f.endsWith(".class"))) {
           Some(Languages.JAVA)
         } else if (fileNames.exists(f => f.endsWith(".php"))) {
           Some(Languages.PHP)

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -36,22 +36,11 @@ package object cpgcreation {
     * Heuristically determines language by inspecting file/dir at path.
     * */
   def guessLanguage(path: String): Option[String] = {
-    val lowerCasePath = path.toLowerCase
-    if (lowerCasePath.endsWith(".jar") ||
-      lowerCasePath.endsWith(".war") ||
-      lowerCasePath.endsWith(".ear") ||
-      lowerCasePath.endsWith(".apk")) {
-      Some(Languages.JAVA)
-    } else if (lowerCasePath.endsWith("csproj")) {
-      Some(Languages.CSHARP)
-    } else if (lowerCasePath.endsWith(".go")) {
-      Some(Languages.GOLANG)
-    } else if (isLlvmSrcFile(lowerCasePath)) {
-      Some(Languages.LLVM)
+    val file = File(path)
+    if (file.isDirectory) {
+      determineMajorityLanguageInDir(file)
     } else {
-      val file = File(path)
-      if (file.isDirectory) determineMajorityLanguageInDir(file)
-      else None
+      guessLanguageForRegularFile(file)
     }
   }
 
@@ -72,21 +61,18 @@ package object cpgcreation {
   }
 
   private def guessLanguageForRegularFile(file: File): Option[String] = {
-    assert(file.isRegularFile, s"$file must be a regular file, but wasn't")
      file.name.toLowerCase match {
-      case f if f.endsWith(".go") || Set("Gopkg.lock", "Gopkg.toml", "go.mod", "go.sum").contains(f) => Some(Languages.GOLANG)
-      case f if f.endsWith(".js") || f == "package.json" => Some(Languages.JAVASCRIPT)
-      case f if f.endsWith(".java") => Some(Languages.JAVASRC)
-      case f if f.endsWith(".class") => Some(Languages.JAVA)
-      case f if f.endsWith(".php") => Some(Languages.PHP)
-      case f if f.endsWith(".py") => Some(Languages.FUZZY_TEST_LANG)
-      case f if isLlvmSrcFile(f) => Some(Languages.LLVM)
-      case f if f.endsWith(".c") => Some(Languages.C)
+       case f if f.endsWith(".jar") || f.endsWith(".war") || f.endsWith(".ear") || f.endsWith(".apk") => Some(Languages.JAVA)
+       case f if f.endsWith(".csproj") || f.endsWith(".cs") => Some(Languages.CSHARP)
+       case f if f.endsWith(".go") || Set("Gopkg.lock", "Gopkg.toml", "go.mod", "go.sum").contains(f) => Some(Languages.GOLANG)
+       case f if f.endsWith(".js") || f == "package.json" => Some(Languages.JAVASCRIPT)
+       case f if f.endsWith(".java") => Some(Languages.JAVASRC)
+       case f if f.endsWith(".class") => Some(Languages.JAVA)
+       case f if f.endsWith(".php") => Some(Languages.PHP)
+       case f if f.endsWith(".py") => Some(Languages.FUZZY_TEST_LANG)
+       case f if f.endsWith(".bc") || f.endsWith(".ll") => Some(Languages.LLVM)
+       case f if f.endsWith(".c") || f.endsWith(".h") => Some(Languages.C)
     }
-  }
-
-  private def isLlvmSrcFile(fileName: String): Boolean = {
-    fileName.endsWith(".bc") || fileName.endsWith(".ll")
   }
 
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -78,7 +78,7 @@ package object cpgcreation {
       case f if f.endsWith(".py")                        => Some(Languages.FUZZY_TEST_LANG)
       case f if f.endsWith(".bc") || f.endsWith(".ll")   => Some(Languages.LLVM)
       case f if f.endsWith(".c") || f.endsWith(".h")     => Some(Languages.C)
-      case _ => None
+      case _                                             => None
     }
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -65,17 +65,19 @@ package object cpgcreation {
   }
 
   private def guessLanguageForRegularFile(file: File): Option[String] = {
-     file.name.toLowerCase match {
-       case f if f.endsWith(".jar") || f.endsWith(".war") || f.endsWith(".ear") || f.endsWith(".apk") => Some(Languages.JAVA)
-       case f if f.endsWith(".csproj") || f.endsWith(".cs") => Some(Languages.CSHARP)
-       case f if f.endsWith(".go") || Set("gopkg.lock", "gopkg.toml", "go.mod", "go.sum").contains(f) => Some(Languages.GOLANG)
-       case f if f.endsWith(".js") || f == "package.json" => Some(Languages.JAVASCRIPT)
-       case f if f.endsWith(".java") => Some(Languages.JAVASRC)
-       case f if f.endsWith(".class") => Some(Languages.JAVA)
-       case f if f.endsWith(".php") => Some(Languages.PHP)
-       case f if f.endsWith(".py") => Some(Languages.FUZZY_TEST_LANG)
-       case f if f.endsWith(".bc") || f.endsWith(".ll") => Some(Languages.LLVM)
-       case f if f.endsWith(".c") || f.endsWith(".h") => Some(Languages.C)
+    file.name.toLowerCase match {
+      case f if f.endsWith(".jar") || f.endsWith(".war") || f.endsWith(".ear") || f.endsWith(".apk") =>
+        Some(Languages.JAVA)
+      case f if f.endsWith(".csproj") || f.endsWith(".cs") => Some(Languages.CSHARP)
+      case f if f.endsWith(".go") || Set("gopkg.lock", "gopkg.toml", "go.mod", "go.sum").contains(f) =>
+        Some(Languages.GOLANG)
+      case f if f.endsWith(".js") || f == "package.json" => Some(Languages.JAVASCRIPT)
+      case f if f.endsWith(".java")                      => Some(Languages.JAVASRC)
+      case f if f.endsWith(".class")                     => Some(Languages.JAVA)
+      case f if f.endsWith(".php")                       => Some(Languages.PHP)
+      case f if f.endsWith(".py")                        => Some(Languages.FUZZY_TEST_LANG)
+      case f if f.endsWith(".bc") || f.endsWith(".ll")   => Some(Languages.LLVM)
+      case f if f.endsWith(".c") || f.endsWith(".h")     => Some(Languages.C)
     }
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -38,7 +38,7 @@ package object cpgcreation {
   def guessLanguage(path: String): Option[String] = {
     val file = File(path)
     if (file.isDirectory) {
-      determineMajorityLanguageInDir(file)
+      guessMajorityLanguageInDir(file)
     } else {
       guessLanguageForRegularFile(file)
     }
@@ -48,7 +48,7 @@ package object cpgcreation {
     * a group count of all individual files.
     * Rationale: many projects contain files from different languages, but most often one language is
     * standing out in numbers. */
-  private def determineMajorityLanguageInDir(directory: File): Option[String] = {
+  private def guessMajorityLanguageInDir(directory: File): Option[String] = {
     assert(directory.isDirectory, s"$directory must be a directory, but wasn't")
     val groupCount = mutable.Map.empty[String, Int].withDefaultValue(0)
 
@@ -78,6 +78,7 @@ package object cpgcreation {
       case f if f.endsWith(".py")                        => Some(Languages.FUZZY_TEST_LANG)
       case f if f.endsWith(".bc") || f.endsWith(".ll")   => Some(Languages.LLVM)
       case f if f.endsWith(".c") || f.endsWith(".h")     => Some(Languages.C)
+      case _ => None
     }
   }
 

--- a/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
@@ -67,9 +67,9 @@ class LanguageHelperTests extends AnyWordSpec with Matchers {
       }
     }
 
-    "guess `C` for a directory that does not contain any special file" in {
+    "not find anything for an empty directory" in {
       File.usingTemporaryDirectory("oculartests") { tmpDir =>
-        guessLanguage(tmpDir.pathAsString) shouldBe Some(Languages.C)
+        guessLanguage(tmpDir.pathAsString) shouldBe None
       }
     }
 

--- a/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
@@ -67,6 +67,19 @@ class LanguageHelperTests extends AnyWordSpec with Matchers {
       }
     }
 
+    "guess the language with the largest number of files" in {
+      File.usingTemporaryDirectory("oculartests") { tmpDir =>
+        val subdir = mkdir(tmpDir / "subdir")
+        touch(subdir / "source.c")
+        touch(subdir / "source.java")
+        touch(subdir / "source.py")
+        touch(subdir / "source.js")
+        touch(subdir / "package.json") // also counts towards javascript
+        touch(subdir / "source.py")
+        guessLanguage(tmpDir.pathAsString) shouldBe Some(Languages.JAVASCRIPT)
+      }
+    }
+
     "not find anything for an empty directory" in {
       File.usingTemporaryDirectory("oculartests") { tmpDir =>
         guessLanguage(tmpDir.pathAsString) shouldBe None

--- a/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
@@ -3,13 +3,12 @@ package io.joern.console
 import better.files.Dsl._
 import better.files._
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.joern.console.cpgcreation.LlvmCpgGenerator
+import io.joern.console.cpgcreation.{guessLanguage, LlvmCpgGenerator}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class LanguageHelperTests extends AnyWordSpec with Matchers {
 
-  import io.joern.console.cpgcreation.guessLanguage
 
   "LanguageHelper.guessLanguage" should {
 

--- a/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
@@ -27,6 +27,14 @@ class LanguageHelperTests extends AnyWordSpec with Matchers {
       guessLanguage("foo.go") shouldBe Some(Languages.GOLANG)
     }
 
+    "guess `JavaSrc` for a directory containing `.java`" in {
+      File.usingTemporaryDirectory("oculartests") { tmpDir =>
+        val subdir = mkdir(tmpDir / "subdir")
+        touch(subdir / "ServiceIdentifierComposerVisitorBasedStrategy.java")
+        guessLanguage(tmpDir.pathAsString) shouldBe Some(Languages.JAVASRC)
+      }
+    }
+
     "guess `Go` for a directory containing `Gopkg.lock`" in {
       File.usingTemporaryDirectory("oculartests") { tmpDir =>
         val subdir = mkdir(tmpDir / "subdir")

--- a/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
@@ -29,35 +29,39 @@ class LanguageHelperTests extends AnyWordSpec with Matchers {
 
     "guess `Go` for a directory containing `Gopkg.lock`" in {
       File.usingTemporaryDirectory("oculartests") { tmpDir =>
-        touch(tmpDir / "Gopkg.lock")
-        guessLanguage(tmpDir.toString) shouldBe Some(Languages.GOLANG)
+        val subdir = mkdir(tmpDir / "subdir")
+        touch(subdir / "Gopkg.lock")
+        guessLanguage(tmpDir.pathAsString) shouldBe Some(Languages.GOLANG)
       }
     }
 
-    "guess `Go` for a directory containing `Gopkg.toml` its root" in {
+    "guess `Go` for a directory containing `Gopkg.toml`" in {
       File.usingTemporaryDirectory("oculartests") { tmpDir =>
-        touch(tmpDir / "Gopkg.toml")
-        guessLanguage(tmpDir.toString) shouldBe Some(Languages.GOLANG)
+        val subdir = mkdir(tmpDir / "subdir")
+        touch(subdir / "Gopkg.toml")
+        guessLanguage(tmpDir.pathAsString) shouldBe Some(Languages.GOLANG)
       }
     }
 
-    "guess `Javascript` for a directory containing `package.json` in its root" in {
+    "guess `Javascript` for a directory containing `package.json`" in {
       File.usingTemporaryDirectory("oculartests") { tmpDir =>
-        touch(tmpDir / "package.json")
-        guessLanguage(tmpDir.toString) shouldBe Some(Languages.JAVASCRIPT)
+        val subdir = mkdir(tmpDir / "subdir")
+        touch(subdir / "package.json")
+        guessLanguage(tmpDir.pathAsString) shouldBe Some(Languages.JAVASCRIPT)
       }
     }
 
-    "guess `C` for a directory containing .ll (LLVM) file in its root" in {
+    "guess `C` for a directory containing .ll (LLVM) file" in {
       File.usingTemporaryDirectory("oculartests") { tmpDir =>
-        touch(tmpDir / "foobar.ll")
-        guessLanguage(tmpDir.toString) shouldBe Some(Languages.LLVM)
+        val subdir = mkdir(tmpDir / "subdir")
+        touch(subdir / "foobar.ll")
+        guessLanguage(tmpDir.pathAsString) shouldBe Some(Languages.LLVM)
       }
     }
 
     "guess `C` for a directory that does not contain any special file" in {
       File.usingTemporaryDirectory("oculartests") { tmpDir =>
-        guessLanguage(tmpDir.toString) shouldBe Some(Languages.C)
+        guessLanguage(tmpDir.pathAsString) shouldBe Some(Languages.C)
       }
     }
 


### PR DESCRIPTION
* if input is a directory, scan it recursively, rather than just the top level
* do a group count of all files in given directory, rather than just searching for one language followed by the next etc. rationale: most projects have a mix of languages
* cleanup, docs, refactor
* add javasrc as potential language option