### PR TITLE
jimple2cpg: Read Classes with ASM9 for Java 16+ compatibility

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -48,7 +48,7 @@ object ProgramHandlingUtil {
   def moveClassFiles(files: List[String]): List[String] = {
     var destPath: Option[String] = None
 
-    sealed class ClassPathVisitor extends ClassVisitor(Opcodes.ASM8) {
+    sealed class ClassPathVisitor extends ClassVisitor(Opcodes.ASM9) {
       override def visit(
         version: Int,
         access: Int,


### PR DESCRIPTION
- Jimple2Cpg uses ASM's `ClassReader` to determine how to extract the file from the class's package. This change allows us to read JDK16+ class files.