### PR TITLE
`parentBlock` step to `AstNode`

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -52,9 +52,7 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
   /** Traverses up the AST and returns the first block node.
     */
   def parentBlock: Traversal[Block] =
-    traversal.repeat(_.in(EdgeTypes.AST))(
-      _.emit.until(_.hasLabel(NodeTypes.BLOCK))
-    ).collectAll[Block]
+    traversal.repeat(_.in(EdgeTypes.AST))(_.emit.until(_.hasLabel(NodeTypes.BLOCK))).collectAll[Block]
 
   /** Nodes of the AST obtained by expanding AST edges backwards until the method root is reached
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -49,6 +49,16 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
   def astParent: Traversal[AstNode] =
     traversal.in(EdgeTypes.AST).cast[AstNode]
 
+  /** Traverses up the AST and returns the first block node.
+    */
+  def parentBlock: Traversal[Block] =
+    traversal
+      .repeat(_.in(EdgeTypes.AST))(
+        _.emit
+          .until(_.hasLabel(NodeTypes.BLOCK))
+      )
+      .cast[Block]
+
   /** Nodes of the AST obtained by expanding AST edges backwards until the method root is reached
     */
   def inAst: Traversal[AstNode] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -57,7 +57,7 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
         _.emit
           .until(_.hasLabel(NodeTypes.BLOCK))
       )
-      .cast[Block]
+      .collectAll[Block]
 
   /** Nodes of the AST obtained by expanding AST edges backwards until the method root is reached
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -52,12 +52,9 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
   /** Traverses up the AST and returns the first block node.
     */
   def parentBlock: Traversal[Block] =
-    traversal
-      .repeat(_.in(EdgeTypes.AST))(
-        _.emit
-          .until(_.hasLabel(NodeTypes.BLOCK))
-      )
-      .collectAll[Block]
+    traversal.repeat(_.in(EdgeTypes.AST))(
+      _.emit.until(_.hasLabel(NodeTypes.BLOCK))
+    ).collectAll[Block]
 
   /** Nodes of the AST obtained by expanding AST edges backwards until the method root is reached
     */

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -97,12 +97,21 @@ class StepsTest extends AnyWordSpec with Matchers {
     cpg.method.id.l should not be empty
   }
 
-  "allow retrieving an AST node's parent block from a child AST node" in {
-    cpg.method("woo").block.size should be > 0
-    val List(block: Block) = cpg.method("woo").block.l
-    block.ast.size should be > 0
-    val childIdentifier: AstNode = cpg.method("woo").block.ast.isIdentifier.head
-    childIdentifier.parentBlock.head shouldBe block
+  "when calling for an AST node's parent block" should {
+
+    "return the parent block for a block's AST child" in {
+      val List(block: Block) = cpg.method("woo").block.l
+      val blockDirectChild: AstNode = cpg.method("woo").block.ast.head
+      val blockLeafChild: AstNode = cpg.method("woo").block.ast.last
+
+      blockDirectChild.parentBlock.head shouldBe block
+      blockLeafChild.parentBlock.head shouldBe block
+    }
+
+    "return an empty traversal if no block is found" in {
+      cpg.method("woo").parentBlock.map(_.label).isEmpty shouldBe true
+    }
+
   }
 
   "toJson" when {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -100,9 +100,9 @@ class StepsTest extends AnyWordSpec with Matchers {
   "when calling for an AST node's parent block" should {
 
     "return the parent block for a block's AST child" in {
-      val List(block: Block) = cpg.method("woo").block.l
+      val List(block: Block)        = cpg.method("woo").block.l
       val blockDirectChild: AstNode = cpg.method("woo").block.ast.head
-      val blockLeafChild: AstNode = cpg.method("woo").block.ast.last
+      val blockLeafChild: AstNode   = cpg.method("woo").block.ast.last
 
       blockDirectChild.parentBlock.head shouldBe block
       blockLeafChild.parentBlock.head shouldBe block

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -97,6 +97,14 @@ class StepsTest extends AnyWordSpec with Matchers {
     cpg.method.id.l should not be empty
   }
 
+  "allow retrieving an AST node's parent block from a child AST node" in {
+    cpg.method("woo").block.size should be > 0
+    val List(block: Block) = cpg.method("woo").block.l
+    block.ast.size should be > 0
+    val childIdentifier: AstNode = cpg.method("woo").block.ast.isIdentifier.head
+    childIdentifier.parentBlock.head shouldBe block
+  }
+
   "toJson" when {
     "operating on StoredNode" in {
       val json   = cpg.method.nameExact("foo").toJson


### PR DESCRIPTION
- Allowing the ability to retrieve the first block on an AST node
- Returns an empty traversal if no AST node is found

This is useful for comparing the scope of identifiers who shadow one another for example.