### PR TITLE
Jimple2Cpg: Use .fieldRef instead of nullable .field

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -160,7 +160,7 @@ class AstCreator(filename: String, global: Global) {
       }
     } catch {
       case e: RuntimeException =>
-        logger.warn(s"Unable to parse method body. ${e.getMessage}")
+        logger.warn(s"Unexpected exception while parsing method body! Will stub the method ${methodNode.fullName}", e)
         Ast(methodNode)
           .withChild(astForMethodReturn(methodDeclaration))
     } finally {
@@ -673,7 +673,7 @@ class AstCreator(filename: String, global: Global) {
     }
     val fieldAccessBlock = NewCall()
       .name(Operators.fieldAccess)
-      .code(s"${leftOpType.toQuotedString}.${fieldRef.getField.getName}")
+      .code(s"${leftOpType.toQuotedString}.${fieldRef.getFieldRef.name()}")
       .typeFullName(registerType(fieldRef.getType.toQuotedString))
       .methodFullName(Operators.fieldAccess)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -696,8 +696,8 @@ class AstCreator(filename: String, global: Global) {
         .argumentIndex(2)
         .lineNumber(line(parentUnit))
         .columnNumber(column(parentUnit))
-        .canonicalName(fieldRef.getField.getSignature)
-        .code(fieldRef.getField.getName)
+        .canonicalName(fieldRef.getFieldRef.getSignature)
+        .code(fieldRef.getFieldRef.name())
     ).map(Ast(_))
 
     Ast(fieldAccessBlock)


### PR DESCRIPTION
Fixed instances where `.fieldRef.getField` would return a null and crash method body parsing. This appears to happen when `.getField` is an external class/type but that's my guess. Have now reverted to `.fieldRef.getFieldRef` which works since it refers to the immediate reference instead of the concrete location of the field.

Resolves #1036 