### PR TITLE
Lower Kotlin `try`-expressions correctly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion    = "1.3.524"
+val cpgVersion    = "1.3.526"
 val js2cpgVersion = "0.2.139"
 
 lazy val joerncli          = Projects.joerncli

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -31,7 +31,6 @@ object Constants {
   val defaultCaseNode                = "default"
   val caseNodeParserTypeName         = "CaseNode"
   val unknownOperator                = "<operator>.unknown"
-  val tryCatchOperator               = "<operator>.tryCatch"
   val operatorSuffix                 = "<operator>"
   val paramNameLambdaDestructureDecl = "DESTRUCTURE_PARAM"
   val wildcardImportName             = "*"
@@ -2210,9 +2209,9 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
   ): AstWithCtx = {
     val callNode =
       NewCall()
-        .name(Constants.tryCatchOperator)
+        .name(Operators.tryCatch)
         .code(expr.getText)
-        .methodFullName(Constants.tryCatchOperator)
+        .methodFullName(Operators.tryCatch)
         .typeFullName(TypeConstants.any)
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .order(order)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -31,6 +31,7 @@ object Constants {
   val defaultCaseNode                = "default"
   val caseNodeParserTypeName         = "CaseNode"
   val unknownOperator                = "<operator>.unknown"
+  val tryCatchOperator               = "<operator>.tryCatch"
   val operatorSuffix                 = "<operator>"
   val paramNameLambdaDestructureDecl = "DESTRUCTURE_PARAM"
   val wildcardImportName             = "*"
@@ -2156,8 +2157,8 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     AstWithCtx(ast, Context())
   }
 
-  // TODO: handle parameters passed to the clauses
-  def astForTry(expr: KtTryExpression, scopeContext: ScopeContext, order: Int, argumentIndex: Int)(implicit
+  private def astForTryAsStatement(expr: KtTryExpression, scopeContext: ScopeContext, order: Int, argumentIndex: Int)(
+    implicit
     fileInfo: FileInfo,
     typeInfoProvider: TypeInfoProvider
   ): AstWithCtx = {
@@ -2200,6 +2201,55 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
       }
     val finalCtx = mergedCtx(Seq(tryAstWithCtx.ctx) ++ clauseAstsWitCtx.map(_.ctx) ++ finallyAstsWithCtx.map(_.ctx))
     AstWithCtx(finalAst, finalCtx)
+  }
+
+  private def astForTryAsExpression(expr: KtTryExpression, scopeContext: ScopeContext, order: Int, argumentIndex: Int)(
+    implicit
+    fileInfo: FileInfo,
+    typeInfoProvider: TypeInfoProvider
+  ): AstWithCtx = {
+    val callNode =
+      NewCall()
+        .name(Constants.tryCatchOperator)
+        .code(expr.getText)
+        .methodFullName(Constants.tryCatchOperator)
+        .typeFullName(TypeConstants.any)
+        .dispatchType(DispatchTypes.STATIC_DISPATCH)
+        .order(order)
+        .argumentIndex(argumentIndex)
+        .lineNumber(line(expr))
+        .columnNumber(column(expr))
+
+    val tryAstWithCtx = astsForExpression(expr.getTryBlock, scopeContext, 1, 1).headOption
+      .getOrElse(AstWithCtx(Ast(), Context()))
+    val tryAst =
+      Ast(callNode)
+        .withChild(tryAstWithCtx.ast)
+        .withArgEdge(callNode, tryAstWithCtx.ast.root.get)
+
+    val clauseAstsWitCtx =
+      withOrder(expr.getCatchClauses) { (entry, order) =>
+        astsForExpression(entry.getCatchBody, scopeContext, order + 1, order + 1)
+      }.flatten
+
+    val finalAst =
+      tryAst
+        .withChildren(clauseAstsWitCtx.map(_.ast))
+        .withArgEdges(callNode, clauseAstsWitCtx.map(_.ast.root.get))
+    val finalCtx = mergedCtx(Seq(tryAstWithCtx.ctx) ++ clauseAstsWitCtx.map(_.ctx))
+    AstWithCtx(finalAst, finalCtx)
+  }
+
+  // TODO: handle parameters passed to the clauses
+  def astForTry(expr: KtTryExpression, scopeContext: ScopeContext, order: Int, argumentIndex: Int)(implicit
+    fileInfo: FileInfo,
+    typeInfoProvider: TypeInfoProvider
+  ): AstWithCtx = {
+    if (KtPsiUtil.isStatement(expr)) {
+      astForTryAsStatement(expr, scopeContext, order, argumentIndex)
+    } else {
+      astForTryAsExpression(expr, scopeContext, order, argumentIndex)
+    }
   }
 
   def astForWhile(expr: KtWhileExpression, scopeContext: ScopeContext, order: Int)(implicit

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IfExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IfExpressionsTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-class ControlStructureExpressionTests extends AnyFreeSpec with Matchers {
+class IfExpressionsTests extends AnyFreeSpec with Matchers {
   "CPG for code with simple `if`-expression" - {
     lazy val cpg = TestContext.buildCpg("""
         |package baz
@@ -247,25 +247,4 @@ class ControlStructureExpressionTests extends AnyFreeSpec with Matchers {
       a3.order shouldBe 3
     }
   }
-
-  "CPG for code with simple `when`-expression" - {
-    lazy val cpg = TestContext.buildCpg("""
-        |package mypkg
-        |
-        |fun myfun() {
-        |  val x =  Random.nextInt(0, 3)
-        |  val foo = when (x) {
-        |      1 -> 123
-        |      2 -> 234
-        |      else -> {
-        |          456
-        |      }
-        |  }
-        |  println(foo)
-        |}
-        | """.stripMargin)
-
-    // TODO: add test case
-  }
-
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
@@ -1,6 +1,7 @@
 package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.TestContext
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier}
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
@@ -29,7 +30,7 @@ class TryExpressionsTests extends AnyFreeSpec with Matchers {
         | """.stripMargin)
 
     "should contain a CALL for the `try`-expression with the correct props set" in {
-      val List(c) = cpg.call.methodFullNameExact("<operator>.tryCatch").l
+      val List(c) = cpg.call.methodFullNameExact(Operators.tryCatch).l
       c.argument.size shouldBe 2
 
       val List(firstArg: Block, secondArg: Block) = c.argument.l

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
@@ -1,0 +1,56 @@
+package io.joern.kotlin2cpg.querying
+
+import io.joern.kotlin2cpg.TestContext
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier}
+import io.shiftleft.semanticcpg.language._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class TryExpressionsTests extends AnyFreeSpec with Matchers {
+  "CPG for code with simple `try`-expression" - {
+    lazy val cpg = TestContext.buildCpg("""
+        |package mypkg
+        |
+        |fun doSomething(x: Int): Int {
+        |    val r = "41414141"
+        |    val out = try {
+        |        x
+        |    } catch (e: Exception) {
+        |        r.toInt()
+        |    }
+        |    return out
+        |}
+        |
+        |fun main() {
+        |    val out = doSomething(42424242)
+        |    println(out)
+        |// prints: `42424242`
+        |}
+        | """.stripMargin)
+
+    "should contain a CALL for the `try`-expression with the correct props set" in {
+      val List(c) = cpg.call.methodFullNameExact("<operator>.tryCatch").l
+      c.argument.size shouldBe 2
+
+      val List(firstArg: Block, secondArg: Block) = c.argument.l
+      firstArg.argumentIndex shouldBe 1
+      secondArg.argumentIndex shouldBe 2
+      firstArg.order shouldBe 1
+      secondArg.order shouldBe 2
+
+      val List(firstAstChildOfFirstArg: Identifier) = firstArg.astChildren.head.l
+      firstAstChildOfFirstArg.order shouldBe 1
+      firstAstChildOfFirstArg.name shouldBe "x"
+      firstAstChildOfFirstArg.code shouldBe "x"
+      firstAstChildOfFirstArg.typeFullName shouldBe "java.lang.Integer"
+      firstAstChildOfFirstArg.lineNumber shouldBe Some(6)
+      firstAstChildOfFirstArg.columnNumber shouldBe Some(8)
+
+      val List(firstAstChildOfSecondArg: Call) = secondArg.astChildren.head.l
+      firstAstChildOfSecondArg.order shouldBe 1
+      firstAstChildOfSecondArg.name shouldBe "toInt"
+      firstAstChildOfSecondArg.code shouldBe "r.toInt()"
+      firstAstChildOfSecondArg.methodFullName shouldBe "java.lang.String.toInt:java.lang.Integer()"
+    }
+  }
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/WhenExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/WhenExpressionTests.scala
@@ -1,0 +1,30 @@
+package io.joern.kotlin2cpg.querying
+
+import io.joern.kotlin2cpg.TestContext
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class WhenExpressionTests extends AnyFreeSpec with Matchers {
+  "CPG for code with simple `when`-expression" - {
+    lazy val cpg = TestContext.buildCpg("""
+        |package mypkg
+        |
+        |fun myfun() {
+        |  val x =  Random.nextInt(0, 3)
+        |  val foo = when (x) {
+        |      1 -> 123
+        |      2 -> 234
+        |      else -> {
+        |          456
+        |      }
+        |  }
+        |  println(foo)
+        |}
+        | """.stripMargin)
+
+    // TODO: add test case
+  }
+
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ArgumentIndexTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ArgumentIndexTests.scala
@@ -95,7 +95,7 @@ class ArgumentIndexTests extends AnyFreeSpec with Matchers {
       c.typeFullName shouldBe "java.lang.String"
       c.argument.size shouldBe 2
 
-      val List(firstArg: ControlStructure, secondArg: Literal) = c.argument.l
+      val List(firstArg: Call, secondArg: Literal) = c.argument.l
       firstArg.argumentIndex shouldBe 0
       secondArg.argumentIndex shouldBe 1
     }


### PR DESCRIPTION
A CONTROL_STRUCTURE is appropriate for `try`-statements, but not
`try`-expressions.