### PR TITLE
Improved parse failure logging

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -43,9 +43,9 @@ class CdtParser(parseConfig: ParserConfig, headerFileFinder: HeaderFileFinder)
 
   private def createParseLanguage(file: Path): ILanguage = {
     if (FileDefaults.isCPPFile(file.toString)) {
-      new GPPLanguage()
+      GPPLanguage.getDefault
     } else {
-      new GCCLanguage()
+      GCCLanguage.getDefault
     }
   }
 
@@ -95,7 +95,9 @@ class CdtParser(parseConfig: ParserConfig, headerFileFinder: HeaderFileFinder)
         logger.info(s"Parsed '${t.getFilePath}' ($c preprocessor error(s), $p problems)")
         Some(t)
       case ParseResult(_, _, _, maybeThrowable) =>
-        logger.warn(s"Failed to parse '$file' ${maybeThrowable.map(_.getMessage).getOrElse("")}")
+        logger.warn(
+          s"Failed to parse '$file': ${maybeThrowable.map(extractParseException).getOrElse("Unknown parse error!")}"
+        )
         None
     }
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParseProblemsLogger.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParseProblemsLogger.scala
@@ -22,4 +22,18 @@ trait ParseProblemsLogger {
     problems.foreach(logProblemNode)
   }
 
+  /** The exception message might be null for parse failures due to ambiguous nodes that can't be resolved successfully.
+    * We extract better log messages for this case here.
+    */
+  protected def extractParseException(exception: Throwable): String = Option(exception.getMessage) match {
+    case Some(message) => message
+    case None =>
+      exception.getStackTrace
+        .collectFirst {
+          case stackTraceElement: StackTraceElement if stackTraceElement.getClassName.endsWith("ASTAmbiguousNode") =>
+            "Could not resolve ambiguous node!"
+        }
+        .getOrElse(exception.getStackTrace.mkString(System.lineSeparator()))
+  }
+
 }


### PR DESCRIPTION
The exception message might be null for parse failures due to ambiguous nodes that can't be resolved successfully.
We now extract better log messages for this case.