### PR TITLE
jimple2cpg: Parameter `index` property + Single `.class` file bug fix

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -186,6 +186,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
       .code(s"$typeFullName ${parameter.getName}")
       .typeFullName(typeFullName)
       .order(childNum)
+      .index(childNum)
       .lineNumber(line(methodDeclaration))
       .columnNumber(column(methodDeclaration))
       .evaluationStrategy(getEvaluationStrategy(parameter.getType))

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -138,11 +138,15 @@ object ProgramHandlingUtil {
   /** Retrieve parseable files from archive types.
     */
   def extractSourceFilesFromArchive(sourceCodeDir: String, archiveFileExtensions: Set[String]): List[String] = {
-    val archives = if (new File(sourceCodeDir).isFile) {
-      List(sourceCodeDir)
-    } else {
-      SourceFiles.determine(Set(sourceCodeDir), archiveFileExtensions)
-    }
+    val archives =
+      if (
+        new File(sourceCodeDir).isFile &&
+        archiveFileExtensions.map(sourceCodeDir.endsWith).reduce((a, b) => a && b)
+      ) {
+        List(sourceCodeDir)
+      } else {
+        SourceFiles.determine(Set(sourceCodeDir), archiveFileExtensions)
+      }
     archives.flatMap { x => unzipArchive(new ZipFile(x), sourceCodeDir) }
   }
 


### PR DESCRIPTION
- `MethodParameterIn` has its `index` property now set
- When a single `.class` file was given it would attempt to be unpacked as if it were an archive - this is now fixed