### PR TITLE
Tweak props around kt fieldAccess calls

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -473,7 +473,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
           val node =
             NewMember()
               .name(param.getName)
-              .code(param.getText)
+              .code(param.getName)
               .typeFullName(typeFullName)
               .lineNumber(line(param))
               .columnNumber(column(param))
@@ -565,6 +565,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
           val fieldAccessCall =
             NewCall()
               .methodFullName(Operators.fieldAccess)
+              .name(Operators.fieldAccess)
               .dispatchType(DispatchTypes.STATIC_DISPATCH)
               .signature("")
               .typeFullName(typeFullName)
@@ -2107,7 +2108,14 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
       } else {
         DispatchTypes.STATIC_DISPATCH
       }
-    val methodName = expr.getSelectorExpression.getFirstChild.getText
+
+    val isFieldAccess = fullNameWithSig._1 == Operators.fieldAccess
+    val methodName =
+      if (isFieldAccess) {
+        Operators.fieldAccess
+      } else {
+        expr.getSelectorExpression.getFirstChild.getText
+      }
     val callNode =
       NewCall()
         .order(order)
@@ -2698,7 +2706,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
 
     val callNode =
       NewCall()
-        .name(expr.getReferencedName)
+        .name(Operators.fieldAccess)
         .code(Constants.this_ + "." + expr.getReferencedName)
         .dispatchType(DispatchTypes.DYNAMIC_DISPATCH)
         .methodFullName(Operators.fieldAccess)
@@ -2991,7 +2999,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     val memberNode =
       NewMember()
         .name(name)
-        .code(code)
+        .code(name)
         .typeFullName(typeFullName)
         .lineNumber(line(decl))
         .columnNumber(column(decl))

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -1,7 +1,7 @@
 package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.Kotlin2CpgTestContext
-import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{FieldIdentifier, Identifier}
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -27,7 +27,7 @@ class CallsToFieldAccessTests extends AnyFreeSpec with Matchers {
     "should contain a CALL node for the referenced member with the correct props set" in {
       val List(c) = cpg.call.codeExact("println(x)").argument.isCall.l
       c.code shouldBe "this.x"
-      c.name shouldBe "x"
+      c.name shouldBe Operators.fieldAccess
       c.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(16)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MemberTests.scala
@@ -48,7 +48,7 @@ class MemberTests extends AnyFreeSpec with Matchers {
 
     "should contain MEMBER node with correct properties" in {
       val List(x) = cpg.member("x").l
-      x.code shouldBe "private val x: String"
+      x.code shouldBe "x"
       x.typeFullName shouldBe "java.lang.String"
     }
   }


### PR DESCRIPTION
- makes them easier to spot in dataflow results
- also make CODE prop of ctor-defined members consistent with
  non-ctor-defined ones