### PR TITLE
Set `order` and `parameterIndex` automatically

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1195,9 +1195,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val ctx = bodyAst.ctx.mergeWith(exprAsts.map(_.ctx))
     val ast = Ast(parentNode)
+      .withChild(modifier)
       .withChildren(exprAsts.map(_.ast))
       .withChild(bodyAst.ast)
-      .withChild(modifier)
 
     AstWithCtx(ast, ctx)
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -1,6 +1,7 @@
 package io.joern.x2cpg
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode.PropertyDefaults
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, ExpressionNew, NewNode}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
@@ -13,6 +14,9 @@ object Ast {
   /** Copy nodes/edges of given `AST` into the given `diffGraph`.
     */
   def storeInDiffGraph(ast: Ast, diffGraph: DiffGraphBuilder): Unit = {
+
+    setOrderWhereNotSet(ast)
+
     ast.nodes.foreach { node =>
       diffGraph.addNode(node)
     }
@@ -37,6 +41,26 @@ object Ast {
       diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.BINDS)
     }
   }
+
+  /** For all `order` fields that are unset, derive the `order` field automatically by determining the position of the
+    * child among its siblings.
+    */
+  private def setOrderWhereNotSet(ast: Ast): Unit = {
+    ast.root.collect { case r: AstNodeNew =>
+      if (r.order == PropertyDefaults.Order) {
+        r.order = 1
+      }
+    }
+    val siblings = ast.edges.groupBy(_.src).map { case (_, edgeToChild) => edgeToChild.map(_.dst) }
+    siblings.foreach { children =>
+      children.zipWithIndex.collect { case (c: AstNodeNew, i) =>
+        if (c.order == PropertyDefaults.Order) {
+          c.order = i + 1
+        }
+      }
+    }
+  }
+
 }
 
 case class Ast(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/Base.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/Base.scala
@@ -17,6 +17,7 @@ object Base {
     new TypeDeclStubCreator(cpg),
     new MethodStubCreator(cpg),
     new MethodDecoratorPass(cpg),
+    new ParameterIndexCompatPass(cpg),
     new AstLinkerPass(cpg),
     new ContainsEdgePass(cpg),
     new TypeUsagePass(cpg)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
@@ -1,0 +1,21 @@
+package io.joern.x2cpg.passes.base
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn.PropertyDefaults
+import io.shiftleft.passes.SimpleCpgPass
+import overflowdb.BatchedUpdate
+import io.shiftleft.semanticcpg.language._
+
+/** Old CPGs use the `order` field to indicate the parameter index while newer CPGs use the `parameterIndex` field. This
+  * pass checks whether `parameterIndex` is not set, in which case the value of `order` is copied over.
+  */
+class ParameterIndexCompatPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+    cpg.parameter.foreach { param =>
+      if (param.index == PropertyDefaults.Index) {
+        diffGraph.setNodeProperty(param, PropertyNames.INDEX, param.order)
+      }
+    }
+  }
+}


### PR DESCRIPTION
For now, set `order` automatically on nodes where it is not set and set `parameterIndex` by copying over the `order` field.