### PR TITLE
Make use of deduplicated CFG edges for dot generation from codepropertygraph

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.7"
 
-val cpgVersion = "1.3.494"
+val cpgVersion = "1.3.495"
 val js2cpgVersion = "0.2.100"
 
 lazy val joerncli = Projects.joerncli

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.7"
 
-val cpgVersion = "1.3.493"
+val cpgVersion = "1.3.494"
 val js2cpgVersion = "0.2.100"
 
 lazy val joerncli = Projects.joerncli

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotCfgGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotCfgGeneratorTests.scala
@@ -3,7 +3,7 @@ package io.joern.c2cpg.dotgenerator
 import io.joern.c2cpg.testfixtures.CCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 
-class DotCfgGeneratorTests extends CCodeToCpgSuite {
+class DotCfgGeneratorTest1 extends CCodeToCpgSuite {
 
   override val code: String =
     """
@@ -20,8 +20,8 @@ class DotCfgGeneratorTests extends CCodeToCpgSuite {
   "A CfgDotGenerator" should {
 
     "create a dot graph" in {
-      inside(cpg.method.name("main").dotCfg.l) { case List(x) =>
-        x should (
+      inside(cpg.method.name("main").dotCfg.l) { case List(dotStr) =>
+        dotStr should (
           startWith("digraph \"main\" {") and
             include("(<operator>.assignment,i = 0)") and
             endWith("}\n")
@@ -30,8 +30,8 @@ class DotCfgGeneratorTests extends CCodeToCpgSuite {
     }
 
     "not contain IDENTIFIER nodes" in {
-      inside(cpg.method.name("main").dotCfg.l) { case List(x) =>
-        x should not include "IDENTIFIER"
+      inside(cpg.method.name("main").dotCfg.l) { case List(dotStr) =>
+        dotStr should not include "IDENTIFIER"
       }
     }
 
@@ -44,6 +44,31 @@ class DotCfgGeneratorTests extends CCodeToCpgSuite {
     "contain seven edges" in {
       inside(cpg.method.name("main").dotCfg.l) { case List(dotStr) =>
         dotStr.split("\n").count(x => x.contains("->")) shouldBe 7
+      }
+    }
+
+  }
+
+}
+
+class DotCfgGeneratorTest2 extends CCodeToCpgSuite {
+
+  override val code: String =
+    """
+      |bool a;
+      |bool b;
+      |
+      |bool test() {
+      |  return a ? a : b;
+      |}""".stripMargin
+
+  "A CfgDotGenerator" should {
+
+    "not contain the same edge more than once" in {
+      inside(cpg.method.name("test").dotCfg.l) { case List(dotStr) =>
+        val rawEdges = dotStr.split("\n").filter(x => x.contains("->"))
+        val dedupEdges = rawEdges.distinct
+        rawEdges.length shouldBe dedupEdges.length
       }
     }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotDdgGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotDdgGeneratorTests.scala
@@ -5,7 +5,7 @@ import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language._
 
-class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
+class DotDdgGeneratorTest1 extends DataFlowCodeToCpgSuite {
 
   override val code: String =
     """
@@ -33,7 +33,7 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
   }
 }
 
-class DotDdgGeneratorTests2 extends DataFlowCodeToCpgSuite {
+class DotDdgGeneratorTest2 extends DataFlowCodeToCpgSuite {
 
   override val code: String =
     """


### PR DESCRIPTION
Depends on: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1588
Fixes: https://github.com/joernio/joern/issues/969