### PR TITLE
Set TYPE_FULL_NAME prop for Kotlin ctor calls

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -2004,6 +2004,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: NameGenerator,
         .argumentIndex(2)
         .methodFullName(fullNameWithSig._1)
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
+        .typeFullName(TypeConstants.void)
         .signature(fullNameWithSig._2)
         .lineNumber(line(expr))
         .columnNumber(column(expr))

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToConstructorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToConstructorTests.scala
@@ -66,6 +66,7 @@ class CallsToConstructorTests extends AnyFreeSpec with Matchers {
       initCall.signature shouldBe "void(java.lang.String)"
       initCall.methodFullName shouldBe "java.io.File.<init>:void(java.lang.String)"
       initCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      initCall.typeFullName shouldBe "void"
 
       val List(initCallLhs: Identifier, initCallRhs: Literal) = initCall.argument.l
       initCallLhs.code shouldBe "tmp_1"


### PR DESCRIPTION
not having it set leads to crashes in backend