### PR TITLE
ghidra2cpg: cache decompiler results

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Decompiler.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Decompiler.scala
@@ -1,0 +1,59 @@
+package io.joern.ghidra2cpg
+
+import ghidra.app.decompiler.{DecompInterface, DecompileOptions, DecompileResults}
+import ghidra.program.model.listing.{Function, Program}
+import ghidra.program.model.pcode.HighFunction
+
+import scala.collection.mutable
+
+object Decompiler {
+
+  /**
+    * Create a new decompiler. Returns Some(decompiler) on
+    * success on None on failure.
+    * */
+  def apply(program: Program): Option[Decompiler] = {
+    val decompilerInterface = new DecompInterface()
+    decompilerInterface.setSimplificationStyle("decompile")
+    val opts = new DecompileOptions()
+    opts.grabFromProgram(program)
+    decompilerInterface.setOptions(opts)
+    if (!decompilerInterface.openProgram(program)) {
+      println("Decompiler error: %s\n", decompilerInterface.getLastMessage)
+      None
+    } else {
+      Some(new Decompiler(decompilerInterface))
+    }
+  }
+}
+
+/**
+  * Interface to the ghidra decompiler, which performs caching
+  * to ensure that functions are not decompiled more than once.
+  * */
+class Decompiler(val decompInterface: DecompInterface) {
+
+  val timeoutInSeconds = 60
+  val cache: mutable.Map[String, DecompileResults] = mutable.Map()
+
+  /**
+    * Decompile the given function, retrieving it from a cache if possible.
+    * Returns Some(highFunction) on success and None on error.
+    * */
+  def decompile(function: Function): Option[DecompileResults] = {
+    val addr = function.getEntryPoint.toString(true)
+    cache.get(addr) match {
+      case Some(x) =>
+        Option(x)
+      case None =>
+        decompInterface.decompileFunction(function, timeoutInSeconds, null) match {
+          case null =>
+            cache.put(addr, null)
+            None
+          case x =>
+            cache.put(addr, x)
+            Some(x)
+        }
+    }
+  }
+}

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Decompiler.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Decompiler.scala
@@ -1,6 +1,6 @@
 package io.joern.ghidra2cpg
 
-import ghidra.app.decompiler.{DecompInterface, DecompileOptions, DecompileResults}
+import ghidra.app.decompiler.{DecompInterface, DecompileOptions, DecompileResults, DecompiledFunction}
 import ghidra.program.model.listing.{Function, Program}
 import ghidra.program.model.pcode.HighFunction
 
