### PR TITLE
Fix method signature.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -321,7 +321,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     substituteTypeVariableInternal(resolvedType, typeParamValues)
   }
 
-  @tailrec
   private def substituteTypeVariableInternal(
     resolvedType: ResolvedType,
     typeParamValues: ResolvedTypeParametersMap
@@ -334,7 +333,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         val assignedType  = typeParamValues.getValue(typeParamDecl)
         if (assignedType.isTypeVariable && assignedType.asTypeParameter() == typeParamDecl) {
           // This is the way the library tells us there is no assigned type.
-          typeParamDecl.getBounds.asScala.find(_.isExtends).map(_.getType.describe()).getOrElse(TypeConstants.Object)
+          typeParamDecl.getBounds.asScala
+            .find(_.isExtends)
+            .map(bound => substituteTypeVariableInternal(bound.getType, typeParamValues))
+            .getOrElse(TypeConstants.Object)
         } else {
           substituteTypeVariableInternal(assignedType, typeParamValues)
         }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -77,6 +77,23 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
         "java.util.function.Function.apply:java.lang.Object(java.lang.Object)"
     }
   }
+
+  "call to generic method of generic type" should {
+    val cpg = code("""
+        |class Foo <T extends Number> {
+        |  <S extends T> void foo(S i) {}
+        |
+        |  static void method() {
+        |    Foo<Integer> obj = new Foo();
+        |    obj.foo(1);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have correct methodFullName" in {
+      cpg.call("foo").methodFullName.head shouldBe "Foo.foo:void(java.lang.Number)"
+    }
+  }
 }
 
 class CallTests extends JavaSrcCodeToCpgFixture {


### PR DESCRIPTION
In case of a type variable bound by a type varible we did correctly
calculate the signature.