### PR TITLE
Jimple2Cpg: Upgrade to Soot 4.3.0

### DIFF
--- a/joern-cli/frontends/jimple2cpg/build.sbt
+++ b/joern-cli/frontends/jimple2cpg/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft"            %% "semanticcpg"       % Versions.cpg,
   "org.apache.logging.log4j" % "log4j-slf4j-impl"  % Versions.log4j     % Runtime,
   "io.shiftleft"            %% "semanticcpg"       % Versions.cpg       % Test classifier "tests",
-  "org.soot-oss"             % "soot"              % "4.3.0",
+  "org.soot-oss"             % "soot"              % "4.2.1",
   "org.scalatest"           %% "scalatest"         % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/jimple2cpg/build.sbt
+++ b/joern-cli/frontends/jimple2cpg/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft"            %% "semanticcpg"       % Versions.cpg,
   "org.apache.logging.log4j" % "log4j-slf4j-impl"  % Versions.log4j     % Runtime,
   "io.shiftleft"            %% "semanticcpg"       % Versions.cpg       % Test classifier "tests",
-  "org.soot-oss"             % "soot"              % "4.2.1",
+  "org.soot-oss"             % "soot"              % "4.3.0",
   "org.scalatest"           %% "scalatest"         % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -136,6 +136,7 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
     Options.v().set_no_bodies_for_excluded(true)
     Options.v().set_allow_phantom_refs(true)
     // keep variable names
+    Options.v.setPhaseOption("jb.sils", "enabled:false")
     PhaseOptions.v().setPhaseOption("jb", "use-original-names:true")
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -1,20 +1,17 @@
 package io.joern.jimple2cpg.passes
 
 import io.joern.jimple2cpg.Jimple2Cpg
+import io.joern.x2cpg.datastructures.Global
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
 import org.slf4j.LoggerFactory
 import soot.Scene
 
-import java.util.concurrent.ConcurrentSkipListSet
-
-case class Global(usedTypes: ConcurrentSkipListSet[String] = new ConcurrentSkipListSet[String]())
-
 /** Creates the AST layer from the given class file and stores all types in the given global parameter.
   */
 class AstCreationPass(filenames: List[String], cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg) {
 
-  val global: Global = Global()
+  val global: Global = new Global()
   private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
   override def generateParts(): Array[_ <: AnyRef] = filenames.toArray
@@ -23,6 +20,7 @@ class AstCreationPass(filenames: List[String], cpg: Cpg) extends ConcurrentWrite
     val qualifiedClassName = Jimple2Cpg.getQualifiedClassPath(part)
     try {
       val sootClass = Scene.v().loadClassAndSupport(qualifiedClassName)
+      sootClass.setApplicationClass()
       new AstCreator(part, builder, global).createAst(sootClass)
     } catch {
       case e: Exception =>

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -4,6 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated._
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.Ast.storeInDiffGraph
+import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 import soot.jimple._
@@ -26,7 +27,7 @@ class AstCreator(filename: String, diffGraph: DiffGraphBuilder, global: Global) 
     * key in the map.
     */
   private def registerType(typeName: String): String = {
-    global.usedTypes.add(typeName)
+    global.usedTypes.put(typeName, true)
     typeName
   }
 


### PR DESCRIPTION
### Changed

- Upgraded Soot to 4.3.0.
- Now using `x2cpg` shared `Global` type.
- Disabled Soot whole program/application mode since we only use AST's / Unit types. This will improve Soot performance.