### PR TITLE
Remove kotlin2cpg `java.lang.String.strip()` calls

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -1036,7 +1036,7 @@ class AstCreator(
       nameGenerator: NameGenerator
   ): AstWithCtx = {
     val containingFile = expr.getContainingKtFile()
-    val fileName = expr.getContainingKtFile.getName.strip()
+    val fileName = expr.getContainingKtFile.getName
     val lambdaNum = lambdaKeyPool.next
     val fullName =
       containingFile.getPackageFqName.toString() + ":<lambda>" + "<f_" + fileName + "_no" + lambdaNum + ">()"

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameGenerator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameGenerator.scala
@@ -691,7 +691,7 @@ class DefaultNameGenerator(environment: KotlinCoreEnvironment) extends NameGener
 
   def fullNameWithSignature(expr: KtLambdaExpression, keyPool: KeyPool): (String, String) = {
     val containingFile = expr.getContainingKtFile()
-    val fileName = containingFile.getName.strip()
+    val fileName = containingFile.getName
     val lambdaNum = keyPool.next
     val astDerivedFullName =
       containingFile.getPackageFqName().toString + ":" + "<lambda>" + "<f_" + fileName + "_no" + lambdaNum + ">" + "()"


### PR DESCRIPTION
Breaks runs on JDK8 (& are not needed) 