### PR TITLE
Added keyset accessor in ResultTable

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -41,6 +41,11 @@ class ResultTable {
     table.get(node)
   }
 
+  /**
+    * Returns all keys to allow for iteration through the table.
+    */
+  def keys(): Vector[StoredNode] = table.keys.toVector
+
 }
 
 /**


### PR DESCRIPTION
Added `ResultTable::keys` in order to obtain the keys from the table to iterate the table using `ResultTable::get`