### PR TITLE
Reduce log noise in `kotlin2cpg`

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -852,7 +852,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
         )
         Seq(astForUnknown(typedExpr, order, argIdx))
       case null =>
-        logger.debug("Received null expression! Skipping...")
+        logger.trace("Received null expression! Skipping...")
         Seq()
       // TODO: handle `KtCallableReferenceExpression` like `this::baseTerrain`
       case unknownExpr =>


### PR DESCRIPTION
empty expressions are passed to that fn in lots of different valid cases and just makes log-debugging harder for DEBUG log level