### PR TITLE
Interprocedural Dot File Generator: Call Graphs

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotCpg14Generator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotCpg14Generator.scala
@@ -15,7 +15,7 @@ object DotCpg14Generator {
     val cfg = new CfgGenerator().generate(method)
     val ddg = new DdgGenerator().generate(method)
     val cdg = new CdgGenerator().generate(method)
-    DotSerializer.dotGraph(method, ast ++ cfg ++ ddg ++ cdg, withEdgeTypes = true)
+    DotSerializer.dotGraph(Some(method), ast ++ cfg ++ ddg ++ cdg, withEdgeTypes = true)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotCpg14Generator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotCpg14Generator.scala
@@ -15,7 +15,7 @@ object DotCpg14Generator {
     val cfg = new CfgGenerator().generate(method)
     val ddg = new DdgGenerator().generate(method)
     val cdg = new CdgGenerator().generate(method)
-    DotSerializer.dotGraph(Some(method), ast ++ cfg ++ ddg ++ cdg, withEdgeTypes = true)
+    DotSerializer.dotGraph(Option(method), ast ++ cfg ++ ddg ++ cdg, withEdgeTypes = true)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -13,7 +13,7 @@ object DotDdgGenerator {
   private def dotGraphForMethod(method: Method)(implicit semantics: Semantics): String = {
     val ddgGenerator = new DdgGenerator()
     val ddg          = ddgGenerator.generate(method)
-    DotSerializer.dotGraph(method, ddg)
+    DotSerializer.dotGraph(Some(method), ddg)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -13,7 +13,7 @@ object DotDdgGenerator {
   private def dotGraphForMethod(method: Method)(implicit semantics: Semantics): String = {
     val ddgGenerator = new DdgGenerator()
     val ddg          = ddgGenerator.generate(method)
-    DotSerializer.dotGraph(Some(method), ddg)
+    DotSerializer.dotGraph(Option(method), ddg)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotPdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotPdgGenerator.scala
@@ -13,7 +13,7 @@ object DotPdgGenerator {
   private def dotGraphForMethod(method: Method)(implicit semantics: Semantics): String = {
     val ddg = new DdgGenerator().generate(method)
     val cdg = new CdgGenerator().generate(method)
-    DotSerializer.dotGraph(Some(method), ddg.++(cdg), withEdgeTypes = true)
+    DotSerializer.dotGraph(Option(method), ddg.++(cdg), withEdgeTypes = true)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotPdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotPdgGenerator.scala
@@ -13,7 +13,7 @@ object DotPdgGenerator {
   private def dotGraphForMethod(method: Method)(implicit semantics: Semantics): String = {
     val ddg = new DdgGenerator().generate(method)
     val cdg = new CdgGenerator().generate(method)
-    DotSerializer.dotGraph(method, ddg.++(cdg), withEdgeTypes = true)
+    DotSerializer.dotGraph(Some(method), ddg.++(cdg), withEdgeTypes = true)
   }
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -1047,6 +1047,8 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
       .isExternal(false)
       .order(childNum)
       .filename(filename)
+      .astParentType(NodeTypes.TYPE_DECL)
+      .astParentFullName(typeDecl.toQuotedString)
       .lineNumber(line(methodDeclaration))
       .columnNumber(column(methodDeclaration))
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CallGraphGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CallGraphGenerator.scala
@@ -12,14 +12,14 @@ class CallGraphGenerator {
   def generate(cpg: Cpg): Graph = {
     val subgraph = mutable.HashMap.empty[String, Seq[StoredNode]]
     val vertices = cpg.all.collect { case m: Method => m }.l
-    val edges = vertices.flatMap { srcMethod =>
-      storeInSubgraph(srcMethod, subgraph)
-      srcMethod.call.flatMap { child =>
-        child.callOut.map { tgt =>
-          storeInSubgraph(tgt, subgraph)
-          Edge(srcMethod, tgt, label = child.dispatchType.stripSuffix("_DISPATCH"))
-        }
-      }
+    val edges = for {
+      srcMethod <- vertices
+      _ = storeInSubgraph(srcMethod, subgraph)
+      child <- srcMethod.call
+      tgt <- child.callOut
+    } yield {
+      storeInSubgraph(tgt, subgraph)
+      Edge(srcMethod, tgt, label = child.dispatchType.stripSuffix("_DISPATCH"))
     }.distinct
     Graph(vertices, edges, subgraph.toMap)
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CallGraphGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CallGraphGenerator.scala
@@ -16,12 +16,12 @@ class CallGraphGenerator {
       srcMethod <- vertices
       _ = storeInSubgraph(srcMethod, subgraph)
       child <- srcMethod.call
-      tgt <- child.callOut
+      tgt   <- child.callOut
     } yield {
       storeInSubgraph(tgt, subgraph)
       Edge(srcMethod, tgt, label = child.dispatchType.stripSuffix("_DISPATCH"))
-    }.distinct
-    Graph(vertices, edges, subgraph.toMap)
+    }
+    Graph(vertices, edges.distinct, subgraph.toMap)
   }
 
   def storeInSubgraph(method: Method, subgraph: mutable.Map[String, Seq[StoredNode]]): Unit = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CallGraphGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CallGraphGenerator.scala
@@ -1,0 +1,36 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Method, StoredNode}
+import io.shiftleft.semanticcpg.dotgenerator.DotSerializer.{Edge, Graph}
+import io.shiftleft.semanticcpg.language._
+
+import scala.collection.mutable
+
+class CallGraphGenerator {
+
+  def generate(cpg: Cpg): Graph = {
+    val subgraph = mutable.HashMap.empty[String, Seq[StoredNode]]
+    val vertices = cpg.all.collect { case m: Method => m }.l
+    val edges = vertices.flatMap { srcMethod =>
+      storeInSubgraph(srcMethod, subgraph)
+      srcMethod.call.flatMap { child =>
+        child.callOut.map { tgt =>
+          storeInSubgraph(tgt, subgraph)
+          Edge(srcMethod, tgt, label = child.dispatchType.stripSuffix("_DISPATCH"))
+        }
+      }
+    }.distinct
+    Graph(vertices, edges, subgraph.toMap)
+  }
+
+  def storeInSubgraph(method: Method, subgraph: mutable.Map[String, Seq[StoredNode]]): Unit = {
+    method._typeDeclViaAstIn match {
+      case Some(typeDeclName) =>
+        subgraph.put(typeDeclName.fullName, subgraph.getOrElse(typeDeclName.fullName, Seq()) ++ Seq(method))
+      case None =>
+        subgraph.put(method.astParentFullName, subgraph.getOrElse(method.astParentFullName, Seq()) ++ Seq(method))
+    }
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
@@ -10,7 +10,7 @@ object DotAstGenerator {
 
   def dotAst(astRoot: AstNode): String = {
     val ast = new AstGenerator().generate(astRoot)
-    DotSerializer.dotGraph(Some(astRoot), ast)
+    DotSerializer.dotGraph(Option(astRoot), ast)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
@@ -10,7 +10,7 @@ object DotAstGenerator {
 
   def dotAst(astRoot: AstNode): String = {
     val ast = new AstGenerator().generate(astRoot)
-    DotSerializer.dotGraph(astRoot, ast)
+    DotSerializer.dotGraph(Some(astRoot), ast)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCallGraphGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCallGraphGenerator.scala
@@ -1,0 +1,13 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.Cpg
+import overflowdb.traversal._
+
+object DotCallGraphGenerator {
+
+  def dotCallGraph(cpg: Cpg): Traversal[String] = {
+    val callGraph = new CallGraphGenerator().generate(cpg)
+    Traversal(DotSerializer.dotGraph(None, callGraph))
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCdgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCdgGenerator.scala
@@ -10,7 +10,7 @@ object DotCdgGenerator {
 
   def dotCdg(method: Method): String = {
     val cdg = new CdgGenerator().generate(method)
-    DotSerializer.dotGraph(method, cdg)
+    DotSerializer.dotGraph(Some(method), cdg)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCdgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCdgGenerator.scala
@@ -10,7 +10,7 @@ object DotCdgGenerator {
 
   def dotCdg(method: Method): String = {
     val cdg = new CdgGenerator().generate(method)
-    DotSerializer.dotGraph(Some(method), cdg)
+    DotSerializer.dotGraph(Option(method), cdg)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -10,7 +10,7 @@ object DotCfgGenerator {
 
   def dotCfg(method: Method): String = {
     val cfg = new CfgGenerator().generate(method)
-    DotSerializer.dotGraph(Some(method), cfg)
+    DotSerializer.dotGraph(Option(method), cfg)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -10,7 +10,7 @@ object DotCfgGenerator {
 
   def dotCfg(method: Method): String = {
     val cfg = new CfgGenerator().generate(method)
-    DotSerializer.dotGraph(method, cfg)
+    DotSerializer.dotGraph(Some(method), cfg)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/InterproceduralNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/InterproceduralNodeDot.scala
@@ -1,0 +1,11 @@
+package io.shiftleft.semanticcpg.language.dotextension
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.dotgenerator.DotCallGraphGenerator
+import overflowdb.traversal.Traversal
+
+class InterproceduralNodeDot(val cpg: Cpg) extends AnyVal {
+
+  def dotCallGraph: Traversal[String] = DotCallGraphGenerator.dotCallGraph(cpg)
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -34,7 +34,7 @@ import io.shiftleft.semanticcpg.language.bindingextension.{
   TypeDeclTraversal => BindingTypeDeclTraversal
 }
 import io.shiftleft.semanticcpg.language.callgraphextension.{CallTraversal, MethodTraversal}
-import io.shiftleft.semanticcpg.language.dotextension.{AstNodeDot, CfgNodeDot}
+import io.shiftleft.semanticcpg.language.dotextension.{AstNodeDot, CfgNodeDot, InterproceduralNodeDot}
 import io.shiftleft.semanticcpg.language.nodemethods._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{
   AstNodeTraversal,
@@ -180,6 +180,9 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
     new CfgNodeDot(Traversal.fromSingle(a))
   implicit def iterOnceToCfgNodeDot[A <: Method](a: IterableOnce[A]): CfgNodeDot =
     new CfgNodeDot(iterableToTraversal(a))
+
+  implicit def graphToInterproceduralDot(cpg: Cpg): InterproceduralNodeDot =
+    new InterproceduralNodeDot(cpg)
 
   implicit def toTraversal[NodeType <: AbstractNode](node: NodeType): Traversal[NodeType] =
     Traversal.fromSingle(node)


### PR DESCRIPTION
- jimple2cpg method nodes now use `astParent` properties
- Extended dot serialised `Graph` case classes to include subgraph clusters
- Added entry point for dot serialisers to now be called from the `cpg` itself
- Type clusters are obtained via `TypeDecl` via AST in info but defaults to `astParentFullName` otherwise

Example call graph on Java
```java
package test;
 class Foo {
   int add(int x, int y) {
     return x + y;
   }

   int main(int argc, char argv) {
     return add(argc, 3);
   }

   int bar(int argc) {
     foo(argc);
   }
 }

class MyObject {
    public static String staticCall(String s) {
        return s;
    }

    public String myMethod(String s) {
        return s;
    }
}

public class Bar {
    MyObject obj = new MyObject();

    public static void staticMethod() {}

    public String foo(MyObject myObj) {
        return myObj.myMethod("Hello, world!");
    }

    public void bar() {
        foo(obj);
    }

    public void baz() {
        this.foo(obj);
    }

    public void qux() {
        staticMethod();
    }

    public void quux() {
      bar();
    }
}
```
![graphviz-2](https://user-images.githubusercontent.com/28294550/165069781-ccd3b8e4-0c7e-4164-9cd9-61a44abb19b6.png)

