### PR TITLE
`reachableByDetailed` replaces `reachableByTable` (minus the race)

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -28,12 +28,12 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
 
   def reachableBy[NodeType <: CfgNode](sourceTravs: Traversal[NodeType]*)(
       implicit context: EngineContext): Traversal[NodeType] = {
-    val reachedSources = reachableByInternal(sourceTravs)._1.map(_.source)
+    val reachedSources = reachableByInternal(sourceTravs).map(_.source)
     Traversal.from(reachedSources).cast[NodeType]
   }
 
   def reachableByFlows[A <: CfgNode](sourceTravs: Traversal[A]*)(implicit context: EngineContext): Traversal[Path] = {
-    val paths = reachableByInternal(sourceTravs)._1
+    val paths = reachableByInternal(sourceTravs)
       .map { result =>
         // We can get back results that start in nodes that are invisible
         // according to the semantic, e.g., arguments that are only used
@@ -52,9 +52,9 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     paths.to(Traversal)
   }
 
-  def reachableByTable[NodeType <: CfgNode](sourceTravs: Traversal[NodeType]*)(
-      implicit context: EngineContext): ResultTable = {
-    reachableByInternal(sourceTravs)._2
+  def reachableByDetailed[NodeType <: CfgNode](sourceTravs: Traversal[NodeType]*)(
+      implicit context: EngineContext): List[ReachableByResult] = {
+    reachableByInternal(sourceTravs)
   }
 
   private def removeConsecutiveDuplicates[T](l: Vector[T]): List[T] = {
@@ -62,7 +62,7 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
   }
 
   private def reachableByInternal[NodeType <: CfgNode](sourceTravs: Seq[Traversal[NodeType]])(
-      implicit context: EngineContext): (List[ReachableByResult], ResultTable) = {
+      implicit context: EngineContext): List[ReachableByResult] = {
     val sources: List[CfgNode] =
       sourceTravs
         .flatMap(_.toList)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -48,10 +48,14 @@ class ResultTable {
   * node in the graph.
   *
   * @param path this is the main result - a known path
+  * @param table the result table - kept to allow for detailed inspection of intermediate paths
   * @param partial indicate whether this result stands on its own or requires further analysis,
   *                e.g., by expanding output arguments backwards into method output parameters.
   * */
-case class ReachableByResult(path: Vector[PathElement], callDepth: Int = 0, partial: Boolean = false) {
+case class ReachableByResult(path: Vector[PathElement],
+                             table: ResultTable,
+                             callDepth: Int = 0,
+                             partial: Boolean = false) {
   def source: CfgNode = path.head.node
 
   def unresolvedArgs: Vector[CfgNode] =

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -21,8 +21,8 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1 = Vector(ReachableByResult(Vector(PathElement(node1))))
-      val res2 = Vector(ReachableByResult(Vector(PathElement(node2))))
+      val res1 = Vector(ReachableByResult(Vector(PathElement(node1)), new ResultTable))
+      val res2 = Vector(ReachableByResult(Vector(PathElement(node2)), new ResultTable))
       table.add(node1, res1)
       table.add(node1, res2)
       table.get(node1) match {
@@ -52,9 +52,9 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node4 = cpg.literal.code("moo").head
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table = new ResultTable
-      table.add(pivotNode, Vector(ReachableByResult(pathContainingPivot)))
+      table.add(pivotNode, Vector(ReachableByResult(pathContainingPivot, new ResultTable)))
       table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
-        case Some(Vector(ReachableByResult(path, _, _))) =>
+        case Some(Vector(ReachableByResult(path, _, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case _ => fail()
       }


### PR DESCRIPTION
Introduces `reachableByDetailed` as a replacement for `reachableByTable`, which was introduced a few weeks back for experimental purposes, but unfortunately, contained a race condition. `reachableByDetailed` returns the sequence of `ReachableByResult`s, which now include the table.