### PR TITLE
Improve descriptor support in type info provider

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
@@ -1,22 +1,8 @@
 package io.joern.kotlin2cpg.types
 
-import com.intellij.util.ReflectionUtil
 import com.intellij.util.keyFMap.KeyFMap
-import org.jetbrains.kotlin.descriptors.{
-  CallableDescriptor,
-  ClassDescriptor,
-  DeclarationDescriptor,
-  FunctionDescriptor,
-  SimpleFunctionDescriptor,
-  ValueDescriptor,
-  ValueParameterDescriptor
-}
-import org.jetbrains.kotlin.descriptors.impl.{
-  ClassConstructorDescriptorImpl,
-  LocalVariableDescriptor,
-  TypeAliasConstructorDescriptor,
-  TypeAliasConstructorDescriptorImpl
-}
+import org.jetbrains.kotlin.descriptors.{DeclarationDescriptor, FunctionDescriptor, ValueDescriptor}
+import org.jetbrains.kotlin.descriptors.impl.{ClassConstructorDescriptorImpl, TypeAliasConstructorDescriptorImpl}
 import org.jetbrains.kotlin.psi.{
   KtBinaryExpression,
   KtCallExpression,
@@ -34,7 +20,7 @@ import org.jetbrains.kotlin.psi.{
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.DescriptorUtils.getSuperclassDescriptors
 import org.jetbrains.kotlin.resolve.`lazy`.descriptors.{LazyClassDescriptor, LazyTypeAliasDescriptor}
-import org.jetbrains.kotlin.types.{ErrorType, UnresolvedType}
+import org.jetbrains.kotlin.types.{ErrorType, SimpleType, UnresolvedType}
 import org.jetbrains.kotlin.cli.jvm.compiler.{
   KotlinCoreEnvironment,
   KotlinToJVMBytecodeCompiler,
@@ -48,6 +34,11 @@ import org.slf4j.LoggerFactory
 import KotlinTypeInfoProvider._
 import org.jetbrains.kotlin.resolve.`lazy`.NoDescriptorForDeclarationException
 import org.jetbrains.kotlin.resolve.descriptorUtil.DescriptorUtilsKt
+
+// representative of `LazyJavaClassDescriptor`, `DeserializedClassDescriptor`, `TypeAliasConstructorDescriptor`, etc.
+trait WithDefaultType {
+  def getDefaultType(): SimpleType
+}
 
 object Constants {
   val kotlinAny = "kotlin.Any"
@@ -343,8 +334,6 @@ class KotlinTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeInf
   }
 
   def fullNameWithSignature(expr: KtClassLiteralExpression, or: (String, String)): (String, String) = {
-    printBindingsForEntity(bindingContext, expr)
-
     val typeInfo = bindingContext.get(BindingContext.EXPRESSION_TYPE_INFO, expr)
     if (typeInfo != null && typeInfo.getType != null && typeInfo.getType.getArguments.size() > 0) {
       val firstTypeArg = typeInfo.getType.getArguments.get(0)
@@ -432,8 +421,10 @@ class KotlinTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeInf
             } else {
               return (fullName, signature)
             }
-          case other: Any =>
-            logger.debug("Unhandled type info fetching for class `" + other.getClass + "`")
+          case unhandled: Any =>
+            logger.debug(
+              s"Unhandled class in fetching type info for `${expr.getText}` with class `${unhandled.getClass}`."
+            )
             return (or._1, or._2)
         }
       }
@@ -485,8 +476,10 @@ class KotlinTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeInf
             } else {
               return (fullName, signature)
             }
-          case other: Any =>
-            logger.debug("Unhandled type info fetching for class `" + other.getClass + "`")
+          case unhandled: Any =>
+            logger.debug(
+              s"Unhandled class in fetching type info for `${expr.getText}` with class `${unhandled.getClass}`."
+            )
             return or
         }
       }
@@ -513,8 +506,10 @@ class KotlinTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeInf
                 val decl = fnDescriptor.getContainingDeclaration
                 val renderedFqName = DescriptorUtils.getFqName(decl)
                 return renderedFqName.toString
-              case other: Any =>
-                logger.debug("Unhandled type info fetching for class `" + other.getClass + "`")
+              case unhandled: Any =>
+                logger.debug(
+                  s"Unhandled class in fetching type info for `${expr.getText}` with class `${unhandled.getClass}`."
+                )
                 return or
             }
           }
@@ -544,8 +539,10 @@ class KotlinTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeInf
               case fnDescriptor: FunctionDescriptor =>
                 val isStatic = DescriptorUtils.isStaticDeclaration(fnDescriptor)
                 return if (isStatic) BindingKinds.Static else BindingKinds.Dynamic
-              case other: Any =>
-                logger.debug("Unhandled type info fetching for class `" + other.getClass + "`")
+              case unhandled: Any =>
+                logger.debug(
+                  s"Unhandled class in fetching type info for `${expr.getText}` with class `${unhandled.getClass}`."
+                )
                 return BindingKinds.Unknown
             }
           }
@@ -623,8 +620,10 @@ class KotlinTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeInf
                   return fn
                 }
 
-              case other: Any =>
-                logger.debug("Unhandled type info fetching for class `" + other.getClass + "`")
+              case unhandled: Any =>
+                logger.debug(
+                  s"Unhandled class in fetching type info for `${expr.getText}` with class `${unhandled.getClass}`."
+                )
                 return (or._1, or._2)
             }
           }
@@ -712,9 +711,11 @@ class KotlinTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeInf
     val renderer = descriptorRenderer(targetDesc)
     val rendered: Option[String] = targetDesc match {
       case typedDesc: ValueDescriptor =>
-        Some(stripped(renderer.renderType(typedDesc.getType)))
+        Some(stripped(renderer.renderType(typedDesc.getType())))
+      case typedDesc: WithDefaultType =>
+        Some(stripped(renderer.renderType(typedDesc.getDefaultType())))
       case unhandled: Any =>
-        logger.warn("Unhandled class in fetching type info `" + unhandled.getClass + "`.")
+        logger.debug(s"Unhandled class in fetching type info for `${expr.getText}` with class `${unhandled.getClass}`.")
         None
     }
 


### PR DESCRIPTION
- introduce `WithDefaultType` trait allows pattern matching on a number of
  descriptors
- improve log messages for failed type info fetching