### PR TITLE
Allow passing arguments to frontends

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -10,9 +10,7 @@ val CirceVersion = "0.12.2"
 val AmmoniteVersion = "2.4.1"
 val ZeroturnaroundVersion = "1.13"
 
-dependsOn(
-  // Projects.macros,
-  Projects.fuzzyc2cpg % Test)
+dependsOn(Projects.fuzzyc2cpg % Test, Projects.c2cpg % Test)
 
 libraryDependencies ++= Seq(
   "io.shiftleft" %% "codepropertygraph" % Versions.cpg,
@@ -32,38 +30,39 @@ libraryDependencies ++= Seq(
 Test / packageBin / publishArtifact := true
 
 scalacOptions ++= Seq(
-  "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-  "-encoding", "utf-8",                // Specify character encoding used by source files.
-  "-explaintypes",                     // Explain type errors in more detail.
-  "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-  "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
-  "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
-  "-language:higherKinds",             // Allow higher-kinded types
-  "-language:implicitConversions",     // Allow definition of implicit functions called views
-  "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-  "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-  "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-  "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-  "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-  "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-  "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-  "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
-  "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-  "-Xlint:option-implicit",            // Option.apply used implicit view.
-  "-Xlint:package-object-classes",     // Class or object defined in package object.
-  "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-  "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-  "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-  "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-  "-Ywarn-dead-code",                  // Warn when dead code is identified.
-  "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-  "-Ywarn-numeric-widen",              // Warn when numerics are widened.
-  "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-  "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
-  "-Ywarn-unused:locals",              // Warn if a local definition is unused.
-  "-Ywarn-unused:params",              // Warn if a value parameter is unused.
-  "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-  "-Ywarn-unused:privates",             // Warn if a private member is unused.
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-encoding",
+  "utf-8", // Specify character encoding used by source files.
+  "-explaintypes", // Explain type errors in more detail.
+  "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+  "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+  "-language:experimental.macros", // Allow macro definition (besides implementation and application)
+  "-language:higherKinds", // Allow higher-kinded types
+  "-language:implicitConversions", // Allow definition of implicit functions called views
+  "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+  "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+  "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+  "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+  "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+  "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+  "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+  "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+  "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+  "-Xlint:option-implicit", // Option.apply used implicit view.
+  "-Xlint:package-object-classes", // Class or object defined in package object.
+  "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+  "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+  "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+  "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+  "-Ywarn-dead-code", // Warn when dead code is identified.
+  "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+  "-Ywarn-numeric-widen", // Warn when numerics are widened.
+  "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+  "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+  "-Ywarn-unused:locals", // Warn if a local definition is unused.
+  "-Ywarn-unused:params", // Warn if a value parameter is unused.
+  "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
+  "-Ywarn-unused:privates", // Warn if a private member is unused.
   "-Yrangepos"
 )
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
@@ -5,8 +5,8 @@ import io.joern.console.FrontendConfig
 import java.nio.file.Path
 
 /**
-  * C/C++ language frontend using Eclipse CDT. Translates C/C++ source files
-  * into code property graphs via fuzzy parsing.
+  * C/C++ language frontend that translates C/C++ source files
+  * into code property graphs using Eclipse CDT parsing / preprocessing.
   * */
 case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   lazy val command: Path = rootPath.resolve("c2cpg.sh")

--- a/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
@@ -5,11 +5,11 @@ import io.joern.console.FrontendConfig
 import java.nio.file.Path
 
 /**
-  * Fuzzy C/C++ language frontend. Translates C/C++ source files
+  * C/C++ language frontend using Eclipse CDT. Translates C/C++ source files
   * into code property graphs via fuzzy parsing.
   * */
 case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
-  lazy val command = rootPath.resolve("c2cpg.sh")
+  lazy val command: Path = rootPath.resolve("c2cpg.sh")
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -10,6 +10,24 @@ import overflowdb.Config
 import java.nio.file.Path
 import scala.util.Try
 
+object CpgGeneratorFactory {
+  private val KNOWN_LANGUAGES = Set(
+    Languages.C,
+    Languages.CSHARP,
+    Languages.GOLANG,
+    Languages.GHIDRA,
+    Languages.JAVA,
+    Languages.JAVASCRIPT,
+    Languages.PYTHON,
+    Languages.FUZZY_TEST_LANG,
+    Languages.LLVM,
+    Languages.PHP,
+    Languages.KOTLIN,
+    Languages.NEWC,
+    Languages.JAVASRC
+  )
+}
+
 class CpgGeneratorFactory(config: ConsoleConfig) {
 
   /**
@@ -35,23 +53,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
       }
   }
 
-  def languageIsKnown(language: String): Boolean = {
-    Set(
-      Languages.C,
-      Languages.CSHARP,
-      Languages.GOLANG,
-      Languages.GHIDRA,
-      Languages.JAVA,
-      Languages.JAVASCRIPT,
-      Languages.PYTHON,
-      Languages.FUZZY_TEST_LANG,
-      Languages.LLVM,
-      Languages.PHP,
-      Languages.KOTLIN,
-      Languages.NEWC,
-      Languages.JAVASRC
-    ).contains(language)
-  }
+  def languageIsKnown(language: String): Boolean = CpgGeneratorFactory.KNOWN_LANGUAGES.contains(language)
 
   def runGenerator(frontend: CpgGenerator,
                    inputPath: String,

--- a/console/src/main/scala/io/joern/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -9,7 +9,7 @@ import java.nio.file.Path
   * into code property graphs via fuzzy parsing.
   * */
 case class FuzzyCCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
-  lazy val command = rootPath.resolve("fuzzyc2cpg.sh")
+  lazy val command: Path = rootPath.resolve("fuzzyc2cpg.sh")
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -82,9 +82,10 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
                             description: String = "Fuzzy Parser for C/C++",
                             extension: String = "c")
       extends Frontend(name, language, description) {
-    def fromString(str: String): Cpg = {
+
+    def fromString(str: String, args: List[String] = List()): Cpg = {
       withCodeInTmpFile(str, "tmp." + extension) { dir =>
-        apply(dir.path.toString)
+        apply(dir.path.toString, args = args)
       } match {
         case Failure(exception) => throw new ConsoleException(s"unable to generate cpg from given String", exception)
         case Success(value)     => value

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
@@ -33,7 +33,7 @@ case class JavaCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
       println("found .apk ending - will first transform it to a jar using dex2jar.sh")
       val dex2jar = rootPath.resolve("dex2jar.sh").toString
       runShellCommand(dex2jar, Seq(inputPath)).flatMap { _ =>
-        val jarPath = s"${inputPath}.jar"
+        val jarPath = s"$inputPath.jar"
         generateCommercial(jarPath, outputPath, namespaces)
       }
     } else {

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -19,8 +19,13 @@ class ConsoleTests extends AnyWordSpec with Matchers {
       console.importCode.toString.contains("| C") shouldBe true
     }
 
-    "allow importing code with specific module" in ConsoleFixture() { (console, codeDir) =>
-      console.importCode(codeDir.toString)
+    "allow importing code with specific module (fuzzyc2cpg)" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode.oldc(codeDir.toString)
+      console.workspace.numberOfProjects shouldBe 1
+    }
+
+    "allow importing code with specific module (c2cpg)" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode.c(codeDir.toString)
       console.workspace.numberOfProjects shouldBe 1
     }
 

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -412,12 +412,12 @@ class ConsoleTests extends AnyWordSpec with Matchers {
     "allow changing workspaces" in ConsoleFixture() { (console, codeDir) =>
       val firstWorkspace = File(console.workspace.getPath)
       File.usingTemporaryDirectory("console") { otherWorkspaceDir =>
-        console.importCode.oldc(codeDir.toString, "projectInFirstWorkspace")
+        console.importCode(codeDir.toString, "projectInFirstWorkspace")
         console.workspace.numberOfProjects shouldBe 1
         console.switchWorkspace(otherWorkspaceDir.path.toString)
         console.workspace.numberOfProjects shouldBe 0
 
-        console.importCode.oldc(codeDir.toString, "projectInSecondWorkspace")
+        console.importCode(codeDir.toString, "projectInSecondWorkspace")
         console.workspace.numberOfProjects shouldBe 1
         console.project.name shouldBe "projectInSecondWorkspace"
         console.switchWorkspace(firstWorkspace.path.toString)


### PR DESCRIPTION
`fromString` now optionally takes arguments and passes them to the individual frontend.
`importCode` already had this. Added tests for that.

Fixes: https://github.com/joernio/joern/issues/762