### PR TITLE
Extracted and `X2CpgFrontend` utility trait from `Javasrc2Cpg`

### DIFF
--- a/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
@@ -92,7 +92,7 @@ class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory
           case List(h, t) if h == "--define" => t
         }
       val cpg =
-        c2cpg.runAndOutput(Config(Set(inputPath), outputPath, defines = defines.toSet))
+        c2cpg.createCpg(Config(Set(inputPath), outputPath, defines = defines.toSet))
       cpg.close()
       Some(outputPath)
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -11,7 +11,7 @@ class C2Cpg {
 
   private val report: Report = new Report()
 
-  def runAndOutput(config: Config): Cpg = {
+  def createCpg(config: Config): Cpg = {
     val cpg = newEmptyCpg(Some(config.outputPath))
 
     new MetaDataPass(cpg, Languages.NEWC).createAndApply()

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -68,7 +68,7 @@ object Main extends App {
       }
     case Some(config) =>
       try {
-        val cpg = new C2Cpg().runAndOutput(config)
+        val cpg = new C2Cpg().createCpg(config)
         cpg.close()
       } catch {
         case NonFatal(ex) =>

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
@@ -18,7 +18,7 @@ class C2CpgFrontend(override val fileSuffix: String = FileDefaults.C_EXT) extend
       outputPath = cpgFile.getAbsolutePath,
       includeComments = true
     )
-    c2cpg.runAndOutput(config)
+    c2cpg.createCpg(config)
   }
 }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -5,10 +5,11 @@ import io.joern.javasrc2cpg.passes.AstCreationPass
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
-import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.X2Cpg.newEmptyCpg
+import io.joern.x2cpg.{SourceFiles, X2CpgConfig}
+import io.joern.x2cpg.X2Cpg.{newEmptyCpg, withErrorsToConsole}
 
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
+import scala.util.Try
 
 object JavaSrc2Cpg {
   val language: String = Languages.JAVASRC
@@ -16,27 +17,46 @@ object JavaSrc2Cpg {
   def apply(): JavaSrc2Cpg = new JavaSrc2Cpg()
 }
 
-class JavaSrc2Cpg {
+trait X2CpgFrontend[T <: X2CpgConfig[_]] {
+  def run(config: T): Unit
+}
+
+class JavaSrc2Cpg extends X2CpgFrontend[Config] {
 
   import JavaSrc2Cpg._
 
   val sourceFileExtensions = Set(".java")
 
+  /** Create CPG according to given configuration, printing errors to the console if they occur. The CPG is not
+    * returned.
+    */
+  def run(config: Config): Unit = {
+    withErrorsToConsole(config) { _ =>
+      if (config.inputPaths.size == 1) {
+        createCpg(config.inputPaths.head, Some(config.outputPath))
+      } else {
+        throw new RuntimeException("This frontend requires exactly one input path")
+      }
+    }
+  }
+
   /** Create CPG for Java source code at `sourceCodePath` and store the CPG at `outputPath`. If `outputPath` is `None`,
     * the CPG is created in-memory.
     */
-  def createCpg(sourceCodePath: String, outputPath: Option[String] = None): Cpg = {
-    val cpg = newEmptyCpg(outputPath)
-    new MetaDataPass(cpg, language).createAndApply()
+  def createCpg(sourceCodePath: String, outputPath: Option[String] = None): Try[Cpg] = {
+    Try {
+      val cpg = newEmptyCpg(outputPath)
+      new MetaDataPass(cpg, language).createAndApply()
 
-    val (sourcesDir, sourceFileNames) = getSourcesFromDir(sourceCodePath)
-    val astCreator                    = new AstCreationPass(sourcesDir, sourceFileNames, cpg)
-    astCreator.createAndApply()
+      val (sourcesDir, sourceFileNames) = getSourcesFromDir(sourceCodePath)
+      val astCreator                    = new AstCreationPass(sourcesDir, sourceFileNames, cpg)
+      astCreator.createAndApply()
 
-    new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
-      .createAndApply()
+      new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
+        .createAndApply()
 
-    cpg
+      cpg
+    }
   }
 
   /** JavaParser requires that the input path is a directory and not a single source file. This is inconvenient for

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -26,7 +26,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
   override def createCpg(config: Config): Try[Cpg] = {
     if (config.inputPaths.size == 1) {
       val sourceCodePath = config.inputPaths.head
-      val outputPath     = Some(config.outputPath)
+      val outputPath     = if (config.outputPath != "") Some(config.outputPath) else None
       Try {
         val cpg = newEmptyCpg(outputPath)
         new MetaDataPass(cpg, language).createAndApply()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -3,6 +3,8 @@ package io.joern.javasrc2cpg
 import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
 import scopt.OParser
 
+import scala.util.{Failure, Success}
+
 /** Command line configuration parameters
   */
 final case class Config(inputPaths: Set[String] = Set.empty, outputPath: String = X2CpgConfig.defaultOutputPath)
@@ -25,13 +27,7 @@ object Main extends App {
 
   X2Cpg.parseCommandLine(args, frontendSpecificOptions, Config()) match {
     case Some(config) =>
-      if (config.inputPaths.size == 1) {
-        val cpg = new JavaSrc2Cpg().createCpg(config.inputPaths.head, Some(config.outputPath))
-        cpg.close()
-      } else {
-        println("This frontend requires exactly one input path")
-        System.exit(1)
-      }
+      new JavaSrc2Cpg().run(config)
     case None =>
       System.exit(1)
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -3,8 +3,6 @@ package io.joern.javasrc2cpg
 import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
 import scopt.OParser
 
-import scala.util.{Failure, Success}
-
 /** Command line configuration parameters
   */
 final case class Config(inputPaths: Set[String] = Set.empty, outputPath: String = X2CpgConfig.defaultOutputPath)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -16,7 +16,7 @@ class JavaSrc2CpgTestContext {
     if (buildResult.isEmpty) {
       val javaSrc2Cpg                    = JavaSrc2Cpg()
       implicit val defaultConfig: Config = Config()
-      val cpg                            = javaSrc2Cpg.createCpg(writeCodeToFile(code).getAbsolutePath)
+      val cpg                            = javaSrc2Cpg.createCpg(writeCodeToFile(code).getAbsolutePath, None)
       val context                        = new LayerCreatorContext(cpg.get)
       new Base().run(context)
       new TypeRelations().run(context)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -14,9 +14,10 @@ class JavaSrc2CpgTestContext {
 
   def buildCpg(runDataflow: Boolean): Cpg = {
     if (buildResult.isEmpty) {
-      val javaSrc2Cpg = JavaSrc2Cpg()
-      val cpg         = javaSrc2Cpg.createCpg(writeCodeToFile(code).getAbsolutePath)
-      val context     = new LayerCreatorContext(cpg)
+      val javaSrc2Cpg                    = JavaSrc2Cpg()
+      implicit val defaultConfig: Config = Config()
+      val cpg                            = javaSrc2Cpg.createCpg(writeCodeToFile(code).getAbsolutePath)
+      val context                        = new LayerCreatorContext(cpg.get)
       new Base().run(context)
       new TypeRelations().run(context)
       new ControlFlow().run(context)
@@ -25,7 +26,7 @@ class JavaSrc2CpgTestContext {
         val options = new OssDataFlowOptions()
         new OssDataFlow(options).run(context)
       }
-      buildResult = Some(cpg)
+      buildResult = Some(cpg.get)
     }
     buildResult.get
   }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -16,7 +16,7 @@ class JavaSrc2CpgTestContext {
     if (buildResult.isEmpty) {
       val javaSrc2Cpg                    = JavaSrc2Cpg()
       implicit val defaultConfig: Config = Config()
-      val cpg                            = javaSrc2Cpg.createCpg(writeCodeToFile(code).getAbsolutePath, None)
+      val cpg                            = javaSrc2Cpg.createCpg(writeCodeToFile(code).getAbsolutePath)
       val context                        = new LayerCreatorContext(cpg.get)
       new Base().run(context)
       new TypeRelations().run(context)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -1,6 +1,6 @@
 package io.joern.javasrc2cpg.testfixtures
 
-import io.joern.javasrc2cpg.JavaSrc2Cpg
+import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.joern.x2cpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
 
@@ -11,7 +11,8 @@ class JavaSrcFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".java"
 
   override def execute(sourceCodeFile: File): Cpg = {
-    new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath)
+    implicit val defaultConfig: Config = Config()
+    new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
   }
 }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -12,7 +12,7 @@ class JavaSrcFrontend extends LanguageFrontend {
 
   override def execute(sourceCodeFile: File): Cpg = {
     implicit val defaultConfig: Config = Config()
-    new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
+    new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath, None).get
   }
 }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -12,7 +12,7 @@ class JavaSrcFrontend extends LanguageFrontend {
 
   override def execute(sourceCodeFile: File): Cpg = {
     implicit val defaultConfig: Config = Config()
-    new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath, None).get
+    new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
   }
 }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -30,7 +30,13 @@ trait X2CpgFrontend[T <: X2CpgConfig[_]] {
     */
   def run(config: T): Unit = {
     withErrorsToConsole(config) { _ =>
-      createCpg(config)
+      createCpg(config) match {
+        case Success(cpg) =>
+          cpg.close()
+          Success(cpg)
+        case Failure(exception) =>
+          Failure(exception)
+      }
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -6,6 +6,8 @@ import org.slf4j.LoggerFactory
 import overflowdb.Config
 import scopt.OParser
 
+import scala.util.{Failure, Try}
+
 object X2CpgConfig {
   def defaultOutputPath: String = "cpg.bin"
 }
@@ -71,6 +73,18 @@ object X2Cpg {
         Config.withDefaults()
       }
     Cpg.withConfig(odbConfig)
+  }
+
+  def withErrorsToConsole[T <: X2CpgConfig[_]](config: T)(f: T => Try[_]): Try[_] = {
+    Try {
+      Some(f(config))
+    } match {
+      case Failure(exception) =>
+        println(exception.getMessage)
+        exception.printStackTrace()
+        System.exit(1)
+        Failure(exception)
+    }
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -40,8 +40,12 @@ trait X2CpgFrontend[T <: X2CpgConfig[_]] {
   def createCpg(inputNames: List[String], outputName: Option[String])(implicit defaultConfig: T): Try[Cpg] = {
     val defaultWithInputPaths = inputNames
       .foldLeft(defaultConfig) { (c, x) => c.withAdditionalInputPath(x).asInstanceOf[T] }
-    val config = if (outputName.isDefined) {
-      defaultWithInputPaths.withOutputPath(outputName.get).asInstanceOf[T]
+    val config = if (!outputName.contains(X2CpgConfig.defaultOutputPath)) {
+      if (outputName.isEmpty) {
+        defaultWithInputPaths.withOutputPath("").asInstanceOf[T]
+      } else {
+        defaultWithInputPaths.withOutputPath(outputName.get).asInstanceOf[T]
+      }
     } else {
       defaultWithInputPaths
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -128,6 +128,21 @@ object X2Cpg {
     Cpg.withConfig(odbConfig)
   }
 
+  def withNewEmptyCpg[T <: X2CpgConfig[_]](outPath: String, config: T)(applyPasses: (Cpg, T) => Unit): Try[Cpg] = {
+    val outputPath = if (outPath != "") Some(outPath) else None
+    Try {
+      val cpg = newEmptyCpg(outputPath)
+      Try {
+        applyPasses(cpg, config)
+      } match {
+        case Success(_) => cpg
+        case Failure(exception) =>
+          cpg.close()
+          throw exception
+      }
+    }
+  }
+
   /** Given a function that receives a configuration and returns an arbitrary result type wrapped in a `Try`, evaluate
     * the function, printing errors to the console.
     */

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -20,6 +20,11 @@ trait X2CpgConfig[R] {
 
 trait X2CpgFrontend[T <: X2CpgConfig[_]] {
 
+  /** Create a CPG according to given configuration. Returns CPG wrapped in a `Try`, making it possible to detect and
+    * inspect exceptions in CPG generation.
+    */
+  def createCpg(config: T): Try[Cpg]
+
   /** Create CPG according to given configuration, printing errors to the console if they occur. The CPG is not
     * returned.
     */
@@ -28,11 +33,6 @@ trait X2CpgFrontend[T <: X2CpgConfig[_]] {
       createCpg(config)
     }
   }
-
-  /** Create a CPG according to given configuration. Returns CPG wrapped in a `Try`, making it possible to detect and
-    * inspect exceptions in CPG generation.
-    */
-  def createCpg(config: T): Try[Cpg]
 
   /** Create a CPG for code at `inputNames` with default frontend configuration. If `outputName` exists, it is the file
     * name of the resulting CPG. Otherwise, the CPG is held in memory.

--- a/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
@@ -19,7 +19,7 @@ trait AbstractJoernCliTest {
     // Create a CPG using the C/C++ parser
     val c2cpg  = new C2Cpg()
     val config = Config(inputPaths = inputFilenames, outputPath = c2cpgOutFilename)
-    c2cpg.runAndOutput(config).close()
+    c2cpg.createCpg(config).close()
     // Link CPG fragments and enhance to create semantic CPG
     val cpg = DefaultOverlays.create(c2cpgOutFilename)
     (cpg, c2cpgOutFilename)


### PR DESCRIPTION
The APIs that frontends currently offer to the user are specific for each frontend, leading to code duplication, missing error handling in some of the frontends, and the necessity to learn per frontend how it is used. In an effort to create a single frontend API that works well across frontends, I have extracted the trait `X2CpgFrontend` from `Javasrc2Cpg`. This trait defines the frontend API.

For frontend authors, with this new API, one only has to implement `createCpg(config : Config)` and `createCpg` methods that accept a single input path and multiple input paths are automatically available.


In follow-up PRs, I will port over other frontends to this API.