### PR TITLE
Update log4j to 2.17.1

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object Versions {
   val antlr = "4.9.3"
   val scalatest = "3.2.10"
   val cats = "3.3.0"
-  val log4j = "2.17.0"
+  val log4j = "2.17.1"
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r


### PR DESCRIPTION
After the recent release of 2.17.0 of log4j, there was [another CVE](https://nvd.nist.gov/vuln/detail/CVE-2021-44832) disclosed. The latest version, 2.17.1, has no disclosed vulnerabilities.