### PR TITLE
Improve c2cpg performance.

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -7,6 +7,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.NewMethodReturn
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 import io.shiftleft.codepropertygraph.generated.nodes.NewCall
 import io.joern.x2cpg.Ast
+import io.shiftleft.utils.IOUtils
 import org.apache.commons.lang.StringUtils
 import org.eclipse.cdt.core.dom.ast._
 import org.eclipse.cdt.core.dom.ast.c.{ICASTArrayDesignator, ICASTDesignatedInitializer, ICASTFieldDesignator}
@@ -16,8 +17,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalBinding
 import org.eclipse.cdt.internal.core.dom.parser.cpp.{CPPASTIdExpression, CPPASTQualifiedName, CPPFunction}
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Path, Paths}
 import scala.annotation.nowarn
 import scala.collection.mutable
 
@@ -65,11 +65,7 @@ trait AstCreatorHelper {
   }
 
   private def genFileOffsetTable(fileName: Path): Array[Int] = {
-    val bytes    = Files.readAllBytes(fileName)
-    var asString = new String(bytes, StandardCharsets.UTF_8)
-    asString = asString.replaceAll("\r\n", "\n")
-    asString = asString.replaceAll("\r", "\n")
-    val asCharArray = asString.toCharArray
+    val asCharArray = IOUtils.readLinesInFile(fileName).mkString("\n").toCharArray
     val offsets     = mutable.ArrayBuffer.empty[Int]
 
     for (i <- Range(0, asCharArray.length)) {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/Global.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/Global.scala
@@ -12,7 +12,7 @@ class Global {
   val usedTypes: ConcurrentHashMap[String, Boolean] =
     new ConcurrentHashMap()
 
-  val file2LinesCache: ConcurrentHashMap[String, Seq[Int]] =
+  val file2OffsetTable: ConcurrentHashMap[String, Array[Int]] =
     new ConcurrentHashMap()
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/Global.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/Global.scala
@@ -40,22 +40,40 @@ object Global {
     linenumber: Option[Integer],
     columnnumber: Option[Integer],
     astCreatorFunction: => Seq[Ast]
-  ): Seq[Ast] = Global.synchronized {
-    if (
-      FileDefaults
-        .isHeaderFile(filename) && filename != fromFilename && linenumber.isDefined && columnnumber.isDefined
-    ) {
-      if (!headerAstCache.contains(filename)) {
-        headerAstCache.put(filename, mutable.HashSet((linenumber.get, columnnumber.get)))
-        astCreatorFunction.foreach(Ast.storeInDiffGraph(_, diffGraph))
-      } else {
-        if (!headerAstCache(filename).contains((linenumber.get, columnnumber.get))) {
-          headerAstCache(filename).add((linenumber.get, columnnumber.get))
-          astCreatorFunction.foreach(Ast.storeInDiffGraph(_, diffGraph))
+  ): Seq[Ast] = {
+    val (callCreatorFunc, addDirectlyToDiff) =
+      Global.synchronized {
+        if (
+          FileDefaults
+            .isHeaderFile(filename) && filename != fromFilename && linenumber.isDefined && columnnumber.isDefined
+        ) {
+          if (!headerAstCache.contains(filename)) {
+            headerAstCache.put(filename, mutable.HashSet((linenumber.get, columnnumber.get)))
+            (true, true)
+          } else {
+            if (!headerAstCache(filename).contains((linenumber.get, columnnumber.get))) {
+              headerAstCache(filename).add((linenumber.get, columnnumber.get))
+              (true, true)
+            } else {
+              (false, false)
+            }
+          }
+        } else {
+          (true, false)
         }
       }
+
+    if (callCreatorFunc) {
+      val asts = astCreatorFunction
+      if (addDirectlyToDiff) {
+        asts.foreach(Ast.storeInDiffGraph(_, diffGraph))
+        Seq.empty
+      } else {
+        asts
+      }
+    } else {
       Seq.empty
-    } else { astCreatorFunction }
+    }
   }
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IOUtils.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IOUtils.scala
@@ -12,7 +12,7 @@ object IOUtils {
   def readFileAsFileContent(path: Path): FileContent = {
     val lines = io.shiftleft.utils.IOUtils
       .readLinesInFile(path)
-      .flatMap(_.toCharArray.appendedAll(System.lineSeparator().toCharArray))
+      .mkString("\n")
       .toArray
     FileContent.create(path.toString, true, lines)
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/MethodHeaderTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/MethodHeaderTests.scala
@@ -21,7 +21,7 @@ class MethodHeaderTests extends AnyWordSpec with Matchers {
       method.property(Properties.FULL_NAME) shouldBe "foo"
       method.property(Properties.SIGNATURE) shouldBe "int foo (int,int)"
       method.property(Properties.LINE_NUMBER) shouldBe 1
-      method.property(Properties.COLUMN_NUMBER) shouldBe 0
+      method.property(Properties.COLUMN_NUMBER) shouldBe 1
       method.property(Properties.LINE_NUMBER_END) shouldBe 3
       method.property(Properties.COLUMN_NUMBER_END) shouldBe 1
       method.property(Properties.CODE) shouldBe "int foo (int x,int y)"
@@ -42,7 +42,7 @@ class MethodHeaderTests extends AnyWordSpec with Matchers {
       param1Option.get.property(Properties.NAME) shouldBe "x"
       param1Option.get.property(Properties.EVALUATION_STRATEGY) shouldBe EvaluationStrategies.BY_VALUE
       param1Option.get.property(Properties.LINE_NUMBER) shouldBe 1
-      param1Option.get.property(Properties.COLUMN_NUMBER) shouldBe 8
+      param1Option.get.property(Properties.COLUMN_NUMBER) shouldBe 9
 
       val param2Option = parameters.find(_.property(PropertyNames.ORDER) == 2)
       param2Option.isDefined shouldBe true
@@ -51,7 +51,7 @@ class MethodHeaderTests extends AnyWordSpec with Matchers {
       param2Option.get.property(Properties.NAME) shouldBe "y"
       param2Option.get.property(Properties.EVALUATION_STRATEGY) shouldBe EvaluationStrategies.BY_VALUE
       param2Option.get.property(Properties.LINE_NUMBER) shouldBe 1
-      param2Option.get.property(Properties.COLUMN_NUMBER) shouldBe 15
+      param2Option.get.property(Properties.COLUMN_NUMBER) shouldBe 16
     }
 
     "have correct METHOD_RETURN node for method foo" in {
@@ -66,7 +66,7 @@ class MethodHeaderTests extends AnyWordSpec with Matchers {
       methodReturn.head.property(Properties.CODE) shouldBe "int"
       methodReturn.head.property(Properties.EVALUATION_STRATEGY) shouldBe EvaluationStrategies.BY_VALUE
       methodReturn.head.property(Properties.LINE_NUMBER) shouldBe 1
-      methodReturn.head.property(Properties.COLUMN_NUMBER) shouldBe 0
+      methodReturn.head.property(Properties.COLUMN_NUMBER) shouldBe 1
     }
 
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
@@ -1877,11 +1877,11 @@ class AstCreationPassTests
       """.stripMargin) { cpg =>
       inside(cpg.identifier.l) { case List(a, b, c) =>
         a.lineNumber shouldBe Some(3)
-        a.columnNumber shouldBe Some(4)
+        a.columnNumber shouldBe Some(5)
         b.lineNumber shouldBe Some(5)
-        b.columnNumber shouldBe Some(4)
+        b.columnNumber shouldBe Some(5)
         c.lineNumber shouldBe Some(6)
-        c.columnNumber shouldBe Some(4)
+        c.columnNumber shouldBe Some(5)
       }
     }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/MacroHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/MacroHandlingTests.scala
@@ -133,7 +133,7 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     call1.name shouldBe "A_MACRO"
     call1.methodFullName.endsWith("A_MACRO:3") shouldBe true
     call1.lineNumber shouldBe Some(22)
-    call1.columnNumber shouldBe Some(8)
+    call1.columnNumber shouldBe Some(9)
     call1.typeFullName shouldBe "ANY"
     call1.dispatchType shouldBe DispatchTypes.INLINED
     val List(arg1, arg2, arg3) = call1.argument.l.sortBy(_.order)
@@ -146,7 +146,7 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     call2.name shouldBe "A_MACRO_2"
     call2.methodFullName.endsWith("A_MACRO_2:0") shouldBe true
     call2.lineNumber shouldBe Some(24)
-    call2.columnNumber shouldBe Some(8)
+    call2.columnNumber shouldBe Some(9)
     call2.typeFullName shouldBe "ANY"
     call2.argument.l.sortBy(_.order).size shouldBe 0
     call2.dispatchType shouldBe DispatchTypes.INLINED

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/standard/CMethodTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/standard/CMethodTests.scala
@@ -27,7 +27,7 @@ class CMethodTest1 extends CCodeToCpgSuite {
       )
       x.lineNumber shouldBe Some(2)
       x.lineNumberEnd shouldBe Some(3)
-      x.columnNumber shouldBe Some(2)
+      x.columnNumber shouldBe Some(3)
       x.columnNumberEnd shouldBe Some(2)
     }
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/standard/CallTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/standard/CallTests.scala
@@ -27,7 +27,7 @@ class CallTests extends CCodeToCpgSuite {
     // TODO x.signature
     // x.typeFullName : deprecated
     x.lineNumber shouldBe Some(6)
-    x.columnNumber shouldBe Some(17)
+    x.columnNumber shouldBe Some(18)
   }
 
   "should allow traversing from call to arguments" in {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/standard/MethodParameterTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/standard/MethodParameterTests.scala
@@ -17,14 +17,14 @@ class MethodParameterTests extends CCodeToCpgSuite {
     x.code shouldBe "int argc"
     x.typeFullName shouldBe "int"
     x.lineNumber shouldBe Some(2)
-    x.columnNumber shouldBe Some(11)
+    x.columnNumber shouldBe Some(12)
     x.order shouldBe 1
 
     val List(y) = cpg.parameter.name("argv").l
     y.code shouldBe "char **argv"
     y.typeFullName shouldBe "char**"
     y.lineNumber shouldBe Some(2)
-    y.columnNumber shouldBe Some(21)
+    y.columnNumber shouldBe Some(22)
     y.order shouldBe 2
   }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/standard/MethodReturnTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/standard/MethodReturnTests.scala
@@ -15,7 +15,7 @@ class MethodReturnTest1 extends CCodeToCpgSuite {
     x.code shouldBe "int*"
     x.typeFullName shouldBe "int*"
     x.lineNumber shouldBe Some(2)
-    x.columnNumber shouldBe Some(1)
+    x.columnNumber shouldBe Some(2)
     // we expect the METHOD_RETURN node to be the right-most
     // child so that when traversing the AST from left to
     // right in CFG construction, we visit it last.
@@ -52,10 +52,10 @@ class MethodReturnTest2 extends CCodeToCpgSuite {
     inside(astReturns) { case List(ret1, ret2) =>
       ret1.code shouldBe "return 1;"
       ret1.lineNumber shouldBe Some(4)
-      ret1.columnNumber shouldBe Some(4)
+      ret1.columnNumber shouldBe Some(5)
       ret2.code shouldBe "return 2;"
       ret2.lineNumber shouldBe Some(6)
-      ret2.columnNumber shouldBe Some(2)
+      ret2.columnNumber shouldBe Some(3)
     }
     astReturns shouldBe cfgReturns
     astReturns shouldBe travReturns


### PR DESCRIPTION
- Moved ast creation out of global lock in order to avoid threads waiting for the
  lock the majority of the time.
- Improve column calculation algorithm.

    The old version managed to be slow enough to be the number one hot spot
    during profiling of c2cpg. The new version makes this fast so that it does
    not show up during performance measuring anymore.

    Column number now start at one instead of zero like the line numbers and
    the new implemention obsoleted a bug in the old column end calculation
    which led to complete bogus numbers.