### PR TITLE
Use ammonite parser instead of scala metas parser.

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -23,7 +23,6 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "ammonite" % AmmoniteVersion cross CrossVersion.full,
   "com.lihaoyi" %% "os-lib" % "0.8.1",
   "com.lihaoyi" %% "cask" % CaskVersion,
-  "org.scalameta" %% "scalameta" % "4.4.33",
   "org.scalatest" %% "scalatest" % Versions.scalatest % Test,
 )
 


### PR DESCRIPTION
This is part of Scala 3 preparations. We need to get rid of the scala
meta dependency since it has transitive dependency conflicts.