### PR TITLE
Make the new C/C++ frontend the default frontend

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -199,8 +199,19 @@ trait BridgeBase {
     val language = config.language.getOrElse(
       io.joern.console.cpgcreation
         .guessLanguage(src)
-        .map(_.toLowerCase)
-        .getOrElse("c"))
+        .map { x =>
+          val lang = x.toLowerCase
+          // TODO we should eventually rename the languages in the
+          // spec to `OLDC` and `C` at which point the match below
+          // is no longer required.
+          lang match {
+            case "newc" => "c"
+            case "c"    => "oldc"
+            case _      => lang
+          }
+        }
+        .getOrElse("c")
+    )
     val storeCode = if (config.store) { "save" } else { "" }
     val runDataflow = if (productName == "ocular") { "run.dataflow" } else { "run.ossdataflow" }
     val code = s"""

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -47,8 +47,8 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
     }
   }
 
-  def c: CFrontend = new CFrontend()
-  def newc: CFrontend = new CFrontend(Languages.NEWC, "Eclipse CDT Based Frontend for C/C++")
+  def oldc: CFrontend = new CFrontend()
+  def c: CFrontend = new CFrontend(Languages.NEWC, "Eclipse CDT Based Frontend for C/C++")
   def llvm: Frontend = new Frontend(Languages.LLVM, "LLVM Bitcode Frontend")
   def java: Frontend = new Frontend(Languages.JAVA, "Java/Dalvik Bytecode Frontend")
   def javasrc: Frontend = new Frontend(Languages.JAVASRC, "Java Source Frontend")
@@ -96,7 +96,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
   }
 
   private def allFrontends: List[Frontend] = List(
-    c,
+    oldc,
     csharp,
     golang,
     java,

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -77,7 +77,7 @@ package object cpgcreation {
       case f if f.endsWith(".php")                       => Some(Languages.PHP)
       case f if f.endsWith(".py")                        => Some(Languages.FUZZY_TEST_LANG)
       case f if f.endsWith(".bc") || f.endsWith(".ll")   => Some(Languages.LLVM)
-      case f if f.endsWith(".c") || f.endsWith(".h")     => Some(Languages.C)
+      case f if f.endsWith(".c") || f.endsWith(".h")     => Some(Languages.NEWC)
       case _                                             => None
     }
   }

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -20,7 +20,7 @@ class ConsoleTests extends AnyWordSpec with Matchers {
     }
 
     "allow importing code with specific module" in ConsoleFixture() { (console, codeDir) =>
-      console.importCode.c(codeDir.toString)
+      console.importCode.oldc(codeDir.toString)
       console.workspace.numberOfProjects shouldBe 1
     }
 


### PR DESCRIPTION
After plenty of testing and improving of the macro handling, with this PR, we make the new Eclipse-CDT-based C/C++ the default frontend for C/C++. This enables us to process modern C++ and handle the preprocessor without requiring the user to jump through configuration hoops. As is the true for the old frontend, the new frontend does NOT require a working build environment: if default header files are installed on the system, they will be taken into account. If they can be heuristically identified in the code base, they are picked up. If not, the analyzer continues with what it has and does not simply abort. This makes the tool ideal for analyzing code that is only partially available, code that comes from a decompiler, old code for which configuring a build environment is time consuming, and finally, settings where learning methods are applied to large amounts of code and configuring a working build environment for each project is not a viable option.