### PR TITLE
Jimple2Cpg: Handles interfaces

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -118,9 +118,8 @@ class AstCreator(filename: String, global: Global) {
     val memberAsts = typ.getSootClass.getFields.asScala
       .filter(_.isDeclared)
       .zipWithIndex
-      .map {
-        case (v, i) =>
-          astForField(v, i + methodAsts.size + 1)
+      .map { case (v, i) =>
+        astForField(v, i + methodAsts.size + 1)
       }
       .toList
 
@@ -164,13 +163,12 @@ class AstCreator(filename: String, global: Global) {
           .withChild(astForMethodReturn(methodDeclaration))
     } finally {
       // Join all targets with CFG edges - this seems to work from what is seen on DotFiles
-      controlTargets.foreach({
-        case (asts, units) =>
-          asts.headOption match {
-            case Some(value) =>
-              diffGraph.addEdge(value.root.get, unitToAsts(units).last.root.get, EdgeTypes.CFG)
-            case None =>
-          }
+      controlTargets.foreach({ case (asts, units) =>
+        asts.headOption match {
+          case Some(value) =>
+            diffGraph.addEdge(value.root.get, unitToAsts(units).last.root.get, EdgeTypes.CFG)
+          case None =>
+        }
       })
       // Clear these maps
       controlTargets.clear()
@@ -372,9 +370,8 @@ class AstCreator(filename: String, global: Global) {
     val argAsts = withOrder(invokeExpr match {
       case x: DynamicInvokeExpr => x.getArgs.asScala ++ x.getBootstrapArgs.asScala
       case x                    => x.getArgs.asScala
-    }) {
-      case (arg, order) =>
-        astsForValue(arg, order, parentUnit)
+    }) { case (arg, order) =>
+      astsForValue(arg, order, parentUnit)
     }.flatten
 
     Ast(callNode)
@@ -582,17 +579,16 @@ class AstCreator(filename: String, global: Global) {
       i <- 0 until totalTgts
       if lookupSwitchStmt.getTarget(i) != lookupSwitchStmt.getDefaultTarget
     } yield (lookupSwitchStmt.getLookupValue(i), lookupSwitchStmt.getTarget(i))
-    val tgtAsts = tgts.map {
-      case (lookup, target) =>
-        Ast(
-          NewJumpTarget()
-            .name(s"case $lookup")
-            .code(s"case $lookup:")
-            .argumentIndex(lookup)
-            .order(lookup)
-            .lineNumber(line(target))
-            .columnNumber(column(target))
-        )
+    val tgtAsts = tgts.map { case (lookup, target) =>
+      Ast(
+        NewJumpTarget()
+          .name(s"case $lookup")
+          .code(s"case $lookup:")
+          .argumentIndex(lookup)
+          .order(lookup)
+          .lineNumber(line(target))
+          .columnNumber(column(target))
+      )
     }
 
     Seq(
@@ -606,17 +602,16 @@ class AstCreator(filename: String, global: Global) {
     val tgtAsts = tableSwitchStmt.getTargets.asScala
       .filter(x => tableSwitchStmt.getDefaultTarget != x)
       .zipWithIndex
-      .map({
-        case (tgt, i) =>
-          Ast(
-            NewJumpTarget()
-              .name(s"case $i")
-              .code(s"case $i:")
-              .argumentIndex(i)
-              .order(i)
-              .lineNumber(line(tgt))
-              .columnNumber(column(tgt))
-          )
+      .map({ case (tgt, i) =>
+        Ast(
+          NewJumpTarget()
+            .name(s"case $i")
+            .code(s"case $i:")
+            .argumentIndex(i)
+            .order(i)
+            .lineNumber(line(tgt))
+            .columnNumber(column(tgt))
+        )
       })
       .toSeq
 
@@ -840,16 +835,14 @@ object AstCreator {
   }
 
   def withOrder[T <: Any, X](nodeList: java.util.List[T])(f: (T, Int) => X): Seq[X] = {
-    nodeList.asScala.zipWithIndex.map {
-      case (x, i) =>
-        f(x, i + 1)
+    nodeList.asScala.zipWithIndex.map { case (x, i) =>
+      f(x, i + 1)
     }.toSeq
   }
 
   def withOrder[T <: Any, X](nodeList: Iterable[T])(f: (T, Int) => X): Seq[X] = {
-    nodeList.zipWithIndex.map {
-      case (x, i) =>
-        f(x, i + 1)
+    nodeList.zipWithIndex.map { case (x, i) =>
+      f(x, i + 1)
     }.toSeq
   }
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
@@ -3,6 +3,7 @@ package io.joern.jimple2cpg.querying
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
+import org.slf4j.LoggerFactory
 
 import java.io.{File => JFile}
 
@@ -30,6 +31,9 @@ class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
     x.inheritsFromTypeFullName shouldBe List("java.lang.Object", "java.io.Serializable")
     x.aliasTypeFullName shouldBe None
     x.order shouldBe 1
+    val logger = LoggerFactory.getLogger(ImplementsInterfaceTests.super.getClass)
+    println(x.filename)
+    logger.info(x.filename)
     x.filename.startsWith(JFile.separator) shouldBe true
     x.filename.endsWith(".class") shouldBe true
   }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 import org.slf4j.LoggerFactory
 
-import java.io.{File => JFile}
+import java.io.{File, File => JFile}
 
 class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
 
@@ -31,8 +31,10 @@ class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
     x.inheritsFromTypeFullName shouldBe List("java.lang.Object", "java.io.Serializable")
     x.aliasTypeFullName shouldBe None
     x.order shouldBe 1
-    x.filename.startsWith(JFile.separator) ||
-      x.filename.startsWith("C:\\\\") shouldBe true
+    x.filename should (
+      startWith(File.separator) or // Unix
+        startWith regex "[A-Z]:" // Windows
+    )
     x.filename.endsWith(".class") shouldBe true
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
@@ -3,9 +3,8 @@ package io.joern.jimple2cpg.querying
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
-import org.slf4j.LoggerFactory
 
-import java.io.{File, File => JFile}
+import java.io.File
 
 class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
@@ -30,10 +30,7 @@ class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
     x.inheritsFromTypeFullName shouldBe List("java.lang.Object", "java.io.Serializable")
     x.aliasTypeFullName shouldBe None
     x.order shouldBe 1
-    x.filename should (
-      startWith(File.separator) or // Unix
-        startWith regex "[A-Z]:" // Windows
-    )
+    x.filename should (startWith(File.separator) or startWith regex "[A-Z]:")
     x.filename.endsWith(".class") shouldBe true
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
@@ -1,0 +1,47 @@
+package io.joern.jimple2cpg.querying
+
+import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
+
+import java.io.{File => JFile}
+
+class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
+
+  override val code: String =
+    """
+        |import java.io.Serializable;
+        |
+        |class Foo implements Serializable {
+        |
+        |   public int add(int x, int y) {
+        |     return x + y;
+        |   }
+        |
+        |}
+        |""".stripMargin
+
+  "should contain a type decl for `Foo` with correct fields" in {
+    val List(x) = cpg.typeDecl.name("Foo").l
+    x.name shouldBe "Foo"
+    x.code shouldBe "Foo"
+    x.fullName shouldBe "Foo"
+    x.isExternal shouldBe false
+    x.inheritsFromTypeFullName shouldBe List("java.lang.Object", "java.io.Serializable")
+    x.aliasTypeFullName shouldBe None
+    x.order shouldBe 1
+    x.filename.startsWith(JFile.separator) shouldBe true
+    x.filename.endsWith(".class") shouldBe true
+  }
+
+  "should contain a type decl for `Serializable` with correct fields" in {
+    val List(x) = cpg.typeDecl.name("Serializable").l
+    x.name shouldBe "Serializable"
+    x.fullName shouldBe "java.io.Serializable"
+    x.isExternal shouldBe true
+    x.aliasTypeFullName shouldBe None
+    x.order shouldBe -1
+    x.filename shouldBe FileTraversal.UNKNOWN
+  }
+
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
@@ -31,10 +31,8 @@ class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
     x.inheritsFromTypeFullName shouldBe List("java.lang.Object", "java.io.Serializable")
     x.aliasTypeFullName shouldBe None
     x.order shouldBe 1
-    val logger = LoggerFactory.getLogger(ImplementsInterfaceTests.super.getClass)
-    println(x.filename)
-    logger.info(x.filename)
-    x.filename.startsWith(JFile.separator) shouldBe true
+    x.filename.startsWith(JFile.separator) ||
+      x.filename.startsWith("C:\\\\") shouldBe true
     x.filename.endsWith(".class") shouldBe true
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
@@ -2,7 +2,7 @@ package io.joern.jimple2cpg.querying
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
 import io.shiftleft.semanticcpg.language._
 
-import java.io.{File => JFile}
+import java.io.{File, File => JFile}
 
 class InterfaceTests extends JimpleCodeToCpgFixture {
 
@@ -24,8 +24,10 @@ class InterfaceTests extends JimpleCodeToCpgFixture {
     x.inheritsFromTypeFullName shouldBe List("java.lang.Object")
     x.aliasTypeFullName shouldBe None
     x.order shouldBe 1
-    x.filename.startsWith(JFile.separator) ||
-      x.filename.startsWith("C:\\\\") shouldBe true
+    x.filename should (
+      startWith(File.separator) or // Unix
+      startWith regex "[A-Z]:" // Windows
+    )
     x.filename.endsWith(".class") shouldBe true
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
@@ -24,10 +24,7 @@ class InterfaceTests extends JimpleCodeToCpgFixture {
     x.inheritsFromTypeFullName shouldBe List("java.lang.Object")
     x.aliasTypeFullName shouldBe None
     x.order shouldBe 1
-    x.filename should (
-      startWith(File.separator) or // Unix
-        startWith regex "[A-Z]:" // Windows
-    )
+    x.filename should (startWith(File.separator) or startWith regex "[A-Z]:")
     x.filename.endsWith(".class") shouldBe true
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
@@ -26,7 +26,7 @@ class InterfaceTests extends JimpleCodeToCpgFixture {
     x.order shouldBe 1
     x.filename should (
       startWith(File.separator) or // Unix
-      startWith regex "[A-Z]:" // Windows
+        startWith regex "[A-Z]:" // Windows
     )
     x.filename.endsWith(".class") shouldBe true
   }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
@@ -1,0 +1,40 @@
+package io.joern.jimple2cpg.querying
+import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.shiftleft.semanticcpg.language._
+
+import java.io.{File => JFile}
+
+class InterfaceTests extends JimpleCodeToCpgFixture {
+
+  override val code: String =
+    """
+      |interface Foo {
+      |
+      |   int add(int x, int y);
+      |
+      |}
+      |""".stripMargin
+
+  "should contain a type decl for `Foo` with correct fields" in {
+    val List(x) = cpg.typeDecl.name("Foo").l
+    x.name shouldBe "Foo"
+    x.code shouldBe "Foo"
+    x.fullName shouldBe "Foo"
+    x.isExternal shouldBe false
+    x.inheritsFromTypeFullName shouldBe List("java.lang.Object")
+    x.aliasTypeFullName shouldBe None
+    x.order shouldBe 1
+    x.filename.startsWith(JFile.separator) shouldBe true
+    x.filename.endsWith(".class") shouldBe true
+  }
+
+  "should contain a method for `Foo.add` with correct fields" in {
+    val List(x) = cpg.typeDecl.name("Foo").method.l
+    x.name shouldBe "add"
+    x.code shouldBe "int add(int param1, int param2)"
+    x.fullName shouldBe "Foo.add:int(int,int)"
+    x.isExternal shouldBe false
+    x.order shouldBe 1
+  }
+
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
@@ -24,7 +24,8 @@ class InterfaceTests extends JimpleCodeToCpgFixture {
     x.inheritsFromTypeFullName shouldBe List("java.lang.Object")
     x.aliasTypeFullName shouldBe None
     x.order shouldBe 1
-    x.filename.startsWith(JFile.separator) shouldBe true
+    x.filename.startsWith(JFile.separator) ||
+      x.filename.startsWith("C:\\\\") shouldBe true
     x.filename.endsWith(".class") shouldBe true
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
@@ -2,7 +2,7 @@ package io.joern.jimple2cpg.querying
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
 import io.shiftleft.semanticcpg.language._
 
-import java.io.{File, File => JFile}
+import java.io.File
 
 class InterfaceTests extends JimpleCodeToCpgFixture {
 


### PR DESCRIPTION
- Interfaces are now recognized and treated as types with implementation represented by `INHERITS_FROM`.