### PR TITLE
Added commonly used data structures to x2cpg

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/Global.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/Global.scala
@@ -1,0 +1,9 @@
+package io.joern.x2cpg.datastructures
+
+import java.util.concurrent.ConcurrentHashMap
+
+class Global {
+
+  val usedTypes: ConcurrentHashMap[String, Boolean] = new ConcurrentHashMap()
+
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/Scope.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/Scope.scala
@@ -1,0 +1,39 @@
+package io.joern.x2cpg.datastructures
+
+/** Handles the scope stack for tracking identifier to variable relation.
+  *
+  * @tparam I
+  *   Identifier type.
+  * @tparam V
+  *   Variable type.
+  * @tparam S
+  *   Scope type.
+  */
+class Scope[I, V, S] {
+  private var stack = List[ScopeElement[I, V, S]]()
+
+  def isEmpty: Boolean = {
+    stack.isEmpty
+  }
+
+  def pushNewScope(scopeNode: S): Unit = {
+    stack = ScopeElement[I, V, S](scopeNode) :: stack
+  }
+
+  def popScope(): Unit = {
+    stack = stack.tail
+  }
+
+  def addToScope(identifier: I, variable: V): S = {
+    stack = stack.head.addVariable(identifier, variable) :: stack.tail
+    stack.head.scopeNode
+  }
+
+  def lookupVariable(identifier: I): Option[V] = {
+    stack.collectFirst {
+      case scopeElement if scopeElement.variables.contains(identifier) =>
+        scopeElement.variables(identifier)
+    }
+  }
+
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ScopeElement.scala
@@ -1,0 +1,15 @@
+package io.joern.x2cpg.datastructures
+
+/** A single element of a scope stack.
+  * @tparam I
+  *   Identifier type.
+  * @tparam V
+  *   Variable type.
+  * @tparam S
+  *   Scope type.
+  */
+case class ScopeElement[I, V, S](scopeNode: S, variables: Map[I, V] = Map[I, V]()) {
+  def addVariable(identifier: I, variable: V): ScopeElement[I, V, S] = {
+    ScopeElement(scopeNode, variables + (identifier -> variable))
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/Stack.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/Stack.scala
@@ -1,0 +1,19 @@
+package io.joern.x2cpg.datastructures
+
+import scala.collection.mutable
+
+object Stack {
+
+  type Stack[StackElement] = mutable.ListBuffer[StackElement]
+
+  implicit class StackWrapper[StackElement](val parentStack: Stack[StackElement]) extends AnyVal {
+    def push(parent: StackElement): Unit = {
+      parentStack.prepend(parent)
+    }
+
+    def pop(): Unit = {
+      parentStack.remove(0)
+    }
+  }
+
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -1,0 +1,26 @@
+package io.joern.x2cpg.utils
+
+import scala.collection.mutable
+import scala.sys.process.{Process, ProcessLogger}
+import scala.util.{Failure, Success, Try}
+
+object ExternalCommand {
+
+  private val IS_WIN: Boolean =
+    scala.util.Properties.isWin
+
+  private val shellPrefix: Seq[String] =
+    if (IS_WIN) "cmd" :: "/c" :: Nil else "sh" :: "-c" :: Nil
+
+  def run(command: String, cwd: String): Try[Seq[String]] = {
+    val result                      = mutable.ArrayBuffer.empty[String]
+    val lineHandler: String => Unit = result.addOne
+    Process(shellPrefix :+ command, new java.io.File(cwd)).!(ProcessLogger(lineHandler, lineHandler)) match {
+      case 0 =>
+        Success(result.toSeq)
+      case _ =>
+        Failure(new RuntimeException(result.mkString(System.lineSeparator())))
+    }
+  }
+
+}


### PR DESCRIPTION
Following off of @max-leuthaeuser's structure on `js2cpg` where these are separated into a package, I'm pulling some of these commonly used data structures into `x2cpg` to avoid duplication on this end.

Note `ExternalCommand` is added since `solidity2cpg` will be calling an `npm` package too.

Should this PR also reformat other frontends to adopt these or shall each frontend's maintainer do it in their own?