### PR TITLE
Extract `classes.jar` from aar dependency files

### DIFF
--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
@@ -117,9 +117,11 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
     fixture.test({ dependenciesResult =>
       dependenciesResult should not be empty
       val dependencyFiles = dependenciesResult.getOrElse(Seq())
-      dependencyFiles.filter(_.endsWith(".jar")) should not be Seq()
+      dependencyFiles.filter(_.endsWith(".jar")) should not be empty
+      dependencyFiles.filter(_.endsWith(".aar")) shouldBe empty
+      dependencyFiles.find(_.endsWith("glide-4.11.0.aar")) shouldBe empty
+      dependencyFiles.find(_.endsWith("glide-4.11.0.jar")) should not be empty
     })
-    // TODO: add test for `.aar` as soon as it's decided what to do about them
   }
 
   "test gradle dependency resolution for simple Android app with incorrect Gradle project name param" in {
@@ -131,7 +133,6 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
       },
       DependencyResolverParams(forGradle = Map(GradleConfigKeys.ProjectName -> "NON_EXISTENT_PROJECT_NAME"))
     )
-    // TODO: add test for `.aar` as soon as it's decided what to do about them
   }
 
   "test gradle dependency resolution for simple Android app with incorrect Gradle configuration param" in {
@@ -143,7 +144,6 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
       },
       DependencyResolverParams(forGradle = Map(GradleConfigKeys.ConfigurationName -> "NON_EXISTENT_CONFIGURATION_NAME"))
     )
-    // TODO: add test for `.aar` as soon as it's decided what to do about them
   }
 
   "test maven dependency resolution" in {

--- a/joern-cli/src/test/resources/testcode/SlimAndroid/app/build.gradle
+++ b/joern-cli/src/test/resources/testcode/SlimAndroid/app/build.gradle
@@ -33,4 +33,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
 }

--- a/joern-cli/src/test/resources/testcode/SlimAndroid/app/build.gradle
+++ b/joern-cli/src/test/resources/testcode/SlimAndroid/app/build.gradle
@@ -8,12 +8,10 @@ android {
 
     defaultConfig {
         applicationId "com.example.slimandroid"
-        minSdk 21
+        minSdk 23
         targetSdk 32
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -32,10 +30,7 @@ android {
 }
 
 dependencies {
-
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:2.0.4'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 }

--- a/joern-cli/src/test/resources/testcode/SlimAndroid/app/src/main/java/com/example/slimandroid/MainActivity.kt
+++ b/joern-cli/src/test/resources/testcode/SlimAndroid/app/src/main/java/com/example/slimandroid/MainActivity.kt
@@ -2,10 +2,14 @@ package com.example.slimandroid
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.bumptech.glide.Glide
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val imageUrl = "http://phrack.org/images/phrack-logo.jpg"
+        Glide.with(applicationContext).load(imageUrl)
     }
 }

--- a/joern-cli/src/test/resources/testcode/SlimAndroid/app/src/main/java/com/example/slimandroid/MainActivity.kt
+++ b/joern-cli/src/test/resources/testcode/SlimAndroid/app/src/main/java/com/example/slimandroid/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.example.slimandroid
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/joern-cli/src/test/resources/testcode/SlimAndroid/app/src/main/res/layout/activity_main.xml
+++ b/joern-cli/src/test/resources/testcode/SlimAndroid/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -15,4 +15,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/joern-cli/src/test/resources/testcode/SlimAndroid/gradle.properties
+++ b/joern-cli/src/test/resources/testcode/SlimAndroid/gradle.properties
@@ -13,3 +13,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.useAndroidX=true


### PR DESCRIPTION
A large number of Android dependencies are distributed as `aar`
files which are just a specially laid-out zip file:
https://developer.android.com/studio/projects/android-library

The embedded Kotlin compiler does not accept `aar` files directly, so 
their `classes.jar` need to be extracted first, which is what this 
PR accomplishes.
