### PR TITLE
dataflowengineoss: Option to Disable Cache Use + Some Simple Documentation

### DIFF
--- a/dataflowengineoss/README.md
+++ b/dataflowengineoss/README.md
@@ -1,0 +1,49 @@
+# Data Flow Engine
+
+A taint-tracking system based on whole-program data-dependence 
+representation. External library calls can be defined by 
+semantic models (see `src/test/resources/default.semantics`)
+
+Basic usage:
+
+```scala
+// If using Joern shell, imports and engine context will be pre-configured and available already
+import io.shiftleft.semanticcpg.language._
+import io.joern.dataflowengineoss.language.toExtendedCfgNode
+
+def sink = cpg.call.argument.code(".*malicious_input.*")
+def source = cpg.call(".*println.*")
+
+// Traverses data flow in the backwards direction
+sink.reachableBy(source)
+```
+
+## Configuration
+
+To begin using the data flow engine on the CPG, we need the following:
+
+```scala
+  // (1) Imports to extend CFG nodes
+  import io.joern.dataflowengineoss.language.toExtendedCfgNode
+  import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics, FlowSemantic}
+  import io.joern.dataflowengineoss.queryengine.{EngineContext, EngineConfig}
+
+  import scala.util.{Failure, Success, Try}
+  import scala.io.{BufferedSource, Source}
+
+  // (2) Parse in semantic models, if none given then external methods will be overtainted by default
+  val semanticsParser = new Parser()
+  val defaultSemantics: Try[BufferedSource] = Try(
+    Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("default.semantics"))
+  )
+  val semantics: List[FlowSemantic] = defaultSemantics match {
+    case Failure(_)         => List()
+    case Success(semantics) => semanticsParser.parse(semantics.getLines().mkString("\n"))
+  }
+
+  // (3) Optional: Configure the engine
+  val engineConfig = EngineConfig(maxCallDepth = 2, initialTable = None, disableCacheUse = false)
+
+  // (4) Create execution context for the engine
+  implicit var context: EngineContext = EngineContext(Semantics.fromList(semantics), engineConfig)
+```

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -87,7 +87,10 @@ class Engine(context: EngineContext) {
   private def submitTask(task: ReachableByTask): Unit = {
     numberOfTasksRunning += 1
     completionService.submit(
-      new ReachableByCallable(if (context.config.disableCacheUse) task.copy(table = new ResultTable) else task, context)
+      new ReachableByCallable(
+        if (context.config.shareCacheBetweenTasks) task else task.copy(table = new ResultTable),
+        context
+      )
     )
   }
 
@@ -294,13 +297,13 @@ case class EngineContext(semantics: Semantics, config: EngineConfig = EngineConf
   *   the k-limit for calls and field accesses.
   * @param initialTable
   *   an initial (starting node) -> (path-edges) cache to initiate data flow queries with.
-  * @param disableCacheUse
-  *   disables re-use of previously calculated paths.
+  * @param shareCacheBetweenTasks
+  *   enables sharing of previously calculated paths among other tasks.
   */
 case class EngineConfig(
   var maxCallDepth: Int = 2,
   initialTable: Option[ResultTable] = None,
-  disableCacheUse: Boolean = false
+  shareCacheBetweenTasks: Boolean = true
 )
 
 /** Callable for solving a ReachableByTask

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -1,24 +1,16 @@
 package io.joern.dataflowengineoss.queryengine
 
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Properties}
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.queryengine.QueryEngineStatistics.{PATH_CACHE_HITS, PATH_CACHE_MISSES}
 import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
+import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.Edge
 import overflowdb.traversal.{NodeOps, Traversal}
 
-import java.util.concurrent.{
-  Callable,
-  ConcurrentHashMap,
-  ConcurrentMap,
-  ExecutorCompletionService,
-  ExecutorService,
-  Executors
-}
+import java.util.concurrent._
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -287,8 +279,27 @@ object Engine {
 
 }
 
+/** The execution context for the data flow engine.
+  * @param semantics
+  *   pre-determined semantic models for method calls e.g., logical operators, operators for common data structures.
+  * @param config
+  *   additional configurations for the data flow engine.
+  */
 case class EngineContext(semantics: Semantics, config: EngineConfig = EngineConfig())
-case class EngineConfig(var maxCallDepth: Int = 2, initialTable: Option[ResultTable] = None)
+
+/** Various configurations for the data flow engine.
+  * @param maxCallDepth
+  *   the k-limit for calls and field accesses.
+  * @param initialTable
+  *   an initial (starting node) -> (path-edges) cache to initiate data flow queries with.
+  * @param disableCacheUse
+  *   disables re-use of previously calculated paths.
+  */
+case class EngineConfig(
+  var maxCallDepth: Int = 2,
+  initialTable: Option[ResultTable] = None,
+  disableCacheUse: Boolean = false
+)
 
 /** Callable for solving a ReachableByTask
   *
@@ -338,7 +349,7 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
 
     val resultsForParents: Vector[ReachableByResult] = {
       expandIn(curNode, path).iterator.flatMap { parent =>
-        val cachedResult = table.createFromTable(parent, path)
+        val cachedResult = if (context.config.disableCacheUse) None else table.createFromTable(parent, path)
         if (cachedResult.isDefined) {
           QueryEngineStatistics.incrementBy(PATH_CACHE_HITS, 1L)
           cachedResult.get


### PR DESCRIPTION
- For experimental purposes to evaluate the effectiveness of the cache, an option to disable re-use of already calculated results. Right now we see the overhead of collecting results to give back to the engine context being quite slow despite the improve cache hit ratio. By measuring the speed of a fully disabled cache we can approximate how useful the current caching strategy is.
- Added some basic documentation to make the engine friendlier

PS: Running experiments locally show that disabling the cache basically doubles memory consumption and increases analysis time by loads!

Example of results from giving `initialTable` to `EngineContext` to re-use results on an m5d.large EC2 instance:

## Cache Hit Ratios
![dflow_cache](https://user-images.githubusercontent.com/28294550/161385573-8e1cb96b-c239-4853-92a9-22b34359b477.png)
## `reachableByDetailed` performance (+ collecting results overhead)
![taint](https://user-images.githubusercontent.com/28294550/161385579-ce356f32-12ba-43f0-b156-b6724841fa89.png)

