### PR TITLE
Fixed DF semantics file location

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -18,7 +18,7 @@ import scala.util.Try
 class DataFlowCodeToCpgSuite extends CCodeToCpgSuite {
 
   var semanticsFilename: String =
-    ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
+    ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
 
   var semantics: Semantics = _
 

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -18,7 +18,7 @@ import scala.util.Try
 
 class DataFlowCodeToCpgSuite extends FuzzyCCodeToCpgSuite {
 
-  var semanticsFilename               = ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
+  var semanticsFilename               = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
   var semantics: Semantics            = _
   implicit var context: EngineContext = _
 

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/DataFlowBinToCpgSuite.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/DataFlowBinToCpgSuite.scala
@@ -20,7 +20,7 @@ import scala.util.Try
 class DataFlowBinToCpgSuite extends GhidraBinToCpgSuite {
 
   var semanticsFilename =
-    ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
+    ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
   var semantics: Semantics            = _
   implicit var context: EngineContext = _
 

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/DataFlowTests.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/DataFlowTests.scala
@@ -27,7 +27,7 @@ class DataFlowTests extends GhidraBinToCpgSuite {
 
   implicit val resolver: ICallResolver = NoResolve
 
-  val semanticsFilename               = ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
+  val semanticsFilename               = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
   val semantics: Semantics            = Semantics.fromList(new Parser().parseFile(semanticsFilename))
   implicit var context: EngineContext = EngineContext(semantics)
 

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/x86/DataFlowTests.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/x86/DataFlowTests.scala
@@ -31,9 +31,9 @@ class DataFlowTests extends GhidraBinToCpgSuite {
 
   "The data flow should contain " in {
     implicit val resolver: ICallResolver = NoResolve
-    val semanticsFilename    = ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
-    val semantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
-    implicit var context: EngineContext = EngineContext(semantics)
+    val semanticsFilename                = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
+    val semantics: Semantics             = Semantics.fromList(new Parser().parseFile(semanticsFilename))
+    implicit var context: EngineContext  = EngineContext(semantics)
 
     def source = cpg.method.name("dataflow").call.argument.code("1")
     def sink =


### PR DESCRIPTION
`relativise` and `Semantics.fromList(new Parser().parseFile(semanticsFilename))` can't handle symlinks (Windows only).
We ended up with empty semantics there.