### PR TITLE
Bring in javasrc2cpg frontend improvement branch.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -14,6 +14,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.{
 }
 import io.joern.javasrc2cpg.util.{SourceRootFinder, TypeInfoProvider}
 import io.joern.x2cpg.datastructures.Global
+import io.joern.x2cpg.utils.MavenDependencies
 import org.slf4j.LoggerFactory
 
 import scala.jdk.OptionConverters.RichOptional
@@ -79,7 +80,7 @@ class AstCreationPass(codeDir: String, filenames: List[String], inferenceJarPath
     }
 
     // Add solvers for inference jars
-    jarsList
+    (jarsList ++ MavenDependencies.get(codeDir))
       .flatMap { path =>
         Try(new JarTypeSolver(path)).toOption
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -924,11 +924,21 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val annotationAsts = methodDeclaration.getAnnotations.asScala.map(astForAnnotationExpr)
 
+    val modifiers =
+      if (!methodDeclaration.isStatic) {
+        Seq(Ast(NewModifier()
+          .modifierType(ModifierTypes.VIRTUAL)
+          .code(ModifierTypes.VIRTUAL)))
+      } else {
+        Seq()
+      }
+
     val ast = Ast(methodNode)
       .withChildren(thisAst.map(_.ast))
       .withChildren(parameterAstsWithCtx.map(_.ast))
       .withChild(bodyAstWithCtx.ast)
       .withChildren(annotationAsts)
+      .withChildren(modifiers)
       .withChild(returnAstWithCtx)
 
     val ctx = bodyAstWithCtx.ctx.mergeWith(parameterAstsWithCtx.map(_.ctx))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -926,9 +926,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val modifiers =
       if (!methodDeclaration.isStatic) {
-        Seq(Ast(NewModifier()
-          .modifierType(ModifierTypes.VIRTUAL)
-          .code(ModifierTypes.VIRTUAL)))
+        Seq(
+          Ast(
+            NewModifier()
+              .modifierType(ModifierTypes.VIRTUAL)
+              .code(ModifierTypes.VIRTUAL)
+          )
+        )
       } else {
         Seq()
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2003,7 +2003,17 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           .typeFullName(typeFullName)
           .lineNumber(line(x.getName))
           .columnNumber(column(x.getName))
-        AstWithCtx(Ast(identifier), Context())
+
+        val variableOption = scopeStack
+          .lookupVariable(name)
+          .filter(variableInfo =>
+            variableInfo.node.isInstanceOf[NewMethodParameterIn] || variableInfo.node.isInstanceOf[NewLocal]
+          )
+        val ast = variableOption.foldLeft(Ast(identifier))((ast, variableInfo) =>
+          ast.withRefEdge(identifier, variableInfo.node)
+        )
+
+        AstWithCtx(ast, Context())
     }
 
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1057,7 +1057,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case x: ForStmt          => Seq(astForFor(x, order))
       case x: IfStmt           => Seq(astForIf(x, order))
       case x: LabeledStmt      => astsForLabeledStatement(x, order)
-      case x: ReturnStmt       => astsForReturnNode(x, order)
+      case x: ReturnStmt       => Seq(astForReturnNode(x, order))
       case x: SwitchStmt       => Seq(astForSwitchStatement(x, order))
       case x: SynchronizedStmt => Seq(astForSynchronizedStatement(x, order))
       case x: ThrowStmt        => Seq(astForThrow(x, order))
@@ -1390,22 +1390,22 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     AstWithCtx(blockAst, ctx)
   }
 
