### PR TITLE
Add single file input support for javasrc2cpg

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -51,10 +51,10 @@ class JavaSrc2Cpg {
   }
 
   /**
-   * JavaParser requires that the input path is a directory and not a single source file.
-   * This is inconvenient for small-scale testing, so if a single source file is created,
-   * copy it to a temp directory.
-   */
+    * JavaParser requires that the input path is a directory and not a single source file.
+    * This is inconvenient for small-scale testing, so if a single source file is created,
+    * copy it to a temp directory.
+    */
   private def getSourcesFromDir(sourceCodePath: String): (String, List[String]) = {
     val sourceFile = File(sourceCodePath)
     if (sourceFile.isDirectory) {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -61,9 +61,9 @@ class JavaSrc2Cpg {
       val sourceFileNames = SourceFiles.determine(Set(sourceCodePath), sourceFileExtensions)
       (sourceCodePath, sourceFileNames)
     } else {
-      val dir = Files.createTempDirectory("javasrc")
-      sourceFile.copyToDirectory(dir)
-      (dir.toAbsolutePath.toString, List(sourceFile.pathAsString))
+      val dir = File.newTemporaryDirectory("javasrc").deleteOnExit()
+      sourceFile.copyToDirectory(dir).deleteOnExit()
+      (dir.pathAsString, List(sourceFile.pathAsString))
     }
   }
 


### PR DESCRIPTION
JavaParser expects the input to be a source code directory (as opposed to a single file). This is somewhat annoying for testing and tinkering with the front-end, so this PR solves the problem by copying the input file to a temporary directory if a single-file input is given. 

The `fileName` used for CPG nodes will still be the original input file.