### PR TITLE
jimple2cpg: Annotation Support

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -1117,7 +1117,7 @@ object AstCreator {
     }.toSeq
   }
 
-  private val PRIMITIVES: Map[Char, String] = Map[Char, String](
+  private val primitives: Map[Char, String] = Map[Char, String](
     'Z' -> "boolean",
     'C' -> "char",
     'B' -> "byte",
@@ -1145,7 +1145,7 @@ object AstCreator {
           .mkString("")
         return s"$prefix$suffix"
       } else if (isPrimitive(c) && sb.indexOf("L") == -1) {
-        return s"${PRIMITIVES(c)}${sb.toString().toSeq.filter { _ == '[' }.map { _ => "[]" }.mkString("")}"
+        return s"${primitives(c)}${sb.toString().toSeq.filter { _ == '[' }.map { _ => "[]" }.mkString("")}"
       } else if (isObject(c)) {
         sb.append(c)
       } else if (isArray(c)) {
@@ -1163,7 +1163,7 @@ object AstCreator {
     *   true if the character is associated with a primitive, false if otherwise.
     */
   def isPrimitive(c: Char): Boolean =
-    PRIMITIVES.contains(c)
+    primitives.contains(c)
 
   /** Checks if the given character is associated an object or not according to Section 2.1.3 of the ASM docs.
     *

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -1132,7 +1132,7 @@ object AstCreator {
   def parseAsmType(signature: String): String = {
     val sigArr = signature.toCharArray
     val sb     = new StringBuilder()
-    sigArr.toSeq.foreach { c: Char =>
+    sigArr.toSeq.foreach { (c: Char) =>
       if (c == ';') {
         val prefix = sb
           .toString()

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
@@ -277,8 +277,8 @@ class AnnotationTestValue3 extends JimpleCodeToCpgFixture {
 
   "test annotation node parameter value" in {
     val Seq(paramValue: Annotation) = cpg.method.name("function").annotation.parameterAssign.value.l
-    paramValue.code shouldBe "@OtherAnnotation"
-    paramValue.fullName shouldBe "some.OtherAnnotation"
+    paramValue.code shouldBe "@OtherAnnotation()"
+    paramValue.fullName shouldBe "OtherAnnotation"
     paramValue.order shouldBe 2
   }
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
@@ -113,20 +113,24 @@ class AnnotationTestConstructor extends JimpleCodeToCpgFixture {
 
 class AnnotationTestParameter extends JimpleCodeToCpgFixture {
   override val code =
-    """
-      |import some.MarkerAnnotation;
-      |public class SomeClass {
+    """import java.lang.annotation.*;
       |
-      |  void function(@MarkerAnnotation int x) {
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.PARAMETER)
+      |@interface MarkerAnnotation { }
+      |
+      |class SomeClass {
+      |
+      |  void function(@MarkerAnnotation int x, int y) {
       |
       |  }
       |}
       |""".stripMargin
   "test annotation node properties" in {
     val annotationNode = cpg.method.name("function").parameter.name("x").annotation.head
-    annotationNode.code shouldBe "@MarkerAnnotation"
+    annotationNode.code shouldBe "@MarkerAnnotation()"
     annotationNode.name shouldBe "MarkerAnnotation"
-    annotationNode.fullName shouldBe "some.MarkerAnnotation"
+    annotationNode.fullName shouldBe "MarkerAnnotation"
   }
 }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
@@ -136,25 +136,37 @@ class AnnotationTestParameter extends JimpleCodeToCpgFixture {
 
 class AnnotationTestField extends JimpleCodeToCpgFixture {
   override val code =
-    """
-      |import some.MarkerAnnotation;
-      |public class SomeClass {
+    """import java.lang.annotation.*;
+      |
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.FIELD)
+      |@interface MarkerAnnotation { }
+      |
+      |class SomeClass {
       |  @MarkerAnnotation int x;
       |}
       |""".stripMargin
   "test annotation node properties" in {
     val annotationNode = cpg.typeDecl.name("SomeClass").member.name("x").annotation.head
-    annotationNode.code shouldBe "@MarkerAnnotation"
+    annotationNode.code shouldBe "@MarkerAnnotation()"
     annotationNode.name shouldBe "MarkerAnnotation"
-    annotationNode.fullName shouldBe "some.MarkerAnnotation"
+    annotationNode.fullName shouldBe "MarkerAnnotation"
   }
 }
 
 class AnnotationTestValue1 extends JimpleCodeToCpgFixture {
   override val code =
-    """
-      |import some.NormalAnnotation;
-      |public class SomeClass {
+    """import java.lang.annotation.*;
+      |
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.METHOD)
+      |@interface NormalAnnotation {
+      |
+      | public int value() default 0;
+      |
+      |}
+      |
+      |class SomeClass {
       |
       |  @NormalAnnotation(value = 2)
       |  void function() {
@@ -166,7 +178,7 @@ class AnnotationTestValue1 extends JimpleCodeToCpgFixture {
     val annotationNode = cpg.method.name("function").annotation.head
     annotationNode.code shouldBe "@NormalAnnotation(value = 2)"
     annotationNode.name shouldBe "NormalAnnotation"
-    annotationNode.fullName shouldBe "some.NormalAnnotation"
+    annotationNode.fullName shouldBe "NormalAnnotation"
   }
 
   "test annotation node parameter value" in {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
@@ -47,7 +47,7 @@ class AnnotationTestMethod1 extends JimpleCodeToCpgFixture {
 
   "test annotation node parameter value" in {
     val Seq(paramValue) = cpg.method.name("function").annotation.parameterAssign.value.l
-    paramValue.code shouldBe "classAnnotation"
+    paramValue.code shouldBe "\"classAnnotation\""
     paramValue.order shouldBe 2
     paramValue.argumentIndex shouldBe 2
   }
@@ -191,9 +191,17 @@ class AnnotationTestValue1 extends JimpleCodeToCpgFixture {
 
 class AnnotationTestValue2 extends JimpleCodeToCpgFixture {
   override val code =
-    """
-      |import some.NormalAnnotation;
-      |public class SomeClass {
+    """import java.lang.annotation.*;
+      |
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.METHOD)
+      |@interface NormalAnnotation {
+      |
+      | public String[] value() default {};
+      |
+      |}
+      |
+      |class SomeClass {
       |
       |  @NormalAnnotation(value = {"aaa", "bbb"})
       |  void function() {
@@ -203,14 +211,14 @@ class AnnotationTestValue2 extends JimpleCodeToCpgFixture {
       |""".stripMargin
   "test annotation node properties" in {
     val annotationNode = cpg.method.name("function").annotation.head
-    annotationNode.code shouldBe "@NormalAnnotation(value = { \"aaa\", \"bbb\" })"
+    annotationNode.code shouldBe "@NormalAnnotation(value = {\"aaa\", \"bbb\"})"
     annotationNode.name shouldBe "NormalAnnotation"
-    annotationNode.fullName shouldBe "some.NormalAnnotation"
+    annotationNode.fullName shouldBe "NormalAnnotation"
   }
 
   "test annotation node parameter assignment child" in {
     val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
-    paramAssign.code shouldBe "value = { \"aaa\", \"bbb\" }"
+    paramAssign.code shouldBe "value = {\"aaa\", \"bbb\"}"
     paramAssign.order shouldBe 1
   }
 
@@ -222,26 +230,37 @@ class AnnotationTestValue2 extends JimpleCodeToCpgFixture {
 
   "test annotation node parameter value" in {
     val Seq(paramValue: ArrayInitializer) = cpg.method.name("function").annotation.parameterAssign.value.l
-    paramValue.code shouldBe "{ \"aaa\", \"bbb\" }"
+    paramValue.code shouldBe "{\"aaa\", \"bbb\"}"
     paramValue.order shouldBe 2
     paramValue.argumentIndex shouldBe 2
   }
 
   "test annotation node array initializer children" in {
     val children = cpg.method.name("function").annotation.parameterAssign.value.astChildren.isExpression.s
-    children.find(_.code == "aaa").map(_.order) shouldBe Some(1)
-    children.find(_.code == "aaa").map(_.argumentIndex) shouldBe Some(1)
-    children.find(_.code == "bbb").map(_.order) shouldBe Some(2)
-    children.find(_.code == "bbb").map(_.argumentIndex) shouldBe Some(2)
+    children.find(_.code == "\"aaa\"").map(_.order) shouldBe Some(1)
+    children.find(_.code == "\"aaa\"").map(_.argumentIndex) shouldBe Some(1)
+    children.find(_.code == "\"bbb\"").map(_.order) shouldBe Some(2)
+    children.find(_.code == "\"bbb\"").map(_.argumentIndex) shouldBe Some(2)
   }
 }
 
 class AnnotationTestValue3 extends JimpleCodeToCpgFixture {
   override val code =
-    """
-      |import some.NormalAnnotation;
-      |import some.OtherAnnotation;
-      |public class SomeClass {
+    """import java.lang.annotation.*;
+      |
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.METHOD)
+      |@interface NormalAnnotation {
+      |
+      | public OtherAnnotation value();
+      |
+      |}
+      |
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.METHOD)
+      |@interface OtherAnnotation { }
+      |
+      |class SomeClass {
       |
       |  @NormalAnnotation(value = @OtherAnnotation)
       |  void function() {
@@ -251,9 +270,9 @@ class AnnotationTestValue3 extends JimpleCodeToCpgFixture {
       |""".stripMargin
   "test annotation node properties" in {
     val annotationNode = cpg.method.name("function").annotation.head
-    annotationNode.code shouldBe "@NormalAnnotation(value = @OtherAnnotation)"
+    annotationNode.code shouldBe "@NormalAnnotation(value = @OtherAnnotation())"
     annotationNode.name shouldBe "NormalAnnotation"
-    annotationNode.fullName shouldBe "some.NormalAnnotation"
+    annotationNode.fullName shouldBe "NormalAnnotation"
   }
 
   "test annotation node parameter value" in {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/AnnotationTests.scala
@@ -1,0 +1,249 @@
+package io.joern.jimple2cpg.querying
+
+import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.{Annotation, AnnotationLiteral, ArrayInitializer}
+
+class AnnotationTestMethod1 extends JimpleCodeToCpgFixture {
+
+  override val code =
+    """import java.lang.annotation.*;
+      |
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.METHOD)
+      |@interface NormalAnnotation {
+      |
+      | public String value() default "";
+      |
+      |}
+      |
+      |class SomeClass {
+      |
+      |  @NormalAnnotation(value = "classAnnotation")
+      |  void function() {
+      |
+      |  }
+      |}
+      |""".stripMargin
+
+  "test annotation node properties" in {
+    val annotationNode = cpg.method.name("function").annotation.head
+    annotationNode.code shouldBe "@NormalAnnotation(value = \"classAnnotation\")"
+    annotationNode.name shouldBe "NormalAnnotation"
+    annotationNode.fullName shouldBe "NormalAnnotation"
+  }
+
+  "test annotation node parameter assignment child" in {
+    val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
+    paramAssign.code shouldBe "value = \"classAnnotation\""
+    paramAssign.order shouldBe 1
+  }
+
+  "test annotation node parameter child" in {
+    val Seq(param) = cpg.method.name("function").annotation.parameterAssign.parameter.l
+    param.code shouldBe "value"
+    param.order shouldBe 1
+  }
+
+  "test annotation node parameter value" in {
+    val Seq(paramValue) = cpg.method.name("function").annotation.parameterAssign.value.l
+    paramValue.code shouldBe "classAnnotation"
+    paramValue.order shouldBe 2
+    paramValue.argumentIndex shouldBe 2
+  }
+}
+
+class AnnotationTestMethod2 extends JimpleCodeToCpgFixture {
+  override val code =
+    """import java.lang.annotation.*;
+      |
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.METHOD)
+      |@interface MarkerAnnotation { }
+      |
+      |class SomeClass {
+      |
+      |  @MarkerAnnotation()
+      |  void function() {
+      |
+      |  }
+      |}
+      |""".stripMargin
+
+  "test annotation node properties" in {
+    val annotationNode = cpg.method.name("function").annotation.head
+    annotationNode.code shouldBe "@MarkerAnnotation()"
+    annotationNode.name shouldBe "MarkerAnnotation"
+    annotationNode.fullName shouldBe "MarkerAnnotation"
+  }
+
+  "test annotation node parameter assignment child" in {
+    cpg.method.name("function").annotation.parameterAssign.isEmpty shouldBe true
+  }
+}
+
+class AnnotationTestConstructor extends JimpleCodeToCpgFixture {
+  override val code =
+    """import java.lang.annotation.*;
+      |
+      |@Retention(RetentionPolicy.RUNTIME)
+      |@Target(ElementType.CONSTRUCTOR)
+      |@interface MarkerAnnotation { }
+      |
+      |class SomeClass {
+      |
+      |  @MarkerAnnotation()
+      |  public SomeClass() {
+      |
+      |  }
+      |}
+      |""".stripMargin
+
+  "test annotation node properties" in {
+    val annotationNode = cpg.method.fullNameExact("SomeClass.<init>:void()").annotation.head
+    annotationNode.code shouldBe "@MarkerAnnotation()"
+    annotationNode.name shouldBe "MarkerAnnotation"
+    annotationNode.fullName shouldBe "MarkerAnnotation"
+  }
+
+  "test annotation node parameter assignment child" in {
+    cpg.method.name("function").annotation.parameterAssign.isEmpty shouldBe true
+  }
+}
+
+class AnnotationTestParameter extends JimpleCodeToCpgFixture {
+  override val code =
+    """
+      |import some.MarkerAnnotation;
+      |public class SomeClass {
+      |
+      |  void function(@MarkerAnnotation int x) {
+      |
+      |  }
+      |}
+      |""".stripMargin
+  "test annotation node properties" in {
+    val annotationNode = cpg.method.name("function").parameter.name("x").annotation.head
+    annotationNode.code shouldBe "@MarkerAnnotation"
+    annotationNode.name shouldBe "MarkerAnnotation"
+    annotationNode.fullName shouldBe "some.MarkerAnnotation"
+  }
+}
+
+class AnnotationTestField extends JimpleCodeToCpgFixture {
+  override val code =
+    """
+      |import some.MarkerAnnotation;
+      |public class SomeClass {
+      |  @MarkerAnnotation int x;
+      |}
+      |""".stripMargin
+  "test annotation node properties" in {
+    val annotationNode = cpg.typeDecl.name("SomeClass").member.name("x").annotation.head
+    annotationNode.code shouldBe "@MarkerAnnotation"
+    annotationNode.name shouldBe "MarkerAnnotation"
+    annotationNode.fullName shouldBe "some.MarkerAnnotation"
+  }
+}
+
+class AnnotationTestValue1 extends JimpleCodeToCpgFixture {
+  override val code =
+    """
+      |import some.NormalAnnotation;
+      |public class SomeClass {
+      |
+      |  @NormalAnnotation(value = 2)
+      |  void function() {
+      |
+      |  }
+      |}
+      |""".stripMargin
+  "test annotation node properties" in {
+    val annotationNode = cpg.method.name("function").annotation.head
+    annotationNode.code shouldBe "@NormalAnnotation(value = 2)"
+    annotationNode.name shouldBe "NormalAnnotation"
+    annotationNode.fullName shouldBe "some.NormalAnnotation"
+  }
+
+  "test annotation node parameter value" in {
+    val Seq(paramValue: AnnotationLiteral) = cpg.method.name("function").annotation.parameterAssign.value.l
+    paramValue.code shouldBe "2"
+    paramValue.order shouldBe 2
+    paramValue.argumentIndex shouldBe 2
+  }
+}
+
+class AnnotationTestValue2 extends JimpleCodeToCpgFixture {
+  override val code =
+    """
+      |import some.NormalAnnotation;
+      |public class SomeClass {
+      |
+      |  @NormalAnnotation(value = {"aaa", "bbb"})
+      |  void function() {
+      |
+      |  }
+      |}
+      |""".stripMargin
+  "test annotation node properties" in {
+    val annotationNode = cpg.method.name("function").annotation.head
+    annotationNode.code shouldBe "@NormalAnnotation(value = { \"aaa\", \"bbb\" })"
+    annotationNode.name shouldBe "NormalAnnotation"
+    annotationNode.fullName shouldBe "some.NormalAnnotation"
+  }
+
+  "test annotation node parameter assignment child" in {
+    val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
+    paramAssign.code shouldBe "value = { \"aaa\", \"bbb\" }"
+    paramAssign.order shouldBe 1
+  }
+
+  "test annotation node parameter child" in {
+    val Seq(param) = cpg.method.name("function").annotation.parameterAssign.parameter.l
+    param.code shouldBe "value"
+    param.order shouldBe 1
+  }
+
+  "test annotation node parameter value" in {
+    val Seq(paramValue: ArrayInitializer) = cpg.method.name("function").annotation.parameterAssign.value.l
+    paramValue.code shouldBe "{ \"aaa\", \"bbb\" }"
+    paramValue.order shouldBe 2
+    paramValue.argumentIndex shouldBe 2
+  }
+
+  "test annotation node array initializer children" in {
+    val children = cpg.method.name("function").annotation.parameterAssign.value.astChildren.isExpression.s
+    children.find(_.code == "aaa").map(_.order) shouldBe Some(1)
+    children.find(_.code == "aaa").map(_.argumentIndex) shouldBe Some(1)
+    children.find(_.code == "bbb").map(_.order) shouldBe Some(2)
+    children.find(_.code == "bbb").map(_.argumentIndex) shouldBe Some(2)
+  }
+}
+
+class AnnotationTestValue3 extends JimpleCodeToCpgFixture {
+  override val code =
+    """
+      |import some.NormalAnnotation;
+      |import some.OtherAnnotation;
+      |public class SomeClass {
+      |
+      |  @NormalAnnotation(value = @OtherAnnotation)
+      |  void function() {
+      |
+      |  }
+      |}
+      |""".stripMargin
+  "test annotation node properties" in {
+    val annotationNode = cpg.method.name("function").annotation.head
+    annotationNode.code shouldBe "@NormalAnnotation(value = @OtherAnnotation)"
+    annotationNode.name shouldBe "NormalAnnotation"
+    annotationNode.fullName shouldBe "some.NormalAnnotation"
+  }
+
+  "test annotation node parameter value" in {
+    val Seq(paramValue: Annotation) = cpg.method.name("function").annotation.parameterAssign.value.l
+    paramValue.code shouldBe "@OtherAnnotation"
+    paramValue.fullName shouldBe "some.OtherAnnotation"
+    paramValue.order shouldBe 2
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -40,15 +40,17 @@ object DotSerializer {
 
   private def stringRepr(vertex: StoredNode): String = {
     escape(vertex match {
-      case call: Call               => (call.name, call.code).toString
-      case expr: Expression         => (expr.label, expr.code, toCfgNode(expr).code).toString
-      case method: Method           => (method.label, method.name).toString
-      case ret: MethodReturn        => (ret.label, ret.typeFullName).toString
-      case param: MethodParameterIn => ("PARAM", param.code).toString
-      case local: Local             => (local.label, s"${local.code}: ${local.typeFullName}").toString
-      case target: JumpTarget       => (target.label, target.name).toString
-      case modifier: Modifier       => ("MODIFIER", modifier.modifierType).toString()
-      case _                        => ""
+      case call: Call                            => (call.name, call.code).toString
+      case expr: Expression                      => (expr.label, expr.code, toCfgNode(expr).code).toString
+      case method: Method                        => (method.label, method.name).toString
+      case ret: MethodReturn                     => (ret.label, ret.typeFullName).toString
+      case param: MethodParameterIn              => ("PARAM", param.code).toString
+      case local: Local                          => (local.label, s"${local.code}: ${local.typeFullName}").toString
+      case target: JumpTarget                    => (target.label, target.name).toString
+      case modifier: Modifier                    => (modifier.label, modifier.modifierType).toString()
+      case annoAssign: AnnotationParameterAssign => (annoAssign.label, annoAssign.code).toString()
+      case annoParam: AnnotationParameter        => (annoParam.label, annoParam.code).toString()
+      case _                                     => ""
     })
   }
 


### PR DESCRIPTION
Borrowed `javasrc2cpg` tests for annotations and have implemented these in `jimple` with subtle differences:

- Included missing string implementation for annotation nodes in `DotSerializer`
- All `code` properties for annotations include call parenthesis e.g. `@NormalAnnotation()`
- `code` properties for string literals are surrounded by double quotations (`"`)