### PR TITLE
Fix withErrorsToConsole.

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -194,14 +194,12 @@ object X2Cpg {
     * the function, printing errors to the console.
     */
   def withErrorsToConsole[T <: X2CpgConfig[_]](config: T)(f: T => Try[_]): Try[_] = {
-    Try {
-      f(config)
-    } match {
+    f(config) match {
       case Failure(exception) =>
-        println(exception.getMessage)
         exception.printStackTrace()
         Failure(exception)
-      case Success(v) => v
+      case Success(v) =>
+        Success(v)
     }
   }
 


### PR DESCRIPTION
This `f` already returns a Try, wrapping it into another `Try` led to
always triggering the `Success` match case, rendering the logging
functionallity of this method to be dead code.