### PR TITLE
Refactor DefaultArgumentProvider to reduce scala.reflect surface.

### DIFF
--- a/console/src/main/scala/io/joern/console/QueryDatabase.scala
+++ b/console/src/main/scala/io/joern/console/QueryDatabase.scala
@@ -139,14 +139,21 @@ class QueryDatabase(defaultArgumentProvider: DefaultArgumentProvider = new Defau
   * */
 class DefaultArgumentProvider {
 
-  def defaultArgument(method: MethodSymbol, im: InstanceMirror, @unused x: Symbol, i: Int): Option[Any] = {
-    val typeSignature = im.symbol.typeSignature
-    val defaultMethodName = s"${method.name}$$default$$${i + 1}"
-    val m = typeSignature.member(TermName(defaultMethodName))
-    if (m.isMethod) {
-      Some(im.reflectMethod(m.asMethod).apply())
-    } else {
-      None
+  def typeSpecificDefaultArg(argTypeFullName: String): Option[Any] = {
+    None
+  }
+
+  final def defaultArgument(method: MethodSymbol, im: InstanceMirror, x: Symbol, i: Int): Option[Any] = {
+    val defaultArgOption = typeSpecificDefaultArg(x.typeSignature.toString)
+    defaultArgOption.orElse {
+      val typeSignature = im.symbol.typeSignature
+      val defaultMethodName = s"${method.name}$$default$$${i + 1}"
+      val m = typeSignature.member(TermName(defaultMethodName))
+      if (m.isMethod) {
+        Some(im.reflectMethod(m.asMethod).apply())
+      } else {
+        None
+      }
     }
   }
 

--- a/joern-cli/src/main/scala/io/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/JoernScan.scala
@@ -16,7 +16,6 @@ import io.joern.Scan.{allTag, defaultTag}
 import io.shiftleft.semanticcpg.language.{DefaultNodeExtensionFinder, NodeExtensionFinder}
 
 import scala.jdk.CollectionConverters._
-import scala.reflect.runtime.universe._
 
 object JoernScanConfig {
   val defaultDbVersion: String = "latest"
@@ -284,11 +283,11 @@ class Scan(options: ScanOptions)(implicit engineContext: EngineContext) extends 
 
 class JoernDefaultArgumentProvider(maxCallDepth: Int)(implicit context: EngineContext) extends DefaultArgumentProvider {
 
-  override def defaultArgument(method: MethodSymbol, im: InstanceMirror, x: Symbol, i: Int): Option[Any] = {
-    if (x.typeSignature.toString.endsWith("EngineContext")) {
+  override def typeSpecificDefaultArg(argTypeFullName: String): Option[Any] = {
+    if (argTypeFullName.endsWith("EngineContext")) {
       Some(context.copy(config = EngineConfig(maxCallDepth = maxCallDepth)))
     } else {
-      super.defaultArgument(method, im, x, i)
+      None
     }
   }
 }

--- a/querydb/src/main/scala/io/joern/dumpq/Main.scala
+++ b/querydb/src/main/scala/io/joern/dumpq/Main.scala
@@ -6,8 +6,6 @@ import io.joern.dataflowengineoss.semanticsloader.Semantics
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.Serialization
 
-import scala.reflect.runtime.universe._
-
 object Main extends App {
 
   dumpQueries()
@@ -30,11 +28,11 @@ object Main extends App {
   class JoernDefaultArgumentProvider(maxCallDepth: Int)(implicit context: EngineContext)
       extends DefaultArgumentProvider {
 
-    override def defaultArgument(method: MethodSymbol, im: InstanceMirror, x: Symbol, i: Int): Option[Any] = {
-      if (x.typeSignature.toString.endsWith("EngineContext")) {
+    override def typeSpecificDefaultArg(argTypeFullName: String): Option[Any] = {
+      if (argTypeFullName.endsWith("EngineContext")) {
         Some(context.copy(config = EngineConfig(maxCallDepth = maxCallDepth)))
       } else {
-        super.defaultArgument(method, im, x, i)
+        None
       }
     }
   }

--- a/querydb/src/test/scala/io/joern/suites/QDBArgumentProvider.scala
+++ b/querydb/src/test/scala/io/joern/suites/QDBArgumentProvider.scala
@@ -4,19 +4,17 @@ import io.joern.console.DefaultArgumentProvider
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 
-import scala.reflect.runtime.universe._
-
 class QDBArgumentProvider(maxCallDepth: Int) extends DefaultArgumentProvider {
   def testSemanticsFilename = "src/test/resources/default.semantics"
 
-  override def defaultArgument(method: MethodSymbol, im: InstanceMirror, x: Symbol, i: Int): Option[Any] = {
-    if (x.typeSignature.toString.endsWith("EngineContext")) {
+  override def typeSpecificDefaultArg(argTypeFullName: String): Option[Any] = {
+    if (argTypeFullName.endsWith("EngineContext")) {
       val newsemantics = Semantics.fromList(new Parser().parseFile(testSemanticsFilename))
       val engineContext = EngineContext(newsemantics)
       engineContext.config.maxCallDepth = maxCallDepth
       Some(engineContext)
     } else {
-      super.defaultArgument(method, im, x, i)
+      None
     }
   }
 }


### PR DESCRIPTION
The refactoring is done to not required the deriving classes to import
scala.reflect. This is part of the preparation for the scala 3
migration.