### PR TITLE
Set inheritsFromFullNames for TYPE_DECL nodes.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -37,6 +37,7 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
     name: String,
     fullName: String,
     fileName: String,
+    inheritsFromFullNames: collection.Seq[String],
     lineAndColumn: LineAndColumn
   ): nodes.NewTypeDecl = {
     val typeDeclNode = nodes
@@ -45,6 +46,7 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .fullName(fullName)
       .isExternal(false)
       .filename(fileName)
+      .inheritsFromTypeFullName(inheritsFromFullNames)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
     addNodeToDiff(typeDeclNode)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -356,7 +356,7 @@ class PythonAstVisitor(fileName: String, protected val nodeToCode: NodeToCode, v
     // For every method we create a corresponding TYPE and TYPE_DECL and
     // a binding for the method into TYPE_DECL.
     val typeNode     = nodeBuilder.typeNode(name, fullName)
-    val typeDeclNode = nodeBuilder.typeDeclNode(name, fullName, fileName, lineAndColumn)
+    val typeDeclNode = nodeBuilder.typeDeclNode(name, fullName, fileName, Seq(Constants.ANY), lineAndColumn)
     edgeBuilder.astEdge(typeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
     createBinding(methodNode, typeDeclNode)
 
@@ -377,7 +377,13 @@ class PythonAstVisitor(fileName: String, protected val nodeToCode: NodeToCode, v
 
     val metaTypeNode = nodeBuilder.typeNode(metaTypeDeclName, metaTypeDeclFullName)
     val metaTypeDeclNode =
-      nodeBuilder.typeDeclNode(metaTypeDeclName, metaTypeDeclFullName, fileName, lineAndColOf(classDef))
+      nodeBuilder.typeDeclNode(
+        metaTypeDeclName,
+        metaTypeDeclFullName,
+        fileName,
+        Seq(Constants.ANY),
+        lineAndColOf(classDef)
+      )
     edgeBuilder.astEdge(metaTypeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
 
     // Create <body> function which contains the code defining the class
@@ -396,9 +402,18 @@ class PythonAstVisitor(fileName: String, protected val nodeToCode: NodeToCode, v
     val instanceTypeDeclName     = classDef.name
     val instanceTypeDeclFullName = calculateFullNameFromContext(instanceTypeDeclName)
 
+    // TODO for now we just take the code of the base expression and pretend they are full names.
+    val inheritsFrom = classDef.bases.map(nodeToCode.getCode)
+
     val instanceType = nodeBuilder.typeNode(instanceTypeDeclName, instanceTypeDeclFullName)
     val instanceTypeDecl =
-      nodeBuilder.typeDeclNode(instanceTypeDeclName, instanceTypeDeclFullName, fileName, lineAndColOf(classDef))
+      nodeBuilder.typeDeclNode(
+        instanceTypeDeclName,
+        instanceTypeDeclFullName,
+        fileName,
+        inheritsFrom,
+        lineAndColOf(classDef)
+      )
     edgeBuilder.astEdge(instanceTypeDecl, contextStack.astParent, contextStack.order.getAndInc)
 
     // Create meta class call handling method and bind it to meta class type.


### PR DESCRIPTION
For now we treat the base expressions as proper full names which is
obviously not correct but at least allows a preliminary access.