### PR TITLE
Jimple2Cpg: Handling Method Resolve Failure on InvokeExpr

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodParameterTests.scala
@@ -30,7 +30,7 @@ class MethodParameterTests extends JimpleCodeToCpgFixture {
     x.code shouldBe "int param1"
     x.typeFullName shouldBe "int"
     x.lineNumber shouldBe Some(3)
-    x.columnNumber shouldBe Some(-1)
+    x.columnNumber shouldBe None
     x.order shouldBe 1
     x.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
 
@@ -38,7 +38,7 @@ class MethodParameterTests extends JimpleCodeToCpgFixture {
     y.code shouldBe "java.lang.Object param2"
     y.typeFullName shouldBe "java.lang.Object"
     y.lineNumber shouldBe Some(3)
-    y.columnNumber shouldBe Some(-1)
+    y.columnNumber shouldBe None
     y.order shouldBe 2
     y.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
   }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
@@ -29,7 +29,7 @@ class MethodTests extends JimpleCodeToCpgFixture {
     )
     x.filename.endsWith(".class") shouldBe true
     x.lineNumber shouldBe Some(2)
-    x.columnNumber shouldBe Some(-1)
+    x.columnNumber shouldBe None
   }
 
 //  "should return correct number of lines" in {


### PR DESCRIPTION
Often during a dynamic invoke, obtaining the method called will fail. I have now replaced the direct method resolution with the method reference since this is enough to generate the `Call` node.