### PR TITLE
Utility functions for method parameter out traversal

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterOutMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterOutMethods.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{MethodParameterIn, MethodParameterOut, NewLocation}
+import io.shiftleft.codepropertygraph.generated.nodes.{MethodParameterOut, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator}
 
@@ -8,8 +8,4 @@ class MethodParameterOutMethods(val paramOut: MethodParameterOut) extends AnyVal
   override def location: NewLocation = {
     LocationCreator(paramOut, paramOut.name, paramOut.label, paramOut.lineNumber, paramOut.method)
   }
-
-  def paramIn: MethodParameterIn = paramOut._parameterLinkIn.next.asInstanceOf[MethodParameterIn]
-  def index: Int                 = paramIn.index
-
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -8,9 +8,13 @@ import scala.jdk.CollectionConverters._
 
 class MethodParameterOutTraversal(val traversal: Traversal[MethodParameterOut]) extends AnyVal {
 
+  def paramIn: Traversal[MethodParameterIn] = traversal.flatMap(_.parameterLinkIn.headOption)
+
+  def index: Traversal[Int] = paramIn.index
+
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def index(num: Int): Traversal[MethodParameterOut] =
-    traversal.filter(_.parameterLinkIn.index(num).nonEmpty)
+    traversal.filter(_.paramIn.index(num).nonEmpty)
 
   /* get all parameters from (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -28,7 +28,7 @@ class MethodParameterOutTraversal(val traversal: Traversal[MethodParameterOut]) 
       method   <- paramOut.method
       call     <- method._callViaCallIn
       arg      <- call._argumentOut.asScala.collect { case node: Expression with HasArgumentIndex => node }
-      if paramOut.paramIn.index == arg.argumentIndex
+      if paramOut._parameterLinkIn.property("INDEX").headOption.contains(arg.argumentIndex)
     } yield arg
 
 }


### PR DESCRIPTION
Due to reasons, adding the `index` method to the method parameter out node doesn't work. It seems to be shadowed by the methods in the corresponding traversal class. Adding those methods there instead.
