### PR TITLE
Add missing args and fields to javasrc returns

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1046,11 +1046,17 @@ class AstCreator(filename: String, global: Global) {
       scopeContext: ScopeContext,
       order: Int
   ): Seq[AstWithCtx] = {
-    // TODO: Make return node with expression as children
     if (ret.getExpression.isPresent) {
       val exprAstsWithCtx = astsForExpression(ret.getExpression.get(), scopeContext, order + 1)
-      val returnNode = NewReturn().order(order)
-      val returnAst = Ast(returnNode).withChildren(exprAstsWithCtx.map(_.ast))
+      val returnNode = NewReturn()
+        .lineNumber(line(ret))
+        .columnNumber(column(ret))
+        .argumentIndex(order)
+        .order(order)
+        .code(ret.toString)
+      val returnAst = Ast(returnNode)
+        .withChildren(exprAstsWithCtx.map(_.ast))
+        .withArgEdges(returnNode, exprAstsWithCtx.flatMap(_.ast.root))
       val ctx = mergedCtx(exprAstsWithCtx.map(_.ctx))
       Seq(AstWithCtx(returnAst, ctx))
     } else {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodReturnTests.scala
@@ -23,6 +23,15 @@ class MethodReturnTests extends JavaSrcCodeToCpgFixture {
     x.order shouldBe 2
   }
 
+  "should have a RETURN node ith correct fields" in {
+    val List(x) = cpg.method.name("foo").ast.isReturn.l
+    x.code shouldBe "return 1;"
+    x.order shouldBe 1
+    x.argumentIndex shouldBe 1
+    x.astChildren.size shouldBe 1
+    x.argumentOut.size shouldBe 1
+  }
+
   "should allow traversing to method" in {
     cpg.methodReturn.code("int").method.name.l shouldBe List("foo")
   }


### PR DESCRIPTION
Return nodes were missing argument edges to the arguments (present in c2cpg), possibly causing some missing nodes in DF flows (still to be confirmed). 

While fixing this, I also noticed that some fields were missing, so added those.