### PR TITLE
Introduce BindingTableAdapter.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -90,7 +90,14 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import com.github.javaparser.symbolsolver.model.typesystem.LazyType
 import io.joern.javasrc2cpg.util.BindingTable.createBindingTable
 import io.joern.javasrc2cpg.util.Scope.WildcardImportName
-import io.joern.javasrc2cpg.util.{BindingTable, BindingTableEntry, NodeTypeInfo, Scope, TypeInfoCalculator}
+import io.joern.javasrc2cpg.util.{
+  BindingTable,
+  BindingTableAdapterForJavaparser,
+  BindingTableEntry,
+  NodeTypeInfo,
+  Scope,
+  TypeInfoCalculator
+}
 import io.joern.javasrc2cpg.util.TypeInfoCalculator.{TypeConstants, UnresolvedTypeDefault}
 import io.shiftleft.codepropertygraph.generated.{
   ControlStructureTypes,
@@ -365,7 +372,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val fullName = typeInfoCalc.fullName(typeDecl)
     bindingTableCache.getOrElseUpdate(
       fullName,
-      createBindingTable(fullName, typeDecl, getBindingTable, methodSignature)
+      createBindingTable(
+        fullName,
+        typeDecl,
+        getBindingTable,
+        methodSignature,
+        new BindingTableAdapterForJavaparser(methodSignature)
+      )
     )
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
@@ -1,0 +1,39 @@
+package io.joern.javasrc2cpg.util
+
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
+import com.github.javaparser.resolution.types.ResolvedReferenceType
+
+import scala.collection.mutable
+import scala.util.Try
+
+import scala.jdk.CollectionConverters._
+
+object Util {
+  def composeMethodFullName(typeDeclFullName: String, name: String, signature: String): String = {
+    s"$typeDeclFullName.$name:$signature"
+  }
+
+  def getAllParents(typeDecl: ResolvedReferenceTypeDeclaration): mutable.ArrayBuffer[ResolvedReferenceType] = {
+    val result = mutable.ArrayBuffer.empty[ResolvedReferenceType]
+
+    if (!typeDecl.isJavaLangObject) {
+      typeDecl.getAncestors(true).asScala.foreach { ancestor =>
+        result.append(ancestor)
+        getAllParents(ancestor, result)
+      }
+    }
+
+    result
+  }
+
+  private def getAllParents(typ: ResolvedReferenceType, result: mutable.ArrayBuffer[ResolvedReferenceType]): Unit = {
+    if (typ.isJavaLangObject) {
+      Iterable.empty
+    } else {
+      Try(typ.getDirectAncestors).map(_.asScala).getOrElse(Nil).foreach { ancestor =>
+        result.append(ancestor)
+        getAllParents(ancestor, result)
+      }
+    }
+  }
+}


### PR DESCRIPTION
The BindingTableAdapter is intended to make the createBindingTable
method reusable for the creation of binding table for the type
declarations for lambda methods. For those there is no type declaration
in the javaparser library which requires us to abstract over this fact.