### PR TITLE
add gradle-tooling to kotlin frontend

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -9,12 +9,13 @@ libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph"          % Versions.cpg,
   "org.apache.logging.log4j" % "log4j-slf4j-impl"           % Versions.log4j % Runtime,
   "org.slf4j"                % "slf4j-api"                  % "1.7.35",
-  "org.scalatest"           %% "scalatest"                  % "3.2.9"        % Test,
+  "org.gradle"               % "gradle-tooling-api"         % Versions.gradleTooling % Optional,
   "org.jetbrains.kotlin"     % "kotlin-stdlib-jdk8"         % kotlinVersion,
   "org.jetbrains.kotlin"     % "kotlin-stdlib"              % kotlinVersion,
   "org.jetbrains.kotlin"     % "kotlin-compiler-embeddable" % kotlinVersion,
   "org.jetbrains.kotlin"     % "kotlin-allopen"             % kotlinVersion,
-  "org.jetbrains.kotlin"     % "kotlin-test"                % kotlinVersion  % Test
+  "org.jetbrains.kotlin"     % "kotlin-test"                % kotlinVersion  % Test,
+  "org.scalatest"           %% "scalatest"                  % "3.2.9"        % Test,
 )
 
 enablePlugins(JavaAppPackaging)

--- a/joern-cli/frontends/x2cpg/build.sbt
+++ b/joern-cli/frontends/x2cpg/build.sbt
@@ -6,8 +6,8 @@ dependsOn(Projects.semanticcpg)
 
 libraryDependencies ++= Seq(
   "org.slf4j"                % "slf4j-api"          % "1.7.36",
-  "org.apache.logging.log4j" % "log4j-slf4j-impl"   % Versions.log4j     % Optional,
-  "org.gradle"               % "gradle-tooling-api" % "6.9.2"            % Optional,
+  "org.apache.logging.log4j" % "log4j-slf4j-impl"   % Versions.log4j % Optional,
+  "org.gradle"               % "gradle-tooling-api" % Versions.gradleTooling % Optional,
   "org.scalatest"           %% "scalatest"          % Versions.scalatest % Test
 )
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -7,6 +7,7 @@ object Versions {
   val cats      = "3.3.10"
   val log4j     = "2.17.2"
   val json4s    = "4.0.4"
+  val gradleTooling = "6.9.2"
 
   private def parseVersion(key: String): String = {
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r


### PR DESCRIPTION
optional dependencies are non-transitive when it comes to staged
binaries, so we need to explicitly list this dependency here as
well...

turns out we can't have the cake and eat it...