### PR TITLE
Jimple2Cpg: Fixed instances where InvokeDynamic Methods would Crash

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -130,7 +130,9 @@ class Jimple2Cpg {
         Scene.v().addBasicClass(cp, SootClass.BODIES)
         Scene.v().loadClassAndSupport(cp).setApplicationClass()
       }
+    Scene.v().loadDynamicClasses()
     Scene.v().loadNecessaryClasses()
+    Scene.v().addBasicClass("soot.dummy.InvokeDynamic", SootClass.SIGNATURES)
   }
 
   private def configureSoot(): Unit = {


### PR DESCRIPTION
- Instances where dynamic calls were failing because of `soot.dummy.InvokeDynamic` not being loaded at `SIGNATURES`
  level. This used to occasionally crash on loading certain methods.