### PR TITLE
[jimple|javasrc]2cpg: Arrays and objects use `Operators.alloc`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion    = "1.3.529"
+val cpgVersion    = "1.3.532"
 val js2cpgVersion = "0.2.140"
 
 lazy val joerncli          = Projects.joerncli

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1,79 +1,11 @@
 package io.joern.javasrc2cpg.passes
 
 import com.github.javaparser.ast.`type`.TypeParameter
-import com.github.javaparser.ast.{CompilationUnit, Node, NodeList, PackageDeclaration}
-import com.github.javaparser.ast.body.{
-  BodyDeclaration,
-  CallableDeclaration,
-  ConstructorDeclaration,
-  EnumConstantDeclaration,
-  FieldDeclaration,
-  InitializerDeclaration,
-  MethodDeclaration,
-  Parameter,
-  TypeDeclaration,
-  VariableDeclarator
-}
+import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.expr.AssignExpr.Operator
-import com.github.javaparser.ast.expr.{
-  AnnotationExpr,
-  ArrayAccessExpr,
-  ArrayCreationExpr,
-  ArrayInitializerExpr,
-  AssignExpr,
-  BinaryExpr,
-  BooleanLiteralExpr,
-  CastExpr,
-  CharLiteralExpr,
-  ClassExpr,
-  ConditionalExpr,
-  DoubleLiteralExpr,
-  EnclosedExpr,
-  Expression,
-  FieldAccessExpr,
-  InstanceOfExpr,
-  IntegerLiteralExpr,
-  LambdaExpr,
-  LiteralExpr,
-  LongLiteralExpr,
-  MarkerAnnotationExpr,
-  MethodCallExpr,
-  NameExpr,
-  NormalAnnotationExpr,
-  NullLiteralExpr,
-  ObjectCreationExpr,
-  SingleMemberAnnotationExpr,
-  StringLiteralExpr,
-  SuperExpr,
-  TextBlockLiteralExpr,
-  ThisExpr,
-  UnaryExpr,
-  VariableDeclarationExpr
-}
-import com.github.javaparser.ast.nodeTypes.NodeWithType
-import com.github.javaparser.ast.stmt.{
-  AssertStmt,
-  BlockStmt,
-  BreakStmt,
-  CatchClause,
-  ContinueStmt,
-  DoStmt,
-  EmptyStmt,
-  ExplicitConstructorInvocationStmt,
-  ExpressionStmt,
-  ForEachStmt,
-  ForStmt,
-  IfStmt,
-  LabeledStmt,
-  ReturnStmt,
-  Statement,
-  SwitchEntry,
-  SwitchStmt,
-  SynchronizedStmt,
-  ThrowStmt,
-  TryStmt,
-  WhileStmt
-}
+import com.github.javaparser.ast.expr._
+import com.github.javaparser.ast.stmt._
+import com.github.javaparser.ast.{CompilationUnit, Node, NodeList, PackageDeclaration}
 import com.github.javaparser.resolution.UnsolvedSymbolException
 import com.github.javaparser.resolution.declarations.{
   ResolvedConstructorDeclaration,
@@ -83,54 +15,18 @@ import com.github.javaparser.resolution.declarations.{
 }
 import io.joern.javasrc2cpg.passes.AstWithCtx.astWithCtxToSeq
 import io.joern.javasrc2cpg.passes.Context.mergedCtx
-import io.joern.javasrc2cpg.util.{NodeTypeInfo, Scope, TypeInfoProvider}
 import io.joern.javasrc2cpg.util.TypeInfoProvider.{TypeConstants, UnresolvedTypeDefault}
-import io.shiftleft.codepropertygraph.generated.{
-  ControlStructureTypes,
-  DispatchTypes,
-  EdgeTypes,
-  EvaluationStrategies,
-  ModifierTypes,
-  Operators,
-  PropertyNames
-}
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  HasTypeFullName,
-  NewAnnotation,
-  NewAnnotationLiteral,
-  NewAnnotationParameter,
-  NewAnnotationParameterAssign,
-  NewArrayInitializer,
-  NewBinding,
-  NewBlock,
-  NewCall,
-  NewClosureBinding,
-  NewControlStructure,
-  NewFieldIdentifier,
-  NewIdentifier,
-  NewJumpTarget,
-  NewLiteral,
-  NewLocal,
-  NewMember,
-  NewMethod,
-  NewMethodParameterIn,
-  NewMethodRef,
-  NewModifier,
-  NewNamespaceBlock,
-  NewNode,
-  NewReturn,
-  NewTypeDecl,
-  NewTypeRef,
-  NewUnknown
-}
-import io.joern.x2cpg.{Ast, AstCreatorBase}
+import io.joern.javasrc2cpg.util.{NodeTypeInfo, Scope, TypeInfoProvider}
 import io.joern.x2cpg.datastructures.Global
