### PR TITLE
Fix invalid expansion in data flow engine

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -1,6 +1,6 @@
 package io.joern.dataflowengineoss.queryengine
 
-import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, StoredNode}
 
 import scala.jdk.CollectionConverters._
 
@@ -49,11 +49,14 @@ class ResultTable {
   *
   * @param path this is the main result - a known path
   * @param table the result table - kept to allow for detailed inspection of intermediate paths
+  * @param callSite the call site that was expanded to kick off the task. We require this to
+  *                 match call sites to exclude non-realizable paths through other callers
   * @param partial indicate whether this result stands on its own or requires further analysis,
   *                e.g., by expanding output arguments backwards into method output parameters.
   * */
 case class ReachableByResult(path: Vector[PathElement],
                              table: ResultTable,
+                             callSite: Option[Call],
                              callDepth: Int = 0,
                              partial: Boolean = false) {
   def source: CfgNode = path.head.node

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -21,8 +21,8 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1 = Vector(ReachableByResult(Vector(PathElement(node1)), new ResultTable))
-      val res2 = Vector(ReachableByResult(Vector(PathElement(node2)), new ResultTable))
+      val res1 = Vector(ReachableByResult(Vector(PathElement(node1)), new ResultTable, None))
+      val res2 = Vector(ReachableByResult(Vector(PathElement(node2)), new ResultTable, None))
       table.add(node1, res1)
       table.add(node1, res2)
       table.get(node1) match {
@@ -52,9 +52,9 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node4 = cpg.literal.code("moo").head
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table = new ResultTable
-      table.add(pivotNode, Vector(ReachableByResult(pathContainingPivot, new ResultTable)))
+      table.add(pivotNode, Vector(ReachableByResult(pathContainingPivot, new ResultTable, None)))
       table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
-        case Some(Vector(ReachableByResult(path, _, _, _))) =>
+        case Some(Vector(ReachableByResult(path, _, _, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case _ => fail()
       }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
@@ -70,8 +70,6 @@ class EnumTests extends JavaSrcCodeToCpgFixture {
     call.astChildren.head shouldBe a[Literal]
     call.astChildren.head.code shouldBe "\"Red\""
 
-
-
     b.code shouldBe "BLUE(\"Blue\")"
     b.astChildren.astChildren.size shouldBe 1
     b.astChildren.astChildren.head.code shouldBe "\"Blue\""

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InstanceOfTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InstanceOfTests.scala
@@ -26,7 +26,6 @@ class InstanceOfTests extends JavaSrcCodeToCpgFixture {
     call.argumentIndex shouldBe 1
     call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
 
-
     val List(o: Identifier, t: TypeRef) = call.argument.l
     o.code shouldBe "o"
     o.order shouldBe 1


### PR DESCRIPTION
When expanding into a sibling callee during backwards tracking, we were not keeping track of the callsite and therefore ended up returning to any caller of the sibling callee - the classical unrealisable path. Fixed that.