### PR TITLE
Add `1` to line numbers of Kotlin CPGs

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/psi/Extractor.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/psi/Extractor.scala
@@ -6,7 +6,7 @@ object Extractor {
   def line(element: PsiElement): Int = {
     try {
       element.getContainingFile.getViewProvider.getDocument
-        .getLineNumber(element.getTextOffset)
+        .getLineNumber(element.getTextOffset) + 1
     } catch {
       case _: Throwable => -1
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AndroidSDKTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AndroidSDKTests.scala
@@ -196,12 +196,12 @@ class AndroidSDKTests extends AnyFreeSpec with Matchers {
       val List(firstArg: Literal, secondArg: Identifier) = cpg.call.methodFullName(".*Log.*").argument.l
       firstArg.code shouldBe "\"PREFIX\""
       firstArg.argumentIndex shouldBe 1
-      firstArg.lineNumber shouldBe Some(12)
+      firstArg.lineNumber shouldBe Some(13)
       firstArg.columnNumber shouldBe Some(10)
 
       secondArg.code shouldBe "username"
       secondArg.argumentIndex shouldBe 2
-      secondArg.lineNumber shouldBe Some(12)
+      secondArg.lineNumber shouldBe Some(13)
       secondArg.columnNumber shouldBe Some(20)
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArithmeticOperationsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArithmeticOperationsTests.scala
@@ -23,7 +23,7 @@ class ArithmeticOperationsTests extends AnyFreeSpec with Matchers {
     "should contain a call node for addition op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.addition).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(2)
+      p.lineNumber shouldBe Some(3)
       p.code shouldBe "1 + 2"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
@@ -31,7 +31,7 @@ class ArithmeticOperationsTests extends AnyFreeSpec with Matchers {
     "should contain a call node for subtraction op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.subtraction).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(3)
+      p.lineNumber shouldBe Some(4)
       p.code shouldBe "1 - 2"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
@@ -39,7 +39,7 @@ class ArithmeticOperationsTests extends AnyFreeSpec with Matchers {
     "should contain a call node for multiplication op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.multiplication).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(4)
+      p.lineNumber shouldBe Some(5)
       p.code shouldBe "1 * 2"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
@@ -47,7 +47,7 @@ class ArithmeticOperationsTests extends AnyFreeSpec with Matchers {
     "should contain a call node for division op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.division).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(5)
+      p.lineNumber shouldBe Some(6)
       p.code shouldBe "1 / 2"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArrayAccessExprsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArrayAccessExprsTests.scala
@@ -28,7 +28,7 @@ class ArrayAccessExprsTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "foo[\"one\"]"
       c.methodFullName shouldBe Operators.indexAccess
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(5)
+      c.lineNumber shouldBe Some(6)
       c.columnNumber shouldBe Some(14)
 
       val List(firstArg: Identifier, secondArg: Literal) = callNodeQ.argument.l
@@ -60,7 +60,7 @@ class ArrayAccessExprsTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "foo[1]"
       c.methodFullName shouldBe Operators.indexAccess
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(5)
+      c.lineNumber shouldBe Some(6)
       c.columnNumber shouldBe Some(14)
 
       val List(firstArg: Identifier, secondArg: Literal) = callNodeQ.argument.l

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AssignmentTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AssignmentTests.scala
@@ -53,7 +53,7 @@ class AssignmentTests extends AnyFreeSpec with Matchers {
     "should contain a call node for `assignment` op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.assignment).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(2)
+      p.lineNumber shouldBe Some(3)
       p.code shouldBe "val x: Int = 5"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
@@ -61,7 +61,7 @@ class AssignmentTests extends AnyFreeSpec with Matchers {
     "should contain a call node for `assignmentPlus` op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.assignmentPlus).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(3)
+      p.lineNumber shouldBe Some(4)
       p.code shouldBe "x += 1"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
@@ -69,7 +69,7 @@ class AssignmentTests extends AnyFreeSpec with Matchers {
     "should contain a call node for `assignmentMinus` op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.assignmentMinus).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(4)
+      p.lineNumber shouldBe Some(5)
       p.code shouldBe "x -= 1"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
@@ -77,7 +77,7 @@ class AssignmentTests extends AnyFreeSpec with Matchers {
     "should contain a call node for `assignmentMultiplication` op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.assignmentMultiplication).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(5)
+      p.lineNumber shouldBe Some(6)
       p.code shouldBe "x *= 1"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
@@ -85,7 +85,7 @@ class AssignmentTests extends AnyFreeSpec with Matchers {
     "should contain a call node for `assignmentDivision` op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.assignmentDivision).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(6)
+      p.lineNumber shouldBe Some(7)
       p.code shouldBe "x /= 1"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
@@ -93,7 +93,7 @@ class AssignmentTests extends AnyFreeSpec with Matchers {
     "should contain a call node for `assignmentModulo` op with correct fields" in {
       val List(p) = cpg.call.methodFullName(Operators.assignmentModulo).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(7)
+      p.lineNumber shouldBe Some(8)
       p.code shouldBe "x %= 1"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BlockTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BlockTests.scala
@@ -19,7 +19,7 @@ class BlockTests extends AnyFreeSpec with Matchers {
 
     "should contain a BLOCK node with the correct props set" in {
       val List(b) = cpg.method.block.take(1).l
-      b.lineNumber shouldBe Some(3)
+      b.lineNumber shouldBe Some(4)
       b.columnNumber shouldBe Some(33)
       b.typeFullName shouldBe "java.lang.Void"
       b.code should not be ""

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BooleanLogicTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BooleanLogicTests.scala
@@ -35,7 +35,7 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.logicalNot).l
       p.argument.size shouldBe 1
-      p.lineNumber shouldBe Some(3)
+      p.lineNumber shouldBe Some(4)
       p.code shouldBe "!w"
     }
 
@@ -48,7 +48,7 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.logicalOr).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(4)
+      p.lineNumber shouldBe Some(5)
       p.code shouldBe "(x < w) || (w < x)"
     }
 
@@ -61,7 +61,7 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.logicalAnd).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(5)
+      p.lineNumber shouldBe Some(6)
       p.code shouldBe "(x < w) && (w < x)"
     }
 
@@ -74,7 +74,7 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.and).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(6)
+      p.lineNumber shouldBe Some(7)
       p.code shouldBe "(1 shl 2) and 0x000FF000"
     }
 
@@ -87,7 +87,7 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.xor).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(7)
+      p.lineNumber shouldBe Some(8)
       p.code shouldBe "(1 shr 2) xor 0x000FF000"
     }
 
@@ -100,7 +100,7 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.or).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(8)
+      p.lineNumber shouldBe Some(9)
       p.code shouldBe "2.inv() or (1 ushr 3)"
     }
 
@@ -113,12 +113,12 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.shiftLeft).order(1).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(6)
+      p.lineNumber shouldBe Some(7)
       p.code shouldBe "1 shl 2"
 
       val List(q) = cpg.call(Operators.shiftLeft).order(2).l
       q.argument.size shouldBe 2
-      q.lineNumber shouldBe Some(9)
+      q.lineNumber shouldBe Some(10)
       q.code shouldBe "1 ushl 2"
     }
 
@@ -131,7 +131,7 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.logicalShiftRight).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(8)
+      p.lineNumber shouldBe Some(9)
       p.code shouldBe "1 ushr 3"
     }
 
@@ -144,7 +144,7 @@ class BooleanLogicTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call(Operators.arithmeticShiftRight).l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(7)
+      p.lineNumber shouldBe Some(8)
       p.code shouldBe "1 shr 2"
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -37,7 +37,7 @@ class CallTests extends AnyFreeSpec with Matchers {
       c.argument.size shouldBe 2
       c.code shouldBe "val argc: Int = args.size"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(8)
+      c.lineNumber shouldBe Some(9)
       c.columnNumber shouldBe Some(6)
     }
 
@@ -48,7 +48,7 @@ class CallTests extends AnyFreeSpec with Matchers {
       c.argument.size shouldBe 2
       c.code shouldBe "x + y"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(9)
     }
 
@@ -58,7 +58,7 @@ class CallTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call("println").l
       p.argument.size shouldBe 1
-      p.lineNumber shouldBe Some(9)
+      p.lineNumber shouldBe Some(10)
       p.code shouldBe "println(foo(argc, 1))"
       p.methodFullName shouldBe "kotlin.io.println:void(int)"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
@@ -70,7 +70,7 @@ class CallTests extends AnyFreeSpec with Matchers {
 
       val List(p) = cpg.call("foo").l
       p.argument.size shouldBe 2
-      p.lineNumber shouldBe Some(9)
+      p.lineNumber shouldBe Some(10)
       p.code shouldBe "foo(argc, 1)"
       p.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       p.columnNumber shouldBe Some(10)
@@ -123,7 +123,7 @@ class CallTests extends AnyFreeSpec with Matchers {
       p.signature shouldBe "void()"
       p.code shouldBe "Foo()"
       p.columnNumber shouldBe Some(10)
-      p.lineNumber shouldBe Some(11)
+      p.lineNumber shouldBe Some(12)
     }
 
     "should contain a CALL node for `add1` with the correct props set" in {
@@ -132,7 +132,7 @@ class CallTests extends AnyFreeSpec with Matchers {
       p.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       p.code shouldBe "x.add1(argc, \"AMESSAGE\")"
       p.columnNumber shouldBe Some(10)
-      p.lineNumber shouldBe Some(12)
+      p.lineNumber shouldBe Some(13)
       p.methodFullName shouldBe "mypkg.Foo.add1:int(int,java.lang.String)"
       p.signature shouldBe "int(int,java.lang.String)"
       p.typeFullName shouldBe "int"
@@ -257,7 +257,7 @@ class CallTests extends AnyFreeSpec with Matchers {
       c.methodFullName shouldBe "kotlin.collections.mutableMapOf:java.util.Map(kotlin.Array)"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.typeFullName shouldBe "java.util.Map"
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(19)
     }
   }
@@ -349,7 +349,7 @@ class CallTests extends AnyFreeSpec with Matchers {
       val List(c) = cpg.call.code("MyCaseClass.PROP").l
       c.methodFullName shouldBe Operators.fieldAccess
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(6)
+      c.lineNumber shouldBe Some(7)
       c.columnNumber shouldBe Some(12)
       c.signature shouldBe ""
     }
@@ -358,7 +358,7 @@ class CallTests extends AnyFreeSpec with Matchers {
       val List(c) = cpg.call.code("MyCaseClass.*AN_ARGUMENT.*").l
       c.methodFullName shouldBe "no.such.CaseClass:ANY(ANY)"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(9)
+      c.lineNumber shouldBe Some(10)
       c.columnNumber shouldBe Some(17)
       c.signature shouldBe "ANY(ANY)"
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallbackTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallbackTests.scala
@@ -42,7 +42,7 @@ class CallbackTests extends AnyFreeSpec with Matchers {
     "method parameter should have the correct properties set" in {
       val List(p) = cpg.method.fullName(".*lambda.*").parameter.l
       p.name shouldBe "token"
-      p.lineNumber shouldBe Some(9)
+      p.lineNumber shouldBe Some(10)
       p.columnNumber shouldBe Some(22)
     }
 
@@ -99,7 +99,7 @@ class CallbackTests extends AnyFreeSpec with Matchers {
 
     "should contain a CALL node for the invocation of method with callback with the correct props" in {
       val List(c) = cpg.call.methodFullName(".*withCallback.*").l
-      c.lineNumber shouldBe Some(9)
+      c.lineNumber shouldBe Some(10)
       c.columnNumber shouldBe Some(8)
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.argument.size shouldBe 1

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToConstructorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToConstructorTests.scala
@@ -36,7 +36,7 @@ class CallsToConstructorTests extends AnyFreeSpec with Matchers {
       val List(assignmentLhs: Identifier, assignmentRhs: Block) = assignmentCall.argument.l
       assignmentLhs.code shouldBe "f"
       assignmentLhs.name shouldBe "f"
-      assignmentLhs.lineNumber shouldBe Some(6)
+      assignmentLhs.lineNumber shouldBe Some(7)
       assignmentLhs.columnNumber shouldBe Some(8)
       local.referencingIdentifiers.id.l.contains(assignmentLhs.id) shouldBe true
       assignmentRhs.typeFullName shouldBe "java.io.File"
@@ -175,7 +175,7 @@ class CallsToConstructorTests extends AnyFreeSpec with Matchers {
       val List(assignmentLhs: Identifier, assignmentRhs: Block) = assignmentCall.argument.l
       assignmentLhs.code shouldBe "a"
       assignmentLhs.name shouldBe "a"
-      assignmentLhs.lineNumber shouldBe Some(10)
+      assignmentLhs.lineNumber shouldBe Some(11)
       assignmentLhs.columnNumber shouldBe Some(8)
       local.referencingIdentifiers.id.l.contains(assignmentLhs.id) shouldBe true
       assignmentRhs.typeFullName shouldBe "mypkg.AClass"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -29,7 +29,7 @@ class CallsToFieldAccessTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "this.x"
       c.name shouldBe Operators.fieldAccess
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(5)
+      c.lineNumber shouldBe Some(6)
       c.columnNumber shouldBe Some(16)
 
       val List(firstArg: Identifier, secondArg: FieldIdentifier) =

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ClassLiteralTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ClassLiteralTests.scala
@@ -29,7 +29,7 @@ class ClassLiteralTests extends AnyFreeSpec with Matchers {
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.code shouldBe "Bar::class"
       c.columnNumber shouldBe Some(10)
-      c.lineNumber shouldBe Some(7)
+      c.lineNumber shouldBe Some(8)
       c.signature shouldBe "kotlin.reflect.KClass()"
       c.typeFullName shouldBe "kotlin.reflect.KClass"
       c.methodFullName shouldBe "mypkg.Bar.getClass:kotlin.reflect.KClass()"
@@ -41,7 +41,7 @@ class ClassLiteralTests extends AnyFreeSpec with Matchers {
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.code shouldBe "Baz::class"
       c.columnNumber shouldBe Some(10)
-      c.lineNumber shouldBe Some(8)
+      c.lineNumber shouldBe Some(9)
       c.signature shouldBe "kotlin.reflect.KClass()"
       c.typeFullName shouldBe "kotlin.reflect.KClass"
       c.methodFullName shouldBe "mypkg.Baz.getClass:kotlin.reflect.KClass()"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ConstructorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ConstructorTests.scala
@@ -174,10 +174,10 @@ class ConstructorTests extends AnyFreeSpec with Matchers {
 
     "should contain a METHOD node for the primary constructor with properties set correctly" in {
       val List(m) = cpg.typeDecl.fullNameExact("mypkg.Foo").method.take(1).l
-      m.lineNumber shouldBe Some(3)
+      m.lineNumber shouldBe Some(4)
       m.columnNumber shouldBe Some(9)
       m.methodReturn.code shouldBe "RET"
-      m.methodReturn.lineNumber shouldBe Some(3)
+      m.methodReturn.lineNumber shouldBe Some(4)
       m.methodReturn.columnNumber shouldBe Some(9)
 
       m.block.size shouldBe 1
@@ -188,10 +188,10 @@ class ConstructorTests extends AnyFreeSpec with Matchers {
       val List(m) = cpg.typeDecl.fullNameExact("mypkg.Foo").method.drop(1).take(1).l
       m.fullName shouldBe "mypkg.Foo.<init>:void(java.lang.String,int)"
       m.name shouldBe "<init>"
-      m.lineNumber shouldBe Some(5)
+      m.lineNumber shouldBe Some(6)
       m.columnNumber shouldBe Some(4)
       m.methodReturn.code shouldBe "RET"
-      m.methodReturn.lineNumber shouldBe Some(5)
+      m.methodReturn.lineNumber shouldBe Some(6)
       m.methodReturn.columnNumber shouldBe Some(4)
 
       m.block.size shouldBe 1

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
@@ -91,7 +91,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
     "complex `if` statement contains all required properties" in {
       val List(i) = cpg.controlStructure.where(_.condition.code("x > 1")).l
       i.controlStructureType shouldBe ControlStructureTypes.IF
-      i.lineNumber shouldBe Some(5)
+      i.lineNumber shouldBe Some(6)
 
       val List(ic) = cpg.controlStructure.where(_.condition.code("x > 1")).condition.l
       ic.code shouldBe "x > 1"
@@ -154,7 +154,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
       val List(c) = cpg.controlStructure.condition.isCall.l
       c.code shouldBe "aList.contains(msg)"
       c.methodFullName shouldBe "kotlin.collections.List.contains:boolean(java.lang.Object)"
-      c.lineNumber shouldBe Some(6)
+      c.lineNumber shouldBe Some(7)
       c.columnNumber shouldBe Some(5)
       c.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       c.signature shouldBe "boolean(java.lang.Object)"
@@ -179,7 +179,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
     "should contain a CONTROL_STRUCTURE node for the try statement with the correct props set" in {
       def matchTryQ = cpg.controlStructure.controlStructureType(ControlStructureTypes.TRY)
       val List(cs)  = matchTryQ.l
-      cs.lineNumber shouldBe Some(4)
+      cs.lineNumber shouldBe Some(5)
       cs.columnNumber shouldBe Some(3)
 
       val List(c1, c2, c3) = matchTryQ.astChildren.l
@@ -205,7 +205,7 @@ class ControlStructureTests extends AnyFreeSpec with Matchers {
     "should contain a CONTROL_STRUCTURE node for the try statement with the correct props set" in {
       def matchTryQ = cpg.controlStructure.controlStructureType(ControlStructureTypes.TRY)
       val List(cs)  = matchTryQ.l
-      cs.lineNumber shouldBe Some(4)
+      cs.lineNumber shouldBe Some(5)
       cs.columnNumber shouldBe Some(3)
 
       val List(c1, c2) = matchTryQ.astChildren.l

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DotQualifiedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DotQualifiedExpressionsTests.scala
@@ -31,7 +31,7 @@ class DotQualifiedExpressionsTests extends AnyFreeSpec with Matchers {
     "should contain a CALL node for `Javalin.create.*` with the correct properties set" in {
       val List(c) = cpg.call.code("Javalin.create.*7000.*").l
       c.methodFullName shouldBe "io.javalin.Javalin.start:io.javalin.Javalin(int)"
-      c.lineNumber shouldBe Some(8)
+      c.lineNumber shouldBe Some(9)
       c.columnNumber shouldBe Some(12)
       c.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FieldAccessTests.scala
@@ -31,7 +31,7 @@ class FieldAccessTests extends AnyFreeSpec with Matchers {
       c.methodFullName shouldBe Operators.fieldAccess
       c.code shouldBe "a.m"
       c.typeFullName shouldBe "java.lang.String"
-      c.lineNumber shouldBe Some(10)
+      c.lineNumber shouldBe Some(11)
       c.columnNumber shouldBe Some(4)
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/HigherOrderFnsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/HigherOrderFnsTests.scala
@@ -29,7 +29,7 @@ class HigherOrderFnsTests extends AnyFreeSpec with Matchers {
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.signature shouldBe "java.lang.Object(java.lang.Object,kotlin.Function2)"
       c.typeFullName shouldBe "int"
-      c.lineNumber shouldBe Some(6)
+      c.lineNumber shouldBe Some(7)
       c.columnNumber shouldBe Some(9)
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IdentifierTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IdentifierTests.scala
@@ -28,10 +28,10 @@ class IdentifierTests extends AnyFreeSpec with Matchers {
     }
 
     "IDENTIFIER nodes have the correct LINE_NUMBER property set" in {
-      cpg.identifier("x").lineNumber.l.head shouldBe 2
-      cpg.identifier("y").lineNumber.l.head shouldBe 2
-      cpg.identifier("argc").lineNumber.l.head shouldBe 6
-      cpg.identifier("args").lineNumber.l.head shouldBe 6
+      cpg.identifier("x").lineNumber.l.head shouldBe 3
+      cpg.identifier("y").lineNumber.l.head shouldBe 3
+      cpg.identifier("argc").lineNumber.l.head shouldBe 7
+      cpg.identifier("args").lineNumber.l.head shouldBe 7
     }
 
     "IDENTIFIER nodes have the correct COLUMN_NUMBER property set" in {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IfExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IfExpressionsTests.scala
@@ -21,7 +21,7 @@ class IfExpressionsTests extends AnyFreeSpec with Matchers {
     "should contain a CALL for the `if`-expression with the correct props set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.conditional).l
       c.code shouldBe "if(argc > 0) argc else 0"
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(16)
       c.argument.size shouldBe 3
     }
@@ -29,19 +29,19 @@ class IfExpressionsTests extends AnyFreeSpec with Matchers {
     "should contain a ARGUMENT nodes for the `if`-expression CALL with the correct props set" in {
       val List(a1) = cpg.call.methodFullNameExact(Operators.conditional).argument(1).l
       a1.code shouldBe "argc > 0"
-      a1.lineNumber shouldBe Some(4)
+      a1.lineNumber shouldBe Some(5)
       a1.columnNumber shouldBe Some(19)
       a1.order shouldBe 1
 
       val List(a2) = cpg.call.methodFullNameExact(Operators.conditional).argument(2).l
       a2.code shouldBe "argc"
-      a2.lineNumber shouldBe Some(4)
+      a2.lineNumber shouldBe Some(5)
       a2.columnNumber shouldBe Some(29)
       a2.order shouldBe 2
 
       val List(a3) = cpg.call.methodFullNameExact(Operators.conditional).argument(3).l
       a3.code shouldBe "0"
-      a3.lineNumber shouldBe Some(4)
+      a3.lineNumber shouldBe Some(5)
       a3.columnNumber shouldBe Some(39)
       a3.order shouldBe 3
     }
@@ -110,7 +110,7 @@ class IfExpressionsTests extends AnyFreeSpec with Matchers {
 
     "should contain a CALL for the `if`-expression with the correct props set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.conditional).l
-      c.lineNumber shouldBe Some(12)
+      c.lineNumber shouldBe Some(13)
       c.columnNumber shouldBe Some(16)
       c.argument.size shouldBe 3
     }
@@ -118,19 +118,19 @@ class IfExpressionsTests extends AnyFreeSpec with Matchers {
     "should contain a ARGUMENT nodes for the `if`-expression CALL with the correct props set" in {
       val List(a1) = cpg.call.methodFullNameExact(Operators.conditional).argument(1).l
       a1.code shouldBe "argc == 0"
-      a1.lineNumber shouldBe Some(12)
+      a1.lineNumber shouldBe Some(13)
       a1.columnNumber shouldBe Some(19)
       a1.order shouldBe 1
 
       val List(a2) = cpg.call.methodFullNameExact(Operators.conditional).argument(2).l
       a2.code shouldBe "some1()"
-      a2.lineNumber shouldBe Some(12)
+      a2.lineNumber shouldBe Some(13)
       a2.columnNumber shouldBe Some(30)
       a2.order shouldBe 2
 
       val List(a3) = cpg.call.methodFullNameExact(Operators.conditional).argument(3).l
       a3.code shouldBe "some2()"
-      a3.lineNumber shouldBe Some(14)
+      a3.lineNumber shouldBe Some(15)
       a3.columnNumber shouldBe Some(10)
       a3.order shouldBe 3
     }
@@ -153,7 +153,7 @@ class IfExpressionsTests extends AnyFreeSpec with Matchers {
     "should contain a CALL for the `if`-expression with the correct props set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.conditional).l
       c.argument.size shouldBe 3
-      c.lineNumber shouldBe Some(7)
+      c.lineNumber shouldBe Some(8)
       c.columnNumber shouldBe Some(15)
     }
   }
@@ -189,24 +189,24 @@ class IfExpressionsTests extends AnyFreeSpec with Matchers {
 
     "should contain a CALL for the `if`-expression with the correct props set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.conditional).l
-      c.lineNumber shouldBe Some(19)
+      c.lineNumber shouldBe Some(20)
       c.columnNumber shouldBe Some(8)
       c.argument.size shouldBe 3
     }
 
     "should contain a ARGUMENT nodes for the `if`-expression CALL with the correct props set" in {
       val List(a1) = cpg.call.methodFullNameExact(Operators.conditional).argument(1).l
-      a1.lineNumber shouldBe Some(19)
+      a1.lineNumber shouldBe Some(20)
       a1.columnNumber shouldBe Some(12)
       a1.order shouldBe 1
 
       val List(a2) = cpg.call.methodFullNameExact(Operators.conditional).argument(2).l
-      a2.lineNumber shouldBe Some(19)
+      a2.lineNumber shouldBe Some(20)
       a2.columnNumber shouldBe Some(20)
       a2.order shouldBe 2
 
       val List(a3) = cpg.call.methodFullNameExact(Operators.conditional).argument(3).l
-      a3.lineNumber shouldBe Some(21)
+      a3.lineNumber shouldBe Some(22)
       a3.columnNumber shouldBe Some(15)
       a3.order shouldBe 3
     }
@@ -236,24 +236,24 @@ class IfExpressionsTests extends AnyFreeSpec with Matchers {
 
     "should contain a CALL for the `if`-expression with the correct props set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.conditional).l
-      c.lineNumber shouldBe Some(12)
+      c.lineNumber shouldBe Some(13)
       c.columnNumber shouldBe Some(8)
       c.argument.size shouldBe 3
     }
 
     "should contain a ARGUMENT nodes for the `if`-expression CALL with the correct props set" in {
       val List(a1) = cpg.call.methodFullNameExact(Operators.conditional).argument(1).l
-      a1.lineNumber shouldBe Some(12)
+      a1.lineNumber shouldBe Some(13)
       a1.columnNumber shouldBe Some(12)
       a1.order shouldBe 1
 
       val List(a2) = cpg.call.methodFullNameExact(Operators.conditional).argument(2).l
-      a2.lineNumber shouldBe Some(12)
+      a2.lineNumber shouldBe Some(13)
       a2.columnNumber shouldBe Some(20)
       a2.order shouldBe 2
 
       val List(a3) = cpg.call.methodFullNameExact(Operators.conditional).argument(3).l
-      a3.lineNumber shouldBe Some(14)
+      a3.lineNumber shouldBe Some(15)
       a3.columnNumber shouldBe Some(15)
       a3.order shouldBe 3
     }
@@ -287,24 +287,24 @@ class IfExpressionsTests extends AnyFreeSpec with Matchers {
 
     "should contain a CALL for the `if`-expression with the correct props set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.conditional).l
-      c.lineNumber shouldBe Some(9)
+      c.lineNumber shouldBe Some(10)
       c.columnNumber shouldBe Some(11)
       c.argument.size shouldBe 3
     }
 
     "should contain a ARGUMENT nodes for the `if`-expression CALL with the correct props set" in {
       val List(a1) = cpg.call.methodFullNameExact(Operators.conditional).argument(1).l
-      a1.lineNumber shouldBe Some(9)
+      a1.lineNumber shouldBe Some(10)
       a1.columnNumber shouldBe Some(15)
       a1.order shouldBe 1
 
       val List(a2) = cpg.call.methodFullNameExact(Operators.conditional).argument(2).l
-      a2.lineNumber shouldBe Some(9)
+      a2.lineNumber shouldBe Some(10)
       a2.columnNumber shouldBe Some(23)
       a2.order shouldBe 2
 
       val List(a3) = cpg.call.methodFullNameExact(Operators.conditional).argument(3).l
-      a3.lineNumber shouldBe Some(11)
+      a3.lineNumber shouldBe Some(12)
       a3.columnNumber shouldBe Some(18)
       a3.order shouldBe 3
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ImportTests.scala
@@ -28,7 +28,7 @@ class ImportTests extends AnyFreeSpec with Matchers {
       val List(imp) = cpg.all.collect { case n: Import => n }.code(".*listOf.*").l
       imp.code shouldBe "import kotlin.io.collections.listOf"
       imp.importedEntity shouldBe Some("kotlin.io.collections.listOf")
-      imp.lineNumber shouldBe Some(3)
+      imp.lineNumber shouldBe Some(4)
       imp.columnNumber shouldBe Some(0)
       imp.isWildcard shouldBe Some(false)
       imp.isExplicit shouldBe Some(true)
@@ -38,7 +38,7 @@ class ImportTests extends AnyFreeSpec with Matchers {
       val List(imp) = cpg.all.collect { case n: Import => n }.code(".*comparisons.*").l
       imp.code shouldBe "import kotlin.comparisons.*"
       imp.importedEntity shouldBe Some("kotlin.comparisons.*")
-      imp.lineNumber shouldBe Some(4)
+      imp.lineNumber shouldBe Some(5)
       imp.columnNumber shouldBe Some(0)
       imp.isWildcard shouldBe Some(true)
       imp.isExplicit shouldBe Some(true)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -106,7 +106,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
       val List(m) = cpg.method.fullName(".*lambda.*").l
       m.fullName shouldBe "mypkg.<lambda><f_generated.kt_no1>:java.lang.Object(java.lang.Object)"
       m.signature shouldBe "java.lang.Object(java.lang.Object)"
-      m.lineNumber shouldBe Some(5)
+      m.lineNumber shouldBe Some(6)
       m.columnNumber shouldBe Some(14)
     }
 
@@ -114,7 +114,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
       val List(mr) = cpg.method.fullName(".*lambda.*").methodReturn.l
       mr.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
       mr.typeFullName shouldBe "java.lang.Object"
-      mr.lineNumber shouldBe Some(5)
+      mr.lineNumber shouldBe Some(6)
       mr.columnNumber shouldBe Some(14)
     }
 
@@ -126,7 +126,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
     "should contain a METHOD_PARAMETER_IN for the lambda with the correct properties set" in {
       val List(p) = cpg.method.fullName(".*lambda.*").parameter.l
       p.code shouldBe "arg"
-      p.lineNumber shouldBe Some(5)
+      p.lineNumber shouldBe Some(6)
       p.columnNumber shouldBe Some(16)
       p.typeFullName shouldBe "java.lang.String"
     }
@@ -135,7 +135,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
       val List(c) = cpg.call.methodFullName(".*forEach.*").l
       c.methodFullName shouldBe "java.lang.Iterable.forEach:void(kotlin.Function1)"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(5)
+      c.lineNumber shouldBe Some(6)
       c.columnNumber shouldBe Some(4)
 
       val List(firstArg, secondArg) = cpg.call.methodFullName(".*forEach.*").argument.l
@@ -252,7 +252,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
       val List(m) = cpg.method.fullName(".*lambda.*").l
       m.fullName shouldBe "mypkg.<lambda><f_generated.kt_no1>:java.lang.Object(java.lang.Object)"
       m.signature shouldBe "java.lang.Object(java.lang.Object)"
-      m.lineNumber shouldBe Some(5)
+      m.lineNumber shouldBe Some(6)
       m.columnNumber shouldBe Some(28)
     }
 
@@ -260,7 +260,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
       val List(mr) = cpg.method.fullName(".*lambda.*").methodReturn.l
       mr.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
       mr.typeFullName shouldBe "java.lang.Object"
-      mr.lineNumber shouldBe Some(5)
+      mr.lineNumber shouldBe Some(6)
       mr.columnNumber shouldBe Some(28)
     }
 
@@ -279,7 +279,7 @@ class LambdaTests extends AnyFreeSpec with Matchers {
       val List(c) = cpg.call.methodFullName(".*map.*").take(1).l
       c.methodFullName shouldBe "java.lang.Iterable.map:java.util.List(kotlin.Function1)"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(5)
+      c.lineNumber shouldBe Some(6)
       c.columnNumber shouldBe Some(20)
     }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MemberTests.scala
@@ -19,7 +19,7 @@ class MemberTests extends AnyFreeSpec with Matchers {
       x.name shouldBe "bar"
       x.code shouldBe "bar"
       x.typeFullName shouldBe "int"
-      x.lineNumber shouldBe Some(2)
+      x.lineNumber shouldBe Some(3)
       x.columnNumber shouldBe Some(6)
       x.order shouldBe 2
     }
@@ -65,7 +65,7 @@ class MemberTests extends AnyFreeSpec with Matchers {
       x.name shouldBe "bar"
       x.code shouldBe "bar"
       x.typeFullName shouldBe "int"
-      x.lineNumber shouldBe Some(2)
+      x.lineNumber shouldBe Some(3)
       x.columnNumber shouldBe Some(6)
       x.order shouldBe 2
     }
@@ -90,7 +90,7 @@ class MemberTests extends AnyFreeSpec with Matchers {
       x.name shouldBe "bar"
       x.code shouldBe "bar"
       x.typeFullName shouldBe "int"
-      x.lineNumber shouldBe Some(2)
+      x.lineNumber shouldBe Some(3)
       x.columnNumber shouldBe Some(6)
       x.order shouldBe 2
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodAtPackageLevelTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodAtPackageLevelTests.scala
@@ -30,7 +30,7 @@ class MethodAtPackageLevelTests extends AnyFreeSpec with Matchers {
       x.code shouldBe "double"
       x.signature shouldBe "int(int)"
       x.isExternal shouldBe false
-      x.lineNumber shouldBe Some(1)
+      x.lineNumber shouldBe Some(2)
       x.columnNumber shouldBe Some(4)
       x.filename.endsWith(".kt") shouldBe true
 
@@ -40,7 +40,7 @@ class MethodAtPackageLevelTests extends AnyFreeSpec with Matchers {
       y.code shouldBe "main"
       y.signature shouldBe "void(kotlin.Array)"
       y.isExternal shouldBe false
-      y.lineNumber shouldBe Some(5)
+      y.lineNumber shouldBe Some(6)
       x.columnNumber shouldBe Some(4)
       y.filename.endsWith(".kt") shouldBe true
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodParameterTests.scala
@@ -27,14 +27,14 @@ class MethodParameterTests extends AnyFreeSpec with Matchers {
       val List(x) = params.name("x").l
       x.code shouldBe "x"
       x.typeFullName shouldBe "int"
-      x.lineNumber shouldBe Some(3)
+      x.lineNumber shouldBe Some(4)
       x.columnNumber shouldBe Some(12)
       x.order shouldBe 1
 
       val List(y) = params.name("y").l
       y.code shouldBe "y"
       y.typeFullName shouldBe "int"
-      y.lineNumber shouldBe Some(3)
+      y.lineNumber shouldBe Some(4)
       y.columnNumber shouldBe Some(20)
       y.order shouldBe 2
     }
@@ -58,14 +58,14 @@ class MethodParameterTests extends AnyFreeSpec with Matchers {
       val List(x) = params.name("x").l
       x.code shouldBe "x"
       x.typeFullName shouldBe "int"
-      x.lineNumber shouldBe Some(4)
+      x.lineNumber shouldBe Some(5)
       x.columnNumber shouldBe Some(10)
       x.order shouldBe 1
 
       val List(y) = params.name("y").l
       y.code shouldBe "y"
       y.typeFullName shouldBe "double"
-      y.lineNumber shouldBe Some(4)
+      y.lineNumber shouldBe Some(5)
       y.columnNumber shouldBe Some(18)
       y.order shouldBe 2
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodReturnTests.scala
@@ -21,7 +21,7 @@ class MethodReturnTests extends AnyFreeSpec with Matchers {
       x.code shouldBe "RET"
       x.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
       x.order shouldBe 5
-      x.lineNumber shouldBe Some(1)
+      x.lineNumber shouldBe Some(2)
       x.columnNumber shouldBe Some(4)
     }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
@@ -26,9 +26,9 @@ class MethodTests extends AnyFreeSpec with Matchers {
       m.code shouldBe "bar"
       m.signature shouldBe "int(int)"
       m.isExternal shouldBe false
-      m.lineNumber shouldBe Some(4)
+      m.lineNumber shouldBe Some(5)
       m.columnNumber shouldBe Some(6)
-      m.lineNumberEnd shouldBe Some(6)
+      m.lineNumberEnd shouldBe Some(7)
       m.columnNumberEnd shouldBe Some(2)
       m.order shouldBe 1
       m.filename.endsWith(".kt") shouldBe true

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectDeclarationsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectDeclarationsTests.scala
@@ -29,7 +29,7 @@ class ObjectDeclarationsTests extends AnyFreeSpec with Matchers {
       x.fullName shouldBe "mypkg.Foo"
       x.inheritsFromTypeFullName shouldBe List("java.lang.Object")
       x.isExternal shouldBe false
-      x.lineNumber shouldBe Some(3)
+      x.lineNumber shouldBe Some(4)
       x.columnNumber shouldBe Some(7)
     }
 
@@ -38,7 +38,7 @@ class ObjectDeclarationsTests extends AnyFreeSpec with Matchers {
       x.name shouldBe "bar"
       x.code shouldBe "bar"
       x.typeFullName shouldBe "java.lang.String"
-      x.lineNumber shouldBe Some(4)
+      x.lineNumber shouldBe Some(5)
       x.columnNumber shouldBe Some(8)
     }
 
@@ -47,7 +47,7 @@ class ObjectDeclarationsTests extends AnyFreeSpec with Matchers {
       x.name shouldBe "baz"
       x.code shouldBe "baz"
       x.typeFullName shouldBe "java.lang.String"
-      x.lineNumber shouldBe Some(5)
+      x.lineNumber shouldBe Some(6)
       x.columnNumber shouldBe Some(8)
     }
 
@@ -115,7 +115,7 @@ class ObjectDeclarationsTests extends AnyFreeSpec with Matchers {
       x.fullName shouldBe "mypkg.Prefs"
       x.inheritsFromTypeFullName shouldBe List("java.lang.Object")
       x.isExternal shouldBe false
-      x.lineNumber shouldBe Some(6)
+      x.lineNumber shouldBe Some(7)
       x.columnNumber shouldBe Some(7)
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
@@ -21,7 +21,7 @@ class ObjectExpressionTests extends AnyFreeSpec with Matchers {
 
     "should contain an unknown node for the object expression" in {
       val List(u) = cpg.all.filter(_.isInstanceOf[Unknown]).map(_.asInstanceOf[Unknown]).l
-      u.lineNumber shouldBe Some(2)
+      u.lineNumber shouldBe Some(3)
       u.columnNumber shouldBe Some(12)
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ParenthesizedExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ParenthesizedExpressionTests.scala
@@ -21,7 +21,7 @@ class ParenthesizedExpressionTests extends AnyFreeSpec with Matchers {
 
     "should contain a CALL node for the expression inside it" in {
       val List(c) = cpg.call.methodFullName(Operators.addition).l
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(19)
       c.code shouldBe "\"a\" + \"b\""
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
@@ -41,7 +41,7 @@ class ParenthesizedExpressionTests extends AnyFreeSpec with Matchers {
 
     "should contain a call node for the expression inside it" in {
       val List(c) = cpg.call.methodFullName(Operators.addition).l
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(19)
       c.code shouldBe "\"a\" + \"b\""
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SafeQualifiedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SafeQualifiedExpressionsTests.scala
@@ -24,7 +24,7 @@ class SafeQualifiedExpressionsTests extends AnyFreeSpec with Matchers {
     "should contain a CALL node for `r?.exec.*` with the correct properties set" in {
       val List(c) = cpg.call.code(".*exec.*").take(1).l
       c.methodFullName shouldBe "java.lang.Runtime.exec:java.lang.Process(java.lang.String)"
-      c.lineNumber shouldBe Some(5)
+      c.lineNumber shouldBe Some(6)
       c.columnNumber shouldBe Some(2)
       c.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SpecialOperatorsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SpecialOperatorsTests.scala
@@ -22,7 +22,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "b?.length"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.methodFullName shouldBe Operators.fieldAccess
-      c.lineNumber shouldBe Some(3)
+      c.lineNumber shouldBe Some(4)
       c.columnNumber shouldBe Some(12)
     }
   }
@@ -39,7 +39,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
       val List(c) = cpg.call.methodFullName(Operators.cast).l
       c.code shouldBe "\"PLACEHOLDER\" as String"
       c.columnNumber shouldBe Some(12)
-      c.lineNumber shouldBe Some(2)
+      c.lineNumber shouldBe Some(3)
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
   }
@@ -69,7 +69,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
       val List(c) = cpg.call.methodFullName(Operators.notNullAssert).l
       c.code shouldBe "\" PLACEHOLDER \"!!"
       c.columnNumber shouldBe Some(14)
-      c.lineNumber shouldBe Some(2)
+      c.lineNumber shouldBe Some(3)
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
   }
@@ -94,7 +94,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
           .isCall
           .l
       c.code shouldBe "o is String"
-      c.lineNumber shouldBe Some(5)
+      c.lineNumber shouldBe Some(6)
       c.columnNumber shouldBe Some(12)
       c.methodFullName shouldBe Operators.is
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
@@ -119,7 +119,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
           .isCall
           .l
       c.code shouldBe "0..2"
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(12)
       c.methodFullName shouldBe Operators.range
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
@@ -139,7 +139,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
     "should contain a CALL node for elvis operator with the correct properties set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.elvis).l
       c.code shouldBe "args[1]?.length ?: -1"
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(14)
       c.methodFullName shouldBe Operators.elvis
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
@@ -182,7 +182,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
     "should contain a CALL node for the notIn operator with the correct properties set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.notIn).l
       c.code shouldBe "1 !in 0..10"
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(14)
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.argument.size shouldBe 2
@@ -202,7 +202,7 @@ class SpecialOperatorsTests extends AnyFreeSpec with Matchers {
     "should contain a CALL node for the notIn operator with the correct properties set" in {
       val List(c) = cpg.call.methodFullNameExact(Operators.in).l
       c.code shouldBe "1 in 0..10"
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.columnNumber shouldBe Some(14)
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.argument.size shouldBe 2

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StdLibTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StdLibTests.scala
@@ -176,7 +176,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
         c.signature shouldBe "java.lang.String()"
         c.typeFullName shouldBe "java.lang.String"
         c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-        c.lineNumber shouldBe Some(4)
+        c.lineNumber shouldBe Some(5)
         c.columnNumber shouldBe Some(12)
       }
 
@@ -186,7 +186,7 @@ class StdLibTests extends AnyFreeSpec with Matchers {
         receiverArg.name shouldBe "p"
         receiverArg.code shouldBe "p"
         receiverArg.typeFullName shouldBe "java.lang.String"
-        receiverArg.lineNumber shouldBe Some(4)
+        receiverArg.lineNumber shouldBe Some(5)
         receiverArg.columnNumber shouldBe Some(12)
       }
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StringInterpolationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StringInterpolationTests.scala
@@ -43,7 +43,7 @@ class StringInterpolationTests extends AnyFreeSpec with Matchers {
 
       val List(c) = cpg.call(Operators.formatString).l
       c.argument.size shouldBe 3
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
       c.code shouldBe "\"$name is $age years old. The string length is ${name.length}\""
     }
 
@@ -51,7 +51,7 @@ class StringInterpolationTests extends AnyFreeSpec with Matchers {
       val List(a) = cpg.call(Operators.formatString).argument.argumentIndex(1).isCall.l
       a.name shouldBe Operators.formattedValue
       a.methodFullName shouldBe Operators.formattedValue
-      a.lineNumber shouldBe Some(4)
+      a.lineNumber shouldBe Some(5)
       a.columnNumber shouldBe Some(12)
       a.code shouldBe "name"
       a.argument.size shouldBe 1
@@ -61,7 +61,7 @@ class StringInterpolationTests extends AnyFreeSpec with Matchers {
       val List(a) = cpg.call(Operators.formatString).argument.argumentIndex(2).isCall.l
       a.name shouldBe Operators.formattedValue
       a.methodFullName shouldBe Operators.formattedValue
-      a.lineNumber shouldBe Some(4)
+      a.lineNumber shouldBe Some(5)
       a.columnNumber shouldBe Some(21)
       a.code shouldBe "age"
       a.argument.size shouldBe 1
@@ -71,7 +71,7 @@ class StringInterpolationTests extends AnyFreeSpec with Matchers {
       val List(a) = cpg.call(Operators.formatString).argument.argumentIndex(3).isCall.l
       a.name shouldBe Operators.formattedValue
       a.methodFullName shouldBe Operators.formattedValue
-      a.lineNumber shouldBe Some(4)
+      a.lineNumber shouldBe Some(5)
       a.columnNumber shouldBe Some(59)
       a.code shouldBe "name.length"
       a.argument.size shouldBe 1

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SubscriptTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SubscriptTests.scala
@@ -21,7 +21,7 @@ class SubscriptTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "names[0]"
       c.methodFullName shouldBe Operators.indexAccess
       c.typeFullName shouldBe "int"
-      c.lineNumber shouldBe Some(3)
+      c.lineNumber shouldBe Some(4)
       c.columnNumber shouldBe Some(9)
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SuperTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SuperTests.scala
@@ -37,7 +37,7 @@ class SuperTests extends AnyFreeSpec with Matchers {
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       c.methodFullName shouldBe "mypkg.BClass.myfun:void()"
       c.signature shouldBe "void()"
-      c.lineNumber shouldBe Some(11)
+      c.lineNumber shouldBe Some(12)
       c.columnNumber shouldBe Some(8)
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ThisTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ThisTests.scala
@@ -58,7 +58,7 @@ class ThisTests extends AnyFreeSpec with Matchers {
 
     "should have a CALL node with _this_ as argument" in {
       val List(a: Identifier) = cpg.call("bar").argument.code("this").l
-      a.lineNumber shouldBe Some(7)
+      a.lineNumber shouldBe Some(8)
       a.columnNumber shouldBe Some(12)
       a.typeFullName shouldBe "mypkg.Foo"
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
@@ -44,7 +44,7 @@ class TryExpressionsTests extends AnyFreeSpec with Matchers {
       firstAstChildOfFirstArg.name shouldBe "x"
       firstAstChildOfFirstArg.code shouldBe "x"
       firstAstChildOfFirstArg.typeFullName shouldBe "int"
-      firstAstChildOfFirstArg.lineNumber shouldBe Some(6)
+      firstAstChildOfFirstArg.lineNumber shouldBe Some(7)
       firstAstChildOfFirstArg.columnNumber shouldBe Some(8)
 
       val List(firstAstChildOfSecondArg: Call) = secondArg.astChildren.head.l

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeDeclTests.scala
@@ -32,7 +32,7 @@ class TypeDeclTests extends AnyFreeSpec with Matchers {
       x.fullName shouldBe "mypkg.Foo"
       x.inheritsFromTypeFullName shouldBe List("java.lang.Object")
       x.isExternal shouldBe false
-      x.lineNumber shouldBe Some(5)
+      x.lineNumber shouldBe Some(6)
       x.columnNumber shouldBe Some(6)
     }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/UnaryOpTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/UnaryOpTests.scala
@@ -52,7 +52,7 @@ class UnaryOpTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "+x"
       c.typeFullName shouldBe "int"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(4)
+      c.lineNumber shouldBe Some(5)
 
       c.argument.size shouldBe 1
     }
@@ -62,7 +62,7 @@ class UnaryOpTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "-x"
       c.typeFullName shouldBe "int"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(5)
+      c.lineNumber shouldBe Some(6)
 
       c.argument.size shouldBe 1
     }
@@ -72,7 +72,7 @@ class UnaryOpTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "!y"
       c.typeFullName shouldBe "boolean"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(6)
+      c.lineNumber shouldBe Some(7)
 
       c.argument.size shouldBe 1
     }
@@ -82,7 +82,7 @@ class UnaryOpTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "++x"
       c.typeFullName shouldBe "int"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(7)
+      c.lineNumber shouldBe Some(8)
 
       c.argument.size shouldBe 1
     }
@@ -92,7 +92,7 @@ class UnaryOpTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "--x"
       c.typeFullName shouldBe "int"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(8)
+      c.lineNumber shouldBe Some(9)
 
       c.argument.size shouldBe 1
     }
@@ -102,7 +102,7 @@ class UnaryOpTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "x++"
       c.typeFullName shouldBe "int"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(9)
+      c.lineNumber shouldBe Some(10)
 
       c.argument.size shouldBe 1
     }
@@ -112,7 +112,7 @@ class UnaryOpTests extends AnyFreeSpec with Matchers {
       c.code shouldBe "x--"
       c.typeFullName shouldBe "int"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.lineNumber shouldBe Some(10)
+      c.lineNumber shouldBe Some(11)
 
       c.argument.size shouldBe 1
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/IdentifierReferencesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/IdentifierReferencesTests.scala
@@ -31,11 +31,11 @@ class IdentifierReferencesTests extends AnyFreeSpec with Matchers {
     "should contain LOCAL nodes with correctly-set referencing IDENTIFIERS" in {
       val List(outerScopeX: Local) = cpg.local.nameExact("x").whereNot(_.closureBindingId).take(1).l
       outerScopeX.referencingIdentifiers.size shouldBe 2
-      outerScopeX.referencingIdentifiers.lineNumber.l shouldBe List(4, 6)
+      outerScopeX.referencingIdentifiers.lineNumber.l shouldBe List(5, 7)
 
       val List(innerScopeX: Local) = cpg.local.nameExact("x").whereNot(_.closureBindingId).drop(1).take(1).l
       innerScopeX.referencingIdentifiers.size shouldBe 1
-      innerScopeX.referencingIdentifiers.lineNumber.l shouldBe List(7)
+      innerScopeX.referencingIdentifiers.lineNumber.l shouldBe List(8)
     }
   }
 


### PR DESCRIPTION
it seems that the `package` directive is not taken into consideration