### PR TITLE
Register types for certain Kotlin lambda calls

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -997,6 +997,8 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
         relativizedPath,
         Seq(lambdaTypeDeclInheritsFromTypeFullName)
       )
+    registerType(lambdaTypeDeclInheritsFromTypeFullName)
+
     val lambdaBinding = bindingNode(Constants.lambdaBindingName, fullNameWithSig._2)
     val bindingInfo = BindingInfo(
       lambdaBinding,

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
@@ -5,12 +5,36 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.edges.Ast
-import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, FieldIdentifier, Identifier}
+import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Declaration, FieldIdentifier, Identifier}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.jIteratortoTraversal
 
 class ValidationTests extends AnyFreeSpec with Matchers {
+  "CPG for code with lambdas with no params and one param" - {
+    lazy val cpg = TestContext.buildCpg("""
+        |package com.example
+        |
+        |fun parseParams(name: String, msg: String): Map<String, String?> {
+        |    val checkedName = name.takeUnless { it -> it.contains('\\') }?.ifBlank { "default_name" }
+        |    val checkedMsg = msg.ifBlank { "default_msg" }
+        |    return mapOf("parsed_name" to checkedName, "parsed_msg" to checkedMsg)
+        |}
+        |
+        |fun main() {
+        |   val p1 = "PARAM_1"
+        |   val p2 = "PARAM_2"
+        |   val parsed = parseParams(p1, p2)
+        |   println("parsed: " + parsed)
+        |}
+        |""".stripMargin)
+
+    "should contain TYPE nodes for `kotlin.Function0` and `kotlin.Function1`" in {
+      cpg.typ.fullNameExact("kotlin.Function0").size should not be 0
+      cpg.typ.fullNameExact("kotlin.Function1").size should not be 0
+    }
+  }
+
   "CPG for code with simple method containing if-expression" - {
     lazy val cpg = TestContext.buildCpg("""
         |package mypkg


### PR DESCRIPTION
following a complaint of the `TypeHierarchyPass`
```
2022-05-02 16:56:19.289 INFO Start of pass: io.joern.x2cpg.passes.typerelations.TypeHierarchyPass
2022-05-02 16:56:19.291 INFO Could not create edge. Destination lookup failed. edgeType=INHERITS_FROM, srcNodeType=TYPE_DECL, srcNodeId=81, dstNodeType=TYPE, dstFullName=kotlin.Function0
2022-05-02 16:56:19.291 INFO Could not create edge. Destination lookup failed. edgeType=INHERITS_FROM, srcNodeType=TYPE_DECL, srcNodeId=82, dstNodeType=TYPE, dstFullName=kotlin.Function1
2022-05-02 16:56:19.291 INFO Could not create edge. Destination lookup failed. edgeType=INHERITS_FROM, srcNodeType=TYPE_DECL, srcNodeId=83, dstNodeType=TYPE, dstFullName=kotlin.Function0
```