### PR TITLE
Handle nested type declarations in javasrc2cpg

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -294,7 +294,7 @@ class AstCreator(filename: String, typeInfoProvider: TypeInfoProvider) {
       AstWithCtx(ast.withChildren(typeDeclAsts).withChildren(lambdaTypeDeclAsts), mergedCtx)
     } catch {
       case t: Throwable =>
-        println(s"Parsing failed with $t")
+        logger.error(s"Parsing file $filename failed with $t")
         throw t
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1,18 +1,118 @@
 package io.joern.javasrc2cpg.passes
 
 import com.github.javaparser.ast.{CompilationUnit, Node, NodeList, PackageDeclaration}
-import com.github.javaparser.ast.body.{BodyDeclaration, CallableDeclaration, ConstructorDeclaration, EnumConstantDeclaration, FieldDeclaration, MethodDeclaration, Parameter, TypeDeclaration, VariableDeclarator}
+import com.github.javaparser.ast.body.{
+  BodyDeclaration,
+  CallableDeclaration,
+  ConstructorDeclaration,
+  EnumConstantDeclaration,
+  FieldDeclaration,
+  MethodDeclaration,
+  Parameter,
+  TypeDeclaration,
+  VariableDeclarator
+}
 import com.github.javaparser.ast.expr.AssignExpr.Operator
-import com.github.javaparser.ast.expr.{AnnotationExpr, ArrayAccessExpr, ArrayCreationExpr, ArrayInitializerExpr, AssignExpr, BinaryExpr, BooleanLiteralExpr, CastExpr, CharLiteralExpr, ClassExpr, ConditionalExpr, DoubleLiteralExpr, EnclosedExpr, Expression, FieldAccessExpr, InstanceOfExpr, IntegerLiteralExpr, LambdaExpr, LiteralExpr, LongLiteralExpr, MethodCallExpr, MethodReferenceExpr, NameExpr, NullLiteralExpr, ObjectCreationExpr, PatternExpr, StringLiteralExpr, SuperExpr, SwitchExpr, TextBlockLiteralExpr, ThisExpr, TypeExpr, UnaryExpr, VariableDeclarationExpr}
+import com.github.javaparser.ast.expr.{
+  AnnotationExpr,
+  ArrayAccessExpr,
+  ArrayCreationExpr,
+  ArrayInitializerExpr,
+  AssignExpr,
+  BinaryExpr,
+  BooleanLiteralExpr,
+  CastExpr,
+  CharLiteralExpr,
+  ClassExpr,
+  ConditionalExpr,
+  DoubleLiteralExpr,
+  EnclosedExpr,
+  Expression,
+  FieldAccessExpr,
+  InstanceOfExpr,
+  IntegerLiteralExpr,
+  LambdaExpr,
+  LiteralExpr,
+  LongLiteralExpr,
+  MethodCallExpr,
+  MethodReferenceExpr,
+  NameExpr,
+  NullLiteralExpr,
+  ObjectCreationExpr,
+  PatternExpr,
+  StringLiteralExpr,
+  SuperExpr,
+  SwitchExpr,
+  TextBlockLiteralExpr,
+  ThisExpr,
+  TypeExpr,
+  UnaryExpr,
+  VariableDeclarationExpr
+}
 import com.github.javaparser.ast.nodeTypes.NodeWithType
-import com.github.javaparser.ast.stmt.{AssertStmt, BlockStmt, BreakStmt, CatchClause, ContinueStmt, DoStmt, EmptyStmt, ExplicitConstructorInvocationStmt, ExpressionStmt, ForEachStmt, ForStmt, IfStmt, LabeledStmt, LocalClassDeclarationStmt, LocalRecordDeclarationStmt, ReturnStmt, Statement, SwitchEntry, SwitchStmt, SynchronizedStmt, ThrowStmt, TryStmt, UnparsableStmt, WhileStmt, YieldStmt}
+import com.github.javaparser.ast.stmt.{
+  AssertStmt,
+  BlockStmt,
+  BreakStmt,
+  CatchClause,
+  ContinueStmt,
+  DoStmt,
+  EmptyStmt,
+  ExplicitConstructorInvocationStmt,
+  ExpressionStmt,
+  ForEachStmt,
+  ForStmt,
+  IfStmt,
+  LabeledStmt,
+  LocalClassDeclarationStmt,
+  LocalRecordDeclarationStmt,
+  ReturnStmt,
+  Statement,
+  SwitchEntry,
+  SwitchStmt,
+  SynchronizedStmt,
+  ThrowStmt,
+  TryStmt,
+  UnparsableStmt,
+  WhileStmt,
+  YieldStmt
+}
 import com.github.javaparser.resolution.Resolvable
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType}
 import io.joern.javasrc2cpg.passes.AstWithCtx.astWithCtxToSeq
 import io.joern.javasrc2cpg.passes.Context.mergedCtx
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, EdgeTypes, EvaluationStrategies, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBinding, NewBlock, NewCall, NewClosureBinding, NewControlStructure, NewFieldIdentifier, NewIdentifier, NewJumpTarget, NewLiteral, NewLocal, NewMember, NewMethod, NewMethodParameterIn, NewMethodRef, NewMethodReturn, NewModifier, NewNamespaceBlock, NewNode, NewReturn, NewTypeDecl, NewTypeRef, NewUnknown}
+import io.shiftleft.codepropertygraph.generated.{
+  ControlStructureTypes,
+  DispatchTypes,
+  EdgeTypes,
+  EvaluationStrategies,
+  Operators
+}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  NewBinding,
+  NewBlock,
+  NewCall,
+  NewClosureBinding,
+  NewControlStructure,
+  NewFieldIdentifier,
+  NewIdentifier,
+  NewJumpTarget,
+  NewLiteral,
+  NewLocal,
+  NewMember,
+  NewMethod,
+  NewMethodParameterIn,
+  NewMethodRef,
+  NewMethodReturn,
+  NewModifier,
+  NewNamespaceBlock,
+  NewNode,
+  NewReturn,
+  NewTypeDecl,
+  NewTypeRef,
+  NewUnknown
+}
 import io.shiftleft.passes.DiffGraph
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName
 import io.shiftleft.x2cpg.Ast
