### PR TITLE
Honor `--for-input-path` when running scripts

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -310,7 +310,11 @@ trait BridgeBase {
       else scriptFile
     val importCpgCode = config.cpgToLoad.map { cpgFile =>
       "importCpg(\"" + cpgFile + "\")"
-    }.toList
+    }.toList ++ config.forInputPath.map { name =>
+      s"""
+         |openForInputPath(\"$name\")
+         |""".stripMargin
+    }
     ammonite
       .Main(
         predefCode = predefPlus(additionalImportCode(config) ++ importCpgCode ++ shutdownHooks),


### PR DESCRIPTION
Previously, `--for-input-path` only worked for the interactive shell and `joern-scan` but not for `--script` runs. This PR fixes that. One thing I noticed here, which we may want to change is that if the joern workspace already contains a CPG for the given input path, then we do not reimport.

In short: `joern --script foo.sc --for-input-path /home/foo/code/project` now works.