### PR TITLE
Fixed c2cpg system header file discovery

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -50,11 +50,10 @@ class CdtParser(parseConfig: ParserConfig, headerFileFinder: HeaderFileFinder)
   }
 
   private def createScannerInfo(file: Path): ScannerInfo = {
-    if (FileDefaults.isCPPFile(file.toString)) {
-      new ScannerInfo(definedSymbols, (includePaths ++ parseConfig.systemIncludePathsCPP).map(_.toString).toArray)
-    } else {
-      new ScannerInfo(definedSymbols, (includePaths ++ parseConfig.systemIncludePathsC).map(_.toString).toArray)
-    }
+    val additionalIncludes =
+      if (FileDefaults.isCPPFile(file.toString)) parseConfig.systemIncludePathsCPP
+      else parseConfig.systemIncludePathsC
+    new ScannerInfo(definedSymbols, (includePaths ++ additionalIncludes).map(_.toString).toArray)
   }
 
   private def parseInternal(file: Path): ParseResult = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -35,9 +35,9 @@ class CdtParser(parseConfig: ParserConfig, headerFileFinder: HeaderFileFinder)
   import CdtParser._
 
   private val definedSymbols: util.Map[String, String] = parseConfig.definedSymbols.asJava
-  private val includePaths: Set[String]                = parseConfig.includePaths.map(_.toString)
-  private val scannerInfo: ScannerInfo                 = new ScannerInfo(definedSymbols, includePaths.toArray)
+  private val includePaths: Set[Path]                  = parseConfig.userIncludePaths
   private val log: DefaultLogService                   = new DefaultLogService
+
   // enables parsing of code behind disabled preprocessor defines:
   private val opts: Int = ILanguage.OPTION_PARSE_INACTIVE_CODE
 
@@ -49,12 +49,21 @@ class CdtParser(parseConfig: ParserConfig, headerFileFinder: HeaderFileFinder)
     }
   }
 
