### PR TITLE
Switch from List to Vector for increased performance.

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -7,8 +7,8 @@ import overflowdb.BatchedUpdate.DiffGraphBuilder
 case class AstEdge(src: NewNode, dst: NewNode)
 
 object Ast {
-  def apply(node: NewNode): Ast = Ast(List(node))
-  def apply(): Ast              = new Ast(List())
+  def apply(node: NewNode): Ast = Ast(Vector.empty :+ node)
+  def apply(): Ast              = new Ast(Vector.empty)
 
   /** Copy nodes/edges of given `AST` into the given `diffGraph`.
     */
@@ -40,13 +40,13 @@ object Ast {
 }
 
 case class Ast(
-  nodes: List[NewNode],
-  edges: List[AstEdge] = List(),
-  conditionEdges: List[AstEdge] = List(),
-  refEdges: List[AstEdge] = List(),
-  bindsEdges: List[AstEdge] = List(),
-  receiverEdges: List[AstEdge] = List(),
-  argEdges: List[AstEdge] = List()
+  nodes: collection.Seq[NewNode],
+  edges: collection.Seq[AstEdge] = Vector.empty,
+  conditionEdges: collection.Seq[AstEdge] = Vector.empty,
+  refEdges: collection.Seq[AstEdge] = Vector.empty,
+  bindsEdges: collection.Seq[AstEdge] = Vector.empty,
+  receiverEdges: collection.Seq[AstEdge] = Vector.empty,
+  argEdges: collection.Seq[AstEdge] = Vector.empty
 ) {
 
   def root: Option[NewNode] = nodes.headOption
@@ -86,7 +86,7 @@ case class Ast(
   /** AST that results when adding all ASTs in `asts` as children, that is, connecting them to the root node of this
     * AST.
     */
-  def withChildren(asts: Seq[Ast]): Ast = {
+  def withChildren(asts: collection.Seq[Ast]): Ast = {
     if (asts.isEmpty) {
       this
     } else {

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/AstTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/AstTests.scala
@@ -40,12 +40,12 @@ class AstTests extends AnyWordSpec with Matchers {
     }
 
     "copy AST edges correctly" in {
-      val List(_, callInCallClone: NewCall, leafClone: NewIdentifier) = copied.nodes
+      val Seq(_, callInCallClone: NewCall, leafClone: NewIdentifier) = copied.nodes
       callInCallClone.order shouldBe 1
       leafClone.order shouldBe 1
 
       copied.edges.filter(_.src == callInCallClone).map(_.dst) match {
-        case List(x: NewIdentifier) =>
+        case Seq(x: NewIdentifier) =>
           x shouldBe leafClone
           x should not be leaf
           x.name shouldBe "leaf"
@@ -54,7 +54,7 @@ class AstTests extends AnyWordSpec with Matchers {
     }
 
     "copy argument edges correctly" in {
-      val List(edge1, edge2) = copied.argEdges
+      val Seq(edge1, edge2) = copied.argEdges
       edge1 match {
         case AstEdge(m: NewCall, c: NewCall) =>
           m should not be moo


### PR DESCRIPTION
Measured this with a c2cpg run on ffmpeg on my laptop and got roughly
15% shorter runtime with Vector. I also tried mutable.ArrayBuffer which
lead to approximately the same performance as for Vector.