### PR TITLE
Jimple2Cpg: Object Data-Flow Tests + Bug Fixes

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/CfgTests.scala
@@ -43,10 +43,7 @@ class CfgTests extends JimpleCodeToCpgFixture {
   "should find sink(x) is dominated by `x < 5` and `y < 10`" in {
     cpg.call("sink").dominatedBy.isCall.code.toSetMutable shouldBe Set(
       "x >= 5",
-      "this = this",
-      "x = @parameter0",
       "y >= 10",
-      "y = @parameter1"
     )
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/CfgTests.scala
@@ -41,10 +41,7 @@ class CfgTests extends JimpleCodeToCpgFixture {
   //  }
 
   "should find sink(x) is dominated by `x < 5` and `y < 10`" in {
-    cpg.call("sink").dominatedBy.isCall.code.toSetMutable shouldBe Set(
-      "x >= 5",
-      "y >= 10",
-    )
+    cpg.call("sink").dominatedBy.isCall.code.toSetMutable shouldBe Set("x >= 5", "y >= 10")
   }
 
   //  "should find that println post dominates correct nodes" in {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
@@ -116,15 +116,15 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
         init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
         init.typeFullName shouldBe "void"
         init.signature shouldBe "void(int,int)"
-        init.code shouldBe "Bar(4, 2)"
+        init.code shouldBe "$stack1.Bar(4, 2)"
 
         init.argument.size shouldBe 3
         val List(obj: Identifier, initArg1: Literal, initArg2: Literal) = init.argument.l
         obj.order shouldBe 0
         obj.argumentIndex shouldBe 0
-        obj.name shouldBe "this"
+        obj.name shouldBe "$stack1"
         obj.typeFullName shouldBe "Bar"
-        obj.code shouldBe "this"
+        obj.code shouldBe "$stack1"
         initArg1.code shouldBe "4"
         initArg2.code shouldBe "2"
 
@@ -135,7 +135,7 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
   "it should create joint `alloc` and `init` calls for a constructor invocation in an assignment" in {
     cpg.typeDecl.name("Bar").method.name("test2").l match {
       case List(method) =>
-        val List(_: Local, _: Local, _: Local, paramAssign: Call, assign: Call, init: Call, _: Call, _: Return) =
+        val List(_: Local, _: Local, assign: Call, init: Call, _: Call, _: Return) =
           method.astChildren.isBlock.astChildren.l
 
         assign.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
@@ -154,15 +154,15 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
         init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
         init.typeFullName shouldBe "void"
         init.signature shouldBe "void(int,int)"
-        init.code shouldBe "Bar(4, 2)"
+        init.code shouldBe "$stack1.Bar(4, 2)"
 
         init.argument.size shouldBe 3
         val List(obj: Identifier, initArg1: Literal, initArg2: Literal) = init.argument.l
         obj.order shouldBe 0
         obj.argumentIndex shouldBe 0
-        obj.name shouldBe "this"
+        obj.name shouldBe "$stack1"
         obj.typeFullName shouldBe "Bar"
-        obj.code shouldBe "this"
+        obj.code shouldBe "$stack1"
         initArg1.code shouldBe "4"
         initArg2.code shouldBe "2"
 
@@ -173,7 +173,7 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
   "it should create `alloc` and `init` calls in a block for complex assignments" in {
     cpg.typeDecl.name("Bar").method.name("test3").l match {
       case List(method) =>
-        val List(assignParam: Call, allocAssign: Call, init: Call, assign: Call, _: Call, indexAccess: Call) =
+        val List(allocAssign: Call, init: Call, assign: Call, _: Call, indexAccess: Call) =
           method.call.l
         val List(arrayAccess: Call, temp: Identifier) = assign.argument.l
         temp.name shouldBe "$stack1"
@@ -196,14 +196,14 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
         init.methodFullName shouldBe "Bar.<init>:void(int)"
         init.callOut.head.fullName shouldBe "Bar.<init>:void(int)"
         init.signature shouldBe "void(int)"
-        init.code shouldBe "Bar(42)"
+        init.code shouldBe "$stack1.Bar(42)"
         init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
 
         init.argument.size shouldBe 2
         val List(receiver: Identifier, initArg1: Literal) = init.argument.l
         receiver.order shouldBe 0
         receiver.argumentIndex shouldBe 0
-        receiver.name shouldBe "this"
+        receiver.name shouldBe "$stack1"
         receiver.typeFullName shouldBe "Bar"
 
         initArg1.code shouldBe "42"
@@ -216,9 +216,6 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
     cpg.typeDecl.name("Bar").method.fullNameExact("Bar.<init>:void(int,int)").l match {
       case List(method) =>
         val List(
-          assignThis: Call,
-          assignParam1: Call,
-          assignParam2: Call,
           assignAddition: Call,
           init: Call,
           addition: Call
@@ -253,20 +250,12 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
   "it should create only `init` call for direct invocation using `super`" in {
     cpg.typeDecl.name("Bar").method.fullNameExact("Bar.<init>:void(int)").l match {
       case List(method) =>
-        val List(assignThis: Call, paramAssign: Call, alloc: Call) = method.call.l
+        val List(alloc: Call) = method.call.l
         alloc.name shouldBe "<init>"
         alloc.methodFullName shouldBe "Foo.<init>:void(int)"
         alloc.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
         alloc.typeFullName shouldBe "void"
         alloc.signature shouldBe "void(int)"
-
-        val List(thisNode: Identifier, thisParam: Identifier) = assignThis.astChildren.l
-        thisNode.name shouldBe "this"
-        thisNode.typeFullName shouldBe "Bar"
-        thisNode.argumentIndex shouldBe 0
-        thisNode.order shouldBe 0
-        thisNode.code shouldBe "this"
-
         alloc.argument(1).code shouldBe "x"
 
       case res => fail(s"Expected Bar constructor but found $res")

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
@@ -215,11 +215,7 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
   "it should create only `init` call for direct invocation using `this`" in {
     cpg.typeDecl.name("Bar").method.fullNameExact("Bar.<init>:void(int,int)").l match {
       case List(method) =>
-        val List(
-          assignAddition: Call,
-          init: Call,
-          addition: Call
-        ) = method.call.l
+        val List(assignAddition: Call, init: Call, addition: Call) = method.call.l
 
         init.name shouldBe "<init>"
         init.methodFullName shouldBe "Bar.<init>:void(int)"

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/StaticCallGraphTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/StaticCallGraphTests.scala
@@ -33,11 +33,9 @@ class StaticCallGraphTests extends JimpleCodeToCpgFixture {
   "should find a set of outgoing calls for main" in {
     cpg.method.name("main").call.code.toSetMutable shouldBe
       Set(
-        "println($stack3)",
         "add(3, 3)",
-        "argc = @parameter0",
+        "$stack2.println($stack3)",
         "$stack2 = java.lang.System.out",
-        "argv = @parameter1",
         "$stack3 = add(3, 3)",
         "java.lang.System.out"
       )

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/ObjectTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/ObjectTests.scala
@@ -1,6 +1,6 @@
 package io.joern.jimple2cpg.querying.dataflow
 
-import io.joern.dataflowengineoss.language.toExtendedCfgNode
+import io.joern.dataflowengineoss.language.{toDdgNodeDot, toExtendedCfgNode}
 import io.joern.jimple2cpg.testfixtures.JimpleDataflowFixture
 import io.shiftleft.semanticcpg.language._
 
@@ -164,13 +164,13 @@ class ObjectTests extends JimpleDataflowFixture {
 
   ignore should "not find a path to a void printer via a safe field" in {
     val (source, sink) = getMultiFnSourceSink("test7", "printT")
-    // TODO: Data flow is field insensitive and if the object is tainted so are all of the fields"
+    // TODO: The data flow appears to be object-field insensitive and taints the whole object instance
     sink.reachableBy(source).size shouldBe 0
   }
 
   ignore should "not find a path if `MALICIOUS` is overwritten via a setter" in {
     val (source, sink) = getConstSourceSink("test8")
-    // TODO: Data flow is field insensitive and if the object is tainted so are all of the fields"
+    // TODO: The data flow appears to be object-field insensitive and taints the whole object instance
     sink.reachableBy(source).size shouldBe 0
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/ObjectTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/ObjectTests.scala
@@ -1,0 +1,202 @@
+package io.joern.jimple2cpg.querying.dataflow
+
+import io.joern.dataflowengineoss.language.toExtendedCfgNode
+import io.joern.jimple2cpg.testfixtures.JimpleDataflowFixture
+import io.shiftleft.semanticcpg.language._
+
+class ObjectTests extends JimpleDataflowFixture {
+
+  behavior of "Dataflow through objects"
+
+  override val code: String =
+    """
+      |class Bar {
+      |    public String s;
+      |    public String t = "SAFE";
+      |
+      |    public Bar(String s) {
+      |        this.s = s;
+      |    }
+      |
+      |    public void setS(String s) {
+      |        this.s = s;
+      |    }
+      |
+      |    public void setT(String t) {
+      |        this.t = t;
+      |    }
+      |
+      |    public void printS() {
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void printT() {
+      |        System.out.println(t);
+      |    }
+      |
+      |    public String getS() {
+      |        return s;
+      |    }
+      |
+      |    public String getT() {
+      |        return t;
+      |    }
+      |}
+      |
+      |class Foo {
+      |
+      |    public void test1() {
+      |        Bar b = new Bar("MALICIOUS");
+      |        System.out.println(b.s);
+      |    }
+      |
+      |    public void test2() {
+      |        Bar b = new Bar("MALICIOUS");
+      |        System.out.println(b.t);
+      |    }
+      |
+      |    public void test3() {
+      |        Bar b = new Bar("SAFE");
+      |        b.s = "MALICIOUS";
+      |        System.out.println(b.s);
+      |    }
+      |
+      |    public void test4() {
+      |        Bar b = new Bar("MALICIOUS");
+      |        String s = b.getS();
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test5() {
+      |        Bar b = new Bar("MALICIOUS");
+      |        String s = b.getT();
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test6() {
+      |        Bar b = new Bar("MALICIOUS");
+      |        b.printS();
+      |    }
+      |
+      |    public void test7() {
+      |        Bar b = new Bar("MALICIOUS");
+      |        b.printT();
+      |    }
+      |
+      |    public void test8() {
+      |        Bar b = new Bar("MALICIOUS");
+      |        b.setS("SAFE");
+      |        String s = b.s;
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test9() {
+      |        Bar b1 = new Bar("MALICIOUS");
+      |        Bar b2 = b1;
+      |        String s = b2.s;
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test10() {
+      |        Bar b1 = new Bar("SAFE");
+      |        Bar b2 = b1;
+      |        b2.s = "MALICIOUS";
+      |        System.out.println(b1.s);
+      |    }
+      |}
+      |
+      |class Baz {
+      |    public String value;
+      |
+      |    public Baz(String s) {
+      |        value = s;
+      |    }
+      |
+      |    public String toString() {
+      |        return value;
+      |    }
+      |
+      |    public static void sink(Baz b) {
+      |        System.out.println(b.toString());
+      |    }
+      |
+      |    public void test11() {
+      |        Baz b = new Baz("MALICIOUS");
+      |        sink(b);
+      |    }
+      |
+      |    public void test12() {
+      |        sink(new Baz("MALICIOUS"));
+      |    }
+      |}
+      |""".stripMargin
+
+  it should "find a path through the constructor and field of an object" in {
+    val (source, sink) = getConstSourceSink("test1")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if a safe field is accessed (approximation)" in {
+    val (source, sink) = getConstSourceSink("test2")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if a field is directly reassigned to `MALICIOUS`" in {
+    val (source, sink) = getConstSourceSink("test3")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path for malicious input via a getter" in {
+    val (source, sink) = getConstSourceSink("test4")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  ignore should "not find a path when accessing a safe field via a getter" in {
+    val (source, sink) = getConstSourceSink("test5")
+    // TODO: This should not find a path, but does due to over-tainting.
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path to a void printer via a field" in {
+    val (source, sink) = getMultiFnSourceSink("test6", "printS")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  ignore should "not find a path to a void printer via a safe field" in {
+    val (source, sink) = getMultiFnSourceSink("test7", "printT")
+    // TODO: Data flow is field insensitive and if the object is tainted so are all of the fields"
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  ignore should "not find a path if `MALICIOUS` is overwritten via a setter" in {
+    val (source, sink) = getConstSourceSink("test8")
+    // TODO: Data flow is field insensitive and if the object is tainted so are all of the fields"
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path via an alias" in {
+    val (source, sink) = getConstSourceSink("test9")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if a field is reassigned to `MALICIOUS` via an alias" in {
+    val (source, sink) = getConstSourceSink("test10")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a inter-procedural path from object variable" in {
+    def source = cpg.method.name("test11").literal.code("\"MALICIOUS\"")
+    def sink   = cpg.method.name("sink").call.name("println").argument
+    // This matches two since both the variable holding System.out and MALICIOUS are considered tainted at this point
+    sink.reachableBy(source).size shouldBe 2
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  it should "find a inter-procedural path from object instantiation in call argument" in {
+    def source = cpg.method.name("test12").literal.code("\"MALICIOUS\"")
+    def sink   = cpg.method.name("sink").call.name("println").argument
+    // This matches two since both the variable holding System.out and MALICIOUS are considered tainted at this point
+    sink.reachableBy(source).size shouldBe 2
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/OperatorTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/OperatorTests.scala
@@ -4,7 +4,9 @@ import io.joern.dataflowengineoss.language.toExtendedCfgNode
 import io.joern.jimple2cpg.testfixtures.JimpleDataflowFixture
 
 class OperatorTests extends JimpleDataflowFixture {
+
   behavior of "Dataflow through operators"
+
   override val code: String = """
     |class Foo {
     |

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleDataflowFixture.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleDataflowFixture.scala
@@ -35,8 +35,8 @@ class JimpleDataflowFixture extends AnyFlatSpec with Matchers {
     sourceCode: String = "\"MALICIOUS\"",
     sinkPattern: String = ".*println.*"
   ): (Traversal[Literal], Traversal[Expression]) = {
-    val sourceMethod = cpg.method(s".*$sourceMethodName.*").head
-    val sinkMethod   = cpg.method(s".*$sinkMethodName.*").head
+    val sourceMethod = cpg.method(s".*$sourceMethodName").head
+    val sinkMethod   = cpg.method(s".*$sinkMethodName").head
     def source       = sourceMethod.literal.code(sourceCode)
     def sink         = sinkMethod.call.name(sinkPattern).argument(1).ast.collectAll[Expression]
 


### PR DESCRIPTION
### Added

- Object data flow tests that explores fields and inter-procedural calls (both static + virtual)

### Changed

- Removed parsing Jimple `IdentityStmt` since they end up duplicating parameters as locals

### Fixed

- Virtual calls now get passed the correct `this` object as the object the method is actually invoked with
- Virtual call `code` properties now include the object invoking the method