### PR TITLE
Do not forget to include method parameter declarations in kill sets

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -54,7 +54,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
   }
 
   /** Once reaching definitions have been computed, we create a data dependence graph by seeing which of these reaching
-    * definitions are relevant in the sense that they are used.
+    * definitions are relevant, meaning that a symbol is propagated that is used by the target node.
     */
   private def addReachingDefEdges(
     problem: DataFlowProblem[mutable.BitSet],
@@ -145,11 +145,9 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
               if (edgesToAdd.nonEmpty) {
                 addEdge(block, call)
               }
-
             case Some(node: Call) =>
               addEdge(node, call, nodeToEdgeLabel(node))
               addEdge(block, call)
-
             case _ => // Do nothing
           }
         }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
@@ -1708,25 +1708,36 @@ class DataFlowTest56 extends DataFlowCodeToCpgSuite {
 class DataFlowTest57 extends DataFlowCodeToCpgSuite {
   override val code: String =
     """
-      |void outer(char* ptr){
-      |  taint1(ptr);
-      |  inner(ptr);
-      |  return;
-      |}
-      |
-      |void inner(char * ptr)
+      |void abc()
       |{
-      |    taint2(ptr);
-      |    ptr = malloc(0x80);
-      |    sink(ptr);
-      |    return;
+      |    int a;
+      |    a = foo();
+      |    a = bar(0x80);
+      |    sink(a);
       |}
       |""".stripMargin
 
-  "should not find flow from taint1 to sink" in {
-    val src = cpg.call("taint1").argument
-    val snk = cpg.method("sink").parameter
+  "should not find a flow from 'a' at 'foo' to 'sink'" in {
+    def src = cpg.call("foo").inAssignment.target.head
+    def snk = cpg.method("sink").parameter
     snk.reachableByFlows(src).size shouldBe 0
   }
+}
 
+class DataFlowTest58 extends DataFlowCodeToCpgSuite {
+  override val code: String =
+    """
+      |void abc(int a)
+      |{
+      |    a = foo();
+      |    a = bar(0x80);
+      |    sink(a);
+      |}
+      |""".stripMargin
+
+  "should not find a flow from parameter 'a' to 'sink'" in {
+    def src = cpg.method("abc").parameter
+    def snk = cpg.method("sink").parameter
+    snk.reachableByFlows(src).size shouldBe 0
+  }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
@@ -1704,3 +1704,29 @@ class DataFlowTest56 extends DataFlowCodeToCpgSuite {
     )
   }
 }
+
+class DataFlowTest57 extends DataFlowCodeToCpgSuite {
+  override val code: String =
+    """
+      |void outer(char* ptr){
+      |  taint1(ptr);
+      |  inner(ptr);
+      |  return;
+      |}
+      |
+      |void inner(char * ptr)
+      |{
+      |    taint2(ptr);
+      |    ptr = malloc(0x80);
+      |    sink(ptr);
+      |    return;
+      |}
+      |""".stripMargin
+
+  "should not find flow from taint1 to sink" in {
+    val src = cpg.call("taint1").argument
+    val snk = cpg.method("sink").parameter
+    snk.reachableByFlows(src).size shouldBe 0
+  }
+
+}

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -7,8 +7,12 @@ import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOpti
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
 import io.shiftleft.semanticcpg.layers.{Base, CallGraph, ControlFlow, LayerCreatorContext, TypeRelations}
 import io.shiftleft.utils.ProjectRoot
+
+import scala.sys.process.Process
+import scala.util.Try
 
 class DataFlowCodeToCpgSuite extends CCodeToCpgSuite {
 
@@ -16,6 +20,11 @@ class DataFlowCodeToCpgSuite extends CCodeToCpgSuite {
     ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
 
   var semantics: Semantics = _
+
+  val viewer: ImageViewer = (pathStr: String) =>
+    Try {
+      Process(Seq("xdg-open", pathStr)).!!
+    }
 
   implicit var context: EngineContext = _
 


### PR DESCRIPTION
Previously, kill sets did not contain method parameter declarations, meaning that data flows in functions where the parameter was redefined were incorrect.