### PR TITLE
javasrc: Clean up typeInfoProvider a bit

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -83,6 +83,7 @@ import com.github.javaparser.resolution.declarations.{
 }
 import io.joern.javasrc2cpg.passes.AstWithCtx.astWithCtxToSeq
 import io.joern.javasrc2cpg.passes.Context.mergedCtx
+import io.joern.javasrc2cpg.util.Scope.WildcardImportName
 import io.joern.javasrc2cpg.util.{NodeTypeInfo, Scope, TypeInfoProvider}
 import io.joern.javasrc2cpg.util.TypeInfoProvider.{TypeConstants, UnresolvedTypeDefault}
 import io.shiftleft.codepropertygraph.generated.{
@@ -221,8 +222,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   private val logger = LoggerFactory.getLogger(this.getClass)
   import AstCreator._
 
-  private val typeInfoProvider: TypeInfoProvider = TypeInfoProvider(global)
   private val scopeStack                         = Scope()
+  private val typeInfoProvider: TypeInfoProvider = TypeInfoProvider(global, scopeStack)
 
   /** Entry point of AST creation. Translates a compilation unit created by JavaParser into a DiffGraph containing the
     * corresponding CPG AST.
@@ -257,15 +258,22 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def addImportsToScope(compilationUnit: CompilationUnit): Unit = {
-
-    typeInfoProvider.registerImports(compilationUnit.getImports.asScala.toList)
-    javaParserAst.getImports.asScala.foreach { importStmt =>
+    val (asteriskImports, specificImports) = compilationUnit.getImports.asScala.toList.partition(_.isAsterisk)
+    specificImports.foreach { importStmt =>
       val name = importStmt.getName.getIdentifier
       val importNode =
         NewIdentifier()
           .name(name)
           .typeFullName(importStmt.getNameAsString) // fully qualified name
       scopeStack.addToScope(name, NodeTypeInfo(importNode))
+    }
+
+    asteriskImports match {
+      case imp :: Nil =>
+        val importNode = NewIdentifier().name(WildcardImportName).typeFullName(imp.getNameAsString)
+        scopeStack.addToScope(WildcardImportName, importNode)
+
+      case _ => // Only try to guess a wildcard import if exactly one is defined
     }
   }
 
@@ -508,8 +516,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       List.empty[String]
     }
 
-    val typeFullName = typeInfoProvider.getTypeName(typ)
-    val name         = typeInfoProvider.getTypeName(typ, fullName = false)
+    val typeFullName = typeInfoProvider.getTypeDeclType(typ)
+    val name         = typeInfoProvider.getTypeDeclType(typ, fullName = false)
 
     val typeDecl = NewTypeDecl()
       .name(name)
@@ -639,9 +647,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def astForFieldVariable(v: VariableDeclarator, fieldDeclaration: FieldDeclaration, order: Int): AstWithCtx = {
     // TODO: Should be able to find expected type here
-    val annotations  = fieldDeclaration.getAnnotations
-    val typeFullName = typeInfoProvider.getTypeFullName(v).getOrElse(UnresolvedTypeDefault)
-    val name         = v.getName.toString
+    val annotations = fieldDeclaration.getAnnotations
+    val typeFullName =
+      typeInfoProvider
+        .getTypeFullName(v)
+        .orElse(scopeStack.getWildcardType(v.getTypeAsString))
+        .getOrElse(UnresolvedTypeDefault)
+    val name = v.getName.toString
     val memberNode =
       NewMember()
         .name(name)
@@ -697,7 +709,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       }
     }
 
-    val typeFullName = typeInfoProvider.getMethodLikeTypeFullName(constructorDeclaration)
+    val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedTypeDefault)
     val thisAst      = thisAstForMethod(typeFullName, line(constructorDeclaration))
 
     val lastOrder = 2 + parameterAstsWithCtx.size
@@ -827,7 +839,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     NewAnnotation()
       .code(annotationExpr.toString)
       .name(annotationExpr.getName.getIdentifier)
-      .fullName(typeInfoProvider.getTypeFullName(annotationExpr).getOrElse(UnresolvedTypeDefault))
+      .fullName(typeInfoProvider.getTypeForExpression(annotationExpr).getOrElse(UnresolvedTypeDefault))
       .order(order)
   }
 
@@ -886,9 +898,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val returnType =
       typeInfoProvider
         .getReturnType(methodDeclaration)
-        .orElse(
-          scopeStack.lookupVariable(methodDeclaration.getTypeAsString).map(_.node.typeFullName)
-        ) // TODO: TYPE_CLEANUP
+        .orElse(scopeStack.lookupVariableType(methodDeclaration.getTypeAsString))
+        .orElse(scopeStack.getWildcardType(methodDeclaration.getTypeAsString))
 
     val parameterTypes = parameterAstsWithCtx.map(rootType(_).getOrElse(UnresolvedTypeDefault))
     val signature = returnType map { typ =>
@@ -935,7 +946,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   private def astForConstructorReturn(constructorDeclaration: ConstructorDeclaration): Ast = {
     val line   = constructorDeclaration.getEnd.map(x => Integer.valueOf(x.line)).toScala
     val column = constructorDeclaration.getEnd.map(x => Integer.valueOf(x.column)).toScala
-    val order  = constructorDeclaration.getParameters.size + 2
     val node   = methodReturnNode(line, column, "void")
     Ast(node)
   }
@@ -1701,11 +1711,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val assignments = variablesWithInitializers.zipWithIndex flatMap { case (variable, idx) =>
       val name                    = variable.getName.toString
       val initializer             = variable.getInitializer.toScala.get // Won't crash because of filter
-      val initializerTypeFullName = typeInfoProvider.getInitializerType(variable)
+      val initializerTypeFullName = variable.getInitializer.toScala.flatMap(typeInfoProvider.getTypeForExpression)
       val variableTypeFullName =
         typeInfoProvider
           .getTypeFullName(variable)
-          .orElse(scopeStack.lookupVariable(name).map(_.node.typeFullName)) // TODO: TYPE_CLEANUP
+          .orElse(scopeStack.lookupVariableType(name))
+          .orElse(scopeStack.getWildcardType(name))
 
       val typeFullName = variableTypeFullName match {
         case Some(typ) if TypeInfoProvider.isAutocastType(typ) => typ
@@ -1928,11 +1939,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   def astForNameExpr(x: NameExpr, order: Int, expectedType: Option[String]): AstWithCtx = {
     val name = x.getName.toString
     val typeFullName = typeInfoProvider
-      .getTypeFullName(x)
-      .orElse({
-        println(s"Looking for name $name in scope stack")
-        scopeStack.lookupVariable(name).map(_.node.typeFullName)
-      }) // TODO: TYPE_CLEANUP
+      .getTypeForExpression(x)
       .orElse(expectedType)
       .getOrElse(UnresolvedTypeDefault)
 
@@ -2136,7 +2143,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   def astForThisExpr(expr: ThisExpr, order: Int, expectedType: Option[String]): AstWithCtx = {
     val typeFullName =
       typeInfoProvider
-        .getTypeFullName(expr)
+        .getTypeForExpression(expr)
         .orElse(expectedType)
         .getOrElse(UnresolvedTypeDefault)
 
@@ -2158,7 +2165,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       astsForExpression(s, o, None)
     }.flatten
 
-    val typeFullName = typeInfoProvider.getTypeFullName(stmt)
+    val typeFullName = typeInfoProvider.getTypeFullName(stmt).getOrElse(UnresolvedTypeDefault)
     val argTypes     = argumentTypesForCall(Try(stmt.resolve()), args)
 
     val signature = s"void(${argTypes.mkString(",")})"
@@ -2252,19 +2259,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case _ =>
         // If the call is unresolvable, we cannot make a good guess about what the prefix should be
         ""
-    }
-  }
-
-  private def getScopeType(expr: Expression): Option[String] = {
-    expr match {
-      case nameExpr: NameExpr =>
-        // TODO: TYPE_CLEANUP
-        scopeStack
-          .lookupVariable(nameExpr.getNameAsString)
-          .map(_.node.typeFullName)
-          .orElse(typeInfoProvider.getTypeFullName(nameExpr))
-
-      case _ => typeInfoProvider.getTypeForExpression(expr)
     }
   }
 
@@ -2487,7 +2481,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           .order(order)
           .argumentIndex(order)
           .code(expr.toString)
-          .typeFullName(typeInfoProvider.getLiteralTypeFullName(expr))
+          .typeFullName(typeInfoProvider.getTypeForExpression(expr).getOrElse(UnresolvedTypeDefault))
           .lineNumber(line(expr))
           .columnNumber(column(expr))
       ),
@@ -2530,7 +2524,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callExpr.getScope.toScala match {
       case Some(scope: ThisExpr) =>
         typeInfoProvider
-          .getTypeFullName(scope)
+          .getTypeForExpression(scope)
           .orElse(scopeStack.getEnclosingTypeDecl.map(_.fullName))
 
       case Some(scope: SuperExpr) =>
@@ -2538,8 +2532,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           .getTypeForExpression(scope)
           .orElse(scopeStack.getEnclosingTypeDecl.flatMap(_.inheritsFromTypeFullName.headOption))
 
-      case Some(scope) =>
-        getScopeType(scope)
+      case Some(scope) => typeInfoProvider.getTypeForExpression(scope)
 
       case None =>
         scopeStack.getEnclosingTypeDecl.map(_.fullName)
@@ -2660,7 +2653,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName =
       typeInfoProvider
         .getTypeFullName(parameter)
-        .orElse(scopeStack.lookupVariable(parameter.getTypeAsString).map(_.node.typeFullName)) // TODO: TYPE_CLEANUP
+        .orElse(scopeStack.lookupVariableType(parameter.getTypeAsString))
+        .orElse(scopeStack.getWildcardType(parameter.getTypeAsString))
         .getOrElse(UnresolvedTypeDefault)
     val parameterNode = NewMethodParameterIn()
       .name(parameter.getName.toString)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/JP2JavaSrcTypeAdapter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/JP2JavaSrcTypeAdapter.scala
@@ -1,0 +1,145 @@
+package io.joern.javasrc2cpg.util
+
+import com.github.javaparser.ast.Node
+import com.github.javaparser.ast.body.TypeDeclaration
+import com.github.javaparser.ast.expr.{
+  BooleanLiteralExpr,
+  CharLiteralExpr,
+  DoubleLiteralExpr,
+  Expression,
+  IntegerLiteralExpr,
+  LiteralExpr,
+  LongLiteralExpr,
+  NullLiteralExpr,
+  StringLiteralExpr,
+  TextBlockLiteralExpr
+}
+import com.github.javaparser.ast.stmt.Statement
+import com.github.javaparser.resolution.Resolvable
+import com.github.javaparser.resolution.declarations.{ResolvedMethodLikeDeclaration, ResolvedTypeDeclaration}
+import com.github.javaparser.resolution.types.{ResolvedArrayType, ResolvedReferenceType, ResolvedType}
+import io.joern.javasrc2cpg.util.TypeInfoProvider.UnresolvedTypeDefault
+import org.slf4j.LoggerFactory
+
+import scala.jdk.OptionConverters.RichOptional
+import scala.util.{Failure, Success, Try}
+
+object JP2JavaSrcTypeAdapter {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  def simpleResolvedTypeFullName(resolvedType: ResolvedType): Option[String] = {
+    if (resolvedType.isTypeVariable) {
+      None
+    } else {
+      Some(resolvedType.describe())
+    }
+  }
+
+  def extractNullableName(tryName: Try[String]): String = {
+    tryName match {
+      case Success(null) => ""
+
+      case Success(name) => name
+
+      case _ => ""
+    }
+  }
+
+  def resolvedTypeDeclFullName(declaration: ResolvedTypeDeclaration): String = {
+    val packageName = extractNullableName(Try(declaration.getPackageName))
+    val className   = extractNullableName(Try(declaration.getClassName))
+    buildTypeString(packageName, className)
+  }
+
+  def resolvedReferenceTypeFullName(resolvedType: ResolvedReferenceType): Option[String] = {
+    resolvedType.getTypeDeclaration.toScala match {
+      case Some(typeDeclaration) => Some(resolvedTypeDeclFullName(typeDeclaration))
+
+      case None =>
+        simpleResolvedTypeFullName(resolvedType)
+    }
+  }
+
+  def resolvedTypeFullName(resolvedType: ResolvedType): Option[String] = {
+    resolvedType match {
+      case resolvedReferenceType: ResolvedReferenceType => resolvedReferenceTypeFullName(resolvedReferenceType)
+
+      case _ => simpleResolvedTypeFullName(resolvedType)
+    }
+  }
+
+  def resolvedMethodLikeDeclFullName(declaration: ResolvedMethodLikeDeclaration): String = {
+    val packageName = Try(declaration.getPackageName).getOrElse("")
+    val className   = Try(declaration.getClassName).getOrElse(declaration.getName)
+
+    JP2JavaSrcTypeAdapter.buildTypeString(packageName, className)
+  }
+
+  def buildTypeString(packageName: String, className: String): String = {
+    val dollaredClass = className.replaceAll("\\.", "\\$")
+    if (packageName.nonEmpty) {
+      s"$packageName.$dollaredClass"
+    } else {
+      dollaredClass
+    }
+  }
+
+  def typeForExpression(expr: Expression): Option[String] = {
+    Try(expr.calculateResolvedType()) match {
+      case Success(resolvedType) => resolvedTypeFullName(resolvedType)
+
+      case Failure(_) =>
+        logger.debug(s"Failed to resolve type for expression $expr")
+        None
+    }
+  }
+
+  def typeForMethodLike(stmt: Resolvable[_ <: ResolvedMethodLikeDeclaration]): Option[String] = {
+    Try(stmt.resolve()) match {
+      case Success(declaration) =>
+        Some(resolvedMethodLikeDeclFullName(declaration))
+
+      case Failure(_) =>
+        logger.debug(s"Failed to resolved type for resolvable $stmt")
+        None
+    }
+  }
+
+  def typeForLiteral(literalExpr: LiteralExpr): Option[String] = {
+    literalExpr match {
+      case _: BooleanLiteralExpr   => Some("boolean")
+      case _: CharLiteralExpr      => Some("char")
+      case _: DoubleLiteralExpr    => Some("double")
+      case _: IntegerLiteralExpr   => Some("int")
+      case _: LongLiteralExpr      => Some("long")
+      case _: NullLiteralExpr      => Some("null")
+      case _: StringLiteralExpr    => Some("java.lang.String")
+      case _: TextBlockLiteralExpr => Some("java.lang.String")
+      case _                       => None
+    }
+  }
+
+  def typeNameForTypeDecl(typeDecl: TypeDeclaration[_], fullName: Boolean): String = {
+    val javaParserName = if (fullName) {
+      typeDecl.getFullyQualifiedName.toScala.getOrElse(typeDecl.getNameAsString)
+    } else {
+      typeDecl.getNameAsString
+    }
+
+    if (typeDecl.isNestedType) {
+
+      typeDecl.getParentNode.toScala match {
+        case Some(parentDecl: TypeDeclaration[_]) =>
+          typeNameForTypeDecl(parentDecl, fullName) ++ "$" ++ typeDecl.getNameAsString
+
+        case _ =>
+          logger.warn("typeNameForTypeDecl expected nested typeDecl to have typeDecl parent.")
+          javaParserName
+      }
+
+    } else {
+      javaParserName
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
@@ -1,5 +1,6 @@
 package io.joern.javasrc2cpg.util
 
+import io.joern.javasrc2cpg.util.Scope.WildcardImportName
 import io.joern.x2cpg.datastructures.Stack.Stack
 import io.joern.x2cpg.datastructures.{ScopeElement, Stack, Scope => X2CpgScope}
 import io.shiftleft.codepropertygraph.generated.nodes.{HasTypeFullName, NewNode, NewTypeDecl}
@@ -40,8 +41,19 @@ class Scope extends X2CpgScope[String, NodeTypeInfo, NewNode] {
   def getEnclosingTypeDecl: Option[NewTypeDecl] = {
     typeDeclStack.headOption
   }
+
+  def lookupVariableType(identifier: String): Option[String] = {
+    lookupVariable(identifier).map(_.node.typeFullName)
+  }
+
+  def getWildcardType(identifier: String): Option[String] = {
+    lookupVariableType(WildcardImportName) map { importName =>
+      s"$importName.$identifier"
+    }
+  }
 }
 
 object Scope {
-  def apply(): Scope = new Scope()
+  val WildcardImportName: String = "*"
+  def apply(): Scope             = new Scope()
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
@@ -1,27 +1,22 @@
 package io.joern.javasrc2cpg.util
 
-import com.github.javaparser.ast.ImportDeclaration
-import com.github.javaparser.ast.`type`.{ClassOrInterfaceType, ReferenceType}
-import com.github.javaparser.ast.body.{EnumConstantDeclaration, TypeDeclaration, VariableDeclarator}
+import com.github.javaparser.ast.`type`.{ClassOrInterfaceType, PrimitiveType, ReferenceType}
+import com.github.javaparser.ast.body.{EnumConstantDeclaration, TypeDeclaration}
 import com.github.javaparser.ast.expr._
-import com.github.javaparser.ast.nodeTypes.{NodeWithName, NodeWithType}
+import com.github.javaparser.ast.nodeTypes.{NodeWithName, NodeWithSimpleName, NodeWithType}
 import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt
 import com.github.javaparser.resolution.Resolvable
 import com.github.javaparser.resolution.declarations._
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType}
 import io.joern.x2cpg.datastructures.Global
-import io.joern.javasrc2cpg.util.TypeInfoProvider.{ImportInfo, UnresolvedTypeDefault}
-import io.shiftleft.codepropertygraph.generated.nodes.NewIdentifier
 import org.slf4j.LoggerFactory
 
-import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.{Failure, Success, Try}
 
-class TypeInfoProvider(global: Global) {
+class TypeInfoProvider(global: Global, scope: Scope) {
 
-  private val logger     = LoggerFactory.getLogger(this.getClass)
-  private var importInfo = ImportInfo(Map.empty, None)
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   /** Add `typeName` to a global map and return it. The map is later passed to a pass that creates TYPE nodes for each
     * key in the map. Skip the `ANY` type, since this is created by default.
@@ -33,92 +28,12 @@ class TypeInfoProvider(global: Global) {
     typeName
   }
 
-  private def simpleResolvedTypeFullName(resolvedType: ResolvedType): Option[String] = {
-    if (resolvedType.isTypeVariable) {
-      None
-    } else {
-      Some(resolvedType.describe())
-    }
-  }
-
-  private def buildTypeString(packageName: String, className: String): String = {
-    val dollaredClass = className.replaceAll("\\.", "\\$")
-    if (packageName.nonEmpty) {
-      s"$packageName.$dollaredClass"
-    } else {
-      dollaredClass
-    }
-  }
-
-  private def extractNullableName(tryName: Try[String]): String = {
-    tryName match {
-      case Success(null) => ""
-
-      case Success(name) => name
-
-      case _ => ""
-    }
-  }
-
-  private def resolvedTypeDeclFullName(declaration: ResolvedTypeDeclaration): String = {
-    val packageName = extractNullableName(Try(declaration.getPackageName))
-    val className   = extractNullableName(Try(declaration.getClassName))
-    buildTypeString(packageName, className)
-  }
-
-  private def resolvedMethodLikeDeclFullName(declaration: ResolvedMethodLikeDeclaration): String = {
-    val packageName = Try(declaration.getPackageName).getOrElse("")
-    val className   = Try(declaration.getClassName).getOrElse(declaration.getName)
-
-    buildTypeString(packageName, className)
-  }
-
-  private def resolvedReferenceTypeFullName(resolvedType: ResolvedReferenceType): Option[String] = {
-    resolvedType.getTypeDeclaration.toScala match {
-      case Some(typeDeclaration) => Some(resolvedTypeDeclFullName(typeDeclaration))
-
-      case None =>
-        simpleResolvedTypeFullName(resolvedType)
-    }
-  }
-
-  private def resolvedTypeFullName(resolvedType: ResolvedType): Option[String] = {
-    resolvedType match {
-      case resolvedReferenceType: ResolvedReferenceType => resolvedReferenceTypeFullName(resolvedReferenceType)
-
-      case _ => simpleResolvedTypeFullName(resolvedType)
-    }
-  }
-
   def getResolvedTypeFullName(resolvedType: ResolvedType): Option[String] = {
-    resolvedTypeFullName(resolvedType).map(registerType)
+    JP2JavaSrcTypeAdapter.resolvedTypeFullName(resolvedType).map(registerType)
   }
 
-  private def typeNameForTypeDecl(typeDecl: TypeDeclaration[_], fullName: Boolean): String = {
-    val javaParserName = if (fullName) {
-      typeDecl.getFullyQualifiedName.toScala.getOrElse(typeDecl.getNameAsString)
-    } else {
-      typeDecl.getNameAsString
-    }
-
-    if (typeDecl.isNestedType) {
-
-      typeDecl.getParentNode.toScala match {
-        case Some(parentDecl: TypeDeclaration[_]) =>
-          typeNameForTypeDecl(parentDecl, fullName) ++ "$" ++ typeDecl.getNameAsString
-
-        case _ =>
-          logger.warn("typeNameForTypeDecl expected nested typeDecl to have typeDecl parent.")
-          javaParserName
-      }
-
-    } else {
-      javaParserName
-    }
-  }
-
-  def getTypeName(typeDecl: TypeDeclaration[_], fullName: Boolean = true): String = {
-    val typeName = typeNameForTypeDecl(typeDecl, fullName)
+  def getTypeDeclType(typeDecl: TypeDeclaration[_], fullName: Boolean = true): String = {
+    val typeName = JP2JavaSrcTypeAdapter.typeNameForTypeDecl(typeDecl, fullName)
     if (fullName) {
       registerType(typeName)
     } else {
@@ -132,13 +47,15 @@ class TypeInfoProvider(global: Global) {
         getTypeFullName(resolvedType)
 
       case Success(resolvedType: ResolvedReferenceType) =>
-        resolvedReferenceTypeFullName(resolvedType)
+        JP2JavaSrcTypeAdapter.resolvedReferenceTypeFullName(resolvedType)
 
-      case Success(resolvedType: ResolvedType) => simpleResolvedTypeFullName(resolvedType)
+      case Success(resolvedType: ResolvedType) => JP2JavaSrcTypeAdapter.simpleResolvedTypeFullName(resolvedType)
 
       case Failure(_) =>
-        logger.debug(s"Resolving type ${node.getTypeAsString} failed. Falling back to import default.")
-        importInfo.getType(node.getTypeAsString)
+        node.getType match {
+          case primitive: PrimitiveType => Some(primitive.toString)
+          case _                        => None
+        }
     }
 
     typeFullName.map(registerType)
@@ -146,25 +63,11 @@ class TypeInfoProvider(global: Global) {
 
   def getTypeFullName(typ: ClassOrInterfaceType): Option[String] = {
     val typeFullName = Try(typ.resolve) match {
-      case Success(resolvedType) => resolvedReferenceTypeFullName(resolvedType)
+      case Success(resolvedType) => JP2JavaSrcTypeAdapter.resolvedReferenceTypeFullName(resolvedType)
 
       case Failure(_) =>
         logger.debug(s"Failed to resolve class type ${typ.getNameAsString}. Falling back to imports info.")
-        importInfo.getType(typ.getNameAsString)
-    }
-
-    typeFullName.map(registerType)
-  }
-
-  def getTypeFullName(annotationExpr: AnnotationExpr): Option[String] = {
-    val typeFullName = Try(annotationExpr.resolve()) match {
-      case Success(resolvedType) => Some(resolvedTypeDeclFullName(resolvedType))
-
-      case Failure(_) =>
-        logger.debug(
-          s"Failed to resolve annotation type ${annotationExpr.getNameAsString}. Falling back to imports info."
-        )
-        importInfo.getType(annotationExpr.getNameAsString)
+        None
     }
 
     typeFullName.map(registerType)
@@ -173,7 +76,7 @@ class TypeInfoProvider(global: Global) {
   def getTypeFullName(enumConstant: EnumConstantDeclaration): Option[String] = {
     val typeFullName = Try(enumConstant.resolve()) match {
       case Success(resolvedDeclaration) =>
-        resolvedTypeFullName(resolvedDeclaration.getType)
+        JP2JavaSrcTypeAdapter.resolvedTypeFullName(resolvedDeclaration.getType)
 
       case Failure(_) =>
         logger.debug(s"Failed to resolve enum entry type for ${enumConstant.getNameAsString}")
@@ -184,14 +87,14 @@ class TypeInfoProvider(global: Global) {
   }
 
   def getTypeFullName(referenceType: ReferenceType): Option[String] = {
-    val typeFullName = Try(referenceType.resolve()).toOption.flatMap(resolvedTypeFullName)
+    val typeFullName = Try(referenceType.resolve()).toOption.flatMap(JP2JavaSrcTypeAdapter.resolvedTypeFullName)
 
     typeFullName.map(registerType)
   }
 
   def getReturnType(node: Resolvable[ResolvedMethodDeclaration]): Option[String] = {
     val typeFullName = Try(node.resolve().getReturnType) match {
-      case Success(resolved) => resolvedTypeFullName(resolved)
+      case Success(resolved) => JP2JavaSrcTypeAdapter.resolvedTypeFullName(resolved)
 
       case Failure(_) =>
         logger.debug(s"Failed to resolve return type.")
@@ -201,70 +104,14 @@ class TypeInfoProvider(global: Global) {
     typeFullName.map(registerType)
   }
 
-  def getTypeFullName(nameExpr: NameExpr): Option[String] = {
-    val typeFullName = Try(nameExpr.calculateResolvedType()) match {
-      case Success(resolvedValueDeclaration) => resolvedTypeFullName(resolvedValueDeclaration)
-
-      case Failure(_) =>
-        logger.debug(s"Failed to resolved type for nameExpr ${nameExpr.getNameAsString}.")
-        None
-
-    }
+  def getTypeFullName(invocation: ExplicitConstructorInvocationStmt): Option[String] = {
+    val typeFullName = JP2JavaSrcTypeAdapter.typeForMethodLike(invocation)
 
     typeFullName.map(registerType)
-  }
-
-  def getTypeFullName(thisExpr: ThisExpr): Option[String] = {
-    val typeFullName =
-      Try(thisExpr.resolve()).toOption
-        .map(typeDecl => resolvedTypeDeclFullName(typeDecl))
-
-    typeFullName.map(registerType)
-  }
-
-  def getMethodLikeTypeFullName(methodLike: Resolvable[_ <: ResolvedMethodLikeDeclaration]): String = {
-    val typeFullName = Try(methodLike.resolve()) match {
-      case Success(declaration) => resolvedMethodLikeDeclFullName(declaration)
-
-      case Failure(_) =>
-        logger.debug(s"Failed to resolve type for method-like $methodLike. Defaulting to ANY")
-        "ANY"
-    }
-
-    registerType(typeFullName)
-  }
-
-  def getLiteralTypeFullName(literalExpr: LiteralExpr): String = {
-    val typeFullName = literalExpr match {
-      case _: BooleanLiteralExpr   => "boolean"
-      case _: CharLiteralExpr      => "char"
-      case _: DoubleLiteralExpr    => "double"
-      case _: IntegerLiteralExpr   => "int"
-      case _: LongLiteralExpr      => "long"
-      case _: NullLiteralExpr      => "null"
-      case _: StringLiteralExpr    => "java.lang.String"
-      case _: TextBlockLiteralExpr => "java.lang.String"
-      case _                       => UnresolvedTypeDefault
-    }
-
-    registerType(typeFullName)
-  }
-
-  def getTypeFullName(invocation: ExplicitConstructorInvocationStmt): String = {
-    val typeFullName = Try(invocation.resolve()) match {
-      case Success(declaration) =>
-        resolvedMethodLikeDeclFullName(declaration)
-
-      case Failure(_) =>
-        logger.debug(s"Could not resolve type for constructor invocation $invocation. Defaulting to ANY.")
-        "ANY"
-    }
-
-    registerType(typeFullName)
   }
 
   def getTypeFullName(resolvedParam: ResolvedParameterDeclaration): Option[String] = {
-    val typeFullName = resolvedTypeFullName(resolvedParam.getType)
+    val typeFullName = JP2JavaSrcTypeAdapter.resolvedTypeFullName(resolvedParam.getType)
     val arraySuffix = if (resolvedParam.isVariadic) {
       "[]"
     } else {
@@ -275,61 +122,27 @@ class TypeInfoProvider(global: Global) {
   }
 
   def getTypeForExpression(expr: Expression): Option[String] = {
-    val typeFullName = Try(expr.calculateResolvedType()) match {
-      case Success(resolvedType) => resolvedTypeFullName(resolvedType)
+    val fallbackType: Option[String] = expr match {
+      case namedExpr: NodeWithName[_] => scope.lookupVariableType(namedExpr.getNameAsString)
 
-      case Failure(_) =>
-        logger.debug(s"Could not resolve type for expr $expr")
-        None
-    }
+      case namedExpr: NodeWithSimpleName[_] => scope.lookupVariableType(namedExpr.getNameAsString)
 
-    typeFullName.map(registerType)
-  }
-
-  def getInitializerType(variableDeclarator: VariableDeclarator): Option[String] = {
-    val typeFullName = variableDeclarator.getInitializer.toScala flatMap { initializer =>
-      Try(initializer.calculateResolvedType()) match {
-        case Success(resolvedType) => resolvedTypeFullName(resolvedType)
-
-        case Failure(_) =>
-          logger.debug(s"Failed to resolve type for initializer ${initializer.toString}")
-          None
-      }
-    }
-
-    typeFullName.map(registerType)
-  }
-
-  def scopeType(scopeStack: Scope, isSuper: Boolean = false): String = {
-    scopeStack.getEnclosingTypeDecl match {
-      case Some(typ) if isSuper =>
-        val parentType = typ.inheritsFromTypeFullName.headOption.getOrElse(UnresolvedTypeDefault)
-        registerType(parentType)
-      case Some(typ) =>
-        registerType(typ.fullName)
-      case None => UnresolvedTypeDefault
-    }
-  }
-
-  def registerImports(imports: List[ImportDeclaration]): Unit = {
-    val (asteriskImports, specificImports) = imports.partition(_.isAsterisk)
-    val identifierMap = specificImports.map { importDecl =>
-      importDecl.getName.getIdentifier -> importDecl.getNameAsString
-    }.toMap
-
-    val wildcardImport = asteriskImports match {
-      case imp :: Nil => Some(imp.getNameAsString)
+      // JavaParser doesn't handle literals well for some reason
+      case literal: LiteralExpr => JP2JavaSrcTypeAdapter.typeForLiteral(literal)
 
       case _ => None
     }
 
-    importInfo = ImportInfo(identifierMap, wildcardImport)
+    val typeFullName = JP2JavaSrcTypeAdapter.typeForExpression(expr).orElse(fallbackType)
+
+    typeFullName.map(registerType)
   }
+
 }
 
 object TypeInfoProvider {
-  def apply(global: Global): TypeInfoProvider = {
-    new TypeInfoProvider(global)
+  def apply(global: Global, scope: Scope): TypeInfoProvider = {
+    new TypeInfoProvider(global, scope)
   }
 
   def isAutocastType(typeName: String): Boolean = {
@@ -348,7 +161,7 @@ object TypeInfoProvider {
     val Object: String  = "java.lang.Object"
   }
 
-  val NumericTypes = Set(
+  val NumericTypes: Set[String] = Set(
     "byte",
     "short",
     "int",
@@ -368,16 +181,4 @@ object TypeInfoProvider {
   )
 
   val UnresolvedTypeDefault = "ANY"
-
-  case class ImportInfo(identifierMap: Map[String, String], wildcardImport: Option[String]) {
-    def getType(name: String): Option[String] = {
-      identifierMap.get(name).orElse {
-        if (NumericTypes.contains(name)) {
-          Some(name)
-        } else {
-          wildcardImport.map(wc => s"$wc.$name")
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
This moves a lot of the ugly JavaParser type resolution logic into a separate class and merges some type methods where possible. Some of the scope type logic has also been moved into the `TypeInfoProvider` in an attempt to contain that as much as possible.

There's still work to do for separating everything cleanly, but this should give a decent indication of the general idea.

This is PR  1269 so, for no reason in particular, I  checked to see if anything interesting happened in the year 1269. From Wikipedia, there were a few mildly interesting candidates, but one stood out in particular:
* [Pélerin de Maricourt](https://en.wikipedia.org/wiki/Peter_of_Maricourt) first describes [magnetic poles](https://en.wikipedia.org/wiki/Magnet), and remarks on the nonexistence of [isolated magnetic poles](https://en.wikipedia.org/wiki/Magnetic_monopole).

This has nothing to do with joern, java, or code in general, but hopefully whoever reads this will find it interesting as well.