### PR TITLE
Refactored c2cpg tests

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotAstGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotAstGeneratorTests.scala
@@ -26,36 +26,32 @@ class DotAstGeneratorTests extends CCodeToCpgSuite {
   "An AstDotGenerator" should {
 
     "generate dot graph" in {
-      cpg.method.name("my_func").dotAst.l match {
-        case x :: _ =>
-          x.startsWith("digraph \"my_func\"") shouldBe true
-          x.contains("""[label = "(CONTROL_STRUCTURE,if (y > 42),if (y > 42))" ]""") shouldBe true
-          x.endsWith("}\n") shouldBe true
-        case _ => fail()
+      inside(cpg.method.name("my_func").dotAst.l) {
+        case List(x) =>
+          x should (
+            startWith("digraph \"my_func\"") and
+              include("""[label = "(CONTROL_STRUCTURE,if (y > 42),if (y > 42))" ]""") and
+              endWith("}\n")
+          )
       }
     }
 
     "allow selection method" in {
-      cpg.method.name("boop").dotAst.l match {
-        case x :: _ => x.startsWith("digraph \"boop\"") shouldBe true
-        case _      => fail()
+      inside(cpg.method.name("boop").dotAst.l) {
+        case List(x) => x should startWith("digraph \"boop\"")
       }
     }
 
     "not include MethodParameterOut nodes" in {
-      cpg.method.name("my_func").dotAst.l match {
-        case x :: _ => x.contains("PARAM_OUT") shouldBe false
-        case _      => fail()
+      inside(cpg.method.name("my_func").dotAst.l) {
+        case List(x) => x should not include "PARAM_OUT"
       }
     }
 
     "allow plotting sub trees of methods" in {
-      cpg.method.ast.isControlStructure.code(".*y > 42.*").dotAst.l match {
-        case x :: _ =>
-          x.contains("y > 42") shouldBe true
-          x.contains("IDENTIFIER,y") shouldBe true
-          x.contains("x * 2") shouldBe false
-        case _ => fail()
+      inside(cpg.method.ast.isControlStructure.code(".*y > 42.*").dotAst.l) {
+        case List(x, _) =>
+          x should (include("y > 42") and include("IDENTIFIER,y") and not include "x * 2")
       }
     }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotCfgGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotCfgGeneratorTests.scala
@@ -20,31 +20,32 @@ class DotCfgGeneratorTests extends CCodeToCpgSuite {
   "A CfgDotGenerator" should {
 
     "create a dot graph" in {
-      cpg.method.name("main").dotCfg.l match {
-        case x :: _ =>
-          x.startsWith("digraph \"main\" {") shouldBe true
-          x.contains("(<operator>.assignment,i = 0)") shouldBe true
-          x.endsWith("}\n") shouldBe true
-        case _ => fail()
+      inside(cpg.method.name("main").dotCfg.l) {
+        case List(x) =>
+          x should (
+            startWith("digraph \"main\" {") and
+              include("(<operator>.assignment,i = 0)") and
+              endWith("}\n")
+          )
       }
     }
 
     "not contain IDENTIFIER nodes" in {
-      cpg.method.name("main").dotCfg.l match {
-        case x :: _ =>
-          x.contains("IDENTIFIER") shouldBe false
-        case _ => fail()
+      inside(cpg.method.name("main").dotCfg.l) {
+        case List(x) => x should not include "IDENTIFIER"
       }
     }
 
     "contain seven nodes" in {
-      val dotStr = cpg.method.name("main").dotCfg.head
-      dotStr.split("\n").count(x => x.contains("label")) shouldBe 7
+      inside(cpg.method.name("main").dotCfg.l) {
+        case List(dotStr) => dotStr.split("\n").count(x => x.contains("label")) shouldBe 7
+      }
     }
 
     "contain seven edges" in {
-      val dotStr = cpg.method.name("main").dotCfg.head
-      dotStr.split("\n").count(x => x.contains("->")) shouldBe 7
+      inside(cpg.method.name("main").dotCfg.l) {
+        case List(dotStr) => dotStr.split("\n").count(x => x.contains("->")) shouldBe 7
+      }
     }
 
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotDdgGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotDdgGeneratorTests.scala
@@ -21,12 +21,15 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       |""".stripMargin
 
   "A DdgDotGenerator" should {
-    "create a dot graph with 31 edges" in {
+    "create correct dot graph" in {
       implicit val s: Semantics = semantics
-      val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
-      lines.head.startsWith("digraph \"foo\"") shouldBe true
-      lines.count(x => x.contains("->")) shouldBe 32
-      lines.last.startsWith("}") shouldBe true
+      inside(cpg.method.name("foo").dotDdg.l) {
+        case List(elem) =>
+          val lines = elem.split("\n")
+          lines.head should startWith("digraph \"foo\"")
+          lines.count(x => x.contains("->")) shouldBe 32
+          lines.last should startWith("}")
+      }
     }
   }
 }
@@ -42,10 +45,15 @@ class DotDdgGeneratorTests2 extends DataFlowCodeToCpgSuite {
       |}
       |""".stripMargin
 
-  "create correct dot graph" in {
-    implicit val s: Semantics = semantics
-    val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
-    lines.count(x => x.contains("->") && x.contains("\"x\"")) shouldBe 3
+  "A DdgDotGenerator" should {
+    "create correct dot graph" in {
+      implicit val s: Semantics = semantics
+      inside(cpg.method.name("foo").dotDdg.l) {
+        case List(elem) =>
+          val lines = elem.split("\n")
+          lines.count(x => x.contains("->") && x.contains("\"x\"")) shouldBe 3
+      }
+    }
   }
 
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/TypeNodePassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/TypeNodePassTests.scala
@@ -1,12 +1,12 @@
 package io.joern.c2cpg.passes
 
 import io.joern.c2cpg.fixtures.CpgTypeNodeFixture
-import io.shiftleft.codepropertygraph.generated.nodes.Type
 import io.shiftleft.semanticcpg.language._
+import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class TypeNodePassTests extends AnyWordSpec with Matchers with CpgTypeNodeFixture {
+class TypeNodePassTests extends AnyWordSpec with Matchers with Inside with CpgTypeNodeFixture {
 
   "TypeNodePass" should {
     "create TYPE nodes for used types" in CpgTypeNodeFixture("""
@@ -20,18 +20,16 @@ class TypeNodePassTests extends AnyWordSpec with Matchers with CpgTypeNodeFixtur
        |int main() {
        |  char test[1024];
        |}""".stripMargin) { cpg =>
-      cpg.local.l match {
+      inside(cpg.local.l) {
         case List(test) =>
           test.typeFullName shouldBe "char[1024]"
           test.evalType.l shouldBe List("char[1024]")
-          test.typ.l match {
-            case List(t: Type) =>
+          inside(test.typ.l) {
+            case List(t) =>
               t.name shouldBe "char[1024]"
               t.fullName shouldBe "char[1024]"
               t.typeDeclFullName shouldBe "char[1024]"
-            case _ => fail()
           }
-        case _ => fail()
       }
     }
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/ExtendedCfgNodeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/ExtendedCfgNodeTests.scala
@@ -26,33 +26,26 @@ class ExtendedCfgNodeTests extends DataFlowCodeToCpgSuite {
       |""".stripMargin
 
   "allow traversing from argument of sink back to param via `ddgIn`" in {
-    cpg.method("sink").parameter.argument.ddgIn.l match {
-      case List(param: nodes.MethodParameterIn) =>
-        param.name shouldBe "y"
-      case _ => fail()
+    inside(cpg.method("sink").parameter.argument.ddgIn.l) {
+      case List(param: nodes.MethodParameterIn) => param.name shouldBe "y"
     }
   }
 
   "allow traversing from argument node to param via `ddgIn`" in {
-    cpg.method("sink").parameter.argument.l match {
-      case List(t: nodes.CfgNode) =>
+    inside(cpg.method("sink").parameter.argument.l) {
+      case List(t) =>
         t.code shouldBe "y"
-        t.ddgIn.l match {
-          case List(param: nodes.MethodParameterIn) =>
-            param.name shouldBe "y"
-          case _ =>
-            fail()
+        inside(t.ddgIn.l) {
+          case List(param: nodes.MethodParameterIn) => param.name shouldBe "y"
         }
-      case _ => fail()
     }
   }
 
   "allow traversing from argument back to param while inspecting edge" in {
-    cpg.method("sink").parameter.argument.ddgInPathElem.l match {
+    inside(cpg.method("sink").parameter.argument.ddgInPathElem.l) {
       case List(pathElem) =>
         pathElem.outEdgeLabel shouldBe "y"
         pathElem.node.isInstanceOf[nodes.MethodParameterIn] shouldBe true
-      case _ => fail()
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
@@ -5,6 +5,7 @@ import io.joern.c2cpg.C2Cpg.Config
 import io.joern.c2cpg.parser.FileDefaults
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
+import org.scalatest.Inside
 
 import java.io.File
 
@@ -20,4 +21,6 @@ class C2CpgFrontend(override val fileSuffix: String = FileDefaults.C_EXT) extend
   }
 }
 
-class CCodeToCpgSuite(fileSuffix: String = FileDefaults.C_EXT) extends CodeToCpgFixture(new C2CpgFrontend(fileSuffix))
+class CCodeToCpgSuite(fileSuffix: String = FileDefaults.C_EXT)
+    extends CodeToCpgFixture(new C2CpgFrontend(fileSuffix))
+    with Inside


### PR DESCRIPTION
* used ScalaTest matcher where possible
* used ScalaTests inside matcher instead of manual pattern matching with fail() case

This improves consistency and readability of test failures a lot.