### PR TITLE
Fixed fullName calculation

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -215,62 +215,60 @@ trait AstCreatorHelper {
   }
 
   protected def fullName(node: IASTNode): String = {
-    val qualifiedName = node match {
+    val qualifiedName: String = node match {
       case d: CPPASTIdExpression if d.getEvaluation.isInstanceOf[EvalBinding] =>
         val evaluation = d.getEvaluation.asInstanceOf[EvalBinding]
         evaluation.getBinding match {
           case f: CPPFunction if f.getDeclarations != null =>
             usingDeclarationMappings.getOrElse(
-              fixQualifiedName(nodeSignature(d.getName)),
-              f.getDeclarations.headOption.map(x => nodeSignature(x.getName)).getOrElse(f.getName)
+              fixQualifiedName(ASTStringUtil.getSimpleName(d.getName)),
+              f.getDeclarations.headOption.map(n => ASTStringUtil.getSimpleName(n.getName)).getOrElse(f.getName)
             )
           case f: CPPFunction if f.getDefinition != null =>
             usingDeclarationMappings.getOrElse(
-              fixQualifiedName(nodeSignature(d.getName)),
-              nodeSignature(f.getDefinition.getName)
+              fixQualifiedName(ASTStringUtil.getSimpleName(d.getName)),
+              ASTStringUtil.getSimpleName(f.getDefinition.getName)
             )
           case other => other.getName
         }
-      case alias: ICPPASTNamespaceAlias =>
-        nodeSignature(alias.getMappingName)
-      case namespace: ICPPASTNamespaceDefinition if nodeSignature(namespace.getName).nonEmpty =>
-        fullName(namespace.getParent) + "." + nodeSignature(namespace.getName)
-      case namespace: ICPPASTNamespaceDefinition if nodeSignature(namespace.getName).isEmpty =>
+      case alias: ICPPASTNamespaceAlias => alias.getMappingName.toString
+      case namespace: ICPPASTNamespaceDefinition if ASTStringUtil.getSimpleName(namespace.getName).nonEmpty =>
+        fullName(namespace.getParent) + "." + ASTStringUtil.getSimpleName(namespace.getName)
+      case namespace: ICPPASTNamespaceDefinition if ASTStringUtil.getSimpleName(namespace.getName).isEmpty =>
         fullName(namespace.getParent) + "." + uniqueName("namespace", "", "")._1
-      case cppClass: ICPPASTCompositeTypeSpecifier if nodeSignature(cppClass.getName).nonEmpty =>
-        fullName(cppClass.getParent) + "." + cppClass.getName.toString
-      case cppClass: ICPPASTCompositeTypeSpecifier if nodeSignature(cppClass.getName).isEmpty =>
+      case cppClass: ICPPASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(cppClass.getName).nonEmpty =>
+        fullName(cppClass.getParent) + "." + ASTStringUtil.getSimpleName(cppClass.getName)
+      case cppClass: ICPPASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(cppClass.getName).isEmpty =>
         val name = cppClass.getParent match {
           case decl: IASTSimpleDeclaration =>
             decl.getDeclarators.headOption
-              .map(x => nodeSignature(x.getName))
+              .map(n => ASTStringUtil.getSimpleName(n.getName))
               .getOrElse(uniqueName("composite_type", "", "")._1)
           case _ => uniqueName("composite_type", "", "")._1
         }
-        val fullname = s"${fullName(cppClass.getParent)}.$name"
-        fullname
+        s"${fullName(cppClass.getParent)}.$name"
       case enumSpecifier: IASTEnumerationSpecifier =>
-        fullName(enumSpecifier.getParent) + "." + nodeSignature(enumSpecifier.getName)
-      case c: IASTCompositeTypeSpecifier => nodeSignature(c.getName)
-      case f: IASTFunctionDeclarator if f.getName.toString.isEmpty && f.getNestedDeclarator != null =>
-        fullName(f.getParent) + "." + nodeSignature(f.getNestedDeclarator.getName)
+        fullName(enumSpecifier.getParent) + "." + ASTStringUtil.getSimpleName(enumSpecifier.getName)
+      case c: IASTCompositeTypeSpecifier =>
+        fullName(c.getParent) + "." + ASTStringUtil.getSimpleName(c.getName)
+      case f: IASTFunctionDeclarator
+          if ASTStringUtil.getSimpleName(f.getName).isEmpty && f.getNestedDeclarator != null =>
+        fullName(f.getParent) + "." + ASTStringUtil.getSimpleName(f.getNestedDeclarator.getName)
       case f: IASTFunctionDeclarator =>
-        fullName(f.getParent) + "." + nodeSignature(f.getName)
+        fullName(f.getParent) + "." + ASTStringUtil.getSimpleName(f.getName)
       case f: ICPPASTLambdaExpression =>
         fullName(f.getParent) + "."
+      case f: IASTFunctionDefinition if f.getDeclarator != null =>
+        fullName(f.getParent) + "." + ASTStringUtil.getQualifiedName(f.getDeclarator.getName)
       case f: IASTFunctionDefinition =>
-        fullName(f.getParent) + "." + nodeSignature(f.getDeclarator.getName)
-      case d: IASTIdExpression    => nodeSignature(d.getName)
-      case _: IASTTranslationUnit => ""
-      case u: IASTUnaryExpression => nodeSignature(u.getOperand)
-      case e: IASTElaboratedTypeSpecifier =>
-        fullName(e.getParent) + "." + nodeSignature(e.getName)
-      case other if other.getParent != null =>
-        fullName(other.getParent)
-      case other if other != null =>
-        notHandledYet(other, -1); ""
-      case null =>
-        ""
+        fullName(f.getParent) + "." + ASTStringUtil.getSimpleName(f.getDeclarator.getName)
+      case d: IASTIdExpression              => ASTStringUtil.getSimpleName(d.getName)
+      case _: IASTTranslationUnit           => ""
+      case u: IASTUnaryExpression           => nodeSignature(u.getOperand)
+      case e: IASTElaboratedTypeSpecifier   => fullName(e.getParent) + "." + ASTStringUtil.getSimpleName(e.getName)
+      case other if other.getParent != null => fullName(other.getParent)
+      case other if other != null           => notHandledYet(other, -1); ""
+      case null                             => ""
     }
     val cleaned = fixQualifiedName(qualifiedName)
     if (cleaned.startsWith(".")) {
@@ -280,22 +278,23 @@ trait AstCreatorHelper {
 
   protected def shortName(node: IASTNode): String = {
     val name = node match {
-      case f: ICPPASTFunctionDefinition => lastNameOfQualifiedName(f.getDeclarator.getName.toString)
-      case f: IASTFunctionDefinition    => f.getDeclarator.getName.toString
-      case f: IASTFunctionDeclarator if f.getName.toString.isEmpty && f.getNestedDeclarator != null =>
-        f.getNestedDeclarator.getName.toString
-      case f: IASTFunctionDeclarator => f.getName.toString
+      case f: ICPPASTFunctionDefinition => lastNameOfQualifiedName(ASTStringUtil.getSimpleName(f.getDeclarator.getName))
+      case f: IASTFunctionDefinition    => ASTStringUtil.getSimpleName(f.getDeclarator.getName)
+      case f: IASTFunctionDeclarator
+          if ASTStringUtil.getSimpleName(f.getName).isEmpty && f.getNestedDeclarator != null =>
+        ASTStringUtil.getSimpleName(f.getNestedDeclarator.getName)
+      case f: IASTFunctionDeclarator => ASTStringUtil.getSimpleName(f.getName)
       case d: CPPASTIdExpression if d.getEvaluation.isInstanceOf[EvalBinding] =>
         val evaluation = d.getEvaluation.asInstanceOf[EvalBinding]
         evaluation.getBinding match {
           case f: CPPFunction if f.getDeclarations != null =>
-            f.getDeclarations.headOption.map(_.getName.toString).getOrElse(f.getName)
+            f.getDeclarations.headOption.map(n => ASTStringUtil.getSimpleName(n.getName)).getOrElse(f.getName)
           case f: CPPFunction if f.getDefinition != null =>
-            f.getDefinition.getName.toString
+            ASTStringUtil.getSimpleName(f.getDefinition.getName)
           case other =>
             other.getName
         }
-      case d: IASTIdExpression           => lastNameOfQualifiedName(d.getName.toString)
+      case d: IASTIdExpression           => lastNameOfQualifiedName(ASTStringUtil.getSimpleName(d.getName))
       case u: IASTUnaryExpression        => shortName(u.getOperand)
       case c: IASTFunctionCallExpression => shortName(c.getFunctionNameExpression)
       case other                         => notHandledYet(other, -1); ""
@@ -447,9 +446,9 @@ trait AstCreatorHelper {
       case s: IASTNamedTypeSpecifier if s.getParent.isInstanceOf[IASTParameterDeclaration] =>
         val parentDecl = s.getParent.asInstanceOf[IASTParameterDeclaration].getDeclarator
         pointersAsString(s, parentDecl)
-      case s: IASTNamedTypeSpecifier     => s.getName.toString
-      case s: IASTCompositeTypeSpecifier => s.getName.toString
-      case s: IASTEnumerationSpecifier   => s.getName.toString
+      case s: IASTNamedTypeSpecifier     => ASTStringUtil.getSimpleName(s.getName)
+      case s: IASTCompositeTypeSpecifier => ASTStringUtil.getSimpleName(s.getName)
+      case s: IASTEnumerationSpecifier   => ASTStringUtil.getSimpleName(s.getName)
       case s: IASTElaboratedTypeSpecifier if s.getParent.isInstanceOf[IASTParameterDeclaration] =>
         val parentDecl = s.getParent.asInstanceOf[IASTParameterDeclaration].getDeclarator
         pointersAsString(s, parentDecl)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -9,6 +9,7 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTLambdaExpression
 import org.eclipse.cdt.core.dom.ast.gnu.c.ICASTKnRFunctionDeclarator
 import org.eclipse.cdt.internal.core.dom.parser.c.{CASTFunctionDeclarator, CASTParameterDeclaration}
 import org.eclipse.cdt.internal.core.dom.parser.cpp.{CPPASTFunctionDeclarator, CPPASTParameterDeclaration}
+import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 import scala.annotation.tailrec
 
@@ -231,10 +232,15 @@ trait AstForFunctionsCreator {
   private def astForParameter(parameter: IASTNode, childNum: Int): Ast = {
     val (name, code, tpe, variadic) = parameter match {
       case p: CASTParameterDeclaration =>
-        (nodeSignature(p.getDeclarator.getName), nodeSignature(p), typeForDeclSpecifier(p.getDeclSpecifier), false)
+        (
+          ASTStringUtil.getSimpleName(p.getDeclarator.getName),
+          nodeSignature(p),
+          typeForDeclSpecifier(p.getDeclSpecifier),
+          false
+        )
       case p: CPPASTParameterDeclaration =>
         (
-          nodeSignature(p.getDeclarator.getName),
+          ASTStringUtil.getSimpleName(p.getDeclarator.getName),
           nodeSignature(p),
           typeForDeclSpecifier(p.getDeclSpecifier),
           p.getDeclarator.declaresParameterPack()
@@ -242,7 +248,7 @@ trait AstForFunctionsCreator {
       case s: IASTSimpleDeclaration =>
         (
           s.getDeclarators.headOption
-            .map(x => nodeSignature(x.getName))
+            .map(n => ASTStringUtil.getSimpleName(n.getName))
             .getOrElse(uniqueName("parameter", "", "")._1),
           nodeSignature(s),
           typeForDeclSpecifier(s),

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -7,6 +7,7 @@ import org.eclipse.cdt.core.dom.ast._
 import org.eclipse.cdt.core.dom.ast.cpp._
 import org.eclipse.cdt.core.dom.ast.gnu.IGNUASTGotoStatement
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTNamespaceAlias
+import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 trait AstForStatementsCreator {
 
@@ -80,7 +81,7 @@ trait AstForStatementsCreator {
   }
 
   private def astForGotoStatement(goto: IASTGotoStatement, order: Int): Ast = {
-    val code = s"goto ${goto.getName.toString};"
+    val code = s"goto ${ASTStringUtil.getSimpleName(goto.getName)};"
     Ast(newControlStructureNode(goto, ControlStructureTypes.GOTO, code, order))
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstNodeBuilder.scala
@@ -2,6 +2,7 @@ package io.joern.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import org.eclipse.cdt.core.dom.ast.{IASTLabelStatement, IASTNode}
+import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 trait AstNodeBuilder {
 
@@ -66,7 +67,7 @@ trait AstNodeBuilder {
   protected def newJumpTarget(node: IASTNode, order: Int): NewJumpTarget = {
     val code = nodeSignature(node)
     val name = node match {
-      case label: IASTLabelStatement    => label.getName.toString
+      case label: IASTLabelStatement    => ASTStringUtil.getSimpleName(label.getName)
       case _ if code.startsWith("case") => "case"
       case _                            => "default"
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -11,6 +11,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
 }
 import io.shiftleft.x2cpg.Ast
 import org.eclipse.cdt.core.dom.ast.{IASTMacroExpansionLocation, IASTNode, IASTPreprocessorMacroDefinition}
+import org.eclipse.cdt.internal.core.model.ASTStringUtil
 import org.eclipse.cdt.internal.core.parser.scanner.MacroArgumentExtractor
 
 import scala.annotation.nowarn
@@ -56,11 +57,11 @@ trait MacroHandler {
       }
       .foreach { m =>
         val nodeOffset = node.getFileLocation.getNodeOffset
-        val macroName = m.getExpansion.getMacroDefinition.getName.toString
+        val macroName = ASTStringUtil.getSimpleName(m.getExpansion.getMacroDefinition.getName)
         while (nodeOffsetMacroPairs.headOption.exists(x => x._1 <= nodeOffset)) {
           val (_, macroDefinition) = nodeOffsetMacroPairs.head
           nodeOffsetMacroPairs.remove(0)
-          val name = macroDefinition.getName.toString
+          val name = ASTStringUtil.getSimpleName(macroDefinition.getName)
           if (macroName == name) {
             val arguments = new MacroArgumentExtractor(parserResult, node.getFileLocation).getArguments
             return Some((macroDefinition, arguments))
@@ -114,7 +115,7 @@ trait MacroHandler {
       arguments: List[String],
       order: Int
   ): Ast = {
-    val name = macroDef.getName.toString
+    val name = ASTStringUtil.getSimpleName(macroDef.getName)
     val code = node.getRawSignature.replaceAll(";$", "")
     val argAsts = argumentTrees(arguments, ast).map(_.getOrElse(Ast()))
 
@@ -148,7 +149,7 @@ trait MacroHandler {
     * correct location information.
     */
   private def fullName(macroDef: IASTPreprocessorMacroDefinition, argAsts: List[Ast]) = {
-    val name = macroDef.getName.toString
+    val name = ASTStringUtil.getSimpleName(macroDef.getName)
     val fileLocation = macroDef.getFileLocation
 
     if (fileLocation != null) {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
@@ -23,6 +23,9 @@ class HeaderContentPass(cpg: Cpg, keyPool: Option[KeyPool], config: Config) exte
   private val globalName: String = NamespaceTraversal.globalNamespaceName
   private val fullName: String = MetaDataPass.getGlobalNamespaceBlockFullName(Some(filename))
 
+  private val typeDeclFullNames: Set[String] =
+    cpg.graph.nodes(NodeTypes.TYPE_DECL).map(_.property(Properties.FULL_NAME)).toSetImmutable
+
   private def setExternal(node: HasFilename, diffGraph: DiffGraph.Builder): Unit = {
     if (node.isInstanceOf[HasIsExternal] && systemIncludePaths.exists(p => node.filename.startsWith(p.toString))) {
       diffGraph.addNodeProperty(node.asInstanceOf[StoredNode], PropertyNames.IS_EXTERNAL, Boolean.box(true))
@@ -82,7 +85,7 @@ class HeaderContentPass(cpg: Cpg, keyPool: Option[KeyPool], config: Config) exte
   }
 
   private def typeNeedsTypeDeclStub(t: Type): Boolean =
-    cpg.graph.nodes(NodeTypes.TYPE_DECL).has(Properties.FULL_NAME, t.typeDeclFullName).isEmpty
+    !typeDeclFullNames.contains(t.typeDeclFullName)
 
   private def createMissingTypeDecls(dstGraph: DiffGraph.Builder): Unit = {
     Traversal(cpg.graph.nodes(NodeTypes.TYPE))


### PR DESCRIPTION
`nodeSignature` sometimes gives wrong names in the context of macro expansion.
`ASTStringUtil.getSimpleName` is more reliable.