### PR TITLE
Put original code into RETURN node code property.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/pythonGrammar.jj
+++ b/joern-cli/frontends/pysrc2cpg/pythonGrammar.jj
@@ -3,6 +3,8 @@ options {
     DEBUG_PARSER = false;
     UNICODE_INPUT = true;
     STATIC = false;
+    TOKEN_EXTENDS = "PositionToken";
+    COMMON_TOKEN_ACTION = true;
 }
 PARSER_BEGIN(PythonParser)
 package io.joern.pythonparser;
@@ -161,6 +163,11 @@ TOKEN_MGR_DECLS:
 
   // Number of opened curly brackets while parsing a format string in FORMAT_SPEC_LEX.
   int formatSpecOpenCurly = 0;
+
+  void CommonTokenAction(Token token) {
+    token.startPos = input_stream.tokenBegin;
+    token.endPos = input_stream.bufpos + 1;
+  }
 }
 
 TOKEN: {

--- a/joern-cli/frontends/pysrc2cpg/src/main/java/io/joern/pythonparser/PositionToken.java
+++ b/joern-cli/frontends/pysrc2cpg/src/main/java/io/joern/pythonparser/PositionToken.java
@@ -1,0 +1,7 @@
+package io.joern.pythonparser;
+
+public class PositionToken {
+    public int startPos = -1;
+    // Non inclusive. Points behind the last token character.
+    public int endPos = -1;
+}

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/CodeToCpg.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/CodeToCpg.scala
@@ -17,7 +17,8 @@ class CodeToCpg(cpg: Cpg, inputProvider: Iterable[InputProvider]) extends Concur
       val parser                 = new PyParser()
       val lineBreakCorrectedCode = inputPair.content.replace("\r\n", "\n").replace("\r", "\n")
       val astRoot                = parser.parse(lineBreakCorrectedCode)
-      val astVisitor             = new PythonAstVisitor(inputPair.file, PythonV2AndV3)
+      val nodeToCode             = new NodeToCode(lineBreakCorrectedCode)
+      val astVisitor             = new PythonAstVisitor(inputPair.file, nodeToCode, PythonV2AndV3)
       astVisitor.convert(astRoot)
 
       diffGraph.absorb(astVisitor.getDiffGraph)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeToCode.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeToCode.scala
@@ -1,0 +1,9 @@
+package io.joern.pysrc2cpg
+
+import io.joern.pythonparser.ast
+
+class NodeToCode(content: String) {
+  def getCode(node: ast.iattributes): String = {
+    content.substring(node.input_offset, node.end_input_offset)
+  }
+}

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -538,14 +538,19 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
     bindingNode
   }
 
-  protected def createReturn(returnExprOption: Option[nodes.NewNode], lineAndColumn: LineAndColumn): nodes.NewReturn = {
-    val code =
+  protected def createReturn(
+    returnExprOption: Option[nodes.NewNode],
+    codeOption: Option[String],
+    lineAndColumn: LineAndColumn
+  ): nodes.NewReturn = {
+    val code = codeOption.getOrElse {
       returnExprOption match {
         case Some(returnExpr) =>
           "return " + codeOf(returnExpr)
         case None =>
           "return"
       }
+    }
     val returnNode = nodeBuilder.returnNode(code, lineAndColumn)
     returnExprOption.foreach { returnExpr => addAstChildrenAsArguments(returnNode, 1, returnExpr) }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/ast/Ast.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/ast/Ast.scala
@@ -1028,10 +1028,12 @@ case class TypeIgnore(lineno: Int, tag: String) extends iast {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 trait iattributes {
   val attributeProvider: AttributeProvider
-  def lineno: Int         = attributeProvider.lineno
-  def col_offset: Int     = attributeProvider.col_offset
-  def end_lineno: Int     = attributeProvider.end_lineno
-  def end_col_offset: Int = attributeProvider.end_col_offset
+  def lineno: Int           = attributeProvider.lineno
+  def col_offset: Int       = attributeProvider.col_offset
+  def input_offset: Int     = attributeProvider.input_offset
+  def end_lineno: Int       = attributeProvider.end_lineno
+  def end_col_offset: Int   = attributeProvider.end_col_offset
+  def end_input_offset: Int = attributeProvider.end_input_offset
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/ast/AttributeProvider.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/ast/AttributeProvider.scala
@@ -5,8 +5,10 @@ import io.joern.pythonparser.Token
 trait AttributeProvider {
   def lineno: Int
   def col_offset: Int
+  def input_offset: Int
   def end_lineno: Int
   def end_col_offset: Int
+  def end_input_offset: Int
 
   override def toString: String = {
     s"$lineno,$col_offset,$end_lineno,$end_col_offset"
@@ -22,12 +24,20 @@ class TokenAttributeProvider(startToken: Token, endToken: Token) extends Attribu
     startToken.beginColumn
   }
 
+  override def input_offset: Int = {
+    startToken.startPos
+  }
+
   override def end_lineno: Int = {
     endToken.endLine
   }
 
   override def end_col_offset: Int = {
     endToken.endColumn
+  }
+
+  override def end_input_offset: Int = {
+    endToken.endPos
   }
 }
 
@@ -40,11 +50,19 @@ class NodeAttributeProvider(astNode: iattributes, endToken: Token) extends Attri
     astNode.col_offset
   }
 
+  override def input_offset: Int = {
+    astNode.input_offset
+  }
+
   override def end_lineno: Int = {
     endToken.endLine
   }
 
   override def end_col_offset: Int = {
     endToken.endColumn
+  }
+
+  override def end_input_offset: Int = {
+    endToken.endPos
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ReturnCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ReturnCpgTests.scala
@@ -34,4 +34,21 @@ class ReturnCpgTests extends AnyFreeSpec with Matchers {
     }
   }
 
+  "value return with lowering" - {
+    lazy val cpg = Py2CpgTestContext.buildCpg("""def func(a, b):
+                                                |  return {a:1}
+                                                |""".stripMargin)
+
+    "test return node properties" in {
+      val returnNode = cpg.ret.head
+      returnNode.code shouldBe "return {a:1}"
+      returnNode.lineNumber shouldBe Some(2)
+    }
+
+    "test return node ast children" in {
+      cpg.ret.astChildren.order(1).head.code shouldBe
+        "tmp0 = {}\ntmp0[a] = 1\ntmp0"
+    }
+  }
+
 }


### PR DESCRIPTION
Most of this PR is the infrastructure needed to obtain the original code
belonging to an AST node which is for now only used to set the code
propertu of RETURN nodes.

As requested by: https://github.com/joernio/joern/issues/1145