### PR TITLE
javasrc: make gradle-tooling-api a transitive dependency

### DIFF
--- a/joern-cli/frontends/x2cpg/build.sbt
+++ b/joern-cli/frontends/x2cpg/build.sbt
@@ -7,7 +7,7 @@ dependsOn(Projects.semanticcpg)
 libraryDependencies ++= Seq(
   "org.slf4j"                % "slf4j-api"          % "1.7.36",
   "org.apache.logging.log4j" % "log4j-slf4j-impl"   % Versions.log4j         % Optional,
-  "org.gradle"               % "gradle-tooling-api" % Versions.gradleTooling % Optional,
+  "org.gradle"               % "gradle-tooling-api" % Versions.gradleTooling,
   "org.scalatest"           %% "scalatest"          % Versions.scalatest     % Test
 )
 


### PR DESCRIPTION
alternative to https://github.com/joernio/joern/pull/1430
fixes https://github.com/joernio/joern/issues/1429