### PR TITLE
Change joern-parse output option to -o or --output for consistency

### DIFF
--- a/joern-cli/src/main/scala/io/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/JoernParse.scala
@@ -18,7 +18,7 @@ object JoernParse extends App {
       .text("source file or directory containing source files")
       .action((x, c) => c.copy(inputPath = x))
 
-    opt[String]("out")
+    opt[String]('o', "output")
       .text("output filename")
       .action((x, c) => c.copy(outputCpgFile = x))
 


### PR DESCRIPTION
Most (all?) front-ends use the `-o` or `--output` options to specify an output file. It makes sense for `joern-parse` to use the same and this is what one would expect after running the front-ends directly.

This change would break any scripts that rely on the output option being `--out`, but given `joern-parse` was recently rewritten almost entirely, the impact of this seems limited.