### PR TITLE
Various javasrc improvements.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -3,6 +3,7 @@ package io.joern.javasrc2cpg.passes
 import com.github.javaparser.ast.`type`.TypeParameter
 import com.github.javaparser.ast.{CompilationUnit, Node, NodeList, PackageDeclaration}
 import com.github.javaparser.ast.body.{
+  AnnotationDeclaration,
   BodyDeclaration,
   CallableDeclaration,
   ConstructorDeclaration,
@@ -77,6 +78,7 @@ import com.github.javaparser.ast.stmt.{
 import com.github.javaparser.resolution.{SymbolResolver, UnsolvedSymbolException}
 import com.github.javaparser.resolution.declarations.{
   ResolvedConstructorDeclaration,
+  ResolvedFieldDeclaration,
   ResolvedMethodDeclaration,
   ResolvedMethodLikeDeclaration,
   ResolvedReferenceTypeDeclaration,
@@ -600,9 +602,15 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .withChildren(annotationAsts)
       .withChildren(clinitAst.toSeq)
 
-    Try(typ.resolve()).toOption.foreach { resolvedTypeDecl =>
-      val bindingTable = getBindingTable(resolvedTypeDecl)
-      createBindingNodes(typeDecl, bindingTable)
+    // Annotation declarations need no binding table as objects of this
+    // typ never get called from user code.
+    // Furthermore the parser library throws an exception when trying to
+    // access e.g. the declared methods of an annotation declaration.
+    if (!typ.isInstanceOf[AnnotationDeclaration]) {
+      Try(typ.resolve()).toOption.foreach { resolvedTypeDecl =>
+        val bindingTable = getBindingTable(resolvedTypeDecl)
+        createBindingNodes(typeDecl, bindingTable)
+      }
     }
 
     scopeStack.popScope()
@@ -1942,7 +1950,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
         val identifierTypeFullName =
           value match {
-            case fieldDecl: JavaParserFieldDeclaration =>
+            case fieldDecl: ResolvedFieldDeclaration =>
               // TODO It is not quite correct to use the declaring classes type.
               // Instead we should take the using classes type which is either the same or a
               // sub class of the declaring class.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -344,11 +344,15 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     typeParamValues: ResolvedTypeParametersMap
   ): collection.Seq[String] = {
     val parameterTypes =
-      Range(0, methodLike.getNumberOfParams).map(methodLike.getParam).map { param =>
-        Try(param.getType).toOption
-          .map(paramType => typeInfoCalc.fullName(paramType, typeParamValues))
-          .getOrElse(UnresolvedTypeDefault)
-      }
+      Range(0, methodLike.getNumberOfParams)
+        .flatMap { index =>
+          Try(methodLike.getParam(index)).toOption
+        }
+        .map { param =>
+          Try(param.getType).toOption
+            .map(paramType => typeInfoCalc.fullName(paramType, typeParamValues))
+            .getOrElse(UnresolvedTypeDefault)
+        }
 
     parameterTypes
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
@@ -6,6 +6,7 @@ import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParame
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 case class BindingTableEntry(name: String, signature: String, implementingMethodFullName: String)
 
@@ -109,7 +110,7 @@ object BindingTable {
     if (typ.isJavaLangObject) {
       Iterable.empty
     } else {
-      typ.getDirectAncestors.asScala.foreach { ancestor =>
+      Try(typ.getDirectAncestors).map(_.asScala).getOrElse(Nil).foreach { ancestor =>
         result.append(ancestor)
         getAllParents(ancestor, result)
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -17,6 +17,7 @@ import com.github.javaparser.resolution.types.{
   ResolvedReferenceType,
   ResolvedType,
   ResolvedTypeVariable,
+  ResolvedUnionType,
   ResolvedVoidType,
   ResolvedWildcard
 }
@@ -98,6 +99,16 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
       case wildcardType: ResolvedWildcard =>
         if (wildcardType.isBounded) {
           nameOrFullName(wildcardType.getBoundedType, typeParamValues, fullyQualified)
+        } else {
+          objectType(fullyQualified)
+        }
+      case unionType: ResolvedUnionType =>
+        // The individual elements of the type union cannot be accessed in ResolvedUnionType.
+        // For whatever reason there is no accessor and the field is private.
+        // So for now we settle with the ancestor type. Maybe we use reflection later.
+        val ancestorOption = unionType.getCommonAncestor
+        if (ancestorOption.isPresent) {
+          nameOrFullName(ancestorOption.get, typeParamValues, fullyQualified)
         } else {
           objectType(fullyQualified)
         }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -14,7 +14,7 @@ object MavenDependencies {
     val tmpFile = Files.createTempFile("mvnClassPass", ".txt")
     tmpFile.toFile.deleteOnExit()
     ExternalCommand.run(
-      s"mvn dependency:build-classpath -DincludeScope=compile -Dmdep.outputFile=$tmpFile",
+      s"mvn -B dependency:build-classpath -DincludeScope=compile -Dmdep.outputFile=$tmpFile",
       projectDir.toString
     ) match {
       case Success(_) =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 object MavenDependencies {
   private val logger = LoggerFactory.getLogger(getClass)
@@ -18,15 +18,25 @@ object MavenDependencies {
       projectDir.toString
     ) match {
       case Success(_) =>
-        val classPath = new String(Files.readAllBytes(tmpFile), StandardCharsets.UTF_8)
-        classPath.split(":").toList
       case Failure(exception) =>
         logger.warn(
-          s"Unable to retrieve compile class path from maven." +
-            s"\n Results will suffer from poor type information.\n${exception.getMessage}"
+          s"Retrieval of compile class path via maven return with error.\n" +
+            "The compile class path may be missing or partial.\n" +
+            "Results will suffer from poor type information.\n" +
+            s"Error: ${exception.getMessage}"
         )
-        Nil
     }
+
+    Try {
+      // Regardless of the external maven comment error status we try to read the
+      // output file because sometimes it contains partial results.
+      val classPath = new String(Files.readAllBytes(tmpFile), StandardCharsets.UTF_8)
+      if (classPath.isEmpty) {
+        Nil
+      } else {
+        classPath.split(":").toList
+      }
+    }.getOrElse(Nil)
   }
 
 }


### PR DESCRIPTION
-  Also take into account partial mvn dependency results.

-  Used maven in batch mode.

-  Handled union type ( can occour in exception handling).

-  Catch exception if parameter cannot be retrieved.

-  Fix crashed in javasrc found on WebGoat input.