### PR TITLE
Use `ConcurrentWriterCpgPass` in pysrc2cpg + cleanup

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kt2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kt2Cpg.scala
@@ -7,7 +7,6 @@ import io.joern.kotlin2cpg.passes.{AstCreationPass, ConfigPass}
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.kotlin2cpg.types.NameGenerator
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.IntervalKeyPool
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 
 object Kt2Cpg {

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
@@ -2,7 +2,7 @@ package io.joern.kotlin2cpg.passes
 
 import io.joern.kotlin2cpg.KtFileWithMeta
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.{ConcurrentWriterCpgPass, DiffGraph, IntervalKeyPool, ParallelCpgPass}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.joern.kotlin2cpg.types.NameGenerator
 
 import java.util.concurrent.ConcurrentHashMap

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/ConfigPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/ConfigPass.scala
@@ -3,7 +3,7 @@ package io.joern.kotlin2cpg.passes
 import io.joern.kotlin2cpg.FileContentAtPath
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile
-import io.shiftleft.passes.{ConcurrentWriterCpgPass, DiffGraph}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
 import org.slf4j.LoggerFactory
 
 class ConfigPass(fileContentsAtPath: Iterable[FileContentAtPath], cpg: Cpg)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/EdgeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/EdgeBuilder.scala
@@ -23,9 +23,9 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewUnknown
 }
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
-import io.shiftleft.passes.DiffGraph
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 
-class EdgeBuilder(diffGraph: DiffGraph.Builder) {
+class EdgeBuilder(diffGraph: DiffGraphBuilder) {
   def astEdge(dstNode: nodes.NewNode, srcNode: nodes.NewNode, order: Int): Unit = {
     diffGraph.addEdge(srcNode, dstNode, EdgeTypes.AST)
     addOrder(dstNode, order)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -2,8 +2,9 @@ package io.joern.pysrc2cpg
 
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, nodes}
 import io.shiftleft.passes.DiffGraph
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 
-class NodeBuilder(diffGraph: DiffGraph.Builder) {
+class NodeBuilder(diffGraph: DiffGraphBuilder) {
 
   private def addNodeToDiff[T <: nodes.NewNode](node: T): T = {
     diffGraph.addNode(node)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -7,6 +7,7 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Dispatch
 import io.shiftleft.passes.DiffGraph
 import io.joern.pysrc2cpg.memop.{AstNodeToMemoryOperationMap, Del, Load, MemoryOperationCalculator, Store}
 import io.joern.pythonparser.ast
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import scala.collection.mutable
 
@@ -24,7 +25,7 @@ object PythonV2AndV3 extends PythonVersion
 
 class PythonAstVisitor(fileName: String, version: PythonVersion) extends PythonAstVisitorHelpers {
 
-  private val diffGraph     = new DiffGraph.Builder()
+  private val diffGraph     = new DiffGraphBuilder()
   protected val nodeBuilder = new NodeBuilder(diffGraph)
   protected val edgeBuilder = new EdgeBuilder(diffGraph)
 
@@ -36,8 +37,8 @@ class PythonAstVisitor(fileName: String, version: PythonVersion) extends PythonA
   // is no more specific type than ast.istmt.
   private val functionDefToMethod = mutable.Map.empty[ast.istmt, nodes.NewMethod]
 
-  def getDiffGraph: DiffGraph = {
-    diffGraph.build()
+  def getDiffGraph: DiffGraphBuilder = {
+    diffGraph
   }
 
   private def createIdentifierLinks(): Unit = {


### PR DESCRIPTION
Turns out that only the deprecation warning was wrong for `DiffGraph.Applier`: one can use the public method `applyDiff` as a replacement. Now the only frontends that still use `ParallelCpgPass` are ghidra2cpg and jimple2cpg.