### PR TITLE
Remove keypools from c2cpg and fuzzyc2cpg

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -5,7 +5,6 @@ import io.joern.c2cpg.passes.{AstCreationPass, HeaderContentPass, PreprocessorPa
 import io.joern.c2cpg.utils.Report
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.shiftleft.passes.{IntervalKeyPool, KeyPoolCreator}
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
@@ -19,14 +18,9 @@ class C2Cpg {
   private val report: Report = new Report()
 
   def runAndOutput(config: Config): Cpg = {
-    val keyPool              = KeyPoolCreator.obtain(4, minValue = 101)
-    val metaDataKeyPool      = new IntervalKeyPool(1, 100)
-    val typesKeyPool         = keyPool.head
-    val headerContentKeyPool = keyPool(3)
-
     val cpg = newEmptyCpg(Some(config.outputPath))
 
-    new MetaDataPass(cpg, Languages.NEWC, Some(metaDataKeyPool)).createAndApply()
+    new MetaDataPass(cpg, Languages.NEWC).createAndApply()
 
     val astCreationPass =
       new AstCreationPass(cpg, AstCreationPass.SourceFiles, config, report)
@@ -36,9 +30,9 @@ class C2Cpg {
     headerAstCreationPass.createAndApply()
 
     val types = astCreationPass.usedTypes() ++ headerAstCreationPass.usedTypes()
-    new TypeNodePass(types.distinct, cpg, Some(typesKeyPool)).createAndApply()
+    new TypeNodePass(types.distinct, cpg).createAndApply()
 
-    new HeaderContentPass(cpg, Some(headerContentKeyPool), config).createAndApply()
+    new HeaderContentPass(cpg, config).createAndApply()
 
     report.print()
     cpg

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -22,8 +22,6 @@ class C2Cpg {
     val keyPool              = KeyPoolCreator.obtain(4, minValue = 101)
     val metaDataKeyPool      = new IntervalKeyPool(1, 100)
     val typesKeyPool         = keyPool.head
-    val astKeyPool           = keyPool(1)
-    val headerKeyPool        = keyPool(2)
     val headerContentKeyPool = keyPool(3)
 
     val cpg = newEmptyCpg(Some(config.outputPath))
@@ -31,10 +29,10 @@ class C2Cpg {
     new MetaDataPass(cpg, Languages.NEWC, Some(metaDataKeyPool)).createAndApply()
 
     val astCreationPass =
-      new AstCreationPass(cpg, AstCreationPass.SourceFiles, Some(astKeyPool), config, report)
+      new AstCreationPass(cpg, AstCreationPass.SourceFiles, config, report)
     astCreationPass.createAndApply()
     val headerAstCreationPass =
-      new AstCreationPass(cpg, AstCreationPass.HeaderFiles, Some(headerKeyPool), config, report)
+      new AstCreationPass(cpg, AstCreationPass.HeaderFiles, config, report)
     headerAstCreationPass.createAndApply()
 
     val types = astCreationPass.usedTypes() ++ headerAstCreationPass.usedTypes()

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -7,7 +7,7 @@ import io.joern.c2cpg.parser.{CdtParser, FileDefaults}
 import io.joern.c2cpg.passes.AstCreationPass.InputFiles
 import io.joern.c2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.{ConcurrentWriterCpgPass, IntervalKeyPool}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.shiftleft.utils.IOUtils
 import io.joern.x2cpg.SourceFiles
 
@@ -20,13 +20,8 @@ object AstCreationPass {
   object SourceFiles extends InputFiles
 }
 
-class AstCreationPass(
-  cpg: Cpg,
-  forFiles: InputFiles,
-  keyPool: Option[IntervalKeyPool],
-  config: C2Cpg.Config,
-  report: Report = new Report()
-) extends ConcurrentWriterCpgPass[String](cpg, keyPool = keyPool) {
+class AstCreationPass(cpg: Cpg, forFiles: InputFiles, config: C2Cpg.Config, report: Report = new Report())
+    extends ConcurrentWriterCpgPass[String](cpg) {
 
   private val global: Global    = new Global()
   private val parser: CdtParser = new CdtParser(config)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
@@ -8,14 +8,13 @@ import io.joern.c2cpg.utils.IncludeAutoDiscovery
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, NodeTypes, Properties, PropertyNames}
-import io.shiftleft.passes.{SimpleCpgPass, KeyPool}
+import io.shiftleft.passes.SimpleCpgPass
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.Ast
 import overflowdb.traversal._
 
-class HeaderContentPass(cpg: Cpg, keyPool: Option[KeyPool], config: Config)
-    extends SimpleCpgPass(cpg, keyPool = keyPool) {
+class HeaderContentPass(cpg: Cpg, config: Config) extends SimpleCpgPass(cpg) {
 
   private val systemIncludePaths =
     IncludeAutoDiscovery.discoverIncludePathsC(config) ++ IncludeAutoDiscovery.discoverIncludePathsCPP(config)

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
@@ -19,7 +19,7 @@ object CompleteCpgFixture {
       val cpg = Cpg.emptyCpg
       new MetaDataPass(cpg, Languages.NEWC).createAndApply()
       val astCreationPass =
-        new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))
+        new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
       astCreationPass.createAndApply()
       new CfgCreationPass(cpg).createAndApply()
       new TypeNodePass(astCreationPass.usedTypes(), cpg).createAndApply()

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
@@ -11,7 +11,7 @@ object CpgAstOnlyFixture {
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
       val file = dir / fileName
       file.write(code)
-      new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))
+      new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
         .createAndApply()
     }
     cpg

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
@@ -18,7 +18,7 @@ class CpgCfgFixture(code: String, fileExtension: String = ".c") {
   File.usingTemporaryDirectory("c2cpgtest") { dir =>
     val file = dir / s"file1$fileExtension"
     file.write(s"RET func() { $code }")
-    new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))
+    new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
       .createAndApply()
     new CfgCreationPass(cpg).createAndApply()
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
@@ -18,7 +18,7 @@ object CpgTypeNodeFixture {
 
       new MetaDataPass(cpg, Languages.NEWC).createAndApply()
       val astCreationPass =
-        new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))
+        new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
       astCreationPass.createAndApply()
       new TypeNodePass(astCreationPass.usedTypes(), cpg).createAndApply()
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
@@ -11,7 +11,7 @@ object TestAstOnlyFixture {
       val file = dir / fileName
       file.write(code)
       val cpg = Cpg.emptyCpg
-      new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))
+      new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
         .createAndApply()
       f(cpg)
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
@@ -20,8 +20,8 @@ case class TestProjectFixture(projectName: String) {
   private val config = Config(inputPaths = Set(dirName))
 
   new MetaDataPass(cpg, Languages.C).createAndApply()
-  new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, config).createAndApply()
-  new AstCreationPass(cpg, AstCreationPass.HeaderFiles, None, config).createAndApply()
+  new AstCreationPass(cpg, AstCreationPass.SourceFiles, config).createAndApply()
+  new AstCreationPass(cpg, AstCreationPass.HeaderFiles, config).createAndApply()
   new HeaderContentPass(cpg, None, config).createAndApply()
   new CfgCreationPass(cpg).createAndApply()
   new FileCreationPass(cpg).createAndApply()

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
@@ -22,7 +22,7 @@ case class TestProjectFixture(projectName: String) {
   new MetaDataPass(cpg, Languages.C).createAndApply()
   new AstCreationPass(cpg, AstCreationPass.SourceFiles, config).createAndApply()
   new AstCreationPass(cpg, AstCreationPass.HeaderFiles, config).createAndApply()
-  new HeaderContentPass(cpg, None, config).createAndApply()
+  new HeaderContentPass(cpg, config).createAndApply()
   new CfgCreationPass(cpg).createAndApply()
   new FileCreationPass(cpg).createAndApply()
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
@@ -32,7 +32,7 @@ class AstCreationPassTests
           file.write("//foo")
           file.path.toAbsolutePath.toString
         }
-        new AstCreationPass(cpg, AstCreationPass.SourceFiles, None, Config(inputPaths = Set(dir.path.toString)))
+        new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
           .createAndApply()
         val expectedNamespaceFullNames = expectedFilenames.map(f => s"$f:<global>")
         cpg.namespaceBlock.fullName.l shouldBe expectedNamespaceFullNames

--- a/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -3,7 +3,6 @@ package io.joern.fuzzyc2cpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.fuzzyc2cpg.passes.{AstCreationPass, StubRemovalPass}
-import io.shiftleft.passes.IntervalKeyPool
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.joern.x2cpg.{SourceFiles, X2Cpg, X2CpgConfig}
@@ -23,18 +22,15 @@ class FuzzyC2Cpg() {
     sourceFileExtensions: Set[String],
     optionalOutputPath: Option[String] = None
   ): Cpg = {
-    val metaDataKeyPool = new IntervalKeyPool(1, 100)
-    val typesKeyPool    = new IntervalKeyPool(100, 1000100)
-    val functionKeyPool = new IntervalKeyPool(1000100, Long.MaxValue)
 
     val cpg             = newEmptyCpg(optionalOutputPath)
     val sourceFileNames = SourceFiles.determine(sourcePaths, sourceFileExtensions)
 
-    new MetaDataPass(cpg, Languages.C, Some(metaDataKeyPool)).createAndApply()
-    val astCreator = new AstCreationPass(sourceFileNames, cpg, functionKeyPool)
+    new MetaDataPass(cpg, Languages.C).createAndApply()
+    val astCreator = new AstCreationPass(sourceFileNames, cpg)
     astCreator.createAndApply()
     new StubRemovalPass(cpg).createAndApply()
-    new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg, Some(typesKeyPool)).createAndApply()
+    new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
     cpg
   }
 

--- a/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/passes/AstCreationPass.scala
@@ -13,8 +13,7 @@ import org.slf4j.LoggerFactory
 /** Given a list of filenames, this pass creates abstract syntax trees for each file, including File and NamespaceBlock
   * Files are processed in parallel.
   */
-class AstCreationPass(filenames: List[String], cpg: Cpg, keyPool: IntervalKeyPool)
-    extends ConcurrentWriterCpgPass[String](cpg, keyPool = Some(keyPool)) {
+class AstCreationPass(filenames: List[String], cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg) {
 
   private val logger = LoggerFactory.getLogger(getClass)
   val global: Global = Global()

--- a/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/main/scala/io/joern/fuzzyc2cpg/passes/AstCreationPass.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes.NewNamespaceBlock
 import io.joern.fuzzyc2cpg.Global
 import io.joern.fuzzyc2cpg.passes.astcreation.{AntlrCModuleParserDriver, AstVisitor}
-import io.shiftleft.passes.{ConcurrentWriterCpgPass, IntervalKeyPool}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import org.slf4j.LoggerFactory

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/CpgTestFixture.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/CpgTestFixture.scala
@@ -3,7 +3,6 @@ package io.joern.fuzzyc2cpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.fuzzyc2cpg.passes.{AstCreationPass, StubRemovalPass}
-import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.passes.base.FileCreationPass
 import io.joern.x2cpg.passes.controlflow.CfgCreationPass
@@ -14,13 +13,12 @@ import overflowdb.traversal.TraversalSource
 
 case class CpgTestFixture(projectName: String) {
 
-  val cpg: Cpg     = Cpg.emptyCpg
-  val dirName      = ProjectRoot.relativise(s"joern-cli/frontends/fuzzyc2cpg/src/test/resources/testcode/$projectName")
-  val keyPoolFile1 = new IntervalKeyPool(1001, 2000)
-  val filenames    = SourceFiles.determine(Set(dirName), Set(".c"))
+  val cpg: Cpg  = Cpg.emptyCpg
+  val dirName   = ProjectRoot.relativise(s"joern-cli/frontends/fuzzyc2cpg/src/test/resources/testcode/$projectName")
+  val filenames = SourceFiles.determine(Set(dirName), Set(".c"))
 
   new MetaDataPass(cpg, Languages.C).createAndApply()
-  new AstCreationPass(filenames, cpg, keyPoolFile1).createAndApply()
+  new AstCreationPass(filenames, cpg).createAndApply()
   if (cpg.method.nonEmpty) {
     new CfgCreationPass(cpg).createAndApply()
   }

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/AstCreationPassTests.scala
@@ -4,7 +4,6 @@ import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
-import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import org.scalatest.matchers.should.Matchers
@@ -21,7 +20,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
       expectedFilenameFields.foreach { filename =>
         (dir / filename).write("//foo")
       }
-      new AstCreationPass(filenames, cpg, new IntervalKeyPool(1, 1000))
+      new AstCreationPass(filenames, cpg)
         .createAndApply()
 
       "create one NamespaceBlock per file" in {
@@ -711,9 +710,8 @@ object Fixture {
       file2.write(file2Code)
 
       val cpg       = Cpg.emptyCpg
-      val keyPool   = new IntervalKeyPool(1001, 2000)
       val filenames = List(file1.path.toAbsolutePath.toString, file2.path.toAbsolutePath.toString)
-      new AstCreationPass(filenames, cpg, keyPool).createAndApply()
+      new AstCreationPass(filenames, cpg).createAndApply()
 
       f(cpg)
     }

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/CfgCreationPassTests.scala
@@ -3,7 +3,6 @@ package io.joern.fuzzyc2cpg.passes
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
-import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.passes.controlflow.CfgCreationPass
 import io.joern.x2cpg.passes.controlflow.cfgcreation.Cfg._
@@ -466,9 +465,8 @@ class CfgFixture(file1Code: String) {
   File.usingTemporaryDirectory("fuzzyctest") { dir =>
     val file1 = dir / "file1.c"
     file1.write(s"RET func() { $file1Code }")
-    val keyPoolFile1 = new IntervalKeyPool(1001, 2000)
-    val filenames    = List(file1.path.toAbsolutePath.toString)
-    new AstCreationPass(filenames, cpg, keyPoolFile1).createAndApply()
+    val filenames = List(file1.path.toAbsolutePath.toString)
+    new AstCreationPass(filenames, cpg).createAndApply()
     new CfgCreationPass(cpg).createAndApply()
   }
 

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/StubRemovalPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/StubRemovalPassTests.scala
@@ -2,7 +2,6 @@ package io.joern.fuzzyc2cpg.passes
 
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.passes.controlflow.CfgCreationPass
 import org.scalatest.matchers.should.Matchers
@@ -54,9 +53,8 @@ object StubRemovalPassFixture {
       val file1 = (dir / "file1.c")
       file1.write(file1Code)
       val cpg       = Cpg.emptyCpg
-      val keyPool   = new IntervalKeyPool(1001, 2000)
       val filenames = List(file1.path.toAbsolutePath.toString)
-      new AstCreationPass(filenames, cpg, keyPool).createAndApply()
+      new AstCreationPass(filenames, cpg).createAndApply()
       new CfgCreationPass(cpg).createAndApply()
       new StubRemovalPass(cpg).createAndApply()
       f(cpg)

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/TypeNodePassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/TypeNodePassTests.scala
@@ -2,7 +2,6 @@ package io.joern.fuzzyc2cpg.passes
 
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.passes.frontend.TypeNodePass
 import org.scalatest.matchers.should.Matchers
@@ -25,9 +24,8 @@ object TypeNodePassFixture {
       file1.write(file1Code)
 
       val cpg        = Cpg.emptyCpg
-      val keyPool    = new IntervalKeyPool(1001, 2000)
       val filenames  = List(file1.path.toAbsolutePath.toString)
-      val astCreator = new AstCreationPass(filenames, cpg, keyPool)
+      val astCreator = new AstCreationPass(filenames, cpg)
       astCreator.createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
 

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -118,7 +118,7 @@ class Ghidra2Cpg() {
     val numOfKeypools   = functions.size * 3 + 2
     val keyPoolIterator = KeyPoolCreator.obtain(numOfKeypools).iterator
 
-    new MetaDataPass(fileAbsolutePath, cpg, keyPoolIterator.next()).createAndApply()
+    new MetaDataPass(fileAbsolutePath, cpg).createAndApply()
     new NamespacePass(cpg, fileAbsolutePath, keyPoolIterator.next()).createAndApply()
 
     program.getLanguage.getLanguageDescription.getProcessor.toString match {

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/MetaDataPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/MetaDataPass.scala
@@ -2,16 +2,12 @@ package io.joern.ghidra2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{Languages, nodes}
-import io.shiftleft.passes.{DiffGraph, IntervalKeyPool, ParallelCpgPass}
+import io.shiftleft.passes.{DiffGraph, IntervalKeyPool, ParallelCpgPass, SimpleCpgPass}
+import overflowdb.BatchedUpdate
 
-class MetaDataPass(filename: String, cpg: Cpg, keyPool: IntervalKeyPool)
-    extends ParallelCpgPass[String](cpg, keyPools = Some(keyPool.split(1))) {
+class MetaDataPass(filename: String, cpg: Cpg) extends SimpleCpgPass(cpg) {
 
-  override def partIterator: Iterator[String] = List("").iterator
-
-  override def runOnPart(part: String): Iterator[DiffGraph] = {
-    implicit val diffGraph: DiffGraph.Builder = DiffGraph.newBuilder
-
+  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
     diffGraph.addNode(
       nodes
         .NewTypeDecl()
@@ -26,7 +22,6 @@ class MetaDataPass(filename: String, cpg: Cpg, keyPool: IntervalKeyPool)
         .language(Languages.GHIDRA)
         .version("0.1")
     )
-
-    Iterator(diffGraph.build())
   }
+
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -4,12 +4,10 @@ import better.files.File
 import io.joern.javasrc2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.shiftleft.passes.IntervalKeyPool
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 
-import java.nio.file.Files
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 object JavaSrc2Cpg {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.Node.Parsedness
 import com.github.javaparser.{JavaParser, ParserConfiguration}
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.{ConcurrentWriterCpgPass, DiffGraph, IntervalKeyPool, ParallelCpgPass}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
 import com.github.javaparser.symbolsolver.resolution.typesolvers.{
   CombinedTypeSolver,
   JavaParserTypeSolver,


### PR DESCRIPTION
As both frontends no longer use `ParallelCpgPass`, they no longer require us to specify keypools manually. Also removing keypools from the `MetaDataPass` in ghidra2cpg, but since the `FunctionPass` still needs to be rewritten, we can't remove keypools from the entire frontend yet.