### PR TITLE
Dot Graph Serializer: Rich HTML Formatting + Line Numbers

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotAstGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotAstGeneratorTests.scala
@@ -33,7 +33,7 @@ class DotAstGeneratorTests extends CCodeToCpgSuite {
       inside(cpg.method.name("my_func").dotAst.l) { case List(x) =>
         x should (
           startWith("digraph \"my_func\"") and
-            include("""[label = "(CONTROL_STRUCTURE,if (y > 42),if (y > 42))" ]""") and
+            include("""[label = <(CONTROL_STRUCTURE,if (y &gt; 42),if (y &gt; 42))<SUB>5</SUB>> ]""") and
             endWith("}\n")
         )
       }
@@ -53,7 +53,7 @@ class DotAstGeneratorTests extends CCodeToCpgSuite {
 
     "allow plotting sub trees of methods" in {
       inside(cpg.method.ast.isControlStructure.code(".*y > 42.*").dotAst.l) { case List(x, _) =>
-        x should (include("y > 42") and include("IDENTIFIER,y") and not include "x * 2")
+        x should (include("y &gt; 42") and include("IDENTIFIER,y") and not include "x * 2")
       }
     }
 
@@ -61,8 +61,8 @@ class DotAstGeneratorTests extends CCodeToCpgSuite {
       inside(cpg.method.name("lemon").dotAst.l) { case List(x) =>
         x should (
           startWith("digraph \"lemon\"") and
-            include("""[label = "(goog,goog(\"\\\"yes\\\"\"))" ]""") and
-            include("""[label = "(LITERAL,\"\\\"yes\\\"\",goog(\"\\\"yes\\\"\"))" ]""") and
+            include("""[label = <(goog,goog(&quot;\&quot;yes\&quot;&quot;))<SUB>18</SUB>> ]""") and
+            include("""[label = <(LITERAL,&quot;\&quot;yes\&quot;&quot;,goog(&quot;\&quot;yes\&quot;&quot;))<SUB>18</SUB>> ]""") and
             endWith("}\n")
         )
       }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotAstGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotAstGeneratorTests.scala
@@ -62,7 +62,9 @@ class DotAstGeneratorTests extends CCodeToCpgSuite {
         x should (
           startWith("digraph \"lemon\"") and
             include("""[label = <(goog,goog(&quot;\&quot;yes\&quot;&quot;))<SUB>18</SUB>> ]""") and
-            include("""[label = <(LITERAL,&quot;\&quot;yes\&quot;&quot;,goog(&quot;\&quot;yes\&quot;&quot;))<SUB>18</SUB>> ]""") and
+            include(
+              """[label = <(LITERAL,&quot;\&quot;yes\&quot;&quot;,goog(&quot;\&quot;yes\&quot;&quot;))<SUB>18</SUB>> ]"""
+            ) and
             endWith("}\n")
         )
       }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotCdgGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotCdgGeneratorTests.scala
@@ -20,9 +20,9 @@ class DotCdgGeneratorTest1 extends DataFlowCodeToCpgSuite {
       inside(cpg.method.name("foo").dotCdg.l) { case List(x) =>
         x should (
           startWith("digraph \"foo\"") and
-            include("""[label = "(<operator>.greaterThan,x > 8)" ]""") and
-            include("""[label = "(<operator>.assignment,z = a(x))" ]""") and
-            include("""[label = "(a,a(x))" ]""") and
+            include("""[label = <(&lt;operator&gt;.greaterThan,x &gt; 8)<SUB>3</SUB>> ]""") and
+            include("""[label = <(&lt;operator&gt;.assignment,z = a(x))<SUB>4</SUB>> ]""") and
+            include("""[label = <(a,a(x))<SUB>4</SUB>> ]""") and
             endWith("}\n")
         )
         val lines = x.split("\n")
@@ -50,9 +50,9 @@ class DotCdgGeneratorTest2 extends DataFlowCodeToCpgSuite {
       inside(cpg.method.name("foo").dotCdg.l) { case List(x) =>
         x should (
           startWith("digraph \"foo\"") and
-            include("""[label = "(<operator>.greaterThan,x > 8)" ]""") and
-            include("""[label = "(<operator>.assignment,z = a(x))" ]""") and
-            include("""[label = "(a,a(x))" ]""") and
+            include("""[label = <(&lt;operator&gt;.greaterThan,x &gt; 8)<SUB>3</SUB>> ]""") and
+            include("""[label = <(&lt;operator&gt;.assignment,z = a(x))<SUB>4</SUB>> ]""") and
+            include("""[label = <(a,a(x))<SUB>4</SUB>> ]""") and
             endWith("}\n")
         )
         val lines = x.split("\n")

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotCfgGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dotgenerator/DotCfgGeneratorTests.scala
@@ -23,7 +23,7 @@ class DotCfgGeneratorTest1 extends CCodeToCpgSuite {
       inside(cpg.method.name("main").dotCfg.l) { case List(dotStr) =>
         dotStr should (
           startWith("digraph \"main\" {") and
-            include("(<operator>.assignment,i = 0)") and
+            include("(&lt;operator&gt;.assignment,i = 0)") and
             endWith("}\n")
         )
       }

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/dotgenerator/DotAstGeneratorTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/dotgenerator/DotAstGeneratorTests.scala
@@ -33,7 +33,7 @@ class DotAstGeneratorTests extends FuzzyCCodeToCpgSuite {
       cpg.method.name("my_func").dotAst.l match {
         case x :: _ =>
           x.startsWith("digraph \"my_func\"") shouldBe true
-          x.contains("""[label = "(CONTROL_STRUCTURE,if (y > 42),if (y > 42))" ]""") shouldBe true
+          x.contains("""[label = <(CONTROL_STRUCTURE,if (y &gt; 42),if (y &gt; 42))<SUB>5</SUB>> ]""") shouldBe true
           x.endsWith("}\n") shouldBe true
         case _ => fail()
       }
@@ -56,7 +56,7 @@ class DotAstGeneratorTests extends FuzzyCCodeToCpgSuite {
     "allow plotting sub trees of methods" in {
       cpg.method.ast.isControlStructure.code(".*y > 42.*").dotAst.l match {
         case x :: _ =>
-          x.contains("y > 42") shouldBe true
+          x.contains("y &gt; 42") shouldBe true
           x.contains("IDENTIFIER,y") shouldBe true
           x.contains("x * 2") shouldBe false
         case _ => fail()
@@ -68,8 +68,10 @@ class DotAstGeneratorTests extends FuzzyCCodeToCpgSuite {
         case x :: _ =>
           x should (
             startWith("digraph \"lemon\"") and
-              include("""[label = "(goog,goog(\"\\\"yes\\\"\"))" ]""") and
-              include("""[label = "(LITERAL,\"\\\"yes\\\"\",goog(\"\\\"yes\\\"\"))" ]""") and
+              include("""[label = <(goog,goog(&quot;\&quot;yes\&quot;&quot;))<SUB>18</SUB>>""") and
+              include(
+                """[label = <(LITERAL,&quot;\&quot;yes\&quot;&quot;,goog(&quot;\&quot;yes\&quot;&quot;))<SUB>18</SUB>> ]"""
+              ) and
               endWith("}\n")
           )
         case _ => fail()

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/dotgenerator/DotCfgGeneratorTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/dotgenerator/DotCfgGeneratorTests.scala
@@ -23,7 +23,7 @@ class DotCfgGeneratorTests extends FuzzyCCodeToCpgSuite {
       cpg.method.name("main").dotCfg.l match {
         case x :: _ =>
           x.startsWith("digraph \"main\" {") shouldBe true
-          x.contains("(<operator>.assignment,i = 0)") shouldBe true
+          x.contains("(&lt;operator&gt;.assignment,i = 0)") shouldBe true
           x.endsWith("}\n") shouldBe true
         case _ => fail()
       }


### PR DESCRIPTION
- Switching from quoted labels to HTML labels on nodes
- Added line number info as subscript if present

Resolves #381 

Example:
```java
class Foo {
 int foo(int x, int y) {
  if (y < 10)
    return -1;
  if (x < 10) {
   sink(x);
  }
  System.out.println("foo");
  return 0;
 }
}
```
![graphviz-5](https://user-images.githubusercontent.com/28294550/166698615-28a7dea6-8217-47a8-8d70-8be913d668a4.png)