@@ -37,10 +37,22 @@ class Decompiler(val decompInterface: DecompInterface) {
   val cache: mutable.Map[String, DecompileResults] = mutable.Map()
 
   /**
+    * Retrieve HighFunction for given function, using the cache.
+    * */
+  def toHighFunction(function: Function): Option[HighFunction] =
+    decompile(function).map(_.getHighFunction)
+
+  /**
+    * Retrieve DecompiledFunction for given function, using the cache.
+    * */
+  def toDecompiledFunction(function: Function): Option[DecompiledFunction] =
+    decompile(function).map(_.getDecompiledFunction)
+
+  /**
     * Decompile the given function, retrieving it from a cache if possible.
     * Returns Some(highFunction) on success and None on error.
     * */
-  def decompile(function: Function): Option[DecompileResults] = {
+  private def decompile(function: Function): Option[DecompileResults] = {
     val addr = function.getEntryPoint.toString(true)
     cache.get(addr) match {
       case Some(x) =>

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
@@ -42,7 +42,7 @@ abstract class FunctionPass(
   val listing: Listing = currentProgram.getListing
   val functionIterator: FunctionIterator = listing.getFunctions(true)
   val functions: List[Function] = functionIterator.iterator.asScala.toList
-  val highFunction: HighFunction = decompiler.decompile(function).map(_.getHighFunction).orNull
+  val highFunction: HighFunction = decompiler.toHighFunction(function).orNull
   protected var methodNode: Option[NewMethod] = None
   // we need it just once with default settings
   protected val blockNode: NewBlock = nodes.NewBlock().code("").order(0)
@@ -178,9 +178,8 @@ abstract class FunctionPass(
           // decompilation for a function is cached so subsequent calls to decompile should be free
           // TODO: replace this later on
           val parameters = decompiler
-            .decompile(callee.head)
+            .toHighFunction(callee.head)
             .get
-            .getHighFunction
             .getLocalSymbolMap
             .getSymbols
             .asScala

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
@@ -32,7 +32,7 @@ abstract class FunctionPass(
     function: Function,
     cpg: Cpg,
     keyPool: IntervalKeyPool,
-    decompInterface: DecompInterface
+    decompiler: Decompiler,
 ) extends ParallelCpgPass[String](
       cpg,
       keyPools = Some(keyPool.split(1))
@@ -42,8 +42,7 @@ abstract class FunctionPass(
   val listing: Listing = currentProgram.getListing
   val functionIterator: FunctionIterator = listing.getFunctions(true)
   val functions: List[Function] = functionIterator.iterator.asScala.toList
-  val highFunction: HighFunction =
-    decompInterface.decompileFunction(function, 60, new ConsoleTaskMonitor).getHighFunction
+  val highFunction: HighFunction = decompiler.decompile(function).map(_.getHighFunction).orNull
   protected var methodNode: Option[NewMethod] = None
   // we need it just once with default settings
   protected val blockNode: NewBlock = nodes.NewBlock().code("").order(0)
@@ -178,8 +177,9 @@ abstract class FunctionPass(
           // need to decompile function to get parameter information
           // decompilation for a function is cached so subsequent calls to decompile should be free
           // TODO: replace this later on
-          val parameters = decompInterface
-            .decompileFunction(callee.head, 60, new ConsoleTaskMonitor())
+          val parameters = decompiler
+            .decompile(callee.head)
+            .get
             .getHighFunction
             .getLocalSymbolMap
             .getSymbols

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/arm/ArmFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/arm/ArmFunctionPass.scala
@@ -1,7 +1,7 @@
 package io.joern.ghidra2cpg.passes.arm
 
-import ghidra.app.decompiler.DecompInterface
 import ghidra.program.model.listing.{Function, Program}
+import io.joern.ghidra2cpg.Decompiler
 import io.joern.ghidra2cpg.passes.FunctionPass
 import io.joern.ghidra2cpg.processors.ArmProcessor
 import io.joern.ghidra2cpg.utils.Nodes.{checkIfExternal, createMethodNode, createReturnNode}
@@ -14,12 +14,12 @@ class ArmFunctionPass(currentProgram: Program,
                       function: Function,
                       cpg: Cpg,
                       keyPool: IntervalKeyPool,
-                      decompInterface: DecompInterface)
-    extends FunctionPass(new ArmProcessor, currentProgram, function, cpg, keyPool, decompInterface) {
+                      decompiler: Decompiler)
+    extends FunctionPass(new ArmProcessor, currentProgram, function, cpg, keyPool, decompiler) {
 
   override def runOnPart(part: String): Iterator[DiffGraph] = {
     methodNode = Some(
-      createMethodNode(decompInterface, function, filename, checkIfExternal(currentProgram, function.getName)))
+      createMethodNode(decompiler, function, filename, checkIfExternal(currentProgram, function.getName)))
     diffGraph.addNode(methodNode.get)
     diffGraph.addNode(blockNode)
     diffGraph.addEdge(methodNode.get, blockNode, EdgeTypes.AST)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -7,7 +7,7 @@ import ghidra.program.model.listing.{Function, Instruction, Program}
 import ghidra.program.model.pcode.PcodeOp.{CALL, CALLIND}
 import ghidra.program.model.scalar.Scalar
 import ghidra.util.task.ConsoleTaskMonitor
-import io.joern.ghidra2cpg.Types
+import io.joern.ghidra2cpg.{Decompiler, Types}
 import io.joern.ghidra2cpg.passes.FunctionPass
 import io.joern.ghidra2cpg.processors.MipsProcessor
 import io.joern.ghidra2cpg.utils.Nodes._
@@ -26,8 +26,8 @@ class MipsFunctionPass(currentProgram: Program,
                        function: Function,
                        cpg: Cpg,
                        keyPool: IntervalKeyPool,
-                       decompInterface: DecompInterface)
-    extends FunctionPass(new MipsProcessor, currentProgram, function, cpg, keyPool, decompInterface) {
+                       decompiler: Decompiler)
+    extends FunctionPass(new MipsProcessor, currentProgram, function, cpg, keyPool, decompiler) {
   private val logger = LoggerFactory.getLogger(classOf[MipsFunctionPass])
   def resolveLiterals(instruction: Instruction, callNode: CfgNodeNew): Unit = {
 
@@ -92,8 +92,9 @@ class MipsFunctionPass(currentProgram: Program,
       // non thunk functions do not contain function parameters by default
       // need to decompile function to get parameter information
       // decompilation for a function is cached so subsequent calls to decompile should be free
-      val parameters = decompInterface
-        .decompileFunction(callee, 60, new ConsoleTaskMonitor())
+      val parameters = decompiler
+        .decompile(callee)
+        .get
         .getHighFunction
         .getLocalSymbolMap
         .getSymbols
@@ -187,7 +188,7 @@ class MipsFunctionPass(currentProgram: Program,
   override def runOnPart(part: String): Iterator[DiffGraph] = {
     try {
       methodNode = Some(
-        createMethodNode(decompInterface, function, filename, checkIfExternal(currentProgram, function.getName)))
+        createMethodNode(decompiler, function, filename, checkIfExternal(currentProgram, function.getName)))
       diffGraph.addNode(methodNode.get)
       diffGraph.addNode(blockNode)
       diffGraph.addEdge(methodNode.get, blockNode, EdgeTypes.AST)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -93,9 +93,8 @@ class MipsFunctionPass(currentProgram: Program,
       // need to decompile function to get parameter information
       // decompilation for a function is cached so subsequent calls to decompile should be free
       val parameters = decompiler
-        .decompile(callee)
+        .toHighFunction(callee)
         .get
-        .getHighFunction
         .getLocalSymbolMap
         .getSymbols
         .asScala

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/X86FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/X86FunctionPass.scala
@@ -2,6 +2,7 @@ package io.joern.ghidra2cpg.passes.x86
 
 import ghidra.app.decompiler.DecompInterface
 import ghidra.program.model.listing.{Function, Program}
+import io.joern.ghidra2cpg.Decompiler
 import io.joern.ghidra2cpg.passes.FunctionPass
 import io.joern.ghidra2cpg.processors.X86Processor
 import io.joern.ghidra2cpg.utils.Nodes._
@@ -15,8 +16,8 @@ class X86FunctionPass(currentProgram: Program,
                       function: Function,
                       cpg: Cpg,
                       keyPool: IntervalKeyPool,
-                      decompInterface: DecompInterface)
-    extends FunctionPass(new X86Processor, currentProgram, function, cpg, keyPool, decompInterface) {
+                      decompiler: Decompiler)
+    extends FunctionPass(new X86Processor, currentProgram, function, cpg, keyPool, decompiler) {
 
   override def handleBody(): Unit = {
     if (instructions.nonEmpty) {
@@ -40,7 +41,7 @@ class X86FunctionPass(currentProgram: Program,
   }
   override def runOnPart(part: String): Iterator[DiffGraph] = {
     methodNode = Some(
-      createMethodNode(decompInterface, function, filename, checkIfExternal(currentProgram, function.getName)))
+      createMethodNode(decompiler, function, filename, checkIfExternal(currentProgram, function.getName)))
     diffGraph.addNode(methodNode.get)
     diffGraph.addNode(blockNode)
     diffGraph.addEdge(methodNode.get, blockNode, EdgeTypes.AST)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Nodes.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Nodes.scala
@@ -70,7 +70,7 @@ object Nodes {
 
   }
   def createMethodNode(decompiler: Decompiler, function: Function, fileName: String, isExternal: Boolean): NewMethod = {
-    val code = decompiler.decompile(function).get.getDecompiledFunction.getC
+    val code = decompiler.toDecompiledFunction(function).get.getC
     val lineNumberEnd = Option(function.getReturn)
       .flatMap(x => Option(x.getMinAddress))
       .flatMap(x => Option(x.getOffsetAsBigInteger))

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Nodes.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Nodes.scala
@@ -3,7 +3,7 @@ package io.joern.ghidra2cpg.utils
 import ghidra.app.decompiler.DecompInterface
 import ghidra.program.model.listing.{Function, Program}
 import ghidra.util.task.ConsoleTaskMonitor
-import io.joern.ghidra2cpg.Types
+import io.joern.ghidra2cpg.{Decompiler, Types}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.passes.DiffGraph
@@ -69,11 +69,8 @@ object Nodes {
     nodes.NewMethodReturn().order(1)
 
   }
-  def createMethodNode(decompInterface: DecompInterface,
-                       function: Function,
-                       fileName: String,
-                       isExternal: Boolean): NewMethod = {
-    val code = decompInterface.decompileFunction(function, 60, new ConsoleTaskMonitor).getDecompiledFunction.getC
+  def createMethodNode(decompiler: Decompiler, function: Function, fileName: String, isExternal: Boolean): NewMethod = {
+    val code = decompiler.decompile(function).get.getDecompiledFunction.getC
     val lineNumberEnd = Option(function.getReturn)
       .flatMap(x => Option(x.getMinAddress))
       .flatMap(x => Option(x.getOffsetAsBigInteger))


### PR DESCRIPTION
Isolated decompiler into a wrapper class that caches and returns options. We now also see clearly where we are still dereferencing potential null pointers - something to take care of in another PR.

This brings down CPG generation time from 1:25 to 0:48 on our current test binary.