### PR TITLE
New test fixture.

### DIFF
--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -33,7 +33,6 @@ scalacOptions ++= Seq() ++ (
         "-language:implicitConversions", // Allow definition of implicit functions called views
         "-unchecked",                    // Enable additional warnings where generated code depends on assumptions.
         "-Xcheckinit",                   // Wrap field accessors to throw an exception on uninitialized access.
-        "-Xfatal-warnings",              // Fail the compilation if there are any warnings.
         "-Xlint:adapted-args",           // Warn if an argument list is modified to match the receiver.
         "-Xlint:constant",               // Evaluation of a constant arithmetic expression results in an error.
         "-Xlint:delayedinit-select",     // Selecting member of DelayedInit.

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
@@ -1,44 +1,19 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Local}
 import io.shiftleft.semanticcpg.language._
 
-class VarDeclTests extends JavaSrcCodeToCpgFixture {
-
-  override val code: String =
-    """
-      |public class Foo {
-      |    public void test1() {
-      |        int x = 1;
-      |    }
-      |
-      |    public void test2() {
-      |        int x;
-      |        x = 1;
-      |    }
-      |
-      |    public void test3() {
-      |        int x, y;
-      |        x = 1;
-      |        y = 2;
-      |    }
-      |
-      |    public void test4() {
-      |        int x, y = 4, z;
-      |        x = 1;
-      |        z = 2;
-      |    }
-      |
-      |    public void test5() {
-      |        int x, y = 2;
-      |        int z = 3;
-      |        x = 1;
-      |    }
-      |}
-      |""".stripMargin
+class VarDeclTests extends JavaSrcCode2CpgFixture {
 
   "it should correctly parse a combined declaration and assignment" in {
+    val cpg = code("""
+        |public class Foo {
+        |      public void test1() {
+        |           int x = 1;
+        |      }
+        |}
+        |""".stripMargin)
     val methodBody = cpg.method.name("test1").astChildren.collect { case b: Block => b }.head
     methodBody.astChildren.size shouldBe 2
 
@@ -56,6 +31,14 @@ class VarDeclTests extends JavaSrcCodeToCpgFixture {
   }
 
   "it should correctly parse separated declarations and assignments" in {
+    val cpg = code("""
+        |public class Foo {
+        |    public void test2() {
+        |        int x;
+        |        x = 1;
+        |    }
+        |}
+        |""".stripMargin)
     val methodBody = cpg.method.name("test2").astChildren.collect { case b: Block => b }.head
     methodBody.astChildren.size shouldBe 2
 
@@ -73,6 +56,15 @@ class VarDeclTests extends JavaSrcCodeToCpgFixture {
   }
 
   "it should correctly parse multiple declarations in a single statement" in {
+    val cpg = code("""
+        |public class Foo {
+        |    public void test3() {
+        |        int x, y;
+        |        x = 1;
+        |        y = 2;
+        |    }
+        |}
+        |""".stripMargin)
     val methodBody = cpg.method.name("test3").astChildren.collect { case b: Block => b }.head
     methodBody.astChildren.size shouldBe 4
 
@@ -94,6 +86,15 @@ class VarDeclTests extends JavaSrcCodeToCpgFixture {
   }
 
   "it should correctly parse mixed declarations and assignments in a single statement" in {
+    val cpg = code("""
+        |public class Foo {
+        |    public void test4() {
+        |        int x, y = 4, z;
+        |        x = 1;
+        |        z = 2;
+        |    }
+        |}
+        |""".stripMargin)
     val methodBody = cpg.method.name("test4").astChildren.collect { case b: Block => b }.head
     methodBody.astChildren.size shouldBe 6
 
@@ -119,6 +120,15 @@ class VarDeclTests extends JavaSrcCodeToCpgFixture {
   }
 
   "it should correctly parse mixed declarations and assignments across statements" in {
+    val cpg = code("""
+        |public class Foo {
+        |    public void test5() {
+        |        int x, y = 2;
+        |        int z = 3;
+        |        x = 1;
+        |    }
+        |}
+        |""".stripMargin)
     val methodBody = cpg.method.name("test5").astChildren.collect { case b: Block => b }.head
     methodBody.astChildren.size shouldBe 6
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -2,7 +2,7 @@ package io.joern.javasrc2cpg.testfixtures
 
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.shiftleft.codepropertygraph.Cpg
-import io.joern.x2cpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, CodeToCpgFixture, LanguageFrontend}
 
 import java.io.File
 
@@ -17,3 +17,5 @@ class JavaSrcFrontend extends LanguageFrontend {
 }
 
 class JavaSrcCodeToCpgFixture extends CodeToCpgFixture(new JavaSrcFrontend) {}
+
+class JavaSrcCode2CpgFixture extends Code2CpgFixture(new JavaSrcFrontend)

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/Code2CpgFixture.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/Code2CpgFixture.scala
@@ -1,0 +1,36 @@
+package io.joern.x2cpg.testfixtures
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{Files, Path}
+import java.util.Comparator
+import scala.collection.mutable
+
+class Code2CpgFixture(val frontend: LanguageFrontend) extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+  private val cleanupRegister = mutable.ArrayBuffer.empty[(Path, TestCpg)]
+
+  def code(code: String): TestCpg = {
+    new TestCpg(frontend, this.registerTmpDir).moreCode(code)
+  }
+
+  def code(code: String, fileName: String): TestCpg = {
+    new TestCpg(frontend, this.registerTmpDir).moreCode(code, fileName)
+  }
+
+  private def registerTmpDir(tmpDir: Path, cpg: TestCpg): Unit = {
+    cleanupRegister.append((tmpDir, cpg))
+  }
+
+  override def afterAll(): Unit = {
+    cleanupRegister.foreach { case (tmpDir, cpg) =>
+      cpg.close()
+
+      Files
+        .walk(tmpDir)
+        .sorted(Comparator.reverseOrder[Path]())
+        .forEach(Files.delete(_))
+    }
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/CodeToCpgFixture.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/CodeToCpgFixture.scala
@@ -9,6 +9,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import java.io.File
 
+@deprecated("Please use Code2CpgFixture instead.", "2022-04-25")
 class CodeToCpgFixture(val frontend: LanguageFrontend) extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   val code                   = ""

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/TestCpg.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/TestCpg.scala
@@ -14,13 +14,13 @@ class TestCpg(frontend: LanguageFrontend, registerCleanup: (Path, TestCpg) => Un
   private val codeFileNamePairs = mutable.ArrayBuffer.empty[(String, Path)]
   private var fileNameCounter   = 0
 
-  def moreCode(code: String): this.type = {
+  def moreCode(code: String): TestCpg = {
     val result = moreCode(code, s"Test$fileNameCounter.java")
     fileNameCounter += 1
     result
   }
 
-  def moreCode(code: String, fileName: String): this.type = {
+  def moreCode(code: String, fileName: String): TestCpg = {
     checkGraphEmpty()
     codeFileNamePairs.append((code, Paths.get(fileName)))
     this

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/TestCpg.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/TestCpg.scala
@@ -1,0 +1,60 @@
+package io.joern.x2cpg.testfixtures
+
+import io.joern.x2cpg.X2Cpg
+import io.shiftleft.codepropertygraph.Cpg
+import overflowdb.Graph
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import scala.collection.mutable
+
+// Lazily populated test CPG which is created upon first access to the underlying graph.
+class TestCpg(frontend: LanguageFrontend, registerCleanup: (Path, TestCpg) => Unit) extends Cpg() {
+  private var _graph            = Option.empty[Graph]
+  private val codeFileNamePairs = mutable.ArrayBuffer.empty[(String, Path)]
+  private var fileNameCounter   = 0
+
+  def moreCode(code: String): this.type = {
+    val result = moreCode(code, s"Test$fileNameCounter.java")
+    fileNameCounter += 1
+    result
+  }
+
+  def moreCode(code: String, fileName: String): this.type = {
+    checkGraphEmpty()
+    codeFileNamePairs.append((code, Paths.get(fileName)))
+    this
+  }
+
+  private def checkGraphEmpty(): Unit = {
+    if (_graph.isDefined) {
+      throw new RuntimeException("Modifying test data is not allowed after accessing graph.")
+    }
+  }
+
+  private def codeToFileSystem(): Path = {
+    val tmpDir = Files.createTempDirectory("x2cpgTestTmpDir")
+    codeFileNamePairs.foreach { case (code, fileName) =>
+      if (fileName.getParent != null) {
+        Files.createDirectories(tmpDir.resolve(fileName.getParent))
+      }
+      val codeAsBytes = code.getBytes(StandardCharsets.UTF_8)
+      Files.write(tmpDir.resolve(Paths.get(fileName.toString)), codeAsBytes)
+    }
+    tmpDir
+  }
+
+  override def graph: Graph = {
+    if (_graph.isEmpty) {
+      val codeDir = codeToFileSystem()
+      registerCleanup(codeDir, this)
+      _graph = Some(frontend.execute(codeDir.toFile).graph)
+      X2Cpg.applyDefaultOverlays(this)
+    }
+    _graph.get
+  }
+
+  override def close(): Unit = {
+    _graph.foreach(_.close())
+  }
+}


### PR DESCRIPTION
This fixture allows to specify multiple input files while not placing
additional burden on the user.

As example i migrated one java src test.

But it is also possible to use the same cpg for multiple different
tests like:

```
class SomeTests extends JavaSrcCode2CpgFixture {

  "foo" should {
    val cpg = code("<someCode>")

    "test1" in {

    }

    "test2" in {
    }
  }
}
```

as reference the initial proposal PR: 
https://github.com/joernio/joern/pull/1230