### PR TITLE
frontend heuristic: take frontend availability into account

### DIFF
--- a/console/src/main/scala/io/joern/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/joern/console/ConsoleConfig.scala
@@ -51,7 +51,7 @@ object InstallConfig {
 }
 
 class ConsoleConfig(val install: InstallConfig = InstallConfig(),
-                    val frontend: FrontendConfig = FrontendConfig(),
+                    val frontendConfig: FrontendConfig = FrontendConfig(),
                     val tools: ToolsConfig = ToolsConfig()) {}
 
 object ToolsConfig {

--- a/console/src/main/scala/io/joern/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/joern/console/ConsoleConfig.scala
@@ -51,7 +51,7 @@ object InstallConfig {
 }
 
 class ConsoleConfig(val install: InstallConfig = InstallConfig(),
-                    val frontendConfig: FrontendConfig = FrontendConfig(),
+                    val frontend: FrontendConfig = FrontendConfig(),
                     val tools: ToolsConfig = ToolsConfig()) {}
 
 object ToolsConfig {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
@@ -9,6 +9,7 @@ import java.nio.file.Path
   * into code property graphs via fuzzy parsing.
   * */
 case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+  lazy val command = rootPath.resolve("c2cpg.sh")
 
   /**
     * Generate a CPG for the given input path.
@@ -18,10 +19,11 @@ case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGene
   override def generate(inputPath: String,
                         outputPath: String = "cpg.bin",
                         namespaces: List[String] = List()): Option[String] = {
-    val command = rootPath.resolve("c2cpg.sh").toString
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
-  override def isAvailable: Boolean = true
+  override def isAvailable: Boolean =
+    command.toFile.exists
+
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -18,7 +18,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
   def forCodeAt(inputPath: String): Option[CpgGenerator] =
     for {
       language <- guessLanguage(inputPath)
-      cpgGenerator <- cpgGeneratorForLanguage(language, config.frontendConfig, config.install.rootPath.path, args = Nil)
+      cpgGenerator <- cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil)
     } yield {
       report(s"Using generator for language: $language: ${cpgGenerator.getClass.getSimpleName}")
       cpgGenerator
@@ -31,7 +31,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     Option(language)
       .filter(languageIsKnown)
       .flatMap { lang =>
-        cpgGeneratorForLanguage(lang, config.frontendConfig, config.install.rootPath.path, args = Nil)
+        cpgGeneratorForLanguage(lang, config.frontend, config.install.rootPath.path, args = Nil)
       }
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -15,12 +15,14 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
   /**
     * For a given input path, try to guess a suitable generator and return it
     * */
-  def forCodeAt(inputPath: String): Option[CpgGenerator] = {
-    guessLanguage(inputPath).flatMap { language =>
-      report(s"Using generator for language: $language and frontend=${config.frontend}")
-      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil)
+  def forCodeAt(inputPath: String): Option[CpgGenerator] =
+    for {
+      language <- guessLanguage(inputPath)
+      cpgGenerator <- cpgGeneratorForLanguage(language, config.frontendConfig, config.install.rootPath.path, args = Nil)
+    } yield {
+      report(s"Using generator for language: $language: ${cpgGenerator.getClass.getSimpleName}")
+      cpgGenerator
     }
-  }
 
   /**
     * For a language, return the generator
@@ -29,7 +31,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     Option(language)
       .filter(languageIsKnown)
       .flatMap { lang =>
-        cpgGeneratorForLanguage(lang, config.frontend, config.install.rootPath.path, args = Nil)
+        cpgGeneratorForLanguage(lang, config.frontendConfig, config.install.rootPath.path, args = Nil)
       }
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -9,6 +9,7 @@ import java.nio.file.Path
   * into code property graphs via fuzzy parsing.
   * */
 case class FuzzyCCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+  lazy val command = rootPath.resolve("fuzzyc2cpg.sh")
 
   /**
     * Generate a CPG for the given input path.
@@ -18,10 +19,10 @@ case class FuzzyCCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
   override def generate(inputPath: String,
                         outputPath: String = "cpg.bin",
                         namespaces: List[String] = List()): Option[String] = {
-    val command = rootPath.resolve("fuzzyc2cpg.sh").toString
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
-  override def isAvailable: Boolean = true
+  override def isAvailable: Boolean =
+    command.toFile.exists
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -66,15 +66,15 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
 
   class Frontend(val name: String, val language: String, val description: String = "") {
     def isAvailable: Boolean = {
-      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil).get.isAvailable
+      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil).filter(_.isAvailable).isDefined
     }
 
     def apply(inputPath: String,
               projectName: String = "",
               namespaces: List[String] = List(),
               args: List[String] = List()): Option[Cpg] = {
-      val frontend = cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args)
-      new ImportCode(console)(frontend.get, inputPath, projectName, namespaces)
+      val frontend = cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args).getOrElse(throw new AssertionError(s"no cpg generator for language=$language available!"))
+      new ImportCode(console)(frontend, inputPath, projectName, namespaces)
     }
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -74,7 +74,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
       io.joern.console.cpgcreation.cpgGeneratorForLanguage(language, config, rootPath, args)
 
     def isAvailable: Boolean = {
-      cpgGeneratorForLanguage(language, config.frontendConfig, config.install.rootPath.path, args = Nil)
+      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil)
         .filter(_.isAvailable)
         .isDefined
     }
@@ -83,7 +83,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
               projectName: String = "",
               namespaces: List[String] = List(),
               args: List[String] = List()): Option[Cpg] = {
-      val frontend = cpgGeneratorForLanguage(language, config.frontendConfig, config.install.rootPath.path, args)
+      val frontend = cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args)
         .getOrElse(throw new AssertionError(s"no cpg generator for language=$language available!"))
       new ImportCode(console)(frontend, inputPath, projectName, namespaces)
     }

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -74,7 +74,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
       io.joern.console.cpgcreation.cpgGeneratorForLanguage(language, config, rootPath, args)
 
     def isAvailable: Boolean = {
-      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil)
+      cpgGeneratorForLanguage(language, config.frontendConfig, config.install.rootPath.path, args = Nil)
         .filter(_.isAvailable)
         .isDefined
     }
@@ -83,7 +83,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
               projectName: String = "",
               namespaces: List[String] = List(),
               args: List[String] = List()): Option[Cpg] = {
-      val frontend = cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args)
+      val frontend = cpgGeneratorForLanguage(language, config.frontendConfig, config.install.rootPath.path, args)
         .getOrElse(throw new AssertionError(s"no cpg generator for language=$language available!"))
       new ImportCode(console)(frontend, inputPath, projectName, namespaces)
     }

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -1,11 +1,13 @@
 package io.joern.console.cpgcreation
 
 import better.files.File
+import io.joern.console.FrontendConfig
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.console.workspacehandling.Project
 import overflowdb.traversal.help.Table
 
+import java.nio.file.Path
 import scala.util.Try
 
 class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
@@ -65,15 +67,24 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
   def php: Frontend = new Frontend("php", Languages.PHP, "PHP bytecode frontend")
 
   class Frontend(val name: String, val language: String, val description: String = "") {
+    def cpgGeneratorForLanguage(language: String,
+                                config: FrontendConfig,
+                                rootPath: Path,
+                                args: List[String]): Option[CpgGenerator] =
+      io.joern.console.cpgcreation.cpgGeneratorForLanguage(language, config, rootPath, args)
+
     def isAvailable: Boolean = {
-      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil).filter(_.isAvailable).isDefined
+      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil)
+        .filter(_.isAvailable)
+        .isDefined
     }
 
     def apply(inputPath: String,
               projectName: String = "",
               namespaces: List[String] = List(),
               args: List[String] = List()): Option[Cpg] = {
-      val frontend = cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args).getOrElse(throw new AssertionError(s"no cpg generator for language=$language available!"))
+      val frontend = cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args)
+        .getOrElse(throw new AssertionError(s"no cpg generator for language=$language available!"))
       new ImportCode(console)(frontend, inputPath, projectName, namespaces)
     }
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -15,9 +15,11 @@ package object cpgcreation {
                               config: FrontendConfig,
                               rootPath: Path,
                               args: List[String]): Option[CpgGenerator] = {
+    lazy val cCpgGenerator = CCpgGenerator(config.withArgs(args), rootPath)
+    lazy val fuzzycCpgGenerator = FuzzyCCpgGenerator(config.withArgs(args), rootPath)
     language match {
       case Languages.CSHARP          => Some(CSharpCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.C               => Some(FuzzyCCpgGenerator(config.withArgs(args), rootPath))
+      case Languages.C               => Seq(fuzzycCpgGenerator, cCpgGenerator).filter(_.isAvailable).headOption
       case Languages.LLVM            => Some(LlvmCpgGenerator(config.withArgs(args), rootPath))
       case Languages.GOLANG          => Some(GoCpgGenerator(config.withArgs(args), rootPath))
       case Languages.JAVA            => Some(JavaCpgGenerator(config.withArgs(args), rootPath))
@@ -27,7 +29,7 @@ package object cpgcreation {
       case Languages.PYTHON          => Some(PythonCpgGenerator(config.withArgs(args), rootPath))
       case Languages.PHP             => Some(PhpCpgGenerator(config.withArgs(args), rootPath))
       case Languages.GHIDRA          => Some(GhidraCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.NEWC            => Some(CCpgGenerator(config.withArgs(args), rootPath))
+      case Languages.NEWC            => Seq(cCpgGenerator, fuzzycCpgGenerator).filter(_.isAvailable).headOption
       case _                         => None
     }
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -19,7 +19,7 @@ package object cpgcreation {
     lazy val fuzzycCpgGenerator = FuzzyCCpgGenerator(config.withArgs(args), rootPath)
     language match {
       case Languages.CSHARP          => Some(CSharpCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.C               => Seq(fuzzycCpgGenerator, cCpgGenerator).filter(_.isAvailable).headOption
+      case Languages.C               => Seq(fuzzycCpgGenerator, cCpgGenerator).find(_.isAvailable)
       case Languages.LLVM            => Some(LlvmCpgGenerator(config.withArgs(args), rootPath))
       case Languages.GOLANG          => Some(GoCpgGenerator(config.withArgs(args), rootPath))
       case Languages.JAVA            => Some(JavaCpgGenerator(config.withArgs(args), rootPath))
@@ -29,7 +29,7 @@ package object cpgcreation {
       case Languages.PYTHON          => Some(PythonCpgGenerator(config.withArgs(args), rootPath))
       case Languages.PHP             => Some(PhpCpgGenerator(config.withArgs(args), rootPath))
       case Languages.GHIDRA          => Some(GhidraCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.NEWC            => Seq(cCpgGenerator, fuzzycCpgGenerator).filter(_.isAvailable).headOption
+      case Languages.NEWC            => Seq(cCpgGenerator, fuzzycCpgGenerator).find(_.isAvailable)
       case _                         => None
     }
   }

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -20,7 +20,7 @@ class ConsoleTests extends AnyWordSpec with Matchers {
     }
 
     "allow importing code with specific module" in ConsoleFixture() { (console, codeDir) =>
-      console.importCode.oldc(codeDir.toString)
+      console.importCode.c(codeDir.toString)
       console.workspace.numberOfProjects shouldBe 1
     }
 

--- a/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
@@ -4,7 +4,7 @@ import better.files.Dsl.mkdir
 import better.files.File
 import io.joern.console.cpgcreation.{CpgGenerator, CpgGeneratorFactory, ImportCode}
 import io.joern.console.workspacehandling.{Project, ProjectFile, WorkspaceLoader}
-import io.joern.console.{Console, ConsoleConfig, DefaultAmmoniteExecutor, InstallConfig}
+import io.joern.console.{Console, ConsoleConfig, DefaultAmmoniteExecutor, FrontendConfig, InstallConfig}
 import io.joern.fuzzyc2cpg.FuzzyC2Cpg
 
 import java.nio.file.Path
@@ -38,12 +38,17 @@ class TestConsole(workspaceDir: String)
     install = new InstallConfig(Map("SHIFTLEFT_OCULAR_INSTALL_DIR" -> workspaceDir))
   )
 
-  class MyImportCode[T <: Project](console: Console[T]) extends ImportCode(console) {
+  override def importCode: ImportCode[Project] = new ImportCode(this) {
     override val generatorFactory = new TestCpgGeneratorFactory(config)
+
+    override def c: SourceBasedFrontend = new SourceBasedFrontend("testCFrontend") {
+      override def cpgGeneratorForLanguage(language: String,
+                                           config: FrontendConfig,
+                                           rootPath: Path,
+                                           args: List[String]): Option[CpgGenerator] =
+        generatorFactory.forLanguage(language)
+    }
   }
-
-  override def importCode = new MyImportCode(this)
-
 }
 
 class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory(config) {


### PR DESCRIPTION
* required for ocular, which ships a different frontend for C
* implement generator.isAvailable for fuzzyc2cpg and c2cpg frontends
* for language.C|NEWC: use the new default frontend if available, otherwise try the alternative one
* improve reporting of chosen frontend
* refactor code: make testable by not linking cpgGeneratorForLanguage statically
* Option.get is unsafe - change to filter, and improve error message