### PR TITLE
Cleanup signature and methodFullName calculation for...

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -1,10 +1,30 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.{JavaSrcCode2CpgFixture, JavaSrcCodeToCpgFixture}
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Local, Method}
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import io.shiftleft.semanticcpg.language._
+
+class NewConstructorInvocationTests extends JavaSrcCode2CpgFixture {
+  "constructor init method call" should {
+    val cpg = code("""
+        |class Foo {
+        |  Foo(long aaa) {
+        |  }
+        |  static void method() {
+        |    Foo foo = new Foo(1);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have correct methodFullName and signature" in {
+      val initCall = cpg.call.nameExact("<init>").head
+      initCall.signature shouldBe "void(long)"
+      initCall.methodFullName shouldBe "Foo.<init>:void(long)"
+    }
+  }
+}
 
 class ConstructorInvocationTests extends JavaSrcCodeToCpgFixture {
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
@@ -46,8 +46,8 @@ class InferenceJarTests extends AnyFreeSpec with Matchers {
 
     "it should fail to resolve the type for Deps" in {
       val call = cpg.method.name("test1").call.name("foo").head
-      call.methodFullName shouldBe ""
-      call.signature shouldBe ""
+      call.methodFullName shouldBe "<unresolvedReceiverType>.foo:ANY()"
+      call.signature shouldBe "ANY()"
       call.typeFullName shouldBe "ANY"
     }
   }


### PR DESCRIPTION
method and construction <init> calls.
This also fixes a bug int signature and thus the methodFullName of
construction <init> calls which have been incorporating the argument
types instead of the parameter types. The argument types are now only
used if the parameter types cannot be resolved.