### PR TITLE
Split off a Main.scala in c2cpg

### DIFF
--- a/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
@@ -2,7 +2,7 @@ package io.joern.console.testing
 
 import better.files.Dsl.mkdir
 import better.files.File
-import io.joern.c2cpg.C2Cpg
+import io.joern.c2cpg.{C2Cpg, Config}
 import io.joern.console.cpgcreation.{CpgGenerator, CpgGeneratorFactory, ImportCode}
 import io.joern.console.workspacehandling.{Project, ProjectFile, WorkspaceLoader}
 import io.joern.console.{Console, ConsoleConfig, DefaultAmmoniteExecutor, FrontendConfig, InstallConfig}
@@ -92,7 +92,7 @@ class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory
           case List(h, t) if h == "--define" => t
         }
       val cpg =
-        c2cpg.runAndOutput(C2Cpg.Config(Set(inputPath), outputPath, defines = defines.toSet))
+        c2cpg.runAndOutput(Config(Set(inputPath), outputPath, defines = defines.toSet))
       cpg.close()
       Some(outputPath)
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -1,17 +1,11 @@
 package io.joern.c2cpg
 
-import io.joern.c2cpg.C2Cpg.Config
 import io.joern.c2cpg.passes.{AstCreationPass, HeaderContentPass, PreprocessorPass}
 import io.joern.c2cpg.utils.Report
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
-import org.slf4j.LoggerFactory
-import scopt.OParser
-
-import scala.util.control.NonFatal
 
 class C2Cpg {
 
@@ -41,84 +35,6 @@ class C2Cpg {
   def printIfDefsOnly(config: Config): Unit = {
     val stmts = new PreprocessorPass(config).run().mkString(",")
     println(stmts)
-  }
-
-}
-
-object C2Cpg {
-
-  private val logger = LoggerFactory.getLogger(classOf[C2Cpg])
-
-  final case class Config(
-    inputPaths: Set[String] = Set.empty,
-    outputPath: String = X2CpgConfig.defaultOutputPath,
-    includePaths: Set[String] = Set.empty,
-    defines: Set[String] = Set.empty,
-    includeComments: Boolean = false,
-    logProblems: Boolean = false,
-    logPreprocessor: Boolean = false,
-    printIfDefsOnly: Boolean = false,
-    includePathsAutoDiscovery: Boolean = true
-  ) extends X2CpgConfig[Config] {
-
-    override def withAdditionalInputPath(inputPath: String): Config = copy(inputPaths = inputPaths + inputPath)
-    override def withOutputPath(x: String): Config                  = copy(outputPath = x)
-  }
-
-  def main(args: Array[String]): Unit = {
-
-    val frontendSpecificOptions = {
-      val builder = OParser.builder[Config]
-      import builder._
-      OParser.sequence(
-        programName(classOf[C2Cpg].getSimpleName),
-        opt[Unit]("include-comments")
-          .text(s"includes all comments into the CPG")
-          .action((_, c) => c.copy(includeComments = true)),
-        opt[Unit]("log-problems")
-          .text(s"enables logging of all parse problems while generating the CPG")
-          .action((_, c) => c.copy(logProblems = true)),
-        opt[Unit]("log-preprocessor")
-          .text(s"enables logging of all preprocessor statements while generating the CPG")
-          .action((_, c) => c.copy(logPreprocessor = true)),
-        opt[Unit]("print-ifdef-only")
-          .text(s"prints a comma-separated list of all preprocessor ifdef and if statements; does not create a CPG")
-          .action((_, c) => c.copy(printIfDefsOnly = true)),
-        opt[String]("include")
-          .unbounded()
-          .text("header include paths")
-          .action((incl, c) => c.copy(includePaths = c.includePaths + incl)),
-        opt[Unit]("no-include-auto-discovery")
-          .text("disables auto discovery of header include paths")
-          .action((_, c) => c.copy(includePathsAutoDiscovery = false)),
-        opt[String]("define")
-          .unbounded()
-          .text("define a name")
-          .action((d, c) => c.copy(defines = c.defines + d))
-      )
-    }
-
-    X2Cpg.parseCommandLine(args, frontendSpecificOptions, Config()) match {
-      case Some(config) if config.printIfDefsOnly =>
-        try {
-          new C2Cpg().printIfDefsOnly(config)
-        } catch {
-          case NonFatal(ex) =>
-            logger.error("Failed to print preprocessor statements.", ex)
-            System.exit(1)
-        }
-      case Some(config) =>
-        try {
-          val cpg = new C2Cpg().runAndOutput(config)
-          cpg.close()
-        } catch {
-          case NonFatal(ex) =>
-            logger.error("Failed to generate CPG.", ex)
-            System.exit(1)
-        }
-      case None =>
-        System.exit(1)
-    }
   }
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -1,0 +1,82 @@
+package io.joern.c2cpg
+
+import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
+import org.slf4j.LoggerFactory
+import scopt.OParser
+
+import scala.util.control.NonFatal
+
+final case class Config(
+  inputPaths: Set[String] = Set.empty,
+  outputPath: String = X2CpgConfig.defaultOutputPath,
+  includePaths: Set[String] = Set.empty,
+  defines: Set[String] = Set.empty,
+  includeComments: Boolean = false,
+  logProblems: Boolean = false,
+  logPreprocessor: Boolean = false,
+  printIfDefsOnly: Boolean = false,
+  includePathsAutoDiscovery: Boolean = true
+) extends X2CpgConfig[Config] {
+
+  override def withAdditionalInputPath(inputPath: String): Config = copy(inputPaths = inputPaths + inputPath)
+  override def withOutputPath(x: String): Config                  = copy(outputPath = x)
+}
+
+object Main extends App {
+
+  private val logger = LoggerFactory.getLogger(classOf[C2Cpg])
+
+  val frontendSpecificOptions = {
+    val builder = OParser.builder[Config]
+    import builder._
+    OParser.sequence(
+      programName(classOf[C2Cpg].getSimpleName),
+      opt[Unit]("include-comments")
+        .text(s"includes all comments into the CPG")
+        .action((_, c) => c.copy(includeComments = true)),
+      opt[Unit]("log-problems")
+        .text(s"enables logging of all parse problems while generating the CPG")
+        .action((_, c) => c.copy(logProblems = true)),
+      opt[Unit]("log-preprocessor")
+        .text(s"enables logging of all preprocessor statements while generating the CPG")
+        .action((_, c) => c.copy(logPreprocessor = true)),
+      opt[Unit]("print-ifdef-only")
+        .text(s"prints a comma-separated list of all preprocessor ifdef and if statements; does not create a CPG")
+        .action((_, c) => c.copy(printIfDefsOnly = true)),
+      opt[String]("include")
+        .unbounded()
+        .text("header include paths")
+        .action((incl, c) => c.copy(includePaths = c.includePaths + incl)),
+      opt[Unit]("no-include-auto-discovery")
+        .text("disables auto discovery of header include paths")
+        .action((_, c) => c.copy(includePathsAutoDiscovery = false)),
+      opt[String]("define")
+        .unbounded()
+        .text("define a name")
+        .action((d, c) => c.copy(defines = c.defines + d))
+    )
+  }
+
+  X2Cpg.parseCommandLine(args, frontendSpecificOptions, Config()) match {
+    case Some(config) if config.printIfDefsOnly =>
+      try {
+        new C2Cpg().printIfDefsOnly(config)
+      } catch {
+        case NonFatal(ex) =>
+          logger.error("Failed to print preprocessor statements.", ex)
+          System.exit(1)
+      }
+    case Some(config) =>
+      try {
+        val cpg = new C2Cpg().runAndOutput(config)
+        cpg.close()
+      } catch {
+        case NonFatal(ex) =>
+          logger.error("Failed to generate CPG.", ex)
+          System.exit(1)
+      }
+    case None =>
+      System.exit(1)
+  }
+
+}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.astcreation
 
-import io.joern.c2cpg.C2Cpg
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.datastructures.Stack._
 import io.joern.c2cpg.datastructures.{Global, Scope}
 import io.shiftleft.codepropertygraph.generated.nodes._
@@ -16,7 +16,7 @@ import scala.collection.mutable
 
 class AstCreator(
   val filename: String,
-  val config: C2Cpg.Config,
+  val config: Config,
   val global: Global,
   val diffGraph: DiffGraphBuilder,
   val parserResult: IASTTranslationUnit

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -2,7 +2,7 @@ package io.joern.c2cpg.parser
 
 import better.files.File
 import io.joern.c2cpg.utils.IOUtils
-import io.joern.c2cpg.C2Cpg
+import io.joern.c2cpg.Config
 import org.eclipse.cdt.core.dom.ast.gnu.c.GCCLanguage
 import org.eclipse.cdt.core.dom.ast.gnu.cpp.GPPLanguage
 import org.eclipse.cdt.core.dom.ast.{IASTPreprocessorStatement, IASTTranslationUnit}
@@ -28,7 +28,7 @@ object CdtParser {
 
 }
 
-class CdtParser(config: C2Cpg.Config) extends ParseProblemsLogger with PreprocessorStatementsLogger {
+class CdtParser(config: Config) extends ParseProblemsLogger with PreprocessorStatementsLogger {
 
   import CdtParser._
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.parser
 
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.utils.IncludeAutoDiscovery
 
 import java.nio.file.{Path, Paths}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.passes
 
-import io.joern.c2cpg.C2Cpg
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.astcreation.{AstCreator, Defines}
 import io.joern.c2cpg.datastructures.Global
 import io.joern.c2cpg.parser.{CdtParser, FileDefaults}
@@ -20,7 +20,7 @@ object AstCreationPass {
   object SourceFiles extends InputFiles
 }
 
-class AstCreationPass(cpg: Cpg, forFiles: InputFiles, config: C2Cpg.Config, report: Report = new Report())
+class AstCreationPass(cpg: Cpg, forFiles: InputFiles, config: Config, report: Report = new Report())
     extends ConcurrentWriterCpgPass[String](cpg) {
 
   private val global: Global    = new Global()

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
@@ -1,7 +1,7 @@
 package io.joern.c2cpg.passes
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.datastructures.Global
 import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.utils.IncludeAutoDiscovery

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/PreprocessorPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/PreprocessorPass.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.passes
 
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.parser.{CdtParser, FileDefaults}
 import io.joern.x2cpg.SourceFiles
 import org.eclipse.cdt.core.dom.ast.{

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.utils
 
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, Paths}

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
@@ -1,12 +1,12 @@
 package io.joern.c2cpg.fixtures
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.passes.AstCreationPass
 import io.joern.x2cpg.layers.{Base, TypeRelations}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.shiftleft.semanticcpg.layers.{LayerCreatorContext}
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import io.joern.x2cpg.passes.controlflow.CfgCreationPass
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
@@ -1,7 +1,7 @@
 package io.joern.c2cpg.fixtures
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
@@ -1,7 +1,7 @@
 package io.joern.c2cpg.fixtures
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.CfgNode

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
@@ -1,7 +1,7 @@
 package io.joern.c2cpg.fixtures
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.passes.AstCreationPass
 import io.joern.x2cpg.layers.Base
 import io.shiftleft.codepropertygraph.Cpg

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
@@ -1,7 +1,7 @@
 package io.joern.c2cpg.fixtures
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.fixtures
 
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.passes.{AstCreationPass, HeaderContentPass}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
@@ -1,7 +1,7 @@
 package io.joern.c2cpg.passes
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import io.joern.c2cpg.fixtures.{CpgAstOnlyFixture, CpgTypeNodeFixture, TestAstOnlyFixture}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
@@ -1,7 +1,7 @@
 package io.joern.c2cpg.passes
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.Config
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.testfixtures
 
-import io.joern.c2cpg.C2Cpg
-import io.joern.c2cpg.C2Cpg.Config
+import io.joern.c2cpg.{C2Cpg, Config}
 import io.joern.c2cpg.parser.FileDefaults
 import io.shiftleft.codepropertygraph.Cpg
 import io.joern.x2cpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -95,7 +95,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewTypeRef,
   NewUnknown
 }
-import io.shiftleft.passes.DiffGraph
+
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName
 import io.joern.x2cpg.Ast
 import org.slf4j.LoggerFactory

--- a/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
@@ -1,7 +1,7 @@
 package io.joern.joerncli
 
 import better.files.File
-import io.joern.c2cpg.C2Cpg
+import io.joern.c2cpg.{C2Cpg, Config}
 import io.shiftleft.codepropertygraph.Cpg
 
 trait AbstractJoernCliTest {
@@ -18,7 +18,7 @@ trait AbstractJoernCliTest {
 
     // Create a CPG using the C/C++ parser
     val c2cpg  = new C2Cpg()
-    val config = C2Cpg.Config(inputPaths = inputFilenames, outputPath = c2cpgOutFilename)
+    val config = Config(inputPaths = inputFilenames, outputPath = c2cpgOutFilename)
     c2cpg.runAndOutput(config).close()
     // Link CPG fragments and enhance to create semantic CPG
     val cpg = DefaultOverlays.create(c2cpgOutFilename)


### PR DESCRIPTION
To be consistent with the other frontends, C2CPG now defines a `Main` class that extends from `App` and it's config is in the root package `io.joern.c2cpg`.
