### PR TITLE
Javasrc: Attempt to find true source roots from given dir.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -64,6 +64,7 @@ import com.github.javaparser.resolution.UnsolvedSymbolException
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration
 import io.joern.javasrc2cpg.passes.AstWithCtx.astWithCtxToSeq
 import io.joern.javasrc2cpg.passes.Context.mergedCtx
+import io.joern.javasrc2cpg.util.TypeInfoProvider
 import io.shiftleft.codepropertygraph.generated.{
   ControlStructureTypes,
   DispatchTypes,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceRootFinder.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceRootFinder.scala
@@ -2,12 +2,14 @@ package io.joern.javasrc2cpg.util
 
 import better.files.File
 
-case class DirectoryStructureInfo(priority: Int, structure: List[String])
-
-/** Given a `codeDirectory`, the HeuristicSourceFinder attempts to find all the source roots.
+/** Given a `codeDirectory`, the SourceRootFinder attempts to find all the source roots (so that the subdirectories
+  * match the package structure of the source files). The JavaParserTypeSolver is path-dependent, so without this the
+  * user would need to ensure that they specify the correct source directory when running javasrc2cpg.
   *
-  * You might wonder, isn't a basic FSM overkill for this? Well, it probably is, but does the job (maybe even moderately
-  * efficiently), so it's hopefully good enough for now.
+  * This works by checking if any subdirectories of the given directory match common java directory structures. In order
+  * of preference: * Maven's default structure, e.g. src/main/java/io/... and src/test/java/io/... * Top-level src and
+  * test directories, e.g. src/io/... and test/io/... If neither of these match, then it defaults to using the given
+  * user input as the source root.
   */
 object SourceRootFinder {
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceRootFinder.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceRootFinder.scala
@@ -1,0 +1,73 @@
+package io.joern.javasrc2cpg.util
+
+import better.files.File
+
+case class DirectoryStructureInfo(priority: Int, structure: List[String])
+
+/** Given a `codeDirectory`, the HeuristicSourceFinder attempts to find all the source roots.
+  *
+  * You might wonder, isn't a basic FSM overkill for this? Well, it probably is, but does the job (maybe even moderately
+  * efficiently), so it's hopefully good enough for now.
+  */
+object SourceRootFinder {
+
+  private def statePreSrc(currentDir: File): List[File] = {
+    currentDir.children.filter(_.isDirectory).toList.flatMap { child =>
+      child.name match {
+        case "src"  => stateSrc(child)
+        case "main" => stateMainTest(child)
+        case "test" => stateMainTest(child)
+        case "java" => child :: Nil
+        case _      => statePreSrc(child)
+      }
+    }
+  }
+
+  private def stateSrc(currentDir: File): List[File] = {
+    val mainTestChildren = currentDir.children.filter(_.isDirectory).toList.flatMap { child =>
+      child.name match {
+        case "main" => stateMainTest(child)
+        case "test" => stateMainTest(child)
+        case _      => Nil
+      }
+    }
+
+    mainTestChildren match {
+      case Nil => List(currentDir)
+      case _   => mainTestChildren
+    }
+  }
+
+  private def stateMainTest(currentDir: File): List[File] = {
+    val javaChildren = currentDir.children.filter(_.isDirectory).toList.flatMap { child =>
+      child.name match {
+        case "java" => child :: Nil
+        case _      => Nil
+      }
+    }
+
+    javaChildren match {
+      case Nil => currentDir :: Nil
+      case _   => javaChildren
+    }
+  }
+
+  private def listBottomLevelSubdirectories(currentDir: File): List[File] = {
+    val srcDirs = currentDir.name match {
+      case "src"  => stateSrc(currentDir)
+      case "main" => stateMainTest(currentDir)
+      case "test" => stateMainTest(currentDir)
+      case "java" => List(currentDir)
+      case _      => statePreSrc(currentDir)
+    }
+
+    srcDirs match {
+      case Nil => List(currentDir)
+      case _   => srcDirs
+    }
+  }
+
+  def getSourceRoots(codeDir: String): List[String] = {
+    listBottomLevelSubdirectories(File(codeDir)).map(_.pathAsString)
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
@@ -1,41 +1,14 @@
-package io.joern.javasrc2cpg.passes
+package io.joern.javasrc2cpg.util
 
 import com.github.javaparser.ast.`type`.ClassOrInterfaceType
-import com.github.javaparser.ast.body.{
-  ConstructorDeclaration,
-  EnumConstantDeclaration,
-  MethodDeclaration,
-  TypeDeclaration,
-  VariableDeclarator
-}
-import com.github.javaparser.ast.expr.{
-  BooleanLiteralExpr,
-  CharLiteralExpr,
-  DoubleLiteralExpr,
-  Expression,
-  IntegerLiteralExpr,
-  LiteralExpr,
-  LongLiteralExpr,
-  MethodCallExpr,
-  NameExpr,
-  NullLiteralExpr,
-  StringLiteralExpr,
-  TextBlockLiteralExpr,
-  ThisExpr
-}
+import com.github.javaparser.ast.body.{EnumConstantDeclaration, TypeDeclaration, VariableDeclarator}
+import com.github.javaparser.ast.expr._
 import com.github.javaparser.ast.nodeTypes.NodeWithType
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt
 import com.github.javaparser.resolution.Resolvable
-import com.github.javaparser.resolution.declarations.{
-  ResolvedDeclaration,
-  ResolvedMethodDeclaration,
-  ResolvedMethodLikeDeclaration,
-  ResolvedParameterDeclaration,
-  ResolvedReferenceTypeDeclaration,
-  ResolvedTypeDeclaration,
-  ResolvedTypeParameterDeclaration
-}
+import com.github.javaparser.resolution.declarations._
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType}
+import io.joern.javasrc2cpg.passes.{Global, ScopeContext}
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
@@ -1,13 +1,10 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
-import io.shiftleft.codepropertygraph.generated.edges.Capture
-import io.shiftleft.codepropertygraph.generated.nodes.ClosureBinding
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import overflowdb.traversal._
 
 class InferenceJarTests extends AnyFreeSpec with Matchers {
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
@@ -1,0 +1,84 @@
+package io.joern.javasrc2cpg.util
+
+import better.files.File
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SourceRootFinderTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private val rootTmpDir: File = File.newTemporaryDirectory("javasrc_root_test").deleteOnExit()
+  private lazy val rootPath    = rootTmpDir.pathAsString
+
+  override def beforeAll(): Unit = {
+
+    val directoriesToCreate = List(
+      File(rootPath, "maven", "mvn1", "src", "main", "java", "io"),
+      File(rootPath, "maven", "mvn1", "src", "main", "scala", "io"),
+      File(rootPath, "maven", "mvn1", "src", "test", "java", "io"),
+      File(rootPath, "maven", "mvn1", "src", "main", "resources", "jars"),
+      File(rootPath, "maven", "mvn2", "src", "main", "java", "io"),
+      File(rootPath, "src", "io"),
+      File(rootPath, "test", "io"),
+      File(rootPath, "some", "nested", "directories", "src", "io"),
+      File(rootPath, "some", "nested", "more", "directories", "src", "io"),
+      File(rootPath, "some", "nested", "more", "directories", "test", "io"),
+      File(rootPath, "nosrc", "nested", "directories", "io")
+    )
+
+    directoriesToCreate.foreach { file =>
+      file.createDirectories()
+      file.deleteOnExit()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    if (rootTmpDir.exists) {
+      rootTmpDir.delete()
+    }
+  }
+
+  it should "find all the correct source directories if tmp root is given" in {
+    val sourceRoots = SourceRootFinder.getSourceRoots(rootPath)
+    sourceRoots.sorted shouldBe List(
+      s"$rootPath/maven/mvn1/src/main/java",
+      s"$rootPath/maven/mvn1/src/test/java",
+      s"$rootPath/maven/mvn2/src/main/java",
+      s"$rootPath/src",
+      s"$rootPath/test",
+      s"$rootPath/some/nested/directories/src",
+      s"$rootPath/some/nested/more/directories/src",
+      s"$rootPath/some/nested/more/directories/test"
+    ).sorted
+  }
+
+  it should "find the given directory if no matching subdirectories are found" in {
+    val sourceRoots = SourceRootFinder.getSourceRoots(s"$rootPath/nosrc")
+    sourceRoots shouldBe List(s"$rootPath/nosrc")
+  }
+
+  it should "find a src directory without main/test subdirectory" in {
+    val sourceRoots = SourceRootFinder.getSourceRoots(s"$rootPath/some/nested/directories")
+    sourceRoots shouldBe List(s"$rootPath/some/nested/directories/src")
+
+    val specificSourceRoots = SourceRootFinder.getSourceRoots(s"$rootPath/some/nested/directories/src")
+    specificSourceRoots shouldBe List(s"$rootPath/some/nested/directories/src")
+  }
+
+  it should "find the correct directory if a rootPath partly into a src/maintest/java string is given" in {
+    val srcRoot = SourceRootFinder.getSourceRoots(s"$rootPath/maven/mvn2/src")
+    srcRoot shouldBe List(s"$rootPath/maven/mvn2/src/main/java")
+
+    val mainRoot = SourceRootFinder.getSourceRoots(s"$rootPath/maven/mvn2/src/main")
+    mainRoot shouldBe List(s"$rootPath/maven/mvn2/src/main/java")
+
+    val javaRoot = SourceRootFinder.getSourceRoots(s"$rootPath/maven/mvn2/src/main/java")
+    javaRoot shouldBe List(s"$rootPath/maven/mvn2/src/main/java")
+
+    // This is an example of where the SourceRootFinder gets the wrong result. This is because it never
+    // searches "up" from the given directory.
+    val ioRoot = SourceRootFinder.getSourceRoots(s"$rootPath/maven/mvn2/src/main/java/io")
+    ioRoot shouldBe List(s"$rootPath/maven/mvn2/src/main/java/io")
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
@@ -39,8 +39,14 @@ class SourceRootFinderTests extends AnyFlatSpec with Matchers with BeforeAndAfte
     }
   }
 
+  private def rootsWithUnixSeparators(path: String): List[String] = {
+    SourceRootFinder
+      .getSourceRoots(path)
+      .map { srcPath => srcPath.replaceAll(java.io.File.pathSeparator, "/")}
+  }
+
   it should "find all the correct source directories if tmp root is given" in {
-    val sourceRoots = SourceRootFinder.getSourceRoots(rootPath)
+    val sourceRoots = rootsWithUnixSeparators(rootPath)
     sourceRoots.sorted shouldBe List(
       s"$rootPath/maven/mvn1/src/main/java",
       s"$rootPath/maven/mvn1/src/test/java",
@@ -54,31 +60,31 @@ class SourceRootFinderTests extends AnyFlatSpec with Matchers with BeforeAndAfte
   }
 
   it should "find the given directory if no matching subdirectories are found" in {
-    val sourceRoots = SourceRootFinder.getSourceRoots(s"$rootPath/nosrc")
+    val sourceRoots = rootsWithUnixSeparators(s"$rootPath/nosrc")
     sourceRoots shouldBe List(s"$rootPath/nosrc")
   }
 
   it should "find a src directory without main/test subdirectory" in {
-    val sourceRoots = SourceRootFinder.getSourceRoots(s"$rootPath/some/nested/directories")
+    val sourceRoots = rootsWithUnixSeparators(s"$rootPath/some/nested/directories")
     sourceRoots shouldBe List(s"$rootPath/some/nested/directories/src")
 
-    val specificSourceRoots = SourceRootFinder.getSourceRoots(s"$rootPath/some/nested/directories/src")
+    val specificSourceRoots = rootsWithUnixSeparators(s"$rootPath/some/nested/directories/src")
     specificSourceRoots shouldBe List(s"$rootPath/some/nested/directories/src")
   }
 
   it should "find the correct directory if a rootPath partly into a src/maintest/java string is given" in {
-    val srcRoot = SourceRootFinder.getSourceRoots(s"$rootPath/maven/mvn2/src")
+    val srcRoot = rootsWithUnixSeparators(s"$rootPath/maven/mvn2/src")
     srcRoot shouldBe List(s"$rootPath/maven/mvn2/src/main/java")
 
-    val mainRoot = SourceRootFinder.getSourceRoots(s"$rootPath/maven/mvn2/src/main")
+    val mainRoot = rootsWithUnixSeparators(s"$rootPath/maven/mvn2/src/main")
     mainRoot shouldBe List(s"$rootPath/maven/mvn2/src/main/java")
 
-    val javaRoot = SourceRootFinder.getSourceRoots(s"$rootPath/maven/mvn2/src/main/java")
+    val javaRoot = rootsWithUnixSeparators(s"$rootPath/maven/mvn2/src/main/java")
     javaRoot shouldBe List(s"$rootPath/maven/mvn2/src/main/java")
 
     // This is an example of where the SourceRootFinder gets the wrong result. This is because it never
     // searches "up" from the given directory.
-    val ioRoot = SourceRootFinder.getSourceRoots(s"$rootPath/maven/mvn2/src/main/java/io")
+    val ioRoot = rootsWithUnixSeparators(s"$rootPath/maven/mvn2/src/main/java/io")
     ioRoot shouldBe List(s"$rootPath/maven/mvn2/src/main/java/io")
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
@@ -46,7 +46,7 @@ class SourceRootFinderTests extends AnyFlatSpec with Matchers with BeforeAndAfte
   private def rootsWithUnixSeparators(file: File): List[String] = {
     SourceRootFinder
       .getSourceRoots(file.pathAsString)
-      .map { srcPath => srcPath.replaceAll(java.io.File.separator, "/") }
+      .map { srcPath => srcPath.replaceAll("\\" ++ java.io.File.separator, "/") }
   }
 
   it should "find all the correct source directories if tmp root is given" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
@@ -42,7 +42,7 @@ class SourceRootFinderTests extends AnyFlatSpec with Matchers with BeforeAndAfte
   private def rootsWithUnixSeparators(path: String): List[String] = {
     SourceRootFinder
       .getSourceRoots(path)
-      .map { srcPath => srcPath.replaceAll(java.io.File.pathSeparator, "/")}
+      .map { srcPath => srcPath.replaceAll(java.io.File.pathSeparator, "/") }
   }
 
   it should "find all the correct source directories if tmp root is given" in {


### PR DESCRIPTION
Copied from `SourceRootFinder` comment:

>Given a `codeDirectory`, the SourceRootFinder attempts to find all the source roots (so that the subdirectories
>match the package structure of the source files). The JavaParserTypeSolver is path-dependent, so without this the
>user would need to ensure that they specify the correct source directory when running javasrc2cpg.
>
>This works by checking if any subdirectories of the given directory match common java directory structures. In order
>of preference: * Maven's default structure, e.g. src/main/java/io/... and src/test/java/io/... * Top-level src and
>test directories, e.g. src/io/... and test/io/... If neither of these match, then it defaults to using the given
>user input as the source root.

This also moves the `TypeInfoProvider` and `SourceRootFinder` into a new `util` package, since they aren't really `passes`, and moves the symbol solver creation out of `runOnPart` to avoid recreating it for every source file.
