### PR TITLE
Add default dispatch type to javasrc2cpg

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1581,7 +1581,10 @@ class AstCreator(filename: String, global: Global) {
         callNode.methodFullName(s"${resolved.getQualifiedName}:$signature")
         callNode.signature(signature)
         callNode.dispatchType(DispatchTypes.STATIC_DISPATCH)
-      case Failure(_) => // TODO: Logging
+      case Failure(_) =>
+        // TODO: Logging
+        // Assume dynamic dispatch if the method declaration could not be resolved.
+        callNode.dispatchType(DispatchTypes.DYNAMIC_DISPATCH)
 
     }
     if (call.getName.getBegin.isPresent) {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -1,7 +1,8 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.semanticcpg.language.NoResolve
 import io.shiftleft.semanticcpg.language._
 
@@ -18,6 +19,10 @@ class CallTests extends JavaSrcCodeToCpgFixture {
       |
       |   int main(int argc, char argv) {
       |     return add(argc, 3);
+      |   }
+      |
+      |   int bar(int argc) {
+      |     foo(argc);
       |   }
       | }
       |""".stripMargin
@@ -72,4 +77,11 @@ class CallTests extends JavaSrcCodeToCpgFixture {
     x.name shouldBe "x"
   }
 
+  "should handle unresolved calls with appropriate defaults" in {
+    val List(call: Call) = cpg.call("foo").l
+    call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH.toString
+    call.methodFullName shouldBe "<empty>"
+    call.signature shouldBe ""
+    call.code shouldBe "foo(argc)"
+  }
 }


### PR DESCRIPTION
This PR adds a default dispatch type of `DYNAMIC_DISPATCH` to unresolved calls. Without this, the `StaticCallLinker` logs an unknown dispatch type warning, which is quite noisy (and expected) for large codebases using external libraries. 

An alternative to using `DYNAMIC_DISPATCH` as a default would be to add a new `UNKNOWN` dispatch type, which would make this issue more explicit.