### PR TITLE
Make javasrc method call AST structure more consistent with c2cpg

### DIFF
--- a/console/src/main/scala/io/joern/console/QueryDatabase.scala
+++ b/console/src/main/scala/io/joern/console/QueryDatabase.scala
@@ -139,7 +139,7 @@ class QueryDatabase(defaultArgumentProvider: DefaultArgumentProvider = new Defau
   * */
 class DefaultArgumentProvider {
 
-  def typeSpecificDefaultArg(argTypeFullName: String): Option[Any] = {
+  def typeSpecificDefaultArg(@unused argTypeFullName: String): Option[Any] = {
     None
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -225,10 +225,10 @@ class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph) extends Trans
             .filter(x => x.id != identifier.id)
 
           /**
-           * Killing an identifier should also kill field accesses on that identifier.
-           * For example, a reassignment `x = new Box()` should kill any previous
-           * calls to `x.value`, `x.length()`, etc.
-           */
+            * Killing an identifier should also kill field accesses on that identifier.
+            * For example, a reassignment `x = new Box()` should kill any previous
+            * calls to `x.value`, `x.length()`, etc.
+            */
           val sameObjects: Iterable[Call] = allCalls.values.flatten
             .filter(_.name == Operators.fieldAccess)
             .filter(_.ast.isIdentifier.name(identifier.name).nonEmpty)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -1,6 +1,6 @@
 package io.joern.dataflowengineoss.passes.reachingdef
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.utils.MemberAccess.isGenericMemberAccessName
@@ -221,8 +221,19 @@ class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph) extends Trans
           allIdentifiers(param.name)
             .filter(x => x.id != param.id)
         case identifier: Identifier =>
-          allIdentifiers(identifier.name)
+          val sameIdentifiers = allIdentifiers(identifier.name)
             .filter(x => x.id != identifier.id)
+
+          /**
+           * Killing an identifier should also kill field accesses on that identifier.
+           * For example, a reassignment `x = new Box()` should kill any previous
+           * calls to `x.value`, `x.length()`, etc.
+           */
+          val sameObjects: Iterable[Call] = allCalls.values.flatten
+            .filter(_.name == Operators.fieldAccess)
+            .filter(_.ast.isIdentifier.name(identifier.name).nonEmpty)
+
+          sameIdentifiers ++ sameObjects
         case call: Call =>
           allCalls(call.code)
             .filter(x => x.id != call.id)

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/CDataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/CDataFlowTests.scala
@@ -980,7 +980,7 @@ class CDataFlowTests32 extends DataFlowCodeToCpgSuite {
   }
 }
 
-class CDatFlowTests33 extends DataFlowCodeToCpgSuite {
+class CDataFlowTests33 extends DataFlowCodeToCpgSuite {
   override val code =
     """
       |int bar(int z) {
@@ -995,7 +995,7 @@ class CDatFlowTests33 extends DataFlowCodeToCpgSuite {
       |}
       |""".stripMargin
 
-  "Tes 33: should provide correct flow for source in sibling callee" in {
+  "Test 33: should provide correct flow for source in sibling callee" in {
     cpg.call("sink").reachableByFlows(cpg.call("source")).size shouldBe 1
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1958,10 +1958,8 @@ class AstCreator(filename: String, global: Global) {
         node.map(x => AstWithCtx(Ast(x), Context(identifiers = List(x)))).getOrElse(AstWithCtx.empty)
     }
 
-    val argumentOrderOffset = if (call.getScope.isPresent) 1 else 0
-
     val argumentAsts = withOrder(call.getArguments) { (x, o) =>
-      astsForExpression(x, scopeContext, o + argumentOrderOffset)
+      astsForExpression(x, scopeContext, o)
     }.flatten
 
     callAst(callNode, Seq(scopeAst) ++ argumentAsts)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallGraphTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallGraphTests.scala
@@ -24,16 +24,16 @@ class CallGraphTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should find that main calls add and others" in {
-    cpg.method.name("main").callee.name.toSet shouldBe Set("add", "println", "<operator>.addition")
+    cpg.method.name("main").callee.name.toSet shouldBe Set("add", "println", "<operator>.addition", "<operator>.fieldAccess")
   }
 
   "should find three outgoing calls for main" in {
     cpg.method.name("main").call.code.toSet shouldBe
-      Set("1 + 2", "add(1 + 2, 3)", "println(add(1 + 2, 3))")
+      Set("1 + 2", "this.add(1 + 2, 3)", "System.out.println(add(1 + 2, 3))", "System.out", "System.out.println")
   }
 
   "should find one callsite for add" in {
-    cpg.method.name("add").callIn.code.toSet shouldBe Set("add(1 + 2, 3)")
+    cpg.method.name("add").callIn.code.toSet shouldBe Set("this.add(1 + 2, 3)")
   }
 
   "should find that argument '1+2' is passed to parameter 'x'" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -121,8 +121,8 @@ class CallTests extends JavaSrcCodeToCpgFixture {
     fieldAccess.code shouldBe "myObj.myMethod"
     fieldAccess.name shouldBe Operators.fieldAccess
     fieldAccess.methodFullName shouldBe Operators.fieldAccess
-    fieldAccess.order shouldBe 1
-    fieldAccess.argumentIndex shouldBe 1
+    fieldAccess.order shouldBe 0
+    fieldAccess.argumentIndex shouldBe 0
 
     val List(identifier: Identifier, fieldIdentifier: FieldIdentifier) = fieldAccess.argument.l
     identifier.order shouldBe 1
@@ -135,8 +135,8 @@ class CallTests extends JavaSrcCodeToCpgFixture {
     fieldIdentifier.canonicalName shouldBe "myMethod"
 
     argument.code shouldBe "\"Hello, world!\""
-    argument.order shouldBe 2
-    argument.argumentIndex shouldBe 2
+    argument.order shouldBe 1
+    argument.argumentIndex shouldBe 1
   }
 
   "should create a call node for a call with an implicit `this`" in {
@@ -172,8 +172,8 @@ class CallTests extends JavaSrcCodeToCpgFixture {
     fieldAccess.code shouldBe "this.foo"
     fieldAccess.name shouldBe Operators.fieldAccess
     fieldAccess.methodFullName shouldBe Operators.fieldAccess
-    fieldAccess.order shouldBe 1
-    fieldAccess.argumentIndex shouldBe 1
+    fieldAccess.order shouldBe 0
+    fieldAccess.argumentIndex shouldBe 0
 
     val List(identifier: Identifier, fieldIdentifier: FieldIdentifier) = fieldAccess.argument.l
     identifier.order shouldBe 1
@@ -186,7 +186,7 @@ class CallTests extends JavaSrcCodeToCpgFixture {
     fieldIdentifier.canonicalName shouldBe "foo"
 
     argument.code shouldBe "obj"
-    argument.order shouldBe 2
-    argument.argumentIndex shouldBe 2
+    argument.order shouldBe 1
+    argument.argumentIndex shouldBe 1
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
@@ -39,7 +39,7 @@ class CfgTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should find that println post dominates correct nodes" in {
-    cpg.call("println").postDominates.size shouldBe 7
+    cpg.call("println").postDominates.size shouldBe 11
   }
 
   "should find that method does not post dominate anything" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/FunctionCallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/FunctionCallTests.scala
@@ -2,6 +2,7 @@ package io.joern.javasrc2cpg.querying.dataflow
 
 import io.joern.javasrc2cpg.testfixtures.JavaDataflowFixture
 import io.joern.dataflowengineoss.language._
+import io.shiftleft.semanticcpg.language._
 
 class FunctionCallTests extends JavaDataflowFixture {
 
@@ -137,6 +138,11 @@ class FunctionCallTests extends JavaDataflowFixture {
       |        String t = safeReturn(s);
       |        System.out.println(t);
       |    }
+      |
+      |    public static void test17(Object o) {
+      |        String s = (String) o;
+      |        System.out.println(s);
+      |    }
       |}
       |""".stripMargin
 
@@ -220,6 +226,12 @@ class FunctionCallTests extends JavaDataflowFixture {
   it should "not find a path where `MALICIOUS` arg is not included in return" in {
     val (source, sink) = getConstSourceSink("test16")
     // This isn't exactly the expected behaviour, but is on par with c2cpg.
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path through a cast expression" in {
+    def source = cpg.method.name("test17").parameter.index(1)
+    def sink = cpg.method.name("test17").methodReturn
     sink.reachableBy(source).size shouldBe 1
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
@@ -122,14 +122,14 @@ class ObjectTests extends JavaDataflowFixture {
   }
 
   it should "find a path for malicious input via a getter" in {
-    // TODO: This should find a path, but the current result is on par with c2cpg.
     val (source, sink) = getConstSourceSink("test4")
-    sink.reachableBy(source).size shouldBe 0
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "not find a path when accessing a safe field via a getter" in {
     val (source, sink) = getConstSourceSink("test5")
-    sink.reachableBy(source).size shouldBe 0
+    // TODO: This should not find a path, but does due to over-tainting.
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "find a path to a void printer via a field" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
@@ -72,49 +72,49 @@ class StaticMemberTests extends JavaDataflowFixture {
 
   it should "find a path for `MALICIOUS` data from different class via a variable" in {
     val source = getSources
-    val sink = cpg.method(".*test1.*").call.name(".*println.*").argument(2)
+    val sink = cpg.method(".*test1.*").call.name(".*println.*").argument(1)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "find a path for `MALICIOUS` data from a different class directly" in {
     val source = getSources
-    val sink = cpg.method(".*test2.*").call.name(".*println.*").argument(2)
+    val sink = cpg.method(".*test2.*").call.name(".*println.*").argument(1)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "not find a path for `SAFE` data directly" in {
     val source = getSources
-    val sink = cpg.method(".*test3.*").call.name(".*println.*").argument(2)
+    val sink = cpg.method(".*test3.*").call.name(".*println.*").argument(1)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "find a path for `MALICIOUS` data from the same class" in {
     val source = getSources
-    val sink = cpg.method(".*test4.*").call.name(".*println.*").argument(2)
+    val sink = cpg.method(".*test4.*").call.name(".*println.*").argument(1)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "not find a path for `SAFE` data in the same class" in {
     val source = getSources
-    val sink = cpg.method(".*test5.*").call.name(".*println.*").argument(2)
+    val sink = cpg.method(".*test5.*").call.name(".*println.*").argument(1)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "not find a path for overwritten `MALICIOUS` data" in {
     val source = getSources
-    val sink = cpg.method(".*test6.*").call.name(".*println.*").argument(2)
+    val sink = cpg.method(".*test6.*").call.name(".*println.*").argument(1)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "find a path for overwritten `SAFE` data" in {
     val source = getSources
-    val sink = cpg.method(".*test7.*").call.name(".*println.*").argument(2)
+    val sink = cpg.method(".*test7.*").call.name(".*println.*").argument(1)
 
     sink.reachableBy(source).size shouldBe 1
   }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
@@ -72,49 +72,49 @@ class StaticMemberTests extends JavaDataflowFixture {
 
   it should "find a path for `MALICIOUS` data from different class via a variable" in {
     val source = getSources
-    val sink = cpg.method(".*test1.*").call.name(".*println.*").argument
+    val sink = cpg.method(".*test1.*").call.name(".*println.*").argument(2)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "find a path for `MALICIOUS` data from a different class directly" in {
     val source = getSources
-    val sink = cpg.method(".*test2.*").call.name(".*println.*").argument
+    val sink = cpg.method(".*test2.*").call.name(".*println.*").argument(2)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "not find a path for `SAFE` data directly" in {
     val source = getSources
-    val sink = cpg.method(".*test3.*").call.name(".*println.*").argument
+    val sink = cpg.method(".*test3.*").call.name(".*println.*").argument(2)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "find a path for `MALICIOUS` data from the same class" in {
     val source = getSources
-    val sink = cpg.method(".*test4.*").call.name(".*println.*").argument
+    val sink = cpg.method(".*test4.*").call.name(".*println.*").argument(2)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "not find a path for `SAFE` data in the same class" in {
     val source = getSources
-    val sink = cpg.method(".*test5.*").call.name(".*println.*").argument
+    val sink = cpg.method(".*test5.*").call.name(".*println.*").argument(2)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "not find a path for overwritten `MALICIOUS` data" in {
     val source = getSources
-    val sink = cpg.method(".*test6.*").call.name(".*println.*").argument
+    val sink = cpg.method(".*test6.*").call.name(".*println.*").argument(2)
 
     sink.reachableBy(source).size shouldBe 0
   }
 
   it should "find a path for overwritten `SAFE` data" in {
     val source = getSources
-    val sink = cpg.method(".*test7.*").call.name(".*println.*").argument
+    val sink = cpg.method(".*test7.*").call.name(".*println.*").argument(2)
 
     sink.reachableBy(source).size shouldBe 1
   }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -39,7 +39,7 @@ class JavaDataflowFixture extends AnyFlatSpec with Matchers {
     val sourceMethod = cpg.method(s".*$sourceMethodName.*").head
     val sinkMethod = cpg.method(s".*$sinkMethodName.*").head
     def source = sourceMethod.literal.code(sourceCode)
-    def sink = sinkMethod.call.name(sinkPattern).argument(1).ast.collectAll[Expression]
+    def sink = sinkMethod.call.name(sinkPattern).argument(2).ast.collectAll[Expression]
 
     // If either of these fail, then the testcase was written incorrectly or the AST was created incorrectly.
     if (source.size <= 0) {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -39,7 +39,7 @@ class JavaDataflowFixture extends AnyFlatSpec with Matchers {
     val sourceMethod = cpg.method(s".*$sourceMethodName.*").head
     val sinkMethod = cpg.method(s".*$sinkMethodName.*").head
     def source = sourceMethod.literal.code(sourceCode)
-    def sink = sinkMethod.call.name(sinkPattern).argument(2).ast.collectAll[Expression]
+    def sink = sinkMethod.call.name(sinkPattern).argument(1).ast.collectAll[Expression]
 
     // If either of these fail, then the testcase was written incorrectly or the AST was created incorrectly.
     if (source.size <= 0) {


### PR DESCRIPTION
* NB!! In the ossdataflowengine, definitions of identifiers will now kill any field access calls accessing an object matching that identifier. For example, the statement `x = new Box()` will kill previous definitions of `x.value()`, `x.value.toString()` etc.
* Add explicit `this` to method `code` fields where required to match `java2cpg`.
* For an explicit method call like `obj.someMethod()` or `this.someMethod()`, represent the left-hand side as a field access operation instead of just an identifier (to match c2cpg).
* Fix some testcases that were broken by this change.