+import io.joern.x2cpg.{Ast, AstCreatorBase}
+import io.shiftleft.codepropertygraph.generated.nodes.{Expression, _}
+import io.shiftleft.codepropertygraph.generated._
 import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import java.util.UUID.randomUUID
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
 import scala.language.{existentials, implicitConversions}
 import scala.util.{Failure, Success, Try}
@@ -1455,12 +1351,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, argsWithCtx)
   }
 
-  def astForArrayCreationExpr(
-    expr: ArrayCreationExpr,
-    scopeContext: ScopeContext,
-    order: Int,
-    expectedType: Option[String]
-  ): AstWithCtx = {
+  def astForArrayCreationExpr(expr: ArrayCreationExpr, order: Int, expectedType: Option[String]): AstWithCtx = {
     val name = Operators.alloc
     val callNode = NewCall()
       .name(name)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1,11 +1,78 @@
 package io.joern.javasrc2cpg.passes
 
 import com.github.javaparser.ast.`type`.TypeParameter
-import com.github.javaparser.ast.body._
-import com.github.javaparser.ast.expr.AssignExpr.Operator
-import com.github.javaparser.ast.expr._
-import com.github.javaparser.ast.stmt._
 import com.github.javaparser.ast.{CompilationUnit, Node, NodeList, PackageDeclaration}
+import com.github.javaparser.ast.body.{
+  BodyDeclaration,
+  CallableDeclaration,
+  ConstructorDeclaration,
+  EnumConstantDeclaration,
+  FieldDeclaration,
+  InitializerDeclaration,
+  MethodDeclaration,
+  Parameter,
+  TypeDeclaration,
+  VariableDeclarator
+}
+import com.github.javaparser.ast.expr.AssignExpr.Operator
+import com.github.javaparser.ast.expr.{
+  AnnotationExpr,
+  ArrayAccessExpr,
+  ArrayCreationExpr,
+  ArrayInitializerExpr,
+  AssignExpr,
+  BinaryExpr,
+  BooleanLiteralExpr,
+  CastExpr,
+  CharLiteralExpr,
+  ClassExpr,
+  ConditionalExpr,
+  DoubleLiteralExpr,
+  EnclosedExpr,
+  Expression,
+  FieldAccessExpr,
+  InstanceOfExpr,
+  IntegerLiteralExpr,
+  LambdaExpr,
+  LiteralExpr,
+  LongLiteralExpr,
+  MarkerAnnotationExpr,
+  MethodCallExpr,
+  NameExpr,
+  NormalAnnotationExpr,
+  NullLiteralExpr,
+  ObjectCreationExpr,
+  SingleMemberAnnotationExpr,
+  StringLiteralExpr,
+  SuperExpr,
+  TextBlockLiteralExpr,
+  ThisExpr,
+  UnaryExpr,
+  VariableDeclarationExpr
+}
+import com.github.javaparser.ast.stmt.{
+  AssertStmt,
+  BlockStmt,
+  BreakStmt,
+  CatchClause,
+  ContinueStmt,
+  DoStmt,
+  EmptyStmt,
+  ExplicitConstructorInvocationStmt,
+  ExpressionStmt,
+  ForEachStmt,
+  ForStmt,
+  IfStmt,
+  LabeledStmt,
+  ReturnStmt,
+  Statement,
+  SwitchEntry,
+  SwitchStmt,
+  SynchronizedStmt,
+  ThrowStmt,
+  TryStmt,
+  WhileStmt
+}
 import com.github.javaparser.resolution.UnsolvedSymbolException
 import com.github.javaparser.resolution.declarations.{
   ResolvedConstructorDeclaration,
@@ -15,12 +82,47 @@ import com.github.javaparser.resolution.declarations.{
 }
 import io.joern.javasrc2cpg.passes.AstWithCtx.astWithCtxToSeq
 import io.joern.javasrc2cpg.passes.Context.mergedCtx
-import io.joern.javasrc2cpg.util.TypeInfoProvider.{TypeConstants, UnresolvedTypeDefault}
 import io.joern.javasrc2cpg.util.{NodeTypeInfo, Scope, TypeInfoProvider}
-import io.joern.x2cpg.datastructures.Global
+import io.joern.javasrc2cpg.util.TypeInfoProvider.{TypeConstants, UnresolvedTypeDefault}
+import io.shiftleft.codepropertygraph.generated.{
+  ControlStructureTypes,
+  DispatchTypes,
+  EdgeTypes,
+  EvaluationStrategies,
+  ModifierTypes,
+  Operators,
+  PropertyNames
+}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  NewAnnotation,
+  NewAnnotationLiteral,
+  NewAnnotationParameter,
+  NewAnnotationParameterAssign,
+  NewArrayInitializer,
+  NewBinding,
+  NewBlock,
+  NewCall,
+  NewClosureBinding,
+  NewControlStructure,
+  NewFieldIdentifier,
+  NewIdentifier,
+  NewJumpTarget,
+  NewLiteral,
+  NewLocal,
+  NewMember,
+  NewMethod,
+  NewMethodParameterIn,
+  NewMethodRef,
+  NewModifier,
+  NewNamespaceBlock,
+  NewNode,
+  NewReturn,
+  NewTypeDecl,
+  NewTypeRef,
+  NewUnknown
+}
 import io.joern.x2cpg.{Ast, AstCreatorBase}
-import io.shiftleft.codepropertygraph.generated.nodes.{Expression, _}
-import io.shiftleft.codepropertygraph.generated._
+import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1367,7 +1367,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     order: Int,
     expectedType: Option[String]
   ): AstWithCtx = {
-    val name = "<operator>.arrayCreator"
+    val name = Operators.alloc
     val callNode = NewCall()
       .name(name)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1943,7 +1943,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       astsForExpression(x, scopeContext, o, expectedArgType)
     }.flatten
 
-    val name = "<operator>.alloc"
+    val name = Operators.alloc
     val typeFullName = typeInfoProvider
       .getTypeFullName(expr)
       .orElse(expectedType)

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -433,8 +433,8 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
         val parentType = registerType(x.getType.toQuotedString)
         Ast(
           NewCall()
-            .name("<operator>.alloc")
-            .methodFullName("<operator>.alloc")
+            .name(Operators.alloc)
+            .methodFullName(Operators.alloc)
             .typeFullName(parentType)
             .code(s"new ${x.getType}")
             .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -457,8 +457,8 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
     val arrayBaseType = registerType(arrayInitExpr.getType.toQuotedString)
     val code = s"new ${arrayBaseType.substring(0, arrayBaseType.indexOf('['))}${sizes.map(s => s"[$s]").mkString}"
     val callBlock = NewCall()
-      .name("<operator>.arrayCreator")
-      .methodFullName("<operator>.arrayCreator")
+      .name(Operators.alloc)
+      .methodFullName(Operators.alloc)
       .code(code)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .order(order)

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ArrayTests.scala
@@ -39,7 +39,7 @@ class ArrayTests extends JimpleCodeToCpgFixture {
     placeholderArg.typeFullName shouldBe "int[]"
 
     arrayInit.code shouldBe "new int[3]"
-    arrayInit.methodFullName shouldBe "<operator>.arrayCreator"
+    arrayInit.methodFullName shouldBe Operators.alloc
     arrayInit.astChildren.headOption match {
       case Some(alloc) =>
         alloc shouldBe a[Literal]

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
@@ -103,10 +103,10 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
         assign.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
         assign.name shouldBe Operators.assignment
         val alloc = assign.argument(2).asInstanceOf[Call]
-        alloc.name shouldBe "<operator>.alloc"
+        alloc.name shouldBe Operators.alloc
         alloc.code shouldBe "new Bar"
         alloc.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
-        alloc.methodFullName shouldBe "<operator>.alloc"
+        alloc.methodFullName shouldBe Operators.alloc
         alloc.typeFullName shouldBe "Bar"
         alloc.argument.size shouldBe 0
 
@@ -141,10 +141,10 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
         assign.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
         assign.name shouldBe Operators.assignment
         val alloc = assign.argument(2).asInstanceOf[Call]
-        alloc.name shouldBe "<operator>.alloc"
+        alloc.name shouldBe Operators.alloc
         alloc.code shouldBe "new Bar"
         alloc.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
-        alloc.methodFullName shouldBe "<operator>.alloc"
+        alloc.methodFullName shouldBe Operators.alloc
         alloc.typeFullName shouldBe "Bar"
         alloc.argument.size shouldBe 0
 
@@ -183,8 +183,8 @@ class ConstructorInvocationTests extends JimpleCodeToCpgFixture {
         temp.code shouldBe "$stack1"
 
         val alloc = allocAssign.argument(2).asInstanceOf[Call]
-        alloc.name shouldBe "<operator>.alloc"
-        alloc.methodFullName shouldBe "<operator>.alloc"
+        alloc.name shouldBe Operators.alloc
+        alloc.methodFullName shouldBe Operators.alloc
         alloc.order shouldBe 2
         alloc.argumentIndex shouldBe 2
         alloc.code shouldBe "new Bar"


### PR DESCRIPTION
- Upgraded CPG
- Memory allocation calls for arrays and objects now use `Operators.alloc`