### PR TITLE
jimple2cpg: Fix JAR File Package Resolution

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -30,6 +30,7 @@ object Jimple2Cpg {
     */
   def getQualifiedClassPath(filename: String): String = {
     val codePath = ProgramHandlingUtil.getUnpackingDir
+
     val codeDir: String = if (codePath.toFile.isDirectory) {
       codePath.toAbsolutePath.normalize.toString
     } else {

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -29,7 +29,7 @@ object Jimple2Cpg {
     *   the correctly formatted class path.
     */
   def getQualifiedClassPath(filename: String): String = {
-    val codePath = ProgramHandlingUtil.TEMP_DIR
+    val codePath = ProgramHandlingUtil.getUnpackingDir
     val codeDir: String = if (codePath.toFile.isDirectory) {
       codePath.toAbsolutePath.normalize.toString
     } else {
@@ -127,7 +127,7 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
     Options.v().set_app(false)
     Options.v().set_whole_program(false)
     // make sure classpath is configured correctly
-    Options.v().set_soot_classpath(ProgramHandlingUtil.TEMP_DIR.toString)
+    Options.v().set_soot_classpath(ProgramHandlingUtil.getUnpackingDir.toString)
     Options.v().set_prepend_classpath(true)
     // keep debugging info
     Options.v().set_keep_line_number(true)

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -27,18 +27,9 @@ class AstCreator(filename: String, diffGraph: DiffGraphBuilder, global: Global) 
     * key in the map.
     */
   private def registerType(typeName: String): String = {
-    val cleanType = removeUnwantedPrefix(typeName)
-    global.usedTypes.put(cleanType, true)
-    cleanType
+    global.usedTypes.put(typeName, true)
+    typeName
   }
-
-  /** For certain frameworks, application classes are lumped into specific directories that produce undesirable class
-    * paths, e.g., Spring Boot places application code in a `BOOT-INF/classes/` directory.
-    * @param typePath
-    *   the path to modify.
-    */
-  private def removeUnwantedPrefix(typePath: String): String =
-    typePath.replaceAll("^(.*)-INF\\.classes\\.", "")
 
   /** Entry point of AST creation. Translates a compilation unit created by JavaParser into a DiffGraph containing the
     * corresponding CPG AST.

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
@@ -27,7 +27,7 @@ class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
     x.code shouldBe "Foo"
     x.fullName shouldBe "Foo"
     x.isExternal shouldBe false
-    x.inheritsFromTypeFullName shouldBe List("java.lang.Object", "java.io.Serializable")
+    x.inheritsFromTypeFullName shouldBe List("java.io.Serializable")
     x.aliasTypeFullName shouldBe None
     x.order shouldBe 1
     x.filename should (startWith(File.separator) or startWith regex "[A-Z]:")

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpacking.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpacking.scala
@@ -36,12 +36,7 @@ class JarUnpacking extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       .filter(f => f.isFile && f.getName.contains(".jar"))
       .map(_.getName)
       .toArray shouldBe Array("HelloWorld.jar")
-    Files
-      .walk(Path.of(ProgramHandlingUtil.getUnpackingDir.toString))
-      .map(_.toFile)
-      .filter(f => f.isFile && f.getName.contains(".class"))
-      .toArray
-      .length shouldBe 0
+    ProgramHandlingUtil.getUnpackingDir.toFile.length() shouldBe 0
   }
 
   "should reflect the correct package order" in {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpacking.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpacking.scala
@@ -37,7 +37,7 @@ class JarUnpacking extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       .map(_.getName)
       .toArray shouldBe Array("HelloWorld.jar")
     Files
-      .walk(Path.of(ProgramHandlingUtil.TEMP_DIR.toString))
+      .walk(Path.of(ProgramHandlingUtil.getUnpackingDir.toString))
       .map(_.toFile)
       .filter(f => f.isFile && f.getName.contains(".class"))
       .toArray


### PR DESCRIPTION
- JARs are now unpacked then repacked according to the package in the class file assembly.
- Fixed issue where if there was an interface for a type, `java.lang.Object` would still be added additionally as an inherited type. 