### PR TITLE
Init x86 return edges

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -15,7 +15,7 @@ import ghidra.util.task.TaskMonitor
 import io.joern.ghidra2cpg.passes._
 import io.joern.ghidra2cpg.passes.arm.ArmFunctionPass
 import io.joern.ghidra2cpg.passes.mips.{LoHiPass, MipsFunctionPass}
-import io.joern.ghidra2cpg.passes.x86.X86FunctionPass
+import io.joern.ghidra2cpg.passes.x86.{X86FunctionPass, ReturnEdgesPass}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.KeyPoolCreator
 import io.shiftleft.x2cpg.X2Cpg
@@ -170,6 +170,7 @@ class Ghidra2Cpg() {
             keyPoolIterator.next(),
             decompiler
           ).createAndApply()
+          new ReturnEdgesPass(cpg).createAndApply()
         }
     }
 

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/ReturnEdgesPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/ReturnEdgesPass.scala
@@ -1,0 +1,25 @@
+package io.joern.ghidra2cpg.passes.x86
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
+import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.semanticcpg.language._
+import org.slf4j.{Logger, LoggerFactory}
+
+class ReturnEdgesPass(cpg: Cpg) extends CpgPass(cpg) {
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  override def run(): Iterator[DiffGraph] = {
+    logger.info("Running ReturnEdgesPass")
+    implicit val diffGraph: DiffGraph.Builder = DiffGraph.newBuilder
+
+    cpg.call.nameNot("<operator>.*").foreach { from =>
+      // We expect RAX/EAX as return
+      val to = from.cfgNext.isCall.argument.code("(R|E)AX").headOption
+      if (to.nonEmpty) {
+        diffGraph.addEdge(from, to.get, EdgeTypes.REACHING_DEF, Seq((PropertyNames.VARIABLE, from.code)))
+      }
+    }
+    Iterator(diffGraph.build())
+  }
+}


### PR DESCRIPTION
First approach to connect the return values of functions to actual register. 

Testing code: https://github.com/hac425xxx/sca-workshop/blob/master/ql-example/example.c#L222-L229 

Queries
```
run.ossdataflow
def src = cpg.call.name("get_user_input_str")
def sink = cpg.call.name("system").argument
sink.reachableByFlows(src).p
```

Flow:
```
  """____________________________________________________________________________________________
| tracked                         | lineNumber| method                   | file             |
|===========================================================================================|
| get_user_input_str              | 1054336   | call_system_safe_example | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x10],RAX | 1054341   | call_system_safe_example | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x10],RAX | 1054341   | call_system_safe_example | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x10] | 1054345   | call_system_safe_example | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x10] | 1054345   | call_system_safe_example | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x8],RAX  | 1054349   | call_system_safe_example | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x8],RAX  | 1054349   | call_system_safe_example | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x8]  | 1054376   | call_system_safe_example | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x8]  | 1054376   | call_system_safe_example | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054380   | call_system_safe_example | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054380   | call_system_safe_example | /tmp/joern/a.out |
| system                          | 1054383   | call_system_safe_example | /tmp/joern/a.out |
""",
````



In addition we should also see longer flows like:
```
  """__________________________________________________________________________________________________________
| tracked                         | lineNumber| method                                 | file             |
|=========================================================================================================|
| get_user_input_str              | 1054153   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x10],RAX | 1054158   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x10],RAX | 1054158   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x10] | 1054162   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x10] | 1054162   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054166   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054166   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| strlen                          | 1054169   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| strlen                          | 1054169   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| ADD RAX,0x1                     | 1054174   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054178   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054178   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| malloc                          | 1054181   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| malloc                          | 1054181   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x8],RAX  | 1054186   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x8],RAX  | 1054186   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x8]  | 1054209   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x8]  | 1054209   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054213   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054213   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| our_wrapper_system              | 1054216   | call_our_wrapper_system_strcpy_example | /tmp/joern/a.out |
| our_wrapper_system(RDI)         | 1054015   | our_wrapper_system                     | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x8],RDI  | 1054023   | our_wrapper_system                     | /tmp/joern/a.out |
| MOV qword ptr [RBP + -0x8],RDI  | 1054023   | our_wrapper_system                     | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x8]  | 1054027   | our_wrapper_system                     | /tmp/joern/a.out |
| MOV RAX,qword ptr [RBP + -0x8]  | 1054027   | our_wrapper_system                     | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054031   | our_wrapper_system                     | /tmp/joern/a.out |
| MOV RDI,RAX                     | 1054031   | our_wrapper_system                     | /tmp/joern/a.out |
| system                          | 1054034   | our_wrapper_system                     | /tmp/joern/a.out |
""",```