### PR TITLE
Jimple2Cpg Unhandled Field/ArrayRefs in Definition Fix

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -89,7 +89,8 @@ class Jimple2Cpg {
       // Load classes into Soot
       sourceFileNames
         .map(getQualifiedClassPath(sourceCodePath, _))
-        .foreach(Scene.v().addBasicClass(_))
+        .map { x => Scene.v().addBasicClass(x); x }
+        .foreach(Scene.v().loadClassAndSupport(_).setApplicationClass())
       Scene.v().loadNecessaryClasses()
       // Project Soot classes
       val astCreator = new AstCreationPass(sourceCodePath, sourceFileNames, cpg, methodKeyPool)

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -15,10 +15,31 @@ import java.nio.file.Files
 import java.util.zip.ZipFile
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 import scala.language.postfixOps
+import scala.tools.nsc
 import scala.util.{Failure, Success, Using}
 
 object Jimple2Cpg {
   val language = "JAVA"
+
+  /** Formats the file name the way Soot refers to classes within a class path. e.g.
+    * /unrelated/paths/class/path/Foo.class => class.path.Foo
+    *
+    * @param codePath the parent directory
+    * @param filename the file name to transform.
+    * @return the correctly formatted class path.
+    */
+  def getQualifiedClassPath(codePath: String, filename: String): String = {
+    val codeDir: String = if (new JFile(codePath).isDirectory) {
+      codePath
+    } else {
+      new JFile(codePath).getParentFile.getAbsolutePath
+    }
+
+    filename
+      .replace(codeDir + nsc.io.File.separator, "")
+      .replace(".class", "")
+      .replace(nsc.io.File.separator, ".")
+  }
 }
 
 class Jimple2Cpg {
@@ -65,8 +86,17 @@ class Jimple2Cpg {
         sourceFileExtensions
       )).distinct
 
+      // Load classes into Soot
+      sourceFileNames
+        .map(getQualifiedClassPath(sourceCodePath, _))
+        .foreach(Scene.v().addBasicClass(_))
+      Scene.v().loadNecessaryClasses()
+      // Project Soot classes
       val astCreator = new AstCreationPass(sourceCodePath, sourceFileNames, cpg, methodKeyPool)
       astCreator.createAndApply()
+      // Clear classes from Soot
+      closeSoot()
+
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg, Some(typesKeyPool))
         .createAndApply()
 
