### PR TITLE
Log no of Java-source files found for `kotlin2cpg`

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -81,6 +81,13 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] {
         }
         logger.info(s"Starting CPG generation for input directory `$sourceDir`.")
 
+        val filesWithJavaExtension = SourceFiles.determine(Set(sourceDir), Set(".java"))
+        if (filesWithJavaExtension.nonEmpty) {
+          logger.info(
+            s"Found ${filesWithJavaExtension.size} files with the `.java` extension which will not be included in the result."
+          )
+        }
+
         val dirsForSourcesToCompile = ContentSourcesPicker.dirsForRoot(sourceDir)
         val jarPathsFromClassPath =
           config.classpath.foldLeft(Seq[String]())((acc, classpathEntry) => {


### PR DESCRIPTION
This information might prove important when type information is missing
from a CPG.