### PR TITLE
CfgNode extension "passesNot" to filter out flows through sanitisers

### DIFF
--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/querying/CfgTests.scala
@@ -46,25 +46,25 @@ class CfgTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should allow CFG successors to be filtered in if they pass a given node" in {
-    val printf = cpg.method.call.name("printf").isCall
-    val lt     = cpg.method.call.name(Operators.lessThan).isCall
-    val sink   = cpg.method.call.name("sink").isCall
-    // LTs always pass before printf
+    def printf = cpg.method.call.name("printf").isCall
+    def lt     = cpg.method.call.name(Operators.lessThan).isCall
+    def sink   = cpg.method.call.name("sink").isCall
+    // printf passes after LTs
     lt.passes(printf).code.toSet shouldBe Set("y < 10", "x < 10")
-    // printf does not pass before the LTs
+    // LTs do not pass after printf
     printf.passes(lt).code.toSet shouldBe Set()
     // "Foo" is after the call to "sink"
     sink.passes(cpg.literal("foo")).code.toSet shouldBe Set()
   }
 
   "should allow CFG successors to be filtered out if they pass a given node" in {
-    val printf = cpg.method.call.name("printf").isCall
-    val lt     = cpg.method.call.name(Operators.lessThan).isCall
-    val sink   = cpg.method.call.name("sink").isCall
+    def printf = cpg.method.call.name("printf").isCall
+    def lt     = cpg.method.call.name(Operators.lessThan).isCall
+    def sink   = cpg.method.call.name("sink").isCall
     // printf not before LTs
     lt.passesNot(printf).code.toSet shouldBe Set()
-    // printf will always pass both of the LTs
-    printf.passesNot(lt).code.toSet shouldBe Set()
+    // printf does not pass lt
+    printf.passesNot(lt).code.toSet shouldBe Set("printf(\"foo\")")
     // "Foo" is after the call to "sink"
     sink.passesNot(cpg.literal("foo")).code.toSet shouldBe Set("sink(x)")
   }

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/querying/CfgTests.scala
@@ -1,6 +1,7 @@
 package io.joern.fuzzyc2cpg.querying
 
 import io.joern.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 
 class CfgTests extends FuzzyCCodeToCpgSuite {
@@ -42,6 +43,18 @@ class CfgTests extends FuzzyCCodeToCpgSuite {
 
   "should find that method does not post dominate anything" in {
     cpg.method("foo").postDominates.l.size shouldBe 0
+  }
+
+  "should allow CFG successors to be filtered out if they pass a given node" in {
+    val printf = cpg.method.call.name("printf").isCall
+    val lt     = cpg.method.call.name(Operators.lessThan).isCall
+    val sink   = cpg.method.call.name("sink").isCall
+    // LTs will never be passed by printf before
+    lt.passesNot(printf).code.toSet shouldBe Set("y < 10", "x < 10")
+    // printf will always pass both of the LTs
+    printf.passesNot(lt).code.toSet shouldBe Set()
+    // "Foo" is after the call to "sink"
+    sink.passesNot(cpg.literal("foo")).code.toSet shouldBe Set()
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -94,6 +94,26 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     }
   }
 
+  /** Using the post dominator tree, will determine if this node passes through the included set of nodes and filter it
+    * in.
+    * @param included
+    *   the nodes this node must pass through.
+    * @return
+    *   the traversal of this node if it passes through the included set.
+    */
+  def passes(included: Set[CfgNode]): Traversal[CfgNode] =
+    node.filter(_.postDominatedBy.toSet.exists(included.contains))
+
+  /** Using the post dominator tree, will determine if this node passes through the excluded set of nodes and filter it
+    * out.
+    * @param excluded
+    *   the nodes this node must not pass through.
+    * @return
+    *   the traversal of this node if it does not pass through the excluded set.
+    */
+  def passesNot(excluded: Set[CfgNode]): Traversal[CfgNode] =
+    node.filterNot(_.postDominatedBy.toSet.exists(excluded.contains))
+
   private def expandExhaustively(expand: CfgNode => Iterator[StoredNode]): Traversal[CfgNode] = {
     var controllingNodes = List.empty[CfgNode]
     var visited          = Set.empty + node

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -102,7 +102,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     *   the traversal of this node if it passes through the included set.
     */
   def passes(included: Set[CfgNode]): Traversal[CfgNode] =
-    node.filter(_.postDominatedBy.toSet.exists(included.contains))
+    node.filter(_.postDominatedBy.exists(included.contains))
 
   /** Using the post dominator tree, will determine if this node passes through the excluded set of nodes and filter it
     * out.
@@ -112,7 +112,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     *   the traversal of this node if it does not pass through the excluded set.
     */
   def passesNot(excluded: Set[CfgNode]): Traversal[CfgNode] =
-    node.filterNot(_.postDominatedBy.toSet.exists(excluded.contains))
+    node.filterNot(_.postDominatedBy.exists(excluded.contains))
 
   private def expandExhaustively(expand: CfgNode => Iterator[StoredNode]): Traversal[CfgNode] = {
     var controllingNodes = List.empty[CfgNode]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.{Traversal, _}
 import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[CfgNode])
@@ -98,5 +98,11 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
   @Doc(info = "Address of the code (for binary code)")
   def address: Traversal[Option[String]] =
     traversal.map(_.address)
+
+  @Doc(info = "Filters out paths that pass though the given traversal")
+  def passesNot(excluded: Traversal[CfgNode]): Traversal[CfgNode] = {
+    val ex = excluded.toSet
+    traversal.flatMap(_.filter(_.postDominatedBy.toSet.exists(ex.contains)))
+  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{Traversal, _}
+import overflowdb.traversal._
 import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[CfgNode])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -99,10 +99,16 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
   def address: Traversal[Option[String]] =
     traversal.map(_.address)
 
+  @Doc(info = "Filters in paths that pass though the given traversal")
+  def passes(included: Traversal[CfgNode]): Traversal[CfgNode] = {
+    val in = included.toSet
+    traversal.flatMap(_.filter(_.postDominatedBy.toSet.exists(in.contains)))
+  }
+
   @Doc(info = "Filters out paths that pass though the given traversal")
   def passesNot(excluded: Traversal[CfgNode]): Traversal[CfgNode] = {
     val ex = excluded.toSet
-    traversal.flatMap(_.filter(_.postDominatedBy.toSet.exists(ex.contains)))
+    traversal.flatMap(_.filterNot(_.postDominatedBy.toSet.exists(ex.contains)))
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -102,13 +102,13 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
   @Doc(info = "Filters in paths that pass though the given traversal")
   def passes(included: Traversal[CfgNode]): Traversal[CfgNode] = {
     val in = included.toSet
-    traversal.flatMap(_.filter(_.postDominatedBy.toSet.exists(in.contains)))
+    traversal.flatMap(_.passes(in))
   }
 
   @Doc(info = "Filters out paths that pass though the given traversal")
   def passesNot(excluded: Traversal[CfgNode]): Traversal[CfgNode] = {
     val ex = excluded.toSet
-    traversal.flatMap(_.filterNot(_.postDominatedBy.toSet.exists(ex.contains)))
+    traversal.flatMap(_.passesNot(ex))
   }
 
 }


### PR DESCRIPTION
- While we have `reachableBy`, as it stands there is no way to kill paths that flow through sanitisers
- Here is a prototype `passes` and `passesNot` that probably needs fine tuning but gets the job done with `postDominatedBy`