### PR TITLE
jimple2cpg: Correctly Handling Class Constants

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -976,7 +976,7 @@ object AstCreator {
     }.toSeq
   }
 
-  private val PRIMITIVES: Map[Char, String] = Map[Char, String](
+  private val primitives: Map[Char, String] = Map[Char, String](
     'Z' -> "boolean",
     'C' -> "char",
     'B' -> "byte",
@@ -1004,7 +1004,7 @@ object AstCreator {
           .mkString("")
         return s"$prefix$suffix"
       } else if (isPrimitive(c) && sb.indexOf("L") == -1) {
-        return s"${PRIMITIVES(c)}${sb.toString().toSeq.filter { _ == '[' }.map { _ => "[]" }.mkString("")}"
+        return s"${primitives(c)}${sb.toString().toSeq.filter { _ == '[' }.map { _ => "[]" }.mkString("")}"
       } else if (isObject(c)) {
         sb.append(c)
       } else if (isArray(c)) {
@@ -1022,7 +1022,7 @@ object AstCreator {
     *   true if the character is associated with a primitive, false if otherwise.
     */
   def isPrimitive(c: Char): Boolean =
-    PRIMITIVES.contains(c)
+    primitives.contains(c)
 
   /** Checks if the given character is associated an object or not according to Section 2.1.3 of the ASM docs.
     *

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ReflectionTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ReflectionTests.scala
@@ -1,0 +1,40 @@
+package io.joern.jimple2cpg.querying
+
+import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.shiftleft.semanticcpg.language._
+
+/** Right now reflection is mostly unsupported. This should be extended in later when it is.
+  */
+class ReflectionTests extends JimpleCodeToCpgFixture {
+
+  override val code: String =
+    """
+      |class Foo {
+      | static int add(int x, int y) {
+      |   return x + y;
+      | }
+      |
+      | static void foo() throws NoSuchMethodException {
+      |   var fooClazz = Foo.class;
+      |   var fooMethod = fooClazz.getMethod("add", int.class, int.class);
+      | }
+      |}
+      |""".stripMargin
+
+  "should assign the class and method variables correctly" in {
+    val List(fooClazz, fooMethod) = cpg.method("foo").ast.isIdentifier.name("fooClazz", "fooMethod").take(2).l
+
+    fooClazz.typeFullName shouldBe "java.lang.Class"
+    fooClazz.parentExpression match {
+      case Some(call) =>
+        call.ast.isLiteral.headOption match {
+          case Some(classLiteral) =>
+            classLiteral.code shouldBe "Foo.class"
+            classLiteral.typeFullName shouldBe "java.lang.Class"
+          case None => fail("Should be assigned to a class literal")
+        }
+      case None => fail("Should be the child of an <operator>.assignment call")
+    }
+    fooMethod.typeFullName shouldBe "java.lang.reflect.Method"
+  }
+}


### PR DESCRIPTION
- Created a test suite for reflection-related operations
- Implemented the `Literal` for class constants and nulls
- Brought in `parseAsmType` from the annotations branch for jimple2cpg