### PR TITLE
Fix various cases of Kotlin CPGs with stray IDENTIFIERs

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
@@ -37,7 +37,9 @@ object SourceFilesPicker {
         "integrationtest",
         "androidTest",
         "sharedTest",
-        "fixtures"
+        "fixtures",
+        "commonTest",
+        "jvmTest"
       )
     val containsUnwantedSubstring =
       substringsToFilterFor.exists { str =>

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -1955,14 +1955,14 @@ class AstCreator(
       .withChild(conditionAst.head.ast)
       .withChildren(thenAsts.map(_.ast) ++ elseAsts.map(_.ast))
 
-    val withCondition =
-      conditionAst.head.ast.root match {
-        case Some(r) =>
-          ast.withConditionEdge(ifNode, r)
-        case None =>
-          ast
-      }
-    AstWithCtx(withCondition, Context())
+    val withCondition = conditionAst.head.ast.root match {
+      case Some(r) =>
+        ast.withConditionEdge(ifNode, r)
+      case None =>
+        ast
+    }
+    val finalCtx = mergedCtx(conditionAst.map(_.ctx) ++ thenAsts.map(_.ctx) ++ elseAsts.map(_.ctx))
+    AstWithCtx(withCondition, finalCtx)
   }
 
   def astForIfAsExpression(expr: KtIfExpression, scopeContext: ScopeContext, order: Int)(implicit

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -1767,14 +1767,16 @@ class AstCreator(
       .withChild(conditionAst.ast)
       .withChildren(stmtAsts.map(_.ast))
 
-    val ast =
+    val ast = {
       conditionAst.ast.root match {
         case Some(r) =>
           tempAst.withConditionEdge(whileNode, r)
         case None =>
           tempAst
       }
-    AstWithCtx(ast, Context())
+    }
+    val finalCtx = mergedCtx(Seq(conditionAst.ctx) ++ stmtAsts.map(_.ctx))
+    AstWithCtx(ast, finalCtx)
   }
 
   def astForDoWhile(expr: KtDoWhileExpression, scopeContext: ScopeContext, order: Int)(implicit

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -335,7 +335,7 @@ class AstCreator(
           }
 
         ImportEntry(
-          entry.getText().replaceAll("^import ", ""),
+          entry.getImportPath.getPathStr,
           importedName,
           true,
           isWildcard,

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -958,7 +958,9 @@ class AstCreator(
       case typedExpr: KtLambdaExpression =>
         Seq(astForLambda(typedExpr, scopeContext, order, argIdx))
       case typedExpr: KtNamedFunction =>
-        Seq(astForAnonymousFunction(typedExpr, scopeContext, order))
+        // TODO: re-enable after all AST issues have been fixed
+        //Seq(astForAnonymousFunction(typedExpr, scopeContext, order))
+        Seq()
       case classExpr: KtClassLiteralExpression =>
         Seq(astForClassLiteral(classExpr, scopeContext, order, argIdx))
       case sqExpr: KtSafeQualifiedExpression =>
@@ -1030,7 +1032,6 @@ class AstCreator(
     AstWithCtx(Ast(callNode), Context())
   }
 
-  // TODO: try to merge with astForLambda if possible
   def astForAnonymousFunction(expr: KtNamedFunction, scopeContext: ScopeContext, order: Int)(implicit
       fileInfo: FileInfo,
       nameGenerator: NameGenerator
@@ -1084,10 +1085,15 @@ class AstCreator(
         .order(order)
     val methodRefAst = Ast(methodRef)
 
-    AstWithCtx(
-      methodRefAst,
-      Context(lambdaAsts = Seq(lambdaMethodAst), identifiers = bodyAstWithCtx.ctx.identifiers)
-    )
+    val finalCtx =
+      Context(
+        lambdaAsts = Seq(lambdaMethodAst),
+        identifiers = bodyAstWithCtx.ctx.identifiers,
+        closureBindingInfo = bodyAstWithCtx.ctx.closureBindingInfo,
+        lambdaBindingInfo = bodyAstWithCtx.ctx.lambdaBindingInfo,
+        bindingsInfo = bodyAstWithCtx.ctx.bindingsInfo
+      )
+    AstWithCtx(methodRefAst, finalCtx)
   }
 
   def astForLambda(expr: KtLambdaExpression, scopeContext: ScopeContext, order: Int, argIdx: Int)(implicit

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameGenerator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameGenerator.scala
@@ -164,17 +164,17 @@ class DefaultNameGenerator(environment: KotlinCoreEnvironment) extends NameGener
     }
   }
 
-  // replaces `ERROR` types with `kotlin.Any`
-  // TODO: consider erasing types over here
   def descriptorRenderer(desc: DeclarationDescriptor): DescriptorRenderer = {
-    val anyT = DescriptorUtilsKt.getBuiltIns(desc).getAny()
     val opts = new DescriptorRendererOptionsImpl
     opts.setParameterNamesInFunctionalTypes(false)
-    opts.setTypeNormalizer { t =>
-      if (t.isInstanceOf[UnresolvedType]) {
-        anyT.getDefaultType
-      } else {
-        t
+    if (desc != null) {
+      val anyT = DescriptorUtilsKt.getBuiltIns(desc).getAny()
+      opts.setTypeNormalizer { t =>
+        if (t.isInstanceOf[UnresolvedType]) {
+          anyT.getDefaultType
+        } else {
+          t
+        }
       }
     }
     new DescriptorRendererImpl(opts)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameGenerator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameGenerator.scala
@@ -21,7 +21,11 @@ import org.jetbrains.kotlin.psi.{
 }
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.DescriptorUtils.getSuperclassDescriptors
-import org.jetbrains.kotlin.resolve.`lazy`.descriptors.{LazyClassDescriptor, LazyTypeAliasDescriptor}
+import org.jetbrains.kotlin.resolve.`lazy`.descriptors.{
+  LazyClassDescriptor,
+  LazyPackageDescriptor,
+  LazyTypeAliasDescriptor
+}
 import org.jetbrains.kotlin.types.{ErrorType, KotlinTypeFactoryKt, KotlinTypeKt, SimpleType, TypeUtils, UnresolvedType}
 import org.jetbrains.kotlin.cli.jvm.compiler.{
   KotlinCoreEnvironment,
@@ -35,8 +39,10 @@ import scala.jdk.CollectionConverters._
 import org.slf4j.LoggerFactory
 import DefaultNameGenerator._
 import io.shiftleft.passes.KeyPool
+import org.jetbrains.kotlin.load.java.`lazy`.descriptors.LazyJavaClassDescriptor
 import org.jetbrains.kotlin.resolve.`lazy`.NoDescriptorForDeclarationException
 import org.jetbrains.kotlin.resolve.descriptorUtil.DescriptorUtilsKt
+import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedClassDescriptor
 
 // representative of `LazyJavaClassDescriptor`, `DeserializedClassDescriptor`, `TypeAliasConstructorDescriptor`, etc.
 trait WithDefaultType {
@@ -762,6 +768,13 @@ class DefaultNameGenerator(environment: KotlinCoreEnvironment) extends NameGener
       case typedDesc: ValueDescriptor =>
         Some(stripped(renderer.renderType(typedDesc.getType())))
       case typedDesc: WithDefaultType =>
+        Some(stripped(renderer.renderType(typedDesc.getDefaultType())))
+      // TODO: add test cases for the LazyClassDescriptors (`okio` codebase serves as good example)
+      case typedDesc: LazyClassDescriptor =>
+        Some(stripped(renderer.renderType(typedDesc.getDefaultType())))
+      case typedDesc: LazyJavaClassDescriptor =>
+        Some(stripped(renderer.renderType(typedDesc.getDefaultType())))
+      case typedDesc: DeserializedClassDescriptor =>
         Some(stripped(renderer.renderType(typedDesc.getDefaultType())))
       case unhandled: Any =>
         logger.debug(s"Unhandled class in fetching type info for `${expr.getText}` with class `${unhandled.getClass}`.")

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/integration/IntegrationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/integration/IntegrationTests.scala
@@ -10,6 +10,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Ignore
+import overflowdb.traversal.jIteratortoTraversal
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import java.nio.file.Files
@@ -32,7 +33,7 @@ class IntegrationTests extends AnyFreeSpec with Matchers with BeforeAndAfterAll 
   }
 
   def makeCpg(inPath: String, outPath: String): Cpg = {
-    val inferenceJarDir = File("src/main/resources/inferencejars")
+    val inferenceJarDir = File("joern-cli/frontends/kotlin2cpg/src/main/resources/inferencejars/")
     val inferenceJarsPaths =
       inferenceJarDir.list
         .filter(_.extension.exists { e => e == ".jar" })
@@ -127,6 +128,13 @@ class IntegrationTests extends AnyFreeSpec with Matchers with BeforeAndAfterAll 
 
     "should not contain any CALL nodes with MFNs with a space character in them" in {
       cpg.call.methodFullName(".*[ ].*").methodFullName.take(1).l shouldBe List()
+    }
+
+    "should not contain any IDENTIFIER nodes without inbound AST edges" in {
+      cpg.identifier
+        .filter(_._astIn.size == 0)
+        .code
+        .l shouldBe Seq()
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnonymousFunctionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnonymousFunctionsTests.scala
@@ -25,6 +25,8 @@ class AnonymousFunctionsTests extends AnyFreeSpec with Matchers {
         |}
         |""".stripMargin)
 
+    // TODO: re-enable after all AST issues have been fixed
+    /*
     "should contain a CALL node for `println`" in {
       cpg.call.code(".*println.*").size shouldBe 1
     }
@@ -32,5 +34,6 @@ class AnonymousFunctionsTests extends AnyFreeSpec with Matchers {
     "should contain a METHOD node for the lambda" in {
       cpg.method.fullName(".*lambda.*").size shouldBe 1
     }
+     */
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
@@ -1,8 +1,8 @@
 package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.Kt2CpgTestContext
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
-
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -33,6 +33,66 @@ class ExtensionTests extends AnyFreeSpec with Matchers {
     "should contain a METHOD node for the extension fn with the correct MFN set" in {
       val List(m) = cpg.method.fullName(".*printBaz.*").l
       m.fullName shouldBe "mypkg.Example.printBaz:kotlin.Unit()"
+    }
+  }
+
+  "CPG for code with differently-scoped extension-fns on stdlib type" - {
+    implicit val resolver = NoResolve
+
+    // TODO: add test cases after the lowering is clear:
+    //   --> right now we cannot differentiate between the fn definitions at different scopes
+    lazy val cpg = Kt2CpgTestContext.buildCpg("""
+        |package mypkg
+        |
+        |fun String.hash() = "HASH_PLACEHOLDER_1: $this"
+        |
+        |internal class AClass{
+        |    private fun String.hash() = "HASH_PLACEHOLDER_2: $this"
+        |    fun hashStr(str: String): String {
+        |       val toHash = str.hash()
+        |       return toHash
+        |    }
+        |}
+        |
+        |internal class BClass {
+        |    private fun String.hash() = "HASH_PLACEHOLDER_3: $this"
+        |    fun hashStr(str: String): String {
+        |       val toHash = str.hash()
+        |       return toHash
+        |    }
+        |}
+        |
+        |fun main() {
+        |    val str = "MESSAGE"
+        |    println(str.hash())
+        |
+        |    val c1 = AClass()
+        |    println(c1.hashStr(str))
+        |
+        |    val c2 = BClass()
+        |    println(c2.hashStr(str))
+        |}
+        |""".stripMargin)
+
+    "should contain a CALL node with the correct props set for the call to the package-level defined extension fn" in {
+      val List(c) = cpg.call.code("str.hash.*").where(_.method.fullName(".*main.*")).l
+      c.methodFullName shouldBe "kotlin.String.hash:kotlin.String()"
+      c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      c.signature shouldBe "kotlin.String()"
+    }
+
+    "should contain a CALL node with the correct props set for the call to the extension fn defined in `AClass`" in {
+      val List(c) = cpg.typeDecl.fullName(".*AClass.*").method.fullName(".*hashStr.*").call.code("str.hash.*").l
+      c.methodFullName shouldBe "kotlin.String.hash:kotlin.String()"
+      c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      c.signature shouldBe "kotlin.String()"
+    }
+
+    "should contain a CALL node with the correct props set for the call to the extension fn defined in `BClass`" in {
+      val List(c) = cpg.typeDecl.fullName(".*BClass.*").method.fullName(".*hashStr.*").call.code("str.hash.*").l
+      c.methodFullName shouldBe "kotlin.String.hash:kotlin.String()"
+      c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      c.signature shouldBe "kotlin.String()"
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -361,4 +361,37 @@ class LambdaTests extends AnyFreeSpec with Matchers {
       m.signature shouldBe "kotlin.Any(kotlin.Any)"
     }
   }
+
+  "CPG for code with call with lambda inside method definition" - {
+    lazy val cpg = Kt2CpgTestContext.buildCpg("""
+        |package mypkg
+        |
+        |import kotlin.random.Random
+        |
+        |class AClass() {
+        |    fun check(col: List<Int?>) {
+        |        val rand = Random.nextInt(0, 100)
+        |        when (rand) {
+        |            1 -> println("1!")
+        |            2 -> println("2!")
+        |            else -> {
+        |                val filtered = col.all { entry -> entry != null }
+        |                println(filtered)
+        |            }
+        |        }
+        |    }
+        |}
+        |
+        |fun main() {
+        |    val list = listOf(1, 2, 3)
+        |    val a = AClass()
+        |    a.check(list)
+        |    println("SCOPE")
+        |}
+        |""".stripMargin)
+
+    "should a METHOD node for the lambda" in {
+      cpg.method.fullName(".*lambda.*").size shouldBe 1
+    }
+  }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
@@ -360,4 +360,49 @@ class ValidationTests extends AnyFreeSpec with Matchers {
     }
   }
 
+  "CPG for code with lambda inside while-statement" - {
+    lazy val cpg = Kt2CpgTestContext.buildCpg(
+      """
+        |
+        |package main
+        |fun main() {
+        |    val str = "ASTRING"
+        |    while(true) {
+        |        1.let {
+        |            println(str)
+        |        }
+        |    }
+        |}
+        |""".stripMargin)
+
+    "should not contain any IDENTIFIER nodes without inbound AST edges" in {
+      cpg.identifier
+        .filter(_._astIn.size == 0)
+        .code
+        .l shouldBe Seq()
+    }
+  }
+
+  "CPG for code with lambda inside do-while-statement" - {
+    lazy val cpg = Kt2CpgTestContext.buildCpg(
+      """
+        |
+        |package main
+        |fun main() {
+        |    val str = "ASTRING"
+        |    do {
+        |        1.let {
+        |            println(str)
+        |        }
+        |    } while(true)
+        |}
+        |""".stripMargin)
+
+    "should not contain any IDENTIFIER nodes without inbound AST edges" in {
+      cpg.identifier
+        .filter(_._astIn.size == 0)
+        .code
+        .l shouldBe Seq()
+    }
+  }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
@@ -287,4 +287,37 @@ class ValidationTests extends AnyFreeSpec with Matchers {
         .l shouldBe Seq()
     }
   }
+
+  "CPG for code with call with lambda param inside if-else-statement" - {
+    lazy val cpg = Kt2CpgTestContext.buildCpg("""
+        |package mypkg
+        |
+        |import kotlin.random.Random
+        |
+        |fun main() {
+        |    val rand = Random.nextInt(0,  100)
+        |    if (rand < 50) {
+        |        1.let {
+        |            println("`rand` is smaller than 50: " + rand)
+        |        }
+        |    } else {
+        |        2.let {
+        |            println("`rand` is greater than or eq to 50: " + rand)
+        |        }
+        |    }
+        |}
+        |""".stripMargin)
+
+    "should METHOD nodes for the lambdas" in {
+      cpg.method.fullName(".*lambda.*").size shouldBe 2
+    }
+
+    "should not contain any IDENTIFIER nodes without inbound AST edges" in {
+      cpg.identifier
+        .filter(_._astIn.size == 0)
+        .code
+        .l shouldBe Seq()
+    }
+  }
+
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
@@ -408,8 +408,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with lambda inside while-statement" - {
-    lazy val cpg = Kt2CpgTestContext.buildCpg(
-      """
+    lazy val cpg = Kt2CpgTestContext.buildCpg("""
         |
         |package main
         |fun main() {
@@ -431,8 +430,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with lambda inside do-while-statement" - {
-    lazy val cpg = Kt2CpgTestContext.buildCpg(
-      """
+    lazy val cpg = Kt2CpgTestContext.buildCpg("""
         |
         |package main
         |fun main() {


### PR DESCRIPTION
- Context not being passed back up the chain led to IDENTIFIER nodes without AST parents
- parsing of inline named function leads to stray IDENTIFIERs, disabled for now
- more tests
- various small fixes