### PR TITLE
Fixed .dump / .dumpRaw for c2cpg

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -105,7 +105,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
       (dir / filename).write(str)
       f(dir)
     }
-    dir.delete()
+    dir.deleteOnExit(swallowIOExceptions = true)
     result
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -62,12 +62,16 @@ class AstCreator(
       path: String,
       iASTTranslationUnit: IASTTranslationUnit
   ): Ast = {
+    val allDecls = iASTTranslationUnit.getDeclarations
+
     val fakeGlobalMethod =
       NewMethod()
         .name(name)
         .code(name)
         .fullName(fullName)
         .filename(path)
+        .lineNumber(allDecls.headOption.flatMap(line))
+        .lineNumberEnd(allDecls.lastOption.flatMap(lineEnd))
         .astParentType(NodeTypes.NAMESPACE_BLOCK)
         .astParentFullName(fullName)
 
@@ -80,7 +84,7 @@ class AstCreator(
       .typeFullName("ANY")
 
     var currOrder = 1
-    val declsAsts = iASTTranslationUnit.getDeclarations.flatMap { stmt =>
+    val declsAsts = allDecls.flatMap { stmt =>
       val r =
         Global.getAstsFromAstCache(
           diffGraph,

--- a/querydb/src/main/scala/io/joern/scanners/c/Metrics.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/Metrics.scala
@@ -16,7 +16,7 @@ object Metrics extends QueryBundle {
       description = s"This query identifies functions with more than $n formal parameters",
       score = 1.0,
       withStrRep({ cpg =>
-        cpg.method.internal.filter(_.parameter.size > n)
+        cpg.method.internal.filter(_.parameter.size > n).nameNot("<global>")
       }),
       tags = List(QueryTags.metrics),
       codeExamples = CodeExamples(
@@ -86,7 +86,7 @@ object Metrics extends QueryBundle {
       description = s"This query identifies functions that are more than $n lines long",
       score = 1.0,
       withStrRep({ cpg =>
-        cpg.method.internal.filter(_.numberOfLines > n)
+        cpg.method.internal.filter(_.numberOfLines > n).nameNot("<global>")
       }),
       tags = List(QueryTags.metrics),
       codeExamples = CodeExamples(


### PR DESCRIPTION
The fake global method needs line numbers to enable dumping its code.
Also: we should not immediately delete the temporary file generated from importCode / writeCodeInTmpFile to keep .dump / .dumpRaw functional after the CPG generation / import.