### PR TITLE
Dot Generator: Type Hierarchy

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -68,6 +68,7 @@ object DotSerializer {
       case modifier: Modifier                    => (modifier.label, modifier.modifierType).toString()
       case annoAssign: AnnotationParameterAssign => (annoAssign.label, annoAssign.code).toString()
       case annoParam: AnnotationParameter        => (annoParam.label, annoParam.code).toString()
+      case typ: Type                             => (typ.label, typ.name).toString()
       case _                                     => ""
     })
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotTypeHierarchyGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotTypeHierarchyGenerator.scala
@@ -1,0 +1,13 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.Cpg
+import overflowdb.traversal._
+
+object DotTypeHierarchyGenerator {
+
+  def dotTypeHierarchy(cpg: Cpg): Traversal[String] = {
+    val typeHierarchy = new TypeHierarchyGenerator().generate(cpg)
+    Traversal(DotSerializer.dotGraph(None, typeHierarchy))
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/TypeHierarchyGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/TypeHierarchyGenerator.scala
@@ -14,12 +14,13 @@ class TypeHierarchyGenerator {
     val vertices         = cpg.all.collect { case m: TypeDecl => m }.l
     val typeToIsExternal = cpg.all.collect { case m: TypeDecl => m }.map { t => t.fullName -> t.isExternal }.toMap
     val edges = for {
-      srcType <- vertices
-      _ = storeInSubgraph(srcType._typeViaRefIn.head, subgraph, typeToIsExternal)
-      tgtType <- srcType.inheritsFromOut
+      srcTypeDecl <- vertices
+      srcType     <- srcTypeDecl._typeViaRefIn.l
+      _ = storeInSubgraph(srcType, subgraph, typeToIsExternal)
+      tgtType <- srcTypeDecl.inheritsFromOut
     } yield {
       storeInSubgraph(tgtType, subgraph, typeToIsExternal)
-      Edge(tgtType, srcType._typeViaRefIn.head)
+      Edge(tgtType, srcType)
     }
     Graph(vertices.flatMap(_._typeViaRefIn.l), edges.distinct, subgraph.toMap)
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/TypeHierarchyGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/TypeHierarchyGenerator.scala
@@ -1,0 +1,48 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{StoredNode, Type, TypeDecl}
+import io.shiftleft.semanticcpg.dotgenerator.DotSerializer.{Edge, Graph}
+import io.shiftleft.semanticcpg.language._
+
+import scala.collection.mutable
+
+class TypeHierarchyGenerator {
+
+  def generate(cpg: Cpg): Graph = {
+    val subgraph         = mutable.HashMap.empty[String, Seq[StoredNode]]
+    val vertices         = cpg.all.collect { case m: TypeDecl => m }.l
+    val typeToIsExternal = cpg.all.collect { case m: TypeDecl => m }.map { t => t.fullName -> t.isExternal }.toMap
+    val edges = for {
+      srcType <- vertices
+      _ = storeInSubgraph(srcType._typeViaRefIn.head, subgraph, typeToIsExternal)
+      tgtType <- srcType.inheritsFromOut
+    } yield {
+      storeInSubgraph(tgtType, subgraph, typeToIsExternal)
+      Edge(tgtType, srcType._typeViaRefIn.head)
+    }
+    Graph(vertices.flatMap(_._typeViaRefIn.l), edges.distinct, subgraph.toMap)
+  }
+
+  def storeInSubgraph(
+    typ: Type,
+    subgraph: mutable.Map[String, Seq[StoredNode]],
+    typeToIsExternal: Map[String, Boolean]
+  ): Unit = {
+    if (!typeToIsExternal(typ.fullName)) {
+      /*
+        We parse the namespace information instead of looking at the namespace node
+        as types such as inner classes may not be attached to a namespace block
+       */
+      val namespace =
+        if (typ.fullName.contains("."))
+          typ.fullName.stripSuffix(s".${typ.name}")
+        else
+          typ.fullName.stripSuffix(s"${typ.name}")
+      subgraph.put(namespace, subgraph.getOrElse(namespace, Seq()) ++ Seq(typ))
+    } else {
+      subgraph.put("<global>", subgraph.getOrElse("<global>", Seq()) ++ Seq(typ))
+    }
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/InterproceduralNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/InterproceduralNodeDot.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.semanticcpg.language.dotextension
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.semanticcpg.dotgenerator.DotCallGraphGenerator
+import io.shiftleft.semanticcpg.dotgenerator.{DotCallGraphGenerator, DotTypeHierarchyGenerator}
 import overflowdb.traversal.Traversal
 
 class InterproceduralNodeDot(val cpg: Cpg) extends AnyVal {
 
   def dotCallGraph: Traversal[String] = DotCallGraphGenerator.dotCallGraph(cpg)
+
+  def dotTypeHierarchy: Traversal[String] = DotTypeHierarchyGenerator.dotTypeHierarchy(cpg)
 
 }


### PR DESCRIPTION
- Added a means to visualise the type hierarchy of the CPG in a traditional type hierarchy sense
- Clusters types by their namespace full names
- This namespace information is simply extracted from type full names as I've found in JavaSrc2Cpg that nested types don't have an associated namespace block

Example Java code:
```java
 package a.b.c.d;
 class Bar extends Woo {
   int x;
   int method () { return 1; }
 };
 class Woo {}

 public class OuterClass {
   interface InnerInterface {
     int id(int x);
   }

   class InnerClass implements InnerInterface {
     @Override
     public int id(int x) {
       return x;
     }

     class InnerClass2 {}
   }

   public int method(int bbb) {
     InnerInterface innerInterface = new InnerClass();
     return innerInterface.id(bbb);
   }
   public static void main(String[] args) { }

 }

 enum TestEnum {
   A, B, C;

   public void enumMethod() {}
 }
 ```
![graphviz-3](https://user-images.githubusercontent.com/28294550/165373715-c837cadb-3781-4ccf-be75-6e771ed9129e.png)
 