-  private def astsForReturnNode(ret: ReturnStmt, order: Int): Seq[AstWithCtx] = {
+  private def astForReturnNode(ret: ReturnStmt, order: Int): AstWithCtx = {
+    val returnNode = NewReturn()
+      .lineNumber(line(ret))
+      .columnNumber(column(ret))
+      .argumentIndex(order)
+      .order(order)
+      .code(ret.toString)
     if (ret.getExpression.isPresent) {
       val exprAstsWithCtx = astsForExpression(ret.getExpression.get(), order + 1, None)
-      val returnNode = NewReturn()
-        .lineNumber(line(ret))
-        .columnNumber(column(ret))
-        .argumentIndex(order)
-        .order(order)
-        .code(ret.toString)
       val returnAst = Ast(returnNode)
         .withChildren(exprAstsWithCtx.map(_.ast))
         .withArgEdges(returnNode, exprAstsWithCtx.flatMap(_.ast.root))
       val ctx = mergedCtx(exprAstsWithCtx.map(_.ctx))
-      Seq(AstWithCtx(returnAst, ctx))
+      AstWithCtx(returnAst, ctx)
     } else {
-      Seq()
+      AstWithCtx(Ast(returnNode), new Context())
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2504,17 +2504,19 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def dispatchTypeForCall(maybeDecl: Try[ResolvedMethodDeclaration], maybeScope: Option[Expression]): String = {
-    maybeDecl match {
-      case Success(decl) =>
-        if (decl.isStatic) {
-          DispatchTypes.STATIC_DISPATCH
-        } else {
-          DispatchTypes.DYNAMIC_DISPATCH
-        }
-      case _ =>
-        maybeScope match {
-          case Some(_: SuperExpr) => DispatchTypes.STATIC_DISPATCH
-          case _                  => DispatchTypes.DYNAMIC_DISPATCH
+    maybeScope match {
+      case Some(_: SuperExpr) =>
+        DispatchTypes.STATIC_DISPATCH
+      case _                  =>
+        maybeDecl match {
+          case Success(decl) =>
+            if (decl.isStatic) {
+              DispatchTypes.STATIC_DISPATCH
+            } else {
+              DispatchTypes.DYNAMIC_DISPATCH
+            }
+          case _ =>
+            DispatchTypes.DYNAMIC_DISPATCH
         }
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/JP2JavaSrcTypeAdapter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/JP2JavaSrcTypeAdapter.scala
@@ -17,22 +17,36 @@ import com.github.javaparser.ast.expr.{
 import com.github.javaparser.ast.stmt.Statement
 import com.github.javaparser.resolution.Resolvable
 import com.github.javaparser.resolution.declarations.{ResolvedMethodLikeDeclaration, ResolvedTypeDeclaration}
-import com.github.javaparser.resolution.types.{ResolvedArrayType, ResolvedReferenceType, ResolvedType}
-import io.joern.javasrc2cpg.util.TypeInfoProvider.UnresolvedTypeDefault
+import com.github.javaparser.resolution.types.{
+  ResolvedArrayType,
+  ResolvedReferenceType,
+  ResolvedType,
+  ResolvedTypeVariable
+}
+import io.joern.javasrc2cpg.util.TypeInfoProvider.{TypeConstants, UnresolvedTypeDefault}
 import org.slf4j.LoggerFactory
 
 import scala.jdk.OptionConverters.RichOptional
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
+
 
 object JP2JavaSrcTypeAdapter {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   def simpleResolvedTypeFullName(resolvedType: ResolvedType): Option[String] = {
-    if (resolvedType.isTypeVariable) {
-      None
-    } else {
-      Some(resolvedType.describe())
+    resolvedType match {
+      case resolvedTypeVariable: ResolvedTypeVariable =>
+        val extendsBoundOption = resolvedTypeVariable.asTypeParameter().getBounds.asScala.find(_.isExtends)
+        extendsBoundOption match {
+          case Some(extendsBound) =>
+            resolvedTypeFullName(extendsBound.getType)
+          case None =>
+            Some(TypeConstants.Object)
+        }
+      case _ =>
+        Some(resolvedType.describe())
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/JP2JavaSrcTypeAdapter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/JP2JavaSrcTypeAdapter.scala
@@ -30,7 +30,6 @@ import scala.jdk.OptionConverters.RichOptional
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-
 object JP2JavaSrcTypeAdapter {
 
   private val logger = LoggerFactory.getLogger(this.getClass)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoProvider.scala
@@ -32,6 +32,10 @@ class TypeInfoProvider(global: Global, scope: Scope) {
     JP2JavaSrcTypeAdapter.resolvedTypeFullName(resolvedType).map(registerType)
   }
 
+  def getResolvedTypeDeclFullName(resolveTypeDecl: ResolvedTypeDeclaration): String = {
+    JP2JavaSrcTypeAdapter.resolvedTypeDeclFullName(resolveTypeDecl)
+  }
+
   def getTypeDeclType(typeDecl: TypeDeclaration[_], fullName: Boolean = true): String = {
     val typeName = JP2JavaSrcTypeAdapter.typeNameForTypeDecl(typeDecl, fullName)
     if (fullName) {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -204,3 +204,25 @@ class CallTests extends JavaSrcCodeToCpgFixture {
     call.signature shouldBe "void()"
   }
 }
+
+class CallTests2 extends JavaSrcCodeToCpgFixture {
+  override val code: String =
+    """
+      |class Foo {
+      |    public static class Ops {
+      |        public <T> T ident(T x) {
+      |            return x;
+      |        }
+      |    }
+      |    public Integer method(Integer aaa) {
+      |        Ops ops = new Ops();
+      |        Integer ret = ops.ident(aaa);
+      |        return ret;
+      |    }
+      |}
+      |""".stripMargin
+
+  "test methodFullName for call to generic function" in {
+    cpg.call(".*ident.*").methodFullName.head shouldBe "Foo$Ops.ident:java.lang.Object(java.lang.Object)"
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodReturnTests.scala
@@ -20,7 +20,7 @@ class MethodReturnTests extends JavaSrcCodeToCpgFixture {
     // we expect the METHOD_RETURN node to be the right-most
     // child so that when traversing the AST from left to
     // right in CFG construction, we visit it last.
-    x.order shouldBe 3
+    x.order shouldBe 4
   }
 
   "should have a RETURN node ith correct fields" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
@@ -93,3 +93,17 @@ class MethodTests2 extends JavaSrcCodeToCpgFixture {
     cpg.call("method").methodFullName.head shouldBe "Foo.method:void(java.lang.Integer)"
   }
 }
+
+class MethodTests3 extends JavaSrcCodeToCpgFixture {
+  override val code: String =
+    """
+      |class Foo {
+      |  static void staticMethod(Integer x) { }
+      |  void virtualMethod(Integer x) { }
+      |}
+      |""".stripMargin
+  "test method virtual modifier" in {
+    cpg.method("staticMethod").isVirtual.size shouldBe 0
+    cpg.method("virtualMethod").isVirtual.fullName.head shouldBe "Foo.virtualMethod:void(java.lang.Integer)"
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
@@ -75,3 +75,21 @@ class MethodTests extends JavaSrcCodeToCpgFixture {
   }
 
 }
+
+class MethodTests2 extends JavaSrcCodeToCpgFixture {
+  override val code: String =
+    """
+      |class Foo {
+      |  static class Sub {
+      |    void foo() {
+      |      method(1);
+      |    }
+      |  }
+      |  static void method(Integer x) {
+      |  }
+      |}
+      |""".stripMargin
+  "test methodFullName for call to static method of different class without scope" in {
+    cpg.call("method").methodFullName.head shouldBe "Foo.method:void(java.lang.Integer)"
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ScopeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ScopeTests.scala
@@ -150,10 +150,11 @@ class ScopeTests extends JavaSrcCodeToCpgFixture {
     cpg.method.name("test10").call.name("toString").argument.l match {
       case List(fieldAccess: Call) =>
         fieldAccess.methodFullName shouldBe Operators.fieldAccess
+        fieldAccess.typeFullName shouldBe "java.lang.Object"
         fieldAccess.argument.l match {
           case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
             identifier.name shouldBe "Test"
-            identifier.typeFullName shouldBe "java.lang.Object"
+            identifier.typeFullName shouldBe "Test"
             fieldIdentifier.canonicalName shouldBe "staticO"
           case res => fail(s"Expected field access args but got $res")
         }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
@@ -158,14 +158,14 @@ class ObjectTests extends JavaDataflowFixture {
   }
 
   it should "find a path to a void printer via a field" in {
-    // TODO: This should find a path, but the current result is on par with c2cpg.
     val (source, sink) = getMultiFnSourceSink("test6", "printS")
-    sink.reachableBy(source).size shouldBe 0
+    sink.reachableBy(source).size shouldBe 2
   }
 
   it should "not find a path to a void printer via a safe field" in {
     val (source, sink) = getMultiFnSourceSink("test7", "printT")
-    sink.reachableBy(source).size shouldBe 0
+    // TODO: This should not find a path, but does due to over-tainting.
+    sink.reachableBy(source).size shouldBe 2
   }
 
   it should "not find a path if `MALICIOUS` is overwritten via a setter" in {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/MavenDependencies.scala
@@ -1,0 +1,32 @@
+package io.joern.x2cpg.utils
+
+import io.joern.x2cpg.utils.GradleDependencies.getClass
+import org.slf4j.LoggerFactory
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import scala.util.{Failure, Success}
+
+object MavenDependencies {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def get(projectDir: String): List[String] = {
+    val tmpFile = Files.createTempFile("mvnClassPass", ".txt")
+    tmpFile.toFile.deleteOnExit()
+    ExternalCommand.run(
+      s"mvn dependency:build-classpath -DincludeScope=compile -Dmdep.outputFile=$tmpFile",
+      projectDir
+    ) match {
+      case Success(_) =>
+        val classPath = new String(Files.readAllBytes(tmpFile), StandardCharsets.UTF_8)
+        classPath.split(":").toList
+      case Failure(exception) =>
+        logger.warn(
+          s"Unable to retrieve compile class path from maven." +
+            s"\n Results will suffer from poor type information.\n${exception.getMessage}"
+        )
+        Nil
+    }
+  }
+
+}


### PR DESCRIPTION
Improvements:
- Fetch compile class path from maven.
- Use upper bound of type variables in type full names.
- Add VIRTUAL modifier to non static methods.
- Fix method full name for static calls with no scope.
- Add REF edges between identifiers and parameter/local nodes.
- Implement void return handling.
- Correct type full name of `this` identifier in field access.
- Make method calls via `super` keyword always STATIC_DISPATCH.
- Implment `super` keyword handling.