### PR TITLE
Downgrade ANTLR to 4.7

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,7 +2,9 @@
 object Versions {
   val cpg           = parseVersion("cpgVersion")
   val js2cpg        = parseVersion("js2cpgVersion")
-  val antlr         = "4.10"
+  // Dont upgrade antlr to 4.10 or above since those versions require java 11 or higher which
+  // causes problems upstreams.
+  val antlr         = "4.7"
   val scalatest     = "3.2.11"
   val cats          = "3.3.11"
   val log4j         = "2.17.2"


### PR DESCRIPTION
Using 4.10 causes problems with upstream since 4.10 requires java 11.