### PR TITLE
joern-parse: cleanup and simplification

### DIFF
--- a/joern-cli/src/main/scala/io/joern/DefaultOverlays.scala
+++ b/joern-cli/src/main/scala/io/joern/DefaultOverlays.scala
@@ -4,7 +4,7 @@ import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOpti
 import io.shiftleft.semanticcpg.layers._
 import io.shiftleft.codepropertygraph.Cpg
 
-object Cpg2Scpg {
+object DefaultOverlays {
 
   val DEFAULT_CPG_IN_FILE = "cpg.bin"
 
@@ -13,17 +13,15 @@ object Cpg2Scpg {
     * turning the CPG into an SCPG.
     * @param storeFilename the filename of the cpg
     * */
-  def run(storeFilename: String, dataFlow: Boolean): Cpg = {
+  def create(storeFilename: String): Cpg = {
     val cpg = CpgBasedTool.loadFromOdb(storeFilename)
     val context = new LayerCreatorContext(cpg)
     new Base().run(context)
     new TypeRelations().run(context)
     new ControlFlow().run(context)
     new CallGraph().run(context)
-    if (dataFlow) {
-      val options = new OssDataFlowOptions()
-      new OssDataFlow(options).run(context)
-    }
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
     cpg
   }
 

--- a/joern-cli/src/test/scala/io/shiftleft/joern/AbstractJoernCliTest.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/AbstractJoernCliTest.scala
@@ -21,7 +21,7 @@ trait AbstractJoernCliTest {
     val config = C2Cpg.Config(inputPaths = inputFilenames, outputPath = c2cpgOutFilename)
     c2cpg.runAndOutput(config).close()
     // Link CPG fragments and enhance to create semantic CPG
-    val cpg = Cpg2Scpg.run(c2cpgOutFilename, dataFlow = true)
+    val cpg = DefaultOverlays.create(c2cpgOutFilename)
     (cpg, c2cpgOutFilename)
   }
 


### PR DESCRIPTION
Now that data flow analysis is sufficiently fast, let's always calculate DDGs instead of having users run into the situation where data flow analysis doesn't work because these edges have not been calculated. Also, let's get rid of the term "enhancing the graph" when we mean enhancing it in a very specific way, that is, by applying the default overlays. Finally, if a user just runs `./joern-parse`, show them how to use it.