### PR TITLE
Do not always log test runs into log file.

### DIFF
--- a/joern-cli/frontends/py2cpg/src/main/resources/log4j2.xml
+++ b/joern-cli/frontends/py2cpg/src/main/resources/log4j2.xml
@@ -4,14 +4,10 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%-5p][%t] %m%n" />
         </Console>
-        <File name="File" fileName="test.log" append="false">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%-5p][%t] %m%n" />
-        </File>
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <AppenderRef ref="Console" />
-            <AppenderRef ref="File" />
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
The release process does not like any additional files to be lingering
around after a test/build cycle.