### PR TITLE
Jimple2Cpg: Parameters Eval Strategies and this Parameters

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodParameterTests.scala
@@ -1,6 +1,7 @@
 package io.joern.jimple2cpg.querying
 
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 import io.shiftleft.semanticcpg.language._
 
 class MethodParameterTests extends JimpleCodeToCpgFixture {
@@ -8,14 +9,22 @@ class MethodParameterTests extends JimpleCodeToCpgFixture {
   override val code: String =
     """package a;
       |class Foo {
-      | int foo(int param1, int param2) {
+      | int foo(int param1, Object param2) {
       |  return 0;
       | }
       |}
       """.stripMargin
 
-  "should return exactly two parameters with correct fields" in {
-    cpg.parameter.filter(_.method.name == "foo").name.toSet shouldBe Set("param1", "param2")
+  "should return exactly three parameters with correct fields" in {
+    cpg.parameter.filter(_.method.name == "foo").name.toSet shouldBe Set("this", "param1", "param2")
+
+    val List(t) = cpg.parameter.filter(_.method.name == "foo").name("this").l
+    t.code shouldBe "this"
+    t.typeFullName shouldBe "a.Foo"
+    t.lineNumber shouldBe Some(3)
+    t.columnNumber shouldBe None
+    t.order shouldBe 0
+    t.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
 
     val List(x) = cpg.parameter.filter(_.method.name == "foo").name("param1").l
     x.code shouldBe "int param1"
@@ -23,13 +32,15 @@ class MethodParameterTests extends JimpleCodeToCpgFixture {
     x.lineNumber shouldBe Some(3)
     x.columnNumber shouldBe Some(-1)
     x.order shouldBe 1
+    x.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
 
     val List(y) = cpg.parameter.filter(_.method.name == "foo").name("param2").l
-    y.code shouldBe "int param2"
-    y.typeFullName shouldBe "int"
+    y.code shouldBe "java.lang.Object param2"
+    y.typeFullName shouldBe "java.lang.Object"
     y.lineNumber shouldBe Some(3)
     y.columnNumber shouldBe Some(-1)
     y.order shouldBe 2
+    y.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
   }
 
   "should allow traversing from parameter to method" in {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
@@ -37,7 +37,7 @@ class MethodTests extends JimpleCodeToCpgFixture {
 //  }
 
   "should allow traversing to parameters" in {
-    cpg.method.name("foo").parameter.name.toSet shouldBe Set("param1", "param2")
+    cpg.method.name("foo").parameter.name.toSet shouldBe Set("this", "param1", "param2")
   }
 
   "should allow traversing to methodReturn" in {


### PR DESCRIPTION
### Added

- Method parameters now have correct evaluation strategies

### Fixed

- Fixed instance in methods where `this` parameter was not generated for dynamic calls.