### PR TITLE
MIPS: Resolving arguments for calls  

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -68,14 +68,8 @@ class MipsFunctionPass(currentProgram: Program,
     }
   }
   def handleAssignment(instruction: Instruction, callNode: CfgNodeNew, to: Varnode, from: Varnode, index: Int): Unit = {
-    val fromNode = resolveVarNode(instruction, callNode, from, 1)
     val toNode = resolveVarNode(instruction, callNode, to, 2)
-    //val assingmentNode = createCallNode(code = s"${toNode.code} = ${fromNode.code}", "<opeator>.assignment", instruction.getMinAddress.getOffsetAsBigInteger.intValue)
-
-    //connectCallToArgument(assingmentNode, toNode)
-    //connectCallToArgument(assingmentNode, fromNode)
     connectCallToArgument(callNode, toNode)
-    connectCallToArgument(callNode, fromNode)
   }
   def handleTwoArguments(instruction: Instruction,
                          callNode: CfgNodeNew,
@@ -152,13 +146,7 @@ class MipsFunctionPass(currentProgram: Program,
       case INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL =>
         logger.warn("INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL ")
       case CALL =>
-        pcodeAst.getInputs.zipWithIndex.foreach {
-          case (value, index) =>
-            if (value.getDef != null)
-              resolveArgument(instruction, callNode, value.getDef, index)
-            else
-              resolveVarNode(instruction, callNode, value, index)
-        }
+        handleAssignment(instruction, callNode, pcodeAst.getOutput, pcodeAst.getInput(0), index)
       case INT_ADD | FLOAT_ADD =>
         handleTwoArguments(instruction,
                            callNode,

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -60,27 +60,22 @@ class MipsFunctionPass(currentProgram: Program,
                     input.getWordOffset.toHexString,
                     instruction.getMinAddress.getOffsetAsBigInteger.intValue)
     } else {
-      //if (input.getDef != null) {
-      //  resolveArgument(instruction, callNode, input.getDef, index)
-      //} else {
-      //  input.toString()
       createLiteral(input.toString(),
                     index + 1,
                     index + 1,
                     input.toString(),
                     instruction.getMinAddress.getOffsetAsBigInteger.intValue)
-      //}
     }
   }
-  def handleAssignment(instruction: Instruction, callNode: CfgNodeNew, to: Varnode, from:Varnode, index: Int):Unit ={
+  def handleAssignment(instruction: Instruction, callNode: CfgNodeNew, to: Varnode, from: Varnode, index: Int): Unit = {
     val fromNode = resolveVarNode(instruction, callNode, from, 1)
     val toNode = resolveVarNode(instruction, callNode, to, 2)
     //val assingmentNode = createCallNode(code = s"${toNode.code} = ${fromNode.code}", "<opeator>.assignment", instruction.getMinAddress.getOffsetAsBigInteger.intValue)
 
     //connectCallToArgument(assingmentNode, toNode)
     //connectCallToArgument(assingmentNode, fromNode)
-    connectCallToArgument(callNode,toNode)
-    connectCallToArgument(callNode,fromNode)
+    connectCallToArgument(callNode, toNode)
+    connectCallToArgument(callNode, fromNode)
   }
   def handleTwoArguments(instruction: Instruction,
                          callNode: CfgNodeNew,
@@ -154,15 +149,16 @@ class MipsFunctionPass(currentProgram: Program,
     POPCOUNT = 72;
     PCODE_MAX = 73;
        */
-      case INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL => logger.warn("INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL ")
+      case INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL =>
+        logger.warn("INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL ")
       case CALL =>
         pcodeAst.getInputs.zipWithIndex.foreach {
-        case (value, index) =>
-          if (value.getDef != null)
-            resolveArgument(instruction, callNode, value.getDef, index)
-          else
-            resolveVarNode(instruction, callNode, value, index)
-      }
+          case (value, index) =>
+            if (value.getDef != null)
+              resolveArgument(instruction, callNode, value.getDef, index)
+            else
+              resolveVarNode(instruction, callNode, value, index)
+        }
       case INT_ADD | FLOAT_ADD =>
         handleTwoArguments(instruction,
                            callNode,
@@ -196,13 +192,14 @@ class MipsFunctionPass(currentProgram: Program,
         handleTwoArguments(instruction, callNode, pcodeAst.getInput(0), pcodeAst.getInput(1), "^", "<operator>.xor")
       case INT_OR =>
         handleTwoArguments(instruction, callNode, pcodeAst.getInput(0), pcodeAst.getInput(1), "^", "<operator>.xor")
-      case COPY | LOAD | STORE | SUBPIECE => handleAssignment(instruction, callNode, pcodeAst.getOutput, pcodeAst.getInput(0), index)
+      case COPY | LOAD | STORE | SUBPIECE =>
+        handleAssignment(instruction, callNode, pcodeAst.getOutput, pcodeAst.getInput(0), index)
       case CAST =>
         // we need to "unpack" the def of the first input of the cast
         // eg. "(param_1 + 5)" in "(void *)(param_1 + 5)"
         resolveArgument(instruction, callNode, pcodeAst.getInput(0).getDef, index)
       case PTRSUB | PTRADD => handlePtrSub(instruction, callNode, pcodeAst.getOutput, index)
-      case _      => handleDefault(pcodeAst)
+      case _               => handleDefault(pcodeAst)
 
     }
   }
@@ -234,7 +231,7 @@ class MipsFunctionPass(currentProgram: Program,
     val arguments = opCodes.head.getInputs.toList.drop(1)
     arguments.zipWithIndex.foreach {
       case (value, index) =>
-          resolveArgument(instruction, callNode, value.getDef, index)
+        resolveArgument(instruction, callNode, value.getDef, index)
     }
   }
   def addArguments(instruction: Instruction, instructionNode: CfgNodeNew): Unit = {

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -76,8 +76,8 @@ class MipsFunctionPass(currentProgram: Program,
                     instruction.getMinAddress.getOffsetAsBigInteger.intValue)
     }
   }
-  def handleAssignment(instruction: Instruction, callNode: CfgNodeNew, to: Varnode): Unit = {
-    val node = resolveVarNode(instruction, to, 1)
+  def handleAssignment(instruction: Instruction, callNode: CfgNodeNew, to: Varnode, index: Int): Unit = {
+    val node = resolveVarNode(instruction, to, index)
     connectCallToArgument(callNode, node)
   }
   def handleTwoArguments(instruction: Instruction,
@@ -107,7 +107,7 @@ class MipsFunctionPass(currentProgram: Program,
       case INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL =>
         logger.warn("INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL ")
       case CALL | CALLIND =>
-        handleAssignment(instruction, callNode, pcodeAst.getOutput)
+        handleAssignment(instruction, callNode, pcodeAst.getOutput, index)
       case INT_ADD | FLOAT_ADD =>
         handleTwoArguments(instruction,
                            callNode,
@@ -142,7 +142,7 @@ class MipsFunctionPass(currentProgram: Program,
       case INT_OR =>
         handleTwoArguments(instruction, callNode, pcodeAst.getInput(0), pcodeAst.getInput(1), "^", "<operator>.xor")
       case COPY | LOAD | STORE | SUBPIECE =>
-        handleAssignment(instruction, callNode, pcodeAst.getOutput)
+        handleAssignment(instruction, callNode, pcodeAst.getOutput, index)
       case CAST =>
         // we need to "unpack" the def of the first input of the cast
         // eg. "(param_1 + 5)" in "(void *)(param_1 + 5)"

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -1,14 +1,14 @@
 package io.joern.ghidra2cpg.passes.mips
-
 import ghidra.program.model.address.GenericAddress
 import ghidra.program.model.lang.Register
 import ghidra.program.model.listing.{Function, Instruction, Program}
-import ghidra.program.model.pcode.PcodeOp.{CALL, CALLIND}
+import ghidra.program.model.pcode.PcodeOp._
+import ghidra.program.model.pcode.{PcodeOp, Varnode}
 import ghidra.program.model.scalar.Scalar
-import io.joern.ghidra2cpg.{Decompiler, Types}
 import io.joern.ghidra2cpg.passes.FunctionPass
 import io.joern.ghidra2cpg.processors.MipsProcessor
 import io.joern.ghidra2cpg.utils.Nodes._
+import io.joern.ghidra2cpg.{Decompiler, Types}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.CfgNodeNew
@@ -28,67 +28,215 @@ class MipsFunctionPass(currentProgram: Program,
     extends FunctionPass(new MipsProcessor, currentProgram, function, cpg, keyPool, decompiler) {
   private val logger = LoggerFactory.getLogger(classOf[MipsFunctionPass])
 
-  def resolveCallArguments(instruction: Instruction, callNode: CfgNodeNew): Unit = {
-    val target = instruction.getPcode.toList.head.getSeqnum.getTarget
-    val opCodes = highFunction
-      .getPcodeOps(target)
-      .asScala
-      .toList
-    //jal 0x00000000 and some jalr t9
-    if (opCodes.isEmpty) {
-      return
-    }
-    opCodes.head.getInputs
-    // First input is the instruction
-    // we have already handled it
-      .drop(1)
-      .zipWithIndex foreach {
-      case (input, index) =>
-        if (input.isRegister) {
-          var name = input.getHigh.getName
-          val high = input.getHigh
-          if (high != null && input.getDef != null && high.getName == "UNNAMED" && input.getDef != null && input.getDef.getInputs != null) {
-            val symbol = input.getDef.getInputs.toList.lastOption
-              .flatMap(x => Option(x.getHigh))
-              .flatMap(x => Option(x.getSymbol))
-            if (symbol.isDefined) {
-              name = symbol.get.getName
-            }
-          }
-          val node = createIdentifier(name,
-                                      name,
-                                      index + 1,
-                                      Types.registerType(name),
-                                      instruction.getMinAddress.getOffsetAsBigInteger.intValue)
-          connectCallToArgument(callNode, node)
-        } else if (input.isConstant) {
-          val node =
-            createLiteral("0x" + input.getWordOffset.toHexString,
-                          index + 1,
-                          index + 1,
-                          "0x" + input.getWordOffset.toHexString,
-                          instruction.getMinAddress.getOffsetAsBigInteger.intValue)
-          connectCallToArgument(callNode, node)
-        } else if (input.isUnique) {
-          val value = address2Literal.getOrElse(input.getDef.getInputs.toList.head.getAddress.getOffset,
-                                                input.getDef.getInputs.toList.head.getAddress.getOffset.toString)
-          val node = createLiteral(value,
-                                   index + 1,
-                                   index + 1,
-                                   input.getWordOffset.toHexString,
-                                   instruction.getMinAddress.getOffsetAsBigInteger.intValue)
-          connectCallToArgument(callNode, node)
-        } else {
-          val node = createLiteral(input.toString(),
-                                   index + 1,
-                                   index + 1,
-                                   input.toString(),
-                                   instruction.getMinAddress.getOffsetAsBigInteger.intValue)
-          connectCallToArgument(callNode, node)
+  def resolveVarNode(instruction: Instruction, callNode: CfgNodeNew, input: Varnode, index: Int): CfgNodeNew = {
+    if (input.isRegister) {
+      var name = input.getHigh.getName
+      val high = input.getHigh
+      if (high != null && input.getDef != null && high.getName == "UNNAMED" && input.getDef != null && input.getDef.getInputs != null) {
+        val symbol = input.getDef.getInputs.toList.lastOption
+          .flatMap(x => Option(x.getHigh))
+          .flatMap(x => Option(x.getSymbol))
+        if (symbol.isDefined) {
+          name = symbol.get.getName
         }
+      }
+      createIdentifier(name,
+                       name,
+                       index + 1,
+                       Types.registerType(name),
+                       instruction.getMinAddress.getOffsetAsBigInteger.intValue)
+    } else if (input.isConstant) {
+      createLiteral("0x" + input.getWordOffset.toHexString,
+                    index + 1,
+                    index + 1,
+                    "0x" + input.getWordOffset.toHexString,
+                    instruction.getMinAddress.getOffsetAsBigInteger.intValue)
+    } else if (input.isUnique) {
+      val value = address2Literal.getOrElse(input.getDef.getInputs.toList.head.getAddress.getOffset,
+                                            input.getDef.getInputs.toList.head.getAddress.getOffset.toString)
+      createLiteral(value,
+                    index + 1,
+                    index + 1,
+                    input.getWordOffset.toHexString,
+                    instruction.getMinAddress.getOffsetAsBigInteger.intValue)
+    } else {
+      //if (input.getDef != null) {
+      //  resolveArgument(instruction, callNode, input.getDef, index)
+      //} else {
+      //  input.toString()
+      createLiteral(input.toString(),
+                    index + 1,
+                    index + 1,
+                    input.toString(),
+                    instruction.getMinAddress.getOffsetAsBigInteger.intValue)
+      //}
+    }
+  }
+  def handleAssignment(instruction: Instruction, callNode: CfgNodeNew, to: Varnode, from:Varnode, index: Int):Unit ={
+    val fromNode = resolveVarNode(instruction, callNode, from, 1)
+    val toNode = resolveVarNode(instruction, callNode, to, 2)
+    //val assingmentNode = createCallNode(code = s"${toNode.code} = ${fromNode.code}", "<opeator>.assignment", instruction.getMinAddress.getOffsetAsBigInteger.intValue)
+
+    //connectCallToArgument(assingmentNode, toNode)
+    //connectCallToArgument(assingmentNode, fromNode)
+    connectCallToArgument(callNode,toNode)
+    connectCallToArgument(callNode,fromNode)
+  }
+  def handleTwoArguments(instruction: Instruction,
+                         callNode: CfgNodeNew,
+                         arg: Varnode,
+                         arg1: Varnode,
+                         operand: String,
+                         name: String): Unit = {
+    val firstOp = resolveVarNode(instruction, callNode, arg, 1)
+    val secondOp = resolveVarNode(instruction, callNode, arg1, 2)
+    val code = s"${firstOp.code} $operand ${secondOp.code}"
+    val opNode = createCallNode(code = code, name, instruction.getMinAddress.getOffsetAsBigInteger.intValue)
+
+    connectCallToArgument(opNode, firstOp)
+    connectCallToArgument(opNode, secondOp)
+    connectCallToArgument(callNode, opNode)
+  }
+  def handlePtrSub(instruction: Instruction, callNode: CfgNodeNew, varNode: Varnode, index: Int): Unit = {
+    val arg = resolveVarNode(instruction, callNode, varNode, index)
+    connectCallToArgument(callNode, arg)
+  }
+  def handleDefault(varNode: PcodeOp): Unit = {
+    println("Unsupported " + varNode.toString + " " + varNode.getOpcode)
+  }
+  def resolveArgument(instruction: Instruction, callNode: CfgNodeNew, pcodeAst: PcodeOp, index: Int): Unit = {
+    pcodeAst.getOpcode match {
+      /*
+    BRANCH = 4;
+    CBRANCH = 5;
+    BRANCHIND = 6;
+    CALLIND = 8;
+    CALLOTHER = 9;
+    RETURN = 10;
+    INT_ZEXT = 17;
+    INT_SEXT = 18;
+    INT_CARRY = 21;
+    INT_SCARRY = 22;
+    INT_SBORROW = 23;
+    INT_2COMP = 24;
+    INT_NEGATE = 25;
+    INT_AND = 27;
+    INT_OR = 28;
+    INT_LEFT = 29;
+    INT_RIGHT = 30;
+    INT_SRIGHT = 31;
+    INT_REM = 35;
+    INT_SREM = 36;
+    BOOL_NEGATE = 37;
+    BOOL_XOR = 38;
+    BOOL_AND = 39;
+    BOOL_OR = 40;
+    FLOAT_EQUAL = 41;
+    FLOAT_NOTEQUAL = 42;
+    FLOAT_LESS = 43;
+    FLOAT_LESSEQUAL = 44;
+    FLOAT_NAN = 46;
+    FLOAT_NEG = 51;
+    FLOAT_ABS = 52;
+    FLOAT_SQRT = 53;
+    FLOAT_INT2FLOAT = 54;
+    FLOAT_FLOAT2FLOAT = 55;
+    FLOAT_TRUNC = 56;
+    FLOAT_CEIL = 57;
+    FLOAT_FLOOR = 58;
+    FLOAT_ROUND = 59;
+    INDIRECT = 61;
+    SEGMENTOP = 67;
+    CPOOLREF = 68;
+    NEW = 69;
+    INSERT = 70;
+    EXTRACT = 71;
+    POPCOUNT = 72;
+    PCODE_MAX = 73;
+       */
+      case INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL => logger.warn("INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL ")
+      case CALL =>
+        pcodeAst.getInputs.zipWithIndex.foreach {
+        case (value, index) =>
+          if (value.getDef != null)
+            resolveArgument(instruction, callNode, value.getDef, index)
+          else
+            resolveVarNode(instruction, callNode, value, index)
+      }
+      case INT_ADD | FLOAT_ADD =>
+        handleTwoArguments(instruction,
+                           callNode,
+                           pcodeAst.getInput(0),
+                           pcodeAst.getInput(1),
+                           "+",
+                           "<operator>.addition")
+      case INT_DIV | FLOAT_DIV | INT_SDIV =>
+        handleTwoArguments(instruction,
+                           callNode,
+                           pcodeAst.getInput(0),
+                           pcodeAst.getInput(1),
+                           "/",
+                           "<operator>.division")
+      case INT_SUB | FLOAT_SUB =>
+        handleTwoArguments(instruction,
+                           callNode,
+                           pcodeAst.getInput(0),
+                           pcodeAst.getInput(1),
+                           "-",
+                           "<operator>.subtraction")
+      case INT_MULT | FLOAT_MULT =>
+        handleTwoArguments(instruction,
+                           callNode,
+                           pcodeAst.getInput(0),
+                           pcodeAst.getInput(1),
+                           "*",
+                           "<operator>.multiplication")
+      case MULTIEQUAL | INDIRECT | PIECE => // not handled
+      case INT_XOR | BOOL_XOR =>
+        handleTwoArguments(instruction, callNode, pcodeAst.getInput(0), pcodeAst.getInput(1), "^", "<operator>.xor")
+      case INT_OR =>
+        handleTwoArguments(instruction, callNode, pcodeAst.getInput(0), pcodeAst.getInput(1), "^", "<operator>.xor")
+      case COPY | LOAD | STORE | SUBPIECE => handleAssignment(instruction, callNode, pcodeAst.getOutput, pcodeAst.getInput(0), index)
+      case CAST =>
+        // we need to "unpack" the def of the first input of the cast
+        // eg. "(param_1 + 5)" in "(void *)(param_1 + 5)"
+        resolveArgument(instruction, callNode, pcodeAst.getInput(0).getDef, index)
+      case PTRSUB | PTRADD => handlePtrSub(instruction, callNode, pcodeAst.getOutput, index)
+      case _      => handleDefault(pcodeAst)
+
     }
   }
 
+  def resolveCallIndArguments(instruction: Instruction, callNode: CfgNodeNew): Unit = {
+    val opCodes = highFunction
+      .getPcodeOps(instruction.getAddress())
+      .asScala
+      .toList
+    if (opCodes.size < 2) {
+      return
+    }
+    val arguments = opCodes.head.getInputs.toList.drop(1)
+    arguments.zipWithIndex.foreach {
+      case (value, index) =>
+        if (value.getDef != null)
+          resolveArgument(instruction, callNode, value.getDef, index)
+    }
+  }
+  def resolveCallArguments(instruction: Instruction, callNode: CfgNodeNew): Unit = {
+    // we know that this is a call
+    val opCodes = highFunction
+      .getPcodeOps(instruction.getAddress())
+      .asScala
+      .toList
+    if (opCodes.size < 2) {
+      return
+    }
+    val arguments = opCodes.head.getInputs.toList.drop(1)
+    arguments.zipWithIndex.foreach {
+      case (value, index) =>
+          resolveArgument(instruction, callNode, value.getDef, index)
+    }
+  }
   def addArguments(instruction: Instruction, instructionNode: CfgNodeNew): Unit = {
     for (index <- 0 until instruction.getNumOperands) {
       val opObjects = instruction.getOpObjects(index)
@@ -133,10 +281,11 @@ class MipsFunctionPass(currentProgram: Program,
       // nop && _nop
       return
     }
-
-    instruction.getPcode.toList.last.getOpcode match {
-      case CALL | CALLIND =>
-        resolveCallArguments(instruction, callNode)
+    // CALL is the last PcodeOp
+    val opCodes = instruction.getPcode.toList //.last.getOpcode
+    opCodes.last.getOpcode match {
+      case CALLIND | CALL =>
+        resolveCallIndArguments(instruction, callNode)
       case _ =>
         // regular instructions, eg. add/sub
         addArguments(instruction, callNode)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -52,8 +52,15 @@ class MipsFunctionPass(currentProgram: Program,
                     "0x" + input.getWordOffset.toHexString,
                     instruction.getMinAddress.getOffsetAsBigInteger.intValue)
     } else if (input.isUnique) {
-      val value = address2Literal.getOrElse(input.getDef.getInputs.toList.head.getAddress.getOffset,
-                                            input.getDef.getInputs.toList.head.getAddress.getOffset.toString)
+      var valueString = ""
+      if (input.getDescendants.asScala.toList.head.getOutput == null) {
+        valueString = input.getDef.getInputs.toList.head.getAddress.getOffset.toString
+      } else {
+        valueString = input.getDescendants.asScala.toList.head.getOutput.getHigh.getName
+      }
+
+      val value = address2Literal.getOrElse(input.getDef.getInputs.toList.head.getAddress.getOffset, valueString)
+
       createLiteral(value,
                     index + 1,
                     index + 1,
@@ -99,7 +106,6 @@ class MipsFunctionPass(currentProgram: Program,
     BRANCH = 4;
     CBRANCH = 5;
     BRANCHIND = 6;
-    CALLIND = 8;
     CALLOTHER = 9;
     RETURN = 10;
     INT_ZEXT = 17;
@@ -145,7 +151,7 @@ class MipsFunctionPass(currentProgram: Program,
        */
       case INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL =>
         logger.warn("INT_EQUAL | INT_NOTEQUAL | INT_SLESS | INT_SLESSEQUAL | INT_LESS | INT_LESSEQUAL ")
-      case CALL =>
+      case CALL | CALLIND =>
         handleAssignment(instruction, callNode, pcodeAst.getOutput, pcodeAst.getInput(0), index)
       case INT_ADD | FLOAT_ADD =>
         handleTwoArguments(instruction,

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/CallArgumentsTest.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/CallArgumentsTest.scala
@@ -45,8 +45,10 @@ class CallArgumentsTest extends GhidraBinToCpgSuite {
       .l shouldBe List("abcdefghij")
   }
 
-  "The call to 'puts' should have two arguments " in {
-    cpg.method.name("main").call.name("puts").argument.code.
-      l shouldBe  List("abcdefghij")
+  "The call to 'puts' in 'main' should have 'abcdefghij' arguments " in {
+    cpg.method.name("main").call.name("puts").argument.code.l shouldBe List("abcdefghij")
+  }
+  "The call to 'puts' in 'test' should have '__s' arguments " in {
+    cpg.method.name("test").call.name("puts").argument.code.l shouldBe List("__s")
   }
 }

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/CallArgumentsTest.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/CallArgumentsTest.scala
@@ -1,0 +1,52 @@
+package io.joern.ghidra2cpg.querying.mips
+
+import io.joern.ghidra2cpg.fixtures.GhidraBinToCpgSuite
+import io.shiftleft.semanticcpg.language._
+
+class CallArgumentsTest extends GhidraBinToCpgSuite {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    buildCpgForBin("mips32_memcpy_test.bin")
+  }
+  /*
+    // Test code is:
+    void test(char *input, int size) {
+      char arr[168];
+      char *chr = (char *)memcpy(arr,input + 5,size - 5);
+    }
+    int main() {
+      char *foo = "abcdefghij";
+      int size = strlen(foo);
+      printf("%s\n", foo);
+      test(foo,size);
+    }
+   */
+  "The call to 'memcpy' should have three arguments " in {
+    cpg.call
+      .name("memcpy")
+      .argument
+      .code
+      .l shouldBe List("auStack180", "param_1 + 0x5", "param_2 - 0x5")
+  }
+  "The call to 'test' should have two arguments " in {
+    cpg.call
+      .name("test")
+      .argument
+      .code
+      .l shouldBe List("abcdefghij", "sVar1")
+  }
+
+  "The call to 'strlen' should have two arguments " in {
+    cpg.call
+      .name("strlen")
+      .argument
+      .code
+      .l shouldBe List("abcdefghij")
+  }
+
+  "The call to 'puts' should have two arguments " in {
+    cpg.method.name("main").call.name("puts").argument.code.
+      l shouldBe  List("abcdefghij")
+  }
+}


### PR DESCRIPTION
Resolving the arguments for MIPS calls (not instructions!) added test for it.

Given the source
```
  /*
    void test(char *input, int size) {
      char arr[168];
      char *chr = (char *)memcpy(arr,input + 5,size - 5);
    }
    int main() {
      char *foo = "abcdefghij";
      int size = strlen(foo);
      printf("%s\n", foo);
      test(foo,size);
    }
   */
```

We now have the arguments `auStack180`, `param_1 + 0x5`, `param_2 - 0x5` for `memcpy`, the operators are calls too. 
The call to `test` has the arguments `abcdefghij` and `sVar1`, meaning we resolve the literal and the variable (instead of an address), Same goes for `strlen` (`"abcdefghij"`) and `puts` (one time `"abcdefghij"` and the other is `__s`) .

