### PR TITLE
Use absolute file names in order to enable `.dump` feature.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/CodeToCpg.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/CodeToCpg.scala
@@ -18,13 +18,13 @@ class CodeToCpg(cpg: Cpg, inputProvider: Iterable[InputProvider]) extends Concur
       val lineBreakCorrectedCode = inputPair.content.replace("\r\n", "\n").replace("\r", "\n")
       val astRoot                = parser.parse(lineBreakCorrectedCode)
       val nodeToCode             = new NodeToCode(lineBreakCorrectedCode)
-      val astVisitor             = new PythonAstVisitor(inputPair.file, nodeToCode, PythonV2AndV3)
+      val astVisitor = new PythonAstVisitor(inputPair.absFileName, inputPair.relFileName, nodeToCode, PythonV2AndV3)
       astVisitor.convert(astRoot)
 
       diffGraph.absorb(astVisitor.getDiffGraph)
     } catch {
       case exception: Throwable =>
-        logger.warn(s"Failed to convert file ${inputPair.file}", exception)
+        logger.warn(s"Failed to convert file ${inputPair.absFileName}", exception)
         Iterator.empty
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2Cpg.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2Cpg.scala
@@ -9,7 +9,7 @@ import overflowdb.BatchedUpdate.DiffGraphBuilder
 import scala.collection.parallel
 
 object Py2Cpg {
-  case class InputPair(content: String, file: String)
+  case class InputPair(content: String, absFileName: String, relFileName: String)
   type InputProvider = () => InputPair
 }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
@@ -29,7 +29,7 @@ object Py2CpgOnFileSystem {
     val inputProviders = inputFiles.map { inputFile => () =>
       {
         val content = IOUtils.readLinesInFile(inputFile).mkString("\n")
-        Py2Cpg.InputPair(content, config.inputDir.relativize(inputFile).toString)
+        Py2Cpg.InputPair(content, inputFile.toString, config.inputDir.relativize(inputFile).toString)
       }
     }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/Py2CpgTestContext.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/Py2CpgTestContext.scala
@@ -28,10 +28,10 @@ class Py2CpgTestContext private () {
     if (buildResult.nonEmpty) {
       throw new RuntimeException("Not allowed to add sources after buildCpg() was called.")
     }
-    if (codeAndFile.exists(_.file == file)) {
+    if (codeAndFile.exists(_.absFileName == file)) {
       throw new RuntimeException(s"Add more than one source under file name $file.")
     }
-    codeAndFile.append(new Py2Cpg.InputPair(code, file))
+    codeAndFile.append(new Py2Cpg.InputPair(code, "<absoluteTestPath>/" + file, file))
     this
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionDefCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionDefCpgTests.scala
@@ -16,7 +16,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       val methodNode = cpg.method.fullName("test.py:<module>.func").head
       methodNode.name shouldBe "func"
       methodNode.fullName shouldBe "test.py:<module>.func"
-      methodNode.filename shouldBe "test.py"
+      methodNode.filename shouldBe "<absoluteTestPath>/test.py"
       methodNode.isExternal shouldBe false
       methodNode.lineNumber shouldBe Some(1)
       methodNode.columnNumber shouldBe Some(1)
@@ -77,7 +77,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
 
       bindingTypeDecl.name shouldBe "func"
       bindingTypeDecl.fullName shouldBe "test.py:<module>.func"
-      bindingTypeDecl.filename shouldBe "test.py"
+      bindingTypeDecl.filename shouldBe "<absoluteTestPath>/test.py"
       bindingTypeDecl.lineNumber shouldBe Some(1)
       bindingTypeDecl.columnNumber shouldBe Some(1)
 


### PR DESCRIPTION
METHOD, TYPE_DECL and NAMESPACE_BLOCK nodes now have absolute file
names.

Required for: github.com/joernio/joern/issues/1141