### PR TITLE
Added a Query Engine Statistics Tracker

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/OperatorTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/OperatorTests.scala
@@ -1,6 +1,7 @@
 package io.joern.jimple2cpg.querying.dataflow
 
 import io.joern.dataflowengineoss.language.toExtendedCfgNode
+import io.joern.dataflowengineoss.queryengine.QueryEngineStatistics
 import io.joern.jimple2cpg.testfixtures.JimpleDataflowFixture
 
 class OperatorTests extends JimpleDataflowFixture {


### PR DESCRIPTION
Added a statistic tracker to the data flow query engine. This is essentially a wrapper around a enum-driven concurrent map.

Example output at the end of Jimple's `OperatorTests`:
```scala
Map(PATH_CACHE_HITS -> 5, PATH_CACHE_MISSES -> 83)
```