### PR TITLE
Include `lineNumberEnd` in method full names of calls to macros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 
-val cpgVersion = "1.3.416"
+val cpgVersion = "1.3.420+0-e892aad2+20211108-1341"
 val js2cpgVersion = "0.2.24"
 
 ThisBuild /Test /fork := true

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.5"
 // don't upgrade to 2.13.6 until https://github.com/com-lihaoyi/Ammonite/issues/1182 is resolved
 
-val cpgVersion = "1.3.420+0-e892aad2+20211108-1341"
+val cpgVersion = "1.3.423"
 val js2cpgVersion = "0.2.24"
 
 ThisBuild /Test /fork := true

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -166,7 +166,7 @@ trait MacroHandler {
       val fileName = fileLocation.getFileName
       fileName + ":" + lineNo + ":" + lineNoEnd + ":" + name + ":" + argAsts.size
     } else {
-      "<empty>:-1:" + name + ":" + argAsts.size
+      "<empty>:-1:-1:" + name + ":" + argAsts.size
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -10,11 +10,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewNode
 }
 import io.shiftleft.x2cpg.Ast
-import org.eclipse.cdt.core.dom.ast.{
-  IASTMacroExpansionLocation,
-  IASTNode,
-  IASTPreprocessorMacroDefinition
-}
+import org.eclipse.cdt.core.dom.ast.{IASTMacroExpansionLocation, IASTNode, IASTPreprocessorMacroDefinition}
 import org.eclipse.cdt.internal.core.parser.scanner.MacroArgumentExtractor
 
 import scala.annotation.nowarn

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/MacroHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/MacroHandlingTests.scala
@@ -41,6 +41,7 @@ class MacroHandlingTests1 extends CCodeToCpgSuite {
     m.fullName.endsWith("A_MACRO:2") shouldBe true
     m.filename.endsWith(".c") shouldBe true
     m.lineNumber shouldBe Some(2)
+    m.lineNumberEnd shouldBe Some(2)
     val List(param1, param2) = m.parameter.l.sortBy(_.order)
     param1.name shouldBe "p1"
     param2.name shouldBe "p2"

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpacking.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpacking.scala
@@ -7,6 +7,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.wordspec.AnyWordSpec
+import io.shiftleft.semanticcpg.language._
 
 import scala.reflect.io.File
 import scala.util.{Failure, Success, Try}
@@ -37,10 +38,10 @@ class JarUnpacking extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "should reflect the correct package order" in {
-    val List(foo) = cpg.typeDecl("Foo").l
+    val List(foo) = cpg.typeDecl.fullName("Foo").l
     foo.name shouldBe "Foo"
 
-    val List(bar) = cpg.typeDecl("pac.Bar").l
+    val List(bar) = cpg.typeDecl.fullName("pac.Bar").l
     bar.name shouldBe "Bar"
 
     cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set("Foo.<init>:void()",


### PR DESCRIPTION
Depends on https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1516