### PR TITLE
Register types of Kotlin binary expressions

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -2892,6 +2892,8 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
         fullNameWithSignature._2
       }
     val typeFullName = typeInfoProvider.typeFullName(expr, TypeConstants.any)
+    registerType(typeFullName)
+
     val name = if (operatorOption.isDefined) {
       operatorOption.get
     } else if (expr.getChildren.toList.size >= 2) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
@@ -29,9 +29,10 @@ class ValidationTests extends AnyFreeSpec with Matchers {
         |}
         |""".stripMargin)
 
-    "should contain TYPE nodes for `kotlin.Function0` and `kotlin.Function1`" in {
+    "should contain TYPE nodes for `kotlin.Function0`, `kotlin.Function1` and `kotlin.Pair`" in {
       cpg.typ.fullNameExact("kotlin.Function0").size should not be 0
       cpg.typ.fullNameExact("kotlin.Function1").size should not be 0
+      cpg.typ.fullNameExact("kotlin.Pair").size should not be 0
     }
 
     "should contain CLOSURE_BINDING nodes for the lambdas" in {


### PR DESCRIPTION
Following complaints of the `TypeUsagePass`
```
2022-05-03 10:19:42.933 INFO Start of pass: io.joern.x2cpg.passes.base.TypeUsagePass
2022-05-03 10:19:42.936 INFO Could not create edge. Destination lookup failed. edgeType=EVAL_TYPE, srcNodeType=CALL, srcNodeId=25, dstNodeType=TYPE, dstFullName=kotlin.Pair
2022-05-03 10:19:42.936 INFO Could not create edge. Destination lookup failed. edgeType=EVAL_TYPE, srcNodeType=CALL, srcNodeId=28, dstNodeType=TYPE, dstFullName=kotlin.Pair
2022-05-03 10:19:42.937 INFO Could not create edge. Destination lookup failed. edgeType=EVAL_TYPE, srcNodeType=BLOCK, srcNodeId=8, dstNodeType=TYPE, dstFullName=java.lang.Void
```