### PR TITLE
Fix for wrong identifier names

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -29,7 +29,7 @@ trait AstForPrimitivesCreator {
       case id: IASTIdExpression => ASTStringUtil.getSimpleName(id.getName)
       case id: IASTName if ASTStringUtil.getSimpleName(id).isEmpty && id.getBinding != null => id.getBinding.getName
       case id: IASTName if ASTStringUtil.getSimpleName(id).isEmpty => uniqueName("name", "", "")._1
-      case _                                                       => ident.toString
+      case _                                                       => nodeSignature(ident)
     }
     val variableOption = scope.lookupVariable(identifierName)
     val identifierTypeName = variableOption match {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
@@ -17,9 +17,11 @@ object CompleteCpgFixture {
       file.write(code)
 
       val cpg = Cpg.emptyCpg
+      val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
+
       new MetaDataPass(cpg, Languages.NEWC).createAndApply()
       val astCreationPass =
-        new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
+        new AstCreationPass(cpg, AstCreationPass.SourceFiles, config)
       astCreationPass.createAndApply()
       new CfgCreationPass(cpg).createAndApply()
       new TypeNodePass(astCreationPass.usedTypes(), cpg).createAndApply()

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CompleteCpgFixture.scala
@@ -16,8 +16,8 @@ object CompleteCpgFixture {
       val file = dir / fileName
       file.write(code)
 
-      val cpg = Cpg.emptyCpg
-      val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
+      val cpg    = Cpg.emptyCpg
+      val config = Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
 
       new MetaDataPass(cpg, Languages.NEWC).createAndApply()
       val astCreationPass =

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
@@ -9,9 +9,10 @@ object CpgAstOnlyFixture {
   def apply(code: String, fileName: String = "file.c"): Cpg = {
     val cpg = Cpg.emptyCpg
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
+      val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
       val file = dir / fileName
       file.write(code)
-      new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
+      new AstCreationPass(cpg, AstCreationPass.SourceFiles, config)
         .createAndApply()
     }
     cpg

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgAstOnlyFixture.scala
@@ -9,8 +9,8 @@ object CpgAstOnlyFixture {
   def apply(code: String, fileName: String = "file.c"): Cpg = {
     val cpg = Cpg.emptyCpg
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
-      val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
-      val file = dir / fileName
+      val config = Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
+      val file   = dir / fileName
       file.write(code)
       new AstCreationPass(cpg, AstCreationPass.SourceFiles, config)
         .createAndApply()

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
@@ -18,7 +18,7 @@ class CpgCfgFixture(code: String, fileExtension: String = ".c") {
   File.usingTemporaryDirectory("c2cpgtest") { dir =>
     val file = dir / s"file1$fileExtension"
     file.write(s"RET func() { $code }")
-    val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
+    val config = Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
     new AstCreationPass(cpg, AstCreationPass.SourceFiles, config)
       .createAndApply()
     new CfgCreationPass(cpg).createAndApply()

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgCfgFixture.scala
@@ -18,7 +18,8 @@ class CpgCfgFixture(code: String, fileExtension: String = ".c") {
   File.usingTemporaryDirectory("c2cpgtest") { dir =>
     val file = dir / s"file1$fileExtension"
     file.write(s"RET func() { $code }")
-    new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
+    val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
+    new AstCreationPass(cpg, AstCreationPass.SourceFiles, config)
       .createAndApply()
     new CfgCreationPass(cpg).createAndApply()
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
@@ -15,7 +15,7 @@ object CpgTypeNodeFixture {
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
       val file = dir / fileName
       file.write(code)
-      val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
+      val config = Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
 
       new MetaDataPass(cpg, Languages.NEWC).createAndApply()
       val astCreationPass =

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/CpgTypeNodeFixture.scala
@@ -15,10 +15,11 @@ object CpgTypeNodeFixture {
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
       val file = dir / fileName
       file.write(code)
+      val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
 
       new MetaDataPass(cpg, Languages.NEWC).createAndApply()
       val astCreationPass =
-        new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
+        new AstCreationPass(cpg, AstCreationPass.SourceFiles, config)
       astCreationPass.createAndApply()
       new TypeNodePass(astCreationPass.usedTypes(), cpg).createAndApply()
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
@@ -11,7 +11,8 @@ object TestAstOnlyFixture {
       val file = dir / fileName
       file.write(code)
       val cpg = Cpg.emptyCpg
-      new AstCreationPass(cpg, AstCreationPass.SourceFiles, Config(inputPaths = Set(dir.path.toString)))
+      val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
+      new AstCreationPass(cpg, AstCreationPass.SourceFiles,config)
         .createAndApply()
       f(cpg)
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestAstOnlyFixture.scala
@@ -10,9 +10,9 @@ object TestAstOnlyFixture {
     File.usingTemporaryDirectory("c2cpgtest") { dir =>
       val file = dir / fileName
       file.write(code)
-      val cpg = Cpg.emptyCpg
-      val config =  Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
-      new AstCreationPass(cpg, AstCreationPass.SourceFiles,config)
+      val cpg    = Cpg.emptyCpg
+      val config = Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
+      new AstCreationPass(cpg, AstCreationPass.SourceFiles, config)
         .createAndApply()
       f(cpg)
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/fixtures/TestProjectFixture.scala
@@ -17,7 +17,7 @@ case class TestProjectFixture(projectName: String) {
   private val dirName: String =
     ProjectRoot.relativise(s"joern-cli/frontends/c2cpg/src/test/resources/testcode/$projectName")
 
-  private val config = Config(inputPaths = Set(dirName))
+  private val config = Config(inputPaths = Set(dirName), includePathsAutoDiscovery = false)
 
   new MetaDataPass(cpg, Languages.C).createAndApply()
   new AstCreationPass(cpg, AstCreationPass.SourceFiles, config).createAndApply()

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
@@ -1371,7 +1371,10 @@ class AstCreationPassTests
         |  return sizeof(int);
         |}
         |""".stripMargin) { cpg =>
-      cpg.call.name(Operators.sizeOf).argument(1).code.l shouldBe List("int")
+      inside(cpg.call.name(Operators.sizeOf).argument(1).l) { case List(i: Identifier) =>
+        i.code shouldBe "int"
+        i.name shouldBe "int"
+      }
     }
 
     "be correct for label" in TestAstOnlyFixture("void foo() { label:; }") { cpg =>

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
@@ -29,8 +29,9 @@ class PreprocessorPassTests extends AnyWordSpec with Matchers {
         val filename = "test.c"
         val file     = dir / filename
         file.write(code)
+        val config = Config(inputPaths = Set(dir.path.toString), includePathsAutoDiscovery = false)
 
-        val stmts = new PreprocessorPass(Config(inputPaths = Set(dir.path.toString))).run().toList
+        val stmts = new PreprocessorPass(config).run().toList
         stmts shouldBe List("SYMBOL", "FOO=true")
       }
     }
@@ -55,7 +56,7 @@ class PreprocessorPassTests extends AnyWordSpec with Matchers {
         val filename = "test.c"
         val file     = dir / filename
         file.write(code)
-        val config = Config(inputPaths = Set(dir.path.toString), defines = Set("SYMBOL"))
+        val config = Config(inputPaths = Set(dir.path.toString), defines = Set("SYMBOL"), includePathsAutoDiscovery = false)
         val stmts  = new PreprocessorPass(config).run().toList
         stmts shouldBe List("SYMBOL=true", "FOO=true")
       }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
@@ -56,8 +56,9 @@ class PreprocessorPassTests extends AnyWordSpec with Matchers {
         val filename = "test.c"
         val file     = dir / filename
         file.write(code)
-        val config = Config(inputPaths = Set(dir.path.toString), defines = Set("SYMBOL"), includePathsAutoDiscovery = false)
-        val stmts  = new PreprocessorPass(config).run().toList
+        val config =
+          Config(inputPaths = Set(dir.path.toString), defines = Set("SYMBOL"), includePathsAutoDiscovery = false)
+        val stmts = new PreprocessorPass(config).run().toList
         stmts shouldBe List("SYMBOL=true", "FOO=true")
       }
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DumpDdgTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DumpDdgTests.scala
@@ -3,6 +3,7 @@ package io.joern.c2cpg.querying
 import better.files.File
 import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.layers.dataflows.{DdgDumpOptions, DumpDdg}
+import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
 import java.nio.file.Files
@@ -20,9 +21,9 @@ class DumpDdgTests extends DataFlowCodeToCpgSuite {
     "create two dot files for a CPG containing two methods" in {
 
       File.usingTemporaryDirectory("dumpast") { tmpDir =>
-        val opts         = DdgDumpOptions(tmpDir.path.toString)
-        implicit val s   = semantics
-        val layerContext = new LayerCreatorContext(cpg)
+        val opts                  = DdgDumpOptions(tmpDir.path.toString)
+        implicit val s: Semantics = semantics
+        val layerContext          = new LayerCreatorContext(cpg)
         new DumpDdg(opts).run(layerContext)
         (tmpDir / "0-ddg.dot").exists shouldBe true
         (tmpDir / "1-ddg.dot").exists shouldBe true

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
@@ -16,7 +16,8 @@ class C2CpgFrontend(override val fileSuffix: String = FileDefaults.C_EXT) extend
     val config = Config(
       inputPaths = Set(sourceCodePath.getAbsolutePath),
       outputPath = cpgFile.getAbsolutePath,
-      includeComments = true
+      includeComments = true,
+      includePathsAutoDiscovery = false
     )
     c2cpg.createCpg(config).get
   }


### PR DESCRIPTION
Fixes: https://github.com/joernio/joern/issues/1326

Also: we do not need to run system header file auto discovery during tests. Just wasting time there.