### PR TITLE
data flow engine: fix for detection of same variable

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -233,7 +233,7 @@ class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph) extends Trans
             */
           val sameObjects: Iterable[Call] = allCalls.values.flatten
             .filter(_.asInstanceOf[HasName].name == Operators.fieldAccess)
-            .filter(_.ast.isIdentifier.name(identifier.name).nonEmpty)
+            .filter(_.ast.isIdentifier.nameExact(identifier.name).nonEmpty)
 
           sameIdentifiers ++ sameObjects
         case call: Call =>


### PR DESCRIPTION
We were using `.name` which performs lookup by regular expression. Some identifiers passed in from `javasrc2cpg` contained non-alphanumeric characters, triggering a crash. Using `.nameExact` now.