### PR TITLE
Move various classes into their own files

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -5,17 +5,17 @@ val kotlinVersion = "1.6.10"
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
-  "com.github.pathikrit"    %% "better-files"       % "3.9.1",
-  "io.shiftleft"            %% "codepropertygraph"  % Versions.cpg,
-  "io.shiftleft"            %% "semanticcpg"        % Versions.cpg,
-  "org.apache.logging.log4j" % "log4j-slf4j-impl"   % Versions.log4j % Runtime,
-  "org.slf4j"                % "slf4j-api"          % "1.7.35",
-  "org.scalatest"           %% "scalatest"          % "3.2.9"        % Test,
-  "org.jetbrains.kotlin"     % "kotlin-stdlib-jdk8" % kotlinVersion,
-  "org.jetbrains.kotlin"     % "kotlin-stdlib"      % kotlinVersion,
-  "org.jetbrains.kotlin"     % "kotlin-compiler-embeddable"    % kotlinVersion,
-  "org.jetbrains.kotlin"     % "kotlin-allopen"       % kotlinVersion,
-  "org.jetbrains.kotlin"     % "kotlin-test"        % kotlinVersion  % Test
+  "com.github.pathikrit"     %% "better-files"              % "3.9.1",
+  "io.shiftleft"             %% "codepropertygraph"         % Versions.cpg,
+  "io.shiftleft"             %% "semanticcpg"               % Versions.cpg,
+  "org.apache.logging.log4j" % "log4j-slf4j-impl"           % Versions.log4j % Runtime,
+  "org.slf4j"                % "slf4j-api"                  % "1.7.35",
+  "org.scalatest"            %% "scalatest"                 % "3.2.9"        % Test,
+  "org.jetbrains.kotlin"     % "kotlin-stdlib-jdk8"         % kotlinVersion,
+  "org.jetbrains.kotlin"     % "kotlin-stdlib"              % kotlinVersion,
+  "org.jetbrains.kotlin"     % "kotlin-compiler-embeddable" % kotlinVersion,
+  "org.jetbrains.kotlin"     % "kotlin-allopen"             % kotlinVersion,
+  "org.jetbrains.kotlin"     % "kotlin-test"                % kotlinVersion  % Test
 )
 
 enablePlugins(JavaAppPackaging)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kt2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kt2Cpg.scala
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 import io.joern.kotlin2cpg.passes.{AstCreationPass, ConfigPass}
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
-import io.joern.kotlin2cpg.types.NameGenerator
+import io.joern.kotlin2cpg.types.TypeInfoProvider
 import io.shiftleft.codepropertygraph.Cpg
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 
@@ -26,7 +26,7 @@ class Kt2Cpg {
   def createCpg(
     filesWithMeta: Iterable[KtFileWithMeta],
     fileContentsAtPath: Iterable[FileContentAtPath],
-    nameGenerator: NameGenerator,
+    typeInfoProvider: TypeInfoProvider,
     outputPath: Option[String] = None
   ): Cpg = {
     val cpg = newEmptyCpg(outputPath)
@@ -34,7 +34,7 @@ class Kt2Cpg {
     new MetaDataPass(cpg, language).createAndApply()
 
     val astCreator =
-      new AstCreationPass(filesWithMeta, nameGenerator, cpg)
+      new AstCreationPass(filesWithMeta, typeInfoProvider, cpg)
     astCreator.createAndApply()
 
     new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
@@ -1,16 +1,20 @@
 package io.joern.kotlin2cpg
 
 import io.joern.kotlin2cpg.files.SourceFilesPicker
-import io.joern.kotlin2cpg.types.ErrorLoggingMessageCollector
-import io.joern.kotlin2cpg.types.{CompilerAPI, DefaultNameGenerator, InferenceSourcesPicker}
+import io.joern.kotlin2cpg.types.{
+  CompilerAPI,
+  DefaultTypeInfoProvider,
+  ErrorLoggingMessageCollector,
+  InferenceSourcesPicker
+}
 import io.joern.kotlin2cpg.utils.PathUtils
-
 import io.joern.x2cpg.{SourceFiles, X2Cpg, X2CpgConfig}
 import io.shiftleft.utils.IOUtils
-
 import better.files.File
+
 import java.nio.file.{Files, Paths}
 import org.slf4j.LoggerFactory
+
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scopt.OParser
 
@@ -87,12 +91,14 @@ object Main extends App {
           }
         }
 
+        val plugins = Seq()
         val inferenceJars =
           InferenceSourcesPicker.defaultInferenceJarPaths ++
             jarPathsFromClassPath.map { path => InferenceJarPath(path, false) }
         val messageCollector = new ErrorLoggingMessageCollector
-        val environment = CompilerAPI.makeEnvironment(dirsForSourcesToCompile, inferenceJars, Seq(), messageCollector)
-        val ktFiles     = environment.getSourceFiles.asScala
+        val environment = CompilerAPI.makeEnvironment(dirsForSourcesToCompile, inferenceJars, plugins, messageCollector)
+
+        val ktFiles = environment.getSourceFiles.asScala
         val filesWithMeta =
           ktFiles
             .flatMap { f =>
@@ -137,8 +143,8 @@ object Main extends App {
               FileContentAtPath(fileContents, fnm._2, fnm._1)
             }
 
-        val nameGenerator = new DefaultNameGenerator(environment)
-        val cpg = new Kt2Cpg().createCpg(filesWithMeta, fileContentsAtPath, nameGenerator, Some(config.outputPath))
+        val typeInfoProvider = new DefaultTypeInfoProvider(environment)
+        val cpg = new Kt2Cpg().createCpg(filesWithMeta, fileContentsAtPath, typeInfoProvider, Some(config.outputPath))
         cpg.close()
       } else {
         println("This frontend requires exactly one input path")

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
@@ -3,14 +3,14 @@ package io.joern.kotlin2cpg.passes
 import io.joern.kotlin2cpg.KtFileWithMeta
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
-import io.joern.kotlin2cpg.types.NameGenerator
+import io.joern.kotlin2cpg.types.TypeInfoProvider
 
 import java.util.concurrent.ConcurrentHashMap
 import org.slf4j.LoggerFactory
 
 case class Global(usedTypes: ConcurrentHashMap[String, Boolean] = new ConcurrentHashMap[String, Boolean]())
 
-class AstCreationPass(filesWithMeta: Iterable[KtFileWithMeta], nameGenerator: NameGenerator, cpg: Cpg)
+class AstCreationPass(filesWithMeta: Iterable[KtFileWithMeta], typeInfoProvider: TypeInfoProvider, cpg: Cpg)
     extends ConcurrentWriterCpgPass[String](cpg) {
   val global: Global = Global()
   private val logger = LoggerFactory.getLogger(getClass)
@@ -27,7 +27,7 @@ class AstCreationPass(filesWithMeta: Iterable[KtFileWithMeta], nameGenerator: Na
       .headOption
     fileWithMeta match {
       case Some(fm) =>
-        diffGraph.absorb(new AstCreator(fm, nameGenerator, global).createAst())
+        diffGraph.absorb(new AstCreator(fm, typeInfoProvider, global).createAst())
         logger.debug("AST created for file at `" + filename + "`.")
       case None =>
         logger.info("Could not find file at `" + filename + "`.")

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/CallKinds.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/CallKinds.scala
@@ -1,0 +1,8 @@
+package io.joern.kotlin2cpg.types
+
+object CallKinds extends Enumeration {
+  type CallKind = Value
+  val Unknown, StaticCall, DynamicCall, ExtensionCall = Value
+}
+
+class CallKinds {}

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/Constants.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/Constants.scala
@@ -1,0 +1,16 @@
+package io.joern.kotlin2cpg.types
+
+object TypeConstants {
+  val any                               = "ANY"
+  val cpgUnresolved                     = "codepropertygraph.Unresolved"
+  val classLiteralReplacementMethodName = "getClass"
+  val initPrefix                        = "<init>"
+  val kotlinFunctionXPrefix             = "kotlin.Function"
+  val kotlinSuspendFunctionXPrefix      = "kotlin.coroutines.SuspendFunction"
+  val kotlinApplyPrefix                 = "kotlin.apply"
+  val kotlinUnit                        = "kotlin.Unit"
+  val javaLangObject                    = "java.lang.Object"
+  val javaLangString                    = "java.lang.String"
+  val tType                             = "T"
+  val void                              = "void"
+}

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameReferenceKinds.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameReferenceKinds.scala
@@ -1,0 +1,6 @@
+package io.joern.kotlin2cpg.types
+
+object NameReferenceKinds extends Enumeration {
+  type NameReferenceKind = Value
+  val Unknown, ClassName, EnumEntry, LocalVariable, Property = Value
+}

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
@@ -1,0 +1,82 @@
+package io.joern.kotlin2cpg.types
+
+import io.shiftleft.passes.KeyPool
+import org.jetbrains.kotlin.psi.{
+  KtBinaryExpression,
+  KtCallExpression,
+  KtClassLiteralExpression,
+  KtClassOrObject,
+  KtExpression,
+  KtLambdaExpression,
+  KtNameReferenceExpression,
+  KtNamedFunction,
+  KtParameter,
+  KtPrimaryConstructor,
+  KtProperty,
+  KtQualifiedExpression,
+  KtSecondaryConstructor,
+  KtTypeAlias,
+  KtTypeReference
+}
+
+trait TypeInfoProvider {
+  def returnType(elem: KtNamedFunction, or: String): String
+
+  def containingDeclType(expr: KtQualifiedExpression, or: String): String
+
+  def expressionType(expr: KtExpression, or: String): String
+
+  def inheritanceTypes(expr: KtClassOrObject, or: Seq[String]): Seq[String]
+
+  def parameterType(expr: KtParameter, or: String): String
+
+  def propertyType(expr: KtProperty, or: String): String
+
+  def fullName(expr: KtClassOrObject, or: String): String
+
+  def fullName(expr: KtTypeAlias, or: String): String
+
+  def aliasTypeFullName(expr: KtTypeAlias, or: String): String
+
+  def typeFullName(expr: KtNameReferenceExpression, or: String): String
+
+  def referenceTargetTypeFullName(expr: KtNameReferenceExpression, or: String): String
+
+  def typeFullName(expr: KtBinaryExpression, defaultValue: String): String
+
+  def bindingKind(expr: KtQualifiedExpression): CallKinds.CallKind
+
+  def isReferencingMember(expr: KtNameReferenceExpression): Boolean
+
+  def fullNameWithSignature(expr: KtQualifiedExpression, or: (String, String)): (String, String)
+
+  def fullNameWithSignature(call: KtCallExpression, or: (String, String)): (String, String)
+
+  def fullNameWithSignature(expr: KtPrimaryConstructor, or: (String, String)): (String, String)
+
+  def fullNameWithSignature(expr: KtSecondaryConstructor, or: (String, String)): (String, String)
+
+  def fullNameWithSignature(call: KtBinaryExpression, or: (String, String)): (String, String)
+
+  def fullNameWithSignature(expr: KtNamedFunction, or: (String, String)): (String, String)
+
+  def fullNameWithSignature(expr: KtClassLiteralExpression, or: (String, String)): (String, String)
+
+  def fullNameWithSignature(expr: KtLambdaExpression, keyPool: KeyPool): (String, String)
+
+  def erasedSignature(args: Seq[Any]): String
+
+  def returnTypeFullName(expr: KtLambdaExpression): String
+
+  def nameReferenceKind(expr: KtNameReferenceExpression): NameReferenceKinds.NameReferenceKind
+
+  def isConstructorCall(expr: KtCallExpression): Option[Boolean]
+
+  def typeFullName(expr: KtTypeReference, or: String): String
+
+  def typeFullName(expr: KtPrimaryConstructor, or: String): String
+
+  def typeFullName(expr: KtSecondaryConstructor, or: String): String
+
+  def hasStaticDesc(expr: KtQualifiedExpression): Boolean
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/Kt2CpgTestContext.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/Kt2CpgTestContext.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg
 
-import io.joern.kotlin2cpg.types.{CompilerAPI, DefaultNameGenerator}
+import io.joern.kotlin2cpg.types.{CompilerAPI, DefaultTypeInfoProvider}
 import io.joern.kotlin2cpg.types.ErrorLoggingMessageCollector
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
@@ -74,7 +74,7 @@ class Kt2CpgTestContext private () {
             KtFileWithMeta(fm, "GENERATED_PLACEHOLDER_FILE.kt", fm.getVirtualFilePath)
           }
 
-      val nameGenerator = new DefaultNameGenerator(environment)
+      val nameGenerator = new DefaultTypeInfoProvider(environment)
       val kt2Cpg        = new Kt2Cpg()
 
       val nonSourceFiles = codeAndFile.map { entry =>

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/integration/IntegrationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/integration/IntegrationTests.scala
@@ -2,7 +2,7 @@ package io.joern.kotlin2cpg.integration
 
 import io.joern.kotlin2cpg.types.ErrorLoggingMessageCollector
 import io.joern.kotlin2cpg.{InferenceJarPath, Kt2Cpg, KtFileWithMeta}
-import io.joern.kotlin2cpg.types.{CompilerAPI, DefaultNameGenerator, InferenceSourcesPicker}
+import io.joern.kotlin2cpg.types.{CompilerAPI, DefaultTypeInfoProvider, InferenceSourcesPicker}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
 import better.files.File
@@ -72,7 +72,7 @@ class IntegrationTests extends AnyFreeSpec with Matchers with BeforeAndAfterAll 
           willFilter
         }
 
-    val nameGenerator = new DefaultNameGenerator(environment)
+    val nameGenerator = new DefaultTypeInfoProvider(environment)
     new Kt2Cpg().createCpg(filesWithMeta, Seq(), nameGenerator, Some(outPath))
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/plugins/KotlinCompilerPluginTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/plugins/KotlinCompilerPluginTests.scala
@@ -2,7 +2,7 @@ package io.joern.kotlin2cpg.plugins
 
 import better.files.File
 import io.joern.kotlin2cpg.InferenceJarPath
-import io.joern.kotlin2cpg.types.{CompilerAPI, CompilerPluginInfo, DefaultNameGenerator, InferenceSourcesPicker}
+import io.joern.kotlin2cpg.types.{CompilerAPI, CompilerPluginInfo, DefaultTypeInfoProvider, InferenceSourcesPicker}
 import io.shiftleft.utils.ProjectRoot
 import org.jetbrains.kotlin.allopen.{AllOpenComponentRegistrar, AllOpenConfigurationKeys}
 import org.jetbrains.kotlin.cli.common.messages.{
@@ -49,7 +49,7 @@ class KotlinCompilerPluginTests extends AnyFreeSpec with Matchers {
       val plugins          = Seq()
       val messageCollector = new ErrorCountMessageCollector()
       val environment      = CompilerAPI.makeEnvironment(Seq(sourceDir), inferenceJarsPaths, plugins, messageCollector)
-      val nameGenerator    = new DefaultNameGenerator(environment)
+      val nameGenerator    = new DefaultTypeInfoProvider(environment)
       nameGenerator.bindingContext should not be null
       messageCollector.hasErrors() shouldBe true
     }
@@ -64,7 +64,7 @@ class KotlinCompilerPluginTests extends AnyFreeSpec with Matchers {
       val plugins          = Seq(allOpenPluginInfo)
       val messageCollector = new ErrorCountMessageCollector()
       val environment      = CompilerAPI.makeEnvironment(Seq(sourceDir), inferenceJarsPaths, plugins, messageCollector)
-      val nameGenerator    = new DefaultNameGenerator(environment)
+      val nameGenerator    = new DefaultTypeInfoProvider(environment)
       nameGenerator.bindingContext should not be null
       messageCollector.hasErrors() shouldBe false
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -2,6 +2,7 @@ package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.Kt2CpgTestContext
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{FieldIdentifier, Identifier}
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -30,6 +31,16 @@ class CallsToFieldAccessTests extends AnyFreeSpec with Matchers {
       c.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(16)
+
+      val List(firstArg: Identifier, secondArg: FieldIdentifier) =
+        cpg.call.codeExact("println(x)").argument.isCall.argument.l
+      firstArg.argumentIndex shouldBe 0
+      firstArg.code shouldBe "this"
+      firstArg.typeFullName shouldBe "mypkg.AClass"
+
+      secondArg.argumentIndex shouldBe 1
+      secondArg.code shouldBe "x"
+      secondArg.canonicalName shouldBe "x"
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FieldAccessTests.scala
@@ -4,7 +4,7 @@ import io.joern.kotlin2cpg.Kt2CpgTestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.{FieldIdentifier, Identifier}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeInferenceForAndroidSDKTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeInferenceForAndroidSDKTests.scala
@@ -2,7 +2,14 @@ package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.Kt2CpgTestContext
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal, NewIdentifier, NewLiteral}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Call,
+  FieldIdentifier,
+  Identifier,
+  Literal,
+  NewIdentifier,
+  NewLiteral
+}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/types/CompilerAPIStabilityTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/types/CompilerAPIStabilityTests.scala
@@ -13,7 +13,7 @@ class CompilerAPIStabilityTests extends AnyFreeSpec with Matchers {
         CompilerAPI.makeEnvironment(dirsForSourcesToCompile, Seq(), Seq(), new ErrorLoggingMessageCollector)
       environment.getSourceFiles should not be List()
 
-      val nameGenerator = new DefaultNameGenerator(environment)
+      val nameGenerator = new DefaultTypeInfoProvider(environment)
       nameGenerator.bindingContext should not be null
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/types/KotlinScriptFilteringTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/types/KotlinScriptFilteringTests.scala
@@ -13,7 +13,7 @@ class KotlinScriptFilteringTests extends AnyFreeSpec with Matchers {
       val environment = CompilerAPI.makeEnvironment(Seq(sourceDir), Seq(), Seq(), new ErrorLoggingMessageCollector)
       environment.getSourceFiles should not be List()
 
-      val nameGenerator = new DefaultNameGenerator(environment)
+      val nameGenerator = new DefaultTypeInfoProvider(environment)
       nameGenerator.bindingContext should not be null
       nameGenerator.hasEmptyBindingContext shouldBe true
     }
@@ -25,7 +25,7 @@ class KotlinScriptFilteringTests extends AnyFreeSpec with Matchers {
         CompilerAPI.makeEnvironment(dirsForSourcesToCompile, Seq(), Seq(), new ErrorLoggingMessageCollector)
       environment.getSourceFiles should not be List()
 
-      val nameGenerator = new DefaultNameGenerator(environment)
+      val nameGenerator = new DefaultTypeInfoProvider(environment)
       nameGenerator.bindingContext should not be null
       nameGenerator.hasEmptyBindingContext shouldBe false
     }


### PR DESCRIPTION
- rename `NameGenerator` -> `TypeInfoProvider`
- move multiple objects from the `*kotlin2cpg.types*` namespace into their own files (IntelliJ sometimes fails to recognize imports otherwise which is really annoying)