### PR TITLE
Added support for calling conventions

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/DefaultDefines.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/DefaultDefines.scala
@@ -2,8 +2,8 @@ package io.joern.c2cpg.parser
 
 object DefaultDefines {
   val DEFAULT_CALL_CONVENTIONS = Map(
-    "__fastcall" -> "__attribute((__fastcall__))",
-    "__cdecl" -> "__attribute((__cdecl__))",
-    "__pascal" -> "__attribute((__pascal__))"
+    "__fastcall" -> "__attribute((fastcall))",
+    "__cdecl" -> "__attribute((cdecl))",
+    "__pascal" -> "__attribute((pascal))"
   )
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/DefaultDefines.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/DefaultDefines.scala
@@ -1,0 +1,9 @@
+package io.joern.c2cpg.parser
+
+object DefaultDefines {
+  val DEFAULT_CALL_CONVENTIONS = Map(
+    "__fastcall" -> "__attribute((__fastcall__))",
+    "__cdecl" -> "__attribute((__cdecl__))",
+    "__pascal" -> "__attribute((__pascal__))"
+  )
+}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
@@ -16,7 +16,7 @@ object ParserConfig {
         val s = define.split("=")
         s.head -> s(1)
       case define => define -> "true"
-    }.toMap,
+    }.toMap ++ DefaultDefines.DEFAULT_CALL_CONVENTIONS,
     config.logProblems,
     config.logPreprocessor
   )

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/CallConventionsTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/CallConventionsTests.scala
@@ -1,0 +1,45 @@
+package io.joern.c2cpg
+
+import io.joern.c2cpg.fixtures.TestAstOnlyFixture
+import io.shiftleft.semanticcpg.language._
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CallConventionsTests extends AnyWordSpec with Matchers with Inside with TestAstOnlyFixture {
+
+  "Using calling conventions" should {
+
+    "be correct for methods" in TestAstOnlyFixture("""
+        |int __stdcall foo1() {
+        |	strstr(a, "a");
+        |}
+        |
+        |int __cdecl foo2() {
+        |	strstr(a, "a");
+        |}
+        |
+        |int __fastcall foo3() {
+        |	strstr(a, "a");
+        |}
+        |
+        |int __pascal foo4() {
+        |	strstr(a, "a");
+        |}
+        |""".stripMargin) { cpg =>
+      inside(cpg.method.nameNot("<global>").l) {
+        case List(foo1, foo2, foo3, foo4) =>
+          foo1.name shouldBe "foo1"
+          foo1.ast.isCall.name.l shouldBe List("strstr")
+          foo2.name shouldBe "foo2"
+          foo2.ast.isCall.name.l shouldBe List("strstr")
+          foo3.name shouldBe "foo3"
+          foo3.ast.isCall.name.l shouldBe List("strstr")
+          foo4.name shouldBe "foo4"
+          foo4.ast.isCall.name.l shouldBe List("strstr")
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Without the default defines for stuff like __cdecl or __fastcall Eclipse CDT is unable to parse the methods.

See: https://stackoverflow.com/a/165529 and Joern Discord.