### PR TITLE
Remove cruft from CODE field of Kotlin LOCALs

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -1488,7 +1488,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
 
         val node =
           NewLocal()
-            .code(entry.getText)
+            .code(entry.getName)
             .name(entry.getName)
             .typeFullName(typeFullName)
             .order(orderForNode)
@@ -1679,7 +1679,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
 
         val node =
           NewLocal()
-            .code(entry.getText)
+            .code(entry.getName)
             .name(entry.getName)
             .typeFullName(typeFullName)
             .order(orderForNode)
@@ -1914,7 +1914,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
 
           val node =
             NewLocal()
-              .code(entry.getText)
+              .code(entry.getName)
               .name(entry.getName)
               .typeFullName(typeFullName)
               .order(orderForNode)
@@ -3425,7 +3425,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     val localNode =
       NewLocal()
         .name(expr.getName)
-        .code(expr.getText)
+        .code(expr.getName)
         .typeFullName(typeFullName)
         .lineNumber(line(elem))
         .columnNumber(column(elem))

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -72,7 +72,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
     }
 
     "should contain a LOCAL node for the captured `baz`" in {
-      cpg.local.code("baz").size shouldBe 1
+      cpg.local.code("baz").size shouldBe 2
     }
 
     "should contain a CLOSURE_BINDING node for captured `baz`" in {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalTests.scala
@@ -8,49 +8,31 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class LocalTests extends AnyFreeSpec with Matchers {
-
   "CPG for code simple local declarations" - {
     lazy val cpg = TestContext.buildCpg("""
-        |fun foo() {
+        |fun main() {
         |  val x: Int = 1
-        |  val y: Int = 2
-        |  println(x + y)
-        |}
-        |""".stripMargin)
-
-    "should contain locals `x` and `y` with correct fields set" in {
-      val List(x) = cpg.local("x").l
-      x.code shouldBe "val x: Int = 1" // TODO: decide whether to remove the `= 1`
-      x.typeFullName shouldBe "java.lang.Integer"
-      x.lineNumber shouldBe Some(2)
-      x.columnNumber shouldBe Some(6)
-      x.order shouldBe 1
-
-      val List(y) = cpg.local("y").l
-      y.code shouldBe "val y: Int = 2" // TODO: decide whether to remove the `= 2`
-      y.typeFullName shouldBe "java.lang.Integer"
-      y.lineNumber shouldBe Some(3)
-      y.columnNumber shouldBe Some(6)
-      y.order shouldBe 3
-    }
-  }
-
-  "CPG for code simple local declarations without explicit types" - {
-    lazy val cpg = TestContext.buildCpg("""
-        |fun foo() {
-        |  val x = 1
         |  val y = 2
         |  println(x + y)
         |}
         |""".stripMargin)
 
-    "should contain locals `x` and `y` with correct TYPE_FULL_NAMEs set" in {
-      val List(x: Local) = cpg.local("x").l
-      x.typeFullName shouldBe "java.lang.Integer"
+    "should contain LOCAL node for `x` and `y` with correct props set" in {
+      val List(l1) = cpg.local("x").l
+      l1.code shouldBe "x"
+      l1.name shouldBe "x"
+      l1.typeFullName shouldBe "java.lang.Integer"
+      l1.lineNumber shouldBe Some(2)
+      l1.columnNumber shouldBe Some(6)
+      l1.order shouldBe 1
 
-      val List(y: Local) = cpg.local("y").l
-      y.typeFullName shouldBe "java.lang.Integer"
+      val List(l2) = cpg.local("y").l
+      l2.code shouldBe "y"
+      l2.name shouldBe "y"
+      l2.typeFullName shouldBe "java.lang.Integer"
+      l2.lineNumber shouldBe Some(3)
+      l2.columnNumber shouldBe Some(6)
+      l2.order shouldBe 3
     }
   }
-
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/IdentifierReferencesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/IdentifierReferencesTests.scala
@@ -1,9 +1,10 @@
 package io.joern.kotlin2cpg.validation
 
 import io.joern.kotlin2cpg.TestContext
+import io.shiftleft.codepropertygraph.generated.Operators
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import io.shiftleft.codepropertygraph.generated.nodes.Local
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Local}
 import io.shiftleft.semanticcpg.language._
 
 class IdentifierReferencesTests extends AnyFreeSpec with Matchers {
@@ -33,6 +34,41 @@ class IdentifierReferencesTests extends AnyFreeSpec with Matchers {
       val List(innerScopeX: Local) = cpg.local.nameExact("x").lineNumber(7).l
       innerScopeX.referencingIdentifiers.size shouldBe 2
       innerScopeX.referencingIdentifiers.lineNumber.l shouldBe List(7, 9)
+    }
+  }
+
+  "CPG for code with locals with the same name, but in different scopes" - {
+    lazy val cpg = TestContext.buildCpg("""
+        |package mypkg
+        |
+        |fun main() {
+        |    val x = "FIRST"
+        |    if (true) {
+        |        val x ="SECOND"
+        |        if (true) {
+        |            val x = "THIRD"
+        |            println("third: " + x)
+        |        } else {
+        |            println("second: " + x)
+        |        }
+        |    }
+        |    println("first: " + x)
+        |}
+        |""".stripMargin)
+
+    "should contain LOCAL nodes with correctly-set referencing IDENTIFIERS" in {
+      val List(firstX: Local, secondX: Local, thirdX: Local) = cpg.local.nameExact("x").l
+      val List(firstXUsage: Identifier) = cpg.call.methodFullName(Operators.addition).code(".*first.*").argument(2).l
+      firstX.referencingIdentifiers.id.l.contains(firstXUsage.id) shouldBe true
+      firstXUsage.refsTo.size shouldBe 1
+
+      val List(secondXUsage: Identifier) = cpg.call.methodFullName(Operators.addition).code(".*second.*").argument(2).l
+      secondX.referencingIdentifiers.id.l.contains(secondXUsage.id) shouldBe true
+      secondXUsage.refsTo.size shouldBe 1
+
+      val List(thirdXUsage: Identifier) = cpg.call.methodFullName(Operators.addition).code(".*third.*").argument(2).l
+      thirdX.referencingIdentifiers.id.l.contains(thirdXUsage.id) shouldBe true
+      thirdXUsage.refsTo.size shouldBe 1
     }
   }
 }


### PR DESCRIPTION
To be consistent with the rest of the frontends

e.g. for:
```
fun main() {
  val x: Int = 1
}
```

before:
```
LOCAL
 \-> NAME: x
 \-> CODE: val x: Int = 1
```

after:
```
LOCAL
 \-> NAME: x
 \-> CODE: x
```