### PR TITLE
Fix DISPATCH_TYPE for certain kt fieldAccess calls

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -2740,7 +2740,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
       NewCall()
         .name(Operators.fieldAccess)
         .code(Constants.this_ + "." + expr.getReferencedName)
-        .dispatchType(DispatchTypes.DYNAMIC_DISPATCH)
+        .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .methodFullName(Operators.fieldAccess)
         .signature("")
         .typeFullName(typeFullName)
@@ -2758,7 +2758,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
         .name(Constants.this_)
         .typeFullName(referenceTargetTypeFullName)
         .order(1)
-        .argumentIndex(0)
+        .argumentIndex(1)
         .lineNumber(line(expr))
         .columnNumber(column(expr))
     val fieldIdentifierNode =
@@ -2766,7 +2766,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
         .code(expr.getReferencedName)
         .canonicalName(expr.getReferencedName)
         .order(2)
-        .argumentIndex(1)
+        .argumentIndex(2)
         .lineNumber(line(expr))
         .columnNumber(column(expr))
     val ast =

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -28,17 +28,17 @@ class CallsToFieldAccessTests extends AnyFreeSpec with Matchers {
       val List(c) = cpg.call.codeExact("println(x)").argument.isCall.l
       c.code shouldBe "this.x"
       c.name shouldBe Operators.fieldAccess
-      c.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(16)
 
       val List(firstArg: Identifier, secondArg: FieldIdentifier) =
         cpg.call.codeExact("println(x)").argument.isCall.argument.l
-      firstArg.argumentIndex shouldBe 0
+      firstArg.argumentIndex shouldBe 1
       firstArg.code shouldBe "this"
       firstArg.typeFullName shouldBe "mypkg.AClass"
 
-      secondArg.argumentIndex shouldBe 1
+      secondArg.argumentIndex shouldBe 2
       secondArg.code shouldBe "x"
       secondArg.canonicalName shouldBe "x"
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
@@ -864,4 +864,30 @@ class ValidationTests extends AnyFreeSpec with Matchers {
         .l shouldBe List()
     }
   }
+
+  "CPG for code with `fieldAccess` call on implicit _this_" - {
+    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+        |package main
+        |
+        |class AClass {
+        |    val AMESSAGE = "AMESSAGE"
+        |    fun printMsg() {
+        |        println(AMESSAGE)
+        |    }
+        |}
+        |
+        |fun main() {
+        |    val aClass = AClass()
+        |    aClass.printMsg()
+        |}
+        |""".stripMargin)
+
+    "should not contain `fieldAccess` CALLs with DYNAMIC_DISPATCH" in {
+      cpg.call
+        .methodFullName(Operators.fieldAccess)
+        .dispatchTypeExact(DispatchTypes.DYNAMIC_DISPATCH)
+        .code
+        .l shouldBe List()
+    }
+  }
 }


### PR DESCRIPTION
i incorrectly assumed a _this_ receiver will always need dynamic dispatch