+  private def createScannerInfo(file: Path): ScannerInfo = {
+    if (FileDefaults.isCPPFile(file.toString)) {
+      new ScannerInfo(definedSymbols, (includePaths ++ parseConfig.systemIncludePathsCPP).map(_.toString).toArray)
+    } else {
+      new ScannerInfo(definedSymbols, (includePaths ++ parseConfig.systemIncludePathsC).map(_.toString).toArray)
+    }
+  }
+
   private def parseInternal(file: Path): ParseResult = {
     val realPath = File(file)
     if (realPath.isRegularFile) { // handling potentially broken symlinks
       val fileContent         = IOUtils.readFileAsFileContent(realPath.path)
       val fileContentProvider = new CustomFileContentProvider(headerFileFinder)
       val lang                = createParseLanguage(realPath.path)
+      val scannerInfo         = createScannerInfo(realPath.path)
       Try(lang.getASTTranslationUnit(fileContent, scannerInfo, fileContentProvider, null, opts, log)) match {
         case Failure(e) =>
           ParseResult(None, failure = Some(e))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
@@ -7,10 +7,13 @@ import java.nio.file.{Path, Paths}
 
 object ParserConfig {
 
-  def empty: ParserConfig = ParserConfig(Set.empty, Map.empty, logProblems = false, logPreprocessor = false)
+  def empty: ParserConfig =
+    ParserConfig(Set.empty, Set.empty, Set.empty, Map.empty, logProblems = false, logPreprocessor = false)
 
   def fromConfig(config: Config): ParserConfig = ParserConfig(
-    config.includePaths.map(Paths.get(_).toAbsolutePath) ++ IncludeAutoDiscovery.discoverIncludePaths(config),
+    config.includePaths.map(Paths.get(_).toAbsolutePath),
+    IncludeAutoDiscovery.discoverIncludePathsC(config),
+    IncludeAutoDiscovery.discoverIncludePathsCPP(config),
     config.defines.map {
       case define if define.contains("=") =>
         val s = define.split("=")
@@ -24,7 +27,9 @@ object ParserConfig {
 }
 
 case class ParserConfig(
-  includePaths: Set[Path],
+  userIncludePaths: Set[Path],
+  systemIncludePathsC: Set[Path],
+  systemIncludePathsCPP: Set[Path],
   definedSymbols: Map[String, String],
   logProblems: Boolean,
   logPreprocessor: Boolean

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -31,6 +31,7 @@ class AstCreationPass(
   private val global: Global                     = new Global()
   private val parserConfig: ParserConfig         = ParserConfig.fromConfig(config)
   private val headerFileFinder: HeaderFileFinder = new HeaderFileFinder(config.inputPaths)
+  private val parser: CdtParser                  = new CdtParser(parserConfig, headerFileFinder)
 
   private def sourceFiles: Set[String] =
     SourceFiles.determine(config.inputPaths, FileDefaults.SOURCE_FILE_EXTENSIONS).toSet
@@ -50,7 +51,6 @@ class AstCreationPass(
   }
 
   override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
-    val parser = new CdtParser(parserConfig, headerFileFinder)
     val (gotCpg, duration) = TimeUtils.time {
       val parseResult = parser.parse(Paths.get(filename))
       parseResult match {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
@@ -16,7 +16,8 @@ import overflowdb.traversal._
 
 class HeaderContentPass(cpg: Cpg, keyPool: Option[KeyPool], config: Config) extends CpgPass(cpg, keyPool = keyPool) {
 
-  private val systemIncludePaths = IncludeAutoDiscovery.discoverIncludePaths(config)
+  private val systemIncludePaths =
+    IncludeAutoDiscovery.discoverIncludePathsC(config) ++ IncludeAutoDiscovery.discoverIncludePathsCPP(config)
 
   private val absolutePath: String = File(config.inputPaths.head).path.toAbsolutePath.normalize().toString
   private val filename: String     = s"$absolutePath:<includes>"

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -25,7 +25,8 @@ object IncludeAutoDiscovery {
   private var isGccAvailable: Option[Boolean] = None
 
   // Only discover them once
-  private var systemIncludePaths: Set[Path] = Set.empty
+  private var systemIncludePathsC: Set[Path]   = Set.empty
+  private var systemIncludePathsCPP: Set[Path] = Set.empty
 
   private def checkForGcc(): Boolean = {
     logger.debug("Checking gcc ...")
@@ -70,19 +71,37 @@ object IncludeAutoDiscovery {
     }
   }
 
-  def discoverIncludePaths(config: Config): Set[Path] = {
-    if (config.includePathsAutoDiscovery && systemIncludePaths.nonEmpty) {
-      systemIncludePaths
-    } else if (config.includePathsAutoDiscovery && systemIncludePaths.isEmpty && gccAvailable()) {
-      val includePaths = discoverPaths(C_INCLUDE_COMMAND) ++ discoverPaths(CPP_INCLUDE_COMMAND)
-      if (includePaths.nonEmpty) {
+  def discoverIncludePathsC(config: Config): Set[Path] = {
+    if (config.includePathsAutoDiscovery && systemIncludePathsC.nonEmpty) {
+      systemIncludePathsC
+    } else if (config.includePathsAutoDiscovery && systemIncludePathsC.isEmpty && gccAvailable()) {
+      val includePathsC = discoverPaths(C_INCLUDE_COMMAND)
+      if (includePathsC.nonEmpty) {
         logger.info(
-          "Using the following system include paths:" + includePaths
+          "Using the following C system include paths:" + includePathsC
             .mkString(System.lineSeparator() + "- ", System.lineSeparator() + "- ", System.lineSeparator())
         )
       }
-      systemIncludePaths = includePaths
-      includePaths
+      systemIncludePathsC = includePathsC
+      includePathsC
+    } else {
+      Set.empty
+    }
+  }
+
+  def discoverIncludePathsCPP(config: Config): Set[Path] = {
+    if (config.includePathsAutoDiscovery && systemIncludePathsCPP.nonEmpty) {
+      systemIncludePathsCPP
+    } else if (config.includePathsAutoDiscovery && systemIncludePathsCPP.isEmpty && gccAvailable()) {
+      val includePathsCPP = discoverPaths(CPP_INCLUDE_COMMAND)
+      if (includePathsCPP.nonEmpty) {
+        logger.info(
+          "Using the following CPP system include paths:" + includePathsCPP
+            .mkString(System.lineSeparator() + "- ", System.lineSeparator() + "- ", System.lineSeparator())
+        )
+      }
+      systemIncludePathsCPP = includePathsCPP
+      includePathsCPP
     } else {
       Set.empty
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/MacroHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/MacroHandlingTests.scala
@@ -5,6 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.joern.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal._
 
 class MacroHandlingTests1 extends CCodeToCpgSuite {
   override val code: String =

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/MacroHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/MacroHandlingTests.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.joern.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class MacroHandlingTests1 extends CCodeToCpgSuite {
   override val code: String =


### PR DESCRIPTION
Before this PR we always included all system header files when creating a CDT scanner.
Without checking whether it is a C or a CPP file.

This PR checks the file to parse beforehand.