### PR TITLE
Do not consider callee to its parameter as partial path

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -133,7 +133,6 @@ class Engine(context: EngineContext) {
             .map(p => ReachableByTask(p, sources, new ResultTable, path, callDepth + 1, arg.inCall.headOption))
         }
     }
-
     forCalls ++ forArgs
   }
 
@@ -337,7 +336,8 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
     val resultsForCurNode = {
       val endStates = if (sources.contains(curNode.asInstanceOf[NodeType])) {
         List(ReachableByResult(path, table, callSite))
-      } else if ((task.callDepth != context.config.maxCallDepth) && curNode.isInstanceOf[MethodParameterIn]) {
+      } else if ((task.callDepth != context.config.maxCallDepth) && curNode
+                   .isInstanceOf[MethodParameterIn] && callSite.isEmpty) {
         List(ReachableByResult(path, table, callSite, partial = true))
       } else {
         List()

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/CDataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/CDataFlowTests.scala
@@ -979,3 +979,24 @@ class CDataFlowTests32 extends DataFlowCodeToCpgSuite {
     sink.reachableBy(source).size shouldBe 4
   }
 }
+
+class CDatFlowTests33 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
+      |int bar(int z) {
+      |  int x = 10;
+      |  int y = x + source()
+      |  return y;
+      |}
+      |
+      |int foo() {
+      |int y = bar(x);
+      |sink(y);
+      |}
+      |""".stripMargin
+
+  "Tes 33: should provide correct flow for source in sibling callee" in {
+    cpg.call("sink").reachableByFlows(cpg.call("source")).size shouldBe 1
+  }
+
+}

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/NewCDataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/NewCDataFlowTests.scala
@@ -41,14 +41,9 @@ class NewCDataFlowTests2 extends DataFlowCodeToCpgSuite {
     val source = cpg.call("source")
     val sink = cpg.call("sink")
     val flows = sink.reachableByFlows(source).l
-    flows.size shouldBe 2
+    flows.size shouldBe 1
     flows.map(flowToResultPairs).toSet shouldBe Set(
       List(("source()", Some(6)), ("sink(source())", Some(6))),
-      List(("source()", Some(6)),
-           ("sink(int arg)", Some(2)),
-           ("return arg;", Some(2)),
-           ("int", Some(2)),
-           ("sink(source())", Some(6)))
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/FunctionCallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/FunctionCallTests.scala
@@ -207,7 +207,7 @@ class FunctionCallTests extends JavaDataflowFixture {
 
   it should "find a path where `MALICIOUS` is added to safe input via a called function" in {
     val (source, sink) = getConstSourceSink("test14")
-    sink.reachableBy(source).size shouldBe 3
+    sink.reachableBy(source).size shouldBe 1
 
   }
 
@@ -220,6 +220,6 @@ class FunctionCallTests extends JavaDataflowFixture {
   it should "not find a path where `MALICIOUS` arg is not included in return" in {
     val (source, sink) = getConstSourceSink("test16")
     // This isn't exactly the expected behaviour, but is on par with c2cpg.
-    sink.reachableBy(source).size shouldBe 2
+    sink.reachableBy(source).size shouldBe 1
   }
 }


### PR DESCRIPTION
Previously, when we had expanded into a callee and then managed to traverse up towards one of its parameters, we would consider this is a partial path that we would need to continue exploring. From there on, we would expand back upwards into the parameter, leading to some very confusing results. Turned that off.