### PR TITLE
Remove unnecessary prefix from test helper class

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/DefaultRegisteredTypesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/DefaultRegisteredTypesTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class DefaultRegisteredTypesTests extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   "CPG for code with simple user-defined class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/TestContext.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/TestContext.scala
@@ -7,25 +7,25 @@ import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import scala.collection.mutable
 import scala.util.Random
 
-object Kotlin2CpgTestContext {
-  def newContext: Kotlin2CpgTestContext = {
-    new Kotlin2CpgTestContext()
+object TestContext {
+  def newContext: TestContext = {
+    new TestContext()
   }
 
   def buildCpg(code: String, file: String = "generated.kt", includeAllJars: Boolean = false): Cpg = {
-    val context = new Kotlin2CpgTestContext()
+    val context = new TestContext()
     context.addSource(code, file)
     context.includeAllJars = includeAllJars
     context.buildCpg
   }
 }
 
-class Kotlin2CpgTestContext private () {
+class TestContext private () {
   private val codeAndFile    = mutable.ArrayBuffer.empty[Kotlin2Cpg.InputPair]
   private var buildResult    = Option.empty[Cpg]
   private var includeAllJars = false
 
-  def addSource(code: String, fileName: String = "generated.kt"): Kotlin2CpgTestContext = {
+  def addSource(code: String, fileName: String = "generated.kt"): TestContext = {
     if (buildResult.nonEmpty) {
       throw new RuntimeException("Not allowed to add sources after buildCpg() was called.")
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AndroidSDKTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AndroidSDKTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{
   Call,
@@ -19,7 +19,7 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
 
   // good source of vulns
   "CPG for code with calls to Android WebView methods" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -54,7 +54,7 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call to method of `Activity` superclass" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -88,7 +88,7 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code using the Android SDK" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -113,7 +113,7 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code using the Android SDK defining a class inheriting from the `androidx` namespace" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package com.insecureshop
         |
@@ -141,7 +141,7 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
 
   // https://developer.android.com/reference/android/R
   "CPG for code with use of Android's `R`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -168,7 +168,7 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with use of Android log" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
       |package mypkg
       |
@@ -209,7 +209,7 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with use of Android's `findViewById`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
       |package mypkg
       |
@@ -250,7 +250,7 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call to Android's `sendBroadcast`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnnotatedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnnotatedExpressionsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 
 class AnnotatedExpressionsTests extends AnyFreeSpec with Matchers {
   "CPG for code with two identical calls, one annotated and one not" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnnotationClassTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnnotationClassTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class AnnotationClassTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple annotation class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |annotation class Special(val why: String)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnonymousFunctionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnonymousFunctionsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -12,7 +12,7 @@ class AnonymousFunctionsTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with anonymous function as argument" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.collections.List

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArithmeticOperationsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArithmeticOperationsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -11,7 +11,7 @@ class ArithmeticOperationsTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple arithmetic operations" - {
 
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |  println(1 + 2)
         |  println(1 - 2)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArrayAccessExprsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArrayAccessExprsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
 class ArrayAccessExprsTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple map construction and access" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(args: Array<String>) {
@@ -42,7 +42,7 @@ class ArrayAccessExprsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple array construction and access" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(args: Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AssignmentTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AssignmentTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -11,7 +11,7 @@ class AssignmentTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple assignments" - {
 
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |  val x: Int = 5
         |  x += 1

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BlockTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BlockTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Block
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class BlockTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with a simple function definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun add1mul(x: Int, y: Int): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BooleanLogicTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BooleanLogicTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple boolean op usage" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |  val w = true
         |  val x: Boolean = !w

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ByTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ByTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -12,7 +12,7 @@ class ByTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with call to lazy block defined using the _by_ keyword" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallGraphTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallGraphTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -11,7 +11,7 @@ class CallGraphTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple function definition" - {
 
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun add(x: Int, y: Int): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
@@ -13,7 +13,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with two functions with the same name, but different params" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo(x: Int, y: Int): Int {
@@ -99,7 +99,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a class declaration " - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo {
@@ -156,7 +156,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a call to an implicitly imported stdlib fn " - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun doSome(x: String) {
@@ -182,7 +182,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a call to a constructor from library with default content root jar" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -204,7 +204,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with invocation of extension function from stdlib" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -222,7 +222,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with QE inside QE" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun main() {
@@ -242,7 +242,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call simple stdlib fn for map creation" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |import kotlin.collections.mutableMapOf
       |
       |fun main(args : Array<String>) {
@@ -263,7 +263,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple method call to decl of Java's stdlib" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun foo(x: String): Int {
@@ -282,7 +282,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with " - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
     |package mypkg
     |
     |fun main() {
@@ -311,7 +311,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple call to class from Java's stdlib imported with _as_" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import java.io.File as MyFile
@@ -331,7 +331,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple call with unknown identifier imported via _as_" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import no.such.CaseClass as MyCaseClass
@@ -365,7 +365,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call to `100.toFloat`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
      |package mypkg
      |
      |fun main() {
@@ -380,7 +380,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call which has parenthesized expression as receiver" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun main() {
@@ -398,7 +398,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of stdlib's `to` on stdlib objects" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -415,7 +415,7 @@ class CallTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of stdlib's `to` on user-defined objects" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass(val msg: String)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallableReferenceTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallableReferenceTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -9,7 +9,7 @@ class CallableReferenceTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple callback usage" - {
 
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun isOdd(x: Int) = x % 2 != 0
         |
         |fun firstOdd(x: Int): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallbackTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallbackTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -12,7 +12,7 @@ class CallbackTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with callback and additional parameter" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun withCallback(p: String, callback: (String) -> Unit) {
@@ -52,7 +52,7 @@ class CallbackTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple callback usage" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun withCallback(fn: (String)->Unit) {
@@ -74,7 +74,7 @@ class CallbackTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple callback inside class method" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |class AClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToConstructorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToConstructorTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Local}
@@ -14,7 +14,7 @@ class CallsToConstructorTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with call to constructor of Java stdlib object inside declaration" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import java.io.File
@@ -86,7 +86,7 @@ class CallsToConstructorTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call to constructor of Java stdlib object inside QE" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import java.io.File
@@ -150,7 +150,7 @@ class CallsToConstructorTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call to simple constructor of user-defined class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass(val x: String) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{FieldIdentifier, Identifier}
 import io.shiftleft.semanticcpg.language._
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class CallsToFieldAccessTests extends AnyFreeSpec with Matchers {
   "CPG for code with class method referencing member in a call" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass(private val x: String) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CfgTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class CfgTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple structures" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun sink(p: Int): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ClassLiteralTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ClassLiteralTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -11,7 +11,7 @@ class ClassLiteralTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple class literals" - {
 
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Bar {}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CollectionAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CollectionAccessTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class CollectionAccessTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple list access" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |import kotlin.collections.mutableListOf
         |
         |fun main(args : Array<String>) {
@@ -29,7 +29,7 @@ class CollectionAccessTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple map access" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |import kotlin.collections.mutableMapOf
         |
         |fun main(args : Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CompanionObjectTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CompanionObjectTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -10,7 +10,7 @@ class CompanionObjectTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple companion object definition" - {
 
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         | class MyClass {
         |   companion object Factory {
         |       fun create(): MyClass = MyClass()

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ComparisonOperatorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ComparisonOperatorTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.codepropertygraph.generated.Operators
 
@@ -11,7 +11,7 @@ class ComparisonOperatorTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple comparison operator usage" - {
 
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>): Int {
         | val x: Int = 1
         | val y: Int = 2

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ComplexExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ComplexExpressionsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.edges.Argument
 import io.shiftleft.semanticcpg.language._
@@ -10,7 +10,7 @@ import overflowdb.traversal.jIteratortoTraversal
 
 class ComplexExpressionsTests extends AnyFreeSpec with Matchers {
   "CPG for code with _and_/_or_ operator and try-catch as one of the arguments" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -56,7 +56,7 @@ class ComplexExpressionsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with _and_ operator and let inside it" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Config {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ConstructorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ConstructorTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier, MethodParameterIn}
@@ -13,7 +13,7 @@ class ConstructorTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for a class declaration with an implicit constructor" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo
@@ -29,7 +29,7 @@ class ConstructorTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with class with param in its primary constructor" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass(x: String)
@@ -46,7 +46,7 @@ class ConstructorTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with class which defines member in its primary constructor" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass(val x: String)
@@ -113,7 +113,7 @@ class ConstructorTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for a class declaration with an implicit constructor with parameters" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo(bar: String) {
@@ -130,7 +130,7 @@ class ConstructorTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for a class declaration with an explicit constructor with parameters" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo constructor(bar: String) {
@@ -147,7 +147,7 @@ class ConstructorTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for a class declaration with secondary constructor" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo(foo: String) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureExpressionTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ControlStructureExpressionTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple `if`-expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package baz
         |
         |fun main(argc: Int): Int {
@@ -47,7 +47,7 @@ class ControlStructureExpressionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `if`-expression with fn calls in branches" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun some1(): Int {
@@ -97,7 +97,7 @@ class ControlStructureExpressionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `if`-expression with DQEs in branches" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -151,7 +151,7 @@ class ControlStructureExpressionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `if`-expression with enum in branches" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -198,7 +198,7 @@ class ControlStructureExpressionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `if`-expression inside method" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -249,7 +249,7 @@ class ControlStructureExpressionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `when`-expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun myfun() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ControlStructureTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple if-else" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo(x: Int): Int {
@@ -26,7 +26,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with `when` statement with assignment in its conditional" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -50,7 +50,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with multiple control structures" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |import kotlin.random.Random
         |
         |class ClassFoo {
@@ -137,7 +137,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `for`-statements" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -158,7 +158,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `if`-statement" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -182,7 +182,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with try-catch-finally statement" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun main() {
@@ -210,7 +210,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with try-catch statement" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun main() {
@@ -235,7 +235,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with range operators inside for-statements" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun foo() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DataClassTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DataClassTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class DataClassTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple data class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |data class Result(val p: Int, val q: String)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DefaultContentRootsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DefaultContentRootsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
 
   "CPG for code with a simple function definition with parameters of stdlib types, but not fully specified" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun add1mul(x: Int, y: Int): Int {
@@ -32,7 +32,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple class definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo {
@@ -57,7 +57,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with type alias of a stdlib type" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |typealias FooList = List<Int>
         |
         |fun foo() {
@@ -73,7 +73,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with array access" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo(): Int {
         |  val x = listOf(1, 2, 3)
         |  return x[0]
@@ -97,7 +97,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with `this` expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo {
@@ -115,7 +115,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a class definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo: Object {
@@ -134,7 +134,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with Java stdlib" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo(cmd: String) {
@@ -160,7 +160,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code using the Javalin web framework" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -234,7 +234,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with CALL to `super`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -271,7 +271,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code using the http4k framework" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package com.example
         |
@@ -337,7 +337,7 @@ class DefaultContentRootsTest extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with addition of aliased type and its original" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |typealias MyInt = Int

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DelegatedPropertiesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DelegatedPropertiesTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -9,7 +9,7 @@ import overflowdb.traversal.jIteratortoTraversal
 class DelegatedPropertiesTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple delegated properties" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class MyClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
@@ -12,7 +12,7 @@ class DestructuringTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with destructuring declaration and a variable as RHS" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |data class AClass(val a: String, val b: Int)
@@ -88,7 +88,7 @@ class DestructuringTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with destructuring expression with a ctor-invocation RHS" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |data class AClass(val a: String, val b: Int)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DotQualifiedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DotQualifiedExpressionsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -12,7 +12,7 @@ class DotQualifiedExpressionsTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with dot qualified expression as a receiver" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/EnumTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/EnumTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class EnumTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple ENUM definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |enum class Direction {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -10,7 +10,7 @@ class ExtensionTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple extension function definitions" - {
     implicit val resolver = NoResolve
 
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Example {
@@ -40,7 +40,7 @@ class ExtensionTests extends AnyFreeSpec with Matchers {
 
     // TODO: add test cases after the lowering is clear:
     //   --> right now we cannot differentiate between the fn definitions at different scopes
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun String.hash() = "HASH_PLACEHOLDER_1: $this"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExternalLibrariesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExternalLibrariesTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ExternalLibrariesTests extends AnyFreeSpec with Matchers {
   "CPG for code with usage of the `timber` logging library" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FieldAccessTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -11,7 +11,7 @@ import io.shiftleft.semanticcpg.language._
 class FieldAccessTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple filed access of user-defined class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FileTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FileTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 
@@ -12,7 +12,7 @@ import java.io.{File => JFile}
 class FileTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple class definition and one method" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg.bar
         |
         |class Foo {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/GenericsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/GenericsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
@@ -14,7 +14,7 @@ class GenericsTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with simple user-defined fn using generics" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |
         |package mypkg
         |
@@ -60,7 +60,7 @@ class GenericsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple user-defined fn using generics and a type parameter subclassed from user-defined fn" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/HigherOrderFnsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/HigherOrderFnsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class HigherOrderFnsTests extends AnyFreeSpec with Matchers {
   "CPG for code with a call to stdlib's `fold`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(args : Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IdentifierTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IdentifierTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class IdentifierTests extends AnyFreeSpec with Matchers {
   "CPG for code with two simple methods" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun add(x: Int, y: Int): Int {
         |  return x + y
         |}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ImportTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Import
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class ImportTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with a stdlib import" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.io.collections.listOf
@@ -46,7 +46,7 @@ class ImportTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code without explicit imports" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(args : Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InheritanceTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InheritanceTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class InheritanceTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple inheritance situation" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |open class Bar {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InnerClassesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InnerClassesTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -11,7 +11,7 @@ class InnerClassesTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with a simple inner class definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         | class Outer {
         |     private val bar: Int = 1
         |     inner class Inner {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ItTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ItTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Local
 import io.shiftleft.semanticcpg.language._
 
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ItTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple `it`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LabeledExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LabeledExpressionsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -11,7 +11,7 @@ class LabeledExpressionsTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with simple call to `println` prefixed by a label" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.joern.kotlin2cpg.passes.Constants
 import io.shiftleft.codepropertygraph.generated.edges.Capture
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, ClosureBinding}
@@ -14,7 +14,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with a simple lambda which captures a method parameter" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.collections.List
@@ -49,7 +49,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple lambda which captures a local" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.collections.List
@@ -85,7 +85,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a list iterator lambda" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo(x: String): Int {
@@ -166,7 +166,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a scope function lambda" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun throughTakeIf(x: String): String? {
@@ -232,7 +232,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a lambda mapping values of a collection" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun mappedListWith(p: String): List<String> {
@@ -304,7 +304,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with destructuring inside lambda" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
        |package mypkg
        |
        |fun main(args: Array<String>) {
@@ -319,7 +319,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple lambda which captures a method parameter inside method" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass {
@@ -343,7 +343,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple lambda which captures a method parameter, nested twice" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun foo(x: String): Int {
@@ -367,7 +367,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call with lambda inside method definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LazyBlocksTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LazyBlocksTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -11,7 +11,7 @@ class LazyBlocksTests extends AnyFreeSpec with Matchers {
   // TODO: add test cases for lazy properties as well
 
   "CPG for code with simple lazy blocks" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import java.nio.file.Files

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LetScopeFunctionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LetScopeFunctionTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Local
 import io.shiftleft.semanticcpg.language._
 
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class LetScopeFunctionTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple `let`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
 import io.shiftleft.semanticcpg.language._
 
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class LiteralTests extends AnyFreeSpec with Matchers {
 
   "CPG for code simple literal declarations" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |  val a: Int = 1
         |  val b: Boolean = true
@@ -55,7 +55,7 @@ class LiteralTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code simple literal declarations without explicit types" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |  val a = 1
         |  val b = true

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Local
 import io.shiftleft.semanticcpg.language._
 
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class LocalTests extends AnyFreeSpec with Matchers {
 
   "CPG for code simple local declarations" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo() {
         |  val x: Int = 1
         |  val y: Int = 2
@@ -36,7 +36,7 @@ class LocalTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code simple local declarations without explicit types" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo() {
         |  val x = 1
         |  val y = 2

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MemberTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class MemberTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple member" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |class Foo {
         |  val bar: Int = 1
         |}
@@ -31,7 +31,7 @@ class MemberTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with member defined in primary constructor" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |class AClass(private val x: String) {
@@ -54,7 +54,7 @@ class MemberTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with member which gets its init from constructor arg" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |class Foo(p: String) {
         |  val bar: Int = p
         |}
@@ -79,7 +79,7 @@ class MemberTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with member which gets its init from constructor arg with expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |class Foo(p: String) {
         |  val bar: Int = p + "baz"
         |}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MetaDataTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MetaDataTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class MetaDataTests extends AnyFreeSpec with Matchers {
 
-  lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+  lazy val cpg = TestContext.buildCpg("""
       |class ClassFoo {}
       |""".stripMargin)
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodAtPackageLevelTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodAtPackageLevelTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class MethodAtPackageLevelTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple method defined at package-level" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun double(x: Int): Int {
         |  return x * 2
         |}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodParameterTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class MethodParameterTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with a simple function definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun add1mul(x: Int, y: Int): Int {
@@ -41,7 +41,7 @@ class MethodParameterTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple class definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodReturnTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class MethodReturnTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple method with two parameters" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |fun foo(x: Int, y: Double): Int {
       |  return x * 2
       |}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class MethodTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple class declaration" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package com.test.pkg
         |
         |class Foo {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/NamespaceBlockTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/NamespaceBlockTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class NamespaceBlockTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple namespace declaration" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package com.test.PackageFoo
         |
         |class ClassFoo {
@@ -54,7 +54,7 @@ class NamespaceBlockTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with imports of simple Android packages" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
        |package mypkg
        |
        |import android.content.Intent

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectDeclarationsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectDeclarationsTests.scala
@@ -1,13 +1,13 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class ObjectDeclarationsTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple object declaration" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |object Foo {
@@ -59,7 +59,7 @@ class ObjectDeclarationsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with complex object declaration" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import android.content.Context

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Unknown
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class ObjectExpressionTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple object expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo() {
         |  val bar = object {
         |    override val baz = 1
@@ -27,7 +27,7 @@ class ObjectExpressionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple object expression with apply called after it" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ParenthesizedExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ParenthesizedExpressionTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class ParenthesizedExpressionTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple paranthesized expression " - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -30,7 +30,7 @@ class ParenthesizedExpressionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a paranthesized expression as part of a dot-qualified expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/QualifiedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/QualifiedExpressionsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class QualifiedExpressionsTests extends AnyFreeSpec with Matchers {
   "CPG for code with qualified expression with QE as a receiver" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(args: Array<String>) {
@@ -30,7 +30,7 @@ class QualifiedExpressionsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with qualified expression with CALL as a receiver" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun getHashMap(): HashMap<String,String> {
@@ -63,7 +63,7 @@ class QualifiedExpressionsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with qualified expression with `when` as receiver" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -87,7 +87,7 @@ class QualifiedExpressionsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with qualified expression in which the receiver is a call to array access" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ResolutionErrorsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ResolutionErrorsTests.scala
@@ -1,7 +1,7 @@
 package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.types.TypeConstants
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ResolutionErrorsTests extends AnyFreeSpec with Matchers {
   "CPG for code with QE of receiver for which the type cannot be inferred" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -28,7 +28,7 @@ class ResolutionErrorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple stdlib fns" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.collections.HashMap
@@ -57,7 +57,7 @@ class ResolutionErrorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with stdlib mutable list of items of class without type info available" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import com.intellij.ide.util.projectWizard.importSources.DetectedProjectRoot
@@ -83,7 +83,7 @@ class ResolutionErrorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with QE expression without type info" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |object AClass {
@@ -119,7 +119,7 @@ class ResolutionErrorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with extension fn defined on unresolvable type " - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import com.intellij.openapi.editor.*
@@ -140,7 +140,7 @@ class ResolutionErrorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with extension fn defined on resolvable type with unresolvable subtypes" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import com.intellij.openapi.editor.*
@@ -162,7 +162,7 @@ class ResolutionErrorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with `containsKey` call on collection of elements without corresponding imported class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import io.no.SuchPackage

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/RunScopeFunctionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/RunScopeFunctionTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Local
 import io.shiftleft.semanticcpg.language._
 
@@ -11,7 +11,7 @@ class RunScopeFunctionTests extends AnyFreeSpec with Matchers {
   // TODO add test case with refs to properties without `this`
 
   "CPG for code with simple `run` usage" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo(x: String) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SafeQualifiedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SafeQualifiedExpressionsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -11,7 +11,7 @@ class SafeQualifiedExpressionsTests extends AnyFreeSpec with Matchers {
   implicit val resolver = NoResolve
 
   "CPG for code with safe qualified expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ScopeCaptureTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ScopeCaptureTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class ScopeCaptureTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with identifier referencing two possible locals" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo() {
         |  val x: String = "n"
         |  1.let {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ScopeFunctionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ScopeFunctionTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class ScopeFunctionTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple `let` scope function" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -43,7 +43,7 @@ class ScopeFunctionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `run` scope function" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -78,7 +78,7 @@ class ScopeFunctionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `also` scope function" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -113,7 +113,7 @@ class ScopeFunctionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with `with` scope function" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo(x: String): Int {
@@ -134,7 +134,7 @@ class ScopeFunctionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `apply` scope function" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Bar(p: String)
@@ -150,7 +150,7 @@ class ScopeFunctionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `takeIf` scope function" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -167,7 +167,7 @@ class ScopeFunctionTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `takeUnless` scope function" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SealedClassTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SealedClassTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -9,7 +9,7 @@ import overflowdb.traversal.jIteratortoTraversal
 class SealedClassTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with sealed class and annotated member" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |sealed class StateEvent {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SpecialOperatorsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SpecialOperatorsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with _safe call_ operator" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |    val b: String? = null
         |    println(b?.length)
@@ -28,7 +28,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with _as_ operator" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |    val b = "PLACEHOLDER" as String
         |    println(b)
@@ -46,7 +46,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with `notNullAssert` operator" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo(x : Int) {
         | val p = x!!
         | println(p)
@@ -59,7 +59,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with _notNullAssert_ operator inside dot-qualified expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo() {
         |    val bar = " PLACEHOLDER "!!.trim()
         |    println(bar)
@@ -76,7 +76,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with _is_ expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |packge mypkg
         |
         |fun main() {
@@ -104,7 +104,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with range expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |packge mypkg
         |
         |fun main() {
@@ -130,7 +130,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple usage of _elvis_ operator" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(args: Array<String>) {
@@ -157,7 +157,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with _elvis_ operator usage and subexpression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |fun main() {
@@ -174,7 +174,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with _notIn_ operator" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(args: Array<String>) {
@@ -195,7 +195,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with _in_ operator" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(args: Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StdLibTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StdLibTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class StdLibTests extends AnyFreeSpec with Matchers {
   "CPG for code with call to `takeIf`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |  package mypkg
         |
         |  import kotlin.random.Random
@@ -37,7 +37,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a single call to println and a corresponding import" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.io.println
@@ -54,7 +54,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a single call to println, a corresponding import and a locally defined println method" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun println(baz: String) {
@@ -73,7 +73,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a call to static class method of imported class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -97,7 +97,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a chained call to static class method of imported class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -112,7 +112,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a call to infix fn `to`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo() {
@@ -136,7 +136,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
     }
 
     "CPG for code with calls to stdlib's `split`s" - {
-      lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+      lazy val cpg = TestContext.buildCpg("""
           |package mypkg
           |
           |fun main() {
@@ -155,7 +155,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
     }
 
     "CPG for code with calls to stdlib's `trim`s" - {
-      lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+      lazy val cpg = TestContext.buildCpg("""
           |package mypkg
           |
           |fun trimParam(p: String): String {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StringInterpolationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StringInterpolationTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class StringInterpolationTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with basic string interpolation" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |  val name = "Peter"
         |  val age = 34

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SubscriptTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SubscriptTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class SubscriptTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with array index access call" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |fun foo(): Int {
       |  val names = listOf(1, 2, 3)
       |  return names[0]

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SuperTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SuperTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class SuperTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple call using _super_" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |open class BClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ThisTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ThisTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.semanticcpg.language._
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ThisTests extends AnyFreeSpec with Matchers {
   "CPG for code with calls to functions of same name, but different scope" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun bar() { println("Top-level function") }
@@ -42,7 +42,7 @@ class ThisTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call that has _this_ as argument" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun bar(x: Any) { println(x) }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TopLevelPropertiesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TopLevelPropertiesTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class TopLevelPropertiesTests extends AnyFreeSpec with Matchers {
   "CPG for code with top-level property" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |const val CSRF_SESSION_KEY = "_csrf"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeAliasTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeAliasTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class TypeAliasTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple typealias to Int" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |typealias MyInt = Int
@@ -33,7 +33,7 @@ class TypeAliasTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple typealias to ListInt" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |typealias Foo = List<Int>
@@ -58,7 +58,7 @@ class TypeAliasTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with typealias of type from external library" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package org.http4k.core.body
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeDeclTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Binding
 import io.shiftleft.semanticcpg.language._
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
 class TypeDeclTests extends AnyFreeSpec with Matchers {
 
   "CPG for simple class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import java.lang.Object
@@ -62,7 +62,7 @@ class TypeDeclTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with user-defined class which has no specific superclasses" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |class AClass
@@ -80,7 +80,7 @@ class TypeDeclTests extends AnyFreeSpec with Matchers {
   }
 
   "class with multiple initializers" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package baz
         |
         |import kotlin.io.println
@@ -109,7 +109,7 @@ class TypeDeclTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple class declaration and usage" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class Foo {
@@ -133,7 +133,7 @@ class TypeDeclTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of setter of simple user-defined class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |class Simple {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class TypeTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with simple class" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package com.test.PackageFoo
         |
         |class Foo {
@@ -68,7 +68,7 @@ class TypeTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with Android SDK fn" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -88,7 +88,7 @@ class TypeTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call to a static method from Java's stdlib with a return type different from its receiver type " - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import javax.crypto.Cipher

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/UnaryOpTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/UnaryOpTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class UnaryOpTests extends AnyFreeSpec with Matchers {
 
   "CPG for code with calls to unary operators" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun main(args : Array<String>) {
         |  val x: Int = 5
         |  val y: Boolean = true

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/VariableReferencingTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/VariableReferencingTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import io.shiftleft.semanticcpg.language._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 class VariableReferencingTests extends AnyFreeSpec with Matchers {
   "should find references for simple case" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo(x: Int): Int {
         |  val y = x
         |  return y
@@ -32,7 +32,7 @@ class VariableReferencingTests extends AnyFreeSpec with Matchers {
   }
 
   "should find references inside expressions" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |fun foo(x: Int): Int {
         |  val y = 1 + x
         |  return y

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ArgumentIndexTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ArgumentIndexTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.validation
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, ControlStructure, Literal}
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 
 class ArgumentIndexTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple if-expression inside DQE" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package main
         |
@@ -40,7 +40,7 @@ class ArgumentIndexTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple when-expression inside DQE" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package mypkg
         |
@@ -72,7 +72,7 @@ class ArgumentIndexTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple try-catch-expression inside DQE" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg(
+    lazy val cpg = TestContext.buildCpg(
       """
         |package main
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ArgumentIndexValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ArgumentIndexValidationTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.validation
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -12,7 +12,7 @@ import overflowdb.traversal.jIteratortoTraversal
 
 class ArgumentIndexValidationTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple qualified-expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import java.lang.Runtime

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/DefaultImportsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/DefaultImportsTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.validation
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.semanticcpg.language._
@@ -9,13 +9,13 @@ class DefaultImportsTests extends AnyFreeSpec with Matchers {
   // It tests if we take into consideration default imports: https://kotlinlang.org/docs/packages.html#default-imports
   "cpg.typ.typeDeclFullName of constructed CPG should remain the same regardless if one uses default imports or explicitly uses FQNs" - {
     "for kotlin.collections.mapOf" in {
-      val cpgExplicitFQNs = Kotlin2CpgTestContext.buildCpg("""
+      val cpgExplicitFQNs = TestContext.buildCpg("""
             |fun main(args: Array<String>) {
             |    val foo = kotlin.collections.mapOf("one" to 1)
             |}
             |""".stripMargin)
 
-      val cpgDefaultImports = Kotlin2CpgTestContext.buildCpg("""
+      val cpgDefaultImports = TestContext.buildCpg("""
             |fun main(args: Array<String>) {
             |    val foo = mapOf("one" to 1)
             |}
@@ -27,12 +27,12 @@ class DefaultImportsTests extends AnyFreeSpec with Matchers {
     }
 
     "for kotlin.comparisons.maxOf" in {
-      val cpgExplicitFQNs = Kotlin2CpgTestContext.buildCpg("""
+      val cpgExplicitFQNs = TestContext.buildCpg("""
             |fun main(args: Array<String>) {
             |    val foo = kotlin.comparisons.maxOf(5, 100)
             |}
             |""".stripMargin)
-      val cpgDefaultImports = Kotlin2CpgTestContext.buildCpg("""
+      val cpgDefaultImports = TestContext.buildCpg("""
             |fun main(args: Array<String>) {
             |    val foo = maxOf(5, 100)
             |}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/DispatchTypeValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/DispatchTypeValidationTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.validation
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -14,7 +14,7 @@ class DispatchTypeValidationTests extends AnyFreeSpec with Matchers {
   // TODO: add inputs as arrays
 
   "CPG for code with simple qualified-expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import java.lang.Runtime

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/IdentifierReferencesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/IdentifierReferencesTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.validation
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.nodes.Local
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 
 class IdentifierReferencesTests extends AnyFreeSpec with Matchers {
   "CPG for code with shadowed local inside lambda" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/PrimitiveArrayTypeMappingTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/PrimitiveArrayTypeMappingTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.validation
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -12,7 +12,7 @@ import overflowdb.traversal.jIteratortoTraversal
 
 class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   "CPG for code with usage of `kotlin.BooleanArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -31,7 +31,7 @@ class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of `kotlin.ByteArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -50,7 +50,7 @@ class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with extension fn called on instance of `kotlin.ByteArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -67,7 +67,7 @@ class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of `kotlin.CharArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -86,7 +86,7 @@ class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of `kotlin.DoubleArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -105,7 +105,7 @@ class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of `kotlin.FloatArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -124,7 +124,7 @@ class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of `kotlin.IntArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -143,7 +143,7 @@ class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of `kotlin.LongArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -162,7 +162,7 @@ class PrimitiveArrayTypeMappingTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with usage of `kotlin.ShortArray`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/UnitTypeMappingTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/UnitTypeMappingTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.validation
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -12,7 +12,7 @@ import overflowdb.traversal.jIteratortoTraversal
 
 class UnitTypeMappingTests extends AnyFreeSpec with Matchers {
   "CPG for code with definion of simple fn returning `kotlin.Unit`" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.validation
 
-import io.joern.kotlin2cpg.Kotlin2CpgTestContext
+import io.joern.kotlin2cpg.TestContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -12,7 +12,7 @@ import overflowdb.traversal.jIteratortoTraversal
 
 class ValidationTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple method containing if-expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main(argc: Int): Int {
@@ -37,7 +37,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple method containing simple class declaration" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |class AClass {
@@ -63,7 +63,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
     }
   }
   "CPG for code with simple lazy blocks" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |import java.nio.file.Files
@@ -84,7 +84,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code call to DSL-like fn" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |import org.http4k.core.HttpHandler
@@ -116,7 +116,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with qualified expression inside qualified expression" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -130,7 +130,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple lambda which captures a method parameter" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun foo(x: String): Int {
@@ -150,7 +150,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple lambda which captures a method parameter inside method" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |class AClass {
@@ -172,7 +172,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple lambda which captures a method parameter, nested twice" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun foo(x: String): Int {
@@ -194,7 +194,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with a simple if-statement" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -214,7 +214,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple `if`-statement" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun main() {
@@ -235,7 +235,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with _safe call_ operator" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |class AClass {
@@ -262,7 +262,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call with lambda param inside try-statement" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |fun main() {
@@ -289,7 +289,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call with lambda param inside if-else-statement" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -321,7 +321,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call with lambda inside method definition" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -361,7 +361,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with anonymous function as argument" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |import kotlin.collections.List
@@ -383,7 +383,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with function defined inside another function" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package mypkg
         |
         |fun withInline(): Int {
@@ -408,7 +408,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with lambda inside while-statement" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |
         |package main
         |fun main() {
@@ -430,7 +430,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with with function which takes a lambda as an argument" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |fun withCallback(callback: (String) -> Unit) {
@@ -465,7 +465,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with class with method which takes a lambda as an argument" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |class AClass {
@@ -502,7 +502,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with simple object expression with apply called after it" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |fun main() {
@@ -521,7 +521,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with method with two callbacks with two generic types" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |class AClass<T>(private val x: T) {
@@ -576,7 +576,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with dynamic dispatch call inside lambda with class name in the receiver" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |class BClass {
@@ -624,7 +624,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with local declaration with RHS a call with lambda argument capturing the parameter of its containing method" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |fun getValidPredefs(startingWith: String): List<String> {
@@ -657,7 +657,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with lambda inside method with captured constructor parameter and method parameter" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |class AClass constructor(val prefix: String = "default_prefix") {
@@ -690,7 +690,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with method that has a suspend lambda parameter" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |
         |package main
         |
@@ -752,7 +752,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call to qualified expression with parenthesized elvis expression as receiver" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
       |package mypkg
       |
       |import java.time.Duration
@@ -775,7 +775,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with call to qualified expression with parenthesized if-else-expression as receiver" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
        |package mypkg
        |
        |import kotlin.random.Random
@@ -804,7 +804,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with variants of user-defined constructors" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
        |package mypkg
        |
        |class AClass
@@ -845,7 +845,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with `fieldAccess` call on Java stdlib type" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |import java.io.File
@@ -866,7 +866,7 @@ class ValidationTests extends AnyFreeSpec with Matchers {
   }
 
   "CPG for code with `fieldAccess` call on implicit _this_" - {
-    lazy val cpg = Kotlin2CpgTestContext.buildCpg("""
+    lazy val cpg = TestContext.buildCpg("""
         |package main
         |
         |class AClass {


### PR DESCRIPTION
the substring _kotlin2cpg_ is already part of the FQN, no need to have it twice