@@ -78,8 +108,8 @@ class Jimple2Cpg {
 
   private def configureSoot(sourceCodePath: String): Unit = {
     // set application mode
-    Options.v().set_app(false)
-    Options.v().set_whole_program(false)
+    Options.v().set_app(true)
+    Options.v().set_whole_program(true)
     // make sure classpath is configured correctly
     Options.v().set_soot_classpath(sourceCodePath)
     Options.v().set_prepend_classpath(true)
@@ -91,13 +121,9 @@ class Jimple2Cpg {
     Options.v().set_allow_phantom_refs(true)
     // keep variable names
     PhaseOptions.v().setPhaseOption("jb", "use-original-names:true")
-    Scene.v().loadBasicClasses()
-    Scene.v().loadDynamicClasses()
   }
 
-  private def closeSoot(): Unit = {
-    G.reset()
-  }
+  private def closeSoot(): Unit = G.reset()
 
   /** Unzips a ZIP file into a sequence of files. All files unpacked are deleted at the end of CPG construction.
     *

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -89,7 +89,9 @@ class Jimple2Cpg {
       // Load classes into Soot
       sourceFileNames
         .map(getQualifiedClassPath(sourceCodePath, _))
-        .map { x => Scene.v().addBasicClass(x); x }
+        .map { x =>
+          Scene.v().addBasicClass(x); x
+        }
         .foreach(Scene.v().loadClassAndSupport(_).setApplicationClass())
       Scene.v().loadNecessaryClasses()
       // Project Soot classes

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -13,7 +13,7 @@ import soot.{G, PhaseOptions, Scene}
 import java.io.{File => JFile}
 import java.nio.file.Files
 import java.util.zip.ZipFile
-import scala.jdk.CollectionConverters.EnumerationHasAsScala
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, EnumerationHasAsScala}
 import scala.language.postfixOps
 import scala.tools.nsc
 import scala.util.{Failure, Success, Using}
@@ -100,7 +100,7 @@ class Jimple2Cpg {
       // Clear classes from Soot
       closeSoot()
 
-      new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg, Some(typesKeyPool))
+      new TypeNodePass(astCreator.global.usedTypes.asScala.toList, cpg, Some(typesKeyPool))
         .createAndApply()
 
       cpg

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -1,17 +1,15 @@
 package io.joern.jimple2cpg.passes
 
+import io.joern.jimple2cpg.Jimple2Cpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.{DiffGraph, IntervalKeyPool, ParallelCpgPass}
 import org.slf4j.LoggerFactory
-import soot.{Scene, SootClass}
+import soot.Scene
 
-import java.io.{File => JFile}
-import java.util.concurrent.{ConcurrentHashMap, Semaphore}
-import scala.tools.nsc
+import java.util.concurrent.ConcurrentHashMap
 
 case class Global(
     usedTypes: ConcurrentHashMap[String, Boolean] = new ConcurrentHashMap[String, Boolean](),
-    sootLock: Semaphore = new Semaphore(1)
 )
 
 class AstCreationPass(codePath: String, filenames: List[String], cpg: Cpg, keyPool: IntervalKeyPool)
@@ -20,53 +18,19 @@ class AstCreationPass(codePath: String, filenames: List[String], cpg: Cpg, keyPo
   val global: Global = Global()
   private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
-  /** The base directory of the source code.
-    */
-  private val codeDir: String = if (new JFile(codePath).isDirectory) {
-    codePath
-  } else {
-    new JFile(codePath).getParentFile.getAbsolutePath
-  }
-
   override def partIterator: Iterator[String] = filenames.iterator
 
   override def runOnPart(filename: String): Iterator[DiffGraph] = {
-    val qualifiedClassName = getQualifiedClassPath(filename)
-    var sootClass: Option[SootClass] = None
+    val qualifiedClassName = Jimple2Cpg.getQualifiedClassPath(codePath, filename)
     try {
-      try {
-        global.sootLock.acquire()
-        sootClass = Option(Scene.v().loadClassAndSupport(qualifiedClassName))
-      } finally {
-        global.sootLock.release()
-      }
-      sootClass match {
-        case Some(clazz) => new AstCreator(filename, global).createAst(clazz)
-        case None        => null
-      }
+      val sootClass = Scene.v().loadClassAndSupport(qualifiedClassName)
+      sootClass.setApplicationClass()
+      new AstCreator(filename, global).createAst(sootClass)
     } catch {
       case e: Exception =>
         logger.warn(s"Cannot parse: $filename ($qualifiedClassName)", e)
         Iterator()
-    } finally {
-      sootClass match {
-        case Some(clazz) => Scene.v().removeClass(clazz)
-        case None        =>
-      }
     }
-  }
-
-  /** Formats the file name the way Soot refers to classes within a class path. e.g.
-    * /unrelated/paths/class/path/Foo.class => class.path.Foo
-    *
-    * @param filename the file name to transform.
-    * @return the correctly formatted class path.
-    */
-  def getQualifiedClassPath(filename: String): String = {
-    filename
-      .replace(codeDir + nsc.io.File.separator, "")
-      .replace(".class", "")
-      .replace(nsc.io.File.separator, ".")
   }
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -6,10 +6,10 @@ import io.shiftleft.passes.{DiffGraph, IntervalKeyPool, ParallelCpgPass}
 import org.slf4j.LoggerFactory
 import soot.Scene
 
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentSkipListSet
 
 case class Global(
-    usedTypes: ConcurrentHashMap[String, Boolean] = new ConcurrentHashMap[String, Boolean](),
+    usedTypes: ConcurrentSkipListSet[String] = new ConcurrentSkipListSet[String](),
 )
 
 class AstCreationPass(codePath: String, filenames: List[String], cpg: Cpg, keyPool: IntervalKeyPool)

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -24,7 +24,6 @@ class AstCreationPass(codePath: String, filenames: List[String], cpg: Cpg, keyPo
     val qualifiedClassName = Jimple2Cpg.getQualifiedClassPath(codePath, filename)
     try {
       val sootClass = Scene.v().loadClassAndSupport(qualifiedClassName)
-      sootClass.setApplicationClass()
       new AstCreator(filename, global).createAst(sootClass)
     } catch {
       case e: Exception =>

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -27,7 +27,7 @@ class AstCreator(filename: String, global: Global) {
     * nodes for each key in the map.
     */
   private def registerType(typeName: String): String = {
-    global.usedTypes.put(typeName, true)
+    global.usedTypes.add(typeName)
     typeName
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -89,8 +89,11 @@ class AstCreator(filename: String, global: Global) {
 
     val relatedClass = typ.getSootClass
     val inheritsFromTypeFullName =
-      if (relatedClass.hasSuperclass) List(typ.getSootClass.getSuperclass.toString)
-      else List()
+      if (relatedClass.hasSuperclass) {
+        if (!typ.getSootClass.getSuperclass.isApplicationClass)
+          registerType(typ.getSootClass.getSuperclass.getType.toQuotedString)
+        List(typ.getSootClass.getSuperclass.toString)
+      } else List()
 
     val typeDecl = NewTypeDecl()
       .name(shortName)

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpacking.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpacking.scala
@@ -38,10 +38,10 @@ class JarUnpacking extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "should reflect the correct package order" in {
-    val List(foo) = cpg.typeDecl.fullName("Foo").l
+    val List(foo) = cpg.typeDecl.fullNameExact("Foo").l
     foo.name shouldBe "Foo"
 
-    val List(bar) = cpg.typeDecl.fullName("pac.Bar").l
+    val List(bar) = cpg.typeDecl.fullNameExact("pac.Bar").l
     bar.name shouldBe "Bar"
 
     cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set("Foo.<init>:void()",


### PR DESCRIPTION
- Fixes bug in `astForDefinition` where LHS is only expected to be a local variable and fails for fields and arrays
- Fixes any bugs related to "whole program" analysis by loading all classes in and removing them together only after AST pass
- Safely adds superclass by checking if it exists
- If a method body cannot be extracted it will safely log the warning and create a "stub-style" method body instead of only catch issue on class-level