### PR TITLE
Use symbolResolver directly instead of .resolve().

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -47,7 +47,7 @@ class AstCreationPass(codeDir: String, filenames: List[String], inferenceJarPath
 
     parseResult.getResult.toScala match {
       case Some(result) if result.getParsed == Parsedness.PARSED =>
-        diffGraph.absorb(new AstCreator(filename, result, global).createAst())
+        diffGraph.absorb(new AstCreator(filename, result, global, symbolResolver).createAst())
       case _ =>
         logger.warn("Failed to parse file " + filename)
         Iterator()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -74,7 +74,7 @@ import com.github.javaparser.ast.stmt.{
   TryStmt,
   WhileStmt
 }
-import com.github.javaparser.resolution.UnsolvedSymbolException
+import com.github.javaparser.resolution.{SymbolResolver, UnsolvedSymbolException}
 import com.github.javaparser.resolution.declarations.{
   ResolvedConstructorDeclaration,
   ResolvedMethodDeclaration,
@@ -177,13 +177,14 @@ object AstWithStaticInit {
 
 /** Translate a Java Parser AST into a CPG AST
   */
-class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Global) extends AstCreatorBase(filename) {
+class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Global, symbolResolver: SymbolResolver)
+    extends AstCreatorBase(filename) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
   import AstCreator._
 
-  private val scopeStack                                                       = Scope()
-  private val typeInfoCalc: TypeInfoCalculator                                 = new TypeInfoCalculator(global)
+  private val scopeStack                       = Scope()
+  private val typeInfoCalc: TypeInfoCalculator = new TypeInfoCalculator(global, symbolResolver)
   private val partialConstructorQueue: mutable.ArrayBuffer[PartialConstructor] = mutable.ArrayBuffer.empty
   private val bindingsQueue: mutable.ArrayBuffer[BindingInfo]                  = mutable.ArrayBuffer.empty
   private val lambdaContextQueue: mutable.ArrayBuffer[Context]                 = mutable.ArrayBuffer.empty

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -29,8 +29,6 @@ import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
-  private val resolveCache = mutable.HashMap.empty[Type, Option[ResolvedType]]
-
   def name(typ: ResolvedType): String = {
     nameOrFullName(typ, false)
   }
@@ -76,18 +74,14 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
       case primitiveType: PrimitiveType =>
         Some(primitiveType.toString)
       case _ =>
-        resolveCache
-          .getOrElseUpdate(
-            typ,
-            // We are using symbolResolver.toResolvedType() instead of typ.resolve() because
-            // the resolve() is just a wrapper for a call to symbolResolver.toResolvedType()
-            // with a specific class given as argument to which the result is casted to.
-            // It appears to be that ClassOrInterfaceType.resolve() is using a too restrictive
-            // bound (ResolvedReferenceType.class) which invalidates an otherwise successful
-            // resolve. Since we anyway dont care about the type cast, we directly access the
-            // symbolResolver and specifiy the most generic type ResolvedType.
-            Try(symbolResolver.toResolvedType(typ, classOf[ResolvedType])).toOption
-          )
+        // We are using symbolResolver.toResolvedType() instead of typ.resolve() because
+        // the resolve() is just a wrapper for a call to symbolResolver.toResolvedType()
+        // with a specific class given as argument to which the result is casted to.
+        // It appears to be that ClassOrInterfaceType.resolve() is using a too restrictive
+        // bound (ResolvedReferenceType.class) which invalidates an otherwise successful
+        // resolve. Since we anyway dont care about the type cast, we directly access the
+        // symbolResolver and specifiy the most generic type ResolvedType.
+        Try(symbolResolver.toResolvedType(typ, classOf[ResolvedType])).toOption
           .map(resolvedType => nameOrFullName(resolvedType, fullyQualified))
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
@@ -1,47 +1,132 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.{JavaSrcCode2CpgFixture, JavaSrcCodeToCpgFixture}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
-class MethodParameterTests extends JavaSrcCodeToCpgFixture {
+class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
+  "non generic method" should {
+    val cpg = code("""
+        |class Foo {
+        |  int foo(int p1, int p2) {
+        |     return 1;
+        |  }
+        |}
+        |""".stripMargin)
 
-  override val code: String =
-    """package a;
-      |class Foo {
-      | int foo(int param1, int param2) {
-      |  return 0;
-      | }
-      |}
-      """.stripMargin
+    "have correct parameter properties for 'this'" in {
+      val List(param) = cpg.method.name("foo").parameter.name("this").l
+      param.order shouldBe 0
+      param.lineNumber shouldBe Some(3)
+      param.columnNumber shouldBe None
+      param.typeFullName shouldBe "Foo"
+    }
 
-  "should return exactly three parameters with correct fields" in {
-    cpg.parameter.name.toSetMutable shouldBe Set("this", "param1", "param2")
+    "have correct parameter properties for p1" in {
+      val List(param) = cpg.method.name("foo").parameter.name("p1").l
+      param.order shouldBe 1
+      param.lineNumber shouldBe Some(3)
+      param.columnNumber shouldBe Some(11)
+      param.typeFullName shouldBe "int"
+    }
 
-    val List(t) = cpg.parameter.filter(_.method.name == "foo").name("this").l
-    t.code shouldBe "this"
-    t.typeFullName shouldBe "a.Foo"
-    t.lineNumber shouldBe Some(3)
-    t.columnNumber shouldBe None
-    t.order shouldBe 0
+    "have correct parameter properties for p2" in {
+      val List(param) = cpg.method.name("foo").parameter.name("p2").l
+      param.order shouldBe 2
+      param.lineNumber shouldBe Some(3)
+      param.columnNumber shouldBe Some(19)
+      param.typeFullName shouldBe "int"
+    }
 
-    val List(x) = cpg.parameter.filter(_.method.name == "foo").name("param1").l
-    x.code shouldBe "int param1"
-    x.typeFullName shouldBe "int"
-    x.lineNumber shouldBe Some(3)
-    x.columnNumber shouldBe Some(10)
-    x.order shouldBe 1
-
-    val List(y) = cpg.parameter.filter(_.method.name == "foo").name("param2").l
-    y.code shouldBe "int param2"
-    y.typeFullName shouldBe "int"
-    y.lineNumber shouldBe Some(3)
-    y.columnNumber shouldBe Some(22)
-    y.order shouldBe 2
+    "should allow traversing from parameter to method" in {
+      cpg.parameter.name("p1").method.filter(_.isExternal == false).name.l shouldBe List("foo")
+    }
   }
 
-  "should allow traversing from parameter to method" in {
-    cpg.parameter.name("param1").method.filter(_.isExternal == false).name.l shouldBe List("foo")
-  }
+  "generic method with unbound type" should {
+    val cpg = code("""
+        |class Foo {
+        |  <T> int foo(T p1) {
+        |     return 1;
+        |  }
+        |}
+        |""".stripMargin)
+    "have correct type for parameter p1" in {
+      val List(param) = cpg.method.name("foo").parameter.name("p1").l
+      param.typeFullName shouldBe "java.lang.Object"
+    }
 
+    "generic method with type bound" should {
+      val cpg = code("""
+          |class Foo {
+          |  <T extends java.lang.Number> int foo(T p1) {
+          |     return 1;
+          |  }
+          |}
+          |""".stripMargin)
+      "have correct type for parameter p1" in {
+        val List(param) = cpg.method.name("foo").parameter.name("p1").l
+        param.typeFullName shouldBe "java.lang.Number"
+      }
+    }
+
+    "generic method with bounded type parameter as type bound" should {
+      val cpg = code("""
+          |class Foo {
+          |  <U extends java.lang.Number, T extends U> int foo(T p1) {
+          |     return 1;
+          |  }
+          |}
+          |""".stripMargin)
+      "have correct type for parameter p1" in {
+        val List(param) = cpg.method.name("foo").parameter.name("p1").l
+        param.typeFullName shouldBe "java.lang.Number"
+      }
+    }
+
+    "method with type parameter from generic class" should {
+      val cpg = code("""
+          |class Foo<T> {
+          |  int foo(T p1) {
+          |     return 1;
+          |  }
+          |}
+          |""".stripMargin)
+
+      "have correct type for parameter p1" in {
+        val List(param) = cpg.method.name("foo").parameter.name("p1").l
+        param.typeFullName shouldBe "java.lang.Object"
+      }
+    }
+
+    "method with bounded type parameter from generic class" should {
+      val cpg = code("""
+          |class Foo<T extends java.lang.Number> {
+          |  int foo(T p1) {
+          |     return 1;
+          |  }
+          |}
+          |""".stripMargin)
+
+      "have correct type for parameter p1" in {
+        val List(param) = cpg.method.name("foo").parameter.name("p1").l
+        param.typeFullName shouldBe "java.lang.Number"
+      }
+    }
+
+    "method with bounded type parameter as type bound from generic class" should {
+      val cpg = code("""
+          |class Foo<U extends java.lang.Number, T extends U> {
+          |  int foo(T p1) {
+          |     return 1;
+          |  }
+          |}
+          |""".stripMargin)
+
+      "have correct type for parameter p1" in {
+        val List(param) = cpg.method.name("foo").parameter.name("p1").l
+        param.typeFullName shouldBe "java.lang.Number"
+      }
+    }
+  }
 }


### PR DESCRIPTION
This avoids running into a bug where successful resolves were rendered
invalid due to overzealous casting. See code comment for more details.

Also extended parameter test suite to be able to test this.