### PR TITLE
Fix call expression type.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2599,9 +2599,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         ("", "")
     }
 
-    val codePrefix = codePrefixForMethodCall(call)
+    val expressionTypeFullName = expressionReturnTypeFullName(call).orElse(expectedReturnType)
+    val codePrefix             = codePrefixForMethodCall(call)
     val callNode = NewCall()
-      .typeFullName(maybeReturnType.getOrElse(UnresolvedTypeDefault))
+      .typeFullName(expressionTypeFullName.getOrElse(UnresolvedTypeDefault))
       .name(call.getNameAsString)
       .methodFullName(methodFullName)
       .signature(signature)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -59,6 +59,24 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
       cpg.call.nameExact("method").methodFullName.head shouldBe "MoreDerived.method:void(int)"
     }
   }
+
+  "call to method with generic return type" should {
+    val cpg = code("""
+        |class Foo {
+        |  void method(java.util.function.Function<String, Integer> supplier) {
+        |     supplier.apply("abc");
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have correct substitute type as expression type" in {
+      cpg.call.name("apply").evalType.head shouldBe "java.lang.Integer"
+    }
+    "have correct methodFullName to erased method signature" in {
+      cpg.call.name("apply").methodFullName.head shouldBe
+        "java.util.function.Function.apply:java.lang.Object(java.lang.Object)"
+    }
+  }
 }
 
 class CallTests extends JavaSrcCodeToCpgFixture {


### PR DESCRIPTION
In case the call was to a generic method, the type parameter was not
correctly replaced by the substitute type of the context.