### PR TITLE
Add some javasrc2cpg fixes for issues parsing spring

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -107,4 +107,24 @@ class LambdaTests extends AnyFreeSpec with Matchers {
       cpg.all.count(_.isInstanceOf[ClosureBinding]) shouldBe 1
     }
   }
+
+  "CPG for `identity-like` supplier" - {
+    lazy val cpg = JavaSrc2CpgTestContext.buildCpg(
+      """
+        |public class Foo {
+        |  public foo() {
+        |    String s = "Hello, world";
+        |    Supplier<String> sup = () -> s;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "should parse a supplier with only a single identifier as the method body" in {
+      cpg.method.name("<lambda>").size shouldBe 1
+      val lambda = cpg.method.name("<lambda>").head
+
+      lambda.ast.isIdentifier.size shouldBe 1
+      lambda.ast.isIdentifier.head.code shouldBe "s"
+    }
+  }
 }


### PR DESCRIPTION
Fixes included:
* Handling of cast expressions
* The body of a lambda expression will now always be represented as a block (to fix an issue where an AST edge from an identifier in the body to the method return was not supported)

Also includes some tests and minor cleanup.