### PR TITLE
Jimple2Cpg: Accurate Definition .code Property

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -501,11 +501,7 @@ class AstCreator(filename: String, global: Global) {
       .argumentIndex(order)
       .typeFullName(registerType(assignStmt.getLeftOp.getType.toQuotedString))
     val initializerAst = Seq(callAst(assignment, identifier ++ initAsts))
-    Seq(
-      Ast(
-        NewLocal().name(name).code(code).typeFullName(typeFullName).order(order)
-      )
-    ) ++ initializerAst.toList
+    Seq(Ast(NewLocal().name(name).code(code).typeFullName(typeFullName).order(order))) ++ initializerAst.toList
   }
 
   private def astsForIfStmt(ifStmt: IfStmt, order: Int): Seq[Ast] = {

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -501,7 +501,11 @@ class AstCreator(filename: String, global: Global) {
       .argumentIndex(order)
       .typeFullName(registerType(assignStmt.getLeftOp.getType.toQuotedString))
     val initializerAst = Seq(callAst(assignment, identifier ++ initAsts))
-    Seq(Ast(NewLocal().name(name).code(code).typeFullName(typeFullName).order(order))) ++ initializerAst.toList
+    Seq(
+      Ast(
+        NewLocal().name(name).code(code).typeFullName(typeFullName).order(order)
+      )
+    ) ++ initializerAst.toList
   }
 
   private def astsForIfStmt(ifStmt: IfStmt, order: Int): Seq[Ast] = {

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -19,7 +19,7 @@ object ProgramHandlingUtil {
 
   /** The temporary directory used to unpack class files to.
     */
-  val TEMP_DIR: Path = Files.createTempDirectory("plume")
+  val TEMP_DIR: Path = Files.createTempDirectory("joern-")
 
   logger.debug(s"Using temporary folder at $TEMP_DIR")
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/CfgTests.scala
@@ -8,17 +8,17 @@ class CfgTests extends JimpleCodeToCpgFixture {
   override val code: String =
     """
       |class Foo {
-      | static int foo(int x, int y) {
+      | int foo(int x, int y) {
       |  if (y < 10)
       |    return -1;
-      |  if (x < 10) {
-      |    sink(x);
+      |  if (x < 5) {
+      |   sink(x);
       |  }
       |  System.out.println("foo");
       |  return 0;
       | }
       |
-      | static void sink(int x) {
+      | void sink(int x) {
       |   System.out.println(x);
       |   return;
       | }
@@ -28,33 +28,34 @@ class CfgTests extends JimpleCodeToCpgFixture {
   "should find that sink is control dependent on condition" in {
     val controllers = cpg.call("sink").controlledBy.isCall.toSet
     controllers.map(_.code) should contain("y >= 10")
-    controllers.map(_.code) should contain("x >= 10")
+    controllers.map(_.code) should contain("x >= 5")
   }
 
   // No control structure node on flat ast
-//  "should find that first if controls `sink`" in {
-//    cpg.controlStructure.condition.code("y < 10").controls.isCall.name("sink").l.size shouldBe 1
-//  }
+  //  "should find that first if controls `sink`" in {
+  //    cpg.controlStructure.condition.code("y < 10").controls.isCall.name("sink").l.size shouldBe 1
+  //  }
 
-//  "should find sink(x) does not dominate anything" in {
-//    cpg.call("sink").dominates.l.size shouldBe 0
-//  }
+  //  "should find sink(x) does not dominate anything" in {
+  //    cpg.call("sink").dominates.l.size shouldBe 0
+  //  }
 
-  "should find sink(x) is dominated by `x<10` and `y < 10`" in {
+  "should find sink(x) is dominated by `x < 5` and `y < 10`" in {
     cpg.call("sink").dominatedBy.isCall.code.toSet shouldBe Set(
-      "y = @parameter1: int",
-      "x >= 10",
+      "x >= 5",
+      "this = this",
+      "x = @parameter0",
       "y >= 10",
-      "x = @parameter0: int"
+      "y = @parameter1"
     )
   }
 
-//  "should find that println post dominates correct nodes" in {
-//    cpg.call("println").postDominates.size shouldBe 6
-//  }
+  //  "should find that println post dominates correct nodes" in {
+  //    cpg.call("println").postDominates.size shouldBe 6
+  //  }
 
-//  "should find that method does not post dominate anything" in {
-//    cpg.method("foo").postDominates.l.size shouldBe 0
-//  }
+  //  "should find that method does not post dominate anything" in {
+  //    cpg.method("foo").postDominates.l.size shouldBe 0
+  //  }
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/StaticCallGraphTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/StaticCallGraphTests.scala
@@ -32,10 +32,10 @@ class StaticCallGraphTests extends JimpleCodeToCpgFixture {
       Set(
         "println($stack3)",
         "add(3, 3)",
-        "$stack2 = <java.lang.System: java.io.PrintStream out>",
-        "argc = @parameter0: int",
-        "$stack3 = staticinvoke <Foo: int add(int,int)>(3, 3)",
-        "argv = @parameter1: char",
+        "argc = @parameter0",
+        "$stack2 = java.lang.System.out",
+        "argv = @parameter1",
+        "$stack3 = add(3, 3)",
         "java.lang.System.out"
       )
   }


### PR DESCRIPTION
- Plume prefix replaced with Joern when naming temporary extraction directory
- Generate `<operator>.assignment` call node's `code` property from child argument `code`