### PR TITLE
Fixed empty code fields

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -169,7 +169,12 @@ trait MacroHandler {
   def nodeSignature(node: IASTNode): String = {
     import org.eclipse.cdt.core.dom.ast.ASTSignatureUtil.getNodeSignature
     if (isExpandedFromMacro(node)) {
-      getNodeSignature(node)
+      val sig = getNodeSignature(node)
+      if (sig.isEmpty) {
+        node.getRawSignature
+      } else {
+        sig
+      }
     } else {
       node.getRawSignature
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/ExternalCommand.scala
@@ -6,18 +6,22 @@ import scala.util.{Failure, Success, Try}
 
 object ExternalCommand {
 
+  private val IS_WIN: Boolean =
+    scala.util.Properties.isWin
+
+  private val shellPrefix: Seq[String] =
+    if (IS_WIN) "cmd" :: "/c" :: Nil else "sh" :: "-c" :: Nil
+
   def run(command: String): Try[Seq[String]] = {
     val result = mutable.ArrayBuffer.empty[String]
     val lineHandler: String => Unit = result.addOne
-    val shellPrefix =
-      if (scala.util.Properties.isWin) {
-        "cmd" :: "/c" :: Nil
-      } else {
-        "sh" :: "-c" :: Nil
-      }
-
     Process(shellPrefix :+ command).!(ProcessLogger(lineHandler, lineHandler)) match {
       case 0 =>
+        Success(result.toSeq)
+      case 1
+          if IS_WIN &&
+            command != IncludeAutoDiscovery.GCC_VERSION_COMMAND &&
+            IncludeAutoDiscovery.gccAvailable() =>
         Success(result.toSeq)
       case _ =>
         Failure(new RuntimeException(result.mkString(System.lineSeparator())))


### PR DESCRIPTION
This happens for C++ field accesses after macro expansion.
`org.eclipse.cdt.core.dom.ast.ASTSignatureUtil.getNodeSignature` will return an empty string for them.
We have to fall-back to `getRawSignature` instead.

Also in this PR: fixed gcc system include file discovery for Windows.