### PR TITLE
jimple2cpg: Data Flow Tests for Arrays, Static Members, Try/Catch, and Switch

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -717,8 +717,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   def astForThrow(stmt: ThrowStmt, scopeContext: ScopeContext, order: Int): AstWithCtx = {
     val throwNode = NewCall()
-      .name("operator.<throw>")
-      .methodFullName("operator.<throw>")
+      .name("<operator>.throw")
+      .methodFullName("<operator>.throw")
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
       .code(stmt.toString())

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ArrayTests.scala
@@ -34,12 +34,12 @@ class ArrayTests extends JimpleCodeToCpgFixture {
     def m = cpg.method(".*foo.*")
 
     val List(placeholderArg: Identifier, arrayInit: Call) =
-      m.assignment.codeExact("$stack2 = newarray (int)[3]").argument.l
+      m.assignment.codeExact("$stack2 = new int[3]").argument.l
     placeholderArg.code shouldBe "$stack2"
     placeholderArg.typeFullName shouldBe "int[]"
 
-    arrayInit.code shouldBe "newarray (int)[3]"
-    arrayInit.methodFullName shouldBe Operators.arrayInitializer
+    arrayInit.code shouldBe "new int[3]"
+    arrayInit.methodFullName shouldBe "<operator>.arrayCreator"
     arrayInit.astChildren.headOption match {
       case Some(alloc) =>
         alloc shouldBe a[Literal]
@@ -85,11 +85,11 @@ class ArrayTests extends JimpleCodeToCpgFixture {
     def m = cpg.method(".*bar.*")
 
     val List(arg1: Identifier, arg2: Call) =
-      m.assignment.codeExact("x = newmultiarray (int)[5][2]").argument.l
+      m.assignment.codeExact("x = new int[5][2]").argument.l
 
     arg1.typeFullName shouldBe "int[][]"
 
-    arg2.code shouldBe "newmultiarray (int)[5][2]"
+    arg2.code shouldBe "new int[5][2]"
     val List(lvl1: Literal, lvl2: Literal) = arg2.argument.l
     lvl1.code shouldBe "5"
     lvl2.code shouldBe "2"

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/IfGotoTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/IfGotoTests.scala
@@ -31,9 +31,8 @@ class IfGotoTests extends JimpleCodeToCpgFixture {
 
   "should identify `goto` blocks" in {
     cpg.all.collect { case x: Unknown => x }.code.toSetMutable shouldBe Set(
-      "goto [?= $stack6 = y]",
-      "goto [?= i = i + 1]",
-      "goto [?= (branch)]"
+      "goto 9",
+      "goto 5",
     )
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/IfGotoTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/IfGotoTests.scala
@@ -30,10 +30,7 @@ class IfGotoTests extends JimpleCodeToCpgFixture {
       |""".stripMargin
 
   "should identify `goto` blocks" in {
-    cpg.all.collect { case x: Unknown => x }.code.toSetMutable shouldBe Set(
-      "goto 9",
-      "goto 5",
-    )
+    cpg.all.collect { case x: Unknown => x }.code.toSetMutable shouldBe Set("goto 9", "goto 5")
   }
 
   "should contain 4 branching nodes at conditional calls" in {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/ArrayTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/ArrayTests.scala
@@ -1,0 +1,165 @@
+package io.joern.jimple2cpg.querying.dataflow
+
+import io.joern.dataflowengineoss.language._
+import io.joern.jimple2cpg.testfixtures.JimpleDataflowFixture
+
+class ArrayTests extends JimpleDataflowFixture {
+
+  behavior of "Dataflow through arrays"
+
+  override val code: String =
+    """
+      |class Foo {
+      |    public void test1() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        System.out.println(vals[2]);
+      |    }
+      |
+      |    public void test2() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        System.out.println(vals[0]);
+      |    }
+      |
+      |    public void test3() {
+      |        String[] vals = new String[]{"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        System.out.println(vals[2]);
+      |    }
+      |
+      |    public void test4() {
+      |        String[] vals = new String[2];
+      |        vals[0] = "SAFE";
+      |        vals[1] = "MALICIOUS";
+      |        System.out.println(vals[0]);
+      |    }
+      |
+      |    public void test5() {
+      |        String[] vals = new String[2];
+      |        vals[0] = "SAFE";
+      |        vals[1] = "MALICIOUS";
+      |        System.out.println(vals[1]);
+      |    }
+      |
+      |    public void test6() {
+      |        String[] vals = {"SAFE", "MALICIOUS"};
+      |        vals[0] = "ALSO SAFE";
+      |        System.out.println(vals[1]);
+      |    }
+      |
+      |    public void test7() {
+      |        String[] vals = {"SAFE", "MALICIOUS"};
+      |        vals[1] = "ALSO SAFE";
+      |        System.out.println(vals[1]);
+      |    }
+      |
+      |    public void test8() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        for (int i = 0; i < vals.length; i++) {
+      |            String val = vals[i];
+      |            System.out.println(val);
+      |        }
+      |    }
+      |
+      |    public void test9() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        for (String val : vals) {
+      |            System.out.println(val);
+      |        }
+      |    }
+      |
+      |    public void test10() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        String acc = "";
+      |        for (String val : vals) {
+      |            acc += val;
+      |        }
+      |        System.out.println(acc);
+      |    }
+      |
+      |    public void test11() {
+      |        String[] vals = {"SAFE", "STILL SAFE", "ALSO SAFE"};
+      |        vals[1] = "MALICIOUS";
+      |        System.out.println(vals[1]);
+      |    }
+      |
+      |    public void test12() {
+      |        String[] vals = {"SAFE", "STILL SAFE", "ALSO SAFE"};
+      |        vals[1] = "MALICIOUS";
+      |        System.out.println(vals[0]);
+      |    }
+      |
+      |    public void test13() {
+      |        String[] vals = {"SAFE", "SAFE", "MALICIOUS", "SAFE"};
+      |        String[] alias = vals;
+      |        System.out.println(alias[2]);
+      |    }
+      |   }
+      |""".stripMargin
+
+  it should "find a path if the `MALICIOUS` array entry is printed" in {
+    val (source, sink) = getConstSourceSink("test1")
+    sink.reachableBy(source).size shouldBe 1
+
+  }
+
+  it should "find a path if an entry in the `MALICIOUS` array is printed (approximation)" in {
+    // The reason this false positive occurs is because Jimple makes an alias in here unlike in test4
+    val (source, sink) = getConstSourceSink("test2")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path for alternative array initializer syntax" in {
+    val (source, sink) = getConstSourceSink("test3")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "not find a path if an unrelated array element not assigned to `MALICIOUS` reaches the sink" in {
+    val (source, sink) = getConstSourceSink("test4")
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path if array element is assigned to `MALICIOUS`" in {
+    val (source, sink) = getConstSourceSink("test5")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if a different array element is overwritten" in {
+    val (source, sink) = getConstSourceSink("test6")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if the `MALICIOUS` array element is overwritten (approximation)" in {
+    // Similarly to test2, this false positive occurs because Jimple makes an alias
+    val (source, sink) = getConstSourceSink("test7")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if sink is in a `FOR` loop" in {
+    val (source, sink) = getConstSourceSink("test8")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if sink is in a `FOREACH` loop over `MALICIOUS` array" in {
+    val (source, sink) = getConstSourceSink("test9")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is added to an accumulator in a loop" in {
+    val (source, sink) = getConstSourceSink("test10")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is assigned to safe array and printed" in {
+    val (source, sink) = getConstSourceSink("test11")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "not find a path if `MALICIOUS` is assigned to safe array and not printed" in {
+    val (source, sink) = getConstSourceSink("test12")
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path through an array alias" in {
+    val (source, sink) = getConstSourceSink("test13")
+    sink.reachableBy(source).size shouldBe 1
+  }
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/StaticMemberTests.scala
@@ -1,0 +1,119 @@
+package io.joern.jimple2cpg.querying.dataflow
+
+import io.joern.dataflowengineoss.language._
+import io.joern.jimple2cpg.testfixtures.JimpleDataflowFixture
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.Traversal
+
+/** These tests are added as a wishlist for static member accesses. These results are consistent with static members in
+  * C++ using c2cgp, however. For practical reasons, only handling `final` static members is probably the way to go, so
+  * at least the first 2 tests should pass.
+  *
+  * TODO: Fix dataflow from static members, treating them as final.
+  */
+class StaticMemberTests extends JimpleDataflowFixture {
+
+  behavior of "Dataflow from static members"
+
+  override val code: String =
+    """
+      |class Bar {
+      |    public static String bad = "MALICIOUS";
+      |    public static String good = "SAFE";
+      |
+      |}
+      |
+      |class Foo {
+      |    public static String good = "MALICIOUS";
+      |    public static String bad = "SAFE";
+      |
+      |    public void test1() {
+      |        String s = Bar.bad;
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test2() {
+      |        System.out.println(Bar.bad);
+      |    }
+      |
+      |    public void test3() {
+      |        System.out.println(Bar.good);
+      |    }
+      |
+      |    public void test4() {
+      |        System.out.println(Foo.good);
+      |    }
+      |
+      |    public void test5() {
+      |        System.out.println(Foo.bad);
+      |    }
+      |
+      |    public void test6() {
+      |        Bar.bad = "SAFE";
+      |        System.out.println(Bar.bad);
+      |    }
+      |
+      |    public void test7() {
+      |        Bar.good = "MALICIOUS";
+      |        System.out.println(Bar.good);
+      |    }
+      |}
+      |""".stripMargin
+
+  private def getSources = {
+    val sources = cpg.literal.code("\"MALICIOUS\"").l
+    if (sources.size <= 0) {
+      fail("Could not find any sources")
+    }
+    Traversal.from(sources)
+  }
+
+  it should "find a path for `MALICIOUS` data from different class via a variable" in {
+    val source = getSources
+    val sink   = cpg.method(".*test1.*").call.name(".*println.*").argument(1)
+
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path for `MALICIOUS` data from a different class directly" in {
+    val source = getSources
+    val sink   = cpg.method(".*test2.*").call.name(".*println.*").argument(1)
+
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "not find a path for `SAFE` data directly" in {
+    val source = getSources
+    val sink   = cpg.method(".*test3.*").call.name(".*println.*").argument(1)
+
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path for `MALICIOUS` data from the same class" in {
+    val source = getSources
+    val sink   = cpg.method(".*test4.*").call.name(".*println.*").argument(1)
+
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "not find a path for `SAFE` data in the same class" in {
+    val source = getSources
+    val sink   = cpg.method(".*test5.*").call.name(".*println.*").argument(1)
+
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "not find a path for overwritten `MALICIOUS` data" in {
+    val source = getSources
+    val sink   = cpg.method(".*test6.*").call.name(".*println.*").argument(1)
+
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path for overwritten `SAFE` data" in {
+    val source = getSources
+    val sink   = cpg.method(".*test7.*").call.name(".*println.*").argument(1)
+
+    sink.reachableBy(source).size shouldBe 1
+  }
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/SwitchTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/SwitchTests.scala
@@ -1,0 +1,53 @@
+package io.joern.jimple2cpg.querying.dataflow
+
+import io.joern.dataflowengineoss.language._
+import io.joern.jimple2cpg.testfixtures.JimpleDataflowFixture
+
+class SwitchTests extends JimpleDataflowFixture {
+
+  behavior of "Dataflow through `SWITCH`"
+
+  override val code: String =
+    """
+      |class Foo {
+      |    public void test1(int input) {
+      |        String s;
+      |
+      |        switch (input) {
+      |            case 0:
+      |            case 1:
+      |                s = "SAFE";
+      |                break;
+      |            case 2:
+      |                s = "MALICIOUS";
+      |                break;
+      |            default:
+      |                s = "SAFE";
+      |        }
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test2(int input) {
+      |        String s = "MALICIOUS";
+      |
+      |        switch(input) {
+      |            case 0:
+      |                System.out.println(s);
+      |                break;
+      |            default:
+      |                System.out.println("SAFE");
+      |        }
+      |    }
+      |}
+      |""".stripMargin
+
+  it should "find a path if the source is in a switch" in {
+    val (source, sink) = getConstSourceSink("test1")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if the sink is in a switch" in {
+    val (source, sink) = getConstSourceSink("test2")
+    sink.reachableBy(source).size shouldBe 1
+  }
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/TryTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/TryTests.scala
@@ -1,0 +1,174 @@
+package io.joern.jimple2cpg.querying.dataflow
+
+import io.joern.dataflowengineoss.language._
+import io.joern.jimple2cpg.testfixtures.JimpleDataflowFixture
+import io.shiftleft.semanticcpg.language._
+
+class TryTests extends JimpleDataflowFixture {
+
+  behavior of "Dataflow through TRY/CATCH"
+
+  override val code: String =
+    """
+      |class Foo {
+      |    public static void foo() throws Exception {
+      |        throw new Exception();
+      |    }
+      |
+      |    public void test1() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            System.out.println(s);
+      |        } catch (Exception e) {
+      |            System.out.println("SAFE");
+      |        }
+      |    }
+      |
+      |    public void test2() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            System.out.println("SAFE");
+      |            foo();
+      |        } catch (Exception e) {
+      |            System.out.println(s);
+      |        }
+      |    }
+      |
+      |    public void test3() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            System.out.println("SAFE");
+      |        } catch (Exception e) {
+      |            System.out.println("ALSO_SAFE");
+      |        } finally {
+      |            System.out.println(s);
+      |        }
+      |    }
+      |
+      |    public void test4() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            throw new Exception(s);
+      |        } catch (Exception e) {
+      |            System.out.println(e);
+      |        }
+      |    }
+      |
+      |    public void test5() {
+      |        String s = "SAFE";
+      |
+      |        try {
+      |            s = "MALICIOUS";
+      |        } catch (Exception e) {
+      |            // Do nothing
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test6() {
+      |        String s = "SAFE";
+      |
+      |        try {
+      |            foo();
+      |        } catch (Exception e) {
+      |            s = "MALICIOUS";
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test7() {
+      |        String s = "SAFE";
+      |
+      |        try {
+      |            foo();
+      |        } catch (Exception e) {
+      |            // Do nothing
+      |        } finally {
+      |            s = "MALICIOUS";
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test8() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            s = "SAFE";
+      |        } catch (Exception e) {
+      |            s = "ALSO SAFE";
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |
+      |    public void test9() {
+      |        String s = "MALICIOUS";
+      |
+      |        try {
+      |            s = "MALICIOUS";
+      |        } catch (Exception e) {
+      |            s = "MALICIOUS";
+      |        } finally {
+      |            s = "SAFE";
+      |        }
+      |
+      |        System.out.println(s);
+      |    }
+      |}
+      |""".stripMargin
+
+  it should "find a path if the sink is in a `TRY`" in {
+    val (source, sink) = getConstSourceSink("test1")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if the sink is in a `CATCH`" in {
+    val (source, sink) = getConstSourceSink("test2")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if the sink is in a `FINALLY`" in {
+    // Jimple's flat AST evaluates multiple paths that will end at the FINALLY sink but it is a conservative result
+    val (source, sink) = getConstSourceSink("test3")
+    sink.reachableBy(source).size shouldBe 3
+  }
+
+  // TODO: This is a very optimistic test. We expect the path to be missing for now.
+  it should "find a path if `MALICIOUS` is contained in thrown string with sink in catch" in {
+    val (source, sink) = getConstSourceSink("test4")
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path if `MALICIOUS` is assigned in `TRY`" in {
+    val (source, sink) = getConstSourceSink("test5")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is assigned in `CATCH`" in {
+    val (source, sink) = getConstSourceSink("test6")
+    sink.reachableBy(source).size shouldBe 1
+  }
+
+  it should "find a path if `MALICIOUS` is assigned in `FINALLY`" in {
+    // Jimple's flat AST evaluates multiple paths that will end at the FINALLY sink but it is a conservative result
+    val (source, sink) = getConstSourceSink("test7")
+    sink.reachableBy(source).size shouldBe 3
+  }
+
+  it should "not find a path if `MALICIOUS` is reassigned in both TRY/CATCH" in {
+    val (source, sink) = getConstSourceSink("test8")
+    sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "not find a path if `MALICIOUS` is reassigned in FINALLY" in {
+    val (source, sink) = getConstSourceSink("test9")
+    sink.reachableBy(source).size shouldBe 0
+  }
+}


### PR DESCRIPTION
- Added the rest of the tests from `javasrc2cpg`
- Improved `code` for `new array`, `throw`, `goto` statements
- Fixed `javasrc2cpg` typo on `operator.<throw>` -> `<operator>.throw`