### PR TITLE
Use `ConcurrentWriterCpgPass` in most frontends

### DIFF
--- a/console/src/main/scala/io/joern/console/scan/ScanPass.scala
+++ b/console/src/main/scala/io/joern/console/scan/ScanPass.scala
@@ -5,8 +5,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
 import io.shiftleft.passes.{ConcurrentWriterCpgPass, DiffGraph, KeyPoolCreator, ParallelCpgPass}
 
-class ScanPass(cpg: Cpg, queries: List[Query])
-    extends ConcurrentWriterCpgPass[Query](cpg) {
+class ScanPass(cpg: Cpg, queries: List[Query]) extends ConcurrentWriterCpgPass[Query](cpg) {
 
   override def generateParts(): Array[Query] = queries.toArray
 

--- a/console/src/main/scala/io/joern/console/scan/ScanPass.scala
+++ b/console/src/main/scala/io/joern/console/scan/ScanPass.scala
@@ -2,19 +2,16 @@ package io.joern.console.scan
 
 import io.joern.console.Query
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.{DiffGraph, KeyPoolCreator, ParallelCpgPass}
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode
+import io.shiftleft.passes.{ConcurrentWriterCpgPass, DiffGraph, KeyPoolCreator, ParallelCpgPass}
 
 class ScanPass(cpg: Cpg, queries: List[Query])
-    extends ParallelCpgPass[Query](
-      cpg,
-      keyPools = Some(KeyPoolCreator.obtain(queries.size.toLong, 42949672950L).iterator)
-    ) {
+    extends ConcurrentWriterCpgPass[Query](cpg) {
 
-  override def partIterator: Iterator[Query] = queries.iterator
+  override def generateParts(): Array[Query] = queries.toArray
 
-  override def runOnPart(query: Query): Iterator[DiffGraph] = {
-    val diffGraph = DiffGraph.newBuilder
+  override def runOnPart(diffGraph: DiffGraphBuilder, query: Query): Unit = {
     query(cpg).foreach(diffGraph.addNode)
-    Iterator(diffGraph.build())
   }
+
 }

--- a/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/passes/StubRemovalPass.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/passes/StubRemovalPass.scala
@@ -2,24 +2,23 @@ package io.joern.fuzzyc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Method
-import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
+import io.shiftleft.passes.{ConcurrentWriterCpgPass, DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 
 /** A pass that ensures that for any method m for which a body exists, there are no more method stubs for corresponding
   * declarations.
   */
-class StubRemovalPass(cpg: Cpg) extends ParallelCpgPass[Method](cpg) {
+class StubRemovalPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Method](cpg) {
 
   private val sigToMethodWithDef = cpg.method.isNotStub.map(m => m.signature -> true).toMap
 
-  override def partIterator: Iterator[Method] =
+  override def generateParts(): Array[Method] =
     cpg.method.isStub.toList
       .filter(m => sigToMethodWithDef.contains(m.signature))
-      .iterator
+      .toArray
 
-  override def runOnPart(stub: Method): Iterator[DiffGraph] = {
-    val diffGraph = DiffGraph.newBuilder
+  override def runOnPart(diffGraph: DiffGraphBuilder, stub: Method): Unit = {
     stub.ast.foreach(diffGraph.removeNode)
-    Iterator(diffGraph.build())
   }
+
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -28,18 +28,14 @@ class JavaSrc2Cpg {
     * the CPG is created in-memory.
     */
   def createCpg(sourceCodePath: String, outputPath: Option[String] = None): Cpg = {
-    val cpg             = newEmptyCpg(outputPath)
-    val metaDataKeyPool = new IntervalKeyPool(1, 100)
-    val typesKeyPool    = new IntervalKeyPool(100, 1000100)
-    val methodKeyPool   = new IntervalKeyPool(first = 1000100, last = Long.MaxValue)
-
-    new MetaDataPass(cpg, language, Some(metaDataKeyPool)).createAndApply()
+    val cpg = newEmptyCpg(outputPath)
+    new MetaDataPass(cpg, language).createAndApply()
 
     val (sourcesDir, sourceFileNames) = getSourcesFromDir(sourceCodePath)
-    val astCreator                    = new AstCreationPass(sourcesDir, sourceFileNames, cpg, methodKeyPool)
+    val astCreator                    = new AstCreationPass(sourcesDir, sourceFileNames, cpg)
     astCreator.createAndApply()
 
-    new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg, Some(typesKeyPool))
+    new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
       .createAndApply()
 
     cpg

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.Node.Parsedness
 import com.github.javaparser.{JavaParser, ParserConfiguration}
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.{DiffGraph, IntervalKeyPool, ParallelCpgPass}
+import io.shiftleft.passes.{ConcurrentWriterCpgPass, DiffGraph, IntervalKeyPool, ParallelCpgPass}
 import com.github.javaparser.symbolsolver.resolution.typesolvers.{
   CombinedTypeSolver,
   JavaParserTypeSolver,
@@ -18,15 +18,14 @@ import scala.jdk.CollectionConverters._
 
 case class Global(usedTypes: ConcurrentHashMap[String, Boolean] = new ConcurrentHashMap[String, Boolean]())
 
-class AstCreationPass(codeDir: String, filenames: List[String], cpg: Cpg, keyPool: IntervalKeyPool)
-    extends ParallelCpgPass[String](cpg, keyPools = Some(keyPool.split(filenames.size))) {
+class AstCreationPass(codeDir: String, filenames: List[String], cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg) {
 
   val global: Global = Global()
   private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
-  override def partIterator: Iterator[String] = filenames.iterator
+  override def generateParts(): Array[String] = filenames.toArray
 
-  override def runOnPart(filename: String): Iterator[DiffGraph] = {
+  override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
     val solver         = typeSolver()
     val symbolResolver = new JavaSymbolSolver(solver)
 
@@ -38,7 +37,7 @@ class AstCreationPass(codeDir: String, filenames: List[String], cpg: Cpg, keyPoo
 
     parseResult.getResult.toScala match {
       case Some(result) if result.getParsed == Parsedness.PARSED =>
-        new AstCreator(filename, typeInfoProvider).createAst(result)
+        diffGraph.absorb(new AstCreator(filename, typeInfoProvider).createAst(result))
       case _ =>
         logger.warn("Cannot parse: " + filename)
         logger.warn("Problems: ", parseResult.getProblems.asScala.toList.map(_.toString))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -99,6 +99,7 @@ import io.shiftleft.passes.DiffGraph
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName
 import io.joern.x2cpg.Ast
 import org.slf4j.LoggerFactory
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import java.util.UUID.randomUUID
 import scala.jdk.CollectionConverters._
@@ -199,14 +200,14 @@ class AstCreator(filename: String, typeInfoProvider: TypeInfoProvider) {
   import AstCreator._
 
   val stack: mutable.Stack[NewNode] = mutable.Stack()
-  val diffGraph: DiffGraph.Builder  = DiffGraph.newBuilder
+  val diffGraph: DiffGraphBuilder   = new DiffGraphBuilder
 
   /** Entry point of AST creation. Translates a compilation unit created by JavaParser into a DiffGraph containing the
     * corresponding CPG AST.
     */
-  def createAst(parserResult: CompilationUnit): Iterator[DiffGraph] = {
+  def createAst(parserResult: CompilationUnit): DiffGraphBuilder = {
     storeInDiffGraph(astForCompilationUnit(parserResult))
-    Iterator(diffGraph.build())
+    diffGraph
   }
 
   /** Copy nodes/edges of given `AST` into the diff graph

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kt2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kt2Cpg.scala
@@ -30,22 +30,18 @@ class Kt2Cpg {
     nameGenerator: NameGenerator,
     outputPath: Option[String] = None
   ): Cpg = {
-    val cpg             = newEmptyCpg(outputPath)
-    val metaDataKeyPool = new IntervalKeyPool(1, 100)
-    val typesKeyPool    = new IntervalKeyPool(100, 1000100)
-    val configKeyPool   = new IntervalKeyPool(1000100, 2000100)
-    val methodKeyPool   = new IntervalKeyPool(first = 2000100, last = Long.MaxValue)
+    val cpg = newEmptyCpg(outputPath)
 
-    new MetaDataPass(cpg, language, Some(metaDataKeyPool)).createAndApply()
+    new MetaDataPass(cpg, language).createAndApply()
 
     val astCreator =
-      new AstCreationPass(filesWithMeta, nameGenerator, cpg, methodKeyPool)
+      new AstCreationPass(filesWithMeta, nameGenerator, cpg)
     astCreator.createAndApply()
 
-    new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg, Some(typesKeyPool))
+    new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
       .createAndApply()
 
-    val configCreator = new ConfigPass(fileContentsAtPath, cpg, configKeyPool)
+    val configCreator = new ConfigPass(fileContentsAtPath, cpg)
     configCreator.createAndApply()
 
     cpg

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.psi._
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.slf4j.{Logger, LoggerFactory}
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import scala.jdk.CollectionConverters._
 import scala.annotation.tailrec
@@ -80,18 +81,18 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: NameGenerator,
   // only here to help in paying back technical debt. Remove after
   private val continueParsingOnAstNodesWithoutRoot = false
 
-  private val diffGraph: DiffGraph.Builder = DiffGraph.newBuilder
+  private val diffGraph: DiffGraphBuilder = new DiffGraphBuilder()
 
   private val lambdaKeyPool = new IntervalKeyPool(first = 1, last = Long.MaxValue)
   private val tmpKeyPool    = new IntervalKeyPool(first = 1, last = Long.MaxValue)
 
   private val relativizedPath = fileWithMeta.relativizedPath
 
-  def createAst(): Iterator[DiffGraph] = {
+  def createAst(): DiffGraphBuilder = {
     implicit val nameGenerator: NameGenerator = xTypeInfoProvider
     logger.debug("Started parsing of file `" + fileWithMeta.filename + "`")
     storeInDiffGraph(astForFile(fileWithMeta))
-    Iterator(diffGraph.build())
+    diffGraph
   }
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])


### PR DESCRIPTION
`ParallelCpgPass` is now deprecated and so I have replaced it with `ConcurrentWriterCpgPass` in all frontends except for ghidra2cpg, jimple2cpg, and pysrc2cpg.

- For ghidra2cpg, @itsacoderepo needs to take a look. The `FunctionPass` seems like it doesn't work as intended. While it extends from `ParallelCpgPass`, the list of parts is `List("")`.
- For jimple2cpg, I did not make changes to not mess with the keypools @DavidBakerEffendi requires for his experiments
- For py2cpg, `DiffGraph.Applier` is used and it is supposed to be replaced with `DiffGraphApplier`, however, that class is private.
