### PR TITLE
Allow passing number of definitions to `joern-parse`

### DIFF
--- a/joern-cli/src/main/scala/io/joern/DefaultOverlays.scala
+++ b/joern-cli/src/main/scala/io/joern/DefaultOverlays.scala
@@ -7,19 +7,20 @@ import io.shiftleft.codepropertygraph.Cpg
 object DefaultOverlays {
 
   val DEFAULT_CPG_IN_FILE = "cpg.bin"
+  val defaultMaxNumberOfDefinitions = 4000
 
   /** Load the CPG at `storeFilename` and add enhancements,
     * turning the CPG into an SCPG.
     * @param storeFilename the filename of the cpg
     */
-  def create(storeFilename: String): Cpg = {
+  def create(storeFilename: String, maxNumberOfDefinitions: Int = defaultMaxNumberOfDefinitions): Cpg = {
     val cpg = CpgBasedTool.loadFromOdb(storeFilename)
     val context = new LayerCreatorContext(cpg)
     new Base().run(context)
     new TypeRelations().run(context)
     new ControlFlow().run(context)
     new CallGraph().run(context)
-    val options = new OssDataFlowOptions()
+    val options = new OssDataFlowOptions(maxNumberOfDefinitions)
     new OssDataFlow(options).run(context)
     cpg
   }

--- a/joern-cli/src/main/scala/io/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/JoernParse.scala
@@ -43,6 +43,10 @@ object JoernParse extends App {
       .text("Only apply default overlays")
       .action((x, c) => c.copy(enhanceOnly = true))
 
+    opt[Int]("max-num-def")
+      .text("Maximum number of definitions in per-method data flow calculation")
+      .action((x, c) => c.copy(maxNumDef = x))
+
     note("Misc")
     help("help").text("display this help message")
 
@@ -143,7 +147,7 @@ object JoernParse extends App {
     try {
       println("[+] Applying default overlays")
       if (config.enhance) {
-        DefaultOverlays.create(config.outputCpgFile).close()
+        DefaultOverlays.create(config.outputCpgFile, config.maxNumDef).close()
       }
       Right("Code property graph generation successful")
     } catch {
@@ -158,7 +162,8 @@ object JoernParse extends App {
       enhance: Boolean = true,
       enhanceOnly: Boolean = false,
       language: String = "",
-      listLanguages: Boolean = false
+      listLanguages: Boolean = false,
+      maxNumDef: Int = DefaultOverlays.defaultMaxNumberOfDefinitions
   )
 
   private def parseConfig(parserArgs: List[String]): Either[String, ParserConfig] = {


### PR DESCRIPTION
The OSS data flow engine has a parameter: the maximum number of definitions a method may have to be considered for data flow analysis. We now let users pass this parameter to `joern-parse`.
```
./joern-parse --max-num-def 10000 <path/to/code>
```