### PR TITLE
Fix flaky test

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -67,7 +67,9 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
       sourceTravs
         .flatMap(_.toList)
         .collect { case n: CfgNode => n }
+        .dedup
         .toList
+        .sortBy(_.id)
     val sinks = traversal.dedup.toList.sortBy(_.id)
     val engine = new Engine(context)
     val result = engine.backwards(sinks, sources)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/LoopTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/LoopTests.scala
@@ -123,7 +123,7 @@ class LoopTests extends JavaDataflowFixture {
 
   it should "find a path if `MALICIOUS` is added in `FOR` update" in {
     val (source, sink) = getConstSourceSink("test3")
-    sink.reachableBy(source).size shouldBe 2
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "not find a path if `MALICIOUS` is always reassigned before sink in loop" in {
@@ -133,14 +133,12 @@ class LoopTests extends JavaDataflowFixture {
 
   it should "find a path if `MALICIOUS` is assigned in `FOR` init" in {
     val (source, sink) = getConstSourceSink("test5")
-    sink.reachableBy(source).size shouldBe 2
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "find a path if sink is in a `DO` loop" in {
     val (source, sink) = getConstSourceSink("test6")
-    // There is a path from "MALICIOUS" to the java.io.PrintStream arg as well.
-    // TODO: Should the java.io.PrintStream arg exist, and should there be a path?
-    sink.reachableBy(source).size shouldBe 2
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "find a path if sink is in `FOREACH` loop" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SwitchTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SwitchTests.scala
@@ -48,6 +48,6 @@ class SwitchTests extends JavaDataflowFixture {
 
   it should "find a path if the sink is in a switch" in {
     val (source, sink) = getConstSourceSink("test2")
-    sink.reachableBy(source).size shouldBe 2
+    sink.reachableBy(source).size shouldBe 1
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/TryTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/TryTests.scala
@@ -125,17 +125,17 @@ class TryTests extends JavaDataflowFixture {
 
   it should "find a path if the sink is in a `TRY`" in {
     val (source, sink) = getConstSourceSink("test1")
-    sink.reachableBy(source).size shouldBe 3
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "find a path if the sink is in a `CATCH`" in {
     val (source, sink) = getConstSourceSink("test2")
-    sink.reachableBy(source).size shouldBe 2
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "find a path if the sink is in a `FINALLY`" in {
     val (source, sink) = getConstSourceSink("test3")
-    sink.reachableBy(source).size shouldBe 2
+    sink.reachableBy(source).size shouldBe 1
   }
 
   // TODO: This is a very optimistic test. We expect the path to be missing for now.

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -39,7 +39,7 @@ class JavaDataflowFixture extends AnyFlatSpec with Matchers {
     val sourceMethod = cpg.method(s".*$sourceMethodName.*").head
     val sinkMethod = cpg.method(s".*$sinkMethodName.*").head
     def source = sourceMethod.literal.code(sourceCode)
-    def sink = sinkMethod.call.name(sinkPattern).argument.ast.collectAll[Expression]
+    def sink = sinkMethod.call.name(sinkPattern).argument(1).ast.collectAll[Expression]
 
     // If either of these fail, then the testcase was written incorrectly or the AST was created incorrectly.
     if (source.size <= 0) {


### PR DESCRIPTION
When executing the data flow engine on a multi-core machine and paths for multiple sinks overlap, results are not 100% stable. I will address this in a follow-up PR. For now, I am fixing the flaky test that highlights this problem by making it more precise.