### PR TITLE
Introduce `X2CpgMain` class

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,8 @@ jobs:
         with:
           java-version: 1.11
       - name: Compile and run tests
-        run: joern-cli/frontends/php2cpg/installdeps.sh; sbt clean +test
+        run: joern-cli/frontends/php2cpg/installdeps.sh
+        run: sbt clean +test
         shell: bash
   formatting:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           java-version: 1.11
       - name: Compile and run tests
-        run: sbt clean +test
+        run: joern-cli/frontends/php2cpg/installdeps.sh; sbt clean +test
         shell: bash
   formatting:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: 1.11
       - name: Compile and run tests
         run: joern-cli/frontends/php2cpg/installdeps.sh
-        run: sbt clean +test
+      - run: sbt clean +test
         shell: bash
   formatting:
     runs-on: ubuntu-18.04

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val c2cpg             = Projects.c2cpg
 lazy val ghidra2cpg        = Projects.ghidra2cpg
 lazy val x2cpg             = Projects.x2cpg
 lazy val pysrc2cpg         = Projects.pysrc2cpg
+lazy val php2cpg           = Projects.php2cpg
 
 ThisBuild / compile / javacOptions ++= Seq(
   "-g", // debug symbols

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -34,6 +34,7 @@ lazy val x2cpg       = project.in(file("frontends/x2cpg"))
 lazy val kotlin2cpg  = project.in(file("frontends/kotlin2cpg"))
 lazy val javasrc2cpg = project.in(file("frontends/javasrc2cpg"))
 lazy val pysrc2cpg   = project.in(file("frontends/pysrc2cpg"))
+lazy val php2cpg     = project.in(file("frontends/php2cpg"))
 lazy val jimple2cpg  = project.in(file("frontends/jimple2cpg"))
 lazy val fuzzyc2cpg  = project.in(file("frontends/fuzzyc2cpg"))
 lazy val js2cpg = project
@@ -52,6 +53,7 @@ Universal / mappings ++= frontendMappings("ghidra2cpg", (Projects.ghidra2cpg / s
 Universal / mappings ++= frontendMappings("js2cpg", (js2cpg / stage).value)
 Universal / mappings ++= frontendMappings("jimple2cpg", (jimple2cpg / stage).value)
 Universal / mappings ++= frontendMappings("pysrc2cpg", (pysrc2cpg / stage).value)
+Universal / mappings ++= frontendMappings("phpcpg", (php2cpg / stage).value)
 
 lazy val cpgVersionFile = taskKey[File]("persist cpg version in file (e.g. for schema-extender)")
 cpgVersionFile := {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -24,10 +24,10 @@ final case class Config(
 }
 
 private object Frontend {
-  implicit val defaultConfig: Config = Config()
   private val logger                 = LoggerFactory.getLogger(classOf[C2Cpg])
+  implicit val defaultConfig: Config = Config()
 
-  val frontendSpecificOptions: OParser[Unit, Config] = {
+  val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
     import builder._
     OParser.sequence(
@@ -58,20 +58,20 @@ private object Frontend {
     )
   }
 
-  def run(config: Config): Unit = {
+  def run(config: Config, c2cpg: C2Cpg): Unit = {
     if (config.printIfDefsOnly) {
       try {
-        new C2Cpg().printIfDefsOnly(config)
+        c2cpg.printIfDefsOnly(config)
       } catch {
         case NonFatal(ex) =>
           logger.error("Failed to print preprocessor statements.", ex)
           throw ex
       }
     } else {
-      new C2Cpg().run(config)
+      c2cpg.run(config)
     }
   }
 
 }
 
-object Main extends X2CpgMain(frontendSpecificOptions, run) {}
+object Main extends X2CpgMain(cmdLineParser, run, new C2Cpg()) {}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -24,7 +24,6 @@ final case class Config(
 }
 
 private object Frontend {
-  private val logger                 = LoggerFactory.getLogger(classOf[C2Cpg])
   implicit val defaultConfig: Config = Config()
 
   val cmdLineParser: OParser[Unit, Config] = {
@@ -58,6 +57,12 @@ private object Frontend {
     )
   }
 
+}
+
+object Main extends X2CpgMain(cmdLineParser, new C2Cpg()) {
+
+  private val logger = LoggerFactory.getLogger(classOf[C2Cpg])
+
   def run(config: Config, c2cpg: C2Cpg): Unit = {
     if (config.printIfDefsOnly) {
       try {
@@ -73,5 +78,3 @@ private object Frontend {
   }
 
 }
-
-object Main extends X2CpgMain(cmdLineParser, run, new C2Cpg()) {}

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -16,7 +16,8 @@ import io.joern.ghidra2cpg.passes._
 import io.joern.ghidra2cpg.passes.arm.ArmFunctionPass
 import io.joern.ghidra2cpg.passes.mips.{LoHiPass, MipsFunctionPass}
 import io.joern.ghidra2cpg.passes.x86.{ReturnEdgesPass, X86FunctionPass}
-import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
+import io.joern.x2cpg.{X2Cpg, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.KeyPoolCreator
 import utilities.util.FileUtilities
@@ -24,45 +25,46 @@ import utilities.util.FileUtilities
 import java.io.File
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
-class Ghidra2Cpg() {
+class Ghidra2Cpg extends X2CpgFrontend[Config] {
 
-  /** Create a CPG representing the given input file. The CPG is stored at the given output file. The caller must close
-    * the CPG.
-    */
-  def createCpg(inputFile: File, outputFile: Option[String]): Cpg = {
+  override def createCpg(config: Config): Try[Cpg] = {
+    if (config.inputPaths.size != 1) {
+      throw new RuntimeException("This frontend requires exactly one input path")
+    }
 
+    val inputFile = new File(config.inputPaths.head)
     if (!inputFile.isDirectory && !inputFile.isFile) {
       throw new InvalidInputException(s"$inputFile is not a valid directory or file.")
     }
 
-    val cpg = X2Cpg.newEmptyCpg(outputFile)
+    withNewEmptyCpg(config.outputPath, config) { (cpg, _) =>
+      better.files.File.usingTemporaryDirectory("ghidra2cpg_tmp") { tempWorkingDir =>
+        initGhidra()
+        val locator = new ProjectLocator(tempWorkingDir.path.toAbsolutePath.toString, CommandLineConfig.projectName)
+        var program: Program = null
+        var project: Project = null
 
-    better.files.File.usingTemporaryDirectory("ghidra2cpg_tmp") { tempWorkingDir =>
-      initGhidra()
-      val locator = new ProjectLocator(tempWorkingDir.path.toAbsolutePath.toString, CommandLineConfig.projectName)
-      var program: Program = null
-      var project: Project = null
-
-      try {
-        val projectManager = new HeadlessGhidraProjectManager
-        project = projectManager.createProject(locator, null, false)
-        program = AutoImporter.importByUsingBestGuess(inputFile, null, this, new MessageLog, TaskMonitor.DUMMY)
-        addProgramToCpg(program, inputFile.getAbsolutePath, cpg)
-      } catch {
-        case e: Exception =>
-          e.printStackTrace()
-      } finally {
-        if (program != null) {
-          AutoAnalysisManager.getAnalysisManager(program).dispose()
-          program.release(this)
+        try {
+          val projectManager = new HeadlessGhidraProjectManager
+          project = projectManager.createProject(locator, null, false)
+          program = AutoImporter.importByUsingBestGuess(inputFile, null, this, new MessageLog, TaskMonitor.DUMMY)
+          addProgramToCpg(program, inputFile.getAbsolutePath, cpg)
+        } catch {
+          case e: Exception =>
+            e.printStackTrace()
+        } finally {
+          if (program != null) {
+            AutoAnalysisManager.getAnalysisManager(program).dispose()
+            program.release(this)
+          }
+          project.close()
+          FileUtilities.deleteDir(locator.getProjectDir)
+          locator.getMarkerFile.delete
         }
-        project.close()
-        FileUtilities.deleteDir(locator.getProjectDir)
-        locator.getMarkerFile.delete
       }
     }
-    cpg
   }
 
   private def initGhidra(): Unit = {
@@ -156,6 +158,7 @@ class Ghidra2Cpg() {
       extends DefaultProject(projectManager, connection) {}
 
   private class HeadlessGhidraProjectManager extends DefaultProjectManager {}
+
 }
 
 object Types {

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Main.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Main.scala
@@ -1,6 +1,7 @@
 package io.joern.ghidra2cpg
 
-import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
+import io.joern.ghidra2cpg.Frontend._
+import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
 /** Command line configuration parameters
@@ -13,18 +14,20 @@ final case class Config(inputPaths: Set[String] = Set.empty, outputPath: String 
   override def withOutputPath(x: String): Config = copy(outputPath = x)
 }
 
-object Main extends App {
-  private val frontendSpecificOptions = {
+private object Frontend {
+
+  implicit val defaultConfig: Config = Config()
+
+  val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
     import builder.programName
     OParser.sequence(programName("ghidra2cpg"))
   }
 
-  X2Cpg.parseCommandLine(args, frontendSpecificOptions, Config()) match {
-    case Some(config) =>
-      new Ghidra2Cpg().run(config)
-    case None =>
-      System.exit(1)
+  def run(config: Config, ghidra2Cpg: Ghidra2Cpg): Unit = {
+    ghidra2Cpg.run(config)
   }
 
 }
+
+object Main extends X2CpgMain(cmdLineParser, run, new Ghidra2Cpg()) {}

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Main.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Main.scala
@@ -3,8 +3,6 @@ package io.joern.ghidra2cpg
 import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
 import scopt.OParser
 
-import java.io.File
-
 /** Command line configuration parameters
   */
 final case class Config(inputPaths: Set[String] = Set.empty, outputPath: String = X2CpgConfig.defaultOutputPath)
@@ -24,13 +22,7 @@ object Main extends App {
 
   X2Cpg.parseCommandLine(args, frontendSpecificOptions, Config()) match {
     case Some(config) =>
-      if (config.inputPaths.size == 1) {
-        val inputFile = new File(config.inputPaths.head)
-        new Ghidra2Cpg().createCpg(inputFile, Some(config.outputPath)).close()
-      } else {
-        println("This frontend requires exactly one input path")
-        System.exit(1)
-      }
+      new Ghidra2Cpg().run(config)
     case None =>
       System.exit(1)
   }

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Main.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Main.scala
@@ -23,11 +23,10 @@ private object Frontend {
     import builder.programName
     OParser.sequence(programName("ghidra2cpg"))
   }
+}
 
+object Main extends X2CpgMain(cmdLineParser, new Ghidra2Cpg()) {
   def run(config: Config, ghidra2Cpg: Ghidra2Cpg): Unit = {
     ghidra2Cpg.run(config)
   }
-
 }
-
-object Main extends X2CpgMain(cmdLineParser, run, new Ghidra2Cpg()) {}

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/GhidraBinToCpgSuite.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/GhidraBinToCpgSuite.scala
@@ -1,17 +1,13 @@
 package io.joern.ghidra2cpg.fixtures
 
-import io.joern.ghidra2cpg.Ghidra2Cpg
+import io.joern.ghidra2cpg.{Config, Ghidra2Cpg}
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.joern.x2cpg.testfixtures.{BinToCpgFixture, LanguageFrontend}
 import io.shiftleft.utils.ProjectRoot
 import org.apache.commons.io.FileUtils
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.dataflowengineoss.language._
-import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
-import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
-import io.shiftleft.semanticcpg.language.{ICallResolver, _}
+import io.shiftleft.semanticcpg.language._
 
 import java.nio.file.Files
 
@@ -25,8 +21,9 @@ class GhidraFrontend extends LanguageFrontend {
     val tempDir = Files.createTempDirectory("ghidra2cpg").toFile
     Runtime.getRuntime.addShutdownHook(new Thread(() => FileUtils.deleteQuietly(tempDir)))
 
-    val cpgBin = dir.getAbsolutePath
-    new Ghidra2Cpg().createCpg(inputFile, Some(cpgBin))
+    val cpgBin                         = dir.getAbsolutePath
+    implicit val defaultConfig: Config = Config()
+    new Ghidra2Cpg().createCpg(inputFile.getAbsolutePath, Some(cpgBin)).get
   }
 
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -23,11 +23,10 @@ private object Frontend {
     import builder.programName
     OParser.sequence(programName("javasrc2cpg"))
   }
+}
 
+object Main extends X2CpgMain(cmdLineParser, new JavaSrc2Cpg()) {
   def run(config: Config, javasrc2Cpg: JavaSrc2Cpg): Unit = {
     javasrc2Cpg.run(config)
   }
-
 }
-
-object Main extends X2CpgMain(cmdLineParser, run, new JavaSrc2Cpg()) {}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg
 
-import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
+import io.joern.javasrc2cpg.Frontend._
+import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
 /** Command line configuration parameters
@@ -13,21 +14,20 @@ final case class Config(inputPaths: Set[String] = Set.empty, outputPath: String 
   override def withOutputPath(x: String): Config = copy(outputPath = x)
 }
 
-/** Entry point for command line CPG creator
-  */
-object Main extends App {
+private object Frontend {
 
-  private val frontendSpecificOptions = {
+  implicit val defaultConfig: Config = Config()
+
+  val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
     import builder.programName
     OParser.sequence(programName("javasrc2cpg"))
   }
 
-  X2Cpg.parseCommandLine(args, frontendSpecificOptions, Config()) match {
-    case Some(config) =>
-      new JavaSrc2Cpg().run(config)
-    case None =>
-      System.exit(1)
+  def run(config: Config, javasrc2Cpg: JavaSrc2Cpg): Unit = {
+    javasrc2Cpg.run(config)
   }
 
 }
+
+object Main extends X2CpgMain(cmdLineParser, run, new JavaSrc2Cpg()) {}

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -1,6 +1,7 @@
 package io.joern.jimple2cpg
 
-import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
+import io.joern.jimple2cpg.Frontend._
+import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
 /** Command line configuration parameters
@@ -13,21 +14,22 @@ final case class Config(inputPaths: Set[String] = Set.empty, outputPath: String 
   override def withOutputPath(x: String): Config = copy(outputPath = x)
 }
 
-/** Entry point for command line CPG creator
-  */
-object Main extends App {
+private object Frontend {
 
-  private val frontendSpecificOptions = {
+  implicit val defaultConfig: Config = Config()
+
+  val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
     import builder.programName
     OParser.sequence(programName("jimple2cpg"))
   }
 
-  X2Cpg.parseCommandLine(args, frontendSpecificOptions, Config()) match {
-    case Some(config) =>
-      new Jimple2Cpg().run(config)
-    case None =>
-      System.exit(1)
+  def run(config: Config, jimple2Cpg: Jimple2Cpg): Unit = {
+    jimple2Cpg.run(config)
   }
 
 }
+
+/** Entry point for command line CPG creator
+  */
+object Main extends X2CpgMain(cmdLineParser, run, new Jimple2Cpg()) {}

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -23,13 +23,12 @@ private object Frontend {
     import builder.programName
     OParser.sequence(programName("jimple2cpg"))
   }
-
-  def run(config: Config, jimple2Cpg: Jimple2Cpg): Unit = {
-    jimple2Cpg.run(config)
-  }
-
 }
 
 /** Entry point for command line CPG creator
   */
-object Main extends X2CpgMain(cmdLineParser, run, new Jimple2Cpg()) {}
+object Main extends X2CpgMain(cmdLineParser, new Jimple2Cpg()) {
+  def run(config: Config, jimple2Cpg: Jimple2Cpg): Unit = {
+    jimple2Cpg.run(config)
+  }
+}

--- a/joern-cli/frontends/php2cpg/README.md
+++ b/joern-cli/frontends/php2cpg/README.md
@@ -1,0 +1,21 @@
+# php2cpg
+
+A PHP to CPG converter based on `php-parse`.
+
+## Requirements
+
+* PHP (>=7.0)
+
+## Installation
+
+sudo apt install php
+sh ./installdeps.sh
+
+# How it works
+
+1. `php-parse --json-dump --with-recovery $file` is invoked on each
+source file to obtain a corresponding abstract syntax tree in JSON
+format.
+
+2. JSON ASTs are parsed and converted into code property graphs.
+

--- a/joern-cli/frontends/php2cpg/build.sbt
+++ b/joern-cli/frontends/php2cpg/build.sbt
@@ -1,0 +1,20 @@
+name := "php2cpg"
+
+scalaVersion := "2.13.8"
+crossScalaVersions := Seq("2.13.8", "3.1.1")
+
+dependsOn(Projects.x2cpg)
+
+libraryDependencies ++= Seq(
+  "com.lihaoyi"   %% "ujson" % "1.5.0",
+  "io.shiftleft"  %% "codepropertygraph"        % Versions.cpg,
+  "io.shiftleft"  %% "semanticcpg"              % Versions.cpg,
+  "org.scalatest" %% "scalatest"                % Versions.scalatest % Test
+)
+
+scalacOptions ++= Seq(
+  "-deprecation" // Emit warning and location for usages of deprecated APIs.
+)
+
+enablePlugins(JavaAppPackaging)
+Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/joern-cli/frontends/php2cpg/installdeps.sh
+++ b/joern-cli/frontends/php2cpg/installdeps.sh
@@ -1,0 +1,8 @@
+# Install `composer`
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -r "if (hash_file('sha384', 'composer-setup.php') === '906a84df04cea2aa72f40b5f787e49f22d4c2f19492ac310e8cba5b96ac8b64115ac402c8cd292b8a03482574915d1a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php composer-setup.php
+php -r "unlink('composer-setup.php');"
+
+# Install Nikic's php-parser
+php composer.phar require nikic/php-parser:4.13.2

--- a/joern-cli/frontends/php2cpg/php-parse
+++ b/joern-cli/frontends/php2cpg/php-parse
@@ -1,0 +1,1 @@
+vendor/bin/php-parse

--- a/joern-cli/frontends/php2cpg/php2cpg
+++ b/joern-cli/frontends/php2cpg/php2cpg
@@ -1,0 +1,1 @@
+./target/universal/stage/bin/php2cpg

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
@@ -23,11 +23,10 @@ private object Frontend {
     import builder.programName
     OParser.sequence(programName("php2cpg"))
   }
+}
 
+object Main extends X2CpgMain(cmdLineParser, new Php2Cpg()) {
   def run(config: Config, php2Cpg: Php2Cpg): Unit = {
     php2Cpg.run(config)
   }
-
 }
-
-object Main extends X2CpgMain(cmdLineParser, run, new Php2Cpg()) {}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
@@ -1,0 +1,33 @@
+package io.joern.php2cpg
+
+import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
+import io.joern.php2cpg.Frontend._
+import scopt.OParser
+
+/** Command line configuration parameters
+  */
+final case class Config(inputPaths: Set[String] = Set.empty, outputPath: String = X2CpgConfig.defaultOutputPath)
+    extends X2CpgConfig[Config] {
+
+  override def withAdditionalInputPath(inputPath: String): Config =
+    copy(inputPaths = inputPaths + inputPath)
+  override def withOutputPath(x: String): Config = copy(outputPath = x)
+}
+
+private object Frontend {
+
+  implicit val defaultConfig: Config = Config()
+
+  val cmdLineParser: OParser[Unit, Config] = {
+    val builder = OParser.builder[Config]
+    import builder.programName
+    OParser.sequence(programName("php2cpg"))
+  }
+
+  def run(config: Config, php2Cpg: Php2Cpg): Unit = {
+    php2Cpg.run(config)
+  }
+
+}
+
+object Main extends X2CpgMain(cmdLineParser, run, new Php2Cpg()) {}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -1,0 +1,18 @@
+package io.joern.php2cpg
+
+import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
+import io.joern.x2cpg.X2CpgFrontend
+import io.joern.x2cpg.passes.frontend.MetaDataPass
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.Languages
+
+import scala.util.Try
+
+class Php2Cpg extends X2CpgFrontend[Config] {
+  override def createCpg(config: Config): Try[Cpg] = {
+    withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
+      new MetaDataPass(cpg, Languages.PHP).createAndApply()
+
+    }
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -18,6 +18,19 @@ trait X2CpgConfig[R] {
   def withOutputPath(x: String): R
 }
 
+/** Base class for `Main` classes of CPG frontends.
+  *
+  * Main classes that inherit from this base class parse the command line, exiting with an error code if this does not
+  * succeed. On success, the method `run` is called, which evaluates, given a frontend and a configuration, creates the
+  * CPG and stores it on disk.
+  *
+  * @param cmdLineParser
+  *   parser for command line arguments
+  * @param run
+  *   method that evaluates frontend with configuration
+  * @param frontend
+  *   the frontend to use for CPG creation
+  */
 class X2CpgMain[T <: X2CpgConfig[T], X <: X2CpgFrontend[_]](
   cmdLineParser: OParser[Unit, T],
   run: (T, X) => Unit,

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -18,6 +18,22 @@ trait X2CpgConfig[R] {
   def withOutputPath(x: String): R
 }
 
+class X2CpgMain[T <: X2CpgConfig[T]](frontendSpecificOptions: OParser[Unit, T], run: T => Unit)(implicit
+  defaultConfig: T
+) extends App {
+  X2Cpg.parseCommandLine(args, frontendSpecificOptions, defaultConfig) match {
+    case Some(config) =>
+      try {
+        run(config)
+      } catch {
+        case _: Throwable =>
+          System.exit(1)
+      }
+    case None =>
+      System.exit(1)
+  }
+}
+
 /** Trait that represents a CPG generator, where T is the frontend configuration class.
   */
 trait X2CpgFrontend[T <: X2CpgConfig[_]] {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -18,9 +18,8 @@ trait X2CpgConfig[R] {
   def withOutputPath(x: String): R
 }
 
-/**
- * Trait that represents a CPG generator, where T is the frontend configuration class.
- * */
+/** Trait that represents a CPG generator, where T is the frontend configuration class.
+  */
 trait X2CpgFrontend[T <: X2CpgConfig[_]] {
 
   /** Create a CPG according to given configuration. Returns CPG wrapped in a `Try`, making it possible to detect and

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -18,14 +18,15 @@ trait X2CpgConfig[R] {
   def withOutputPath(x: String): R
 }
 
+/** */
 trait X2CpgFrontend[T <: X2CpgConfig[_]] {
 
   /** Create a CPG according to given configuration. Returns CPG wrapped in a `Try`, making it possible to detect and
-    * inspect exceptions in CPG generation.
+    * inspect exceptions in CPG generation. To be provided by the frontend.
     */
   def createCpg(config: T): Try[Cpg]
 
-  /** Create CPG according to given configuration, printing errors to the console if they occur. The CPG is not
+  /** Create CPG according to given configuration, printing errors to the console if they occur. The CPG closed not
     * returned.
     */
   def run(config: T): Unit = {
@@ -65,7 +66,12 @@ trait X2CpgFrontend[T <: X2CpgConfig[_]] {
     createCpg(List(inputName), outputName)(defaultConfig)
   }
 
+  /** Create a CPG in memory for file at `inputName` with default configuration.
+    */
   def createCpg(inputName: String)(implicit defaultConfig: T): Try[Cpg] = createCpg(inputName, None)(defaultConfig)
+
+  /** Create a CPG in memory for files at `inputNames` with default configuration.
+    */
   def createCpg(inputNames: List[String])(implicit defaultConfig: T): Try[Cpg] =
     createCpg(inputNames, None)(defaultConfig)
 }
@@ -75,10 +81,8 @@ object X2Cpg {
   private val logger = LoggerFactory.getLogger(X2Cpg.getClass)
 
   /** Parse commands line arguments in `args` using an X2Cpg command line parser, extended with the frontend specific
-    * options in `frontendSpecific` with the initial configuration set to `initialConf`.
-    *
-    * On success, the configuration is returned wrapped into an Option. On failure, error messages are printed and
-    * `None` is returned.
+    * options in `frontendSpecific` with the initial configuration set to `initialConf`. On success, the configuration
+    * is returned wrapped into an Option. On failure, error messages are printed and, `None` is returned.
     */
   def parseCommandLine[R <: X2CpgConfig[R]](
     args: Array[String],
@@ -128,6 +132,9 @@ object X2Cpg {
     Cpg.withConfig(odbConfig)
   }
 
+  /** Apply function `applyPasses` to a newly created CPG. The CPG is wrapped in a `Try` and returned. On failure, the
+    * CPG is ensured to be closed.
+    */
   def withNewEmptyCpg[T <: X2CpgConfig[_]](outPath: String, config: T)(applyPasses: (Cpg, T) => Unit): Try[Cpg] = {
     val outputPath = if (outPath != "") Some(outPath) else None
     Try {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -31,12 +31,12 @@ trait X2CpgConfig[R] {
   * @param frontend
   *   the frontend to use for CPG creation
   */
-class X2CpgMain[T <: X2CpgConfig[T], X <: X2CpgFrontend[_]](
-  cmdLineParser: OParser[Unit, T],
-  run: (T, X) => Unit,
-  frontend: X
-)(implicit defaultConfig: T)
-    extends App {
+abstract class X2CpgMain[T <: X2CpgConfig[T], X <: X2CpgFrontend[_]](cmdLineParser: OParser[Unit, T], frontend: X)(
+  implicit defaultConfig: T
+) extends App {
+
+  def run(t: T, x: X): Unit
+
   X2Cpg.parseCommandLine(args, cmdLineParser, defaultConfig) match {
     case Some(config) =>
       try {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -18,7 +18,9 @@ trait X2CpgConfig[R] {
   def withOutputPath(x: String): R
 }
 
-/** */
+/**
+ * Trait that represents a CPG generator, where T is the frontend configuration class.
+ * */
 trait X2CpgFrontend[T <: X2CpgConfig[_]] {
 
   /** Create a CPG according to given configuration. Returns CPG wrapped in a `Try`, making it possible to detect and

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -26,8 +26,6 @@ trait X2CpgConfig[R] {
   *
   * @param cmdLineParser
   *   parser for command line arguments
-  * @param run
-  *   method that evaluates frontend with configuration
   * @param frontend
   *   the frontend to use for CPG creation
   */
@@ -35,17 +33,22 @@ abstract class X2CpgMain[T <: X2CpgConfig[T], X <: X2CpgFrontend[_]](cmdLinePars
   implicit defaultConfig: T
 ) extends App {
 
-  def run(t: T, x: X): Unit
+  /** method that evaluates frontend with configuration
+    */
+  def run(config: T, frontend: X): Unit
 
   X2Cpg.parseCommandLine(args, cmdLineParser, defaultConfig) match {
     case Some(config) =>
       try {
         run(config, frontend)
       } catch {
-        case _: Throwable =>
+        case ex: Throwable =>
+          println(ex.getMessage)
+          ex.printStackTrace()
           System.exit(1)
       }
     case None =>
+      println("Error parsing the command line")
       System.exit(1)
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -18,13 +18,16 @@ trait X2CpgConfig[R] {
   def withOutputPath(x: String): R
 }
 
-class X2CpgMain[T <: X2CpgConfig[T]](frontendSpecificOptions: OParser[Unit, T], run: T => Unit)(implicit
-  defaultConfig: T
-) extends App {
-  X2Cpg.parseCommandLine(args, frontendSpecificOptions, defaultConfig) match {
+class X2CpgMain[T <: X2CpgConfig[T], X <: X2CpgFrontend[_]](
+  cmdLineParser: OParser[Unit, T],
+  run: (T, X) => Unit,
+  frontend: X
+)(implicit defaultConfig: T)
+    extends App {
+  X2Cpg.parseCommandLine(args, cmdLineParser, defaultConfig) match {
     case Some(config) =>
       try {
-        run(config)
+        run(config, frontend)
       } catch {
         case _: Throwable =>
           System.exit(1)

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -13,5 +13,6 @@ object Projects {
   lazy val ghidra2cpg = project.in(frontendsRoot / "ghidra2cpg")
   lazy val fuzzyc2cpg = project.in(frontendsRoot / "fuzzyc2cpg")
   lazy val x2cpg      = project.in(frontendsRoot / "x2cpg")
-  lazy val pysrc2cpg     = project.in(frontendsRoot / "pysrc2cpg")
+  lazy val pysrc2cpg  = project.in(frontendsRoot / "pysrc2cpg")
+  lazy val php2cpg    = project.in(frontendsRoot / "php2cpg")
 }


### PR DESCRIPTION
This PR brings in a new class called `X2CpgMain` which can be used to implement Main classes for CPG frontends. The class is then used in `javasrc2cpg`, `c2cpg`, `jimple2cpg` and `ghidra2cpg`. Moreover, this PR brings in boilerplate for a new `phpsrc2cpg` frontend.