### PR TITLE
Dynamic Call Graph: Variable Type Analysis (VTA)

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/DynamicCallGraphTests.scala
@@ -1,9 +1,9 @@
-package io.joern.jimple2cpg.querying
+package io.joern.javasrc2cpg.querying
 
-import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
 import io.shiftleft.semanticcpg.language.{NoResolve, _}
 
-class DynamicCallGraphTests extends JimpleCodeToCpgFixture {
+class DynamicCallGraphTests extends JavaSrcCodeToCpgFixture {
 
   implicit val resolver: NoResolve.type = NoResolve
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/DynamicCallGraphTests.scala
@@ -9,58 +9,58 @@ class DynamicCallGraphTests extends JavaSrcCodeToCpgFixture {
 
   override val code =
     """
-class Foo {
-
-	public static void main(String[] args){
-		A b1 = new B();
-		A c1 = new C();
-
-		A b2 = b1;
-		A c2 = c1;
-        A cOrD;
-
-        if (System.currentTimeMillis() > 100) {
-          cOrD = new C();
-        } else {
-          cOrD = new D();
-        }
-
-		// what will get printed?
-		b2.print(c2);
-        c2.print(b2);
-        cOrD.print(b1);
-	}
-
-	public static class A extends Object {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to A's print(A object)");
-		}
-	}
-
-	public static class B extends A {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to B's print(A object)");
-		}
-	}
-
-	public static class C extends B {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to C's print(A object)");
-		}
-	}
-
-	public static class D extends A {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to D's print(A object)");
-		}
-	}
-
-}
-    """
+      |class Foo {
+      |
+      |	public static void main(String[] args){
+      |		A b1 = new B();
+      |		A c1 = new C();
+      |
+      |		A b2 = b1;
+      |		A c2 = c1;
+      |     A cOrD;
+      |
+      |     if (System.currentTimeMillis() > 100) {
+      |       cOrD = new C();
+      |     } else {
+      |       cOrD = new D();
+      |     }
+      |
+      |		// what will get printed?
+      |		b2.print(c2);
+      |     c2.print(b2);
+      |     cOrD.print(b1);
+      |	}
+      |
+      |	public static class A extends Object {
+      |		public void print(A object) {
+      |			System.out.println("An instance of " + object.getClass().getSimpleName()
+      |					+ " was passed to A's print(A object)");
+      |		}
+      |	}
+      |
+      |	public static class B extends A {
+      |		public void print(A object) {
+      |			System.out.println("An instance of " + object.getClass().getSimpleName()
+      |					+ " was passed to B's print(A object)");
+      |		}
+      |	}
+      |
+      |	public static class C extends B {
+      |		public void print(A object) {
+      |			System.out.println("An instance of " + object.getClass().getSimpleName()
+      |					+ " was passed to C's print(A object)");
+      |		}
+      |	}
+      |
+      |	public static class D extends A {
+      |		public void print(A object) {
+      |			System.out.println("An instance of " + object.getClass().getSimpleName()
+      |					+ " was passed to D's print(A object)");
+      |		}
+      |	}
+      |
+      |}
+      |""".stripMargin
 
   "should find that add is called by main" in {
     cpg.method.name("print").caller.name.toSetMutable shouldBe Set("main")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/DynamicCallGraphTests.scala
@@ -17,10 +17,18 @@ class Foo {
 
 		A b2 = b1;
 		A c2 = c1;
+        A cOrD;
+
+        if (System.currentTimeMillis() > 100) {
+          cOrD = new C();
+        } else {
+          cOrD = new D();
+        }
 
 		// what will get printed?
 		b2.print(c2);
         c2.print(b2);
+        cOrD.print(b1);
 	}
 
 	public static class A extends Object {
@@ -61,6 +69,7 @@ class Foo {
   "should account for print calls from all subclasses due to using CHA with points-to information" in {
     cpg.call.codeExact("b2.print(c2)").callee.definingTypeDecl.fullName.toSetMutable shouldBe Set("Foo$B")
     cpg.call.codeExact("c2.print(b2)").callee.definingTypeDecl.fullName.toSetMutable shouldBe Set("Foo$C")
+    cpg.call.codeExact("cOrD.print(b1)").callee.definingTypeDecl.fullName.toSetMutable shouldBe Set("Foo$C", "Foo$D")
   }
 
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/DynamicCallGraphTests.scala
@@ -12,11 +12,11 @@ class DynamicCallGraphTests extends JavaSrcCodeToCpgFixture {
       |class Foo {
       |
       |	public static void main(String[] args){
-      |		A b1 = new B();
-      |		A c1 = new C();
+      |     A b1 = new B();
+      |     A c1 = new C();
       |
-      |		A b2 = b1;
-      |		A c2 = c1;
+      |     A b2 = b1;
+      |     A c2 = c1;
       |     A cOrD;
       |
       |     if (System.currentTimeMillis() > 100) {
@@ -25,8 +25,8 @@ class DynamicCallGraphTests extends JavaSrcCodeToCpgFixture {
       |       cOrD = new D();
       |     }
       |
-      |		// what will get printed?
-      |		b2.print(c2);
+      |     // what will get printed?
+      |     b2.print(c2);
       |     c2.print(b2);
       |     cOrD.print(b1);
       |	}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
@@ -9,58 +9,58 @@ class DynamicCallGraphTests extends JimpleCodeToCpgFixture {
 
   override val code =
     """
-class Foo {
-
-	public static void main(String[] args){
-		A b1 = new B();
-		A c1 = new C();
-
-		A b2 = b1;
-		A c2 = c1;
-        A cOrD;
-
-        if (System.currentTimeMillis() > 100) {
-          cOrD = new C();
-        } else {
-          cOrD = new D();
-        }
-
-		// what will get printed?
-		b2.print(c2);
-        c2.print(b2);
-        cOrD.print(b1);
-	}
-
-	public static class A extends Object {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to A's print(A object)");
-		}
-	}
-
-	public static class B extends A {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to B's print(A object)");
-		}
-	}
-
-	public static class C extends B {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to C's print(A object)");
-		}
-	}
-
-	public static class D extends A {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to D's print(A object)");
-		}
-	}
-
-}
-    """
+      |class Foo {
+      |
+      |	public static void main(String[] args){
+      |		A b1 = new B();
+      |		A c1 = new C();
+      |
+      |		A b2 = b1;
+      |		A c2 = c1;
+      |     A cOrD;
+      |
+      |     if (System.currentTimeMillis() > 100) {
+      |       cOrD = new C();
+      |     } else {
+      |       cOrD = new D();
+      |     }
+      |
+      |		// what will get printed?
+      |		b2.print(c2);
+      |     c2.print(b2);
+      |     cOrD.print(b1);
+      |	}
+      |
+      |	public static class A extends Object {
+      |		public void print(A object) {
+      |			System.out.println("An instance of " + object.getClass().getSimpleName()
+      |					+ " was passed to A's print(A object)");
+      |		}
+      |	}
+      |
+      |	public static class B extends A {
+      |		public void print(A object) {
+      |			System.out.println("An instance of " + object.getClass().getSimpleName()
+      |					+ " was passed to B's print(A object)");
+      |		}
+      |	}
+      |
+      |	public static class C extends B {
+      |		public void print(A object) {
+      |			System.out.println("An instance of " + object.getClass().getSimpleName()
+      |					+ " was passed to C's print(A object)");
+      |		}
+      |	}
+      |
+      |	public static class D extends A {
+      |		public void print(A object) {
+      |			System.out.println("An instance of " + object.getClass().getSimpleName()
+      |					+ " was passed to D's print(A object)");
+      |		}
+      |	}
+      |
+      |}
+      |""".stripMargin
 
   "should find that add is called by main" in {
     cpg.method.name("print").caller.name.toSetMutable shouldBe Set("main")

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
@@ -17,10 +17,18 @@ class Foo {
 
 		A b2 = b1;
 		A c2 = c1;
+        A cOrD;
+
+        if (System.currentTimeMillis() > 100) {
+          cOrD = new C();
+        } else {
+          cOrD = new D();
+        }
 
 		// what will get printed?
 		b2.print(c2);
         c2.print(b2);
+        cOrD.print(b1);
 	}
 
 	public static class A extends Object {
@@ -61,6 +69,7 @@ class Foo {
   "should account for print calls from all subclasses due to using CHA with points-to information" in {
     cpg.call.codeExact("b2.print(c2)").callee.definingTypeDecl.fullName.toSetMutable shouldBe Set("Foo$B")
     cpg.call.codeExact("c2.print(b2)").callee.definingTypeDecl.fullName.toSetMutable shouldBe Set("Foo$C")
+    cpg.call.codeExact("cOrD.print(b1)").callee.definingTypeDecl.fullName.toSetMutable shouldBe Set("Foo$C", "Foo$D")
   }
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
@@ -12,11 +12,11 @@ class DynamicCallGraphTests extends JimpleCodeToCpgFixture {
       |class Foo {
       |
       |	public static void main(String[] args){
-      |		A b1 = new B();
-      |		A c1 = new C();
+      |     A b1 = new B();
+      |     A c1 = new C();
       |
-      |		A b2 = b1;
-      |		A c2 = c1;
+      |     A b2 = b1;
+      |     A c2 = c1;
       |     A cOrD;
       |
       |     if (System.currentTimeMillis() > 100) {
@@ -25,8 +25,8 @@ class DynamicCallGraphTests extends JimpleCodeToCpgFixture {
       |       cOrD = new D();
       |     }
       |
-      |		// what will get printed?
-      |		b2.print(c2);
+      |     // what will get printed?
+      |     b2.print(c2);
       |     c2.print(b2);
       |     cOrD.print(b1);
       |	}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -18,8 +18,8 @@ import scala.jdk.CollectionConverters._
   * This pass intentionally ignores the vtable mechanism based on BINDING nodes but does check for an existing call edge
   * before adding one. It assumes non-circular inheritance, on pain of endless recursion / stack overflow.
   *
-  * This pass will attempt to use intra-procedural points-to information to refine possible call targets and can
-  * be best described as variable type analysis (VTA).
+  * This pass will attempt to use intra-procedural points-to information to refine possible call targets and can be best
+  * described as variable type analysis (VTA).
   *
   * Based on the algorithm by Jang, Dongseok & Tatlock, Zachary & Lerner, Sorin. (2014). SAFEDISPATCH: Securing C++
   * Virtual Calls from Memory Corruption Attacks. 10.14722/ndss.2014.23287.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -161,8 +161,8 @@ class DynamicCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
         receivers
           .flatMap(_.pointsToOut)
           .collect {
-            case x: Call if x.methodFullName == Operators.alloc            => x.typeFullName
-            case x: Call if x.methodFullName == Operators.arrayInitializer => x.typeFullName
+            case x: Call if x.methodFullName == Operators.alloc || x.methodFullName == Operators.arrayInitializer => 
+              x.typeFullName
           }
           .toSet
       filterTargets(tgts, allocatedSuperTypes)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -159,7 +159,7 @@ class DynamicCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
           .flatMap(_.pointsToOut)
           .collect {
             case x: Call if x.methodFullName == Operators.alloc || x.methodFullName == Operators.arrayInitializer =>
-              Option(x.typeFullName)
+              x.evalType.toSeq
           }
           .flatten
           .toSet

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -154,7 +154,6 @@ class DynamicCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
       filterTargets(tgts, thisType)
     } else {
       // Receiver is an object that may have points-to information, attempt to use it
-      println(s"Receivers ${receivers.flatMap(_.pointsToOut)}")
       val allocatedSuperTypes =
         receivers
           .flatMap(_.pointsToOut)
@@ -163,7 +162,6 @@ class DynamicCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
               x.typeFullName
           }
           .toSet
-      println(s"$tgts => $allocatedSuperTypes")
       filterTargets(tgts, allocatedSuperTypes)
     }
   }


### PR DESCRIPTION
- Based on the pointer assignment graph (PAG) pass, will refine possible call targets using pointer information
- Limited to intra-procedural PAG information as the PAG is intra-procedural (for now)
- Does not consider `Operators.cast`
- If no pointer information is available it will default to CHA