### PR TITLE
Fix javasrc super types

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
@@ -326,16 +326,11 @@ class TypeInfoProvider(global: Global) {
 
   def scopeType(scopeContext: ScopeContext, isSuper: Boolean = false): String = {
     scopeContext.typeDecl match {
+      case Some(typ) if isSuper =>
+        val parentType = typ.inheritsFromTypeFullName.headOption.getOrElse("ANY")
+        registerType(parentType)
       case Some(typ) =>
-        if (isSuper) {
-          val parentType =
-            typ.inheritsFromTypeFullName.headOption
-              .getOrElse("ANY")
-          registerType(parentType)
-        } else {
-          registerType(typ.fullName)
-        }
-
+        registerType(typ.fullName)
       case None => "ANY"
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInfoProvider.scala
@@ -323,6 +323,22 @@ class TypeInfoProvider(global: Global) {
       }
     }
   }
+
+  def scopeType(scopeContext: ScopeContext, isSuper: Boolean = false): String = {
+    scopeContext.typeDecl match {
+      case Some(typ) =>
+        if (isSuper) {
+          val parentType =
+            typ.inheritsFromTypeFullName.headOption
+              .getOrElse("ANY")
+          registerType(parentType)
+        } else {
+          registerType(typ.fullName)
+        }
+
+      case None => "ANY"
+    }
+  }
 }
 
 object TypeInfoProvider {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
@@ -39,7 +39,7 @@ class CfgTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should find that println post dominates correct nodes" in {
-    cpg.call("println").postDominates.size shouldBe 7
+    cpg.call("println").postDominates.size shouldBe 8
   }
 
   "should find that method does not post dominate anything" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -289,7 +289,7 @@ class ConstructorInvocationTests extends JavaSrcCodeToCpgFixture {
 
         val List(obj: Identifier, initArg: Identifier) = init.argument.l
         obj.name shouldBe "this"
-        obj.typeFullName shouldBe "Bar"
+        obj.typeFullName shouldBe "Foo"
         obj.argumentIndex shouldBe 0
         obj.order shouldBe 0
         obj.code shouldBe "this"


### PR DESCRIPTION
This PR fixes some inconsistencies between static/dynamic dispatch logic and when `this` nodes are created for implicit `this` arguments. It also fixes the type of the `this` node for the `<init>` call used to represent `super`.