### PR TITLE
Jimple2Cpg: Array/Multi-array Support + Single File Load Bug Fix

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -60,17 +60,17 @@ class Jimple2Cpg {
     try {
       // Determine if the given path is a file or directory and sanitize accordingly
       val rawSourceCodeFile = new JFile(rawSourceCodePath)
-      val normSourceCodePath = rawSourceCodeFile.toPath.toAbsolutePath.normalize.toString
-      val sourceCodePath = if (rawSourceCodeFile.isDirectory) {
-        normSourceCodePath
+      val sourceTarget = rawSourceCodeFile.toPath.toAbsolutePath.normalize.toString
+      val sourceCodeDir = if (rawSourceCodeFile.isDirectory) {
+        sourceTarget
       } else {
         Paths
-          .get(new JFile(normSourceCodePath).getParentFile.getAbsolutePath)
+          .get(new JFile(sourceTarget).getParentFile.getAbsolutePath)
           .normalize
           .toString
       }
 
-      configureSoot(sourceCodePath)
+      configureSoot(sourceCodeDir)
       val cpg = newEmptyCpg(outputPath)
       val metaDataKeyPool = new IntervalKeyPool(1, 100)
       val typesKeyPool = new IntervalKeyPool(100, 1000100)
@@ -80,26 +80,19 @@ class Jimple2Cpg {
 
       val sourceFileExtensions = Set(".class", ".jimple")
       val archiveFileExtensions = Set(".jar", ".war")
-      // Unpack any archives on the path onto the source code path as project root
-      val archives: List[String] =
-        if (rawSourceCodeFile.isDirectory)
-          SourceFiles.determine(Set(sourceCodePath), archiveFileExtensions)
-        else if (normSourceCodePath.endsWith(archiveFileExtensions))
-          List(normSourceCodePath)
-        else List()
       // Load source files and unpack archives if necessary
-      val sourceFileNames = loadSourceFiles(sourceCodePath, sourceFileExtensions, archives)
+      val sourceFileNames = if (sourceTarget == sourceCodeDir) {
+        // Load all source files in a directory
+        loadSourceFiles(sourceCodeDir, sourceFileExtensions, archiveFileExtensions)
+      } else {
+        // Load single file that was specified
+        loadSourceFiles(sourceTarget, sourceFileExtensions, archiveFileExtensions)
+      }
 
       // Load classes into Soot
-      sourceFileNames
-        .map(getQualifiedClassPath(sourceCodePath, _))
-        .map { x =>
-          Scene.v().addBasicClass(x, SootClass.BODIES); x
-        }
-        .foreach(Scene.v().loadClassAndSupport(_).setApplicationClass())
-      Scene.v().loadNecessaryClasses()
+      loadClassesIntoSoot(sourceCodeDir, sourceFileNames)
       // Project Soot classes
-      val astCreator = new AstCreationPass(sourceCodePath, sourceFileNames, cpg, methodKeyPool)
+      val astCreator = new AstCreationPass(sourceCodeDir, sourceFileNames, cpg, methodKeyPool)
       astCreator.createAndApply()
       // Clear classes from Soot
       closeSoot()
@@ -113,24 +106,45 @@ class Jimple2Cpg {
     }
   }
 
+  /** Retrieve parseable files from archive types.
+    */
+  private def extractSourceFilesFromArchive(sourceCodeDir: String, archiveFileExtensions: Set[String]): List[String] = {
+    val archives = if (new JFile(sourceCodeDir).isFile) {
+      List(sourceCodeDir)
+    } else {
+      SourceFiles.determine(Set(sourceCodeDir), archiveFileExtensions)
+    }
+    archives.flatMap { x =>
+      unzipArchive(new ZipFile(x), sourceCodeDir) match {
+        case Failure(e) =>
+          throw new RuntimeException(s"Error extracting files from archive at $x", e)
+        case Success(files) => files
+      }
+    }
+  }
+
+  /** Load all source files from archive and/or source file types.
+    */
   private def loadSourceFiles(
       sourceCodePath: String,
       sourceFileExtensions: Set[String],
-      archives: List[String]
-  ) = {
-    (archives
-      .map(new ZipFile(_))
-      .flatMap(x => {
-        unzipArchive(x, sourceCodePath) match {
-          case Failure(e) =>
-            logger.error(s"Error extracting files from archive at ${x.getName}", e); null
-          case Success(value) => value
-        }
-      })
-      .map(_.getAbsolutePath) ++ SourceFiles.determine(
-      Set(sourceCodePath),
-      sourceFileExtensions
-    )).distinct
+      archiveFileExtensions: Set[String]
+  ): List[String] = {
+    (
+      extractSourceFilesFromArchive(sourceCodePath, archiveFileExtensions) ++
+        SourceFiles.determine(Set(sourceCodePath), sourceFileExtensions)
+    ).distinct
+  }
+
+  private def loadClassesIntoSoot(sourceCodePath: String, sourceFileNames: List[String]): Unit = {
+    sourceFileNames
+      .map { fName =>
+        val cp = getQualifiedClassPath(sourceCodePath, fName)
+        Scene.v().addBasicClass(cp, SootClass.BODIES)
+        cp
+      }
+      .foreach(Scene.v().loadClassAndSupport(_).setApplicationClass())
+    Scene.v().loadNecessaryClasses()
   }
 
   private def configureSoot(sourceCodePath: String): Unit = {
@@ -163,9 +177,8 @@ class Jimple2Cpg {
       zip
         .entries()
         .asScala
-        .filter(!_.isDirectory)
-        .filter(_.getName.contains(".class"))
-        .flatMap(entry => {
+        .filter(f => !f.isDirectory && f.getName.contains(".class"))
+        .flatMap { entry =>
           val sourceCodePathFile = new JFile(sourceCodePath)
           // Handle the case if the input source code path is an archive itself
           val destFile = if (sourceCodePathFile.isDirectory) {
@@ -186,7 +199,7 @@ class Jimple2Cpg {
               Files.copy(input, destFile.toPath)
             }
             destFile.deleteOnExit()
-            Option(destFile)
+            Option(destFile.getAbsolutePath)
           } catch {
             case e: Exception =>
               logger.warn(
@@ -195,7 +208,7 @@ class Jimple2Cpg {
               )
               Option.empty
           }
-        })
+        }
         .toSeq
     }
   }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -304,7 +304,7 @@ class AstCreator(filename: String, global: Global) {
       .columnNumber(column(parentUnit))
       .typeFullName(registerType(arrRef.getType.toQuotedString))
 
-    val astChildren = astsForValue(arrRef.getBase, 0, parentUnit) ++ astsForValue(arrRef.getIndex, 1, parentUnit)
+    val astChildren = astsForValue(arrRef.getBase, 1, parentUnit) ++ astsForValue(arrRef.getIndex, 2, parentUnit)
     Ast(indexAccess)
       .withChildren(astChildren)
       .withArgEdges(indexAccess, astChildren.flatMap(_.root))
@@ -377,15 +377,20 @@ class AstCreator(filename: String, global: Global) {
   }
 
   private def astForNewExpr(x: AnyNewExpr, order: Int, parentUnit: soot.Unit): Ast = {
-    Ast(
-      NewUnknown()
-        .typeFullName(registerType(x.getType.toQuotedString))
-        .code("new")
-        .order(order)
-        .argumentIndex(order)
-        .lineNumber(line(parentUnit))
-        .columnNumber(column(parentUnit))
-    )
+    x match {
+      case u: NewArrayExpr =>
+        astForUnaryExpr(Operators.arrayInitializer, x, u.getSize, order, parentUnit)
+      case _ =>
+        Ast(
+          NewUnknown()
+            .typeFullName(registerType(x.getType.toQuotedString))
+            .code("new")
+            .order(order)
+            .argumentIndex(order)
+            .lineNumber(line(parentUnit))
+            .columnNumber(column(parentUnit))
+        )
+    }
   }
 
   private def astForUnaryExpr(

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -379,7 +379,9 @@ class AstCreator(filename: String, global: Global) {
   private def astForNewExpr(x: AnyNewExpr, order: Int, parentUnit: soot.Unit): Ast = {
     x match {
       case u: NewArrayExpr =>
-        astForUnaryExpr(Operators.arrayInitializer, x, u.getSize, order, parentUnit)
+        astForArrayInitializeExpr(x, List(u.getSize), order, parentUnit)
+      case u: NewMultiArrayExpr =>
+        astForArrayInitializeExpr(x, u.getSizes.asScala, order, parentUnit)
       case _ =>
         Ast(
           NewUnknown()
@@ -391,6 +393,28 @@ class AstCreator(filename: String, global: Global) {
             .columnNumber(column(parentUnit))
         )
     }
+  }
+
+  private def astForArrayInitializeExpr(
+      arrayInitExpr: Expr,
+      sizes: Iterable[Value],
+      order: Int,
+      parentUnit: soot.Unit
+  ): Ast = {
+    val callBlock = NewCall()
+      .name(Operators.arrayInitializer)
+      .methodFullName(Operators.arrayInitializer)
+      .code(arrayInitExpr.toString())
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .order(order)
+      .typeFullName(registerType(arrayInitExpr.getType.toQuotedString))
+      .argumentIndex(order)
+      .lineNumber(line(parentUnit))
+      .columnNumber(column(parentUnit))
+    val valueAsts = withOrder(sizes) { (s, o) => astsForValue(s, o, parentUnit) }.flatten
+    Ast(callBlock)
+      .withChildren(valueAsts)
+      .withArgEdges(callBlock, valueAsts.flatMap(_.root))
   }
 
   private def astForUnaryExpr(

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ArrayTests.scala
@@ -1,0 +1,119 @@
+package io.joern.jimple2cpg.querying
+
+import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
+import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
+import io.shiftleft.semanticcpg.language._
+import org.scalatest.Failed
+
+class ArrayTests extends JimpleCodeToCpgFixture {
+
+  implicit val resolver: ICallResolver = NoResolve
+
+  override val code: String =
+    """
+      |class Foo {
+      |  public void foo() {
+      |    int[] x = {0, 1, 2};
+      |  }
+      |
+      |  public void bar() {
+      |    int[][] x = new int[5][2];
+      |  }
+      |
+      |  public void baz() {
+      |    int[] x = new int[2];
+      |    x[0] = 1;
+      |    x[1] = x[0] + 2;
+      |  }
+      |}
+      |""".stripMargin
+
+  "should initialize array with three address code initialization expressions" in {
+    def m = cpg.method(".*foo.*")
+
+    val List(placeholderArg: Identifier, arrayInit: Call) =
+      m.assignment.codeExact("$stack2 = newarray (int)[3]").argument.l
+    placeholderArg.code shouldBe "$stack2"
+    placeholderArg.typeFullName shouldBe "int[]"
+
+    arrayInit.code shouldBe "newarray (int)[3]"
+    arrayInit.methodFullName shouldBe Operators.arrayInitializer
+    arrayInit.astChildren.headOption match {
+      case Some(alloc) =>
+        alloc shouldBe a[Literal]
+        alloc.code shouldBe "3"
+      case None => Failed("arrayInitializer should have a literal with the value of 3")
+    }
+
+    val List(stackAt0: Call, arg0: Literal) = m.assignment.codeExact("$stack2[0] = 0").argument.l
+
+    arg0.code shouldBe "0"
+    arg0.typeFullName shouldBe "int"
+
+    stackAt0.code shouldBe "$stack2[0]"
+    stackAt0.methodFullName shouldBe Operators.indexAccess
+    val List(stackPointerAt0: Identifier, zero: Literal) = stackAt0.astChildren.l
+    stackPointerAt0.code shouldBe "$stack2"
+    zero.code shouldBe "0"
+
+    val List(stackAt1: Call, arg1: Literal) = m.assignment.codeExact("$stack2[1] = 1").argument.l
+
+    arg1.code shouldBe "1"
+    arg1.typeFullName shouldBe "int"
+
+    stackAt1.code shouldBe "$stack2[1]"
+    stackAt1.methodFullName shouldBe Operators.indexAccess
+    val List(stackPointerAt1: Identifier, one: Literal) = stackAt1.astChildren.l
+    stackPointerAt1.code shouldBe "$stack2"
+    one.code shouldBe "1"
+
+    val List(stackAt2: Call, arg2: Literal) = m.assignment.codeExact("$stack2[2] = 2").argument.l
+
+    arg2.code shouldBe "2"
+    arg2.typeFullName shouldBe "int"
+
+    stackAt2.code shouldBe "$stack2[2]"
+    stackAt2.methodFullName shouldBe Operators.indexAccess
+    val List(stackPointerAt2: Identifier, two: Literal) = stackAt2.astChildren.l
+    stackPointerAt2.code shouldBe "$stack2"
+    two.code shouldBe "2"
+  }
+
+  "should initialize an array with empty initialization expression" in {
+    def m = cpg.method(".*bar.*")
+
+    val List(arg1: Identifier, arg2: Call) =
+      m.assignment.codeExact("x = newmultiarray (int)[5][2]").argument.l
+
+    arg1.typeFullName shouldBe "int[][]"
+
+    arg2.code shouldBe "newmultiarray (int)[5][2]"
+    val List(lvl1: Literal, lvl2: Literal) = arg2.argument.l
+    lvl1.code shouldBe "5"
+    lvl2.code shouldBe "2"
+  }
+
+  "should handle arrayIndexAccesses correctly (3-address code form)" in {
+    def m = cpg.method(".*baz.*")
+
+    val List(indexAccess: Call, rhsStub: Identifier) = m.assignment.codeExact("x[1] = $stack3").argument.l
+    indexAccess.name shouldBe Operators.indexAccess
+    indexAccess.methodFullName shouldBe Operators.indexAccess
+
+    withClue("indexAccess on LHS of assignment") {
+      val List(arg1: Identifier, arg2: Literal) = indexAccess.argument.l
+      arg1.code shouldBe "x"
+      arg1.name shouldBe "x"
+      arg1.typeFullName shouldBe "int[]"
+      arg2.code shouldBe "1"
+    }
+
+    withClue("placeholder in expr on RHS of assignment") {
+      rhsStub.name shouldBe "$stack3"
+      rhsStub.typeFullName shouldBe "int"
+      rhsStub.code shouldBe "$stack3"
+    }
+  }
+}


### PR DESCRIPTION
- Fixed access path issue where array index accesses were reported to be invalid ASTs. This was just a change in AST children's `order` from `(0, 1)` to `(1, 2)`
- Updated frontend to leverage `Call(<operator>.arrayInitializer)` instead of `Unknown(new)` vertices
- Support for multi-array creation added
- Array tests derived from JavaSrc2Cpg included
- Fixed bug where if a single file was specified then all files in the directory were loaded