### PR TITLE
javasrc: Add warnings for all parse problems and add logging config

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/resources/log4j2.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5p] %m%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="${env:SL_LOGGING_LEVEL:-info}">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -36,12 +36,20 @@ class AstCreationPass(codeDir: String, filenames: List[String], inferenceJarPath
     val parser       = new JavaParser(parserConfig)
     val parseResult  = parser.parse(new java.io.File(filename))
 
+    parseResult.getProblems.asScala.toList match {
+      case Nil => // Just carry on as usual
+      case problems =>
+        logger.warn(s"Encountered problems while parsing file $filename:")
+        problems.foreach { problem =>
+          logger.warn(s"- ${problem.getMessage}")
+        }
+    }
+
     parseResult.getResult.toScala match {
       case Some(result) if result.getParsed == Parsedness.PARSED =>
         diffGraph.absorb(new AstCreator(filename, result, global).createAst())
       case _ =>
-        logger.warn("Cannot parse: " + filename)
-        logger.warn("Problems: ", parseResult.getProblems.asScala.toList.map(_.toString))
+        logger.warn("Failed to parse file " + filename)
         Iterator()
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/log4j2-test.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5p] %m%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="WARN">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
* Warn about JavaParser parse problems even if the overall parse attempt returned a result.
* Add logger config to actually show warnings when running unit tests.