### PR TITLE
joern-export arguments grouped differently

### DIFF
--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -4,7 +4,7 @@ import better.files.Dsl._
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows._
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.joerncli.JoernExport.Representations
+import io.joern.joerncli.JoernExport.{Format, Representations}
 import io.joern.joerncli.console.JoernWorkspaceLoader
 import io.joern.x2cpg.layers._
 import io.shiftleft.semanticcpg.layers._
@@ -13,20 +13,23 @@ import overflowdb.formats.neo4jcsv.Neo4jCsvExporter
 
 import scala.util.Using
 
-case class ExporterConfig(
-  cpgFileName: String = "cpg.bin",
-  outDir: String = "out",
-  repr: Representations.Value = Representations.cpg14
-)
-
 object JoernExport extends App {
 
+  case class Config(
+     cpgFileName: String = "cpg.bin",
+     outDir: String = "out",
+     repr: Representations.Value = Representations.cpg14,
+   )
+
+  /**
+    * Choose from either a subset of the graph, or the entire graph (all).
+    */
   object Representations extends Enumeration {
-    val ast, cfg, ddg, cdg, pdg, cpg14, neo4jcsv = Value
+    val ast, cfg, ddg, cdg, pdg, cpg14, all = Value
   }
 
-  private def parseConfig: Option[ExporterConfig] =
-    new scopt.OptionParser[ExporterConfig]("joern-export") {
+  private def parseConfig: Option[Config] =
+    new scopt.OptionParser[Config]("joern-export") {
       head("Dump intermediate graph representations of code onto disk")
       help("help")
       arg[String]("cpg")
@@ -39,7 +42,7 @@ object JoernExport extends App {
       opt[String]("repr")
         .text(s"representation to extract: [${Representations.values.toSeq.sorted.mkString("|")}]")
         .action((x, c) => c.copy(repr = Representations.withName(x)))
-    }.parse(args, ExporterConfig())
+    }.parse(args, Config())
 
   parseConfig.foreach { config =>
     if (File(config.outDir).exists) {

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -4,7 +4,7 @@ import better.files.Dsl._
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows._
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.joerncli.JoernExport.{Format, Representations}
+import io.joern.joerncli.JoernExport.{Format, Representation}
 import io.joern.joerncli.console.JoernWorkspaceLoader
 import io.joern.x2cpg.layers._
 import io.shiftleft.semanticcpg.layers._
@@ -16,32 +16,40 @@ import scala.util.Using
 object JoernExport extends App {
 
   case class Config(
-     cpgFileName: String = "cpg.bin",
-     outDir: String = "out",
-     repr: Representations.Value = Representations.cpg14,
+                     cpgFileName: String = "cpg.bin",
+                     outDir: String = "out",
+                     repr: Representation.Value = Representation.cpg14,
+                     format: Format.Value = Format.dot
    )
 
   /**
     * Choose from either a subset of the graph, or the entire graph (all).
     */
-  object Representations extends Enumeration {
+  object Representation extends Enumeration {
     val ast, cfg, ddg, cdg, pdg, cpg14, all = Value
+  }
+  object Format extends Enumeration {
+    val dot, neo4jcsv = Value
   }
 
   private def parseConfig: Option[Config] =
     new scopt.OptionParser[Config]("joern-export") {
-      head("Dump intermediate graph representations of code onto disk")
+      head("Dump intermediate graph representations (or entire graph) of code in a given export format")
       help("help")
       arg[String]("cpg")
-        .text("CPG file name ('cpg.bin' by default)")
+        .text("input CPG file name - defaults to `cpg.bin`")
         .optional()
         .action((x, c) => c.copy(cpgFileName = x))
       opt[String]("out")
-        .text("output directory")
+        .text("output directory - will be created and must not yet exist")
         .action((x, c) => c.copy(outDir = x))
       opt[String]("repr")
-        .text(s"representation to extract: [${Representations.values.toSeq.sorted.mkString("|")}]")
-        .action((x, c) => c.copy(repr = Representations.withName(x)))
+        .text(s"representation to extract: [${Representation.values.toSeq.sorted.mkString("|")}] - defaults to ${Representation.cpg14}")
+        .action((x, c) => c.copy(repr = Representation.withName(x)))
+      opt[String]("format")
+        .required()
+        .action((x, c) => c.copy(format = Format.withName(x)))
+        .text(s"export format, one of [${Format.values.toSeq.sorted.mkString("|")}] - defaults to ${Format.dot}")
     }.parse(args, Config())
 
   parseConfig.foreach { config =>
@@ -62,19 +70,19 @@ object JoernExport extends App {
           }
 
           config.repr match {
-            case Representations.ast =>
+            case Representation.ast =>
               new DumpAst(AstDumpOptions(config.outDir)).create(context)
-            case Representations.cfg =>
+            case Representation.cfg =>
               new DumpCfg(CfgDumpOptions(config.outDir)).create(context)
-            case Representations.ddg =>
+            case Representation.ddg =>
               new DumpDdg(DdgDumpOptions(config.outDir)).create(context)
-            case Representations.cdg =>
+            case Representation.cdg =>
               new DumpCdg(CdgDumpOptions(config.outDir)).create(context)
-            case Representations.pdg =>
+            case Representation.pdg =>
               new DumpPdg(PdgDumpOptions(config.outDir)).create(context)
-            case Representations.cpg14 =>
+            case Representation.cpg14 =>
               new DumpCpg14(Cpg14DumpOptions(config.outDir)).create(context)
-            case Representations.neo4jcsv =>
+            case Representation.neo4jcsv =>
               val ExportResult(nodeCount, edgeCount, files, additionalInfo) =
                 Neo4jCsvExporter.runExport(cpg.graph, config.outDir)
               println(s"export completed successfully: $nodeCount nodes, $edgeCount edges in ${files.size} files")

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -15,13 +15,14 @@ import scala.util.control.NoStackTrace
 
 object JoernExport extends App {
 
-  case class Config(cpgFileName: String = "cpg.bin",
-                    outDir: String = "out",
-                    repr: Representation.Value = Representation.cpg14,
-                    format: Format.Value = Format.dot)
+  case class Config(
+    cpgFileName: String = "cpg.bin",
+    outDir: String = "out",
+    repr: Representation.Value = Representation.cpg14,
+    format: Format.Value = Format.dot
+  )
 
-  /**
-    * Choose from either a subset of the graph, or the entire graph (all).
+  /** Choose from either a subset of the graph, or the entire graph (all).
     */
   object Representation extends Enumeration {
     val ast, cfg, ddg, cdg, pdg, cpg14, all = Value
@@ -42,7 +43,9 @@ object JoernExport extends App {
         .text("output directory - will be created and must not yet exist")
         .action((x, c) => c.copy(outDir = x))
       opt[String]("repr")
-        .text(s"representation to extract: [${Representation.values.toSeq.sorted.mkString("|")}] - defaults to `${Representation.cpg14}`")
+        .text(
+          s"representation to extract: [${Representation.values.toSeq.sorted.mkString("|")}] - defaults to `${Representation.cpg14}`"
+        )
         .action((x, c) => c.copy(repr = Representation.withName(x)))
       opt[String]("format")
         .action((x, c) => c.copy(format = Format.withName(x)))

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -4,7 +4,6 @@ import better.files.Dsl._
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows._
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.joerncli.JoernExport.{Format, Representation}
 import io.joern.joerncli.console.JoernWorkspaceLoader
 import io.joern.x2cpg.layers._
 import io.shiftleft.semanticcpg.layers._
@@ -15,12 +14,10 @@ import scala.util.Using
 
 object JoernExport extends App {
 
-  case class Config(
-                     cpgFileName: String = "cpg.bin",
-                     outDir: String = "out",
-                     repr: Representation.Value = Representation.cpg14,
-                     format: Format.Value = Format.dot
-   )
+  case class Config(cpgFileName: String = "cpg.bin",
+                    outDir: String = "out",
+                    repr: Representation.Value = Representation.cpg14,
+                    format: Format.Value = Format.dot)
 
   /**
     * Choose from either a subset of the graph, or the entire graph (all).
@@ -53,44 +50,41 @@ object JoernExport extends App {
     }.parse(args, Config())
 
   parseConfig.foreach { config =>
-    if (File(config.outDir).exists) {
-      System.err.println(s"Output directory ${config.outDir} already exists. Bailing out.")
-    } else {
-      if (!File(config.cpgFileName).exists) {
-        System.err.println(s"CPG at ${config.cpgFileName} does not exist. Bailing out.")
-      } else {
-        Using.resource(CpgBasedTool.loadFromOdb(config.cpgFileName)) { cpg =>
-          CpgBasedTool.addDataFlowOverlayIfNonExistent(cpg)
-          val context = new LayerCreatorContext(cpg)
+    if (File(config.outDir).exists)
+      throw new AssertionError(s"Output directory ${config.outDir} already exists.")
+    if (File(config.cpgFileName).notExists)
+      throw new AssertionError(s"CPG at ${config.cpgFileName} does not exist.")
 
-          mkdir(File(config.outDir))
-          implicit val semantics: Semantics = JoernWorkspaceLoader.defaultSemantics
-          if (semantics.elements.isEmpty) {
-            System.err.println("Warning: semantics are empty.")
-          }
+    Using.resource(CpgBasedTool.loadFromOdb(config.cpgFileName)) { cpg =>
+      CpgBasedTool.addDataFlowOverlayIfNonExistent(cpg)
+      val context = new LayerCreatorContext(cpg)
 
-          config.repr match {
-            case Representation.ast =>
-              new DumpAst(AstDumpOptions(config.outDir)).create(context)
-            case Representation.cfg =>
-              new DumpCfg(CfgDumpOptions(config.outDir)).create(context)
-            case Representation.ddg =>
-              new DumpDdg(DdgDumpOptions(config.outDir)).create(context)
-            case Representation.cdg =>
-              new DumpCdg(CdgDumpOptions(config.outDir)).create(context)
-            case Representation.pdg =>
-              new DumpPdg(PdgDumpOptions(config.outDir)).create(context)
-            case Representation.cpg14 =>
-              new DumpCpg14(Cpg14DumpOptions(config.outDir)).create(context)
-            case Representation.neo4jcsv =>
-              val ExportResult(nodeCount, edgeCount, files, additionalInfo) =
-                Neo4jCsvExporter.runExport(cpg.graph, config.outDir)
-              println(s"export completed successfully: $nodeCount nodes, $edgeCount edges in ${files.size} files")
-              println(additionalInfo)
-            case repr =>
-              System.err.println(s"unknown representation: $repr. Baling out.")
-          }
-        }
+      mkdir(File(config.outDir))
+      implicit val semantics: Semantics = JoernWorkspaceLoader.defaultSemantics
+      if (semantics.elements.isEmpty) {
+        System.err.println("Warning: semantics are empty.")
+      }
+
+      (config.repr, config.format) match {
+        case (Representation.ast, Format.dot) =>
+          new DumpAst(AstDumpOptions(config.outDir)).create(context)
+        case (Representation.cfg, Format.dot) =>
+          new DumpCfg(CfgDumpOptions(config.outDir)).create(context)
+        case (Representation.ddg, Format.dot) =>
+          new DumpDdg(DdgDumpOptions(config.outDir)).create(context)
+        case (Representation.cdg, Format.dot) =>
+          new DumpCdg(CdgDumpOptions(config.outDir)).create(context)
+        case (Representation.pdg, Format.dot) =>
+          new DumpPdg(PdgDumpOptions(config.outDir)).create(context)
+        case (Representation.cpg14, Format.dot) =>
+          new DumpCpg14(Cpg14DumpOptions(config.outDir)).create(context)
+        case (Representation.all, Format.neo4jcsv) =>
+          val ExportResult(nodeCount, edgeCount, files, additionalInfo) =
+            Neo4jCsvExporter.runExport(cpg.graph, config.outDir)
+          println(s"export completed successfully: $nodeCount nodes, $edgeCount edges in ${files.size} files")
+          println(additionalInfo)
+        case (repr, format) =>
+          throw new NotImplementedError(s"combination of repr=$repr and $format not (yet) supported")
       }
     }
   }


### PR DESCRIPTION
`neo4jcsv` really isn't a repr(esentation), but rather a format. This PR cleans up after #1402
Example for valid arguments:
```
--repr=ast
--repr=cfg
--repr=all --format=neo4jcsv
```