### PR TITLE
Allow for type variable substitution in TypeInfoCalculator.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -94,6 +94,24 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
       cpg.call("foo").methodFullName.head shouldBe "Foo.foo:void(java.lang.Number)"
     }
   }
+
+  "call to method with generic array parameter" should {
+    val cpg = code("""
+        |class Foo <T> {
+        |  void foo(T[] aaa) {}
+        |
+        |  static void method() {
+        |    Foo<Integer> obj = new Foo();
+        |    Integer[] array = new Integer[3];
+        |    obj.foo(array);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "should have correct methodFullName" in {
+      cpg.call("foo").methodFullName.head shouldBe "Foo.foo:void(java.lang.Object[])"
+    }
+  }
 }
 
 class CallTests extends JavaSrcCodeToCpgFixture {


### PR DESCRIPTION
Doing possible type variable substitutions in TypeInfoCalculator avoid
having dublicate code in substituteTypeVariable().

This also fixes the bug of not properly substituted type variables in
array types.