### PR TITLE
jimple2cpg: Return Arg + Order Fix and Defined Code Property

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -203,7 +203,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
     Ast(block)
       .withChildren(locals)
       .withChildren(withOrder(body.getUnits.asScala) { (x, order) =>
-        astsForStatement(x, order + locals.size - 2)
+        astsForStatement(x, (order - 1) + (locals.size - 1))
       }.flatten)
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -203,7 +203,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
     Ast(block)
       .withChildren(locals)
       .withChildren(withOrder(body.getUnits.asScala) { (x, order) =>
-        astsForStatement(x, order + locals.size - 1)
+        astsForStatement(x, order + locals.size - 2)
       }.flatten)
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -203,7 +203,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
     Ast(block)
       .withChildren(locals)
       .withChildren(withOrder(body.getUnits.asScala) { (x, order) =>
-        astsForStatement(x, order + locals.size)
+        astsForStatement(x, order + locals.size - 1)
       }.flatten)
   }
 
@@ -701,9 +701,18 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
   }
 
   private def astsForReturnNode(returnStmt: ReturnStmt, order: Int): Seq[Ast] = {
+    val astChildren = astsForValue(returnStmt.getOp, 1, returnStmt)
+    val returnNode = NewReturn()
+      .argumentIndex(order)
+      .order(order)
+      .code(s"return ${astChildren.flatMap(_.root).map(_.properties(PropertyNames.CODE)).mkString(" ")};")
+      .lineNumber(line(returnStmt))
+      .columnNumber(column(returnStmt))
+
     Seq(
-      Ast(NewReturn().order(order).lineNumber(line(returnStmt)).columnNumber(column(returnStmt)))
-        .withChildren(astsForValue(returnStmt.getOp, order + 1, returnStmt))
+      Ast(returnNode)
+        .withChildren(astChildren)
+        .withArgEdges(returnNode, astChildren.flatMap(_.root))
     )
   }
 
@@ -711,7 +720,9 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
     Seq(
       Ast(
         NewReturn()
+          .argumentIndex(order)
           .order(order)
+          .code(s"return;")
           .lineNumber(line(returnVoidStmt))
           .columnNumber(column(returnVoidStmt))
       )

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -202,9 +202,17 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
     }
     Ast(block)
       .withChildren(locals)
-      .withChildren(withOrder(body.getUnits.asScala) { (x, order) =>
-        astsForStatement(x, (order - 1) + (locals.size - 1))
+      .withChildren(withOrder(body.getUnits.asScala.filterNot(isIgnoredUnit)) { (x, order) =>
+        astsForStatement(x, order + locals.size)
       }.flatten)
+  }
+
+  private def isIgnoredUnit(unit: soot.Unit): Boolean = {
+    unit match {
+      case _: IdentityStmt => true
+      case _: NopStmt      => true
+      case _               => false
+    }
   }
 
   private def astsForStatement(statement: soot.Unit, order: Int): Seq[Ast] = {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodReturnTests.scala
@@ -22,6 +22,15 @@ class MethodReturnTests extends JimpleCodeToCpgFixture {
     x.order shouldBe 2
   }
 
+  "should have a RETURN node with correct fields" in {
+    val List(x) = cpg.method.name("foo").ast.isReturn.l
+    x.code shouldBe "return 1;"
+    x.order shouldBe 2
+    x.argumentIndex shouldBe 2
+    x.astChildren.size shouldBe 1
+    x.argumentOut.size shouldBe 1
+  }
+
   "should allow traversing to method" in {
     cpg.methodReturn.code("int").method.name.l shouldBe List("foo")
   }


### PR DESCRIPTION
Added code for `Return` nodes, fixed lack of argument edges and issue with orders