### PR TITLE
Bump `codepropertygraph`; set execution context.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.7"
 
-val cpgVersion = "1.3.433"
+val cpgVersion = "1.3.434"
 val js2cpgVersion = "0.2.28"
 
 lazy val joerncli = Projects.joerncli

--- a/console/src/main/scala/io/joern/console/Commit.scala
+++ b/console/src/main/scala/io/joern/console/Commit.scala
@@ -3,6 +3,8 @@ package io.joern.console
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
+import scala.concurrent.ExecutionContext
+
 object Commit {
   val overlayName: String = "commit"
   val description: String = "Apply current custom diffgraph"
@@ -16,7 +18,7 @@ class Commit(opts: CommitOptions) extends LayerCreator {
   override val overlayName: String = Commit.overlayName
   override val description: String = Commit.description
 
-  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
+  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
     val pass: CpgPass = new CpgPass(context.cpg) {
       override val name = "commit"
       override def run(): Iterator[DiffGraph] = Iterator(opts.diffGraphBuilder.build())

--- a/console/src/main/scala/io/joern/console/Commit.scala
+++ b/console/src/main/scala/io/joern/console/Commit.scala
@@ -18,7 +18,8 @@ class Commit(opts: CommitOptions) extends LayerCreator {
   override val overlayName: String = Commit.overlayName
   override val description: String = Commit.description
 
-  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
+  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(
+      implicit ec: ExecutionContext): Unit = {
     val pass: CpgPass = new CpgPass(context.cpg) {
       override val name = "commit"
       override def run(): Iterator[DiffGraph] = Iterator(opts.diffGraphBuilder.build())

--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -13,6 +13,7 @@ import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
 import io.shiftleft.semanticcpg.layers.{Base, CallGraph, ControlFlow, LayerCreator, LayerCreatorContext, TypeRelations}
 import overflowdb.traversal.help.Doc
 
+import scala.concurrent.ExecutionContext
 import scala.sys.process.Process
 import scala.util.{Failure, Success, Try}
 
@@ -448,6 +449,7 @@ class Console[T <: Project](executor: AmmoniteExecutor,
   }
 
   protected def runCreator(creator: LayerCreator, overlayDirName: Option[String]): Unit = {
+    implicit val ec: ExecutionContext = ExecutionContext.global
     val context = new LayerCreatorContext(cpg, overlayDirName)
     creator.run(context, storeUndoInfo = true)
   }

--- a/console/src/main/scala/io/joern/console/Run.scala
+++ b/console/src/main/scala/io/joern/console/Run.scala
@@ -6,6 +6,7 @@ import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
 import org.reflections8.Reflections
 import org.reflections8.util.{ClasspathHelper, ConfigurationBuilder}
 
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 object Run {
@@ -16,7 +17,7 @@ object Run {
         override val overlayName: String = "custom"
         override val description: String = "A custom pass"
 
-        override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
+        override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
           val pass: CpgPass = new CpgPass(console.cpg) {
             override val name = "custom"
             override def run(): Iterator[DiffGraph] = {

--- a/console/src/main/scala/io/joern/console/Run.scala
+++ b/console/src/main/scala/io/joern/console/Run.scala
@@ -17,7 +17,8 @@ object Run {
         override val overlayName: String = "custom"
         override val description: String = "A custom pass"
 
-        override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
+        override def createWithExecutionContext(context: LayerCreatorContext,
+                                                storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
           val pass: CpgPass = new CpgPass(console.cpg) {
             override val name = "custom"
             override def run(): Iterator[DiffGraph] = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -3,6 +3,8 @@ package io.joern.dataflowengineoss.layers.dataflows
 import io.joern.dataflowengineoss.passes.reachingdef.ReachingDefPass
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
+import scala.concurrent.ExecutionContext
+
 object OssDataFlow {
   val overlayName: String = "dataflowOss"
   val description: String = "Layer to support the OSS lightweight data flow tracker"
@@ -17,7 +19,7 @@ class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description
 
-  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
+  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
     val cpg = context.cpg
     val enhancementExecList = Iterator(new ReachingDefPass(cpg, opts.maxNumberOfDefinitions))
     enhancementExecList.zipWithIndex.foreach {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -19,7 +19,8 @@ class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description
 
-  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
+  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(
+      implicit ec: ExecutionContext): Unit = {
     val cpg = context.cpg
     val enhancementExecList = Iterator(new ReachingDefPass(cpg, opts.maxNumberOfDefinitions))
     enhancementExecList.zipWithIndex.foreach {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -11,6 +11,7 @@ import io.shiftleft.x2cpg.{X2Cpg, X2CpgConfig}
 import org.slf4j.LoggerFactory
 import scopt.OParser
 
+import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
 class C2Cpg {
@@ -23,6 +24,8 @@ class C2Cpg {
     val headerKeyPool = keyPool(2)
 
     val cpg = newEmptyCpg(Some(config.outputPath))
+
+    implicit val ec: ExecutionContext = ExecutionContext.global
 
     new MetaDataPass(cpg, Languages.NEWC, Some(metaDataKeyPool)).createAndApply()
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
@@ -9,6 +9,8 @@ import io.shiftleft.semanticcpg.layers.{Base, LayerCreatorContext, TypeRelations
 import io.shiftleft.semanticcpg.passes.controlflow.CfgCreationPass
 import io.shiftleft.semanticcpg.passes.frontend.{MetaDataPass, TypeNodePass}
 
+import scala.concurrent.ExecutionContext
+
 object CompleteCpgFixture {
   def apply(code: String, fileName: String = "test.cpp")(f: Cpg => Unit): Unit = {
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
@@ -16,6 +18,7 @@ object CompleteCpgFixture {
       file.write(code)
 
       val cpg = Cpg.emptyCpg
+      implicit val ec: ExecutionContext = ExecutionContext.global
       new MetaDataPass(cpg, Languages.NEWC).createAndApply()
       val astCreationPass =
         new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
@@ -5,12 +5,15 @@ import io.joern.c2cpg.C2Cpg.Config
 import io.joern.c2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
 
+import scala.concurrent.ExecutionContext
+
 object CpgAstOnlyFixture {
   def apply(code: String, fileName: String = "file.c"): Cpg = {
     val cpg = Cpg.emptyCpg
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
       val file = dir / fileName
       file.write(code)
+      implicit val ec: ExecutionContext = ExecutionContext.global
       new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))
         .createAndApply()
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
@@ -9,9 +9,11 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.controlflow.CfgCreationPass
 import io.shiftleft.semanticcpg.passes.controlflow.cfgcreation.Cfg.CfgEdgeType
 
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class CpgCfgFixture(code: String, fileExtension: String = ".c") {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   private val cpg: Cpg = Cpg.emptyCpg
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
@@ -8,12 +8,16 @@ import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.layers.{Base, LayerCreatorContext}
 import io.shiftleft.semanticcpg.passes.frontend.{MetaDataPass, TypeNodePass}
 
+import scala.concurrent.ExecutionContext
+
 object CpgTypeNodeFixture {
   def apply(code: String, fileName: String = "test.c")(f: Cpg => Unit): Unit = {
     val cpg = Cpg.emptyCpg
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
       val file = dir / fileName
       file.write(code)
+
+      implicit val ec: ExecutionContext = ExecutionContext.global
 
       new MetaDataPass(cpg, Languages.NEWC).createAndApply()
       val astCreationPass =

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
@@ -5,12 +5,15 @@ import io.joern.c2cpg.C2Cpg.Config
 import io.joern.c2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
 
+import scala.concurrent.ExecutionContext
+
 object TestAstOnlyFixture {
   def apply(code: String, fileName: String = "file.c")(f: Cpg => Unit): Unit = {
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
       val file = dir / fileName
       file.write(code)
       val cpg = Cpg.emptyCpg
+      implicit val ec: ExecutionContext = ExecutionContext.global
       new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))
         .createAndApply()
       f(cpg)

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
@@ -10,7 +10,10 @@ import io.shiftleft.semanticcpg.passes.frontend.MetaDataPass
 import io.shiftleft.utils.ProjectRoot
 import overflowdb.traversal.TraversalSource
 
+import scala.concurrent.ExecutionContext
+
 case class TestProjectFixture(projectName: String) {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   val cpg: Cpg = Cpg.emptyCpg
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
@@ -12,12 +12,15 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.traversal.NodeOps
 
+import scala.concurrent.ExecutionContext
+
 class AstCreationPassTests
     extends AnyWordSpec
     with Matchers
     with Inside
     with CpgAstOnlyFixture
     with TestAstOnlyFixture {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   "AstCreationPass" should {
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/MetaDataPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/MetaDataPassTests.scala
@@ -8,12 +8,14 @@ import io.shiftleft.semanticcpg.passes.frontend.MetaDataPass
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class MetaDataPassTests extends AnyWordSpec with Matchers {
 
   "MetaDataPass" should {
     val cpg = Cpg.emptyCpg
+    implicit val ec: ExecutionContext = ExecutionContext.global
     new MetaDataPass(cpg, Languages.C).createAndApply()
 
     "create exactly two nodes" in {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -12,10 +12,12 @@ import io.shiftleft.semanticcpg.layers.{Base, CallGraph, ControlFlow, LayerCreat
 import io.shiftleft.utils.ProjectRoot
 import overflowdb.traversal.Traversal
 
+import scala.concurrent.ExecutionContext
 import scala.sys.process.Process
 import scala.util.Try
 
 class DataFlowCodeToCpgSuite extends CCodeToCpgSuite {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   var semanticsFilename = ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
   var semantics: Semantics = _

--- a/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory
 import scopt.OParser
 
 import java.util.concurrent.ConcurrentHashMap
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
@@ -27,6 +28,8 @@ class FuzzyC2Cpg() {
 
     val cpg = newEmptyCpg(optionalOutputPath)
     val sourceFileNames = SourceFiles.determine(sourcePaths, sourceFileExtensions)
+
+    implicit val ec: ExecutionContext = ExecutionContext.global
 
     new MetaDataPass(cpg, Languages.C, Some(metaDataKeyPool)).createAndApply()
     val astCreator = new AstCreationPass(sourceFileNames, cpg, functionKeyPool)

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/CpgTestFixture.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/CpgTestFixture.scala
@@ -12,7 +12,10 @@ import io.shiftleft.utils.ProjectRoot
 import io.shiftleft.x2cpg.SourceFiles
 import overflowdb.traversal.TraversalSource
 
+import scala.concurrent.ExecutionContext
+
 case class CpgTestFixture(projectName: String) {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   val cpg: Cpg = Cpg.emptyCpg
   val dirName = ProjectRoot.relativise(s"joern-cli/frontends/fuzzyc2cpg/src/test/resources/testcode/$projectName")

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/AstCreationPassTests.scala
@@ -10,6 +10,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.traversal._
 
+import scala.concurrent.ExecutionContext
+
 class AstCreationPassTests extends AnyWordSpec with Matchers {
 
   "AstCreationPass" should {
@@ -20,6 +22,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
       expectedFilenameFields.foreach { filename =>
         (dir / filename).write("//foo")
       }
+      implicit val ec: ExecutionContext = ExecutionContext.global
       new AstCreationPass(filenames, cpg, new IntervalKeyPool(1, 1000))
         .createAndApply()
 
@@ -753,6 +756,7 @@ object Fixture {
       val cpg = Cpg.emptyCpg
       val keyPool = new IntervalKeyPool(1001, 2000)
       val filenames = List(file1.path.toAbsolutePath.toString, file2.path.toAbsolutePath.toString)
+      implicit val ec: ExecutionContext = ExecutionContext.global
       new AstCreationPass(filenames, cpg, keyPool).createAndApply()
 
       f(cpg)

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/CfgCreationPassTests.scala
@@ -10,6 +10,7 @@ import io.shiftleft.semanticcpg.passes.controlflow.cfgcreation.Cfg._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class CfgCreationPassTests extends AnyWordSpec with Matchers {
@@ -458,6 +459,7 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
 }
 
 class CfgFixture(file1Code: String) {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   val cpg: Cpg = Cpg.emptyCpg
 

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/MetaDataPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/MetaDataPassTests.scala
@@ -8,12 +8,14 @@ import io.shiftleft.semanticcpg.passes.frontend.MetaDataPass
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class MetaDataPassTests extends AnyWordSpec with Matchers {
 
   "MetaDataPass" should {
     val cpg = Cpg.emptyCpg
+    implicit val ec: ExecutionContext = ExecutionContext.global
     new MetaDataPass(cpg, Languages.C).createAndApply()
 
     "create exactly two nodes" in {

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/StubRemovalPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/StubRemovalPassTests.scala
@@ -8,6 +8,8 @@ import io.shiftleft.semanticcpg.passes.controlflow.CfgCreationPass
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.concurrent.ExecutionContext
+
 class StubRemovalPassTests extends AnyWordSpec with Matchers {
 
   "StubRemovalPass" should {
@@ -56,6 +58,7 @@ object StubRemovalPassFixture {
       val cpg = Cpg.emptyCpg
       val keyPool = new IntervalKeyPool(1001, 2000)
       val filenames = List(file1.path.toAbsolutePath.toString)
+      implicit val ec: ExecutionContext = ExecutionContext.global
       new AstCreationPass(filenames, cpg, keyPool).createAndApply()
       new CfgCreationPass(cpg).createAndApply()
       new StubRemovalPass(cpg).createAndApply()

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/TypeNodePassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/TypeNodePassTests.scala
@@ -8,6 +8,7 @@ import io.shiftleft.semanticcpg.passes.frontend.TypeNodePass
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class TypeNodePassTests extends AnyWordSpec with Matchers {
@@ -28,6 +29,7 @@ object TypeNodePassFixture {
       val keyPool = new IntervalKeyPool(1001, 2000)
       val filenames = List(file1.path.toAbsolutePath.toString)
       val astCreator = new AstCreationPass(filenames, cpg, keyPool)
+      implicit val ec: ExecutionContext = ExecutionContext.global
       astCreator.createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
 

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/testfixtures/CodeDirToCpgFixture.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/testfixtures/CodeDirToCpgFixture.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.io.File
+import scala.concurrent.ExecutionContext
 
 class CodeDirToCpgFixture extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
@@ -22,6 +23,7 @@ class CodeDirToCpgFixture extends AnyWordSpec with Matchers with BeforeAndAfterA
 
   def createEnhancements(cpg: Cpg): Unit = {
     val context = new LayerCreatorContext(cpg)
+    implicit val ec: ExecutionContext = ExecutionContext.global
     new Base().run(context)
   }
 

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -12,10 +12,12 @@ import io.shiftleft.semanticcpg.layers.{Base, CallGraph, ControlFlow, LayerCreat
 import io.shiftleft.utils.ProjectRoot
 import overflowdb.traversal.Traversal
 
+import scala.concurrent.ExecutionContext
 import scala.sys.process.Process
 import scala.util.Try
 
 class DataFlowCodeToCpgSuite extends FuzzyCCodeToCpgSuite {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
   var semanticsFilename = ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
   var semantics: Semantics = _

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -23,6 +23,7 @@ import utilities.util.FileUtilities
 
 import java.io.File
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class Ghidra2Cpg() {
@@ -131,6 +132,8 @@ class Ghidra2Cpg() {
     // Also we have + 2 for MetaDataPass and Namespacepass
     val numOfKeypools = functions.size * 3 + 2
     val keyPoolIterator = KeyPoolCreator.obtain(numOfKeypools).iterator
+
+    implicit val ec: ExecutionContext = ExecutionContext.global
 
     new MetaDataPass(fileAbsolutePath, cpg, keyPoolIterator.next()).createAndApply()
     new NamespacePass(cpg, fileAbsolutePath, keyPoolIterator.next()).createAndApply()

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/GhidraBinToCpgSuite.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/GhidraBinToCpgSuite.scala
@@ -14,6 +14,7 @@ import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.shiftleft.semanticcpg.language.{ICallResolver, _}
 
 import java.nio.file.Files
+import scala.concurrent.ExecutionContext
 
 class GhidraFrontend extends LanguageFrontend {
   override val fileSuffix: String = ""
@@ -32,6 +33,8 @@ class GhidraFrontend extends LanguageFrontend {
 }
 
 class GhidraBinToCpgSuite extends BinToCpgFixture(new GhidraFrontend) {
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
   override val binDirectory = ProjectRoot.relativise("joern-cli/frontends/ghidra2cpg/src/test/testbinaries/")
 
   def flowToResultPairs(path: Path): List[String] = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -8,6 +8,7 @@ import io.shiftleft.semanticcpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.shiftleft.x2cpg.SourceFiles
 import io.shiftleft.x2cpg.X2Cpg.newEmptyCpg
 
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 object JavaSrc2Cpg {
@@ -33,6 +34,8 @@ class JavaSrc2Cpg {
     val metaDataKeyPool = new IntervalKeyPool(1, 100)
     val typesKeyPool = new IntervalKeyPool(100, 1000100)
     val methodKeyPool = new IntervalKeyPool(first = 1000100, last = Long.MaxValue)
+
+    implicit val ec: ExecutionContext = ExecutionContext.global
 
     new MetaDataPass(cpg, language, Some(metaDataKeyPool)).createAndApply()
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -6,6 +6,7 @@ import io.shiftleft.semanticcpg.layers.{Base, CallGraph, ControlFlow, LayerCreat
 
 import java.io.{File, PrintWriter}
 import java.nio.file.Files
+import scala.concurrent.ExecutionContext
 
 class JavaSrc2CpgTestContext {
   private var code: String = ""
@@ -16,6 +17,7 @@ class JavaSrc2CpgTestContext {
       val javaSrc2Cpg = JavaSrc2Cpg()
       val cpg = javaSrc2Cpg.createCpg(writeCodeToFile(code).getAbsolutePath)
       val context = new LayerCreatorContext(cpg)
+      implicit val ec: ExecutionContext = ExecutionContext.global
       new Base().run(context)
       new TypeRelations().run(context)
       new ControlFlow().run(context)

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -13,6 +13,7 @@ import soot.{G, PhaseOptions, Scene, SootClass}
 import java.io.{File => JFile}
 import java.nio.file.Files
 import java.util.zip.ZipFile
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.{CollectionHasAsScala, EnumerationHasAsScala}
 import scala.language.postfixOps
 import scala.tools.nsc
@@ -64,6 +65,8 @@ class Jimple2Cpg {
       val metaDataKeyPool = new IntervalKeyPool(1, 100)
       val typesKeyPool = new IntervalKeyPool(100, 1000100)
       val methodKeyPool = new IntervalKeyPool(first = 1000100, last = Long.MaxValue)
+
+      implicit val ec: ExecutionContext = ExecutionContext.global
 
       new MetaDataPass(cpg, language, Some(metaDataKeyPool)).createAndApply()
 

--- a/joern-cli/src/main/scala/io/joern/CpgBasedTool.scala
+++ b/joern-cli/src/main/scala/io/joern/CpgBasedTool.scala
@@ -7,6 +7,8 @@ import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOpti
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import io.shiftleft.semanticcpg.language._
 
+import scala.concurrent.ExecutionContext
+
 object CpgBasedTool {
 
   /**
@@ -27,6 +29,7 @@ object CpgBasedTool {
       System.err.println("CPG does not have dataflow overlay. Calculating.")
       val opts = new OssDataFlowOptions()
       val context = new LayerCreatorContext(cpg)
+      implicit val ec: ExecutionContext = ExecutionContext.global
       new OssDataFlow(opts).run(context)
     }
   }

--- a/joern-cli/src/main/scala/io/joern/DefaultOverlays.scala
+++ b/joern-cli/src/main/scala/io/joern/DefaultOverlays.scala
@@ -4,6 +4,8 @@ import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOpti
 import io.shiftleft.semanticcpg.layers._
 import io.shiftleft.codepropertygraph.Cpg
 
+import scala.concurrent.ExecutionContext
+
 object DefaultOverlays {
 
   val DEFAULT_CPG_IN_FILE = "cpg.bin"
@@ -14,6 +16,7 @@ object DefaultOverlays {
     * @param storeFilename the filename of the cpg
     * */
   def create(storeFilename: String): Cpg = {
+    implicit val ec: ExecutionContext = ExecutionContext.global
     val cpg = CpgBasedTool.loadFromOdb(storeFilename)
     val context = new LayerCreatorContext(cpg)
     new Base().run(context)

--- a/joern-cli/src/main/scala/io/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/JoernScan.scala
@@ -244,7 +244,8 @@ class Scan(options: ScanOptions)(implicit engineContext: EngineContext) extends 
   override val overlayName: String = Scan.overlayName
   override val description: String = Scan.description
 
-  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
+  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(
+      implicit ec: ExecutionContext): Unit = {
     val allQueries = getQueriesFromQueryDb(new JoernDefaultArgumentProvider(options.maxCallDepth))
     val queriesAfterFilter = filteredQueries(allQueries, options.names, options.tags)
     if (queriesAfterFilter.isEmpty) {

--- a/joern-cli/src/main/scala/io/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/JoernScan.scala
@@ -15,6 +15,7 @@ import io.joern.JoernScan.getQueriesFromQueryDb
 import io.joern.Scan.{allTag, defaultTag}
 import io.shiftleft.semanticcpg.language.{DefaultNodeExtensionFinder, NodeExtensionFinder}
 
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 
@@ -243,7 +244,7 @@ class Scan(options: ScanOptions)(implicit engineContext: EngineContext) extends 
   override val overlayName: String = Scan.overlayName
   override val description: String = Scan.description
 
-  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
+  override def createWithExecutionContext(context: LayerCreatorContext, storeUndoInfo: Boolean)(implicit ec: ExecutionContext): Unit = {
     val allQueries = getQueriesFromQueryDb(new JoernDefaultArgumentProvider(options.maxCallDepth))
     val queriesAfterFilter = filteredQueries(allQueries, options.names, options.tags)
     if (queriesAfterFilter.isEmpty) {


### PR DESCRIPTION
Use global one for now, until we have need for more specific
configuration.