### PR TITLE
Ghidra2cpg FunctionPass nits

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Decompiler.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Decompiler.scala
@@ -30,8 +30,11 @@ object Decompiler {
   */
 class Decompiler(val decompInterface: DecompInterface) {
 
-  val timeoutInSeconds                                      = 60
-  @volatile private var cache                               = immutable.HashMap[String, DecompileResults]()
+  val timeoutInSeconds        = 60
+  @volatile private var cache = immutable.HashMap[String, DecompileResults]()
+
+  /** Return the cache of decompile results. For debugging only.
+    */
   def getCache: immutable.HashMap[String, DecompileResults] = this.cache
 
   /** Retrieve HighFunction for given function, using the cache.

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
@@ -13,6 +13,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{CfgNodeNew, NewBlock, New
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.passes.ConcurrentWriterCpgPass
 
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 
@@ -23,6 +24,14 @@ abstract class FunctionPass(
   cpg: Cpg,
   decompiler: Decompiler
 ) extends ConcurrentWriterCpgPass[Function](cpg) {
+
+  protected val functionByName = mutable.HashMap[String, Function]()
+  for(fn<- functions){
+    val other = functionByName.getOrElseUpdate(fn.getName, fn)
+    if(!(other eq fn)){
+      baseLogger.warn(s"Multiple functions with same name ${fn.getName}, can't disambiguate: ${fn}, ${other}")
+    }
+  }
 
   def getHighFunction(function: Function): HighFunction = decompiler.toHighFunction(function).orNull
   protected def getInstructions(function: Function): Seq[Instruction] =
@@ -141,7 +150,7 @@ abstract class FunctionPass(
     if (mnemonicString.equals("CALL")) {
       val calledFunction =
         codeUnitFormat.getOperandRepresentationString(instruction, 0)
-      val callee = functions.find(function => function.getName().equals(calledFunction))
+      val callee = functionByName.get(calledFunction)
       if (callee.nonEmpty) {
         // Array of tuples containing (checked parameter name, parameter index, parameter data type)
         var checkedParameters = Array.empty[(String, Int, String)]

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
@@ -26,9 +26,9 @@ abstract class FunctionPass(
 ) extends ConcurrentWriterCpgPass[Function](cpg) {
 
   protected val functionByName = mutable.HashMap[String, Function]()
-  for(fn<- functions){
+  for (fn <- functions) {
     val other = functionByName.getOrElseUpdate(fn.getName, fn)
-    if(!(other eq fn)){
+    if (!(other eq fn)) {
       baseLogger.warn(s"Multiple functions with same name ${fn.getName}, can't disambiguate: ${fn}, ${other}")
     }
   }

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/arm/ArmFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/arm/ArmFunctionPass.scala
@@ -15,7 +15,7 @@ class ArmFunctionPass(
   functions: List[Function],
   cpg: Cpg,
   decompiler: Decompiler
-) extends FunctionPass(new ArmProcessor, currentProgram, functions, cpg, decompiler) {
+) extends FunctionPass(ArmProcessor, currentProgram, functions, cpg, decompiler) {
 
   override def runOnPart(diffGraphBuilder: DiffGraphBuilder, function: Function): Unit = {
     val localDiffGraph = new DiffGraphBuilder()

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -24,7 +24,7 @@ class MipsFunctionPass(
   functions: List[Function],
   cpg: Cpg,
   decompiler: Decompiler
-) extends FunctionPass(new MipsProcessor, currentProgram, functions, cpg, decompiler) {
+) extends FunctionPass(MipsProcessor, currentProgram, functions, cpg, decompiler) {
   private val logger = LoggerFactory.getLogger(classOf[MipsFunctionPass])
 
   def resolveVarNode(instruction: Instruction, input: Varnode, index: Int): CfgNodeNew = {

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/X86FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/X86FunctionPass.scala
@@ -17,7 +17,7 @@ class X86FunctionPass(
   functions: List[Function],
   cpg: Cpg,
   decompiler: Decompiler
-) extends FunctionPass(new X86Processor, currentProgram, functions, cpg, decompiler) {
+) extends FunctionPass(X86Processor, currentProgram, functions, cpg, decompiler) {
 
   override def handleBody(
     diffGraphBuilder: DiffGraphBuilder,

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/ArmProcessor.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/ArmProcessor.scala
@@ -1,9 +1,9 @@
 package io.joern.ghidra2cpg.processors
 
-import scala.collection.immutable._
+import scala.collection.mutable.HashMap
 
-class ArmProcessor extends Processor {
-  override def getInstructions: HashMap[String, String] =
+object ArmProcessor extends Processor {
+  override val getInstructions: HashMap[String, String] =
     HashMap(
       "add"     -> "<operator>.incBy",
       "adr"     -> "<operator>.assignment",

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/MipsProcessor.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/MipsProcessor.scala
@@ -1,7 +1,6 @@
 package io.joern.ghidra2cpg.processors
 import scala.collection.mutable.HashMap
 
-
 object MipsProcessor extends Processor {
   override val getInstructions: HashMap[String, String] =
     HashMap(

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/MipsProcessor.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/MipsProcessor.scala
@@ -1,8 +1,9 @@
 package io.joern.ghidra2cpg.processors
-import scala.collection.immutable._
+import scala.collection.mutable.HashMap
 
-class MipsProcessor extends Processor {
-  override def getInstructions: HashMap[String, String] =
+
+object MipsProcessor extends Processor {
+  override val getInstructions: HashMap[String, String] =
     HashMap(
       "_add.D"     -> "<operator>.incBy",
       "_addiu"     -> "<operator>.incBy",

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/PCodeProcessor.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/PCodeProcessor.scala
@@ -1,8 +1,8 @@
 package io.joern.ghidra2cpg.processors
-import scala.collection.immutable._
+import scala.collection.mutable.HashMap
 
-class PCodeProcessor extends Processor {
-  override def getInstructions: HashMap[String, String] =
+object PCodeProcessor extends Processor {
+  override val getInstructions: HashMap[String, String] =
     HashMap(
       "BOOL_AND"          -> "<operator>.TODO",
       "BOOL_NEGATE"       -> "<operator>.TODO",

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/Processor.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/Processor.scala
@@ -1,6 +1,6 @@
 package io.joern.ghidra2cpg.processors
 
-import scala.collection.immutable._
+import scala.collection.mutable.HashMap
 
 trait Processor {
   def getInstructions: HashMap[String, String]

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/X86Processor.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/processors/X86Processor.scala
@@ -1,9 +1,9 @@
 package io.joern.ghidra2cpg.processors
 
-import scala.collection.immutable._
+import scala.collection.mutable.HashMap
 
-class X86Processor extends Processor {
-  override def getInstructions: HashMap[String, String] =
+object X86Processor extends Processor {
+  override val getInstructions: HashMap[String, String] =
     HashMap(
       "ADC"       -> "<operator>.incBy",
       "ADD"       -> "<operator>.incBy",


### PR DESCRIPTION
@itsacoderepo Since this came up today in the meeting, I took a quick look at the FunctionPass and addressed some nits.

1. The cache of Decompiler had a race condition. Now fixed.
2. We used to search `functions: List[Function]` quite often for matching names. Let's put it into a hashtable instead of a singly linked list. I took the liberty of adding a warning if two functions name-clash -- is this correct? Or was the old behavior better (take first matching name, silently ignore the other ones)?
3. The various `Processor` subclasses instantiated a brand-new HashMap for every lookup. That is silly, we only need one.
4. The `Processor` interface used `scala.collection.immutable.HashMap`. It is a common misconception that `scala.collection.immutable` is meant for immutable data -- it is really not, these classes are mostly meant for copy-on-write performance. If we don't actively need efficient copy-on-write, then the mutable versions are almost always preferable. So I switched that out. An example where `scala.collection.immutable.HashMap` makes sense is `Decompiler.cache`, where it allows us to make the happy-path lock-free.