@@ -281,7 +381,7 @@ class AstCreator(filename: String, typeInfoProvider: TypeInfoProvider) {
       typ: TypeDeclaration[_],
       order: Int,
       astParentType: String,
-      astParentFullName: String,
+      astParentFullName: String
   ): AstWithCtx = {
     val baseTypeFullNames = if (typ.isClassOrInterfaceDeclaration) {
       val decl = typ.asClassOrInterfaceDeclaration()
@@ -317,8 +417,15 @@ class AstCreator(filename: String, typeInfoProvider: TypeInfoProvider) {
       List.empty
     }
 
-    val (memberAsts, _) = withOrderAndCtx(typ.getMembers.asScala, initScopeContext, initialOrder = enumEntryAsts.size) { (member, scopeContext, idx) =>
-      astForTypeDeclMember(member, scopeContext, order + idx, astParentType = "TYPE_DECL", astParentFullName = typeFullName)
+    val (memberAsts, _) = withOrderAndCtx(typ.getMembers.asScala, initScopeContext, initialOrder = enumEntryAsts.size) {
+      (member, scopeContext, idx) =>
+        astForTypeDeclMember(
+          member,
+          scopeContext,
+          order + idx,
+          astParentType = "TYPE_DECL",
+          astParentFullName = typeFullName
+        )
     }
 
     val typeDeclAst = Ast(typeDecl)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
@@ -60,8 +60,7 @@ class TypeInfoProvider(global: Global) {
   }
 
   private def buildTypeString(packageName: String, className: String, typeParameterString: String): String = {
-    // val dollaredClass = className.replaceAll("\\.", "\\$")
-    val dollaredClass = className
+    val dollaredClass = className.replaceAll("\\.", "\\$")
     if (packageName.nonEmpty) {
       s"$packageName.$dollaredClass$typeParameterString"
     } else {
@@ -150,8 +149,7 @@ class TypeInfoProvider(global: Global) {
 
       typeDecl.getParentNode.toScala match {
         case Some(parentDecl: TypeDeclaration[_]) =>
-          // typeNameForTypeDecl(parentDecl, fullName) ++ "$" ++ typeDecl.getNameAsString
-          typeNameForTypeDecl(parentDecl, fullName) ++ "." ++ typeDecl.getNameAsString
+          typeNameForTypeDecl(parentDecl, fullName) ++ "$" ++ typeDecl.getNameAsString
 
         case _ =>
           logger.warn("typeNameForTypeDecl expected nested typeDecl to have typeDecl parent.")

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
@@ -1,39 +1,12 @@
 package io.joern.javasrc2cpg.passes
 
 import com.github.javaparser.ast.`type`.ClassOrInterfaceType
-import com.github.javaparser.ast.body.{
-  ConstructorDeclaration,
-  EnumConstantDeclaration,
-  MethodDeclaration,
-  TypeDeclaration,
-  VariableDeclarator
-}
-import com.github.javaparser.ast.expr.{
-  BooleanLiteralExpr,
-  CharLiteralExpr,
-  DoubleLiteralExpr,
-  Expression,
-  IntegerLiteralExpr,
-  LiteralExpr,
-  LongLiteralExpr,
-  MethodCallExpr,
-  NameExpr,
-  NullLiteralExpr,
-  StringLiteralExpr,
-  TextBlockLiteralExpr,
-  ThisExpr
-}
+import com.github.javaparser.ast.body.{ConstructorDeclaration, EnumConstantDeclaration, MethodDeclaration, TypeDeclaration, VariableDeclarator}
+import com.github.javaparser.ast.expr.{BooleanLiteralExpr, CharLiteralExpr, DoubleLiteralExpr, Expression, IntegerLiteralExpr, LiteralExpr, LongLiteralExpr, MethodCallExpr, NameExpr, NullLiteralExpr, StringLiteralExpr, TextBlockLiteralExpr, ThisExpr}
 import com.github.javaparser.ast.nodeTypes.NodeWithType
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt
 import com.github.javaparser.resolution.Resolvable
-import com.github.javaparser.resolution.declarations.{
-  ResolvedDeclaration,
-  ResolvedMethodDeclaration,
-  ResolvedMethodLikeDeclaration,
-  ResolvedReferenceTypeDeclaration,
-  ResolvedTypeDeclaration,
-  ResolvedTypeParameterDeclaration
-}
+import com.github.javaparser.resolution.declarations.{ResolvedDeclaration, ResolvedMethodDeclaration, ResolvedMethodLikeDeclaration, ResolvedParameterDeclaration, ResolvedReferenceTypeDeclaration, ResolvedTypeDeclaration, ResolvedTypeParameterDeclaration}
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType}
 import org.slf4j.LoggerFactory
 
@@ -284,6 +257,12 @@ class TypeInfoProvider(global: Global) {
         logger.info(s"Could not resolve type for constructor invocation $invocation. Defaulting to <empty>.")
         "<empty>"
     }
+
+    registerType(typeFullName)
+  }
+
+  def getTypeFullName(resolvedParam: ResolvedParameterDeclaration): String = {
+    val typeFullName = resolvedTypeFullName(resolvedParam.getType)
 
     registerType(typeFullName)
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
@@ -1,12 +1,40 @@
 package io.joern.javasrc2cpg.passes
 
 import com.github.javaparser.ast.`type`.ClassOrInterfaceType
-import com.github.javaparser.ast.body.{ConstructorDeclaration, EnumConstantDeclaration, MethodDeclaration, TypeDeclaration, VariableDeclarator}
-import com.github.javaparser.ast.expr.{BooleanLiteralExpr, CharLiteralExpr, DoubleLiteralExpr, Expression, IntegerLiteralExpr, LiteralExpr, LongLiteralExpr, MethodCallExpr, NameExpr, NullLiteralExpr, StringLiteralExpr, TextBlockLiteralExpr, ThisExpr}
+import com.github.javaparser.ast.body.{
+  ConstructorDeclaration,
+  EnumConstantDeclaration,
+  MethodDeclaration,
+  TypeDeclaration,
+  VariableDeclarator
+}
+import com.github.javaparser.ast.expr.{
+  BooleanLiteralExpr,
+  CharLiteralExpr,
+  DoubleLiteralExpr,
+  Expression,
+  IntegerLiteralExpr,
+  LiteralExpr,
+  LongLiteralExpr,
+  MethodCallExpr,
+  NameExpr,
+  NullLiteralExpr,
+  StringLiteralExpr,
+  TextBlockLiteralExpr,
+  ThisExpr
+}
 import com.github.javaparser.ast.nodeTypes.NodeWithType
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt
 import com.github.javaparser.resolution.Resolvable
-import com.github.javaparser.resolution.declarations.{ResolvedDeclaration, ResolvedMethodDeclaration, ResolvedMethodLikeDeclaration, ResolvedParameterDeclaration, ResolvedReferenceTypeDeclaration, ResolvedTypeDeclaration, ResolvedTypeParameterDeclaration}
+import com.github.javaparser.resolution.declarations.{
+  ResolvedDeclaration,
+  ResolvedMethodDeclaration,
+  ResolvedMethodLikeDeclaration,
+  ResolvedParameterDeclaration,
+  ResolvedReferenceTypeDeclaration,
+  ResolvedTypeDeclaration,
+  ResolvedTypeParameterDeclaration
+}
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType}
 import org.slf4j.LoggerFactory
 
@@ -32,7 +60,8 @@ class TypeInfoProvider(global: Global) {
   }
 
   private def buildTypeString(packageName: String, className: String, typeParameterString: String): String = {
-    val dollaredClass = className.replaceAll("\\.", "\\$")
+    // val dollaredClass = className.replaceAll("\\.", "\\$")
+    val dollaredClass = className
     if (packageName.nonEmpty) {
       s"$packageName.$dollaredClass$typeParameterString"
     } else {
@@ -121,7 +150,8 @@ class TypeInfoProvider(global: Global) {
 
       typeDecl.getParentNode.toScala match {
         case Some(parentDecl: TypeDeclaration[_]) =>
-          typeNameForTypeDecl(parentDecl, fullName) ++ "$" ++ typeDecl.getNameAsString
+          // typeNameForTypeDecl(parentDecl, fullName) ++ "$" ++ typeDecl.getNameAsString
+          typeNameForTypeDecl(parentDecl, fullName) ++ "." ++ typeDecl.getNameAsString
 
         case _ =>
           logger.warn("typeNameForTypeDecl expected nested typeDecl to have typeDecl parent.")

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
@@ -71,21 +71,27 @@ class TypeInfoProvider(global: Global) {
       declaration: ResolvedTypeDeclaration,
       typeParameterString: String = ""
   ): String = {
-    buildTypeString(declaration.getPackageName, declaration.getClassName, typeParameterString)
+    val packageName = Try(declaration.getPackageName).getOrElse("")
+    val className = Try(declaration.getClassName).getOrElse(declaration.getName)
+    buildTypeString(packageName, className, typeParameterString)
   }
 
   private def resolvedTypeParamFullName(
       declaration: ResolvedTypeParameterDeclaration,
       typeParameterString: String = ""
   ): String = {
-    buildTypeString(declaration.getPackageName, declaration.getClassName, typeParameterString)
+    val packageName = Try(declaration.getPackageName).getOrElse("")
+    val className = Try(declaration.getClassName).getOrElse(declaration.getName)
+    buildTypeString(packageName, className, typeParameterString)
   }
 
   private def resolvedMethodLikeDeclFullName(
       declaration: ResolvedMethodLikeDeclaration,
       typeParameterString: String = ""
   ): String = {
-    val baseString = buildTypeString(declaration.getPackageName, declaration.getClassName, typeParameterString)
+    val packageName = Try(declaration.getPackageName).getOrElse("")
+    val className = Try(declaration.getClassName).getOrElse(declaration.getName)
+    val baseString = buildTypeString(packageName, className, typeParameterString)
     val typeParameters =
       declaration.getTypeParameters.asScala.map(resolvedTypeParamFullName(_, typeParameterString)).toList
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
@@ -131,17 +131,21 @@ class TypeInfoProvider(global: Global) {
     }
   }
 
-  private def typeFullNameForTypeDecl(typeDecl: TypeDeclaration[_]): String = {
-    val javaParserName = typeDecl.getFullyQualifiedName.toScala.getOrElse(typeDecl.getNameAsString)
+  private def typeNameForTypeDecl(typeDecl: TypeDeclaration[_], fullName: Boolean): String = {
+    val javaParserName = if (fullName) {
+      typeDecl.getFullyQualifiedName.toScala.getOrElse(typeDecl.getNameAsString)
+    } else {
+      typeDecl.getNameAsString
+    }
 
     if (typeDecl.isNestedType) {
 
       typeDecl.getParentNode.toScala match {
         case Some(parentDecl: TypeDeclaration[_]) =>
-          typeFullNameForTypeDecl(parentDecl) ++ "$" ++ typeDecl.getNameAsString
+          typeNameForTypeDecl(parentDecl, fullName) ++ "$" ++ typeDecl.getNameAsString
 
         case _ =>
-          logger.warn("typeFullNameForTypeDecl expected nested typeDecl to have typeDecl parent.")
+          logger.warn("typeNameForTypeDecl expected nested typeDecl to have typeDecl parent.")
           javaParserName
       }
 
@@ -150,8 +154,13 @@ class TypeInfoProvider(global: Global) {
     }
   }
 
-  def getTypeFullName(typeDecl: TypeDeclaration[_]): String = {
-    registerType(typeFullNameForTypeDecl(typeDecl))
+  def getTypeName(typeDecl: TypeDeclaration[_], fullName: Boolean = true): String = {
+    val typeName = typeNameForTypeDecl(typeDecl, fullName)
+    if (fullName) {
+      registerType(typeName)
+    } else {
+      typeName
+    }
   }
 
   def getTypeFullName(node: NodeWithType[_, _ <: Resolvable[ResolvedType]]): String = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
@@ -56,7 +56,7 @@ class EnumTests extends JavaSrcCodeToCpgFixture {
     cpg.typeDecl.name(".*Color.*").nonEmpty shouldBe true
     // 2 enum values and `label` makes 3 members
     cpg.typeDecl.name(".*Color.*").member.size shouldBe 3
-    val List(l, r, b) = cpg.typeDecl.name(".*Color.*").member.l
+    val List(r, b, l) = cpg.typeDecl.name(".*Color.*").member.l
 
     l.code shouldBe "java.lang.String label"
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
@@ -96,11 +96,10 @@ class TypeDeclTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should create type decl for inner class implementing interface" in {
-    // TODO Fix this
-    cpg.typeDecl.name("OuterClass$InnerClass").l match {
+    cpg.typeDecl.nameExact("OuterClass$InnerClass").l match {
       case List(innerClass) =>
-        innerClass.fullName shouldBe "a.b.c.d.OuterClas$.InnerClass"
-        innerClass.inheritsFromTypeFullName should contain theSameElementsAs List("Foo.OuterClass.InnerInterface")
+        innerClass.fullName shouldBe "a.b.c.d.OuterClass$InnerClass"
+        innerClass.inheritsFromTypeFullName should contain theSameElementsAs List("a.b.c.d.OuterClass$InnerInterface")
         innerClass.isExternal shouldBe false
 
         innerClass.method.nameExact("id").l match {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
@@ -74,4 +74,47 @@ class TypeDeclTests extends JavaSrcCodeToCpgFixture {
     x.filename shouldBe FileTraversal.UNKNOWN
   }
 
+  "should create a correct type decl for inner interface" in {
+    cpg.typeDecl.nameExact("OuterClass$InnerInterface").l match {
+      case List(interface) =>
+        interface.fullName shouldBe "a.b.c.d.OuterClass$InnerInterface"
+        interface.inheritsFromTypeFullName.toList shouldBe List()
+        interface.isExternal shouldBe false
+        interface.method.toList match {
+          case List(method) =>
+            method.name shouldBe "id"
+            method.fullName shouldBe "a.b.c.d.OuterClass$InnerInterface.id:int(int)"
+            method.signature shouldBe "int(int)"
+            method.parameter.size shouldBe 2
+          // TODO: Add and check modifiers
+
+          case res => fail(s"Expected method id on interface but got $res")
+        }
+
+      case res => fail(s"Expected typeDecl for interface but got $res")
+    }
+  }
+
+  "should create type decl for inner class implementing interface" in {
+    // TODO Fix this
+    cpg.typeDecl.name("OuterClass$InnerClass").l match {
+      case List(innerClass) =>
+        innerClass.fullName shouldBe "a.b.c.d.OuterClas$.InnerClass"
+        innerClass.inheritsFromTypeFullName should contain theSameElementsAs List("Foo.OuterClass.InnerInterface")
+        innerClass.isExternal shouldBe false
+
+        innerClass.method.nameExact("id").l match {
+          case List(method) =>
+            method.fullName shouldBe "a.b.c.d.OuterClass$InnerClass.id:int(int)"
+            method.signature shouldBe "int(int)"
+            method.block.astChildren.head shouldBe a[Return]
+            method.block.ast.isIdentifier.head.name shouldBe "x"
+
+          case res => fail(s"Expected id method in InnerClass but got $res")
+        }
+
+      case res => fail(s"Expected type decl for inner class but got $res")
+    }
+  }
+
 }


### PR DESCRIPTION
* Before we only parsed top-level classes. This PR adds recursive parsing for nested type declarations. Note: This still doesn't add support for classes defined in methods (as opposed to in other classes). Support for that will be added along with support for lambdas.
* Change nested class names to be consistent with java2cpg where class names are separated by a `$` instead of a `.`
* Fix some type name issues from a previous PR.