### PR TITLE
javasrc: Make use of more available type info to infer types where javaparser resolution fails.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -16,7 +16,6 @@ import io.joern.javasrc2cpg.util.{SourceRootFinder, TypeInfoProvider}
 import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory
 
-import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.OptionConverters.RichOptional
 import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.expr.{
   MethodCallExpr,
   NameExpr,
   ObjectCreationExpr,
+  SuperExpr,
   ThisExpr,
   UnaryExpr,
   VariableDeclarationExpr
@@ -60,10 +61,16 @@ import com.github.javaparser.ast.stmt.{
   WhileStmt
 }
 import com.github.javaparser.resolution.UnsolvedSymbolException
-import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration
+import com.github.javaparser.resolution.declarations.{
+  ResolvedConstructorDeclaration,
+  ResolvedMethodDeclaration,
+  ResolvedMethodLikeDeclaration,
+  ResolvedParameterDeclaration
+}
 import io.joern.javasrc2cpg.passes.AstWithCtx.astWithCtxToSeq
 import io.joern.javasrc2cpg.passes.Context.mergedCtx
 import io.joern.javasrc2cpg.util.TypeInfoProvider
+import io.joern.javasrc2cpg.util.TypeInfoProvider.UnresolvedTypeDefault
 import io.shiftleft.codepropertygraph.generated.{
   ControlStructureTypes,
   DispatchTypes,
@@ -96,7 +103,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewTypeRef,
   NewUnknown
 }
-import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName
 import io.joern.x2cpg.{Ast, AstCreatorBase}
 import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory
@@ -106,7 +112,7 @@ import java.util.UUID.randomUUID
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.jdk.OptionConverters.RichOptional
-import scala.language.implicitConversions
+import scala.language.{existentials, implicitConversions}
 import scala.util.{Failure, Success, Try}
 
 case class BindingInfo(node: NewBinding, edgeMeta: Seq[(NewNode, NewNode, String)])
@@ -199,17 +205,18 @@ object AstWithCtx {
   */
 class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Global) extends AstCreatorBase(filename) {
 
-  private val typeInfoProvider = TypeInfoProvider(global)
-
   private val logger = LoggerFactory.getLogger(this.getClass)
   import AstCreator._
 
   val stack: mutable.Stack[NewNode] = mutable.Stack()
 
+  private val typeInfoProvider: TypeInfoProvider = TypeInfoProvider(global)
+
   /** Entry point of AST creation. Translates a compilation unit created by JavaParser into a DiffGraph containing the
     * corresponding CPG AST.
     */
   def createAst(): DiffGraphBuilder = {
+    typeInfoProvider.registerImports(javaParserAst.getImports.asScala.toList)
     val ast = astForTranslationUnit(javaParserAst)
     storeInDiffGraph(ast)
     diffGraph
@@ -314,7 +321,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     member: BodyDeclaration[_],
     scopeContext: ScopeContext,
     order: Int,
-    astParentType: String,
     astParentFullName: String
   ): Seq[AstWithCtx] = {
     member match {
@@ -331,7 +337,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         AstWithCtx(ast, ctx.addBindings(bindingInfo))
 
       case typeDeclaration: TypeDeclaration[_] =>
-        astForTypeDecl(typeDeclaration, order, astParentType, astParentFullName)
+        astForTypeDecl(typeDeclaration, order, "TYPE_DECL", astParentFullName)
 
       case fieldDeclaration: FieldDeclaration =>
         withOrder(fieldDeclaration.getVariables) { (variable, idx) =>
@@ -341,7 +347,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case unhandled =>
         // AnnotationMemberDeclarations and InitializerDeclarations as children of typeDecls are the
         // expected cases.
-        logger.info(s"Found unhandled typeDecl member ${unhandled.getClass} in file ${filename}")
+        logger.info(s"Found unhandled typeDecl member ${unhandled.getClass} in file $filename")
         AstWithCtx.empty
     }
   }
@@ -365,7 +371,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       } else {
         Seq()
       }
-      maybeJavaObjectType ++ (extendedTypes ++ implementedTypes).map(typeInfoProvider.getTypeFullName).toList
+      maybeJavaObjectType ++ (extendedTypes ++ implementedTypes)
+        .map(typ => typeInfoProvider.getTypeFullName(typ).getOrElse(UnresolvedTypeDefault))
+        .toList
     } else {
       List.empty[String]
     }
@@ -376,6 +384,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeDecl = NewTypeDecl()
       .name(name)
       .fullName(typeFullName)
+      .lineNumber(line(typ))
+      .columnNumber(column(typ))
       .inheritsFromTypeFullName(baseTypeFullNames)
       .order(order)
       .filename(filename)
@@ -395,13 +405,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val (memberAsts, _) = withOrderAndCtx(typ.getMembers.asScala, initScopeContext, initialOrder = enumEntryAsts.size) {
       (member, scopeContext, idx) =>
-        astForTypeDeclMember(
-          member,
-          scopeContext,
-          order + idx,
-          astParentType = "TYPE_DECL",
-          astParentFullName = typeFullName
-        )
+        astForTypeDeclMember(member, scopeContext, order + idx, astParentFullName = typeFullName)
     }
 
     val defaultConstructorAst = if (typ.getConstructors.isEmpty) {
@@ -466,7 +470,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .typeFullName(typeFullName)
 
     val args = withOrder(entry.getArguments) { case (x, o) =>
-      val children = astsForExpression(x, ScopeContext(), o)
+      val children = astsForExpression(x, ScopeContext(), o, None)
       val callNode =
         NewCall()
           .name(s"$typeFullName.<init>")
@@ -485,7 +489,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForVariableDeclarator(v: VariableDeclarator, order: Int): AstWithCtx = {
-    val typeFullName = typeInfoProvider.getTypeFullName(v)
+    // TODO: Should be able to find expected type here
+    val typeFullName = typeInfoProvider.getTypeFullName(v).getOrElse(UnresolvedTypeDefault)
     val name         = v.getName.toString
     val ast = Ast(
       NewMember()
@@ -575,7 +580,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForMethodReturn(methodDeclaration: MethodDeclaration): Ast = {
-    val typeFullName = typeInfoProvider.getReturnType(methodDeclaration)
+    val typeFullName = typeInfoProvider.getReturnType(methodDeclaration).getOrElse(UnresolvedTypeDefault)
     val order        = methodDeclaration.getParameters.size + 2
     Ast(methodReturnNode(line(methodDeclaration.getType), column(methodDeclaration.getType), order, typeFullName))
   }
@@ -625,7 +630,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def createMethodNode(methodDeclaration: MethodDeclaration, typeDecl: Option[NewTypeDecl], childNum: Int) = {
     val fullName   = methodFullName(typeDecl, methodDeclaration)
-    val returnType = typeInfoProvider.getTypeFullName(methodDeclaration)
+    val returnType = typeInfoProvider.getTypeFullName(methodDeclaration).getOrElse(UnresolvedTypeDefault)
     val signature  = returnType + paramListSignature(methodDeclaration)
     createPartialMethod(methodDeclaration, childNum)
       .fullName(fullName)
@@ -659,7 +664,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .argumentIndex(order)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
 
-    val args = astsForExpression(stmt.getExpression, scopeContext, order = 1)
+    val args = astsForExpression(stmt.getExpression, scopeContext, order = 1, None)
 
     callAst(throwNode, args)
   }
@@ -713,7 +718,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case x: ContinueStmt     => Seq(astForContinueStatement(x, order))
       case x: DoStmt           => Seq(astForDo(x, scopeContext, order))
       case _: EmptyStmt        => Seq() // Intentionally skipping this
-      case x: ExpressionStmt   => astsForExpression(x.getExpression, scopeContext, order)
+      case x: ExpressionStmt   => astsForExpression(x.getExpression, scopeContext, order, Some("void"))
       case x: ForEachStmt      => Seq(astForForEach(x, scopeContext, order))
       case x: ForStmt          => Seq(astForFor(x, scopeContext, order))
       case x: IfStmt           => Seq(astForIf(x, scopeContext, order))
@@ -728,15 +733,15 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  private def astForElse(maybeStmt: Option[Statement], scopeContext: ScopeContext, order: Int): Option[AstWithCtx] = {
+  private def astForElse(maybeStmt: Option[Statement], scopeContext: ScopeContext): Option[AstWithCtx] = {
     maybeStmt.map { stmt =>
       val elseAstsWithCtx = astsForStatement(stmt, scopeContext, 1)
 
       val elseNode =
         NewControlStructure()
           .controlStructureType(ControlStructureTypes.ELSE)
-          .order(order)
-          .argumentIndex(order)
+          .order(3)
+          .argumentIndex(3)
           .lineNumber(line(stmt))
           .columnNumber(column(stmt))
           .code("else")
@@ -756,11 +761,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .code(s"if (${stmt.getCondition.toString})")
 
     val conditionAstWithCtx =
-      astsForExpression(stmt.getCondition, scopeContext, order = 1).headOption
+      astsForExpression(stmt.getCondition, scopeContext, order = 1, Some("boolean")).headOption
         .getOrElse(AstWithCtx.empty)
 
     val thenAstsWithCtx = astsForStatement(stmt.getThenStmt, scopeContext, order = 2)
-    val elseAstWithCtx  = astForElse(stmt.getElseStmt.toScala, scopeContext, order = 3)
+    val elseAstWithCtx  = astForElse(stmt.getElseStmt.toScala, scopeContext)
 
     val ast = Ast(ifNode)
       .withChild(conditionAstWithCtx.ast)
@@ -792,7 +797,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .code(s"while (${stmt.getCondition.toString})")
 
     val conditionAstWithCtx =
-      astsForExpression(stmt.getCondition, scopeContext, order = 1).headOption
+      astsForExpression(stmt.getCondition, scopeContext, order = 1, Some("boolean")).headOption
         .getOrElse(AstWithCtx.empty)
     val stmtAstsWithCtx = astsForStatement(stmt.getBody, scopeContext, order = 2)
 
@@ -815,7 +820,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val doNode =
       NewControlStructure().controlStructureType(ControlStructureTypes.DO).order(order)
     val conditionAstWithCtx =
-      astsForExpression(stmt.getCondition, scopeContext, order = 0).headOption
+      astsForExpression(stmt.getCondition, scopeContext, order = 0, Some("boolean")).headOption
         .getOrElse(AstWithCtx.empty)
     val stmtAstsWithCtx = astsForStatement(stmt.getBody, scopeContext, order = 1)
     val ast = Ast(doNode)
@@ -871,18 +876,18 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val (initAstsWithCtx, scopeCtxWithInit) =
       withOrderAndCtx(stmt.getInitialization.asScala, scopeContext) { (s, scopeCtx, o) =>
-        astsForExpression(s, scopeCtx, o)
+        astsForExpression(s, scopeCtx, o, None)
       }
 
     val (compareAstsWithCtx, scopeCtxWithComp) =
       withOrderAndCtx(stmt.getCompare.toScala, scopeCtxWithInit, initAstsWithCtx.size + 1) { (x, scopeCtx, o) =>
-        astsForExpression(x, scopeCtx, o)
+        astsForExpression(x, scopeCtx, o, Some("boolean"))
       }
 
     val newOrder = initAstsWithCtx.size + compareAstsWithCtx.size
     val (updateAstsWithCtx, scopeCtxWithUpdt) =
       withOrderAndCtx(stmt.getUpdate.asScala, scopeCtxWithComp, newOrder + 1) { (x, scopeCtx, o) =>
-        astsForExpression(x, scopeCtx, o)
+        astsForExpression(x, scopeCtx, o, None)
       }
 
     val stmtAstsWithCtx =
@@ -909,7 +914,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .controlStructureType(ControlStructureTypes.FOR)
       .order(order)
 
-    val iterableAstsWithCtx = astsForExpression(stmt.getIterable, scopeContext, 1)
+    val iterableAstsWithCtx = astsForExpression(stmt.getIterable, scopeContext, 1, None)
     val variableAstsWithCtx =
       astsForVariableDecl(stmt.getVariable, scopeContext, iterableAstsWithCtx.size + 1)
     val initContext      = mergedCtx((iterableAstsWithCtx ++ variableAstsWithCtx).map(_.ctx))
@@ -935,7 +940,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .argumentIndex(order)
         .code(s"switch(${stmt.getSelector.toString})")
 
-    val selectorAstsWithCtx = astsForExpression(stmt.getSelector, scopeContext, 1)
+    val selectorAstsWithCtx = astsForExpression(stmt.getSelector, scopeContext, 1, None)
     val selectorNode        = selectorAstsWithCtx.head.ast.root.get
 
     val (entryAstsWithCtx, _) = withOrderAndCtx(stmt.getEntries.asScala, scopeContext) { (e, scopeCtx, o) =>
@@ -969,7 +974,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val modifier = Ast(NewModifier().modifierType("SYNCHRONIZED"))
 
-    val exprAsts = astsForExpression(stmt.getExpression, scopeContext, 1)
+    val exprAsts = astsForExpression(stmt.getExpression, scopeContext, 1, None)
     val bodyAst  = astForBlockStatement(stmt.getBody, scopeContext, 1 + exprAsts.size)
 
     val ctx = bodyAst.ctx.mergeWith(exprAsts.map(_.ctx))
@@ -999,7 +1004,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
             .code(label.toString)
             .order(labelOrder)
             .argumentIndex(labelOrder)
-          val labelAsts = astsForExpression(label, scopeContext, labelOrder)
+          val labelAsts = astsForExpression(label, scopeContext, labelOrder, None)
 
           Seq(Ast(jumpTarget)) ++ labelAsts.map(_.ast)
         }
@@ -1030,7 +1035,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
 
-    val args = astsForExpression(stmt.getCheck, scopeContext, 1)
+    val args = astsForExpression(stmt.getCheck, scopeContext, 1, Some("boolean"))
     callAst(callNode, args)
   }
 
@@ -1059,7 +1064,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def astsForReturnNode(ret: ReturnStmt, scopeContext: ScopeContext, order: Int): Seq[AstWithCtx] = {
     if (ret.getExpression.isPresent) {
-      val exprAstsWithCtx = astsForExpression(ret.getExpression.get(), scopeContext, order + 1)
+      val exprAstsWithCtx = astsForExpression(ret.getExpression.get(), scopeContext, order + 1, None)
       val returnNode = NewReturn()
         .lineNumber(line(ret))
         .columnNumber(column(ret))
@@ -1076,8 +1081,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  def astForUnaryExpr(stmt: UnaryExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
-    val operatorName = stmt.getOperator match {
+  def astForUnaryExpr(
+    expr: UnaryExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
+    val operatorName = expr.getOperator match {
       case UnaryExpr.Operator.LOGICAL_COMPLEMENT => Operators.logicalNot
       case UnaryExpr.Operator.POSTFIX_DECREMENT  => Operators.postDecrement
       case UnaryExpr.Operator.POSTFIX_INCREMENT  => Operators.postIncrement
@@ -1088,19 +1098,33 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case UnaryExpr.Operator.MINUS              => Operators.minus
     }
 
+    val argsWithCtx = astsForExpression(expr.getExpression, scopeContext, 1, expectedType)
+
+    val typeFullName =
+      typeInfoProvider
+        .getTypeForExpression(expr)
+        .orElse(argsWithCtx.headOption.flatMap(rootType))
+        .orElse(expectedType)
+        .getOrElse(UnresolvedTypeDefault)
+
     val callNode = NewCall()
       .name(operatorName)
       .methodFullName(operatorName)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
-      .code(stmt.toString)
+      .code(expr.toString)
       .argumentIndex(order)
       .order(order)
+      .typeFullName(typeFullName)
 
-    val argsWithCtx = astsForExpression(stmt.getExpression, scopeContext, 1)
     callAst(callNode, argsWithCtx)
   }
 
-  def astForArrayAccessExpr(expr: ArrayAccessExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
+  def astForArrayAccessExpr(
+    expr: ArrayAccessExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
     val callNode = NewCall()
       .name(Operators.indexAccess)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1112,11 +1136,21 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .columnNumber(column(expr))
 
     val argsWithCtx =
-      astsForExpression(expr.getName, scopeContext, 1) ++ astsForExpression(expr.getIndex, scopeContext, 2)
+      astsForExpression(expr.getName, scopeContext, 1, expectedType.map(_ ++ "[]")) ++ astsForExpression(
+        expr.getIndex,
+        scopeContext,
+        2,
+        Some("int")
+      )
     callAst(callNode, argsWithCtx)
   }
 
-  def astForArrayCreationExpr(expr: ArrayCreationExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
+  def astForArrayCreationExpr(
+    expr: ArrayCreationExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
     val name = "<operator>.arrayCreator"
     val callNode = NewCall()
       .name(name)
@@ -1127,10 +1161,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .methodFullName(name)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
+      .typeFullName(
+        typeInfoProvider.getTypeForExpression(expr).getOrElse(expectedType.getOrElse(UnresolvedTypeDefault))
+      )
 
     val levelAsts = expr.getLevels.asScala.zipWithIndex.flatMap { case (lvl, idx) =>
       lvl.getDimension.toScala match {
-        case Some(dimension) => astsForExpression(dimension, scopeContext, idx + 1)
+        case Some(dimension) => astsForExpression(dimension, scopeContext, idx + 1, Some("int"))
 
         case None => Seq.empty
       }
@@ -1138,7 +1175,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val initializerAstWithCtx =
       expr.getInitializer.toScala
-        .map(astForArrayInitializerExpr(_, scopeContext, expr.getLevels.size() + 1))
+        .map(astForArrayInitializerExpr(_, scopeContext, expr.getLevels.size() + 1, expectedType))
         .getOrElse(AstWithCtx.empty)
 
     val argsWithCtx = (levelAsts ++ List(initializerAstWithCtx)).toSeq
@@ -1146,7 +1183,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, argsWithCtx)
   }
 
-  def astForArrayInitializerExpr(expr: ArrayInitializerExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
+  def astForArrayInitializerExpr(
+    expr: ArrayInitializerExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
+    val typeFullName = typeInfoProvider.getTypeForExpression(expr).orElse(expectedType).getOrElse(UnresolvedTypeDefault)
     val callNode = NewCall()
       .name("<operator>.arrayInitializer")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1156,14 +1199,16 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .methodFullName("<operator>.arrayInitializer")
       .lineNumber(line(expr))
       .columnNumber(column(expr))
+      .typeFullName(typeFullName)
 
     val MAX_INITIALIZERS = 1000
 
+    val expectedValueType = expr.getValues.asScala.headOption.flatMap(typeInfoProvider.getTypeForExpression)
     val argsWithCtx = expr.getValues.asScala
       .slice(0, MAX_INITIALIZERS)
       .zipWithIndex
       .flatMap { case (c, o) =>
-        astsForExpression(c, scopeContext, o)
+        astsForExpression(c, scopeContext, o, expectedValueType)
       }
       .toSeq
 
@@ -1185,7 +1230,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     AstWithCtx(initAst, ctx)
   }
 
-  def astForBinaryExpr(expr: BinaryExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
+  def astForBinaryExpr(
+    expr: BinaryExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
     val operatorName = expr.getOperator match {
       case BinaryExpr.Operator.OR                   => Operators.logicalOr
       case BinaryExpr.Operator.AND                  => Operators.logicalAnd
@@ -1208,6 +1258,22 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case BinaryExpr.Operator.REMAINDER            => Operators.modulo
     }
 
+    val argsWithCtx =
+      astsForExpression(expr.getLeft, scopeContext, 1, expectedType) ++ astsForExpression(
+        expr.getRight,
+        scopeContext,
+        2,
+        expectedType
+      )
+
+    val typeFullName =
+      typeInfoProvider
+        .getTypeForExpression(expr)
+        .orElse(argsWithCtx.headOption.flatMap(rootType))
+        .orElse(argsWithCtx.lastOption.flatMap(rootType))
+        .orElse(expectedType)
+        .getOrElse(UnresolvedTypeDefault)
+
     val callNode = NewCall()
       .name(operatorName)
       .methodFullName(operatorName)
@@ -1217,14 +1283,23 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
-
-    val argsWithCtx =
-      astsForExpression(expr.getLeft, scopeContext, 1) ++ astsForExpression(expr.getRight, scopeContext, 2)
+      .typeFullName(typeFullName)
 
     callAst(callNode, argsWithCtx)
   }
 
-  def astForCastExpr(expr: CastExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
+  def astForCastExpr(
+    expr: CastExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
+    val typeFullName =
+      typeInfoProvider
+        .getTypeFullName(expr)
+        .orElse(expectedType)
+        .getOrElse(UnresolvedTypeDefault)
+
     val callNode = NewCall()
       .name(Operators.cast)
       .methodFullName(Operators.cast)
@@ -1234,8 +1309,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
+      .typeFullName(typeFullName)
 
-    val typeFullName = typeInfoProvider.getTypeFullName(expr)
     val typeNode = NewTypeRef()
       .code(expr.getType.toString)
       .order(1)
@@ -1245,12 +1320,21 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .columnNumber(column(expr))
     val typeAst = AstWithCtx(Ast(typeNode), Context())
 
-    val exprAst = astsForExpression(expr.getExpression, scopeContext, 2)
+    val exprAst = astsForExpression(expr.getExpression, scopeContext, 2, None)
 
     callAst(callNode, Seq(typeAst) ++ exprAst)
   }
 
-  def astsForAssignExpr(expr: AssignExpr, scopeContext: ScopeContext, order: Int): Seq[AstWithCtx] = {
+  private def rootType(astWithCtx: AstWithCtx): Option[String] = {
+    astWithCtx.ast.root.flatMap(_.properties.get("TYPE_FULL_NAME").map(_.toString))
+  }
+
+  def astsForAssignExpr(
+    expr: AssignExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): Seq[AstWithCtx] = {
     val methodName = expr.getOperator match {
       case Operator.ASSIGN               => Operators.assignment
       case Operator.PLUS                 => Operators.assignmentPlus
@@ -1266,7 +1350,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case Operator.UNSIGNED_RIGHT_SHIFT => Operators.assignmentLogicalShiftRight
     }
 
-    def callNode =
+    val targetAst  = astsForExpression(expr.getTarget, scopeContext, 1, None)
+    val targetType = targetAst.headOption.flatMap(rootType)
+    val argsAsts   = astsForExpression(expr.getValue, scopeContext, 2, targetType)
+    val valueType  = argsAsts.headOption.flatMap(rootType)
+    val argsCtx    = mergedCtx(targetAst.map(_.ctx) ++ argsAsts.map(_.ctx))
+
+    val callNode =
       NewCall()
         .name(methodName)
         .methodFullName(methodName)
@@ -1276,10 +1366,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .argumentIndex(order)
         .order(order)
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
-
-    val targetAst = astsForExpression(expr.getTarget, scopeContext, 1)
-    val argsAsts  = astsForExpression(expr.getValue, scopeContext, 2)
-    val argsCtx   = mergedCtx(targetAst.map(_.ctx) ++ argsAsts.map(_.ctx))
+        .typeFullName(targetType.orElse(valueType).orElse(expectedType).getOrElse(UnresolvedTypeDefault))
 
     if (argsCtx.partialConstructors.isEmpty) {
       val assignAst = callAst(callNode, targetAst ++ argsAsts)
@@ -1309,8 +1396,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def localsForVarDecl(varDecl: VariableDeclarationExpr, order: Int): List[NewLocal] = {
     varDecl.getVariables.asScala.zipWithIndex.map { case (variable, idx) =>
-      val name         = variable.getName.toString
-      val typeFullName = typeInfoProvider.getTypeFullName(variable)
+      val name = variable.getName.toString
+      // TODO Should be able to find expected type here
+      val typeFullName = typeInfoProvider.getTypeFullName(variable).getOrElse(UnresolvedTypeDefault)
       val code         = s"${variable.getType} $name"
 
       NewLocal().name(name).code(code).typeFullName(typeFullName).order(order + idx)
@@ -1329,7 +1417,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       val name                    = variable.getName.toString
       val initializer             = variable.getInitializer.toScala.get // Won't crash because of filter
       val initializerTypeFullName = typeInfoProvider.getInitializerType(variable)
-      val variableTypeFullName    = typeInfoProvider.getTypeFullName(variable)
+      val variableTypeFullName    = typeInfoProvider.getTypeFullName(variable).getOrElse(UnresolvedTypeDefault)
 
       val typeFullName = if (TypeInfoProvider.isAutocastType(variableTypeFullName)) {
         variableTypeFullName
@@ -1358,7 +1446,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .columnNumber(column(variable))
       val identifierAst = AstWithCtx(Ast(identifier), Context(identifiers = Map(identifier.name -> identifier)))
 
-      val initializerAstsWithCtx = astsForExpression(initializer, scopeContext, 2)
+      // TODO Add expected type here if possible
+      val initializerAstsWithCtx = astsForExpression(initializer, scopeContext, 2, Some(typeFullName))
       // Since all partial constructors will be dealt with here, don't pass them up.
       val initAstsWithoutConstructorCtx = initializerAstsWithCtx.map { case AstWithCtx(ast, ctx) =>
         AstWithCtx(ast, ctx.clearConstructors())
@@ -1418,7 +1507,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     localAsts ++ assignmentsWithCtx
   }
 
-  def callAst(rootNode: NewNode, args: Seq[AstWithCtx]): AstWithCtx = {
+  def callAst(rootNode: NewCall, args: Seq[AstWithCtx]): AstWithCtx = {
     val asts = args.map(_.ast)
     val ctx  = mergedCtx(args.map(_.ctx))
     val ast = Ast(rootNode)
@@ -1427,7 +1516,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     AstWithCtx(ast, ctx)
   }
 
-  def astForClassExpr(expr: ClassExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
+  def astForClassExpr(expr: ClassExpr, order: Int): AstWithCtx = {
     val callNode = NewCall()
       .name(Operators.fieldAccess)
       .methodFullName(Operators.fieldAccess)
@@ -1437,7 +1526,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
 
     val identifier = NewIdentifier()
-      .typeFullName(typeInfoProvider.getTypeFullName(expr))
+      .typeFullName(typeInfoProvider.getTypeFullName(expr).getOrElse(UnresolvedTypeDefault))
       .code(expr.getTypeAsString)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
@@ -1457,7 +1546,24 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, Seq(idAstWithCtx, fieldIdAstWithCtx))
   }
 
-  def astForConditionalExpr(expr: ConditionalExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
+  def astForConditionalExpr(
+    expr: ConditionalExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
+    val condAst = astsForExpression(expr.getCondition, scopeContext, 1, Some("boolean"))
+    val thenAst = astsForExpression(expr.getThenExpr, scopeContext, 2, expectedType)
+    val elseAst = astsForExpression(expr.getElseExpr, scopeContext, 3, expectedType)
+
+    val typeFullName =
+      typeInfoProvider
+        .getTypeForExpression(expr)
+        .orElse(thenAst.headOption.flatMap(rootType))
+        .orElse(elseAst.headOption.flatMap(rootType))
+        .orElse(expectedType)
+        .getOrElse(UnresolvedTypeDefault)
+
     val callNode = NewCall()
       .name(Operators.conditional)
       .methodFullName(Operators.conditional)
@@ -1467,19 +1573,32 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
-
-    val condAst = astsForExpression(expr.getCondition, scopeContext, 1)
-    val thenAst = astsForExpression(expr.getThenExpr, scopeContext, 2)
-    val elseAst = astsForExpression(expr.getElseExpr, scopeContext, 3)
+      .typeFullName(typeFullName)
 
     callAst(callNode, condAst ++ thenAst ++ elseAst)
   }
 
-  def astForEnclosedExpression(expr: EnclosedExpr, scopeContext: ScopeContext, order: Int): Seq[AstWithCtx] = {
-    astsForExpression(expr.getInner, scopeContext, order)
+  def astForEnclosedExpression(
+    expr: EnclosedExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): Seq[AstWithCtx] = {
+    astsForExpression(expr.getInner, scopeContext, order, expectedType)
   }
 
-  def astForFieldAccessExpr(expr: FieldAccessExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
+  def astForFieldAccessExpr(
+    expr: FieldAccessExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
+    val typeFullName =
+      typeInfoProvider
+        .getTypeForExpression(expr)
+        .orElse(expectedType)
+        .getOrElse(UnresolvedTypeDefault)
+
     val callNode = NewCall()
       .name(Operators.fieldAccess)
       .methodFullName(Operators.fieldAccess)
@@ -1489,9 +1608,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
+      .typeFullName(typeFullName)
 
     val fieldIdentifier = expr.getName
-    val identifierAsts  = astsForExpression(expr.getScope, scopeContext, 1)
+    val identifierAsts  = astsForExpression(expr.getScope, scopeContext, 1, None)
     val fieldIdentifierNode = NewFieldIdentifier()
       .canonicalName(fieldIdentifier.toString)
       .argumentIndex(2)
@@ -1514,28 +1634,38 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
+      .typeFullName("boolean")
 
-    val exprAst = astsForExpression(expr.getExpression, scopeContext, order = 1)
-    val typ     = expr.getType
+    val exprAst      = astsForExpression(expr.getExpression, scopeContext, order = 1, None)
+    val typeFullName = typeInfoProvider.getTypeFullName(expr.getType).getOrElse(UnresolvedTypeDefault)
     val typeNode =
       NewTypeRef()
-        .code(typ.toString)
+        .code(expr.getType.toString)
         .order(exprAst.size + 1)
         .argumentIndex(exprAst.size + 1)
         .lineNumber(line(expr))
         .columnNumber(column(expr.getType))
-        .typeFullName(Try(typ.resolve().describe()).toOption.getOrElse("<empty>"))
+        .typeFullName(typeFullName)
     val typeAst = AstWithCtx(Ast(typeNode), Context())
 
     callAst(callNode, exprAst ++ Seq(typeAst))
   }
 
-  def astForNameExpr(x: NameExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
-    val name = x.getName.toString
-    val typeFullName = scopeContext.identifiers
+  private def nameExprTypeFromScope(name: String, scopeContext: ScopeContext): Option[String] = {
+    scopeContext.identifiers
       .get(name)
       .map(_.typeFullName)
-      .getOrElse(typeInfoProvider.getTypeFullName(x))
+      .orElse(scopeContext.methodParameters.find(_.name == name).map(_.typeFullName))
+  }
+
+  def astForNameExpr(x: NameExpr, scopeContext: ScopeContext, order: Int, expectedType: Option[String]): AstWithCtx = {
+    val name = x.getName.toString
+
+    val typeFullName = typeInfoProvider
+      .getTypeFullName(x)
+      .orElse(nameExprTypeFromScope(name, scopeContext))
+      .orElse(expectedType)
+      .getOrElse(UnresolvedTypeDefault)
 
     val identifier = NewIdentifier()
       .name(name)
@@ -1574,11 +1704,26 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     * This is not valid Java code, but this representation is a decent compromise between staying faithful to Java and
     * being consistent with the Java bytecode frontend.
     */
-  def astForObjectCreationExpr(expr: ObjectCreationExpr, scopeContext: ScopeContext, order: Int): AstWithCtx = {
-    val name         = "<operator>.alloc"
-    val typeFullName = typeInfoProvider.getTypeFullName(expr)
-    val argTypes =
-      expr.getArguments.asScala.map(expr => Try(expr.calculateResolvedType().describe()).getOrElse("<empty>"))
+  def astForObjectCreationExpr(
+    expr: ObjectCreationExpr,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): AstWithCtx = {
+    val maybeResolvedExpr = Try(expr.resolve())
+    val args = withOrder(expr.getArguments) { (x, o) =>
+      val expectedArgType = getExpectedConsParamType(maybeResolvedExpr, o - 1)
+      astsForExpression(x, scopeContext, o, expectedArgType)
+    }.flatten
+
+    val name = "<operator>.alloc"
+    val typeFullName = typeInfoProvider
+      .getTypeFullName(expr)
+      .orElse(expectedType)
+      .getOrElse(UnresolvedTypeDefault)
+    val argTypes = args.map { arg =>
+      arg.ast.root.flatMap(_.properties.get("TYPE_FULL_NAME")).getOrElse("<empty>")
+    }
     val signature = s"void(${argTypes.mkString(",")})"
 
     val allocNode = NewCall()
@@ -1591,6 +1736,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .typeFullName(typeFullName)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
+      .signature(s"$typeFullName()")
 
     val initNode = NewCall()
       .name("<init>")
@@ -1600,10 +1746,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .code(expr.toString)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .signature(signature)
-
-    val args = withOrder(expr.getArguments) { (x, o) =>
-      astsForExpression(x, scopeContext, o)
-    }.flatten
 
     // Assume that a block ast is required, since there isn't enough information to decide otherwise.
     // This simplifies logic elsewhere, and unnecessary blocks will be garbage collected soon.
@@ -1682,8 +1824,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     AstWithCtx(blockAst, Context())
   }
 
-  def astForThisExpr(expr: ThisExpr, order: Int): AstWithCtx = {
-    val typeFullName = typeInfoProvider.getTypeFullName(expr)
+  def astForThisExpr(expr: ThisExpr, order: Int, expectedType: Option[String]): AstWithCtx = {
+    val typeFullName =
+      typeInfoProvider
+        .getTypeFullName(expr)
+        .orElse(expectedType)
+        .getOrElse(UnresolvedTypeDefault)
+
     val identifier =
       NewIdentifier()
         .name("this")
@@ -1702,9 +1849,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     scopeContext: ScopeContext,
     order: Int
   ): AstWithCtx = {
+    val args = withOrder(stmt.getArguments) { (s, o) =>
+      astsForExpression(s, scopeContext, o, None)
+    }.flatten
+
     val typeFullName = typeInfoProvider.getTypeFullName(stmt)
-    val argTypes =
-      stmt.getArguments.asScala.map(expr => Try(expr.calculateResolvedType().describe()).getOrElse("<empty>"))
+    val argTypes     = argumentTypesForCall(Try(stmt.resolve()), args)
+
     val signature = s"void(${argTypes.mkString(",")})"
     val callNode = NewCall()
       .name("<init>")
@@ -1726,10 +1877,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .typeFullName(typeFullName)
     val thisAst = AstWithCtx(Ast(thisNode), Context())
 
-    val args = withOrder(stmt.getArguments) { (s, o) =>
-      astsForExpression(s, scopeContext, o)
-    }.flatten
-
     val AstWithCtx(ast, ctx) = callAst(callNode, Seq(thisAst) ++ args)
 
     // ast.root should just be `callNode`, but do a sanity check in any case.
@@ -1743,7 +1890,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  private def astsForExpression(expression: Expression, scopeContext: ScopeContext, order: Int): Seq[AstWithCtx] = {
+  private def astsForExpression(
+    expression: Expression,
+    scopeContext: ScopeContext,
+    order: Int,
+    expectedType: Option[String]
+  ): Seq[AstWithCtx] = {
     // TODO: Implement missing handlers
     // case _: MethodReferenceExpr     => Seq()
     // case _: PatternExpr             => Seq()
@@ -1752,24 +1904,24 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     // case _: TypeExpr                => Seq()
     expression match {
       case _: AnnotationExpr          => Seq()
-      case x: ArrayAccessExpr         => Seq(astForArrayAccessExpr(x, scopeContext, order))
-      case x: ArrayCreationExpr       => Seq(astForArrayCreationExpr(x, scopeContext, order))
-      case x: ArrayInitializerExpr    => Seq(astForArrayInitializerExpr(x, scopeContext, order))
-      case x: AssignExpr              => astsForAssignExpr(x, scopeContext, order)
-      case x: BinaryExpr              => Seq(astForBinaryExpr(x, scopeContext, order))
-      case x: CastExpr                => Seq(astForCastExpr(x, scopeContext, order))
-      case x: ClassExpr               => Seq(astForClassExpr(x, scopeContext, order))
-      case x: ConditionalExpr         => Seq(astForConditionalExpr(x, scopeContext, order))
-      case x: EnclosedExpr            => astForEnclosedExpression(x, scopeContext, order)
-      case x: FieldAccessExpr         => Seq(astForFieldAccessExpr(x, scopeContext, order))
+      case x: ArrayAccessExpr         => Seq(astForArrayAccessExpr(x, scopeContext, order, expectedType))
+      case x: ArrayCreationExpr       => Seq(astForArrayCreationExpr(x, scopeContext, order, expectedType))
+      case x: ArrayInitializerExpr    => Seq(astForArrayInitializerExpr(x, scopeContext, order, expectedType))
+      case x: AssignExpr              => astsForAssignExpr(x, scopeContext, order, expectedType)
+      case x: BinaryExpr              => Seq(astForBinaryExpr(x, scopeContext, order, expectedType))
+      case x: CastExpr                => Seq(astForCastExpr(x, scopeContext, order, expectedType))
+      case x: ClassExpr               => Seq(astForClassExpr(x, order))
+      case x: ConditionalExpr         => Seq(astForConditionalExpr(x, scopeContext, order, expectedType))
+      case x: EnclosedExpr            => astForEnclosedExpression(x, scopeContext, order, expectedType)
+      case x: FieldAccessExpr         => Seq(astForFieldAccessExpr(x, scopeContext, order, expectedType))
       case x: InstanceOfExpr          => Seq(astForInstanceOfExpr(x, scopeContext, order))
       case x: LambdaExpr              => Seq(astForLambdaExpr(x, scopeContext, order))
       case x: LiteralExpr             => Seq(astForLiteralExpr(x, order))
-      case x: MethodCallExpr          => Seq(astForMethodCall(x, scopeContext, order))
-      case x: NameExpr                => Seq(astForNameExpr(x, scopeContext, order))
-      case x: ObjectCreationExpr      => Seq(astForObjectCreationExpr(x, scopeContext, order))
-      case x: ThisExpr                => Seq(astForThisExpr(x, order))
-      case x: UnaryExpr               => Seq(astForUnaryExpr(x, scopeContext, order))
+      case x: MethodCallExpr          => Seq(astForMethodCall(x, scopeContext, order, expectedType))
+      case x: NameExpr                => Seq(astForNameExpr(x, scopeContext, order, expectedType))
+      case x: ObjectCreationExpr      => Seq(astForObjectCreationExpr(x, scopeContext, order, expectedType))
+      case x: ThisExpr                => Seq(astForThisExpr(x, order, expectedType))
+      case x: UnaryExpr               => Seq(astForUnaryExpr(x, scopeContext, order, expectedType))
       case x: VariableDeclarationExpr => astsForVariableDecl(x, scopeContext, order)
       case x                          => Seq(unknownAst(x, order))
     }
@@ -1787,14 +1939,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     AstWithCtx(Ast(unknownNode), Context())
   }
 
-  private def createCallSignature(decl: ResolvedMethodDeclaration, returnType: String): String = {
-    val paramTypes =
-      for (i <- 0 until decl.getNumberOfParams)
-        yield typeInfoProvider.getTypeFullName(decl.getParam(i))
-
-    s"$returnType(${paramTypes.mkString(",")})"
-  }
-
   private def codePrefixForMethodCall(call: MethodCallExpr): String = {
     Try(call.resolve()) match {
       case Success(resolvedCall) =>
@@ -1810,72 +1954,22 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         ""
     }
   }
-  private def createCallNode(
-    call: MethodCallExpr,
-    resolvedDecl: Try[ResolvedMethodDeclaration],
-    returnType: String,
-    order: Int
-  ) = {
-    val codePrefix = codePrefixForMethodCall(call)
-    val dispatchType = resolvedDecl match {
-      case Success(decl) =>
-        if (decl.isStatic) {
-          DispatchTypes.STATIC_DISPATCH
-        } else {
-          DispatchTypes.DYNAMIC_DISPATCH
-        }
-      case _ => DispatchTypes.DYNAMIC_DISPATCH
 
-    }
-
-    val callNode = NewCall()
-      .name(call.getNameAsString)
-      .code(s"$codePrefix${call.getNameAsString}(${call.getArguments.asScala.mkString(", ")})")
-      .typeFullName(returnType)
-      .order(order)
-      .argumentIndex(order)
-      .dispatchType(dispatchType)
-    resolvedDecl match {
-      case Success(resolved) =>
-        val signature = createCallSignature(resolved, returnType)
-        callNode.methodFullName(s"${resolved.getQualifiedName}:$signature")
-        callNode.signature(signature)
-      case Failure(_) =>
-        logger.warn(s"Could not resolve method for call ${call.getNameAsString}. Type info will be missing.")
-    }
-    if (call.getName.getBegin.isPresent) {
-      callNode
-        .lineNumber(line(call.getName))
-        .columnNumber(column(call.getName))
-    }
-    callNode
-  }
-
-  private def getScopeType(expr: Expression, scopeContext: ScopeContext): String = {
-
+  private def getScopeType(expr: Expression, scopeContext: ScopeContext): Option[String] = {
     expr match {
       case nameExpr: NameExpr =>
+        typeInfoProvider.getTypeFullName(nameExpr)
         scopeContext.identifiers
           .get(nameExpr.getName.toString)
           .map(_.typeFullName)
-          .getOrElse(typeInfoProvider.getTypeForExpression(expr))
+          .orElse(typeInfoProvider.getTypeFullName(nameExpr))
 
       case _ => typeInfoProvider.getTypeForExpression(expr)
     }
   }
 
-  private def createObjectNode(
-    call: MethodCallExpr,
-    callNode: NewCall,
-    scopeContext: ScopeContext
-  ): Option[NewIdentifier] = {
-
-    val maybeScope     = call.getScope.toScala
-    val maybeScopeType = maybeScope.map(getScopeType(_, scopeContext))
-
-    // Default to the type of the enclosing `typeDecl` for implicit this nodes.
-    val typeDeclType = scopeContext.typeDecl.map(_.fullName).getOrElse("<empty>")
-    val typeFullName = maybeScopeType.getOrElse(typeDeclType)
+  private def createObjectNode(typeFullName: String, call: MethodCallExpr, callNode: NewCall): Option[NewIdentifier] = {
+    val maybeScope = call.getScope.toScala
 
     if (maybeScope.isDefined || callNode.dispatchType == DispatchTypes.DYNAMIC_DISPATCH) {
       val name = maybeScope.map(_.toString).getOrElse("this")
@@ -2107,22 +2201,129 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     )
   }
 
-  private def astForMethodCall(call: MethodCallExpr, scopeContext: ScopeContext, order: Int = 1): AstWithCtx = {
+  private def getExpectedParamType(maybeResolvedCall: Try[ResolvedMethodDeclaration], idx: Int): Option[String] = {
+    maybeResolvedCall.toOption.flatMap { call =>
+      Try(typeInfoProvider.resolvedTypeFullName(call.getParam(idx).getType)).toOption
+    }
+  }
 
-    val resolvedDecl = Try(call.resolve())
-    val returnType   = typeInfoProvider.getReturnType(call)
-    val callNode     = createCallNode(call, resolvedDecl, returnType, order)
+  private def getExpectedConsParamType(
+    maybeResolvedCall: Try[ResolvedConstructorDeclaration],
+    idx: Int
+  ): Option[String] = {
+    maybeResolvedCall.toOption.flatMap { call =>
+      Try(typeInfoProvider.resolvedTypeFullName(call.getParam(idx).getType)).toOption
+    }
+  }
 
-    val objectNode = createObjectNode(call, callNode, scopeContext)
+  private def dispatchTypeForCall(maybeDecl: Try[ResolvedMethodDeclaration], maybeScope: Option[Expression]): String = {
+    maybeDecl match {
+      case Success(decl) =>
+        if (decl.isStatic) {
+          DispatchTypes.STATIC_DISPATCH
+        } else {
+          DispatchTypes.DYNAMIC_DISPATCH
+        }
+      case _ =>
+        maybeScope match {
+          case Some(_: SuperExpr) => DispatchTypes.STATIC_DISPATCH
+          case _                  => DispatchTypes.DYNAMIC_DISPATCH
+        }
+    }
+  }
+
+  private def targetTypeForCall(callExpr: MethodCallExpr, scopeContext: ScopeContext): Option[String] = {
+    callExpr.getScope.toScala match {
+      case Some(scope: ThisExpr) =>
+        typeInfoProvider
+          .getTypeFullName(scope)
+          .orElse(scopeContext.typeDecl.map(_.fullName))
+
+      case Some(scope: SuperExpr) =>
+        typeInfoProvider
+          .getTypeForExpression(scope)
+          .orElse(scopeContext.typeDecl.flatMap(_.inheritsFromTypeFullName.headOption))
+
+      case Some(scope) =>
+        getScopeType(scope, scopeContext)
+
+      case None =>
+        scopeContext.typeDecl.map(_.fullName)
+    }
+  }
+
+  private def argumentTypesForCall(
+    maybeMethod: Try[ResolvedMethodLikeDeclaration],
+    argAsts: Seq[AstWithCtx]
+  ): List[String] = {
+    maybeMethod match {
+      case Success(resolved) =>
+        (0 until resolved.getNumberOfParams).map { idx =>
+          val param = resolved.getParam(idx)
+          typeInfoProvider.getTypeFullName(param)
+        }.toList
+
+      case Failure(_) =>
+        // Fall back to actual argument types if the called method couldn't be resolved.
+        // This may result in missing dataflows.
+        argAsts.map(arg => rootType(arg).getOrElse(UnresolvedTypeDefault)).toList
+    }
+  }
+
+  private def astForMethodCall(
+    call: MethodCallExpr,
+    scopeContext: ScopeContext,
+    order: Int = 1,
+    expectedReturnType: Option[String]
+  ): AstWithCtx = {
+    val maybeResolvedCall = Try(call.resolve())
+    val argumentAsts = withOrder(call.getArguments) { (arg, o) =>
+      // TODO: Verify index
+      val expectedType = getExpectedParamType(maybeResolvedCall, o - 1)
+      astsForExpression(arg, scopeContext, o, expectedType)
+    }.flatten
+
+    val maybeReturnType = typeInfoProvider
+      .getReturnType(call)
+      .orElse(expectedReturnType)
+
+    println(s"In call $call with maybe return $maybeReturnType")
+
+    val dispatchType = dispatchTypeForCall(maybeResolvedCall, call.getScope.toScala)
+
+    val maybeTargetType = targetTypeForCall(call, scopeContext)
+
+    val argumentTypes = argumentTypesForCall(maybeResolvedCall, argumentAsts)
+
+    val (signature, methodFullName) = (maybeTargetType, maybeReturnType) match {
+      case (Some(targetType), Some(returnType)) =>
+        val signature      = s"$returnType(${argumentTypes.mkString(",")})"
+        val methodFullName = s"$targetType.${call.getNameAsString}:$signature"
+        (signature, methodFullName)
+
+      case _ =>
+        ("", "")
+    }
+
+    val codePrefix = codePrefixForMethodCall(call)
+    val callNode = NewCall()
+      .typeFullName(maybeReturnType.getOrElse(UnresolvedTypeDefault))
+      .name(call.getNameAsString)
+      .methodFullName(methodFullName)
+      .signature(signature)
+      .dispatchType(dispatchType)
+      .code(s"$codePrefix${call.getNameAsString}(${call.getArguments.asScala.mkString(", ")})")
+      .order(order)
+      .argumentIndex(order)
+      .lineNumber(line(call))
+      .columnNumber(column(call))
+
+    val objectNode = createObjectNode(maybeTargetType.getOrElse(UnresolvedTypeDefault), call, callNode)
     val objectAst = objectNode
       .map(objIdentifier =>
         AstWithCtx(Ast(objIdentifier), Context(identifiers = Map(objIdentifier.name -> objIdentifier)))
       )
       .getOrElse(AstWithCtx.empty)
-
-    val argumentAsts = withOrder(call.getArguments) { (x, o) =>
-      astsForExpression(x, scopeContext, o)
-    }.flatten
 
     val ast = callAst(callNode, Seq(objectAst) ++ argumentAsts)
 
@@ -2141,7 +2342,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForParameter(parameter: Parameter, childNum: Int): AstWithCtx = {
-    val typeFullName = typeInfoProvider.getTypeFullName(parameter)
+    val typeFullName = typeInfoProvider.getTypeFullName(parameter).getOrElse(UnresolvedTypeDefault)
     val parameterNode = NewMethodParameterIn()
       .name(parameter.getName.toString)
       .code(parameter.toString)
@@ -2156,7 +2357,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def methodFullName(typeDecl: Option[NewTypeDecl], methodDeclaration: MethodDeclaration): String = {
     val typeName   = typeDecl.map(_.fullName).getOrElse("")
-    val returnType = typeInfoProvider.getTypeFullName(methodDeclaration)
+    val returnType = typeInfoProvider.getTypeFullName(methodDeclaration).getOrElse(UnresolvedTypeDefault)
     val methodName = methodDeclaration.getNameAsString
     s"$typeName.$methodName:$returnType${paramListSignature(methodDeclaration)}"
   }
@@ -2165,12 +2366,14 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     typeDecl: Option[NewTypeDecl],
     constructorDeclaration: ConstructorDeclaration
   ): String = {
-    val typeName = typeDecl.map(_.fullName).getOrElse("<unresolved>")
+    val typeName = typeDecl.map(_.fullName).getOrElse(UnresolvedTypeDefault)
     s"$typeName.<init>:void${paramListSignature(constructorDeclaration)}"
   }
 
   private def paramListSignature(methodDeclaration: CallableDeclaration[_]) = {
-    val paramTypes = methodDeclaration.getParameters.asScala.map(typeInfoProvider.getTypeFullName)
+    val paramTypes = methodDeclaration.getParameters.asScala.map(p =>
+      typeInfoProvider.getTypeFullName(p).getOrElse(UnresolvedTypeDefault)
+    )
     "(" + paramTypes.mkString(",") + ")"
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -70,14 +70,15 @@ import com.github.javaparser.resolution.declarations.{
 import io.joern.javasrc2cpg.passes.AstWithCtx.astWithCtxToSeq
 import io.joern.javasrc2cpg.passes.Context.mergedCtx
 import io.joern.javasrc2cpg.util.TypeInfoProvider
-import io.joern.javasrc2cpg.util.TypeInfoProvider.UnresolvedTypeDefault
+import io.joern.javasrc2cpg.util.TypeInfoProvider.{Primitives, UnresolvedTypeDefault}
 import io.shiftleft.codepropertygraph.generated.{
   ControlStructureTypes,
   DispatchTypes,
   EdgeTypes,
   EvaluationStrategies,
   ModifierTypes,
-  Operators
+  Operators,
+  PropertyNames
 }
 import io.shiftleft.codepropertygraph.generated.nodes.{
   NewBinding,
@@ -1326,7 +1327,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def rootType(astWithCtx: AstWithCtx): Option[String] = {
-    astWithCtx.ast.root.flatMap(_.properties.get("TYPE_FULL_NAME").map(_.toString))
+    astWithCtx.ast.root.flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
   }
 
   def astsForAssignExpr(
@@ -1552,7 +1553,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     order: Int,
     expectedType: Option[String]
   ): AstWithCtx = {
-    val condAst = astsForExpression(expr.getCondition, scopeContext, 1, Some("boolean"))
+    val condAst = astsForExpression(expr.getCondition, scopeContext, 1, Some(Primitives.Boolean))
     val thenAst = astsForExpression(expr.getThenExpr, scopeContext, 2, expectedType)
     val elseAst = astsForExpression(expr.getElseExpr, scopeContext, 3, expectedType)
 
@@ -1722,7 +1723,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .orElse(expectedType)
       .getOrElse(UnresolvedTypeDefault)
     val argTypes = args.map { arg =>
-      arg.ast.root.flatMap(_.properties.get("TYPE_FULL_NAME")).getOrElse("<empty>")
+      arg.ast.root.flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME)).getOrElse(UnresolvedTypeDefault)
     }
     val signature = s"void(${argTypes.mkString(",")})"
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
@@ -349,6 +349,17 @@ object TypeInfoProvider {
     NumericTypes.contains(typeName)
   }
 
+  object Primitives {
+    val Byte: String    = "byte"
+    val Short: String   = "short"
+    val Int: String     = "int"
+    val Long: String    = "long"
+    val Float: String   = "float"
+    val Double: String  = "double"
+    val Char: String    = "char"
+    val Boolean: String = "boolean"
+  }
+
   val NumericTypes = Set(
     "byte",
     "short",

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
@@ -1,15 +1,17 @@
 package io.joern.javasrc2cpg.util
 
-import com.github.javaparser.ast.`type`.ClassOrInterfaceType
+import com.github.javaparser.ast.ImportDeclaration
+import com.github.javaparser.ast.`type`.{ClassOrInterfaceType, ReferenceType}
 import com.github.javaparser.ast.body.{EnumConstantDeclaration, TypeDeclaration, VariableDeclarator}
 import com.github.javaparser.ast.expr._
-import com.github.javaparser.ast.nodeTypes.NodeWithType
+import com.github.javaparser.ast.nodeTypes.{NodeWithName, NodeWithType}
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt
 import com.github.javaparser.resolution.Resolvable
 import com.github.javaparser.resolution.declarations._
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType}
 import io.joern.javasrc2cpg.passes.ScopeContext
 import io.joern.x2cpg.datastructures.Global
+import io.joern.javasrc2cpg.util.TypeInfoProvider.{ImportInfo, UnresolvedTypeDefault}
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._
@@ -18,7 +20,8 @@ import scala.util.{Failure, Success, Try}
 
 class TypeInfoProvider(global: Global) {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  private val logger     = LoggerFactory.getLogger(this.getClass)
+  private var importInfo = ImportInfo(Map.empty, None)
 
   /** Add `typeName` to a global map and return it. The map is later passed to a pass that creates TYPE nodes for each
     * key in the map. Skip the `ANY` type, since this is created by default.
@@ -115,7 +118,7 @@ class TypeInfoProvider(global: Global) {
     }
   }
 
-  private def resolvedTypeFullName(resolvedType: ResolvedType): String = {
+  def resolvedTypeFullName(resolvedType: ResolvedType): String = {
     resolvedType match {
       case resolvedReferenceType: ResolvedReferenceType => resolvedReferenceTypeFullName(resolvedReferenceType)
 
@@ -155,30 +158,30 @@ class TypeInfoProvider(global: Global) {
     }
   }
 
-  def getTypeFullName(node: NodeWithType[_, _ <: Resolvable[ResolvedType]]): String = {
+  def getTypeFullName(node: NodeWithType[_, _ <: Resolvable[ResolvedType]]): Option[String] = {
     val typeFullName = Try(node.getType.resolve()) match {
-      case Success(resolvedType: ResolvedReferenceType) => resolvedReferenceTypeFullName(resolvedType)
+      case Success(resolvedType: ResolvedReferenceType) => Some(resolvedReferenceTypeFullName(resolvedType))
 
-      case Success(resolvedType: ResolvedType) => simpleResolvedTypeFullName(resolvedType)
+      case Success(resolvedType: ResolvedType) => Some(simpleResolvedTypeFullName(resolvedType))
 
       case Failure(_) =>
-        logger.debug(s"Resolving type ${node.getTypeAsString} failed. Falling back to unresolved default.")
-        "<unresolved>." ++ node.getTypeAsString
+        logger.debug(s"Resolving type ${node.getTypeAsString} failed. Falling back to import default.")
+        importInfo.getType(node.getTypeAsString)
     }
 
-    registerType(typeFullName)
+    typeFullName.map(registerType)
   }
 
-  def getTypeFullName(typ: ClassOrInterfaceType): String = {
+  def getTypeFullName(typ: ClassOrInterfaceType): Option[String] = {
     val typeFullName = Try(typ.resolve) match {
-      case Success(resolvedType) => resolvedReferenceTypeFullName(resolvedType)
+      case Success(resolvedType) => Some(resolvedReferenceTypeFullName(resolvedType))
 
       case Failure(_) =>
-        logger.debug(s"Failed to resolve class type ${typ.getNameAsString}. Falling back to unresolved default.")
-        "<unresolved>." ++ typ.getNameAsString
+        logger.debug(s"Failed to resolve class type ${typ.getNameAsString}. Falling back to imports info.")
+        importInfo.getType(typ.getNameAsString)
     }
 
-    registerType(typeFullName)
+    typeFullName.map(registerType)
   }
 
   def getTypeFullName(enumConstant: EnumConstantDeclaration): String = {
@@ -194,45 +197,48 @@ class TypeInfoProvider(global: Global) {
     registerType(typeFullName)
   }
 
-  def getReturnType(node: Resolvable[ResolvedMethodDeclaration]): String = {
+  def getTypeFullName(referenceType: ReferenceType): Option[String] = {
+    val typeFullName = Try(referenceType.resolve()) match {
+      case Success(resolvedType) => Some(resolvedTypeFullName(resolvedType))
+
+      case Failure(_) => None
+    }
+
+    typeFullName.map(registerType)
+  }
+
+  def getReturnType(node: Resolvable[ResolvedMethodDeclaration]): Option[String] = {
     val typeFullName = Try(node.resolve().getReturnType) match {
-      case Success(resolved) => resolvedTypeFullName(resolved)
+      case Success(resolved) => Some(resolvedTypeFullName(resolved))
 
       case Failure(_) =>
-        logger.debug(s"Failed to resolve return type. Defaulting to ANY.")
-        "ANY"
+        logger.debug(s"Failed to resolve return type.")
+        None
     }
 
-    registerType(typeFullName)
+    typeFullName.map(registerType)
   }
 
-  def getTypeFullName(nameExpr: NameExpr): String = {
-    val typeFullName = Try(nameExpr.resolve()) match {
+  def getTypeFullName(nameExpr: NameExpr): Option[String] = {
+    val typeFullName = Try(nameExpr.calculateResolvedType()) match {
       case Success(resolvedValueDeclaration) =>
-        Try(resolvedTypeFullName(resolvedValueDeclaration.getType)).getOrElse {
-          logger.debug(s"Failed to resolve type of ${resolvedValueDeclaration}. Falling back to name.")
-          nameExpr.getNameAsString
-        }
+        Try(resolvedTypeFullName(resolvedValueDeclaration)).toOption
 
       case Failure(_) =>
-        logger.debug(s"Failed to resolved type for nameExpr ${nameExpr.getNameAsString}. Falling back to name.")
-        nameExpr.getNameAsString
+        logger.debug(s"Failed to resolved type for nameExpr ${nameExpr.getNameAsString}.")
+        None
 
     }
 
-    registerType(typeFullName)
+    typeFullName.map(registerType)
   }
 
-  def getTypeFullName(thisExpr: ThisExpr): String = {
-    val typeFullName = Try(thisExpr.resolve()) match {
-      case Success(declaration) => resolvedTypeDeclFullName(declaration)
+  def getTypeFullName(thisExpr: ThisExpr): Option[String] = {
+    val typeFullName =
+      Try(thisExpr.resolve()).toOption
+        .map(typeDecl => resolvedTypeDeclFullName(typeDecl))
 
-      case Failure(_) =>
-        logger.debug(s"Failed to resolve type for `this` expr. Defaulting to ANY")
-        "ANY"
-    }
-
-    registerType(typeFullName)
+    typeFullName.map(registerType)
   }
 
   def getMethodLikeTypeFullName(methodLike: Resolvable[_ <: ResolvedMethodLikeDeclaration]): String = {
@@ -257,10 +263,9 @@ class TypeInfoProvider(global: Global) {
       case _: NullLiteralExpr      => "null"
       case _: StringLiteralExpr    => "java.lang.String"
       case _: TextBlockLiteralExpr => "java.lang.String"
-      case _                       => "ANY"
+      case _                       => UnresolvedTypeDefault
     }
 
-    logger.debug(s"Processing type for literal ${literalExpr.getClass}: $typeFullName")
     registerType(typeFullName)
   }
 
@@ -283,16 +288,16 @@ class TypeInfoProvider(global: Global) {
     registerType(typeFullName)
   }
 
-  def getTypeForExpression(expr: Expression): String = {
+  def getTypeForExpression(expr: Expression): Option[String] = {
     val typeFullName = Try(expr.calculateResolvedType()) match {
-      case Success(resolvedType) => resolvedTypeFullName(resolvedType)
+      case Success(resolvedType) => Some(resolvedTypeFullName(resolvedType))
 
       case Failure(_) =>
         logger.debug(s"Could not resolve type for expr $expr")
-        "ANY"
+        None
     }
 
-    registerType(typeFullName)
+    typeFullName.map(registerType)
   }
 
   def getInitializerType(variableDeclarator: VariableDeclarator): Option[String] = {
@@ -317,6 +322,21 @@ class TypeInfoProvider(global: Global) {
         registerType(typ.fullName)
       case None => "ANY"
     }
+  }
+
+  def registerImports(imports: List[ImportDeclaration]): Unit = {
+    val (asteriskImports, specificImports) = imports.partition(_.isAsterisk)
+    val identifierMap = specificImports.map { importDecl =>
+      importDecl.getName.getIdentifier -> importDecl.getNameAsString
+    }.toMap
+
+    val wildcardImport = asteriskImports match {
+      case imp :: Nil => Some(imp.getNameAsString)
+
+      case _ => None
+    }
+
+    importInfo = ImportInfo(identifierMap, wildcardImport)
   }
 }
 
@@ -347,4 +367,18 @@ object TypeInfoProvider {
     "java.lang.Character",
     "java.lang.Boolean"
   )
+
+  val UnresolvedTypeDefault = "ANY"
+
+  case class ImportInfo(identifierMap: Map[String, String], wildcardImport: Option[String]) {
+    def getType(name: String): Option[String] = {
+      identifierMap.get(name).orElse {
+        if (NumericTypes.contains(name)) {
+          Some(name)
+        } else {
+          wildcardImport.map(wc => s"$wc.$name")
+        }
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -117,8 +117,8 @@ class CallTests extends JavaSrcCodeToCpgFixture {
   "should handle unresolved calls with appropriate defaults" in {
     val List(call: Call) = cpg.typeDecl.name("Foo").ast.isCall.name("foo").l
     call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH.toString
-    call.methodFullName shouldBe "<empty>"
-    call.signature shouldBe ""
+    call.methodFullName shouldBe "test.Foo.foo:void(int)"
+    call.signature shouldBe "void(int)"
     call.code shouldBe "foo(argc)"
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
@@ -46,7 +46,7 @@ class InferenceJarTests extends AnyFreeSpec with Matchers {
 
     "it should fail to resolve the type for Deps" in {
       val call = cpg.method.name("test1").call.name("foo").head
-      call.methodFullName shouldBe "<empty>"
+      call.methodFullName shouldBe ""
       call.signature shouldBe ""
       call.typeFullName shouldBe "ANY"
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
@@ -1,0 +1,224 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
+import io.shiftleft.semanticcpg.language._
+
+class TypeInferenceTests extends JavaSrcCodeToCpgFixture {
+
+  override val code: String =
+    """
+      |package pakfoo;
+      |
+      |import a.b.c.Bar;
+      |import d.*;
+      |import e.Unknown;
+      |
+      |class Foo extends Unknown {
+      |
+      |    public static void foo(int x) {}
+      |
+      |    public void test1() {
+      |        // Should find a.b.c.Bar
+      |        Bar b;
+      |    }
+      |
+      |    public void test2() {
+      |        // Should create constructor for a.b.c.Bar
+      |        Bar b = new Bar(0);
+      |    }
+      |
+      |    // Should find a.b.c.Bar for parameter type
+      |    public void test3(Bar b) {}
+      |
+      |    public void test4(Bar b) {
+      |        // Should find methodFullName a.b.c.Bar.bar:int()
+      |        int x = b.bar();
+      |    }
+      |
+      |    public void test6(Baz z) {}
+      |
+      |    public void test7(Bar b, Baz z) {
+      |        // Should find methodFullName a.b.c.Bar.bar:void(d.Baz, int)
+      |        b.bar(z, 1);
+      |    }
+      |
+      |    public void test8() {
+      |        // Should find methodFullName pakfoo.Foo.missing:void()
+      |        this.missing();
+      |    }
+      |
+      |    public void test9() {
+      |        // Should find methodFullName e.Unknown.missing:void()
+      |        super.missing();
+      |    }
+      |
+      |    public void test10() {
+      |        // Should find arg type
+      |        Foo f = new Foo(
+      |    }
+      |}
+      |""".stripMargin
+
+  "should find typeFullName from matching import" in {
+    cpg.method.name("test1").local.nameExact("b").l match {
+      case b :: Nil => b.typeFullName shouldBe "a.b.c.Bar"
+
+      case res => fail(s"Expected identifier b but got $res")
+    }
+  }
+
+  "should create a constructor based on import info" in {
+    cpg.method.name("test2").call.nameExact("<operator>.alloc").l match {
+      case alloc :: Nil =>
+        alloc.typeFullName shouldBe "a.b.c.Bar"
+        alloc.signature shouldBe "a.b.c.Bar()"
+        alloc.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+      case res => fail(s"Expected single alloc call but got $res")
+    }
+
+    val init = cpg.method.name("test2").call.nameExact("<init>").l match {
+      case init :: Nil => init
+      case res         => fail(s"Expected single init call but got $res")
+
+    }
+
+    init.typeFullName shouldBe "void"
+    init.signature shouldBe "void(int)"
+    init.methodFullName shouldBe "a.b.c.Bar.<init>:void(int)"
+
+    init.argument.size shouldBe 2
+
+    init.argument.l match {
+      case List(obj: Identifier, arg: Literal) =>
+        obj.name shouldBe "b"
+        obj.code shouldBe "b"
+        obj.typeFullName shouldBe "a.b.c.Bar"
+        obj.order shouldBe 0
+        obj.argumentIndex shouldBe 0
+
+        arg.typeFullName shouldBe "int"
+        arg.code shouldBe "0"
+        arg.order shouldBe 1
+        arg.argumentIndex shouldBe 1
+
+      case res => fail(s"Expected identifier and literal arguments for init but got $res")
+    }
+  }
+
+  "should find typeFullName for param from import" in {
+    cpg.method.name("test3").parameter.order(1).l match {
+      case param :: Nil =>
+        param.name shouldBe "b"
+        param.typeFullName shouldBe "a.b.c.Bar"
+
+      case res => fail(s"Expected single parameter but got $res")
+    }
+  }
+
+  "should find methodFullName for unresolved call in assignment" in {
+    val call = cpg.method.name("test4").call.name("bar").l match {
+      case call :: Nil => call
+
+      case res => fail(s"Expected single call to bar but got $res")
+    }
+
+    call.typeFullName shouldBe "int"
+    call.methodFullName shouldBe "a.b.c.Bar.bar:int()"
+    call.signature shouldBe "int()"
+
+    call.argument.l match {
+      case (obj: Identifier) :: Nil =>
+        obj.name shouldBe "b"
+        obj.code shouldBe "b"
+        obj.typeFullName shouldBe "a.b.c.Bar"
+
+      case res => fail(s"Expected single argument b but got $res")
+    }
+  }
+
+  "should find typeFullName for unresolved param from single wildcard import" in {
+    cpg.method.name("test6").parameter.l match {
+      case List(_, bazParam) =>
+        bazParam.name shouldBe "z"
+        bazParam.typeFullName shouldBe "d.Baz"
+
+      case res => fail(s"Expected param of type d.Baz but got $res")
+    }
+  }
+
+  "should find methodFullName for unresolved call with unresolved argument" in {
+    val call = cpg.method.name("test7").call.name("bar").l match {
+      case call :: Nil => call
+
+      case res => fail(s"Expected single call to bar but got $res")
+    }
+
+    call.typeFullName shouldBe "void"
+    call.signature shouldBe "void(d.Baz,int)"
+    call.methodFullName shouldBe "a.b.c.Bar.bar:void(d.Baz,int)"
+
+    call.argument.l match {
+      case List(obj: Identifier, arg1: Identifier, arg2: Literal) =>
+        obj.name shouldBe "b"
+        obj.typeFullName shouldBe "a.b.c.Bar"
+
+        arg1.name shouldBe "z"
+        arg1.typeFullName shouldBe "d.Baz"
+
+        arg2.code shouldBe "1"
+        arg2.typeFullName shouldBe "int"
+
+      case res => fail(s"Expected 3 arguments but got $res")
+    }
+  }
+
+  "should guess the enclosing typeDecl type for unresolved explicit this calls" in {
+    val call = cpg.method.name("test8").call.name("missing").l match {
+      case call :: Nil => call
+
+      case res => fail(s"Expected single call to missing but got $res")
+    }
+
+    call.typeFullName shouldBe "void"
+    call.signature shouldBe "void()"
+    call.methodFullName shouldBe "pakfoo.Foo.missing:void()"
+    call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+
+    call.argument.l match {
+      case (obj: Identifier) :: Nil =>
+        obj.name shouldBe "this"
+        obj.order shouldBe 0
+        obj.argumentIndex shouldBe 0
+        obj.typeFullName shouldBe "pakfoo.Foo"
+
+      case res => fail(s"Expected single this identifier but found $res")
+    }
+  }
+
+  "should find type and methodFullName for unresolved super call" in {
+    val call = cpg.method.name("test9").call.name("missing").l match {
+      case call :: Nil => call
+
+      case res => fail(s"Expected single call to missing but got $res")
+    }
+
+    call.typeFullName shouldBe "void"
+    call.signature shouldBe "void()"
+    call.methodFullName shouldBe "e.Unknown.missing:void()"
+    call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+    call.argument.l match {
+      case (obj: Identifier) :: Nil =>
+        obj.name shouldBe "super"
+        obj.order shouldBe 0
+        obj.argumentIndex shouldBe 0
+        obj.typeFullName shouldBe "e.Unknown"
+
+      case res => fail(s"Expected single super identifier but found $res")
+    }
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
@@ -193,6 +193,10 @@ class ObjectTests extends JavaDataflowFixture {
     sink.reachableByFlows(source).size shouldBe 1
   }
 
+  it should "not create Baz method with ANY type in signature" in {
+    cpg.method.fullNameExact("Baz.sink:void(ANY)").size shouldBe 0
+  }
+
   it should "find a inter-procedural path from object instantiation in call argument" in {
     def source = cpg.method.name("test12").literal.code("\"MALICIOUS\"")
     def sink   = cpg.method.name("sink").call.name("println").argument


### PR DESCRIPTION
With these changes, javasrc2cpg will use more available information improve type information where JavaParser's type solver has failed.

Notably: 
* If a vardecl/param type could not be resolved, check the imports for a matching type (based on name) and use that if one was found. If no matching import was found, but there's only a single wildcard import, use that instead. If there are 2 or more wildcard imports, then we don't know which it could've come from, so give up at this point.
* If a call could not be resolved, try to infer the methodFullName from type information we have in scope about the target, an expected return type (defaulting to void if the return value isn't used), and type info from arguments if those can be resolved/retrieved otherwise.