### PR TITLE
Re-implement javasrc lambdas and add more comprehensive tests

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -9,8 +9,7 @@ import io.shiftleft.passes.ConcurrentWriterCpgPass
 import com.github.javaparser.symbolsolver.resolution.typesolvers.{
   CombinedTypeSolver,
   JarTypeSolver,
-  JavaParserTypeSolver,
-  ReflectionTypeSolver
+  JavaParserTypeSolver
 }
 import io.joern.javasrc2cpg.Config
 import io.joern.javasrc2cpg.util.{CachingReflectionTypeSolver, SourceRootFinder}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.body.{
   AnnotationDeclaration,
   BodyDeclaration,
   CallableDeclaration,
+  ClassOrInterfaceDeclaration,
   ConstructorDeclaration,
   EnumConstantDeclaration,
   FieldDeclaration,
@@ -82,33 +83,38 @@ import com.github.javaparser.resolution.declarations.{
   ResolvedMethodDeclaration,
   ResolvedMethodLikeDeclaration,
   ResolvedReferenceTypeDeclaration,
-  ResolvedTypeDeclaration
+  ResolvedTypeParameterDeclaration
 }
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
-import com.github.javaparser.resolution.types.{ResolvedType, ResolvedTypeVariable}
-import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserFieldDeclaration
-import com.github.javaparser.symbolsolver.model.typesystem.LazyType
+import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType, ResolvedTypeVariable}
 import io.joern.javasrc2cpg.util.BindingTable.createBindingTable
-import io.joern.javasrc2cpg.util.Scope.WildcardImportName
+import io.joern.javasrc2cpg.util.Scope.ScopeTypes.{BlockScope, MethodScope, NamespaceScope, TypeDeclScope}
+import io.joern.javasrc2cpg.util.Scope.{NamedVariableNodeType, WildcardImportName}
 import io.joern.javasrc2cpg.util.{
   BindingTable,
   BindingTableAdapterForJavaparser,
+  BindingTableAdapterForLambdas,
   BindingTableEntry,
+  LambdaBindingInfo,
   NodeTypeInfo,
   Scope,
   TypeInfoCalculator
 }
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.{TypeConstants, UnresolvedTypeDefault}
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.{TypeConstants, UnresolvedConstants}
+import io.joern.javasrc2cpg.util.Util.composeMethodFullName
 import io.shiftleft.codepropertygraph.generated.{
   ControlStructureTypes,
   DispatchTypes,
   EdgeTypes,
   EvaluationStrategies,
   ModifierTypes,
+  NodeTypes,
   Operators,
   PropertyNames
 }
 import io.shiftleft.codepropertygraph.generated.nodes.{
+  HasFullName,
+  HasSignature,
   NewAnnotation,
   NewAnnotationLiteral,
   NewAnnotationParameter,
@@ -128,6 +134,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewMethod,
   NewMethodParameterIn,
   NewMethodRef,
+  NewMethodReturn,
   NewModifier,
   NewNamespaceBlock,
   NewNode,
@@ -142,39 +149,28 @@ import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import java.util.UUID.randomUUID
-import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
 import scala.language.{existentials, implicitConversions}
 import scala.util.{Failure, Success, Try}
 
-case class BindingInfo(newBinding: NewBinding, typeDecl: NewTypeDecl)
-case class ClosureBindingInfo(identifier: NewIdentifier, closure: NewClosureBinding, bindingId: String)
-case class ClosureBindingMeta(node: NewClosureBinding, edgeMeta: Seq[(NewNode, NewNode, String)])
+case class ClosureBindingEntry(node: NamedVariableNodeType, binding: NewClosureBinding)
+
+case class LambdaImplementedInfo(
+  implementedInterface: Option[ResolvedReferenceType],
+  implementedMethod: Option[ResolvedMethodDeclaration]
+)
 
 case class PartialConstructor(initNode: NewCall, initArgs: Seq[Ast], blockAst: Ast)
 
-case class Context(lambdaAsts: Seq[Ast] = List(), closureBindingInfo: Seq[ClosureBindingMeta] = List()) {
-  def ++(other: Context): Context = {
-    val newLambdas         = lambdaAsts ++ other.lambdaAsts
-    val newClosureBindings = closureBindingInfo ++ other.closureBindingInfo
-
-    Context(newLambdas, newClosureBindings)
-  }
-
-  def mergeWith(others: Iterable[Context]): Context = {
-    Context.mergedCtx(Seq(this) ++ others)
-  }
+case class ExpectedType(fullName: String, resolvedType: Option[ResolvedType] = None)
+object ExpectedType {
+  val default: ExpectedType = ExpectedType(UnresolvedConstants.UnresolvedType)
+  val Int: ExpectedType     = ExpectedType(TypeConstants.Int)
+  val Boolean: ExpectedType = ExpectedType(TypeConstants.Boolean)
+  val Void: ExpectedType    = ExpectedType(TypeConstants.Void)
 }
-
-object Context {
-  def mergedCtx(ctxs: Seq[Context]): Context = {
-    ctxs.foldLeft(Context())((acc, ctx) => { acc ++ ctx })
-  }
-}
-
-case class RefEdgePair(from: NewIdentifier, to: NewMethodParameterIn)
 
 case class AstWithStaticInit(ast: Seq[Ast], staticInits: Seq[Ast])
 
@@ -195,9 +191,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   import AstCreator._
 
   private val scopeStack                       = Scope()
-  private val typeInfoCalc: TypeInfoCalculator = new TypeInfoCalculator(global, symbolResolver)
+  private val typeInfoCalc: TypeInfoCalculator = TypeInfoCalculator(global, symbolResolver)
   private val partialConstructorQueue: mutable.ArrayBuffer[PartialConstructor] = mutable.ArrayBuffer.empty
-  private val lambdaContextQueue: mutable.ArrayBuffer[Context]                 = mutable.ArrayBuffer.empty
   private val bindingTableCache = mutable.HashMap.empty[String, BindingTable]
 
   /** Entry point of AST creation. Translates a compilation unit created by JavaParser into a DiffGraph containing the
@@ -213,14 +208,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     */
   def storeInDiffGraph(ast: Ast): Unit = {
     Ast.storeInDiffGraph(ast, diffGraph)
-
-    lambdaContextQueue.flatMap(_.closureBindingInfo).foreach { closureBindingInfo =>
-      diffGraph.addNode(closureBindingInfo.node)
-
-      closureBindingInfo.edgeMeta.foreach { case (src, dest, label) =>
-        diffGraph.addEdge(src, dest, label)
-      }
-    }
   }
 
   private def addImportsToScope(compilationUnit: CompilationUnit): Unit = {
@@ -250,28 +237,24 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     try {
       val ast = astForPackageDeclaration(compilationUnit.getPackageDeclaration.toScala)
 
+      scopeStack.pushNewScope(NamespaceScope)
+
       val namespaceBlockFullName = {
         ast.root.collect { case x: NewNamespaceBlock => x.fullName }.getOrElse("none")
       }
-      val namespaceScopeNode = {
-        ast.root.collect { case x: NewNamespaceBlock => x }.getOrElse(NewUnknown())
-      }
 
-      scopeStack.pushNewScope(namespaceScopeNode)
       addImportsToScope(compilationUnit)
 
       val typeDeclAsts = withOrder(compilationUnit.getTypes) { (typ, order) =>
-        astForTypeDecl(typ, order, astParentType = "NAMESPACE_BLOCK", astParentFullName = namespaceBlockFullName)
+        astForTypeDecl(
+          typ,
+          order,
+          astParentType = NodeTypes.NAMESPACE_BLOCK,
+          astParentFullName = namespaceBlockFullName
+        )
       }
 
-      val lambdaTypeDeclAsts = lambdaContextQueue.flatMap(_.lambdaAsts).map { lambdaAst =>
-        val root = lambdaAst.root.get.asInstanceOf[NewMethod]
-        // TODO: Inherit from implemented interface and bind to implemented method
-        val lambdaTypeDecl = NewTypeDecl()
-          .name(root.name)
-          .fullName(root.fullName)
-        Ast(lambdaTypeDecl).withChild(lambdaAst)
-      }
+      val lambdaTypeDeclAsts = scopeStack.getLambdaDeclsInScope.toSeq
 
       scopeStack.popScope()
       ast.withChildren(typeDeclAsts).withChildren(lambdaTypeDeclAsts)
@@ -302,37 +285,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     Ast(namespaceBlock.filename(absolutePath(filename)).order(1))
   }
 
-  private def bindingForMethod(
-    maybeMethodNode: Option[NewMethod],
-    bindingSignatures: Iterable[String]
-  ): List[BindingInfo] = {
-    maybeMethodNode match {
-      case Some(methodNode) =>
-        scopeStack.getEnclosingTypeDecl match {
-          case Some(typeDecl) =>
-            bindingSignatures.map { bindingSignature =>
-              val node = NewBinding()
-                .name(methodNode.name)
-                .methodFullName(methodNode.fullName)
-                .signature(bindingSignature)
-
-              BindingInfo(node, typeDecl)
-            }.toList
-
-          case None => Nil
-        }
-
-      case None => Nil
-    }
-  }
-
   private def constructorSignature(
     constructor: ResolvedConstructorDeclaration,
     typeParamValues: ResolvedTypeParametersMap
   ): String = {
     val parameterTypes = calcParameterTypes(constructor, typeParamValues)
 
-    composeMethodLikeSignature("void", parameterTypes)
+    composeMethodLikeSignature(TypeConstants.Void, parameterTypes)
   }
 
   private def methodSignature(method: ResolvedMethodDeclaration, typeParamValues: ResolvedTypeParametersMap): String = {
@@ -341,7 +300,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val returnType =
       Try(method.getReturnType).toOption
         .map(returnType => typeInfoCalc.fullName(returnType, typeParamValues))
-        .getOrElse(UnresolvedTypeDefault)
+        .getOrElse(UnresolvedConstants.UnresolvedType)
 
     composeMethodLikeSignature(returnType, parameterTypes)
   }
@@ -358,7 +317,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .map { param =>
           Try(param.getType).toOption
             .map(paramType => typeInfoCalc.fullName(paramType, typeParamValues))
-            .getOrElse(UnresolvedTypeDefault)
+            .getOrElse(UnresolvedConstants.UnresolvedType)
         }
 
     parameterTypes
@@ -378,6 +337,21 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         getBindingTable,
         methodSignature,
         new BindingTableAdapterForJavaparser(methodSignature)
+      )
+    )
+  }
+
+  def getLambdaBindingTable(lambdaBindingInfo: LambdaBindingInfo): BindingTable = {
+    val fullName = lambdaBindingInfo.fullName
+
+    bindingTableCache.getOrElseUpdate(
+      fullName,
+      createBindingTable(
+        fullName,
+        lambdaBindingInfo,
+        getBindingTable,
+        methodSignature,
+        new BindingTableAdapterForLambdas()
       )
     )
   }
@@ -406,19 +380,17 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   ): AstWithStaticInit = {
     member match {
       case constructor: ConstructorDeclaration =>
-        val ast      = astForConstructor(constructor)
-        val rootNode = Try(ast.root.get.asInstanceOf[NewMethod]).toOption
+        val ast = astForConstructor(constructor)
 
         AstWithStaticInit(ast)
 
       case method: MethodDeclaration =>
-        val ast      = astForMethod(method)
-        val rootNode = Try(ast.root.get.asInstanceOf[NewMethod]).toOption
+        val ast = astForMethod(method)
 
         AstWithStaticInit(ast)
 
       case typeDeclaration: TypeDeclaration[_] =>
-        AstWithStaticInit(astForTypeDecl(typeDeclaration, order, "TYPE_DECL", astParentFullName))
+        AstWithStaticInit(astForTypeDecl(typeDeclaration, order, NodeTypes.TYPE_DECL, astParentFullName))
 
       case fieldDeclaration: FieldDeclaration =>
         val memberAsts = withOrder(fieldDeclaration.getVariables) { (variable, idx) =>
@@ -496,7 +468,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       None
     } else {
       // TODO: Get rid of magic strings
-      val signature = "void()"
+      val signature = s"${TypeConstants.Void}()"
       val fullName = scopeStack.getEnclosingTypeDecl
         .map { typeDecl =>
           s"${typeDecl.fullName}.<clinit>:$signature"
@@ -506,17 +478,16 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       val methodNode = NewMethod()
         .name("<clinit>")
         .fullName(fullName)
-        .signature("void()")
+        .signature(s"${TypeConstants.Void}()")
         .order(order)
 
       val staticModifier = NewModifier()
         .modifierType(ModifierTypes.STATIC)
         .code(ModifierTypes.STATIC)
-        .order(-1)
 
       val body = Ast(NewBlock().order(1)).withChildren(staticInits)
 
-      val methodReturn = methodReturnNode("void", None, None, None)
+      val methodReturn = methodReturnNode(TypeConstants.Void, None, None, None)
 
       val methodAst =
         Ast(methodNode)
@@ -528,27 +499,64 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  private def astForTypeDecl(
+  private def codeForTypeDecl(typ: TypeDeclaration[_], isInterface: Boolean): String = {
+    val codeBuilder = new mutable.StringBuilder()
+    if (typ.isPublic) {
+      codeBuilder.append("public ")
+    } else if (typ.isPrivate) {
+      codeBuilder.append("private ")
+    } else if (typ.isProtected) {
+      codeBuilder.append("protected ")
+    }
+    if (typ.isStatic) {
+      codeBuilder.append("static ")
+    }
+
+    val classPrefix = if (isInterface) "interface " else "class "
+    codeBuilder.append(classPrefix)
+    codeBuilder.append(typ.getNameAsString)
+
+    codeBuilder.toString()
+  }
+
+  private def modifiersForTypeDecl(typ: TypeDeclaration[_], isInterface: Boolean): List[NewModifier] = {
+    val accessModifierType = if (typ.isPublic) {
+      Some(ModifierTypes.PUBLIC)
+    } else if (typ.isPrivate) {
+      Some(ModifierTypes.PRIVATE)
+    } else if (typ.isProtected) {
+      Some(ModifierTypes.PROTECTED)
+    } else {
+      None
+    }
+    val accessModifier = accessModifierType.map(NewModifier().modifierType(_))
+
+    val abstractModifier = Option.when(isInterface || typ.getMethods.asScala.exists(_.isAbstract))(
+      NewModifier().modifierType(ModifierTypes.ABSTRACT)
+    )
+
+    List(accessModifier, abstractModifier).flatten
+  }
+
+  private def createTypeDeclNode(
     typ: TypeDeclaration[_],
     order: Int,
     astParentType: String,
-    astParentFullName: String
-  ): Ast = {
+    astParentFullName: String,
+    isInterface: Boolean
+  ): NewTypeDecl = {
     val baseTypeFullNames = if (typ.isClassOrInterfaceDeclaration) {
       val decl             = typ.asClassOrInterfaceDeclaration()
       val extendedTypes    = decl.getExtendedTypes.asScala
       val implementedTypes = decl.getImplementedTypes.asScala
-      // For some reason, `typ.resolve().isInterface` returns `false` for interfaces,
-      // so they now extend `Object` as well since checking for interfaces becomes
-      // rather difficult.
       val maybeJavaObjectType = if (extendedTypes.isEmpty) {
         typeInfoCalc.registerType(TypeConstants.Object)
-        Seq("java.lang.Object")
+        Seq(TypeConstants.Object)
       } else {
         Seq()
       }
       maybeJavaObjectType ++ (extendedTypes ++ implementedTypes)
-        .map(typ => typeInfoCalc.fullName(typ).getOrElse(UnresolvedTypeDefault))
+        .map(typ => typeInfoCalc.fullName(typ).getOrElse(UnresolvedConstants.UnresolvedType))
         .toList
     } else {
       List.empty[String]
@@ -558,7 +566,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val name         = resolvedType.map(typeInfoCalc.name).getOrElse(typ.getNameAsString)
     val typeFullName = resolvedType.map(typeInfoCalc.fullName).getOrElse(typ.getNameAsString)
 
-    val typeDecl = NewTypeDecl()
+    val code = codeForTypeDecl(typ, isInterface)
+
+    NewTypeDecl()
       .name(name)
       .fullName(typeFullName)
       .lineNumber(line(typ))
@@ -566,11 +576,25 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .inheritsFromTypeFullName(baseTypeFullNames)
       .order(order)
       .filename(filename)
-      .code(typ.getNameAsString)
+      .code(code)
       .astParentType(astParentType)
       .astParentFullName(astParentFullName)
+  }
 
-    scopeStack.pushNewScope(typeDecl)
+  private def astForTypeDecl(
+    typ: TypeDeclaration[_],
+    order: Int,
+    astParentType: String,
+    astParentFullName: String
+  ): Ast = {
+    val isInterface = typ match {
+      case classDeclaration: ClassOrInterfaceDeclaration if classDeclaration.isInterface => true
+      case _                                                                             => false
+    }
+
+    val typeDeclNode = createTypeDeclNode(typ, order, astParentType, astParentFullName, isInterface)
+
+    scopeStack.pushNewScope(TypeDeclScope(typeDeclNode))
 
     val typeParameterMap = getTypeParameterMap(Try(typ.resolve()))
     typeParameterMap.foreach { case (identifier, node) =>
@@ -593,7 +617,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           member,
           order + enumEntryAsts.size + idx - 1,
           clinitOrder,
-          astParentFullName = typeFullName
+          astParentFullName = NodeTypes.TYPE_DECL
         )
       clinitOrder += astWithInits.staticInits.size
       staticInits.appendAll(astWithInits.staticInits)
@@ -612,12 +636,28 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val clinitAst =
       clinitAstsFromStaticInits(staticInits.toSeq, memberAsts.size + defaultConstructorAst.size + 1)
 
-    val typeDeclAst = Ast(typeDecl)
+    val lambdaMethods = scopeStack.getLambdaMethodsInScope.toSeq
+
+    val modifiers = modifiersForTypeDecl(typ, isInterface)
+
+    val typeDeclAst = Ast(typeDeclNode)
       .withChildren(enumEntryAsts)
       .withChildren(memberAsts)
       .withChildren(defaultConstructorAst.toList)
       .withChildren(annotationAsts)
       .withChildren(clinitAst.toSeq)
+      .withChildren(lambdaMethods)
+      .withChildren(modifiers.map(Ast(_)))
+
+    val defaultConstructorBindingEntry =
+      defaultConstructorAst
+        .flatMap(_.root)
+        .collect { case defaultConstructor: NewNode with HasFullName with HasSignature =>
+          defaultConstructor
+        }
+        .map { defaultConstructor =>
+          BindingTableEntry("<init>", defaultConstructor.signature, defaultConstructor.fullName)
+        }
 
     // Annotation declarations need no binding table as objects of this
     // typ never get called from user code.
@@ -626,7 +666,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     if (!typ.isInstanceOf[AnnotationDeclaration]) {
       Try(typ.resolve()).toOption.foreach { resolvedTypeDecl =>
         val bindingTable = getBindingTable(resolvedTypeDecl)
-        createBindingNodes(typeDecl, bindingTable)
+        defaultConstructorBindingEntry.foreach(bindingTable.add)
+        createBindingNodes(typeDeclNode, bindingTable)
       }
     }
 
@@ -639,8 +680,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse("<empty>")
     val constructorNode = NewMethod()
       .name("<init>")
-      .fullName(s"$typeFullName.<init>:void()")
-      .signature("void()")
+      .fullName(s"$typeFullName.<init>:${TypeConstants.Void}()")
+      .signature(s"${TypeConstants.Void}()")
       .order(order)
       .filename(filename)
       .isExternal(false)
@@ -648,7 +689,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val thisAst = thisAstForMethod(typeFullName, lineNumber = None)
     val bodyAst = Ast(NewBlock().order(1).argumentIndex(1))
 
-    val returnNode = methodReturnNode("void", None, None, None)
+    val returnNode = methodReturnNode(TypeConstants.Void, None, None, None)
     val returnAst  = Ast(returnNode)
 
     val modifiers = List(
@@ -664,7 +705,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForEnumEntry(entry: EnumConstantDeclaration, order: Int): Ast = {
-    val typeFullName = Try(entry.resolve().getType).toOption.map(typeInfoCalc.fullName).getOrElse(UnresolvedTypeDefault)
+    val typeFullName =
+      Try(entry.resolve().getType).toOption.map(typeInfoCalc.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
     val entryNode = NewMember()
       .lineNumber(line(entry))
       .columnNumber(column(entry))
@@ -698,7 +740,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       typeInfoCalc
         .fullName(v.getType)
         .orElse(scopeStack.getWildcardType(v.getTypeAsString))
-        .getOrElse(UnresolvedTypeDefault)
+        .getOrElse(UnresolvedConstants.UnresolvedType)
     val name = v.getName.toString
     val memberNode =
       NewMember()
@@ -710,17 +752,17 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val annotationAsts = annotations.asScala.map(astForAnnotationExpr)
 
     val staticModifier = if (fieldDeclaration.isStatic) {
-      Some(NewModifier().modifierType(ModifierTypes.STATIC).code(ModifierTypes.STATIC).order(-1))
+      Some(NewModifier().modifierType(ModifierTypes.STATIC).code(ModifierTypes.STATIC))
     } else {
       None
     }
 
     val accessModifier = if (fieldDeclaration.isPublic) {
-      Some(NewModifier().modifierType(ModifierTypes.PUBLIC).code(ModifierTypes.PUBLIC).order(-1))
+      Some(NewModifier().modifierType(ModifierTypes.PUBLIC).code(ModifierTypes.PUBLIC))
     } else if (fieldDeclaration.isPrivate) {
-      Some(NewModifier().modifierType(ModifierTypes.PRIVATE).code(ModifierTypes.PRIVATE).order(-1))
+      Some(NewModifier().modifierType(ModifierTypes.PRIVATE).code(ModifierTypes.PRIVATE))
     } else if (fieldDeclaration.isProtected) {
-      Some(NewModifier().modifierType(ModifierTypes.PROTECTED).code(ModifierTypes.PROTECTED).order(-1))
+      Some(NewModifier().modifierType(ModifierTypes.PROTECTED).code(ModifierTypes.PROTECTED))
     } else {
       None
     }
@@ -735,11 +777,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForConstructor(constructorDeclaration: ConstructorDeclaration): Ast = {
-    scopeStack.pushNewScope(NewMethod())
+    scopeStack.pushNewScope(MethodScope(ExpectedType.Void))
 
     val parameterAsts  = astsForParameterList(constructorDeclaration.getParameters)
-    val parameterTypes = parameterAsts.map(rootType(_).getOrElse(UnresolvedTypeDefault))
-    val signature      = s"void(${parameterTypes.mkString(",")})"
+    val parameterTypes = parameterAsts.map(rootType(_).getOrElse(UnresolvedConstants.UnresolvedType))
+    val signature      = s"${TypeConstants.Void}(${parameterTypes.mkString(",")})"
     val fullName       = constructorFullName(scopeStack.getEnclosingTypeDecl, signature)
 
     val constructorNode = createPartialMethod(constructorDeclaration)
@@ -753,7 +795,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       }
     }
 
-    val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedTypeDefault)
+    val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
     val thisAst      = thisAstForMethod(typeFullName, line(constructorDeclaration))
 
     val lastOrder = 2 + parameterAsts.size
@@ -903,7 +945,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     NewAnnotation()
       .code(annotationExpr.toString)
       .name(annotationExpr.getName.getIdentifier)
-      .fullName(expressionReturnTypeFullName(annotationExpr).getOrElse(UnresolvedTypeDefault))
+      .fullName(expressionReturnTypeFullName(annotationExpr).getOrElse(UnresolvedConstants.UnresolvedType))
       .order(order)
   }
 
@@ -932,25 +974,25 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  private def getMethodFullName(
-    typeDecl: Option[NewTypeDecl],
-    methodDeclaration: MethodDeclaration,
-    signature: Option[String]
-  ) = {
-    val typeName   = typeDecl.map(_.fullName)
-    val methodName = methodDeclaration.getNameAsString
+  private def getMethodFullName(typeDecl: Option[NewTypeDecl], methodName: String, maybeSignature: Option[String]) = {
+    val typeName  = typeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
+    val signature = maybeSignature.getOrElse(UnresolvedConstants.UnresolvedSignature)
 
-    (typeName, signature) match {
-      case (Some(typ), Some(sig)) =>
-        s"$typ.$methodName:$sig"
-
-      case _ => ""
-    }
+    composeMethodFullName(typeName, methodName, signature)
   }
 
   private def astForMethod(methodDeclaration: MethodDeclaration): Ast = {
 
-    scopeStack.pushNewScope(NewMethod())
+    val expectedReturnType = Try(
+      symbolResolver.toResolvedType(methodDeclaration.getType, classOf[ResolvedType])
+    ).toOption
+    val expectedReturnTypeName = expectedReturnType.map(typeInfoCalc.fullName)
+
+    scopeStack.pushNewScope(
+      MethodScope(
+        ExpectedType(expectedReturnTypeName.getOrElse(UnresolvedConstants.UnresolvedType), expectedReturnType)
+      )
+    )
 
     val typeParamMap = getTypeParameterMap(methodDeclaration.getTypeParameters.asScala)
     typeParamMap.foreach { case (identifier, typeParam) =>
@@ -960,16 +1002,19 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val parameterAsts = astsForParameterList(methodDeclaration.getParameters)
 
     val returnType =
-      typeInfoCalc
-        .fullName(methodDeclaration.getType)
+      expectedReturnTypeName
+        // This duplicates some code from TypeInfoCalculator.nameOrFullName, but provides a way to calculate
+        // the expected return type above, re-use that here and avoid attempting to resolve unresolvable
+        // types twice.
         .orElse(scopeStack.lookupVariableType(methodDeclaration.getTypeAsString))
         .orElse(scopeStack.getWildcardType(methodDeclaration.getTypeAsString))
 
-    val parameterTypes = parameterAsts.map(rootType(_).getOrElse(UnresolvedTypeDefault))
+    val parameterTypes = parameterAsts.map(rootType(_).getOrElse(UnresolvedConstants.UnresolvedType))
     val signature = returnType map { typ =>
       s"$typ(${parameterTypes.mkString(",")})"
     }
-    val methodFullName = getMethodFullName(scopeStack.getEnclosingTypeDecl, methodDeclaration, signature)
+    val methodFullName =
+      getMethodFullName(scopeStack.getEnclosingTypeDecl, methodDeclaration.getNameAsString, signature)
 
     val methodNode = createPartialMethod(methodDeclaration)
       .fullName(methodFullName)
@@ -978,7 +1023,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val thisAst = if (methodDeclaration.isStatic) {
       Seq()
     } else {
-      val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedTypeDefault)
+      val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
       Seq(thisAstForMethod(typeFullName, line(methodDeclaration)))
     }
     val lastOrder = 1 + parameterAsts.size
@@ -989,18 +1034,24 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val annotationAsts = methodDeclaration.getAnnotations.asScala.map(astForAnnotationExpr)
 
-    val modifiers =
-      if (!methodDeclaration.isStatic) {
-        Seq(
-          Ast(
-            NewModifier()
-              .modifierType(ModifierTypes.VIRTUAL)
-              .code(ModifierTypes.VIRTUAL)
-          )
-        )
-      } else {
-        Seq()
-      }
+    val isInterfaceMethod         = scopeStack.getEnclosingTypeDecl.exists(_.code.contains("interface "))
+    val isAbstractMethod          = methodDeclaration.isAbstract || (isInterfaceMethod && !methodDeclaration.isDefault)
+    val abstractModifier          = Option.when(isAbstractMethod)(NewModifier().modifierType(ModifierTypes.ABSTRACT))
+    val staticVirtualModifierType = if (methodDeclaration.isStatic) ModifierTypes.STATIC else ModifierTypes.VIRTUAL
+    val staticVirtualModifier     = Some(NewModifier().modifierType(staticVirtualModifierType))
+    val accessModifierType = if (methodDeclaration.isPublic) {
+      Some(ModifierTypes.PUBLIC)
+    } else if (methodDeclaration.isPrivate) {
+      Some(ModifierTypes.PRIVATE)
+    } else if (isInterfaceMethod) {
+      // TODO: more robust interface check
+      Some(ModifierTypes.PUBLIC)
+    } else {
+      None
+    }
+    val accessModifier = accessModifierType.map(NewModifier().modifierType(_))
+
+    val modifiers = List(accessModifier, abstractModifier, staticVirtualModifier).flatten.map(Ast(_))
 
     scopeStack.popScope()
 
@@ -1014,14 +1065,14 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForMethodReturn(methodDeclaration: MethodDeclaration): Ast = {
-    val typeFullName = typeInfoCalc.fullName(methodDeclaration.getType).getOrElse(UnresolvedTypeDefault)
+    val typeFullName = typeInfoCalc.fullName(methodDeclaration.getType).getOrElse(UnresolvedConstants.UnresolvedType)
     Ast(methodReturnNode(typeFullName, None, line(methodDeclaration.getType), column(methodDeclaration.getType)))
   }
 
   private def astForConstructorReturn(constructorDeclaration: ConstructorDeclaration): Ast = {
     val line   = constructorDeclaration.getEnd.map(x => Integer.valueOf(x.line)).toScala
     val column = constructorDeclaration.getEnd.map(x => Integer.valueOf(x.column)).toScala
-    val node   = methodReturnNode("void", None, line, column)
+    val node   = methodReturnNode(TypeConstants.Void, None, line, column)
     Ast(node)
   }
 
@@ -1111,7 +1162,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     // TODO: Implement missing handlers
     // case _: LocalClassDeclarationStmt  => Seq()
     // case _: LocalRecordDeclarationStmt => Seq()
-    // case _: UnparsableStmt             => Seq() // TODO: log a warning
     // case _: YieldStmt                  => Seq()
     statement match {
       case x: ExplicitConstructorInvocationStmt =>
@@ -1122,7 +1172,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case x: ContinueStmt     => Seq(astForContinueStatement(x, order))
       case x: DoStmt           => Seq(astForDo(x, order))
       case _: EmptyStmt        => Seq() // Intentionally skipping this
-      case x: ExpressionStmt   => astsForExpression(x.getExpression, order, Some("void"))
+      case x: ExpressionStmt   => astsForExpression(x.getExpression, order, Some(ExpectedType.Void))
       case x: ForEachStmt      => Seq(astForForEach(x, order))
       case x: ForStmt          => Seq(astForFor(x, order))
       case x: IfStmt           => Seq(astForIf(x, order))
@@ -1133,7 +1183,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case x: ThrowStmt        => Seq(astForThrow(x, order))
       case x: TryStmt          => Seq(astForTry(x, order))
       case x: WhileStmt        => Seq(astForWhile(x, order))
-      case x                   => Seq(unknownAst(x, order))
+      case x =>
+        logger.warn(s"Attempting to generate AST for unknown statement $x")
+        Seq(unknownAst(x, order))
     }
   }
 
@@ -1164,7 +1216,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .columnNumber(column(stmt))
         .code(s"if (${stmt.getCondition.toString})")
 
-    val conditionAst = astsForExpression(stmt.getCondition, order = 1, Some("boolean")).headOption.toList
+    val conditionAst =
+      astsForExpression(stmt.getCondition, order = 1, Some(ExpectedType.Boolean)).headOption.toList
 
     val thenAsts = astsForStatement(stmt.getThenStmt, order = 2)
     val elseAst  = astForElse(stmt.getElseStmt.toScala).toList
@@ -1193,7 +1246,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .code(s"while (${stmt.getCondition.toString})")
 
     val conditionAst =
-      astsForExpression(stmt.getCondition, order = 1, Some("boolean")).headOption.toList
+      astsForExpression(stmt.getCondition, order = 1, Some(ExpectedType.Boolean)).headOption.toList
     val stmtAsts = astsForStatement(stmt.getBody, order = 2)
 
     val ast = Ast(whileNode)
@@ -1212,7 +1265,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val doNode =
       NewControlStructure().controlStructureType(ControlStructureTypes.DO).order(order)
     val conditionAst =
-      astsForExpression(stmt.getCondition, order = 0, Some("boolean")).headOption.toList
+      astsForExpression(stmt.getCondition, order = 0, Some(ExpectedType.Boolean)).headOption.toList
     val stmtAsts = astsForStatement(stmt.getBody, order = 1)
     val ast = Ast(doNode)
       .withChildren(conditionAst)
@@ -1268,7 +1321,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       }.flatten
 
     val compareAsts = stmt.getCompare.toScala.toList.flatMap {
-      astsForExpression(_, initAsts.size + 1, Some(TypeConstants.Boolean))
+      astsForExpression(_, initAsts.size + 1, Some(ExpectedType.Boolean))
     }
 
     val newOrder = initAsts.size + compareAsts.size
@@ -1404,11 +1457,18 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
 
-    val args = astsForExpression(stmt.getCheck, 1, Some("boolean"))
+    val args = astsForExpression(stmt.getCheck, 1, Some(ExpectedType.Boolean))
     callAst(callNode, args)
   }
 
-  private def astForBlockStatement(stmt: BlockStmt, order: Int, codeStr: String = "<empty>"): Ast = {
+  private def astForBlockStatement(
+    stmt: BlockStmt,
+    order: Int,
+    codeStr: String = "<empty>",
+    localsToAdd: Seq[NewLocal] = Seq.empty
+  ): Ast = {
+    scopeStack.pushNewScope(BlockScope)
+
     val block = NewBlock()
       .order(order)
       .code(codeStr)
@@ -1416,9 +1476,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
 
-    scopeStack.pushNewScope(block)
-
-    var orderOffset = 0
+    var orderOffset = localsToAdd.size
     val stmtAsts = withOrder(stmt.getStatements) { (x, o) =>
       val asts = astsForStatement(x, o + orderOffset)
       orderOffset += asts.size - 1
@@ -1426,7 +1484,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }.flatten
 
     scopeStack.popScope()
-    Ast(block).withChildren(stmtAsts)
+    Ast(block)
+      .withChildren(localsToAdd.map(Ast(_)))
+      .withChildren(stmtAsts)
   }
 
   private def astForReturnNode(ret: ReturnStmt, order: Int): Ast = {
@@ -1437,7 +1497,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
       .code(ret.toString)
     if (ret.getExpression.isPresent) {
-      val exprAsts = astsForExpression(ret.getExpression.get(), order + 1, None)
+      val expectedType = scopeStack.getEnclosingMethodReturnType
+      val exprAsts     = astsForExpression(ret.getExpression.get(), order + 1, expectedType)
       val returnAst = Ast(returnNode)
         .withChildren(exprAsts)
         .withArgEdges(returnNode, exprAsts.flatMap(_.root))
@@ -1447,7 +1508,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  def astForUnaryExpr(expr: UnaryExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForUnaryExpr(expr: UnaryExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val operatorName = expr.getOperator match {
       case UnaryExpr.Operator.LOGICAL_COMPLEMENT => Operators.logicalNot
       case UnaryExpr.Operator.POSTFIX_DECREMENT  => Operators.postDecrement
@@ -1464,8 +1525,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(argsAsts.headOption.flatMap(rootType))
-        .orElse(expectedType)
-        .getOrElse(UnresolvedTypeDefault)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(operatorName)
@@ -1479,8 +1540,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, argsAsts)
   }
 
-  def astForArrayAccessExpr(expr: ArrayAccessExpr, order: Int, expectedType: Option[String]): Ast = {
-    val typeFullName = expressionReturnTypeFullName(expr).orElse(expectedType).getOrElse(UnresolvedTypeDefault)
+  def astForArrayAccessExpr(expr: ArrayAccessExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
+    val typeFullName =
+      expressionReturnTypeFullName(expr)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
     val callNode = NewCall()
       .name(Operators.indexAccess)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1492,16 +1556,18 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .columnNumber(column(expr))
       .typeFullName(typeFullName)
 
-    val args =
-      astsForExpression(expr.getName, 1, expectedType.map(_ ++ "[]")) ++ astsForExpression(
+    val arrayExpectedType = expectedType.map(exp => ExpectedType(exp.fullName ++ "[]", exp.resolvedType))
+    val args = {
+      astsForExpression(expr.getName, 1, arrayExpectedType) ++ astsForExpression(
         expr.getIndex,
         2,
-        Some("int")
+        Some(ExpectedType.Int)
       )
+    }
     callAst(callNode, args)
   }
 
-  def astForArrayCreationExpr(expr: ArrayCreationExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForArrayCreationExpr(expr: ArrayCreationExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val name = Operators.alloc
     val callNode = NewCall()
       .name(name)
@@ -1512,11 +1578,14 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .methodFullName(name)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
-      .typeFullName(expressionReturnTypeFullName(expr).getOrElse(expectedType.getOrElse(UnresolvedTypeDefault)))
+      .typeFullName(
+        expressionReturnTypeFullName(expr)
+          .getOrElse(expectedType.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType))
+      )
 
     val levelAsts = expr.getLevels.asScala.zipWithIndex.flatMap { case (lvl, idx) =>
       lvl.getDimension.toScala match {
-        case Some(dimension) => astsForExpression(dimension, idx + 1, Some("int"))
+        case Some(dimension) => astsForExpression(dimension, idx + 1, Some(ExpectedType.Int))
 
         case None => Seq.empty
       }
@@ -1531,22 +1600,33 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, args)
   }
 
-  def astForArrayInitializerExpr(expr: ArrayInitializerExpr, order: Int, expectedType: Option[String]): Ast = {
-    val typeFullName = expressionReturnTypeFullName(expr).orElse(expectedType).getOrElse(UnresolvedTypeDefault)
+  def astForArrayInitializerExpr(expr: ArrayInitializerExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
+    val typeFullName =
+      expressionReturnTypeFullName(expr)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
     val callNode = NewCall()
-      .name("<operator>.arrayInitializer")
+      .name(Operators.arrayInitializer)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .code(expr.toString)
       .order(order)
       .argumentIndex(order)
-      .methodFullName("<operator>.arrayInitializer")
+      .methodFullName(Operators.arrayInitializer)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
       .typeFullName(typeFullName)
 
     val MAX_INITIALIZERS = 1000
 
-    val expectedValueType = expr.getValues.asScala.headOption.flatMap(expressionReturnTypeFullName)
+    val expectedValueType = expr.getValues.asScala.headOption.flatMap { value =>
+      // typeName and resolvedType may represent different types since typeName can fall
+      // back to known information or primitive types. While this certainly isn't ideal,
+      // it shouldn't cause issues since resolvedType is only used where the extra type
+      // information not available in typeName is necessary.
+      val typeName     = expressionReturnTypeFullName(value)
+      val resolvedType = Try(value.calculateResolvedType()).toOption
+      typeName.map(ExpectedType(_, resolvedType))
+    }
     val args = expr.getValues.asScala
       .slice(0, MAX_INITIALIZERS)
       .zipWithIndex
@@ -1571,7 +1651,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  def astForBinaryExpr(expr: BinaryExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForBinaryExpr(expr: BinaryExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val operatorName = expr.getOperator match {
       case BinaryExpr.Operator.OR                   => Operators.logicalOr
       case BinaryExpr.Operator.AND                  => Operators.logicalAnd
@@ -1601,8 +1681,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       expressionReturnTypeFullName(expr)
         .orElse(args.headOption.flatMap(rootType))
         .orElse(args.lastOption.flatMap(rootType))
-        .orElse(expectedType)
-        .getOrElse(UnresolvedTypeDefault)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(operatorName)
@@ -1618,12 +1698,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, args)
   }
 
-  def astForCastExpr(expr: CastExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForCastExpr(expr: CastExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val typeFullName =
       typeInfoCalc
         .fullName(expr.getType)
-        .orElse(expectedType)
-        .getOrElse(UnresolvedTypeDefault)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(Operators.cast)
@@ -1654,7 +1734,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     ast.root.flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
   }
 
-  def astsForAssignExpr(expr: AssignExpr, order: Int, expectedType: Option[String]): Seq[Ast] = {
+  private def rootCode(ast: Seq[Ast]): String = {
+    ast.headOption.flatMap(_.root).flatMap(_.properties.get(PropertyNames.CODE).map(_.toString)).getOrElse("")
+  }
+
+  def astsForAssignExpr(expr: AssignExpr, order: Int, expectedExprType: Option[ExpectedType]): Seq[Ast] = {
     val methodName = expr.getOperator match {
       case Operator.ASSIGN               => Operators.assignment
       case Operator.PLUS                 => Operators.assignmentPlus
@@ -1670,10 +1754,24 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case Operator.UNSIGNED_RIGHT_SHIFT => Operators.assignmentLogicalShiftRight
     }
 
-    val targetAst  = astsForExpression(expr.getTarget, 1, None)
-    val targetType = targetAst.headOption.flatMap(rootType)
-    val argsAsts   = astsForExpression(expr.getValue, 2, targetType)
-    val valueType  = argsAsts.headOption.flatMap(rootType)
+    val maybeResolvedType = Try(expr.getTarget.calculateResolvedType()).toOption
+    val expectedType = maybeResolvedType
+      .map { resolvedType =>
+        ExpectedType(typeInfoCalc.fullName(resolvedType), Some(resolvedType))
+      }
+      .orElse(expectedExprType) // resolved target type should be more accurate
+    val targetAst = astsForExpression(expr.getTarget, 1, expectedType)
+    val argsAsts  = astsForExpression(expr.getValue, 2, expectedType)
+    val valueType = argsAsts.headOption.flatMap(rootType)
+
+    val typeFullName =
+      targetAst.headOption
+        .flatMap(rootType)
+        .orElse(valueType)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
+
+    val code = s"${rootCode(targetAst)} ${expr.getOperator.asString} ${rootCode(argsAsts)}"
 
     val callNode =
       NewCall()
@@ -1681,11 +1779,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .methodFullName(methodName)
         .lineNumber(line(expr))
         .columnNumber(column(expr))
-        .code(expr.toString)
+        .code(code)
         .argumentIndex(order)
         .order(order)
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
-        .typeFullName(targetType.orElse(valueType).orElse(expectedType).getOrElse(UnresolvedTypeDefault))
+        .typeFullName(typeFullName)
 
     if (partialConstructorQueue.isEmpty) {
       val assignAst = callAst(callNode, targetAst ++ argsAsts)
@@ -1720,11 +1818,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       val typeFullName = typeInfoCalc
         .fullName(variable.getType)
         .orElse(scopeStack.lookupVariable(variable.getTypeAsString).map(_.node.typeFullName)) // TODO: TYPE_CLEANUP
-        .getOrElse(UnresolvedTypeDefault)
+        .getOrElse(UnresolvedConstants.UnresolvedType)
       val code = s"${variable.getType} $name"
 
       val local = NewLocal().name(name).code(code).typeFullName(typeFullName).order(order + idx)
-      scopeStack.addToScope(name, local)
       local
     }.toList
   }
@@ -1742,18 +1839,27 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       val name                    = variable.getName.toString
       val initializer             = variable.getInitializer.toScala.get // Won't crash because of filter
       val initializerTypeFullName = variable.getInitializer.toScala.flatMap(expressionReturnTypeFullName)
+      val javaParserVarType       = variable.getTypeAsString
       val variableTypeFullName =
         typeInfoCalc
           .fullName(variable.getType)
           .orElse(scopeStack.lookupVariableType(name))
-          .orElse(scopeStack.getWildcardType(name))
+          .orElse(scopeStack.lookupVariableType(javaParserVarType))
+          .orElse(scopeStack.getWildcardType(javaParserVarType))
 
-      val typeFullName = variableTypeFullName.orElse(initializerTypeFullName).getOrElse(UnresolvedTypeDefault)
+      val typeFullName =
+        variableTypeFullName.orElse(initializerTypeFullName).getOrElse(UnresolvedConstants.UnresolvedType)
+
+      // Need the actual resolvedType here for when the RHS is a lambda expression.
+      val resolvedExpectedType = Try(symbolResolver.toResolvedType(variable.getType, classOf[ResolvedType])).toOption
+      val initializerAsts = astsForExpression(initializer, 2, Some(ExpectedType(typeFullName, resolvedExpectedType)))
+
+      val code = s"$name = ${rootCode(initializerAsts)}"
 
       val callNode = NewCall()
         .name(Operators.assignment)
         .methodFullName(Operators.assignment)
-        .code(s"$name = ${initializer.toString()}")
+        .code(code)
         .order(order + idx + constructorCount)
         .argumentIndex(order + idx + constructorCount)
         .lineNumber(lineNumber)
@@ -1771,8 +1877,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .columnNumber(column(variable))
       val targetAst = Ast(identifier)
 
-      // TODO Add expected type here if possible
-      val initializerAsts = astsForExpression(initializer, 2, Some(typeFullName))
       // Since all partial constructors will be dealt with here, don't pass them up.
       val declAst = callAst(callNode, Seq(targetAst) ++ initializerAsts)
 
@@ -1821,6 +1925,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val assignments =
       assignmentsForVarDecl(varDecl.getVariables.asScala, line(varDecl), column(varDecl), assignOrder)
 
+    locals.foreach { local =>
+      scopeStack.addToScope(local.name, local)
+    }
+
     localAsts ++ assignments
   }
 
@@ -1841,7 +1949,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
 
     val identifier = NewIdentifier()
-      .typeFullName(typeInfoCalc.fullName(expr.getType).getOrElse(UnresolvedTypeDefault))
+      .typeFullName(typeInfoCalc.fullName(expr.getType).getOrElse(UnresolvedConstants.UnresolvedType))
       .code(expr.getTypeAsString)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
@@ -1861,8 +1969,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, Seq(idAst, fieldIdAst))
   }
 
-  def astForConditionalExpr(expr: ConditionalExpr, order: Int, expectedType: Option[String]): Ast = {
-    val condAst = astsForExpression(expr.getCondition, 1, Some(TypeConstants.Boolean))
+  def astForConditionalExpr(expr: ConditionalExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
+    val condAst = astsForExpression(expr.getCondition, 1, Some(ExpectedType.Boolean))
     val thenAst = astsForExpression(expr.getThenExpr, 2, expectedType)
     val elseAst = astsForExpression(expr.getElseExpr, 3, expectedType)
 
@@ -1870,8 +1978,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       expressionReturnTypeFullName(expr)
         .orElse(thenAst.headOption.flatMap(rootType))
         .orElse(elseAst.headOption.flatMap(rootType))
-        .orElse(expectedType)
-        .getOrElse(UnresolvedTypeDefault)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(Operators.conditional)
@@ -1887,15 +1995,15 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, condAst ++ thenAst ++ elseAst)
   }
 
-  def astForEnclosedExpression(expr: EnclosedExpr, order: Int, expectedType: Option[String]): Seq[Ast] = {
+  def astForEnclosedExpression(expr: EnclosedExpr, order: Int, expectedType: Option[ExpectedType]): Seq[Ast] = {
     astsForExpression(expr.getInner, order, expectedType)
   }
 
-  def astForFieldAccessExpr(expr: FieldAccessExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForFieldAccessExpr(expr: FieldAccessExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val typeFullName =
       expressionReturnTypeFullName(expr)
-        .orElse(expectedType)
-        .getOrElse(UnresolvedTypeDefault)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(Operators.fieldAccess)
@@ -1935,7 +2043,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .typeFullName(TypeConstants.Boolean)
 
     val exprAst      = astsForExpression(expr.getExpression, order = 1, None)
-    val typeFullName = typeInfoCalc.fullName(expr.getType).getOrElse(UnresolvedTypeDefault)
+    val typeFullName = typeInfoCalc.fullName(expr.getType).getOrElse(UnresolvedConstants.UnresolvedType)
     val typeNode =
       NewTypeRef()
         .code(expr.getType.toString)
@@ -1949,18 +2057,18 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callAst(callNode, exprAst ++ Seq(typeAst))
   }
 
-  def astForNameExpr(x: NameExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForNameExpr(x: NameExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val name = x.getName.toString
     val typeFullName = expressionReturnTypeFullName(x)
-      .orElse(expectedType)
-      .getOrElse(UnresolvedTypeDefault)
+      .orElse(expectedType.map(_.fullName))
+      .getOrElse(UnresolvedConstants.UnresolvedType)
 
     Try(x.resolve()) match {
       case Success(value) if value.isField =>
         val identifierName = if (value.asField.isStatic) {
           // A static field represented by a NameExpr must belong to the class in which it's used. Static fields
           // from other classes are represented by a FieldAccessExpr instead.
-          scopeStack.getEnclosingTypeDecl.map(_.name).getOrElse(UnresolvedTypeDefault)
+          scopeStack.getEnclosingTypeDecl.map(_.name).getOrElse(UnresolvedConstants.UnresolvedType)
         } else {
           "this"
         }
@@ -2053,18 +2161,15 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     * This is not valid Java code, but this representation is a decent compromise between staying faithful to Java and
     * being consistent with the Java bytecode frontend.
     */
-  def astForObjectCreationExpr(expr: ObjectCreationExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForObjectCreationExpr(expr: ObjectCreationExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val maybeResolvedExpr = Try(expr.resolve())
-    val argumentAsts = withOrder(expr.getArguments) { (x, o) =>
-      val expectedArgType = getExpectedParamType(maybeResolvedExpr, o - 1)
-      astsForExpression(x, o, expectedArgType)
-    }.flatten
+    val argumentAsts      = argAstsForCall(expr, maybeResolvedExpr, expr.getArguments)
 
     val allocFullName = Operators.alloc
     val typeFullName = typeInfoCalc
       .fullName(expr.getType)
-      .orElse(expectedType)
-      .getOrElse("<unresolvedType>")
+      .orElse(expectedType.map(_.fullName))
+      .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val signature =
       maybeResolvedExpr match {
@@ -2074,11 +2179,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           // Fallback. Method could not be resolved. So we fall back to using
           // expressionTypeFullName and the argument types to approximate the method
           // signature.
-          val argumentTypes = argumentAsts.map(arg => rootType(arg).getOrElse(UnresolvedTypeDefault))
-          composeMethodLikeSignature("void", argumentTypes)
+          val argumentTypes = argumentAsts.map(arg => rootType(arg).getOrElse(UnresolvedConstants.UnresolvedType))
+          composeMethodLikeSignature(TypeConstants.Void, argumentTypes)
       }
 
-    val initFullName = s"$typeFullName.<init>:$signature"
+    val initFullName = composeMethodFullName(typeFullName, "<init>", signature)
 
     val allocNode = NewCall()
       .name(allocFullName)
@@ -2096,7 +2201,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .name("<init>")
       .methodFullName(initFullName)
       .lineNumber(line(expr))
-      .typeFullName("void")
+      .typeFullName(TypeConstants.Void)
       .code(expr.toString)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .signature(signature)
@@ -2178,11 +2283,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .withChild(returnAst)
   }
 
-  def astForThisExpr(expr: ThisExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForThisExpr(expr: ThisExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val typeFullName =
       expressionReturnTypeFullName(expr)
-        .orElse(expectedType)
-        .getOrElse(UnresolvedTypeDefault)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val identifier =
       NewIdentifier()
@@ -2198,20 +2303,19 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForExplicitConstructorInvocation(stmt: ExplicitConstructorInvocationStmt, order: Int): Ast = {
-    val args = withOrder(stmt.getArguments) { (s, o) =>
-      astsForExpression(s, o, None)
-    }.flatten
+    val maybeResolved = Try(stmt.resolve())
+    val args          = argAstsForCall(stmt, maybeResolved, stmt.getArguments)
 
     val typeFullName = Try(stmt.resolve())
       .map(_.declaringType())
       .map(typeInfoCalc.fullName)
-      .getOrElse(UnresolvedTypeDefault)
+      .getOrElse(UnresolvedConstants.UnresolvedType)
     val argTypes = argumentTypesForCall(Try(stmt.resolve()), args)
 
-    val signature = s"void(${argTypes.mkString(",")})"
+    val signature = s"${TypeConstants.Void}(${argTypes.mkString(",")})"
     val callNode = NewCall()
       .name("<init>")
-      .methodFullName(s"$typeFullName.<init>:$signature")
+      .methodFullName(composeMethodFullName(typeFullName, "<init>", signature))
       .argumentIndex(order)
       .order(order)
       .code(stmt.toString)
@@ -2219,7 +2323,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .columnNumber(column(stmt))
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .signature(signature)
-      .typeFullName("void")
+      .typeFullName(TypeConstants.Void)
 
     val thisNode = NewIdentifier()
       .name("this")
@@ -2242,7 +2346,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  private def astsForExpression(expression: Expression, order: Int, expectedType: Option[String]): Seq[Ast] = {
+  private def astsForExpression(expression: Expression, order: Int, expectedType: Option[ExpectedType]): Seq[Ast] = {
     // TODO: Implement missing handlers
     // case _: MethodReferenceExpr     => Seq()
     // case _: PatternExpr             => Seq()
@@ -2262,7 +2366,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case x: EnclosedExpr            => astForEnclosedExpression(x, order, expectedType)
       case x: FieldAccessExpr         => Seq(astForFieldAccessExpr(x, order, expectedType))
       case x: InstanceOfExpr          => Seq(astForInstanceOfExpr(x, order))
-      case x: LambdaExpr              => Seq(astForLambdaExpr(x, order))
+      case x: LambdaExpr              => Seq(astForLambdaExpr(x, order, expectedType))
       case x: LiteralExpr             => Seq(astForLiteralExpr(x, order))
       case x: MethodCallExpr          => Seq(astForMethodCall(x, order, expectedType))
       case x: NameExpr                => Seq(astForNameExpr(x, order, expectedType))
@@ -2323,183 +2427,349 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  var lambdaCounter = 0
+  var lambdaCounter    = 0
+  val LambdaNamePrefix = "lambda$"
   private def nextLambdaName(): String = {
+    val name = s"$LambdaNamePrefix$lambdaCounter"
     lambdaCounter += 1
-    s"<lambda>$lambdaCounter"
+    name
   }
 
-  private def lambdaSignature(params: List[Parameter]): String = {
-    params match {
-      case Nil => ""
-
-      case List(_) => "ANY"
-
-      case values => s"(${values.map(_ => "ANY").mkString(",")})"
-    }
-  }
-
-  private def astForLambdaExpr(expr: LambdaExpr, order: Int): Ast = {
-    // TODO: Fix types in scope for lambdas
-    // TODO: Fix class name (currently `com.github.javaparser.ast.expr.LambdaExpr`)
-    val className = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse("<empty>")
-    val fullName  = s"$className:${nextLambdaName()}"
-
-    val parameterAsts       = astsForParameterList(expr.getParameters)
-    val namesToMethodParams = mapNamesToParams(parameterAsts)
-
-    val bodyOrder = parameterAsts.size + 2
-    val bodyAst = if (expr.getBody.isBlockStmt) {
-      astsForStatement(expr.getBody, bodyOrder).headOption
-        .getOrElse(emptyBlock(bodyOrder))
-    } else {
-      val blockNode =
-        NewBlock()
-          .lineNumber(line(expr.getBody))
-          .columnNumber(column(expr.getBody))
-          .order(bodyOrder)
-          .argumentIndex(bodyOrder)
-
-      val args = astsForStatement(expr.getBody, 1)
-
-      Ast(blockNode).withChildren(args)
-    }
-
-    val (identifiersMatchingParams, identifiersNotMatchingParams) = {
-      // bodyAst.ctx.identifiers.values.toSeq.partition(identifier => namesToMethodParams.contains(identifier.name))
-      (Nil, Nil)
-    }
-
-    val closureBindings = closureBindingsForLambdas(identifiersNotMatchingParams)
-    val refEdgePairs    = buildRefEdgePairs(identifiersMatchingParams, namesToMethodParams)
-
-    val methodAst =
-      lambdaMethodAst(expr, fullName, parameterAsts, bodyAst, closureBindings, refEdgePairs)
-
-    val methodRef = lambdaMethodRef(expr, fullName, order)
-
-    val closuresWithMeta = buildClosuresWithMeta(closureBindings, methodRef)
-    lambdaContextQueue.append(Context(lambdaAsts = Seq(methodAst), closureBindingInfo = closuresWithMeta))
-
-    Ast(methodRef)
-  }
-
-  private def buildClosuresWithMeta(
-    closureBindings: Seq[ClosureBindingInfo],
-    methodRef: NewMethodRef
-  ): Seq[ClosureBindingMeta] = {
-    // This is just to get javasrc to compile. Lambdas are completeley broken, so this will probably be rewritten
-    // completely
-    val nameToNode: Map[String, NewNode] = Map.empty
-
-    closureBindings.map { closureBindingInfo =>
-      val name  = closureBindingInfo.identifier.name
-      val edges = List((methodRef, closureBindingInfo.closure, EdgeTypes.CAPTURE))
-
-      val refEdges =
-        if (nameToNode.contains(name)) {
-          val node = nameToNode(name)
-          List((closureBindingInfo.closure, node, EdgeTypes.REF))
-        } else {
-          List()
-        }
-      ClosureBindingMeta(closureBindingInfo.closure, edges ++ refEdges)
-    }
-  }
-
-  private def buildRefEdgePairs(
-    identifiers: Seq[NewIdentifier],
-    namesToMethodParams: Map[String, Ast]
-  ): Seq[RefEdgePair] = {
-    identifiers.map { identifier =>
-      val methodParamInNode =
-        namesToMethodParams(identifier.name).root.get.asInstanceOf[NewMethodParameterIn]
-      RefEdgePair(identifier, methodParamInNode)
-    }
-  }
-
-  private def closureBindingsForLambdas(identifiers: Seq[NewIdentifier]): Seq[ClosureBindingInfo] = {
-    identifiers.map { identifier =>
-      val closureBindingId = randomUUID().toString
-      val closure =
-        NewClosureBinding()
-          .closureBindingId(Some(closureBindingId))
-          .evaluationStrategy(EvaluationStrategies.BY_REFERENCE)
-          .closureOriginalName(Some(identifier.name))
-
-      ClosureBindingInfo(identifier, closure, closureBindingId)
-    }.toList
-  }
-
-  private def mapNamesToParams(parameterAsts: Seq[Ast]): Map[String, Ast] = {
-    parameterAsts
-      .filter(_.root.get.isInstanceOf[NewMethodParameterIn])
-      .map { paramAst =>
-        val node = paramAst.root.get.asInstanceOf[NewMethodParameterIn]
-        node.name -> paramAst
+  private def genericParamTypeMapForLambda(
+    expectedType: Option[ExpectedType]
+  ): Map[ResolvedTypeParameterDeclaration, ResolvedType] = {
+    expectedType
+      .flatMap(_.resolvedType)
+      // This should always be true for correct code
+      .collect { case r: ResolvedReferenceType => r }
+      .map { resolvedType =>
+        resolvedType.getTypeParametersMap.asScala.map { tp =>
+          tp.a -> tp.b
+        }.toMap
       }
-      .toMap
+      .getOrElse(Map.empty)
   }
 
-  private def lambdaMethodRef(expr: LambdaExpr, fullName: String, order: Int): NewMethodRef = {
-    NewMethodRef()
-      .code("")
-      .methodFullName(fullName)
-      .typeFullName("ANY")
-      .lineNumber(line(expr))
-      .columnNumber(column(expr))
-      .order(order)
-  }
-
-  private def lambdaMethodAst(
+  private def buildParamListForLambda(
     expr: LambdaExpr,
-    fullName: String,
-    parameterAsts: Seq[Ast],
-    bodyAst: Ast,
-    closureBindings: Seq[ClosureBindingInfo],
-    refEdgePairs: Seq[RefEdgePair]
-  ): Ast = {
-    val signature    = lambdaSignature(expr.getParameters.asScala.toList)
-    val lineNumber   = line(expr)
-    val columnNumber = column(expr)
+    maybeBoundMethod: Option[ResolvedMethodDeclaration],
+    expectedTypeParamTypes: Map[ResolvedTypeParameterDeclaration, ResolvedType]
+  ): Seq[Ast] = {
+    val lambdaParameters = expr.getParameters.asScala.toList
+    val paramTypesList = maybeBoundMethod match {
+      case Some(resolvedMethod) =>
+        val resolvedParameters = (0 until resolvedMethod.getNumberOfParams).map(resolvedMethod.getParam)
 
-    val lambdaMethodNode =
-      NewMethod()
-        .name("<lambda>")
-        .code("")
-        .isExternal(false)
-        .fullName(fullName)
-        .lineNumber(lineNumber)
-        .columnNumber(columnNumber)
-        .signature(signature)
-        .filename(filename)
+        // Substitute generic typeParam with the expected type if it can be found; leave unchanged otherwise.
+        val paramsWithSubstitutedTypes = resolvedParameters.map(_.getType).map {
+          case resolvedType: ResolvedTypeVariable =>
+            expectedTypeParamTypes.getOrElse(resolvedType.asTypeParameter(), resolvedType)
 
-    val localsForCapturedIdentifiers =
-      closureBindings.map { bindingWithInfo =>
-        val identifier = bindingWithInfo.identifier
-        Ast(
-          NewLocal()
-            .name(identifier.name)
-            .code(identifier.code)
-            .typeFullName(identifier.typeFullName)
-            .lineNumber(identifier.lineNumber)
-            .columnNumber(identifier.columnNumber)
-            .closureBindingId(bindingWithInfo.bindingId)
-        )
+          case resolvedType => resolvedType
+        }
+
+        paramsWithSubstitutedTypes.map(typeInfoCalc.fullName)
+
+      case None =>
+        // Unless types are explicitly specified in the lambda definition,
+        // this will yield the erased types which is why the actual lambda
+        // expression parameters are only used as a fallback.
+        lambdaParameters
+          .map(_.getType)
+          .map(typeInfoCalc.fullName)
+          .map(_.getOrElse(UnresolvedConstants.UnresolvedType))
+    }
+
+    if (paramTypesList.size != lambdaParameters.size) {
+      logger.error(s"Found different number lambda params and param types for $expr. Some parameters will be missing.")
+    }
+
+    val parameterNodes = lambdaParameters
+      .lazyZip(paramTypesList)
+      .lazyZip(LazyList.from(1))
+      .map { case (param, typ, idx) =>
+        val name = param.getNameAsString
+        NewMethodParameterIn()
+          .name(name)
+          .typeFullName(typ)
+          .order(idx)
+          .code(s"$typ $name")
+          .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+          .lineNumber(line(expr))
       }
 
-    val retNode = methodReturnNode("ANY", None, lineNumber, columnNumber)
+    parameterNodes.foreach { paramNode =>
+      scopeStack.addToScope(paramNode.name, paramNode)
+    }
 
-    val lambdaMethodAst = Ast(lambdaMethodNode)
-      .withChildren(parameterAsts)
-      .withChild(bodyAst.withChildren(localsForCapturedIdentifiers))
-      .withChild(Ast(retNode))
+    parameterNodes.map(Ast(_))
+  }
 
-    val lambdaMethodAstWithRefEdges = refEdgePairs.foldLeft(lambdaMethodAst)((acc, edgePair) => {
-      acc.withRefEdge(edgePair.from, edgePair.to)
-    })
+  private def getLambdaReturnType(
+    maybeResolvedLambdaType: Option[ResolvedType],
+    maybeBoundMethod: Option[ResolvedMethodDeclaration],
+    expectedTypeParamTypes: Map[ResolvedTypeParameterDeclaration, ResolvedType]
+  ): String = {
+    maybeBoundMethod
+      .map { boundMethod =>
+        boundMethod.getReturnType match {
+          case returnType: ResolvedTypeVariable =>
+            expectedTypeParamTypes.getOrElse(returnType.asTypeParameter, returnType)
 
-    lambdaMethodAstWithRefEdges
+          case returnType => returnType
+        }
+      }
+      .orElse {
+        maybeResolvedLambdaType
+      }
+      .map {
+        typeInfoCalc.fullName
+      }
+      .getOrElse(UnresolvedConstants.UnresolvedType)
+  }
+
+  def closureBinding(closureBindingId: String, originalName: String): NewClosureBinding = {
+    NewClosureBinding()
+      .closureBindingId(closureBindingId)
+      .closureOriginalName(originalName)
+      .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+  }
+
+  private def closureBindingsForCapturedNodes(captured: List[NamedVariableNodeType]): List[ClosureBindingEntry] = {
+    captured
+      .map { capturedNode =>
+        val closureBindingId   = randomUUID().toString
+        val closureBindingNode = closureBinding(closureBindingId, capturedNode.name)
+
+        ClosureBindingEntry(capturedNode, closureBindingNode)
+      }
+  }
+
+  private def localsForCapturedNodes(closureBindingEntries: List[ClosureBindingEntry]): List[NewLocal] = {
+    val localsForCaptured =
+      closureBindingEntries.map { case ClosureBindingEntry(node, binding) =>
+        val local = NewLocal()
+          .name(node.name)
+          .code(node.name)
+          .typeFullName(node.typeFullName)
+          .closureBindingId(binding.closureBindingId)
+        local
+      }
+    localsForCaptured.foreach { local => scopeStack.addToScope(local.name, local) }
+    localsForCaptured
+  }
+
+  private def astForLambdaBody(
+    body: Statement,
+    localsForCapturedVars: Seq[NewLocal],
+    returnType: String,
+    order: Int
+  ): Ast = {
+    body match {
+      case block: BlockStmt => astForBlockStatement(block, order, localsToAdd = localsForCapturedVars)
+
+      case stmt =>
+        val returnOrder = localsForCapturedVars.size + 1
+        val blockAst    = Ast(NewBlock().order(order).argumentIndex(order).lineNumber(line(body)))
+        val bodyAst = if (returnType == TypeConstants.Void) {
+          astsForStatement(stmt, returnOrder)
+        } else {
+          val returnAst = Ast(
+            NewReturn()
+              .order(returnOrder)
+              .argumentIndex(returnOrder)
+              .code(s"return ${body.toString}")
+              .lineNumber(line(body))
+          )
+          val argumentAst = astsForStatement(stmt, 1)
+          Seq(returnAst.withChildren(argumentAst))
+        }
+
+        blockAst
+          .withChildren(localsForCapturedVars.map(Ast(_)))
+          .withChildren(bodyAst)
+    }
+  }
+
+  private def createLambdaMethodNode(expr: LambdaExpr, parameters: Seq[Ast], returnType: String): NewMethod = {
+    val lambdaName = nextLambdaName()
+    val enclosingTypeName =
+      scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
+    val signature =
+      s"$returnType(${parameters.map(rootType).map(_.getOrElse(UnresolvedConstants.UnresolvedType)).mkString(",")})"
+    val lambdaFullName = composeMethodFullName(enclosingTypeName, lambdaName, signature)
+
+    NewMethod()
+      .name(lambdaName)
+      .fullName(lambdaFullName)
+      .signature(signature)
+      .filename(filename)
+      .code("<lambda>")
+  }
+
+  private def addLambdaMethodBindingToDiffGraph(lambdaMethodNode: NewMethod): Unit = {
+    val lambdaMethodBinding =
+      NewBinding()
+        .name(lambdaMethodNode.name)
+        .methodFullName(lambdaMethodNode.fullName)
+        .signature(lambdaMethodNode.signature)
+    scopeStack.getEnclosingTypeDecl.foreach { typeDecl =>
+      diffGraph.addNode(lambdaMethodBinding)
+      diffGraph.addEdge(typeDecl, lambdaMethodBinding, EdgeTypes.BINDS)
+    }
+  }
+
+  private def addClosureBindingsToDiffGraph(
+    bindingEntries: Iterable[ClosureBindingEntry],
+    methodRef: NewMethodRef
+  ): Unit = {
+    bindingEntries.foreach { case ClosureBindingEntry(node, closureBinding) =>
+      diffGraph.addNode(closureBinding)
+      diffGraph.addEdge(closureBinding, node, EdgeTypes.REF)
+      diffGraph.addEdge(methodRef, closureBinding, EdgeTypes.CAPTURE)
+    }
+  }
+
+  private def createAndPushLambdaMethod(
+    expr: LambdaExpr,
+    implementedInfo: LambdaImplementedInfo,
+    localsForCaptured: Seq[NewLocal],
+    expectedLambdaType: Option[ExpectedType]
+  ): NewMethod = {
+    val implementedMethod    = implementedInfo.implementedMethod
+    val implementedInterface = implementedInfo.implementedInterface
+
+    // We need to get this information from the expected type as the JavaParser
+    // symbol solver returns the erased types when resolving the lambda itself.
+    val expectedTypeParamTypes = genericParamTypeMapForLambda(expectedLambdaType)
+    val parametersWithoutThis  = buildParamListForLambda(expr, implementedMethod, expectedTypeParamTypes)
+
+    val returnType = getLambdaReturnType(implementedInterface, implementedMethod, expectedTypeParamTypes)
+
+    val lambdaMethodBody = astForLambdaBody(expr.getBody, localsForCaptured, returnType, parametersWithoutThis.size + 1)
+
+    val thisParam = lambdaMethodBody.nodes
+      .collect { case identifier: NewIdentifier => identifier }
+      .find { identifier => identifier.name == "this" || identifier.name == "super" }
+      .map { _ =>
+        val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
+        thisAstForMethod(typeFullName, line(expr))
+      }
+      .toList
+
+    val parameters = thisParam ++ parametersWithoutThis
+
+    val lambdaMethodNode = createLambdaMethodNode(expr, parametersWithoutThis, returnType)
+    addLambdaMethodBindingToDiffGraph(lambdaMethodNode)
+
+    val methodReturnNode = methodReturnNode(returnType, None,  line(expr), column(expr))
+    val virtualModifier = Some(NewModifier().modifierType(ModifierTypes.VIRTUAL))
+    val staticModifier  = Option.when(thisParam.isEmpty)(NewModifier().modifierType(ModifierTypes.STATIC))
+    val privateModifier = Some(NewModifier().modifierType(ModifierTypes.PRIVATE))
+
+    val modifiers = List(virtualModifier, staticModifier, privateModifier).flatten.map(Ast(_))
+
+    val lambdaParameterNamesToNodes =
+      parameters
+        .flatMap(_.root)
+        .collect { case param: NewMethodParameterIn => param }
+        .map { param => param.name -> param }
+        .toMap
+
+    val identifiersMatchingParams = lambdaMethodBody.nodes
+      .collect { case identifier: NewIdentifier => identifier }
+      .filter { identifier => lambdaParameterNamesToNodes.contains(identifier.name) }
+
+    val lambdaMethodAstWithoutRefs =
+      Ast(lambdaMethodNode)
+        .withChildren(modifiers)
+        .withChildren(parameters)
+        .withChild(lambdaMethodBody)
+        .withChild(Ast(methodReturnNode))
+
+    val lambdaMethodAst = identifiersMatchingParams.foldLeft(lambdaMethodAstWithoutRefs)((ast, identifier) =>
+      ast.withRefEdge(identifier, lambdaParameterNamesToNodes(identifier.name))
+    )
+
+    scopeStack.addLambdaMethod(lambdaMethodAst)
+
+    lambdaMethodNode
+  }
+
+  private def createAndPushLambdaTypeDecl(
+    lambdaMethodNode: NewMethod,
+    implementedInfo: LambdaImplementedInfo
+  ): NewTypeDecl = {
+    val inheritsFromTypeFullName =
+      implementedInfo.implementedInterface
+        .map(typeInfoCalc.fullName)
+        .orElse(Some(TypeConstants.Object))
+        .toList
+
+    typeInfoCalc.registerType(lambdaMethodNode.fullName)
+    val lambdaTypeDeclNode =
+      NewTypeDecl()
+        .fullName(lambdaMethodNode.fullName)
+        .name(lambdaMethodNode.name)
+        .inheritsFromTypeFullName(inheritsFromTypeFullName)
+    scopeStack.addLambdaDecl(Ast(lambdaTypeDeclNode))
+
+    lambdaTypeDeclNode
+  }
+
+  private def getLambdaImplementedInfo(expr: LambdaExpr, expectedType: Option[ExpectedType]): LambdaImplementedInfo = {
+    val maybeImplementedType =
+      Try(expr.calculateResolvedType()).toOption
+        .orElse(expectedType.flatMap(_.resolvedType))
+        .collect { case refType: ResolvedReferenceType => refType }
+
+    val maybeImplementedInterface = maybeImplementedType.flatMap(_.getTypeDeclaration.toScala)
+
+    if (maybeImplementedInterface.isEmpty) {
+      logger.warn(s"Could not resolve the interface implemented by the lambda $expr. Type info may be missing.")
+    }
+
+    // By definition, a functional interface will declare exactly one abstract method, so `find` is fine.
+    val maybeBoundMethod = maybeImplementedInterface.flatMap(_.getDeclaredMethods.asScala.find(_.isAbstract))
+
+    LambdaImplementedInfo(maybeImplementedType, maybeBoundMethod)
+  }
+
+  private def astForLambdaExpr(expr: LambdaExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
+    scopeStack.pushNewScope(MethodScope(expectedType.getOrElse(ExpectedType.default)))
+
+    val capturedVariables = scopeStack.getCapturedVariables
+    val closureBindingsForCapturedVars = closureBindingsForCapturedNodes(capturedVariables)
+    val localsForCaptured              = localsForCapturedNodes(closureBindingsForCapturedVars)
+    val implementedInfo                = getLambdaImplementedInfo(expr, expectedType)
+    val lambdaMethodNode = createAndPushLambdaMethod(expr, implementedInfo, localsForCaptured, expectedType)
+
+    val methodRef =
+      NewMethodRef()
+        .methodFullName(lambdaMethodNode.fullName)
+        .typeFullName(lambdaMethodNode.fullName)
+        .code(lambdaMethodNode.fullName)
+        .order(order)
+        .argumentIndex(order)
+
+    addClosureBindingsToDiffGraph(closureBindingsForCapturedVars, methodRef)
+
+    val interfaceBinding = implementedInfo.implementedMethod.map { implementedMethod =>
+      NewBinding()
+        .name(implementedMethod.getName)
+        .methodFullName(lambdaMethodNode.fullName)
+        .signature(lambdaMethodNode.signature)
+    }
+
+    val bindingTable = getLambdaBindingTable(
+      LambdaBindingInfo(lambdaMethodNode.fullName, implementedInfo.implementedInterface, interfaceBinding)
+    )
+
+    val lambdaTypeDeclNode = createAndPushLambdaTypeDecl(lambdaMethodNode, implementedInfo)
+    createBindingNodes(lambdaTypeDeclNode, bindingTable)
+
+    scopeStack.popScope()
+    Ast(methodRef)
   }
 
   private def astForLiteralExpr(expr: LiteralExpr, order: Int = 1): Ast = {
@@ -2508,15 +2778,29 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .order(order)
         .argumentIndex(order)
         .code(expr.toString)
-        .typeFullName(expressionReturnTypeFullName(expr).getOrElse(UnresolvedTypeDefault))
+        .typeFullName(expressionReturnTypeFullName(expr).getOrElse(UnresolvedConstants.UnresolvedType))
         .lineNumber(line(expr))
         .columnNumber(column(expr))
     )
   }
 
-  private def getExpectedParamType(maybeResolvedCall: Try[ResolvedMethodLikeDeclaration], idx: Int): Option[String] = {
-    maybeResolvedCall.toOption.flatMap { methodDecl =>
-      Try(typeInfoCalc.fullName(methodDecl.getParam(idx).getType)).toOption
+  private def getExpectedParamType(
+    maybeResolvedCall: Try[ResolvedMethodLikeDeclaration],
+    idx: Int
+  ): Option[ExpectedType] = {
+    maybeResolvedCall.toOption.map { methodDecl =>
+      val paramCount = methodDecl.getNumberOfParams
+
+      val resolvedType = if (idx < paramCount) {
+        Some(methodDecl.getParam(idx).getType)
+      } else if (paramCount > 0 && methodDecl.getParam(paramCount - 1).isVariadic) {
+        Some(methodDecl.getParam(paramCount - 1).getType)
+      } else {
+        None
+      }
+
+      val typeName = resolvedType.map(typeInfoCalc.fullName)
+      ExpectedType(typeName.getOrElse(UnresolvedConstants.UnresolvedType), resolvedType)
     }
   }
 
@@ -2572,21 +2856,62 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case Failure(_) =>
         // Fall back to actual argument types if the called method couldn't be resolved.
         // This may result in missing dataflows.
-        argAsts.map(arg => rootType(arg).getOrElse(UnresolvedTypeDefault)).toList
+        argAsts.map(arg => rootType(arg).getOrElse(UnresolvedConstants.UnresolvedType)).toList
     }
   }
 
-  private def astForMethodCall(call: MethodCallExpr, order: Int = 1, expectedReturnType: Option[String]): Ast = {
-    val maybeResolvedCall = Try(call.resolve())
-    val argumentAsts = withOrder(call.getArguments) { (arg, o) =>
-      // TODO: Verify index
-      val expectedType = getExpectedParamType(maybeResolvedCall, o - 1)
-      astsForExpression(arg, o, expectedType)
+  private def argAstsForCall(
+    call: Node,
+    tryResolvedDecl: Try[ResolvedMethodLikeDeclaration],
+    args: NodeList[Expression]
+  ): Seq[Ast] = {
+    val hasVariadicParameter = tryResolvedDecl.map(_.hasVariadicParameter).getOrElse(false)
+    val paramCount           = tryResolvedDecl.map(_.getNumberOfParams).getOrElse(-1)
+
+    val argsAsts = withOrder(args) { (arg, o) =>
+      val expectedType = getExpectedParamType(tryResolvedDecl, o - 1)
+      // Calculate order, taking into account varargs which will be children to a new arrayInitializer node.
+      val order = if (hasVariadicParameter && (o >= paramCount)) o - paramCount + 1 else o
+      astsForExpression(arg, order, expectedType)
     }.flatten
 
+    tryResolvedDecl match {
+      case Success(_) if hasVariadicParameter =>
+        val expectedVariadicTypeFullName =
+          getExpectedParamType(tryResolvedDecl, paramCount - 1)
+            .map(_.fullName)
+            .getOrElse(UnresolvedConstants.UnresolvedType)
+        val (regularArgs, varargs) = argsAsts.splitAt(paramCount - 1)
+        val arrayInitializer =
+          NewCall()
+            .name(Operators.arrayInitializer)
+            .methodFullName(Operators.arrayInitializer)
+            .code(Operators.arrayInitializer)
+            .typeFullName(expectedVariadicTypeFullName)
+            .order(paramCount)
+            .argumentIndex(paramCount)
+            .dispatchType(DispatchTypes.STATIC_DISPATCH)
+            .lineNumber(line(call))
+            .columnNumber(column(call))
+
+        val arrayInitializerAst = callAst(arrayInitializer, varargs)
+
+        regularArgs ++ Seq(arrayInitializerAst)
+
+      case _ => argsAsts
+    }
+  }
+  private def astForMethodCall(call: MethodCallExpr, order: Int = 1, expectedReturnType: Option[ExpectedType]): Ast = {
+    val maybeResolvedCall = Try(call.resolve())
+    val maybeResolvedType = Try(call.calculateResolvedType())
+    val callArgTypes = call.getArguments.asScala.map { arg =>
+      arg.toString -> Try(arg.calculateResolvedType())
+    }
+    val argumentAsts = argAstsForCall(call, maybeResolvedCall, call.getArguments)
+
     val expressionTypeFullName = expressionReturnTypeFullName(call)
-      .orElse(expectedReturnType)
-      .getOrElse(UnresolvedTypeDefault)
+      .orElse(expectedReturnType.map(_.fullName))
+      .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val signature =
       maybeResolvedCall match {
@@ -2596,19 +2921,14 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           // Fallback. Method could not be resolved. So we fall back to using
           // expressionTypeFullName and the argument types to approximate the method
           // signature.
-          val argumentTypes = argumentAsts.map(arg => rootType(arg).getOrElse(UnresolvedTypeDefault))
+          val argumentTypes = argumentAsts.map(arg => rootType(arg).getOrElse(UnresolvedConstants.UnresolvedType))
           composeMethodLikeSignature(expressionTypeFullName, argumentTypes)
       }
 
     val receiverTypeOption = targetTypeForCall(call)
+    val receiverType       = receiverTypeOption.getOrElse(UnresolvedConstants.UnresolvedReceiver)
 
-    val methodFullName =
-      receiverTypeOption match {
-        case Some(receiverType) =>
-          s"$receiverType.${call.getNameAsString}:$signature"
-        case None =>
-          s"<unresolvedReceiverType>.${call.getNameAsString}:$signature"
-      }
+    val methodFullName = composeMethodFullName(receiverType, call.getNameAsString, signature)
 
     val dispatchType = dispatchTypeForCall(maybeResolvedCall, call.getScope.toScala)
 
@@ -2627,10 +2947,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val scopeAsts = call.getScope.toScala match {
       case Some(scope) =>
-        astsForExpression(scope, 0, receiverTypeOption)
+        astsForExpression(scope, 0, receiverTypeOption.map(ExpectedType(_)))
 
       case None =>
-        val objectNode = createObjectNode(receiverTypeOption.getOrElse(UnresolvedTypeDefault), call, callNode)
+        val objectNode =
+          createObjectNode(receiverTypeOption.getOrElse(UnresolvedConstants.UnresolvedType), call, callNode)
         objectNode.map(Ast(_)).toList
     }
 
@@ -2644,11 +2965,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
-  def astForSuperExpr(superExpr: SuperExpr, order: Int, expectedType: Option[String]): Ast = {
+  def astForSuperExpr(superExpr: SuperExpr, order: Int, expectedType: Option[ExpectedType]): Ast = {
     val typeFullName =
       expressionReturnTypeFullName(superExpr)
-        .orElse(expectedType)
-        .getOrElse(UnresolvedTypeDefault)
+        .orElse(expectedType.map(_.fullName))
+        .getOrElse(UnresolvedConstants.UnresolvedType)
 
     val thisIdentifier = NewIdentifier()
       .name("this")
@@ -2669,20 +2990,22 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForParameter(parameter: Parameter, childNum: Int): Ast = {
-    val typeFullName =
+    val maybeArraySuffix = if (parameter.isVarArgs) "[]" else ""
+    val typeFullName = {
       typeInfoCalc
         .fullName(parameter.getType)
         .orElse(scopeStack.lookupVariableType(parameter.getTypeAsString))
         .orElse(scopeStack.getWildcardType(parameter.getTypeAsString))
-        .getOrElse(UnresolvedTypeDefault)
+        .getOrElse(UnresolvedConstants.UnresolvedType)
+    }
     val parameterNode = NewMethodParameterIn()
       .name(parameter.getName.toString)
       .code(parameter.toString)
-      .typeFullName(typeFullName)
+      .typeFullName(s"$typeFullName$maybeArraySuffix")
       .order(childNum)
       .lineNumber(line(parameter))
       .columnNumber(column(parameter))
-      .evaluationStrategy(EvaluationStrategies.BY_VALUE)
+      .evaluationStrategy(EvaluationStrategies.BY_SHARING)
     val annotationAsts = parameter.getAnnotations.asScala.map(astForAnnotationExpr)
     val ast            = Ast(parameterNode)
 
@@ -2691,14 +3014,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def constructorFullName(typeDecl: Option[NewTypeDecl], signature: String): String = {
-    val typeName = typeDecl.map(_.fullName).getOrElse(UnresolvedTypeDefault)
+    val typeName = typeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
     s"$typeName.<init>:$signature"
   }
 
-  private def emptyBlock(order: Int): Ast = {
-    val node = NewBlock().order(order).argumentIndex(order)
-    Ast(node)
-  }
 }
 
 object AstCreator {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2,24 +2,148 @@ package io.joern.javasrc2cpg.passes
 
 import com.github.javaparser.ast.`type`.TypeParameter
 import com.github.javaparser.ast.{CompilationUnit, Node, NodeList, PackageDeclaration}
-import com.github.javaparser.ast.body.{AnnotationDeclaration, BodyDeclaration, CallableDeclaration, ClassOrInterfaceDeclaration, ConstructorDeclaration, EnumConstantDeclaration, FieldDeclaration, InitializerDeclaration, MethodDeclaration, Parameter, TypeDeclaration, VariableDeclarator}
+import com.github.javaparser.ast.body.{
+  AnnotationDeclaration,
+  BodyDeclaration,
+  CallableDeclaration,
+  ClassOrInterfaceDeclaration,
+  ConstructorDeclaration,
+  EnumConstantDeclaration,
+  FieldDeclaration,
+  InitializerDeclaration,
+  MethodDeclaration,
+  Parameter,
+  TypeDeclaration,
+  VariableDeclarator
+}
 import com.github.javaparser.ast.expr.AssignExpr.Operator
-import com.github.javaparser.ast.expr.{AnnotationExpr, ArrayAccessExpr, ArrayCreationExpr, ArrayInitializerExpr, AssignExpr, BinaryExpr, BooleanLiteralExpr, CastExpr, CharLiteralExpr, ClassExpr, ConditionalExpr, DoubleLiteralExpr, EnclosedExpr, Expression, FieldAccessExpr, InstanceOfExpr, IntegerLiteralExpr, LambdaExpr, LiteralExpr, LongLiteralExpr, MarkerAnnotationExpr, MethodCallExpr, NameExpr, NormalAnnotationExpr, NullLiteralExpr, ObjectCreationExpr, SingleMemberAnnotationExpr, StringLiteralExpr, SuperExpr, TextBlockLiteralExpr, ThisExpr, UnaryExpr, VariableDeclarationExpr}
+import com.github.javaparser.ast.expr.{
+  AnnotationExpr,
+  ArrayAccessExpr,
+  ArrayCreationExpr,
+  ArrayInitializerExpr,
+  AssignExpr,
+  BinaryExpr,
+  BooleanLiteralExpr,
+  CastExpr,
+  CharLiteralExpr,
+  ClassExpr,
+  ConditionalExpr,
+  DoubleLiteralExpr,
+  EnclosedExpr,
+  Expression,
+  FieldAccessExpr,
+  InstanceOfExpr,
+  IntegerLiteralExpr,
+  LambdaExpr,
+  LiteralExpr,
+  LongLiteralExpr,
+  MarkerAnnotationExpr,
+  MethodCallExpr,
+  NameExpr,
+  NormalAnnotationExpr,
+  NullLiteralExpr,
+  ObjectCreationExpr,
+  SingleMemberAnnotationExpr,
+  StringLiteralExpr,
+  SuperExpr,
+  TextBlockLiteralExpr,
+  ThisExpr,
+  UnaryExpr,
+  VariableDeclarationExpr
+}
 import com.github.javaparser.ast.nodeTypes.{NodeWithName, NodeWithSimpleName}
-import com.github.javaparser.ast.stmt.{AssertStmt, BlockStmt, BreakStmt, CatchClause, ContinueStmt, DoStmt, EmptyStmt, ExplicitConstructorInvocationStmt, ExpressionStmt, ForEachStmt, ForStmt, IfStmt, LabeledStmt, ReturnStmt, Statement, SwitchEntry, SwitchStmt, SynchronizedStmt, ThrowStmt, TryStmt, WhileStmt}
+import com.github.javaparser.ast.stmt.{
+  AssertStmt,
+  BlockStmt,
+  BreakStmt,
+  CatchClause,
+  ContinueStmt,
+  DoStmt,
+  EmptyStmt,
+  ExplicitConstructorInvocationStmt,
+  ExpressionStmt,
+  ForEachStmt,
+  ForStmt,
+  IfStmt,
+  LabeledStmt,
+  ReturnStmt,
+  Statement,
+  SwitchEntry,
+  SwitchStmt,
+  SynchronizedStmt,
+  ThrowStmt,
+  TryStmt,
+  WhileStmt
+}
 import com.github.javaparser.resolution.{SymbolResolver, UnsolvedSymbolException}
-import com.github.javaparser.resolution.declarations.{ResolvedConstructorDeclaration, ResolvedFieldDeclaration, ResolvedMethodDeclaration, ResolvedMethodLikeDeclaration, ResolvedReferenceTypeDeclaration, ResolvedTypeParameterDeclaration}
+import com.github.javaparser.resolution.declarations.{
+  ResolvedConstructorDeclaration,
+  ResolvedFieldDeclaration,
+  ResolvedMethodDeclaration,
+  ResolvedMethodLikeDeclaration,
+  ResolvedReferenceTypeDeclaration,
+  ResolvedTypeParameterDeclaration
+}
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType, ResolvedTypeVariable}
 import io.joern.javasrc2cpg.util.BindingTable.createBindingTable
 import io.joern.javasrc2cpg.util.NodeBuilders.{assignmentNode, indexAccessNode}
 import io.joern.javasrc2cpg.util.Scope.ScopeTypes.{BlockScope, MethodScope, NamespaceScope, TypeDeclScope}
 import io.joern.javasrc2cpg.util.Scope.{NamedVariableNodeType, WildcardImportName}
-import io.joern.javasrc2cpg.util.{BindingTable, BindingTableAdapterForFlatEntries, BindingTableAdapterForJavaparser, BindingTableAdapterForLambdas, BindingTableEntry, LambdaBindingInfo, NodeTypeInfo, Scope, TypeInfoCalculator}
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.{TypeConstants, UnresolvedConstants}
-import io.joern.javasrc2cpg.util.Util.composeMethodFullName
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, EdgeTypes, EvaluationStrategies, ModifierTypes, NodeTypes, Operators, PropertyNames}
-import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasSignature, NewAnnotation, NewAnnotationLiteral, NewAnnotationParameter, NewAnnotationParameterAssign, NewArrayInitializer, NewBinding, NewBlock, NewCall, NewClosureBinding, NewControlStructure, NewFieldIdentifier, NewIdentifier, NewJumpTarget, NewLiteral, NewLocal, NewMember, NewMethod, NewMethodParameterIn, NewMethodRef, NewMethodReturn, NewModifier, NewNamespaceBlock, NewNode, NewReturn, NewTypeDecl, NewTypeRef, NewUnknown}
+import io.joern.javasrc2cpg.util.{
+  BindingTable,
+  BindingTableAdapterForJavaparser,
+  BindingTableAdapterForLambdas,
+  BindingTableEntry,
+  LambdaBindingInfo,
+  NodeTypeInfo,
+  Scope,
+  TypeInfoCalculator
+}
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
+import io.joern.javasrc2cpg.util.Util.{composeMethodFullName, composeMethodLikeSignature, rootCode, rootType}
+import io.shiftleft.codepropertygraph.generated.{
+  ControlStructureTypes,
+  DispatchTypes,
+  EdgeTypes,
+  EvaluationStrategies,
+  ModifierTypes,
+  NodeTypes,
+  Operators,
+  PropertyNames
+}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  HasFullName,
+  HasSignature,
+  NewAnnotation,
+  NewAnnotationLiteral,
+  NewAnnotationParameter,
+  NewAnnotationParameterAssign,
+  NewArrayInitializer,
+  NewBinding,
+  NewBlock,
+  NewCall,
+  NewClosureBinding,
+  NewControlStructure,
+  NewFieldIdentifier,
+  NewIdentifier,
+  NewJumpTarget,
+  NewLiteral,
+  NewLocal,
+  NewMember,
+  NewMethod,
+  NewMethodParameterIn,
+  NewMethodRef,
+  NewMethodReturn,
+  NewModifier,
+  NewNamespaceBlock,
+  NewNode,
+  NewReturn,
+  NewTypeDecl,
+  NewTypeRef,
+  NewUnknown
+}
 import io.joern.x2cpg.{Ast, AstCreatorBase}
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.passes.frontend.TypeNodePass
@@ -45,7 +169,7 @@ case class PartialConstructor(initNode: NewCall, initArgs: Seq[Ast], blockAst: A
 
 case class ExpectedType(fullName: String, resolvedType: Option[ResolvedType] = None)
 object ExpectedType {
-  val default: ExpectedType = ExpectedType(UnresolvedConstants.UnresolvedType)
+  val default: ExpectedType = ExpectedType(TypeConstants.UnresolvedType)
   val Int: ExpectedType     = ExpectedType(TypeConstants.Int)
   val Boolean: ExpectedType = ExpectedType(TypeConstants.Boolean)
   val Void: ExpectedType    = ExpectedType(TypeConstants.Void)
@@ -74,6 +198,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   private val partialConstructorQueue: mutable.ArrayBuffer[PartialConstructor] = mutable.ArrayBuffer.empty
   private val bindingTableCache = mutable.HashMap.empty[String, BindingTable]
 
+  // TODO: Perhaps move this to a NameProvider or some such? Look at kt2cpg to see if some unified representation
+  // makes sense.
   private val LambdaNamePrefix   = "lambda$"
   private val lambdaKeyPool      = new IntervalKeyPool(first = 0, last = Long.MaxValue)
   private val IndexNamePrefix    = "$idx"
@@ -186,7 +312,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val returnType =
       Try(method.getReturnType).toOption
         .map(returnType => typeInfoCalc.fullName(returnType, typeParamValues))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     composeMethodLikeSignature(returnType, parameterTypes)
   }
@@ -203,14 +329,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .map { param =>
           Try(param.getType).toOption
             .map(paramType => typeInfoCalc.fullName(paramType, typeParamValues))
-            .getOrElse(UnresolvedConstants.UnresolvedType)
+            .getOrElse(TypeConstants.UnresolvedType)
         }
 
     parameterTypes
-  }
-
-  private def composeMethodLikeSignature(returnType: String, parameterTypes: collection.Seq[String]): String = {
-    s"$returnType(${parameterTypes.mkString(",")})"
   }
 
   def getBindingTable(typeDecl: ResolvedReferenceTypeDeclaration): BindingTable = {
@@ -238,21 +360,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         getBindingTable,
         methodSignature,
         new BindingTableAdapterForLambdas()
-      )
-    )
-  }
-
-  def getFlatBindingTable(typeDecl: NewTypeDecl, bindingEntries: Seq[BindingTableEntry]): BindingTable = {
-    val fullName = typeDecl.fullName
-
-    bindingTableCache.getOrElseUpdate(
-      fullName,
-      createBindingTable(
-        fullName,
-        typeDecl,
-        getBindingTable,
-        methodSignature,
-        new BindingTableAdapterForFlatEntries(bindingEntries)
       )
     )
   }
@@ -457,7 +564,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         Seq()
       }
       maybeJavaObjectType ++ (extendedTypes ++ implementedTypes)
-        .map(typ => typeInfoCalc.fullName(typ).getOrElse(UnresolvedConstants.UnresolvedType))
+        .map(typ => typeInfoCalc.fullName(typ).getOrElse(TypeConstants.UnresolvedType))
         .toList
     } else {
       List.empty[String]
@@ -489,8 +596,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     astParentFullName: String
   ): Ast = {
     val isInterface = typ match {
-      case classDeclaration: ClassOrInterfaceDeclaration if classDeclaration.isInterface => true
-      case _                                                                             => false
+      case classDeclaration: ClassOrInterfaceDeclaration => classDeclaration.isInterface
+      case _                                             => false
     }
 
     val typeDeclNode = createTypeDeclNode(typ, order, astParentType, astParentFullName, isInterface)
@@ -607,7 +714,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def astForEnumEntry(entry: EnumConstantDeclaration, order: Int): Ast = {
     val typeFullName =
-      Try(entry.resolve().getType).toOption.map(typeInfoCalc.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
+      Try(entry.resolve().getType).toOption.map(typeInfoCalc.fullName).getOrElse(TypeConstants.UnresolvedType)
     val entryNode = NewMember()
       .lineNumber(line(entry))
       .columnNumber(column(entry))
@@ -634,6 +741,26 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     Ast(entryNode).withChildren(args)
   }
 
+  private def modifiersForFieldDeclaration(decl: FieldDeclaration): Seq[Ast] = {
+    val staticModifier = if (decl.isStatic) {
+      Some(NewModifier().modifierType(ModifierTypes.STATIC).code(ModifierTypes.STATIC))
+    } else {
+      None
+    }
+
+    val accessModifier = if (decl.isPublic) {
+      Some(NewModifier().modifierType(ModifierTypes.PUBLIC).code(ModifierTypes.PUBLIC))
+    } else if (decl.isPrivate) {
+      Some(NewModifier().modifierType(ModifierTypes.PRIVATE).code(ModifierTypes.PRIVATE))
+    } else if (decl.isProtected) {
+      Some(NewModifier().modifierType(ModifierTypes.PROTECTED).code(ModifierTypes.PROTECTED))
+    } else {
+      None
+    }
+
+    List(staticModifier, accessModifier).flatten.map(Ast(_))
+  }
+
   private def astForFieldVariable(v: VariableDeclarator, fieldDeclaration: FieldDeclaration, order: Int): Ast = {
     // TODO: Should be able to find expected type here
     val annotations = fieldDeclaration.getAnnotations
@@ -641,7 +768,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       typeInfoCalc
         .fullName(v.getType)
         .orElse(scopeStack.getWildcardType(v.getTypeAsString))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
     val name = v.getName.toString
     val memberNode =
       NewMember()
@@ -652,36 +779,21 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val memberAst      = Ast(memberNode)
     val annotationAsts = annotations.asScala.map(astForAnnotationExpr)
 
-    val staticModifier = if (fieldDeclaration.isStatic) {
-      Some(NewModifier().modifierType(ModifierTypes.STATIC).code(ModifierTypes.STATIC))
-    } else {
-      None
-    }
-
-    val accessModifier = if (fieldDeclaration.isPublic) {
-      Some(NewModifier().modifierType(ModifierTypes.PUBLIC).code(ModifierTypes.PUBLIC))
-    } else if (fieldDeclaration.isPrivate) {
-      Some(NewModifier().modifierType(ModifierTypes.PRIVATE).code(ModifierTypes.PRIVATE))
-    } else if (fieldDeclaration.isProtected) {
-      Some(NewModifier().modifierType(ModifierTypes.PROTECTED).code(ModifierTypes.PROTECTED))
-    } else {
-      None
-    }
+    val fieldDeclModifiers = modifiersForFieldDeclaration(fieldDeclaration)
 
     val nodeTypeInfo = NodeTypeInfo(memberNode, isField = true, isStatic = fieldDeclaration.isStatic)
     scopeStack.addToScope(name, nodeTypeInfo)
 
     memberAst
       .withChildren(annotationAsts)
-      .withChildren(staticModifier.map(Ast(_)).toSeq)
-      .withChildren(accessModifier.map(Ast(_)).toSeq)
+      .withChildren(fieldDeclModifiers)
   }
 
   private def astForConstructor(constructorDeclaration: ConstructorDeclaration): Ast = {
     scopeStack.pushNewScope(MethodScope(ExpectedType.Void))
 
     val parameterAsts  = astsForParameterList(constructorDeclaration.getParameters)
-    val parameterTypes = parameterAsts.map(rootType(_).getOrElse(UnresolvedConstants.UnresolvedType))
+    val parameterTypes = parameterAsts.map(rootType(_).getOrElse(TypeConstants.UnresolvedType))
     val signature      = s"${TypeConstants.Void}(${parameterTypes.mkString(",")})"
     val fullName       = constructorFullName(scopeStack.getEnclosingTypeDecl, signature)
 
@@ -696,7 +808,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       }
     }
 
-    val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
+    val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(TypeConstants.UnresolvedType)
     val thisAst      = thisAstForMethod(typeFullName, line(constructorDeclaration))
 
     val lastOrder = 2 + parameterAsts.size
@@ -846,7 +958,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     NewAnnotation()
       .code(annotationExpr.toString)
       .name(annotationExpr.getName.getIdentifier)
-      .fullName(expressionReturnTypeFullName(annotationExpr).getOrElse(UnresolvedConstants.UnresolvedType))
+      .fullName(expressionReturnTypeFullName(annotationExpr).getOrElse(TypeConstants.UnresolvedType))
       .order(order)
   }
 
@@ -876,65 +988,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def getMethodFullName(typeDecl: Option[NewTypeDecl], methodName: String, maybeSignature: Option[String]) = {
-    val typeName  = typeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
-    val signature = maybeSignature.getOrElse(UnresolvedConstants.UnresolvedSignature)
+    val typeName  = typeDecl.map(_.fullName).getOrElse(TypeConstants.UnresolvedType)
+    val signature = maybeSignature.getOrElse(TypeConstants.UnresolvedSignature)
 
     composeMethodFullName(typeName, methodName, signature)
   }
 
-  private def astForMethod(methodDeclaration: MethodDeclaration): Ast = {
-
-    val expectedReturnType = Try(
-      symbolResolver.toResolvedType(methodDeclaration.getType, classOf[ResolvedType])
-    ).toOption
-    val expectedReturnTypeName = expectedReturnType.map(typeInfoCalc.fullName)
-
-    scopeStack.pushNewScope(
-      MethodScope(
-        ExpectedType(expectedReturnTypeName.getOrElse(UnresolvedConstants.UnresolvedType), expectedReturnType)
-      )
-    )
-
-    val typeParamMap = getTypeParameterMap(methodDeclaration.getTypeParameters.asScala)
-    typeParamMap.foreach { case (identifier, typeParam) =>
-      scopeStack.addToScope(identifier, typeParam)
-    }
-
-    val parameterAsts = astsForParameterList(methodDeclaration.getParameters)
-
-    val returnType =
-      expectedReturnTypeName
-        // This duplicates some code from TypeInfoCalculator.nameOrFullName, but provides a way to calculate
-        // the expected return type above, re-use that here and avoid attempting to resolve unresolvable
-        // types twice.
-        .orElse(scopeStack.lookupVariableType(methodDeclaration.getTypeAsString))
-        .orElse(scopeStack.getWildcardType(methodDeclaration.getTypeAsString))
-
-    val parameterTypes = parameterAsts.map(rootType(_).getOrElse(UnresolvedConstants.UnresolvedType))
-    val signature = returnType map { typ =>
-      s"$typ(${parameterTypes.mkString(",")})"
-    }
-    val methodFullName =
-      getMethodFullName(scopeStack.getEnclosingTypeDecl, methodDeclaration.getNameAsString, signature)
-
-    val methodNode = createPartialMethod(methodDeclaration)
-      .fullName(methodFullName)
-      .signature(signature.getOrElse(""))
-
-    val thisAst = if (methodDeclaration.isStatic) {
-      Seq()
-    } else {
-      val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
-      Seq(thisAstForMethod(typeFullName, line(methodDeclaration)))
-    }
-    val lastOrder = 1 + parameterAsts.size
-
-    val bodyAst =
-      astForMethodBody(methodDeclaration.getBody.toScala, lastOrder)
-    val returnAst = astForMethodReturn(methodDeclaration)
-
-    val annotationAsts = methodDeclaration.getAnnotations.asScala.map(astForAnnotationExpr)
-
+  private def modifierAstsForMethod(methodDeclaration: MethodDeclaration): Seq[Ast] = {
     val isInterfaceMethod         = scopeStack.getEnclosingTypeDecl.exists(_.code.contains("interface "))
     val isAbstractMethod          = methodDeclaration.isAbstract || (isInterfaceMethod && !methodDeclaration.isDefault)
     val abstractModifier          = Option.when(isAbstractMethod)(NewModifier().modifierType(ModifierTypes.ABSTRACT))
@@ -952,7 +1012,61 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
     val accessModifier = accessModifierType.map(NewModifier().modifierType(_))
 
-    val modifiers = List(accessModifier, abstractModifier, staticVirtualModifier).flatten.map(Ast(_))
+    List(accessModifier, abstractModifier, staticVirtualModifier).flatten.map(Ast(_))
+  }
+
+  private def astForMethod(methodDeclaration: MethodDeclaration): Ast = {
+
+    val expectedReturnType = Try(
+      symbolResolver.toResolvedType(methodDeclaration.getType, classOf[ResolvedType])
+    ).toOption
+    val expectedReturnTypeName = expectedReturnType.map(typeInfoCalc.fullName)
+
+    scopeStack.pushNewScope(
+      MethodScope(ExpectedType(expectedReturnTypeName.getOrElse(TypeConstants.UnresolvedType), expectedReturnType))
+    )
+
+    val typeParamMap = getTypeParameterMap(methodDeclaration.getTypeParameters.asScala)
+    typeParamMap.foreach { case (identifier, typeParam) =>
+      scopeStack.addToScope(identifier, typeParam)
+    }
+
+    val parameterAsts = astsForParameterList(methodDeclaration.getParameters)
+
+    val returnType =
+      expectedReturnTypeName
+        // This duplicates some code from TypeInfoCalculator.nameOrFullName, but provides a way to calculate
+        // the expected return type above, re-use that here and avoid attempting to resolve unresolvable
+        // types twice.
+        .orElse(scopeStack.lookupVariableType(methodDeclaration.getTypeAsString))
+        .orElse(scopeStack.getWildcardType(methodDeclaration.getTypeAsString))
+
+    val parameterTypes = parameterAsts.map(rootType(_).getOrElse(TypeConstants.UnresolvedType))
+    val signature = returnType map { typ =>
+      s"$typ(${parameterTypes.mkString(",")})"
+    }
+    val methodFullName =
+      getMethodFullName(scopeStack.getEnclosingTypeDecl, methodDeclaration.getNameAsString, signature)
+
+    val methodNode = createPartialMethod(methodDeclaration)
+      .fullName(methodFullName)
+      .signature(signature.getOrElse(""))
+
+    val thisAst = if (methodDeclaration.isStatic) {
+      Seq()
+    } else {
+      val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(TypeConstants.UnresolvedType)
+      Seq(thisAstForMethod(typeFullName, line(methodDeclaration)))
+    }
+    val lastOrder = 1 + parameterAsts.size
+
+    val bodyAst =
+      astForMethodBody(methodDeclaration.getBody.toScala, lastOrder)
+    val returnAst = astForMethodReturn(methodDeclaration)
+
+    val annotationAsts = methodDeclaration.getAnnotations.asScala.map(astForAnnotationExpr)
+
+    val modifierAsts = modifierAstsForMethod(methodDeclaration)
 
     scopeStack.popScope()
 
@@ -961,12 +1075,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .withChildren(parameterAsts)
       .withChild(bodyAst)
       .withChildren(annotationAsts)
-      .withChildren(modifiers)
+      .withChildren(modifierAsts)
       .withChild(returnAst)
   }
 
   private def astForMethodReturn(methodDeclaration: MethodDeclaration): Ast = {
-    val typeFullName = typeInfoCalc.fullName(methodDeclaration.getType).getOrElse(UnresolvedConstants.UnresolvedType)
+    val typeFullName = typeInfoCalc.fullName(methodDeclaration.getType).getOrElse(TypeConstants.UnresolvedType)
     Ast(methodReturnNode(typeFullName, None, line(methodDeclaration.getType), column(methodDeclaration.getType)))
   }
 
@@ -1295,7 +1409,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .argumentIndex(1)
         .lineNumber(lineNo)
     val iterableAssignArgs = List(Ast(iterableAssignIdentifier), iterableAst)
-    val iterableAssignAst  =
+    val iterableAssignAst =
       callAst(iterableAssignNode, iterableAssignArgs)
         .withRefEdge(iterableAssignIdentifier, iterableLocalNode)
 
@@ -1420,9 +1534,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     maybeVariable match {
       case Some(variable) =>
-        val typeFullName = typeInfoCalc.fullName(variable.getType).getOrElse(UnresolvedConstants.UnresolvedType)
+        val typeFullName = typeInfoCalc.fullName(variable.getType).getOrElse(TypeConstants.UnresolvedType)
         val localNode = partialLocalNode
           .name(variable.getNameAsString)
+          .code(variable.getNameAsString)
           .typeFullName(typeFullName)
         scopeStack.addToScope(localNode.name, localNode)
         localNode
@@ -1522,15 +1637,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val lineNo = line(stmt)
 
-    val idxLocal = nativeForEachIdxLocalNode(lineNo)
-
+    val idxLocal          = nativeForEachIdxLocalNode(lineNo)
     val idxInitializerAst = nativeForEachIdxInitializerAst(lineNo, idxLocal)
-
-    val compareAst = nativeForEachCompareAst(lineNo, iterableSourceNode, idxLocal)
-
-    val incrementAst = nativeForEachIncrementAst(lineNo, idxLocal)
-
-    val bodyAst = nativeForEachBodyAst(stmt, idxLocal, iterableSourceNode)
+    val compareAst        = nativeForEachCompareAst(lineNo, iterableSourceNode, idxLocal)
+    val incrementAst      = nativeForEachIncrementAst(lineNo, idxLocal)
+    val bodyAst           = nativeForEachBodyAst(stmt, idxLocal, iterableSourceNode)
 
     val forAst = Ast(forNode)
       .withChild(Ast(idxLocal))
@@ -1538,38 +1649,38 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .withChild(compareAst)
       .withChild(incrementAst)
       .withChild(bodyAst)
+      .withConditionEdges(forNode, compareAst.root.toList)
 
     tempIterableInitAsts ++ Seq(forAst)
   }
 
-  private def astForIterableForEach(stmt: ForEachStmt, maybeTypeFullName: Option[String], order: Int): Seq[Ast] = {
-    val lineNo = line(stmt)
-    val iterableType = expressionReturnTypeFullName(stmt.getIterable).getOrElse(UnresolvedConstants.UnresolvedType)
-    // Create iter local
-   val iteratorLocalName = nextIterableName()
-    val iteratorLocalNode =
-      NewLocal()
-        .name(iteratorLocalName)
-        .code(iteratorLocalName)
-        .typeFullName(TypeConstants.Iterator)
-        .order(order)
-        .lineNumber(lineNo)
+  private def iteratorLocalForForEach(order: Int, lineNumber: Option[Integer]): NewLocal = {
+    val iteratorLocalName = nextIterableName()
+    NewLocal()
+      .name(iteratorLocalName)
+      .code(iteratorLocalName)
+      .typeFullName(TypeConstants.Iterator)
+      .order(order)
+      .lineNumber(lineNumber)
+  }
 
-    // Create local assign from iterator
+  private def iteratorAssignAstForForEach(
+    iterExpr: Expression,
+    iteratorLocalNode: NewLocal,
+    iterableType: String,
+    lineNo: Option[Integer],
+    order: Int
+  ): Ast = {
     val iteratorAssignNode =
       assignmentNode()
         .typeFullName(TypeConstants.Iterator)
-        .order(order + 1)
-        .argumentIndex(order + 1)
+        .order(order)
+        .argumentIndex(order)
         .lineNumber(lineNo)
     val iteratorAssignIdentifier = identifierFromNamedVarType(iteratorLocalNode, lineNo, 1)
-    val iteratorMethodName = "iterator"
-    val iteratorMethodSignature = composeMethodLikeSignature(TypeConstants.Iterator, parameterTypes = Nil)
-    val iteratorMethodFullName = composeMethodFullName(
-      iterableType,
-      iteratorMethodName,
-      iteratorMethodSignature
-    )
+    val iteratorMethodName       = "iterator"
+    val iteratorMethodSignature  = composeMethodLikeSignature(TypeConstants.Iterator, parameterTypes = Nil)
+    val iteratorMethodFullName   = composeMethodFullName(iterableType, iteratorMethodName, iteratorMethodSignature)
     // TODO: This is the only section that needs to be updated for unified native/collection foreach representations.
     val iteratorCallNode =
       NewCall()
@@ -1582,18 +1693,19 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .order(2)
         .argumentIndex(2)
         .lineNumber(lineNo)
-    val actualIteratorAst = astsForExpression(stmt.getIterable, 0, expectedType = None) // TODO: Expected type here?
+    val actualIteratorAst = astsForExpression(iterExpr, 0, expectedType = None) // TODO: Expected type here?
     val iteratorCallAst =
       callAst(iteratorCallNode, actualIteratorAst)
         .withReceiverEdges(iteratorCallNode, actualIteratorAst.headOption.flatMap(_.root).toList)
-    val iteratorAssignAst =
-      callAst(iteratorAssignNode, Seq(Ast(iteratorAssignIdentifier), iteratorCallAst))
-        .withRefEdge(iteratorAssignIdentifier, iteratorLocalNode)
 
-    // Add local HasNext call
-    val hasNextCallName = "hasNext"
+    callAst(iteratorAssignNode, Seq(Ast(iteratorAssignIdentifier), iteratorCallAst))
+      .withRefEdge(iteratorAssignIdentifier, iteratorLocalNode)
+  }
+
+  private def hasNextCallAstForForEach(iteratorLocalNode: NewLocal, lineNo: Option[Integer]): Ast = {
+    val hasNextCallName      = "hasNext"
     val hasNextCallSignature = composeMethodLikeSignature(TypeConstants.Boolean, parameterTypes = Nil)
-    val hasNextCallFullName = composeMethodFullName(TypeConstants.Iterator, hasNextCallName, hasNextCallSignature)
+    val hasNextCallFullName  = composeMethodFullName(TypeConstants.Iterator, hasNextCallName, hasNextCallSignature)
     val iteratorHasNextCallNode =
       NewCall()
         .name(hasNextCallName)
@@ -1606,24 +1718,21 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .argumentIndex(1)
         .lineNumber(lineNo)
     val iteratorHasNextCallReceiver = identifierFromNamedVarType(iteratorLocalNode, lineNo, 1).argumentIndex(0)
-    val iteratorHasNextCallAst =
-      callAst(iteratorHasNextCallNode, Seq(Ast(iteratorHasNextCallReceiver)))
-        .withRefEdge(iteratorHasNextCallReceiver, iteratorLocalNode)
-        .withReceiverEdge(iteratorHasNextCallNode, iteratorHasNextCallReceiver)
 
-    // Empty block update
-//    val emptyUpdateNode = NewBlock().order(4).argumentIndex(4).lineNumber(lineNo)
-//    val emptyUpdateAst  = Ast(emptyUpdateNode)
+    callAst(iteratorHasNextCallNode, Seq(Ast(iteratorHasNextCallReceiver)))
+      .withRefEdge(iteratorHasNextCallReceiver, iteratorLocalNode)
+      .withReceiverEdge(iteratorHasNextCallNode, iteratorHasNextCallReceiver)
+  }
 
-    // Body
+  private def localForIterableForEachVariable(stmt: ForEachStmt, lineNo: Option[Integer]): NewLocal = {
     // According to the Java language specification, there should be exactly one variable defined here.
     val (forVariableName, forVariableType) = stmt.getVariable.getVariables.asScala.headOption match {
       case Some(variable) =>
         val variableName = variable.getNameAsString
-        val variableType = typeInfoCalc.fullName(variable.getType).getOrElse(UnresolvedConstants.UnresolvedType)
+        val variableType = typeInfoCalc.fullName(variable.getType).getOrElse(TypeConstants.UnresolvedType)
         (variableName, variableType)
 
-      case None => (nextIterableName(), UnresolvedConstants.UnresolvedType)
+      case None => (nextIterableName(), TypeConstants.UnresolvedType)
     }
     val variableLocal =
       NewLocal()
@@ -1633,8 +1742,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .order(1)
         .lineNumber(lineNo)
     scopeStack.addToScope(forVariableName, variableLocal)
+    variableLocal
+  }
 
-    // -- assign from iterator.next
+  private def astForIterableForEachItemAssign(iteratorLocalNode: NewLocal, variableLocal: NewLocal): Ast = {
+    val lineNo          = variableLocal.lineNumber
+    val forVariableType = variableLocal.typeFullName
     val varLocalAssignNode =
       assignmentNode()
         .typeFullName(forVariableType)
@@ -1643,9 +1756,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .lineNumber(lineNo)
     val varLocalAssignIdentifier = identifierFromNamedVarType(variableLocal, lineNo, 1)
 
-    val iterNextCallName = "next"
+    val iterNextCallName      = "next"
     val iterNextCallSignature = composeMethodLikeSignature(TypeConstants.Object, parameterTypes = Nil)
-    val iterNextCallFullName = composeMethodFullName(TypeConstants.Iterator, iterNextCallName, iterNextCallSignature)
+    val iterNextCallFullName  = composeMethodFullName(TypeConstants.Iterator, iterNextCallName, iterNextCallSignature)
     val iterNextCallNode =
       NewCall()
         .name(iterNextCallName)
@@ -1663,22 +1776,32 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .withRefEdge(iterNextCallReceiver, iteratorLocalNode)
         .withReceiverEdge(iterNextCallNode, iterNextCallReceiver)
 
-    val varLocalAssignAst =
-      callAst(varLocalAssignNode, Seq(Ast(varLocalAssignIdentifier), iterNextCallAst))
-        .withRefEdge(varLocalAssignIdentifier, variableLocal)
+    callAst(varLocalAssignNode, Seq(Ast(varLocalAssignIdentifier), iterNextCallAst))
+      .withRefEdge(varLocalAssignIdentifier, variableLocal)
+  }
 
-    // -- rest of body
-    val bodyPrefixAsts = Seq(Ast(variableLocal), varLocalAssignAst)
+  private def astForIterableForEach(stmt: ForEachStmt, maybeTypeFullName: Option[String], order: Int): Seq[Ast] = {
+    val lineNo       = line(stmt)
+    val iterableType = maybeTypeFullName.getOrElse(TypeConstants.UnresolvedType)
+
+    val iteratorLocalNode = iteratorLocalForForEach(order, lineNo)
+    val iteratorAssignAst =
+      iteratorAssignAstForForEach(stmt.getIterable, iteratorLocalNode, iterableType, lineNo, order + 1)
+    val iteratorHasNextCallAst = hasNextCallAstForForEach(iteratorLocalNode, lineNo)
+    val variableLocal          = variableLocalForForEachBody(stmt)
+    val variableAssignAst      = astForIterableForEachItemAssign(iteratorLocalNode, variableLocal)
+
+    val bodyPrefixAsts = Seq(Ast(variableLocal), variableAssignAst)
     val bodyAst = stmt.getBody match {
       case block: BlockStmt =>
         astForBlockStatement(block, 2, prefixAsts = bodyPrefixAsts)
 
       case bodyStmt =>
         val bodyBlockNode = NewBlock().order(2).argumentIndex(2).lineNumber(lineNo)
-        val bodyStmtAsts = astsForStatement(bodyStmt, bodyPrefixAsts.size + 1)
+        val bodyStmtAsts  = astsForStatement(bodyStmt, bodyPrefixAsts.size + 1)
         Ast(bodyBlockNode)
-        .withChildren(bodyPrefixAsts)
-        .withChildren(bodyStmtAsts)
+          .withChildren(bodyPrefixAsts)
+          .withChildren(bodyStmtAsts)
     }
 
     val forNode =
@@ -1690,46 +1813,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .lineNumber(lineNo)
         .columnNumber(column(stmt))
 
-//    val forAst = Ast(forNode)
-//      .withChild(Ast(iteratorLocalNode))
-//      .withChild(iteratorAssignAst)
-//      .withChild(iteratorHasNextCallAst)
-//      .withChild(emptyUpdateAst)
-//      .withChild(bodyAst)
-
-    val forAst = Ast(forNode)
-      .withChild(iteratorHasNextCallAst)
-      .withChild(bodyAst)
-      .withConditionEdge(forNode, iteratorHasNextCallNode)
-
-//    val javaUtilIteratorTypeDecl = NewTypeDecl().name("Iterator").fullName(TypeConstants.Iterator)
-//    val constructedIteratorTypeDecl = NewTypeDecl().fullName(iteratorLocalNode.typeFullName).name(TypeNodePass.fullToShortName(iteratorLocalNode.typeFullName))
-//
-//    val javaUtilIteratorBindings = List(
-//      BindingTableEntry(
-//        hasNextCallName,
-//        hasNextCallSignature,
-//        hasNextCallFullName
-//      ),
-//      BindingTableEntry(
-//        iterNextCallName,
-//        iterNextCallSignature,
-//        iterNextCallFullName
-//      )
-//    )
-//
-//    val javaUtilIteratorBindingTable = getFlatBindingTable(javaUtilIteratorTypeDecl, javaUtilIteratorBindings)
-//    createBindingNodes(javaUtilIteratorTypeDecl, javaUtilIteratorBindingTable)
-//
-//    val constructedIteratorBindings = List(
-//      BindingTableEntry(
-//        iteratorMethodName,
-//        iteratorMethodSignature,
-//        iteratorMethodFullName
-//      )
-//    )
-//    val constructedIteratorBindingTable = getFlatBindingTable(constructedIteratorTypeDecl, constructedIteratorBindings)
-//    createBindingNodes(constructedIteratorTypeDecl, constructedIteratorBindingTable)
+    val forAst = controlStructureAst(forNode, Some(iteratorHasNextCallAst), List(bodyAst))
 
     Seq(Ast(iteratorLocalNode), iteratorAssignAst, forAst)
   }
@@ -1743,22 +1827,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
       case maybeType =>
         astForIterableForEach(stmt, maybeType, order)
-//        val forNode = NewControlStructure()
-//          .controlStructureType(ControlStructureTypes.FOR)
-//          .order(order)
-//
-//        val iterableAsts = astsForExpression(stmt.getIterable, 1, None)
-//        val variableAsts =
-//          astsForVariableDecl(stmt.getVariable, iterableAsts.size + 1)
-//
-//        val bodyOrder = iterableAsts.size + variableAsts.size + 1
-//        val bodyAsts  = astsForStatement(stmt.getBody, bodyOrder)
-//
-//        val ast = Ast(forNode)
-//          .withChildren(iterableAsts)
-//          .withChildren(variableAsts)
-//          .withChildren(bodyAsts)
-//        Seq(ast)
     }
 
     scopeStack.popScope()
@@ -1928,7 +1996,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       expressionReturnTypeFullName(expr)
         .orElse(argsAsts.headOption.flatMap(rootType))
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(operatorName)
@@ -1946,7 +2014,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
     val callNode = NewCall()
       .name(Operators.indexAccess)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1982,7 +2050,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .columnNumber(column(expr))
       .typeFullName(
         expressionReturnTypeFullName(expr)
-          .getOrElse(expectedType.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType))
+          .getOrElse(expectedType.map(_.fullName).getOrElse(TypeConstants.UnresolvedType))
       )
 
     val levelAsts = expr.getLevels.asScala.zipWithIndex.flatMap { case (lvl, idx) =>
@@ -2006,7 +2074,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
     val callNode = NewCall()
       .name(Operators.arrayInitializer)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -2084,7 +2152,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(args.headOption.flatMap(rootType))
         .orElse(args.lastOption.flatMap(rootType))
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(operatorName)
@@ -2105,7 +2173,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       typeInfoCalc
         .fullName(expr.getType)
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(Operators.cast)
@@ -2130,14 +2198,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val exprAst = astsForExpression(expr.getExpression, 2, None)
 
     callAst(callNode, Seq(typeAst) ++ exprAst)
-  }
-
-  private def rootType(ast: Ast): Option[String] = {
-    ast.root.flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
-  }
-
-  private def rootCode(ast: Seq[Ast]): String = {
-    ast.headOption.flatMap(_.root).flatMap(_.properties.get(PropertyNames.CODE).map(_.toString)).getOrElse("")
   }
 
   def astsForAssignExpr(expr: AssignExpr, order: Int, expectedExprType: Option[ExpectedType]): Seq[Ast] = {
@@ -2171,7 +2231,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .flatMap(rootType)
         .orElse(valueType)
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     val code = s"${rootCode(targetAst)} ${expr.getOperator.asString} ${rootCode(argsAsts)}"
 
@@ -2220,7 +2280,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       val typeFullName = typeInfoCalc
         .fullName(variable.getType)
         .orElse(scopeStack.lookupVariable(variable.getTypeAsString).map(_.node.typeFullName)) // TODO: TYPE_CLEANUP
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
       val code = s"${variable.getType} $name"
 
       val local = NewLocal().name(name).code(code).typeFullName(typeFullName).order(order + idx)
@@ -2250,7 +2310,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           .orElse(scopeStack.getWildcardType(javaParserVarType))
 
       val typeFullName =
-        variableTypeFullName.orElse(initializerTypeFullName).getOrElse(UnresolvedConstants.UnresolvedType)
+        variableTypeFullName.orElse(initializerTypeFullName).getOrElse(TypeConstants.UnresolvedType)
 
       // Need the actual resolvedType here for when the RHS is a lambda expression.
       val resolvedExpectedType = Try(symbolResolver.toResolvedType(variable.getType, classOf[ResolvedType])).toOption
@@ -2356,7 +2416,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .order(order)
 
     val identifier = NewIdentifier()
-      .typeFullName(typeInfoCalc.fullName(expr.getType).getOrElse(UnresolvedConstants.UnresolvedType))
+      .typeFullName(typeInfoCalc.fullName(expr.getType).getOrElse(TypeConstants.UnresolvedType))
       .code(expr.getTypeAsString)
       .lineNumber(line(expr))
       .columnNumber(column(expr))
@@ -2386,7 +2446,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(thenAst.headOption.flatMap(rootType))
         .orElse(elseAst.headOption.flatMap(rootType))
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(Operators.conditional)
@@ -2410,7 +2470,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     val callNode = NewCall()
       .name(Operators.fieldAccess)
@@ -2450,7 +2510,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .typeFullName(TypeConstants.Boolean)
 
     val exprAst      = astsForExpression(expr.getExpression, order = 1, None)
-    val typeFullName = typeInfoCalc.fullName(expr.getType).getOrElse(UnresolvedConstants.UnresolvedType)
+    val typeFullName = typeInfoCalc.fullName(expr.getType).getOrElse(TypeConstants.UnresolvedType)
     val typeNode =
       NewTypeRef()
         .code(expr.getType.toString)
@@ -2468,14 +2528,14 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val name = x.getName.toString
     val typeFullName = expressionReturnTypeFullName(x)
       .orElse(expectedType.map(_.fullName))
-      .getOrElse(UnresolvedConstants.UnresolvedType)
+      .getOrElse(TypeConstants.UnresolvedType)
 
     Try(x.resolve()) match {
       case Success(value) if value.isField =>
         val identifierName = if (value.asField.isStatic) {
           // A static field represented by a NameExpr must belong to the class in which it's used. Static fields
           // from other classes are represented by a FieldAccessExpr instead.
-          scopeStack.getEnclosingTypeDecl.map(_.name).getOrElse(UnresolvedConstants.UnresolvedType)
+          scopeStack.getEnclosingTypeDecl.map(_.name).getOrElse(TypeConstants.UnresolvedType)
         } else {
           "this"
         }
@@ -2576,7 +2636,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName = typeInfoCalc
       .fullName(expr.getType)
       .orElse(expectedType.map(_.fullName))
-      .getOrElse(UnresolvedConstants.UnresolvedType)
+      .getOrElse(TypeConstants.UnresolvedType)
 
     val signature =
       maybeResolvedExpr match {
@@ -2586,7 +2646,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           // Fallback. Method could not be resolved. So we fall back to using
           // expressionTypeFullName and the argument types to approximate the method
           // signature.
-          val argumentTypes = argumentAsts.map(arg => rootType(arg).getOrElse(UnresolvedConstants.UnresolvedType))
+          val argumentTypes = argumentAsts.map(arg => rootType(arg).getOrElse(TypeConstants.UnresolvedType))
           composeMethodLikeSignature(TypeConstants.Void, argumentTypes)
       }
 
@@ -2694,7 +2754,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     val identifier =
       NewIdentifier()
@@ -2716,7 +2776,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName = Try(stmt.resolve())
       .map(_.declaringType())
       .map(typeInfoCalc.fullName)
-      .getOrElse(UnresolvedConstants.UnresolvedType)
+      .getOrElse(TypeConstants.UnresolvedType)
     val argTypes = argumentTypesForCall(Try(stmt.resolve()), args)
 
     val signature = s"${TypeConstants.Void}(${argTypes.mkString(",")})"
@@ -2798,31 +2858,47 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     Ast(unknownNode)
   }
 
+  private def codeForScopeExpr(scopeExpr: Expression, isScopeForStaticCall: Boolean): Option[String] = {
+    scopeExpr match {
+      case scope: NameExpr => Some(s"${scope.getNameAsString}.")
+
+      case fieldAccess: FieldAccessExpr =>
+        val maybeScopeString = codeForScopeExpr(fieldAccess.getScope, isScopeForStaticCall = false)
+        val name             = fieldAccess.getNameAsString
+        maybeScopeString
+          .map { scopeString =>
+            s"$scopeString$name"
+          }
+          .orElse(Some(name))
+          .map(result => s"${result}.")
+
+      case _: SuperExpr => Some("super.")
+
+      case _: ThisExpr => Some("this.")
+
+      case scopeMethodCall: MethodCallExpr =>
+        codePrefixForMethodCall(scopeMethodCall) match {
+          case "" => Some("")
+          case prefix =>
+            val argumentsCode = getArgumentCodeString(scopeMethodCall.getArguments)
+            Some(s"$prefix${scopeMethodCall.getNameAsString}($argumentsCode).")
+        }
+
+      case objectCreationExpr: ObjectCreationExpr =>
+        val typeName        = objectCreationExpr.getTypeAsString
+        val argumentsString = getArgumentCodeString(objectCreationExpr.getArguments)
+        Some(s"new $typeName($argumentsString).")
+
+      case _ => None
+    }
+  }
+
   private def codePrefixForMethodCall(call: MethodCallExpr): String = {
     Try(call.resolve()) match {
       case Success(resolvedCall) =>
-        call.getScope.toScala match {
-          case Some(scope: NameExpr) => s"${scope.getNameAsString}."
-
-          case Some(_: SuperExpr) => "super."
-
-          case Some(_: ThisExpr) => "this."
-
-          case Some(scopeMethodCall: MethodCallExpr) =>
-            codePrefixForMethodCall(scopeMethodCall) match {
-              case "" => ""
-              case prefix =>
-                val argumentsCode = getArgumentCodeString(scopeMethodCall.getArguments)
-                s"$prefix${scopeMethodCall.getNameAsString}($argumentsCode)."
-            }
-
-          case Some(objectCreationExpr: ObjectCreationExpr) =>
-            val typeName        = objectCreationExpr.getTypeAsString
-            val argumentsString = getArgumentCodeString(objectCreationExpr.getArguments)
-            s"new $typeName($argumentsString)."
-
-          case _ => if (resolvedCall.isStatic) "" else "this."
-        }
+        call.getScope.toScala
+          .flatMap(codeForScopeExpr(_, resolvedCall.isStatic))
+          .getOrElse(if (resolvedCall.isStatic) "" else "this.")
 
       case _ =>
         // If the call is unresolvable, we cannot make a good guess about what the prefix should be
@@ -2904,7 +2980,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         lambdaParameters
           .map(_.getType)
           .map(typeInfoCalc.fullName)
-          .map(_.getOrElse(UnresolvedConstants.UnresolvedType))
+          .map(_.getOrElse(TypeConstants.UnresolvedType))
     }
 
     if (paramTypesList.size != lambdaParameters.size) {
@@ -2952,7 +3028,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .map {
         typeInfoCalc.fullName
       }
-      .getOrElse(UnresolvedConstants.UnresolvedType)
+      .getOrElse(TypeConstants.UnresolvedType)
   }
 
   def closureBinding(closureBindingId: String, originalName: String): NewClosureBinding = {
@@ -3021,9 +3097,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   private def createLambdaMethodNode(expr: LambdaExpr, parameters: Seq[Ast], returnType: String): NewMethod = {
     val lambdaName = nextLambdaName()
     val enclosingTypeName =
-      scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
+      scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(TypeConstants.UnresolvedType)
     val signature =
-      s"$returnType(${parameters.map(rootType).map(_.getOrElse(UnresolvedConstants.UnresolvedType)).mkString(",")})"
+      s"$returnType(${parameters.map(rootType).map(_.getOrElse(TypeConstants.UnresolvedType)).mkString(",")})"
     val lambdaFullName = composeMethodFullName(enclosingTypeName, lambdaName, signature)
 
     NewMethod()
@@ -3079,7 +3155,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .collect { case identifier: NewIdentifier => identifier }
       .find { identifier => identifier.name == "this" || identifier.name == "super" }
       .map { _ =>
-        val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
+        val typeFullName = scopeStack.getEnclosingTypeDecl.map(_.fullName).getOrElse(TypeConstants.UnresolvedType)
         thisAstForMethod(typeFullName, line(expr))
       }
       .toList
@@ -3089,7 +3165,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val lambdaMethodNode = createLambdaMethodNode(expr, parametersWithoutThis, returnType)
     addLambdaMethodBindingToDiffGraph(lambdaMethodNode)
 
-    val returnNode = methodReturnNode(returnType, None,  line(expr), column(expr))
+    val returnNode      = methodReturnNode(returnType, None, line(expr), column(expr))
     val virtualModifier = Some(NewModifier().modifierType(ModifierTypes.VIRTUAL))
     val staticModifier  = Option.when(thisParam.isEmpty)(NewModifier().modifierType(ModifierTypes.STATIC))
     val privateModifier = Some(NewModifier().modifierType(ModifierTypes.PRIVATE))
@@ -3205,7 +3281,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .order(order)
         .argumentIndex(order)
         .code(expr.toString)
-        .typeFullName(expressionReturnTypeFullName(expr).getOrElse(UnresolvedConstants.UnresolvedType))
+        .typeFullName(expressionReturnTypeFullName(expr).getOrElse(TypeConstants.UnresolvedType))
         .lineNumber(line(expr))
         .columnNumber(column(expr))
     )
@@ -3227,7 +3303,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       }
 
       val typeName = resolvedType.map(typeInfoCalc.fullName)
-      ExpectedType(typeName.getOrElse(UnresolvedConstants.UnresolvedType), resolvedType)
+      ExpectedType(typeName.getOrElse(TypeConstants.UnresolvedType), resolvedType)
     }
   }
 
@@ -3283,7 +3359,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case Failure(_) =>
         // Fall back to actual argument types if the called method couldn't be resolved.
         // This may result in missing dataflows.
-        argAsts.map(arg => rootType(arg).getOrElse(UnresolvedConstants.UnresolvedType)).toList
+        argAsts.map(arg => rootType(arg).getOrElse(TypeConstants.UnresolvedType)).toList
     }
   }
 
@@ -3307,7 +3383,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         val expectedVariadicTypeFullName =
           getExpectedParamType(tryResolvedDecl, paramCount - 1)
             .map(_.fullName)
-            .getOrElse(UnresolvedConstants.UnresolvedType)
+            .getOrElse(TypeConstants.UnresolvedType)
         val (regularArgs, varargs) = argsAsts.splitAt(paramCount - 1)
         val arrayInitializer =
           NewCall()
@@ -3340,15 +3416,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def astForMethodCall(call: MethodCallExpr, order: Int = 1, expectedReturnType: Option[ExpectedType]): Ast = {
     val maybeResolvedCall = Try(call.resolve())
-    val maybeResolvedType = Try(call.calculateResolvedType())
-    val callArgTypes = call.getArguments.asScala.map { arg =>
-      arg.toString -> Try(arg.calculateResolvedType())
-    }
-    val argumentAsts = argAstsForCall(call, maybeResolvedCall, call.getArguments)
+    val argumentAsts      = argAstsForCall(call, maybeResolvedCall, call.getArguments)
 
     val expressionTypeFullName = expressionReturnTypeFullName(call)
       .orElse(expectedReturnType.map(_.fullName))
-      .getOrElse(UnresolvedConstants.UnresolvedType)
+      .getOrElse(TypeConstants.UnresolvedType)
 
     val signature =
       maybeResolvedCall match {
@@ -3358,12 +3430,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
           // Fallback. Method could not be resolved. So we fall back to using
           // expressionTypeFullName and the argument types to approximate the method
           // signature.
-          val argumentTypes = argumentAsts.map(arg => rootType(arg).getOrElse(UnresolvedConstants.UnresolvedType))
+          val argumentTypes = argumentAsts.map(arg => rootType(arg).getOrElse(TypeConstants.UnresolvedType))
           composeMethodLikeSignature(expressionTypeFullName, argumentTypes)
       }
 
     val receiverTypeOption = targetTypeForCall(call)
-    val receiverType       = receiverTypeOption.getOrElse(UnresolvedConstants.UnresolvedReceiver)
+    val receiverType       = receiverTypeOption.getOrElse(TypeConstants.UnresolvedReceiver)
 
     val methodFullName = composeMethodFullName(receiverType, call.getNameAsString, signature)
 
@@ -3390,7 +3462,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
       case None =>
         val objectNode =
-          createObjectNode(receiverTypeOption.getOrElse(UnresolvedConstants.UnresolvedType), call, callNode)
+          createObjectNode(receiverTypeOption.getOrElse(TypeConstants.UnresolvedType), call, callNode)
         objectNode.map(Ast(_)).toList
     }
 
@@ -3408,7 +3480,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val typeFullName =
       expressionReturnTypeFullName(superExpr)
         .orElse(expectedType.map(_.fullName))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
 
     val thisIdentifier = NewIdentifier()
       .name("this")
@@ -3435,7 +3507,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .fullName(parameter.getType)
         .orElse(scopeStack.lookupVariableType(parameter.getTypeAsString))
         .orElse(scopeStack.getWildcardType(parameter.getTypeAsString))
-        .getOrElse(UnresolvedConstants.UnresolvedType)
+        .getOrElse(TypeConstants.UnresolvedType)
     }
     val parameterNode = NewMethodParameterIn()
       .name(parameter.getName.toString)
@@ -3453,7 +3525,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def constructorFullName(typeDecl: Option[NewTypeDecl], signature: String): String = {
-    val typeName = typeDecl.map(_.fullName).getOrElse(UnresolvedConstants.UnresolvedType)
+    val typeName = typeDecl.map(_.fullName).getOrElse(TypeConstants.UnresolvedType)
     s"$typeName.<init>:$signature"
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
@@ -33,16 +33,6 @@ trait BindingTableAdapter[T] {
   def directBindingTableEntries(typeDeclFullName: String, typeDecl: T): collection.Seq[BindingTableEntry]
 }
 
-class BindingTableAdapterForFlatEntries(
-                                        bindings: collection.Seq[BindingTableEntry]
-) extends BindingTableAdapter[NewTypeDecl] {
-  override def directParents(typeDecl: NewTypeDecl): collection.Seq[ResolvedReferenceTypeDeclaration] = Seq.empty
-
-  override def allParentsWithTypeMap(typeDecl: NewTypeDecl): collection.Seq[(ResolvedReferenceTypeDeclaration, ResolvedTypeParametersMap)] = Seq.empty
-
-  override def directBindingTableEntries(typeDeclFullName: String, typeDecl: NewTypeDecl): collection.Seq[BindingTableEntry] = bindings
-}
-
 class BindingTableAdapterForJavaparser(
   methodSignature: (ResolvedMethodDeclaration, ResolvedTypeParametersMap) => String
 ) extends BindingTableAdapter[ResolvedReferenceTypeDeclaration] {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
@@ -4,9 +4,11 @@ import com.github.javaparser.resolution.declarations.{ResolvedMethodDeclaration,
 import com.github.javaparser.resolution.types.ResolvedReferenceType
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
 import io.joern.javasrc2cpg.util.Util.{composeMethodFullName, getAllParents}
+import io.shiftleft.codepropertygraph.generated.nodes.{Binding, NewBinding, TypeDecl}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptional
 import scala.util.Try
 
 case class BindingTableEntry(name: String, signature: String, implementingMethodFullName: String)
@@ -64,6 +66,39 @@ class BindingTableAdapterForJavaparser(
         )
       }
       .toBuffer
+  }
+}
+
+case class LambdaBindingInfo(
+  fullName: String,
+  implementedType: Option[ResolvedReferenceType],
+  directBinding: Option[NewBinding]
+)
+
+class BindingTableAdapterForLambdas(
+) extends BindingTableAdapter[LambdaBindingInfo] {
+
+  override def directParents(lambdaBindingInfo: LambdaBindingInfo): collection.Seq[ResolvedReferenceTypeDeclaration] = {
+    lambdaBindingInfo.implementedType.flatMap(_.getTypeDeclaration.toScala).toList
+  }
+
+  override def allParentsWithTypeMap(
+    lambdaBindingInfo: LambdaBindingInfo
+  ): collection.Seq[(ResolvedReferenceTypeDeclaration, ResolvedTypeParametersMap)] = {
+    val nonDirectParents =
+      lambdaBindingInfo.implementedType.flatMap(_.getTypeDeclaration.toScala).toList.flatMap(getAllParents)
+    (lambdaBindingInfo.implementedType.toList ++ nonDirectParents).map { typ =>
+      (typ.getTypeDeclaration.get, typ.typeParametersMap())
+    }
+  }
+
+  override def directBindingTableEntries(
+    typeDeclFullName: String,
+    lambdaBindingInfo: LambdaBindingInfo
+  ): collection.Seq[BindingTableEntry] = {
+    lambdaBindingInfo.directBinding.map { binding =>
+      BindingTableEntry(binding.name, binding.signature, binding.methodFullName)
+    }.toList
   }
 }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
@@ -4,7 +4,7 @@ import com.github.javaparser.resolution.declarations.{ResolvedMethodDeclaration,
 import com.github.javaparser.resolution.types.ResolvedReferenceType
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
 import io.joern.javasrc2cpg.util.Util.{composeMethodFullName, getAllParents}
-import io.shiftleft.codepropertygraph.generated.nodes.{Binding, NewBinding, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{Binding, NewBinding, NewTypeDecl, TypeDecl}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -31,6 +31,16 @@ trait BindingTableAdapter[T] {
   def allParentsWithTypeMap(typeDecl: T): collection.Seq[(ResolvedReferenceTypeDeclaration, ResolvedTypeParametersMap)]
 
   def directBindingTableEntries(typeDeclFullName: String, typeDecl: T): collection.Seq[BindingTableEntry]
+}
+
+class BindingTableAdapterForFlatEntries(
+                                        bindings: collection.Seq[BindingTableEntry]
+) extends BindingTableAdapter[NewTypeDecl] {
+  override def directParents(typeDecl: NewTypeDecl): collection.Seq[ResolvedReferenceTypeDeclaration] = Seq.empty
+
+  override def allParentsWithTypeMap(typeDecl: NewTypeDecl): collection.Seq[(ResolvedReferenceTypeDeclaration, ResolvedTypeParametersMap)] = Seq.empty
+
+  override def directBindingTableEntries(typeDeclFullName: String, typeDecl: NewTypeDecl): collection.Seq[BindingTableEntry] = bindings
 }
 
 class BindingTableAdapterForJavaparser(

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/NodeBuilders.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/NodeBuilders.scala
@@ -1,0 +1,17 @@
+package io.joern.javasrc2cpg.util
+
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.NewCall
+
+// TODO: Decide which of these should be moved to x2cpg
+object NodeBuilders {
+  def assignmentNode(): NewCall = NewCall()
+    .name(Operators.assignment)
+    .methodFullName(Operators.assignment)
+    .dispatchType(DispatchTypes.STATIC_DISPATCH)
+
+  def indexAccessNode(): NewCall = NewCall()
+    .name(Operators.indexAccess)
+    .methodFullName(Operators.indexAccess)
+    .dispatchType(DispatchTypes.STATIC_DISPATCH)
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
@@ -1,44 +1,123 @@
 package io.joern.javasrc2cpg.util
 
-import io.joern.javasrc2cpg.util.Scope.WildcardImportName
-import io.joern.x2cpg.datastructures.Stack.Stack
-import io.joern.x2cpg.datastructures.{ScopeElement, Stack, Scope => X2CpgScope}
-import io.shiftleft.codepropertygraph.generated.nodes.{HasTypeFullName, NewNode, NewTypeDecl}
+import io.joern.javasrc2cpg.passes.ExpectedType
+import io.joern.javasrc2cpg.util.Scope.ScopeTypes.{MethodScope, NamespaceScope, ScopeType, TypeDeclScope}
+import io.joern.javasrc2cpg.util.Scope.{VariableNodeType, WildcardImportName}
+import io.joern.x2cpg.Ast
+import io.joern.x2cpg.datastructures.{ScopeElement, Scope => X2CpgScope}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  DeclarationNew,
+  HasName,
+  HasNameMutable,
+  HasTypeFullName,
+  NewLocal,
+  NewMember,
+  NewMethod,
+  NewMethodParameterIn,
+  NewNamespaceBlock,
+  NewNode,
+  NewTypeDecl
+}
+import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 
-case class NodeTypeInfo(node: NewNode with HasTypeFullName, isField: Boolean = false, isStatic: Boolean = false)
+case class NodeTypeInfo(node: VariableNodeType, isField: Boolean = false, isStatic: Boolean = false)
 
-class Scope extends X2CpgScope[String, NodeTypeInfo, NewNode] {
+class Scope extends X2CpgScope[String, NodeTypeInfo, ScopeType] {
 
-  private var typeDeclStack: List[NewTypeDecl] = Nil
+  private val logger                                        = LoggerFactory.getLogger(this.getClass)
+  private var typeDeclStack: List[NewTypeDecl]              = Nil
+  private var lambdaMethods: List[mutable.ArrayBuffer[Ast]] = Nil
+  private var lambdaDecls: List[mutable.ArrayBuffer[Ast]]   = Nil
 
-  override def pushNewScope(scopeNode: NewNode): Unit = {
-    scopeNode match {
-      case typeDecl: NewTypeDecl => typeDeclStack = typeDecl :: typeDeclStack
-      case _                     => // Nothing to do in this case
+  override def pushNewScope(scope: ScopeType): Unit = {
+    scope match {
+      case TypeDeclScope(declNode) =>
+        typeDeclStack = declNode :: typeDeclStack
+        lambdaMethods = mutable.ArrayBuffer[Ast]() :: lambdaMethods
+      case NamespaceScope =>
+        lambdaDecls = mutable.ArrayBuffer[Ast]() :: lambdaMethods
+      case _ => // Nothing to do in this case
     }
 
-    super.pushNewScope(scopeNode)
+    super.pushNewScope(scope)
   }
 
-  override def popScope(): Option[NewNode] = {
+  def getCapturedVariables: List[NewNode with HasTypeFullName with HasNameMutable] = {
+    stack
+      .foldLeft(List.empty[NewNode]) { (acc, stackEntry) =>
+        acc ++ stackEntry.variables.values.map(_.node)
+      }
+      .collect {
+        case param: NewMethodParameterIn => param
+        case local: NewLocal             => local
+      }
+      .groupBy(_.name)
+      .map { case (_, vars) => vars.head }
+      .toList
+  }
+
+  override def popScope(): Option[ScopeType] = {
     super.popScope() match {
 
-      case Some(typeDecl: NewTypeDecl) =>
+      case Some(TypeDeclScope(typeDecl)) =>
         typeDeclStack = typeDeclStack.tail
-        Some(typeDecl)
+        lambdaMethods = lambdaMethods.tail
+        Some(TypeDeclScope(typeDecl))
 
-      case ret => ret
+      case Some(NamespaceScope) =>
+        lambdaDecls = lambdaDecls.tail
+        None
+
+      case _ => None
     }
   }
 
-  def addToScope(identifier: String, node: NewNode with HasTypeFullName): Unit = {
+  def addToScope(identifier: String, node: VariableNodeType): Unit = {
     addToScope(identifier, NodeTypeInfo(node))
   }
 
   def getEnclosingTypeDecl: Option[NewTypeDecl] = {
     typeDeclStack.headOption
+  }
+
+  def getLambdaMethodsInScope: Iterable[Ast] = {
+    lambdaMethods match {
+      case methodsInScope :: _ => methodsInScope
+
+      case Nil =>
+        logger.warn(s"Attempting to get lambdas from non-existent scope. Defaulting to empty list.")
+        List()
+    }
+  }
+
+  def addLambdaMethod(method: Ast): Unit = {
+    lambdaMethods match {
+      case methodsInScope :: _ => methodsInScope.addOne(method)
+
+      case Nil =>
+        logger.warn(s"Attempting to add lambda method to non-existent scope. Dropping.")
+    }
+  }
+
+  def getLambdaDeclsInScope: Iterable[Ast] = {
+    lambdaDecls match {
+      case declsInScope :: _ => declsInScope
+
+      case Nil =>
+        logger.warn(s"Attempting to get decls from non-existent scope. Defaulting to empty list")
+        List()
+    }
+  }
+
+  def addLambdaDecl(ast: Ast): Unit = {
+    lambdaDecls match {
+      case declsInScope :: _ => declsInScope.addOne(ast)
+
+      case Nil =>
+        logger.warn(s"Attempting to add lambda type decl to non-existent scope. Dropping.")
+    }
   }
 
   def lookupVariableType(identifier: String): Option[String] = {
@@ -50,9 +129,26 @@ class Scope extends X2CpgScope[String, NodeTypeInfo, NewNode] {
       s"$importName.$identifier"
     }
   }
+
+  def getEnclosingMethodReturnType: Option[ExpectedType] = {
+    stack.collectFirst { case ScopeElement(MethodScope(expectedType), _) =>
+      expectedType
+    }
+  }
 }
 
 object Scope {
   val WildcardImportName: String = "*"
-  def apply(): Scope             = new Scope()
+  type VariableNodeType      = NewNode with HasTypeFullName
+  type NamedVariableNodeType = VariableNodeType with HasName
+
+  object ScopeTypes {
+    sealed trait ScopeType
+    final case class TypeDeclScope(declNode: NewTypeDecl)  extends ScopeType
+    final case class MethodScope(returnType: ExpectedType) extends ScopeType
+    final case object BlockScope                           extends ScopeType
+    final case object NamespaceScope                       extends ScopeType
+  }
+
+  def apply(): Scope = new Scope()
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -226,6 +226,15 @@ object TypeInfoCalculator {
     val Boolean: String = "boolean"
     val Object: String  = "java.lang.Object"
     val Class: String   = "java.lang.Class"
+    val Void: String    = "void"
+  }
+
+  object UnresolvedConstants {
+    val UnresolvedType: String      = "<unresolvedType>"
+    val UnresolvedSignature: String = "<unresolvedSignature>"
+    val UnresolvedReceiver: String  = "<unresolvedReceiverType>"
+
+    val all: Set[String] = Set(UnresolvedType, UnresolvedSignature, UnresolvedReceiver)
   }
 
   object TypeNameConstants {
@@ -251,5 +260,9 @@ object TypeInfoCalculator {
     "java.lang.Boolean"
   )
 
-  val UnresolvedTypeDefault = "ANY"
+  def apply(global: Global, symbolResolver: SymbolResolver): TypeInfoCalculator = {
+    val typeInfoCalculator = new TypeInfoCalculator(global, symbolResolver)
+    UnresolvedConstants.all.foreach(typeInfoCalculator.registerType)
+    typeInfoCalculator
+  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -216,27 +216,25 @@ object TypeInfoCalculator {
   }
 
   object TypeConstants {
-    val Byte: String     = "byte"
-    val Short: String    = "short"
-    val Int: String      = "int"
-    val Long: String     = "long"
-    val Float: String    = "float"
-    val Double: String   = "double"
-    val Char: String     = "char"
-    val Boolean: String  = "boolean"
-    val Object: String   = "java.lang.Object"
-    val Class: String    = "java.lang.Class"
-    val Iterator: String = "java.util.Iterator"
-    val Void: String     = "void"
-  }
-
-  object UnresolvedConstants {
+    val Byte: String                = "byte"
+    val Short: String               = "short"
+    val Int: String                 = "int"
+    val Long: String                = "long"
+    val Float: String               = "float"
+    val Double: String              = "double"
+    val Char: String                = "char"
+    val Boolean: String             = "boolean"
+    val Object: String              = "java.lang.Object"
+    val Class: String               = "java.lang.Class"
+    val Iterator: String            = "java.util.Iterator"
+    val Void: String                = "void"
     val UnresolvedType: String      = "<unresolvedType>"
     val UnresolvedSignature: String = "<unresolvedSignature>"
     val UnresolvedReceiver: String  = "<unresolvedReceiverType>"
-
-    val all: Set[String] = Set(UnresolvedType, UnresolvedSignature, UnresolvedReceiver)
   }
+
+  val unresolvedConstants =
+    List(TypeConstants.UnresolvedType, TypeConstants.UnresolvedSignature, TypeConstants.UnresolvedReceiver)
 
   object TypeNameConstants {
     val Object: String = "Object"
@@ -263,7 +261,7 @@ object TypeInfoCalculator {
 
   def apply(global: Global, symbolResolver: SymbolResolver): TypeInfoCalculator = {
     val typeInfoCalculator = new TypeInfoCalculator(global, symbolResolver)
-    UnresolvedConstants.all.foreach(typeInfoCalculator.registerType)
+    unresolvedConstants.foreach(typeInfoCalculator.registerType)
     typeInfoCalculator
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -216,17 +216,18 @@ object TypeInfoCalculator {
   }
 
   object TypeConstants {
-    val Byte: String    = "byte"
-    val Short: String   = "short"
-    val Int: String     = "int"
-    val Long: String    = "long"
-    val Float: String   = "float"
-    val Double: String  = "double"
-    val Char: String    = "char"
-    val Boolean: String = "boolean"
-    val Object: String  = "java.lang.Object"
-    val Class: String   = "java.lang.Class"
-    val Void: String    = "void"
+    val Byte: String     = "byte"
+    val Short: String    = "short"
+    val Int: String      = "int"
+    val Long: String     = "long"
+    val Float: String    = "float"
+    val Double: String   = "double"
+    val Char: String     = "char"
+    val Boolean: String  = "boolean"
+    val Object: String   = "java.lang.Object"
+    val Class: String    = "java.lang.Class"
+    val Iterator: String = "java.util.Iterator"
+    val Void: String     = "void"
   }
 
   object UnresolvedConstants {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
@@ -2,10 +2,11 @@ package io.joern.javasrc2cpg.util
 
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
 import com.github.javaparser.resolution.types.ResolvedReferenceType
+import io.joern.x2cpg.Ast
+import io.shiftleft.codepropertygraph.generated.PropertyNames
 
 import scala.collection.mutable
 import scala.util.Try
-
 import scala.jdk.CollectionConverters._
 
 object Util {
@@ -24,6 +25,18 @@ object Util {
     }
 
     result
+  }
+
+  def composeMethodLikeSignature(returnType: String, parameterTypes: collection.Seq[String]): String = {
+    s"$returnType(${parameterTypes.mkString(",")})"
+  }
+
+  def rootCode(ast: Seq[Ast]): String = {
+    ast.headOption.flatMap(_.root).flatMap(_.properties.get(PropertyNames.CODE).map(_.toString)).getOrElse("")
+  }
+
+  def rootType(ast: Ast): Option[String] = {
+    ast.root.flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
   }
 
   private def getAllParents(typ: ResolvedReferenceType, result: mutable.ArrayBuffer[ResolvedReferenceType]): Unit = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
@@ -2,8 +2,10 @@ package io.joern.javasrc2cpg.util
 
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
 import com.github.javaparser.resolution.types.ResolvedReferenceType
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
 import io.joern.x2cpg.Ast
-import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewFieldIdentifier}
 
 import scala.collection.mutable
 import scala.util.Try
@@ -48,5 +50,43 @@ object Util {
         getAllParents(ancestor, result)
       }
     }
+  }
+
+  // TODO: Move to x2cpg once order setting is no longer required
+  // TODO: Switch to this for all operators. Some were moved in https://github.com/joernio/joern/pull/1437,
+  // but that PR was long enough as is.
+  def operatorCallNode(
+    name: String,
+    code: String,
+    order: Int,
+    typeFullName: Option[String] = None,
+    line: Option[Integer] = None,
+    column: Option[Integer] = None
+  ): NewCall = {
+    NewCall()
+      .name(name)
+      .methodFullName(name)
+      .code(code)
+      .signature("")
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .typeFullName(typeFullName.getOrElse(TypeConstants.UnresolvedType))
+      .lineNumber(line)
+      .columnNumber(column)
+      .order(order)
+      .argumentIndex(order)
+  }
+
+  def fieldIdentifierNode(
+    name: String,
+    line: Option[Integer] = None,
+    column: Option[Integer] = None
+  ): NewFieldIdentifier = {
+    NewFieldIdentifier()
+      .canonicalName(name)
+      .code(name)
+      .lineNumber(line)
+      .columnNumber(column)
+      .order(2)
+      .argumentIndex(2)
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
@@ -1,9 +1,644 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, ControlStructure, Identifier, Local}
+import io.joern.javasrc2cpg.testfixtures.{JavaSrcCode2CpgFixture, JavaSrcCodeToCpgFixture}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Block, Call, ControlStructure, FieldIdentifier, Identifier, Literal, Local}
 import io.shiftleft.semanticcpg.language._
-import org.scalatest.Ignore
+
+import scala.jdk.CollectionConverters._
+
+class NewControlStructureTests extends JavaSrcCode2CpgFixture {
+  "foreach loops over native array initialization expressions" should {
+    val cpg = code("""
+                     |public class Foo {
+                     |  public static void sink(String s) {}
+                     |
+                     |  public static void foo() {
+                     |    for (String item : new String[] {"a", "b", "c"}) {
+                     |      sink(item);
+                     |    }
+                     |  }
+                     |}
+                     |""".stripMargin)
+
+    "create a local node for the array" in {
+      val local = cpg.method.name("foo").local.nameExact("$iterLocal0").l match {
+        case List(local) => local
+        case result => fail(s"Expected single iterator local but got $result")
+      }
+
+      local.typeFullName shouldBe "java.lang.String[]"
+      local.order shouldBe 1
+    }
+
+    "assign the array to the created local" in {
+      val assignment = cpg.method.name("foo").assignment
+        .find { assignment =>
+          assignment.argument.l match {
+            case List(identifier: Identifier, _: Call) if identifier.name == "$iterLocal0" => true
+            case _ => false
+          }
+        } match {
+        case Some(iterAssign) => iterAssign
+        case result => fail(s"Expected an assign to iterLocal in method but got $result")
+      }
+
+      assignment.name shouldBe Operators.assignment
+      assignment.methodFullName shouldBe Operators.assignment
+      assignment.order shouldBe 2
+      assignment.typeFullName shouldBe "java.lang.String[]"
+
+      val (iterIdentifier, arrayAlloc) = assignment.argument.l match {
+        case List(iterIdentifier: Identifier, arrayAlloc: Call) => (iterIdentifier, arrayAlloc)
+        case result => fail(s"Expected arrayInitializer assign to iterLocal but got $result")
+      }
+
+      iterIdentifier.name shouldBe "$iterLocal0"
+      iterIdentifier.typeFullName shouldBe "java.lang.String[]"
+      iterIdentifier.order shouldBe 1
+      iterIdentifier.argumentIndex shouldBe 1
+      iterIdentifier.refOut.toSet should contain(cpg.local.nameExact("$iterLocal0").head)
+
+      arrayAlloc.name shouldBe Operators.alloc
+      arrayAlloc.methodFullName shouldBe Operators.alloc
+      arrayAlloc.typeFullName shouldBe "java.lang.String[]"
+      arrayAlloc.order shouldBe 2
+      arrayAlloc.argumentIndex shouldBe 2
+
+      val arrayInitializer = arrayAlloc.argument.l match {
+        case List(arrayInitializer: Call) => arrayInitializer
+        case result => fail(s"Expected single argument ot arrayAlloc but got $result")
+      }
+
+      val allocChildren = arrayAlloc.astChildren.l
+      arrayInitializer.name shouldBe Operators.arrayInitializer
+      arrayInitializer.methodFullName shouldBe Operators.arrayInitializer
+      arrayInitializer.order shouldBe 1
+      arrayInitializer.argumentIndex shouldBe 1
+      arrayInitializer.astChildren.size shouldBe 3
+      val expectedLiterals = List("\"a\"", "\"b\"", "\"c\"")
+      arrayInitializer.astChildren.zip(expectedLiterals).foreach { case (initChild, expectedCode) =>
+        initChild shouldBe a[Literal]
+        initChild.asInstanceOf[Literal].code shouldBe expectedCode
+      }
+    }
+
+    "create a local node for idx" in {
+      val local = cpg.controlStructure.astChildren.l match {
+        case List(local: Local, _, _, _, _) => local
+        case result                         => fail(s"Expected local as first AST child but got $result")
+      }
+      local.name shouldBe "$idx0"
+      local.typeFullName shouldBe "int"
+      local.order shouldBe 1
+    }
+
+    "initialize idx to 0" in {
+      val (idxLocal, initializer) = cpg.controlStructure.astChildren.l match {
+        case List(itemLocal: Local, initializer: Call, _, _, _) => (itemLocal, initializer)
+        case result => fail(s"Expected initializer as second ast child but got $result")
+      }
+
+      initializer.name shouldBe Operators.assignment
+      initializer.methodFullName shouldBe Operators.assignment
+      initializer.typeFullName shouldBe "int"
+      initializer.order shouldBe 2
+
+      initializer.argument.l match {
+        case List(idx: Identifier, zeroLiteral: Literal) =>
+          idx.name shouldBe "$idx0"
+          idx.typeFullName shouldBe "int"
+          idx.order shouldBe 1
+          idx.argumentIndex shouldBe 1
+          idx.refOut.toSet should contain(idxLocal)
+
+          zeroLiteral.code shouldBe "0"
+          zeroLiteral.typeFullName shouldBe "int"
+          zeroLiteral.order shouldBe 2
+          zeroLiteral.argumentIndex shouldBe 2
+
+        case result => fail(s"Expected args for idx = 0 but got $result")
+      }
+    }
+
+    "compare idx to input array size" in {
+      val (idxLocal, condition) = cpg.controlStructure.astChildren.l match {
+        case List(idxLocal: Local, _, conditionCall: Call, _, _) => (idxLocal, conditionCall)
+        case result => fail(s"Expected condition call as third AST child but got $result")
+      }
+
+      condition.name shouldBe Operators.lessThan
+      condition.methodFullName shouldBe Operators.lessThan
+      condition.typeFullName shouldBe "boolean"
+      condition.order shouldBe 3
+
+      condition.argument.l match {
+        case List(idx: Identifier, arraySize: Call) =>
+          idx.name shouldBe "$idx0"
+          idx.typeFullName shouldBe "int"
+          idx.order shouldBe 1
+          idx.argumentIndex shouldBe 1
+          idx.refOut.toSet should contain(idxLocal)
+
+          arraySize.name shouldBe Operators.fieldAccess
+          arraySize.typeFullName shouldBe "int"
+          arraySize.order shouldBe 2
+          arraySize.argumentIndex shouldBe 2
+
+          arraySize.argument.l match {
+            case List(items: Identifier, length: FieldIdentifier) =>
+              items.name shouldBe "$iterLocal0"
+              items.typeFullName shouldBe "java.lang.String[]"
+              items.order shouldBe 1
+              items.argumentIndex shouldBe 1
+              items.refOut.toSet should contain(cpg.method.name("foo").local.nameExact("$iterLocal0").head)
+
+              length.code shouldBe "length"
+              length.order shouldBe 2
+              length.argumentIndex shouldBe 2
+
+            case result => fail(s"Expected array.length field access but got $result")
+          }
+
+        case result => fail(s"Expected idx < array.length args but got $result")
+      }
+    }
+
+    "update idx on each loop" in {
+      val (idxLocal, update) = cpg.controlStructure.astChildren.l match {
+        case List(idxLocal: Local, _, _, update: Call, _) => (idxLocal, update)
+        case result                                       => fail(s"Expected update as 4th AST child but got $result")
+      }
+
+      update.name shouldBe Operators.postIncrement
+      update.typeFullName shouldBe "int"
+      update.order shouldBe 4
+
+      update.argument.l match {
+        case List(idx: Identifier) =>
+          idx.name shouldBe "$idx0"
+          idx.typeFullName shouldBe "int"
+          idx.order shouldBe 1
+          idx.argumentIndex shouldBe 1
+          idx.refOut.toSet should contain(idxLocal)
+
+        case result => fail(s"Expected single argument to ++ call but got $result")
+      }
+    }
+
+    "create an assignment to the `item` local in the FOR body" in {
+      val (idxLocal, body) = cpg.controlStructure.astChildren.l match {
+        case List(idxLocal: Local, _, _, _, body: Block) => (idxLocal, body)
+        case result                                      => fail(s"Expected body as 5th AST child but got $result")
+      }
+
+      val (itemLocal: Local, itemAssign: Call, sink: Call) = body.astChildren.l match {
+        case List(itemLocal: Local, itemAssign: Call, sink: Call) => (itemLocal, itemAssign, sink)
+        case result => fail(s"Expected local, assign and sink, but got $result")
+      }
+
+      itemLocal.name shouldBe "item"
+      itemLocal.typeFullName shouldBe "java.lang.String"
+      itemLocal.order shouldBe 1
+
+      itemAssign.name shouldBe Operators.assignment
+      itemAssign.typeFullName shouldBe "java.lang.String"
+      itemAssign.order shouldBe 2
+      itemAssign.argument.l match {
+        case List(itemIdentifier: Identifier, indexAccess: Call) =>
+          itemIdentifier.name shouldBe "item"
+          itemIdentifier.typeFullName shouldBe "java.lang.String"
+          itemIdentifier.order shouldBe 1
+          itemIdentifier.argumentIndex shouldBe 1
+          itemIdentifier.refOut.toSet should contain(itemLocal)
+
+          indexAccess.name shouldBe Operators.indexAccess
+          indexAccess.typeFullName shouldBe "java.lang.String"
+          indexAccess.order shouldBe 2
+          indexAccess.argumentIndex shouldBe 2
+          val (iterLocal: Identifier, idx: Identifier) = indexAccess.argument.l match {
+            case List(items: Identifier, idx: Identifier) => (items, idx)
+            case result                                   => s"Expected iterLocal0[idx] args but got $result"
+          }
+          iterLocal.name shouldBe "$iterLocal0"
+          iterLocal.typeFullName shouldBe "java.lang.String[]"
+          iterLocal.order shouldBe 1
+          iterLocal.argumentIndex shouldBe 1
+          iterLocal.refOut.toSet should contain(cpg.local.nameExact("$iterLocal0").head)
+
+          idx.name shouldBe "$idx0"
+          idx.typeFullName shouldBe "int"
+          idx.order shouldBe 2
+          idx.argumentIndex shouldBe 2
+          idx.refOut.toSet should contain(idxLocal)
+        case result => fail(s"Expected item = iterLocal0[idx] args but got $result")
+      }
+
+      sink.name shouldBe "sink"
+      sink.methodFullName shouldBe "Foo.sink:void(java.lang.String)"
+      sink.order shouldBe 3
+      sink.argument.l match {
+        case List(item: Identifier) =>
+          item.name shouldBe "item"
+          item.typeFullName shouldBe "java.lang.String"
+          item.order shouldBe 1
+          item.argumentIndex shouldBe 1
+          item.refOut.toSet should contain(itemLocal)
+
+        case result => fail(s"Expected single identifier argument to sink but got $result")
+      }
+    }
+  }
+
+  "foreach loops over native arrays" should {
+    val cpg = code("""
+        |public class Foo {
+        |  public static void sink(String s) {}
+        |
+        |  public static void foo(String[] items) {
+        |    for (String item : items) {
+        |      sink(item);
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+
+    "create a local node for idx" in {
+      val local = cpg.controlStructure.astChildren.l match {
+        case List(local: Local, _, _, _, _) => local
+        case result                         => fail(s"Expected local as first AST child but got $result")
+      }
+      local.name shouldBe "$idx0"
+      local.typeFullName shouldBe "int"
+      local.order shouldBe 1
+    }
+
+    "initialize idx to 0" in {
+      val (idxLocal, initializer) = cpg.controlStructure.astChildren.l match {
+        case List(itemLocal: Local, initializer: Call, _, _, _) => (itemLocal, initializer)
+        case result => fail(s"Expected initializer as second ast child but got $result")
+      }
+
+      initializer.name shouldBe Operators.assignment
+      initializer.methodFullName shouldBe Operators.assignment
+      initializer.typeFullName shouldBe "int"
+      initializer.order shouldBe 2
+
+      initializer.argument.l match {
+        case List(idx: Identifier, zeroLiteral: Literal) =>
+          idx.name shouldBe "$idx0"
+          idx.typeFullName shouldBe "int"
+          idx.order shouldBe 1
+          idx.argumentIndex shouldBe 1
+          idx.refOut.toSet should contain(idxLocal)
+
+          zeroLiteral.code shouldBe "0"
+          zeroLiteral.typeFullName shouldBe "int"
+          zeroLiteral.order shouldBe 2
+          zeroLiteral.argumentIndex shouldBe 2
+
+        case result => fail(s"Expected args for idx = 0 but got $result")
+      }
+    }
+
+    "compare idx to input array size" in {
+      val (idxLocal, condition) = cpg.controlStructure.astChildren.l match {
+        case List(idxLocal: Local, _, conditionCall: Call, _, _) => (idxLocal, conditionCall)
+        case result => fail(s"Expected condition call as third AST child but got $result")
+      }
+
+      condition.name shouldBe Operators.lessThan
+      condition.methodFullName shouldBe Operators.lessThan
+      condition.typeFullName shouldBe "boolean"
+      condition.order shouldBe 3
+
+      condition.argument.l match {
+        case List(idx: Identifier, arraySize: Call) =>
+          idx.name shouldBe "$idx0"
+          idx.typeFullName shouldBe "int"
+          idx.order shouldBe 1
+          idx.argumentIndex shouldBe 1
+          idx.refOut.toSet should contain(idxLocal)
+
+          arraySize.name shouldBe Operators.fieldAccess
+          arraySize.typeFullName shouldBe "int"
+          arraySize.order shouldBe 2
+          arraySize.argumentIndex shouldBe 2
+
+          arraySize.argument.l match {
+            case List(items: Identifier, length: FieldIdentifier) =>
+              items.name shouldBe "items"
+              items.typeFullName shouldBe "java.lang.String[]"
+              items.order shouldBe 1
+              items.argumentIndex shouldBe 1
+              items.refOut.toSet should contain(cpg.parameter.name("items").head)
+
+              length.code shouldBe "length"
+              length.order shouldBe 2
+              length.argumentIndex shouldBe 2
+
+            case result => fail(s"Expected array.length field access but got $result")
+          }
+
+        case result => fail(s"Expected idx < array.length args but got $result")
+      }
+    }
+
+    "update idx on each loop" in {
+      val (idxLocal, update) = cpg.controlStructure.astChildren.l match {
+        case List(idxLocal: Local, _, _, update: Call, _) => (idxLocal, update)
+        case result                                       => fail(s"Expected update as 4th AST child but got $result")
+      }
+
+      update.name shouldBe Operators.postIncrement
+      update.typeFullName shouldBe "int"
+      update.order shouldBe 4
+
+      update.argument.l match {
+        case List(idx: Identifier) =>
+          idx.name shouldBe "$idx0"
+          idx.typeFullName shouldBe "int"
+          idx.order shouldBe 1
+          idx.argumentIndex shouldBe 1
+          idx.refOut.toSet should contain(idxLocal)
+
+        case result => fail(s"Expected single argument to ++ call but got $result")
+      }
+    }
+
+    "create an assignment to the `item` local in the FOR body" in {
+      val (idxLocal, body) = cpg.controlStructure.astChildren.l match {
+        case List(idxLocal: Local, _, _, _, body: Block) => (idxLocal, body)
+        case result                                      => fail(s"Expected body as 5th AST child but got $result")
+      }
+
+      val (itemLocal: Local, itemAssign: Call, sink: Call) = body.astChildren.l match {
+        case List(itemLocal: Local, itemAssign: Call, sink: Call) => (itemLocal, itemAssign, sink)
+        case result => fail(s"Expected local, assign and sink, but got $result")
+      }
+
+      itemLocal.name shouldBe "item"
+      itemLocal.typeFullName shouldBe "java.lang.String"
+      itemLocal.order shouldBe 1
+
+      itemAssign.name shouldBe Operators.assignment
+      itemAssign.typeFullName shouldBe "java.lang.String"
+      itemAssign.order shouldBe 2
+      itemAssign.argument.l match {
+        case List(itemIdentifier: Identifier, indexAccess: Call) =>
+          itemIdentifier.name shouldBe "item"
+          itemIdentifier.typeFullName shouldBe "java.lang.String"
+          itemIdentifier.order shouldBe 1
+          itemIdentifier.argumentIndex shouldBe 1
+          itemIdentifier.refOut.toSet should contain(itemLocal)
+
+          indexAccess.name shouldBe Operators.indexAccess
+          indexAccess.typeFullName shouldBe "java.lang.String"
+          indexAccess.order shouldBe 2
+          indexAccess.argumentIndex shouldBe 2
+          val (items: Identifier, idx: Identifier) = indexAccess.argument.l match {
+            case List(items: Identifier, idx: Identifier) => (items, idx)
+            case result                                   => s"Expected items[idx] args but got $result"
+          }
+          items.name shouldBe "items"
+          items.typeFullName shouldBe "java.lang.String[]"
+          items.order shouldBe 1
+          items.argumentIndex shouldBe 1
+          items.refOut.toSet should contain(cpg.parameter.name("items").head)
+
+          idx.name shouldBe "$idx0"
+          idx.typeFullName shouldBe "int"
+          idx.order shouldBe 2
+          idx.argumentIndex shouldBe 2
+          idx.refOut.toSet should contain(idxLocal)
+        case result => fail(s"Expected item = items[idx] args but got $result")
+      }
+
+      sink.name shouldBe "sink"
+      sink.methodFullName shouldBe "Foo.sink:void(java.lang.String)"
+      sink.order shouldBe 3
+      sink.argument.l match {
+        case List(item: Identifier) =>
+          item.name shouldBe "item"
+          item.typeFullName shouldBe "java.lang.String"
+          item.order shouldBe 1
+          item.argumentIndex shouldBe 1
+          item.refOut.toSet should contain(itemLocal)
+
+        case result => fail(s"Expected single identifier argument to sink but got $result")
+      }
+    }
+  }
+
+  "foreach loops over collections" should {
+    val cpg = code("""
+                     |import java.util.List;
+                     |
+                     |public class Foo {
+                     |  public static void sink(String s) {}
+                     |
+                     |  public static void foo(List<String> items) {
+                     |    for (String item : items) {
+                     |      sink(item);
+                     |    }
+                     |  }
+                     |}
+                     |""".stripMargin)
+
+    "create a local for the iterator as a child of the FOR block" in {
+      val iterLocal = cpg.controlStructure.astChildren.l match {
+        case List(iterLocal: Local, _, _, _, _) => iterLocal
+        case result => fail(s"Expected iterLocal as first of 4 FOR children but got $result")
+      }
+
+      iterLocal.name shouldBe "$iterLocal0"
+      iterLocal.typeFullName shouldBe "java.util.Iterator"
+      iterLocal.code shouldBe "$iterLocal0"
+      iterLocal.order shouldBe 1
+    }
+
+    "assign items.iterator() to iterLocal" in {
+      val (iterLocal, iterAssign) = cpg.controlStructure.astChildren.l match {
+        case List(iterLocal: Local, iterAssign: Call, _, _, _) => (iterLocal, iterAssign)
+        case result => fail(s"Expected local and assign as first 2 FOR children but got $result")
+      }
+
+      iterAssign.name shouldBe Operators.assignment
+      iterAssign.methodFullName shouldBe Operators.assignment
+      iterAssign.typeFullName shouldBe "java.util.Iterator"
+      iterAssign.order shouldBe 2
+      iterAssign.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+      val (target, iteratorCall) = iterAssign.argument.l match {
+        case List(target: Identifier, iteratorCall: Call) => (target, iteratorCall)
+        case result => fail(s"Expected iter = items.iterator() args but got $result")
+      }
+
+      target.name shouldBe "$iterLocal0"
+      target.typeFullName shouldBe "java.util.Iterator"
+      target.order shouldBe 1
+      target.argumentIndex shouldBe 1
+      target.refOut.toSet should contain(iterLocal)
+
+      iteratorCall.name shouldBe "iterator"
+      iteratorCall.methodFullName shouldBe "java.util.List.iterator:java.util.Iterator()"
+      iteratorCall.signature shouldBe "java.util.Iterator()"
+      iteratorCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      iteratorCall.typeFullName shouldBe "java.util.Iterator"
+      iteratorCall.order shouldBe 2
+      iteratorCall.argumentIndex shouldBe 2
+
+      iteratorCall.receiver.l match {
+        case List(items: Identifier) =>
+          items.name shouldBe "items"
+          items.typeFullName shouldBe "java.util.List"
+          items.order shouldBe 0
+          items.argumentIndex shouldBe 0
+
+        case result => fail(s"Expected single identifier receiver but got $result")
+      }
+    }
+
+    "create hasNext() condition call" in {
+      val (iterLocal, conditionCall) = cpg.controlStructure.astChildren.l match {
+        case List(iterLocal: Local, _, conditionCall: Call, _, _) => (iterLocal, conditionCall)
+        case result => fail(s"Expected condition call as 3rd for child but got $result")
+      }
+
+      conditionCall.name shouldBe "hasNext"
+      conditionCall.methodFullName shouldBe "java.util.Iterator.hasNext:boolean()"
+      conditionCall.signature shouldBe "boolean()"
+      conditionCall.typeFullName shouldBe "boolean"
+      conditionCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      conditionCall.order shouldBe 3
+      conditionCall.argumentIndex shouldBe 3
+
+      conditionCall.receiver.l match {
+        case List(receiver: Identifier) =>
+          receiver.name shouldBe "$iterLocal0"
+          receiver.typeFullName shouldBe "java.util.Iterator"
+          receiver.order shouldBe 0
+          receiver.argumentIndex shouldBe 0
+          receiver.refOut.toSet should contain(iterLocal)
+
+        case result => fail(s"Expected single identifier receiver but got $result")
+      }
+    }
+
+    "create an empty block for the update statement" in {
+      val updateBlock = cpg.controlStructure.astChildren.l match {
+        case List(_, _, _, updateBlock: Block, _) => updateBlock
+        case result => fail(s"Expected update block as 4th argument but got $result")
+      }
+
+      updateBlock.order shouldBe 4
+      updateBlock.argumentIndex shouldBe 4
+      updateBlock.astChildren.isEmpty shouldBe true
+    }
+
+    "create an item local and assignment in the body of the FOR loop" in {
+      val (iterLocal, body) = cpg.controlStructure.astChildren.l match {
+        case List(iterLocal: Local, _, _, _, body: Block) => (iterLocal, body)
+        case result => fail(s"Expected body as last child of FOR but got $result")
+      }
+
+      body.order shouldBe 5
+
+      val (itemLocal, itemAssign, sinkCall) = body.astChildren.l match {
+        case List(itemLocal: Local, itemAssign: Call, sinkCall: Call) => (itemLocal, itemAssign, sinkCall)
+        case result => fail(s"Expected 3 statements in for body but got $result")
+      }
+
+      itemLocal.name shouldBe "item"
+      itemLocal.code shouldBe "item"
+      itemLocal.typeFullName shouldBe "java.lang.String"
+      itemLocal.order shouldBe 1
+
+      itemAssign.name shouldBe Operators.assignment
+      itemAssign.methodFullName shouldBe Operators.assignment
+      itemAssign.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      itemAssign.typeFullName shouldBe "java.lang.String"
+      itemAssign.order shouldBe 2
+      val (assignTarget, assignSource) = itemAssign.argument.l match {
+        case List(assignTarget: Identifier, assignSource: Call) => (assignTarget, assignSource)
+        case result => fail(s"Expected item = iterLocal.next args but got $result")
+      }
+
+      assignTarget.name shouldBe "item"
+      assignTarget.typeFullName shouldBe "java.lang.String"
+      assignTarget.order shouldBe 1
+      assignTarget.argumentIndex shouldBe 1
+      assignTarget.refOut.toSet should contain(itemLocal)
+
+      assignSource.name shouldBe "next"
+      assignSource.methodFullName shouldBe "java.util.Iterator.next:java.lang.String()"
+      assignSource.signature shouldBe "java.lang.String()"
+      assignSource.typeFullName shouldBe "java.lang.String"
+      assignSource.order shouldBe 2
+      assignSource.argumentIndex shouldBe 2
+      assignSource.receiver.l match {
+        case List(iterIdent: Identifier) =>
+          iterIdent.name shouldBe "$iterLocal0"
+          iterIdent.typeFullName shouldBe "java.util.Iterator"
+          iterIdent.order shouldBe 0
+          iterIdent.argumentIndex shouldBe 0
+          iterIdent.refOut.toSet should contain(iterLocal)
+
+        case result => fail(s"Expected single identifier receiver but got $result")
+      }
+
+      sinkCall.name shouldBe "sink"
+      sinkCall.methodFullName shouldBe "Foo.sink:void(java.lang.String)"
+      sinkCall.signature shouldBe "void(java.lang.String)"
+      sinkCall.typeFullName shouldBe "void"
+      sinkCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      sinkCall.order shouldBe 3
+      sinkCall.argument.l match {
+        case List(itemIdent: Identifier) =>
+          itemIdent.name shouldBe "item"
+          itemIdent.typeFullName shouldBe "java.lang.String"
+          itemIdent.order shouldBe 1
+          itemIdent.argumentIndex shouldBe 1
+          itemIdent.refOut.toSet should contain(itemLocal)
+
+        case result => fail(s"Expected single identifier arg to sink but got $result")
+      }
+    }
+
+    "create a binding for the constructed iterator() call" in {
+      cpg.all.collectAll[Binding].name("iterator").l match {
+        case List(iteratorBinding) =>
+          iteratorBinding.methodFullName shouldBe "java.util.List.iterator:java.util.Iterator()"
+          iteratorBinding.signature shouldBe "java.util.Iterator()"
+
+        case result => fail(s"Expected iterator binding but found $result")
+      }
+    }
+
+    "create a binding for the constructed hasNext() call" in {
+      cpg.all.collectAll[Binding].name("hasNext").l match {
+        case List(binding) =>
+          binding.methodFullName shouldBe "java.util.Iterator.hasNext:boolean()"
+          binding.signature shouldBe "boolean()"
+
+        case result => fail(s"Expected hasNext binding but found $result")
+      }
+    }
+
+    "create bindings for the constructed next() call" in {
+      cpg.all.collectAll[Binding].name("next").sortBy(_.signature).toList match {
+        case List(erasedBinding, binding) =>
+          erasedBinding.methodFullName shouldBe "java.util.Iterator.next:java.lang.String()"
+          erasedBinding.signature shouldBe "java.lang.Object()"
+
+          binding.methodFullName shouldBe "java.util.Iterator.next:java.lang.String()"
+          binding.signature shouldBe "java.lang.String()"
+
+        case result => fail(s"Expected two next bindings but found $result")
+      }
+    }
+  }
+}
 
 class ControlStructureTests extends JavaSrcCodeToCpgFixture {
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.UnresolvedConstants
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.freespec.AnyFreeSpec
@@ -46,9 +47,9 @@ class InferenceJarTests extends AnyFreeSpec with Matchers {
 
     "it should fail to resolve the type for Deps" in {
       val call = cpg.method.name("test1").call.name("foo").head
-      call.methodFullName shouldBe "<unresolvedReceiverType>.foo:ANY()"
-      call.signature shouldBe "ANY()"
-      call.typeFullName shouldBe "ANY"
+      call.methodFullName shouldBe s"${UnresolvedConstants.UnresolvedReceiver}.foo:${UnresolvedConstants.UnresolvedType}()"
+      call.signature shouldBe s"${UnresolvedConstants.UnresolvedType}()"
+      call.typeFullName shouldBe s"${UnresolvedConstants.UnresolvedType}"
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
@@ -1,7 +1,7 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.UnresolvedConstants
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.freespec.AnyFreeSpec
@@ -47,9 +47,9 @@ class InferenceJarTests extends AnyFreeSpec with Matchers {
 
     "it should fail to resolve the type for Deps" in {
       val call = cpg.method.name("test1").call.name("foo").head
-      call.methodFullName shouldBe s"${UnresolvedConstants.UnresolvedReceiver}.foo:${UnresolvedConstants.UnresolvedType}()"
-      call.signature shouldBe s"${UnresolvedConstants.UnresolvedType}()"
-      call.typeFullName shouldBe s"${UnresolvedConstants.UnresolvedType}"
+      call.methodFullName shouldBe s"${TypeConstants.UnresolvedReceiver}.foo:${TypeConstants.UnresolvedType}()"
+      call.signature shouldBe s"${TypeConstants.UnresolvedType}()"
+      call.typeFullName shouldBe s"${TypeConstants.UnresolvedType}"
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -1,130 +1,747 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
-import io.shiftleft.codepropertygraph.generated.edges.Capture
-import io.shiftleft.codepropertygraph.generated.nodes.ClosureBinding
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.edges.{Binds, Capture, Ref}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Binding,
+  Block,
+  Call,
+  ClosureBinding,
+  Identifier,
+  Local,
+  MethodParameterIn,
+  MethodRef,
+  Return,
+  TypeDecl
+}
 import io.shiftleft.semanticcpg.language._
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-import overflowdb.traversal._
+import overflowdb.traversal.jIteratortoTraversal
 
-class LambdaTests extends AnyFreeSpec with Matchers {
-
-  "CPG for code with a simple lambda which captures a method parameter" - {
-    lazy val cpg = JavaSrc2CpgTestContext.buildCpg("""
-      |import java.util.Comparator;
-      |
-      |public class Foo {
-      |
-      |    int value;
-      |
-      |    public Foo(int value) {
-      |        this.value = value;
-      |    }
-      |
-      |    public static Comparator<Foo> getComparator(int offset) {
-      |        return (fst, snd) -> fst.value - snd.value + offset;
-      |    }
-      |
-      |    public static void main(String[] args) {
-      |        Comparator<Foo> valueComparator = getComparator(1);
-      |
-      |        Foo t1 = new Foo(5);
-      |        Foo t2 = new Foo(3);
-      |
-      |        if (valueComparator.compare(t1, t2) > 0) {
-      |            System.out.println("T1 is bigger");
-      |        }
-      |    }
-      |}
-      |""".stripMargin)
-
-    "it should contain a METHOD_REF node" in {
-      cpg.methodRef.size shouldBe 1
-    }
-
-    "it should contain a capture edge for the methodRef" in {
-      pendingUntilFixed(cpg.methodRef.outE.count(_.isInstanceOf[Capture]) shouldBe 1)
-    }
-
-    "it should contain a LOCAL node for the captured `offset`" in {
-      pendingUntilFixed(cpg.local.count(_.name == "offset") shouldBe 1)
-    }
-
-    "it should contain a CLOSURE_BINDING node for the captured `offset`" in {
-      pendingUntilFixed(cpg.all.count(_.isInstanceOf[ClosureBinding]) shouldBe 1)
-    }
-
-    "the CLOSURE_BINDING node should contain a REF edge to METHOD_PARAMETER_IN" in {
-      pendingUntilFixed(cpg.all.filter(_.isInstanceOf[ClosureBinding]).outE.size shouldBe 1)
-    }
-  }
-
-  "CPG for code with a simple lambda which captures a local" - {
-    lazy val cpg = JavaSrc2CpgTestContext.buildCpg("""
-        |import java.util.Comparator;
+class LambdaTests extends JavaSrcCode2CpgFixture {
+  "nested lambdas" should {
+    val cpg = code(
+      """
+        |import java.util.ArrayList;
+        |import java.util.List;
+        |import java.util.stream.Collectors;
         |
-        |public class Foo {
+        |public class TestClass {
+        |  public Integer method(Integer aaa) {
+        |    List<Integer> list = new ArrayList<>();
+        |    list.add(1);
         |
-        |    int value;
+        |    List<Integer> mappedList = list.stream().map(integer -> {
+        |      List<Integer> nestedList = new ArrayList<>();
+        |      nestedList.add(1);
         |
-        |    public Foo(int value) {
-        |        this.value = value;
-        |    }
-        |
-        |    public static Comparator<Foo> getComparator(int offset) {
-        |        int diff = offset + 12;
-        |        return (fst, snd) -> fst.value - snd.value + diff;
-        |    }
-        |
-        |    public static void main(String[] args) {
-        |        Comparator<Foo> valueComparator = getComparator(1);
-        |
-        |        Foo t1 = new Foo(5);
-        |        Foo t2 = new Foo(3);
-        |
-        |        if (valueComparator.compare(t1, t2) > 0) {
-        |            System.out.println("T1 is bigger");
-        |        }
-        |    }
-        |}
-        |""".stripMargin)
-
-    "should contain a METHOD_REF node" in {
-      cpg.methodRef.size shouldBe 1
-    }
-
-    "should contain a capture edge for the methodRef" in {
-      pendingUntilFixed(cpg.methodRef.outE.count(_.isInstanceOf[Capture]) shouldBe 1)
-    }
-
-    "should contain a LOCAL node for the captured `diff`" in {
-      // The code for the `getComparator` local is `int diff`, so
-      // this pattern matches only the local created for the lambda.
-      pendingUntilFixed(cpg.local.code("diff").size shouldBe 1)
-    }
-
-    "should contain a CLOSURE_BINDING node for the captured `diff`" in {
-      pendingUntilFixed(cpg.all.count(_.isInstanceOf[ClosureBinding]) shouldBe 1)
-    }
-  }
-
-  "CPG for `identity-like` supplier" - {
-    lazy val cpg = JavaSrc2CpgTestContext.buildCpg("""
-        |public class Foo {
-        |  public foo() {
-        |    String s = "Hello, world";
-        |    Supplier<String> sup = () -> s;
+        |      List<Integer> nestedMappedList =
+        |          nestedList.stream().map(nestedInteger -> nestedInteger + aaa).collect(Collectors.toList());
+        |      return nestedMappedList.get(0);
+        |    }).collect(Collectors.toList());
+        |    Integer ret = mappedList.get(0);
+        |    return ret;
         |  }
         |}
         |""".stripMargin)
 
-    "should parse a supplier with only a single identifier as the method body" in {
-      cpg.method.name("<lambda>").size shouldBe 1
-      val lambda = cpg.method.name("<lambda>").head
+    "create 2 method nodes for the respective lambdas" in {
+      cpg.method.name(".*lambda.*").l match {
+        case List(lambda0, lambda1) =>
+          lambda0.name shouldBe "lambda$0"
 
-      lambda.ast.isIdentifier.size shouldBe 1
-      lambda.ast.isIdentifier.head.code shouldBe "s"
+          lambda1.name shouldBe "lambda$1"
+
+        case result => fail(s"Expected 2 lambda methods but got $result")
+      }
+    }
+  }
+
+  "lambdas used as a function argument" should {
+    val cpg = code("""
+        |import java.util.function.Function;
+        |
+        |public class Foo {
+        |  public static String getFromSupplier(String input, Function<String, String> mapper) {
+        |    return mapper.apply(input);
+        |  }
+        |
+        |  public void test1(String input, String fallback) {
+        |    getFromSupplier(
+        |      input,
+        |      lambdaInput -> lambdaInput.length() > 5 ? "Long" : fallback
+        |    );
+        |  }
+        |}
+        |""".stripMargin)
+
+    "create a method node for the lambda" in {
+      cpg.typeDecl.name("Foo").method.name(".*lambda.*").l match {
+        case List(lambdaMethod) =>
+          // Lambda body creation tested separately
+          lambdaMethod.name shouldBe "lambda$0"
+          lambdaMethod.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+          lambdaMethod.parameter.l match {
+            case List(lambdaInput) =>
+              lambdaInput.name shouldBe "lambdaInput"
+              lambdaInput.typeFullName shouldBe "java.lang.String"
+
+            case result => fail(s"Expected single lambda parameter but got $result")
+          }
+          lambdaMethod.methodReturn.typeFullName shouldBe "java.lang.String"
+
+        case result => fail(s"Expected single lambda method but got $result")
+      }
+    }
+
+    "create the correct binding for the lambda method" in {
+      cpg.all.collectAll[Binding].filter(_.name == "lambda$0").l match {
+        case List(lambdaBinding) =>
+          lambdaBinding.methodFullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+          lambdaBinding.signature shouldBe "java.lang.String(java.lang.String)"
+
+          lambdaBinding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) =>
+              typeDecl.fullName shouldBe "Foo"
+
+            case result => fail(s"Expected single typeDecl but got $result")
+          }
+
+        case result => fail(s"Expected single binding for lambda method but got $result")
+      }
+    }
+
+    "create a method body for the lambda method" in {
+      cpg.typeDecl.name("Foo").method.name(".*lambda.*").block.astChildren.l match {
+        case List(_: Local, _: Local, returnNode: Return) =>
+          returnNode.code shouldBe "return lambdaInput.length() > 5 ? \"Long\" : fallback;"
+          returnNode.astChildren.l match {
+            case List(expr: Call) =>
+              expr.methodFullName shouldBe Operators.conditional
+
+            case result => fail(s"Expected return conditional, but got $result")
+          }
+
+        case result => fail(s"Expected lambda body with single return but got $result")
+      }
+    }
+
+    "create locals for captured identifiers in the lambda method" in {
+      cpg.typeDecl.name("Foo").method.name(".*lambda.*").local.l match {
+        case List(fallbackLocal: Local, inputLocal: Local) =>
+          inputLocal.name shouldBe "input"
+          inputLocal.code shouldBe "input"
+          inputLocal.typeFullName shouldBe "java.lang.String"
+
+          fallbackLocal.name shouldBe "fallback"
+          fallbackLocal.code shouldBe "fallback"
+          fallbackLocal.typeFullName shouldBe "java.lang.String"
+
+        case result => fail(s"Expected single local for fallback but got $result")
+      }
+    }
+
+    "create closure bindings for captured identifiers" in {
+      cpg.all.collectAll[ClosureBinding].l match {
+        case List(fallbackClosureBinding, _) =>
+          fallbackClosureBinding.label shouldBe "CLOSURE_BINDING"
+
+          val fallbackLocal = cpg.method.name(".*lambda.*").local.name("fallback").head
+          fallbackClosureBinding.closureBindingId shouldBe fallbackLocal.closureBindingId
+
+          fallbackClosureBinding.outE.collectAll[Ref].map(_.inNode()).l match {
+            case List(capturedParam: MethodParameterIn) =>
+              capturedParam.name shouldBe "fallback"
+              capturedParam.method.head.fullName shouldBe "Foo.test1:void(java.lang.String,java.lang.String)"
+            case result => fail(s"Expected single capturedParam but got $result")
+          }
+
+          fallbackClosureBinding.inE.collectAll[Capture].map(_.outNode()).l match {
+            case List(outMethod: MethodRef) =>
+              outMethod.methodFullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+            case result => fail(s"Expected single METHOD_REF but got $result")
+          }
+
+        case result => fail(s"Expected 2 closure bindings for captured variables but got $result")
+      }
+    }
+
+    "create a typeDecl node inheriting from correct interface" in {
+      cpg.typeDecl.name(".*lambda.*").l match {
+        case List(lambdaDecl) =>
+          lambdaDecl.name shouldBe "lambda$0"
+          lambdaDecl.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+          lambdaDecl.inheritsFromTypeFullName should contain theSameElementsAs List("java.util.function.Function")
+
+        case result => fail(s"Expected a single typeDecl for the lambda but got $result")
+      }
+    }
+
+    "create bindings to implemented method" in {
+      cpg.all.collectAll[Binding].nameExact("apply").sortBy(_.signature).toList match {
+        case List(erasedBinding, binding) =>
+          binding.methodFullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+          binding.signature shouldBe "java.lang.String(java.lang.String)"
+          binding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) =>
+              typeDecl.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+            case result => fail(s"Expected typeDecl but got $result")
+          }
+
+          erasedBinding.methodFullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+          erasedBinding.signature shouldBe "java.lang.Object(java.lang.Object)"
+          erasedBinding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) =>
+              typeDecl.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+            case result => fail(s"Expected typeDecl but got $result")
+          }
+
+        case result => fail(s"Expected two bindings to apply method but got $result")
+      }
+    }
+  }
+
+  "lambdas assigned to a variable an a vardecl" should {
+    val cpg = code("""
+        |import java.util.function.Function;
+        |
+        |public class Foo {
+        |  public void test(String input, String fallback) {
+        |    Function<String, String> mapper = lambdaInput -> lambdaInput.length() > 5 ? "Long" : fallback;
+        |  }
+        |}
+        |""".stripMargin)
+
+    // Only test the method node for type info, since this is effectively the same test as above
+    // with a different source for the expected type.
+    "create a method node for the lambda" in {
+      cpg.typeDecl.name("Foo").method.name(".*lambda.*").l match {
+        case List(lambdaMethod) =>
+          // Lambda body creation tested separately
+          lambdaMethod.name shouldBe "lambda$0"
+          lambdaMethod.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+          lambdaMethod.parameter.l match {
+            case List(lambdaInput) =>
+              lambdaInput.name shouldBe "lambdaInput"
+              lambdaInput.typeFullName shouldBe "java.lang.String"
+
+            case result => fail(s"Expected single lambda parameter but got $result")
+          }
+          lambdaMethod.methodReturn.typeFullName shouldBe "java.lang.String"
+
+        case result => fail(s"Expected single lambda method but got $result")
+      }
+    }
+  }
+
+  "lambdas reassigned to a variable" should {
+    val cpg = code("""
+                     |import java.util.function.Function;
+                     |
+                     |public class Foo {
+                     |  public void test(String input, String fallback, Function<String, String> mapper) {
+                     |    mapper = lambdaInput -> lambdaInput.length() > 5 ? "Long" : fallback;
+                     |  }
+                     |}
+                     |""".stripMargin)
+
+    // Only test the method node for type info, since this is effectively the same test as above
+    // with a different source for the expected type.
+    "create a method node for the lambda" in {
+      cpg.typeDecl.name("Foo").method.name(".*lambda.*").l match {
+        case List(lambdaMethod) =>
+          // Lambda body creation tested separately
+          lambdaMethod.name shouldBe "lambda$0"
+          lambdaMethod.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+          lambdaMethod.parameter.l match {
+            case List(lambdaInput) =>
+              lambdaInput.name shouldBe "lambdaInput"
+              lambdaInput.typeFullName shouldBe "java.lang.String"
+
+            case result => fail(s"Expected single lambda parameter but got $result")
+          }
+          lambdaMethod.methodReturn.typeFullName shouldBe "java.lang.String"
+
+        case result => fail(s"Expected single lambda method but got $result")
+      }
+    }
+  }
+
+  "lambdas returned from a function" should {
+    val cpg = code("""
+        |import java.util.function.Function;
+        |
+        |public class Foo {
+        |  public Function<String, String> test(String input, String fallback) {
+        |    return lambdaInput -> lambdaInput.length() > 5 ? "Long" : fallback;
+        |  }
+        |}
+        |""".stripMargin)
+
+    // Only test the method node for type info, since this is effectively the same test as above
+    // with a different source for the expected type.
+    "create a method node for the lambda" in {
+      cpg.typeDecl.name("Foo").method.name(".*lambda.*").l match {
+        case List(lambdaMethod) =>
+          // Lambda body creation tested separately
+          lambdaMethod.name shouldBe "lambda$0"
+          lambdaMethod.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
+          lambdaMethod.parameter.l match {
+            case List(lambdaInput) =>
+              lambdaInput.name shouldBe "lambdaInput"
+              lambdaInput.typeFullName shouldBe "java.lang.String"
+
+            case result => fail(s"Expected single lambda parameter but got $result")
+          }
+          lambdaMethod.methodReturn.typeFullName shouldBe "java.lang.String"
+
+        case result => fail(s"Expected single lambda method but got $result")
+      }
+    }
+  }
+
+  "lambdas capturing instance vars" should {
+    val cpg = code("""
+        |import java.util.function.Consumer;
+        |
+        |public class Foo {
+        |    public String s;
+        |
+        |    public static void sink(String s) {}
+        |
+        |    public Consumer<String> test() {
+        |        return input -> sink(input + s);
+        |    }
+        |}
+        |""".stripMargin)
+
+    // TODO: Add 0th parameter logic
+    "create a 0th `this` parameter" in {
+      cpg.method.name(".*lambda.*").parameter.l match {
+        case List(thisParam, inputParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.code shouldBe "this"
+          thisParam.typeFullName shouldBe "Foo"
+          thisParam.order shouldBe 0
+          thisParam.index shouldBe 0
+
+          inputParam.name shouldBe "input"
+          inputParam.typeFullName shouldBe "java.lang.String"
+          inputParam.order shouldBe 1
+          inputParam.index shouldBe 1
+
+        case result => fail(s"Expected two params for lambda method but got $result")
+      }
+    }
+  }
+
+  "lambdas calling instance methods" should {
+    val cpg = code("""
+        |import java.util.function.Consumer;
+        |
+        |public class Foo {
+        |    public static String s;
+        |
+        |    public void sink(String s) {}
+        |
+        |    public Consumer<String> test() {
+        |        return input -> sink(input + s);
+        |    }
+        |}
+        |""".stripMargin)
+
+    // TODO: Add 0th parameter logic
+    "create a 0th `this` parameter" in {
+      cpg.method.name(".*lambda.*").parameter.l match {
+        case List(thisParam, inputParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.code shouldBe "this"
+          thisParam.typeFullName shouldBe "Foo"
+          thisParam.order shouldBe 0
+          thisParam.index shouldBe 0
+
+          inputParam.name shouldBe "input"
+          inputParam.typeFullName shouldBe "java.lang.String"
+          inputParam.order shouldBe 1
+          inputParam.index shouldBe 1
+
+        case result => fail(s"Expected two params for lambda method but got $result")
+      }
+    }
+  }
+
+  "lambdas using only static context" should {
+    val cpg = code("""
+        |import java.util.function.Consumer;
+        |
+        |public class Foo {
+        |    public static String s;
+        |
+        |    public static void sink(String s) {}
+        |
+        |    public Consumer<String> test() {
+        |        return input -> sink(input + s);
+        |    }
+        |}
+        |""".stripMargin)
+
+    "not create a 0th `this` parameter" in {
+      cpg.method.name(".*lambda.*").parameter.l match {
+        case List(inputParam) =>
+          inputParam.name shouldBe "input"
+          inputParam.typeFullName shouldBe "java.lang.String"
+          inputParam.order shouldBe 1
+          inputParam.index shouldBe 1
+
+        case result => fail(s"Expected a single param for lambda method but got $result")
+      }
+    }
+  }
+
+  "lambdas with multiple statements in the body" should {
+    val cpg = code("""
+                     |import java.util.function.Function;
+                     |
+                     |public class Foo {
+                     |    public static String s;
+                     |
+                     |    public static String f(String s) { return s;}
+                     |
+                     |    public Function<String, String> test() {
+                     |        return input -> {
+                     |          String concatenated = input + s;
+                     |          return f(concatenated);
+                     |        };
+                     |    }
+                     |}
+                     |""".stripMargin)
+
+    "have the correct method body with locals for captured variables" in {
+      cpg.method.name(".*lambda.*").body.astChildren.l match {
+        case List(concatenated: Local, assignment: Call, ret: Return) =>
+          concatenated.order shouldBe 1
+          concatenated.name shouldBe "concatenated"
+          concatenated.typeFullName shouldBe "java.lang.String"
+
+          assignment.order shouldBe 2
+          assignment.methodFullName shouldBe Operators.assignment
+
+          ret.order shouldBe 3
+          ret.astChildren.l match {
+            case List(call: Call) =>
+              call.name shouldBe "f"
+              call.methodFullName shouldBe "Foo.f:java.lang.String(java.lang.String)"
+
+            case result => fail(s"Expected single return argument but got $result")
+          }
+
+        case result => fail(s"Expected 4 children in block but got $result")
+      }
+    }
+  }
+
+  "single-statement lambdas with no return values" should {
+    val cpg = code("""
+        |import java.util.function.Consumer;
+        |
+        |public class Foo {
+        |    public static void sink(String s) {};
+        |
+        |    public static Consumer<String> test() {
+        |        return input -> sink(input);
+        |    }
+        |}
+        |""".stripMargin)
+
+    "have a method body block without a return statement" in {
+      cpg.method.name(".*lambda.*").body.astChildren.l match {
+        case List(call: Call) =>
+          call.methodFullName shouldBe "Foo.sink:void(java.lang.String)"
+          call.argument.l match {
+            case List(identifier: Identifier) =>
+              identifier.name shouldBe "input"
+              identifier.typeFullName shouldBe "java.lang.String"
+            case result => fail(s"Expected single String identifier a call arg but got $result")
+          }
+        case result => fail(s"Expected single call in body but got $result")
+      }
+    }
+  }
+
+  "lambdas with an Integer param type followed by a Float param type" should {
+    val cpg = code("""
+        |import java.util.function.BiConsumer;
+        |class Foo {
+        |  public static void sink(Float i, String f) {}
+        |
+        |  public static BiConsumer<Float, String> foo() {
+        |    return (input1, input2) -> sink(input1, input2);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "resolve calls in the body of the lambda" in {
+      cpg.method.name(".*lambda.*").call.name("sink").l match {
+        case sink :: Nil =>
+          sink.methodFullName shouldBe "Foo.sink:void(java.lang.Float,java.lang.String)"
+          sink.signature shouldBe "void(java.lang.Float,java.lang.String)"
+
+        case result => fail(s"Expected single call to sink but got $result")
+      }
+    }
+  }
+
+  "lambdas implementing a user-defined functional interface" should {
+    val cpg = code(
+      """
+        |public interface Foo<T, R> {
+        |
+        |    default String foo() {
+        |        return "FOO";
+        |    }
+        |
+        |    String baz(T input, R moreInput);
+        |
+        |    default T bar(T input) {
+        |        return input;
+        |    }
+        |}
+        |""".stripMargin,
+      fileName = "Foo.java"
+    ).moreCode("""
+        |public class TestClass {
+        |
+        |    public static String foo(Integer x, Integer y, String z) { return z; }
+        |
+        |    public static Foo<Integer, Integer> test(String captured) {
+        |        return (input, moreInput) -> foo(input, moreInput, captured);
+        |    }
+        |}
+        |""".stripMargin)
+
+    "create a method node for the lambda" in {
+      cpg.typeDecl.name("TestClass").method.name(".*lambda.*").l match {
+        case List(lambdaMethod) =>
+          lambdaMethod.name shouldBe "lambda$0"
+          lambdaMethod.fullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
+          lambdaMethod.signature shouldBe "java.lang.String(java.lang.Integer,java.lang.Integer)"
+          lambdaMethod.methodReturn.typeFullName shouldBe "java.lang.String"
+          lambdaMethod.parameter.l match {
+            case List(input, moreInput) =>
+              input.name shouldBe "input"
+              input.code shouldBe "java.lang.Integer input"
+              input.typeFullName shouldBe "java.lang.Integer"
+              input.order shouldBe 1
+              input.index shouldBe 1
+
+              moreInput.name shouldBe "moreInput"
+              moreInput.code shouldBe "java.lang.Integer moreInput"
+              moreInput.typeFullName shouldBe "java.lang.Integer"
+              moreInput.order shouldBe 2
+              moreInput.index shouldBe 2
+
+            case result => fail(s"Expected two lambda parameters but got $result")
+          }
+
+        case result => fail(s"Expected single lambda method but got $result")
+      }
+    }
+
+    "create the method body for the lambda" in {
+      cpg.typeDecl.name("TestClass").method.name(".*lambda.*").body.astChildren.l match {
+        case List(capturedLocal: Local, ret: Return) =>
+          capturedLocal.name shouldBe "captured"
+          capturedLocal.typeFullName shouldBe "java.lang.String"
+
+          ret.order shouldBe 2
+          ret.astChildren.size shouldBe 1
+          ret.astChildren.collectAll[Call].size shouldBe 1
+          val fooCall = ret.astChildren.collectAll[Call].head
+          fooCall.name shouldBe "foo"
+          fooCall.methodFullName shouldBe "TestClass.foo:java.lang.String(java.lang.Integer,java.lang.Integer,java.lang.String)"
+          fooCall.typeFullName shouldBe "java.lang.String"
+          fooCall.signature shouldBe "java.lang.String(java.lang.Integer,java.lang.Integer,java.lang.String)"
+          fooCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+          fooCall.argument.l match {
+            case List(input: Identifier, moreInput: Identifier, captured: Identifier) =>
+              input.name shouldBe "input"
+              input.typeFullName shouldBe "java.lang.Integer"
+
+              moreInput.name shouldBe "moreInput"
+              moreInput.typeFullName shouldBe "java.lang.Integer"
+
+              captured.name shouldBe "captured"
+              captured.typeFullName shouldBe "java.lang.String"
+
+            case result => fail(s"Expected three identifier arguments to foo but got $result")
+          }
+
+        case result => fail(s"Expected single captured local and return in method body but got $result")
+      }
+    }
+
+    "create the correct binding for the lambda method" in {
+      cpg.all.collectAll[Binding].filter(_.name == "lambda$0").l match {
+        case List(lambdaBinding) =>
+          lambdaBinding.methodFullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
+          lambdaBinding.signature shouldBe "java.lang.String(java.lang.Integer,java.lang.Integer)"
+
+          lambdaBinding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) =>
+              typeDecl.fullName shouldBe "TestClass"
+
+            case result => fail(s"Expected single typeDecl but got $result")
+          }
+
+        case result => fail(s"Expected single binding for lambda method but got $result")
+      }
+    }
+
+    "create closure bindings for captured identifiers" in {
+      cpg.all.collectAll[ClosureBinding].l match {
+        case List(capturedClosureBinding) =>
+          capturedClosureBinding.label shouldBe "CLOSURE_BINDING"
+
+          val capturedLocal = cpg.method.name(".*lambda.*").local.name("captured").head
+          capturedClosureBinding.closureBindingId shouldBe capturedLocal.closureBindingId
+
+          capturedClosureBinding.outE.collectAll[Ref].map(_.inNode()).l match {
+            case List(capturedParam: MethodParameterIn) =>
+              capturedParam.name shouldBe "captured"
+              capturedParam.method.head.fullName shouldBe "TestClass.test:Foo(java.lang.String)"
+            case result => fail(s"Expected single capturedParam but got $result")
+          }
+
+          capturedClosureBinding.inE.collectAll[Capture].map(_.outNode()).l match {
+            case List(outMethod: MethodRef) =>
+              outMethod.methodFullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
+            case result => fail(s"Expected single out METHOD_REF but got $result")
+          }
+
+        case result => fail(s"Expected 2 closure bindings for captured variables but got $result")
+      }
+    }
+
+    "create a typeDecl node inheriting from correct interface" in {
+      cpg.typeDecl.name(".*lambda.*").l match {
+        case List(lambdaDecl) =>
+          lambdaDecl.name shouldBe "lambda$0"
+          lambdaDecl.fullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
+          lambdaDecl.inheritsFromTypeFullName should contain theSameElementsAs List("Foo")
+
+        case result => fail(s"Expected a single typeDecl for the lambda but got $result")
+      }
+    }
+
+    // TODO: Fix typeDecl for interfaceBinding
+    "create bindings to implemented method" in {
+      cpg.all.collectAll[Binding].nameExact("baz").sortBy(_.methodFullName).toList match {
+        case List(interfaceBinding, binding, erasedBinding) =>
+          interfaceBinding.methodFullName shouldBe "Foo.baz:java.lang.String(java.lang.Object,java.lang.Object)"
+          interfaceBinding.signature shouldBe "java.lang.String(java.lang.Object,java.lang.Object)"
+          interfaceBinding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) => typeDecl.fullName shouldBe "Foo"
+            case result                   => fail(s"Expected typeDecl but got $result")
+          }
+
+          binding.methodFullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
+          binding.signature shouldBe "java.lang.String(java.lang.Integer,java.lang.Integer)"
+          binding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) =>
+              typeDecl.fullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
+            case result => fail(s"Expected typeDecl but got $result")
+          }
+
+          erasedBinding.methodFullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
+          erasedBinding.signature shouldBe "java.lang.String(java.lang.Object,java.lang.Object)"
+          erasedBinding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) =>
+              typeDecl.fullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
+            case result => fail(s"Expected typeDecl but got $result")
+          }
+
+        case result => fail(s"Expected three bindings to baz method but got $result")
+      }
+    }
+  }
+
+  // This is an example of a case where all the type info we need to figure out that the lambda implements
+  // `Function<String, String>`, but from JavaParser and the current expectedType propagation we only get
+  // `java.util.Function<Object, Object>`. Ideally we'd want all occurrences of `java.lang.Object` to be
+  // `java.lang.String` instead.
+  "a lambda implementing a mapper in stream" should {
+    val cpg = code("""
+        |import java.util.List;
+        |import java.util.stream.Collectors;
+        |
+        |public class Foo {
+        |  public List<String> method(List<String> list) {
+        |    return list.stream().map(string -> string).collect(Collectors.toList());
+        |  }
+        |}
+        |""".stripMargin)
+
+    "create a method node for the lambda" in {
+      cpg.typeDecl.name("Foo").method.name(".*lambda.*").l match {
+        case List(lambdaMethod) =>
+          // Lambda body creation tested separately
+          lambdaMethod.name shouldBe "lambda$0"
+          lambdaMethod.fullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
+          lambdaMethod.parameter.l match {
+            case List(lambdaInput) =>
+              lambdaInput.name shouldBe "string"
+              lambdaInput.typeFullName shouldBe "java.lang.Object"
+
+            case result => fail(s"Expected single lambda parameter but got $result")
+          }
+          lambdaMethod.methodReturn.typeFullName shouldBe "java.lang.Object"
+
+        case result => fail(s"Expected single lambda method but got $result")
+      }
+    }
+
+    "create the correct binding for the lambda method" in {
+      cpg.all.collectAll[Binding].filter(_.name == "lambda$0").l match {
+        case List(lambdaBinding) =>
+          lambdaBinding.methodFullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
+          lambdaBinding.signature shouldBe "java.lang.Object(java.lang.Object)"
+
+          lambdaBinding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) =>
+              typeDecl.fullName shouldBe "Foo"
+
+            case result => fail(s"Expected single typeDecl but got $result")
+          }
+
+        case result => fail(s"Expected single binding for lambda method but got $result")
+      }
+    }
+
+    "create a typeDecl node inheriting from correct interface" in {
+      cpg.typeDecl.name(".*lambda.*").l match {
+        case List(lambdaDecl) =>
+          lambdaDecl.name shouldBe "lambda$0"
+          lambdaDecl.fullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
+          lambdaDecl.inheritsFromTypeFullName should contain theSameElementsAs List("java.util.function.Function")
+
+        case result => fail(s"Expected a single typeDecl for the lambda but got $result")
+      }
+    }
+
+    "create bindings to implemented method" in {
+      cpg.all.collectAll[Binding].nameExact("apply").sortBy(_.signature).toList match {
+        case List(binding) =>
+          binding.methodFullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
+          binding.signature shouldBe "java.lang.Object(java.lang.Object)"
+          binding.inE.collectAll[Binds].map(_.outNode()).l match {
+            case List(typeDecl: TypeDecl) =>
+              typeDecl.fullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
+            case result => fail(s"Expected typeDecl but got $result")
+          }
+
+        case result => fail(s"Expected single binding to apply method but got $result")
+      }
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -20,8 +20,7 @@ import overflowdb.traversal.jIteratortoTraversal
 
 class LambdaTests extends JavaSrcCode2CpgFixture {
   "nested lambdas" should {
-    val cpg = code(
-      """
+    val cpg = code("""
         |import java.util.ArrayList;
         |import java.util.List;
         |import java.util.stream.Collectors;
@@ -681,6 +680,15 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         |  }
         |}
         |""".stripMargin)
+
+    "create the correct code string for call chains involving lambdas" in {
+      cpg.call.name("collect").l match {
+        case List(collectCall) =>
+          collectCall.code shouldBe "list.stream().map(<lambda>).collect(Collectors.toList())"
+
+        case result => fail(s"Expected single call to collect but got $result")
+      }
+    }
 
     "create a method node for the lambda" in {
       cpg.typeDecl.name("Foo").method.name(".*lambda.*").l match {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -45,14 +45,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         |""".stripMargin)
 
     "create 2 method nodes for the respective lambdas" in {
-      cpg.method.name(".*lambda.*").l match {
-        case List(lambda0, lambda1) =>
-          lambda0.name shouldBe "lambda$0"
-
-          lambda1.name shouldBe "lambda$1"
-
-        case result => fail(s"Expected 2 lambda methods but got $result")
-      }
+      cpg.method.name(".*lambda.*").name.l should contain theSameElementsAs List("lambda$0", "lambda$1")
     }
   }
 
@@ -93,21 +86,8 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
       }
     }
 
-    "create the correct binding for the lambda method" in {
-      cpg.all.collectAll[Binding].filter(_.name == "lambda$0").l match {
-        case List(lambdaBinding) =>
-          lambdaBinding.methodFullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
-          lambdaBinding.signature shouldBe "java.lang.String(java.lang.String)"
-
-          lambdaBinding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) =>
-              typeDecl.fullName shouldBe "Foo"
-
-            case result => fail(s"Expected single typeDecl but got $result")
-          }
-
-        case result => fail(s"Expected single binding for lambda method but got $result")
-      }
+    "not create a binding for the lambda method" in {
+      cpg.all.collectAll[Binding].exists(_.name == "lambda$0") shouldBe false
     }
 
     "create a method body for the lambda method" in {
@@ -181,19 +161,11 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         case List(erasedBinding, binding) =>
           binding.methodFullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
           binding.signature shouldBe "java.lang.String(java.lang.String)"
-          binding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) =>
-              typeDecl.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
-            case result => fail(s"Expected typeDecl but got $result")
-          }
+          binding.bindingTypeDecl.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
 
           erasedBinding.methodFullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
           erasedBinding.signature shouldBe "java.lang.Object(java.lang.Object)"
-          erasedBinding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) =>
-              typeDecl.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
-            case result => fail(s"Expected typeDecl but got $result")
-          }
+          erasedBinding.bindingTypeDecl.fullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
 
         case result => fail(s"Expected two bindings to apply method but got $result")
       }
@@ -580,21 +552,8 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
       }
     }
 
-    "create the correct binding for the lambda method" in {
-      cpg.all.collectAll[Binding].filter(_.name == "lambda$0").l match {
-        case List(lambdaBinding) =>
-          lambdaBinding.methodFullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
-          lambdaBinding.signature shouldBe "java.lang.String(java.lang.Integer,java.lang.Integer)"
-
-          lambdaBinding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) =>
-              typeDecl.fullName shouldBe "TestClass"
-
-            case result => fail(s"Expected single typeDecl but got $result")
-          }
-
-        case result => fail(s"Expected single binding for lambda method but got $result")
-      }
+    "not create a binding for the lambda method" in {
+      cpg.all.collectAll[Binding].exists(_.name == "lambda$0") shouldBe false
     }
 
     "create closure bindings for captured identifiers" in {
@@ -639,26 +598,15 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         case List(interfaceBinding, binding, erasedBinding) =>
           interfaceBinding.methodFullName shouldBe "Foo.baz:java.lang.String(java.lang.Object,java.lang.Object)"
           interfaceBinding.signature shouldBe "java.lang.String(java.lang.Object,java.lang.Object)"
-          interfaceBinding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) => typeDecl.fullName shouldBe "Foo"
-            case result                   => fail(s"Expected typeDecl but got $result")
-          }
+          interfaceBinding.bindingTypeDecl.fullName shouldBe "Foo"
 
           binding.methodFullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
           binding.signature shouldBe "java.lang.String(java.lang.Integer,java.lang.Integer)"
-          binding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) =>
-              typeDecl.fullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
-            case result => fail(s"Expected typeDecl but got $result")
-          }
+          binding.bindingTypeDecl.fullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
 
           erasedBinding.methodFullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
           erasedBinding.signature shouldBe "java.lang.String(java.lang.Object,java.lang.Object)"
-          erasedBinding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) =>
-              typeDecl.fullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
-            case result => fail(s"Expected typeDecl but got $result")
-          }
+          erasedBinding.bindingTypeDecl.fullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
 
         case result => fail(s"Expected three bindings to baz method but got $result")
       }
@@ -709,21 +657,8 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
       }
     }
 
-    "create the correct binding for the lambda method" in {
-      cpg.all.collectAll[Binding].filter(_.name == "lambda$0").l match {
-        case List(lambdaBinding) =>
-          lambdaBinding.methodFullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
-          lambdaBinding.signature shouldBe "java.lang.Object(java.lang.Object)"
-
-          lambdaBinding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) =>
-              typeDecl.fullName shouldBe "Foo"
-
-            case result => fail(s"Expected single typeDecl but got $result")
-          }
-
-        case result => fail(s"Expected single binding for lambda method but got $result")
-      }
+    "not create a binding for the lambda method" in {
+      cpg.all.collectAll[Binding].exists(_.name == "lambda$0") shouldBe false
     }
 
     "create a typeDecl node inheriting from correct interface" in {
@@ -742,11 +677,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         case List(binding) =>
           binding.methodFullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
           binding.signature shouldBe "java.lang.Object(java.lang.Object)"
-          binding.inE.collectAll[Binds].map(_.outNode()).l match {
-            case List(typeDecl: TypeDecl) =>
-              typeDecl.fullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
-            case result => fail(s"Expected typeDecl but got $result")
-          }
+          binding.bindingTypeDecl.fullName shouldBe "Foo.lambda$0:java.lang.Object(java.lang.Object)"
 
         case result => fail(s"Expected single binding to apply method but got $result")
       }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/SynchronizedTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/SynchronizedTests.scala
@@ -1,15 +1,8 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  Block,
-  Identifier,
-  Method,
-  MethodParameterIn,
-  MethodReturn,
-  Modifier,
-  Return
-}
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Identifier, Method, MethodParameterIn, MethodReturn, Modifier, Return}
 import io.shiftleft.semanticcpg.language._
 
 class SynchronizedTests extends JavaSrcCodeToCpgFixture {
@@ -34,10 +27,12 @@ class SynchronizedTests extends JavaSrcCodeToCpgFixture {
   "it should process a synchronized method the same as a non-synchronized method" in {
     val List(method: Method) = cpg.method.name("foo").l
 
-    method.astChildren.size shouldBe 4
-    val List(param: MethodParameterIn, _, body: Block, _: MethodReturn) = method.astChildren.l
+    method.astChildren.size shouldBe 6
+    val List(param: MethodParameterIn, _, body: Block, publicModifier: Modifier, staticModifier: Modifier, _: MethodReturn) = method.astChildren.l
     param.code shouldBe "String s"
     body.astChildren.head shouldBe a[Return]
+    publicModifier.modifierType shouldBe ModifierTypes.PUBLIC
+    staticModifier.modifierType shouldBe ModifierTypes.STATIC
   }
 
   "it should create a synchronized block" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/SynchronizedTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/SynchronizedTests.scala
@@ -2,7 +2,15 @@ package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Identifier, Method, MethodParameterIn, MethodReturn, Modifier, Return}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Block,
+  Identifier,
+  Method,
+  MethodParameterIn,
+  MethodReturn,
+  Modifier,
+  Return
+}
 import io.shiftleft.semanticcpg.language._
 
 class SynchronizedTests extends JavaSrcCodeToCpgFixture {
@@ -28,7 +36,14 @@ class SynchronizedTests extends JavaSrcCodeToCpgFixture {
     val List(method: Method) = cpg.method.name("foo").l
 
     method.astChildren.size shouldBe 6
-    val List(param: MethodParameterIn, _, body: Block, publicModifier: Modifier, staticModifier: Modifier, _: MethodReturn) = method.astChildren.l
+    val List(
+      param: MethodParameterIn,
+      _,
+      body: Block,
+      publicModifier: Modifier,
+      staticModifier: Modifier,
+      _: MethodReturn
+    ) = method.astChildren.l
     param.code shouldBe "String s"
     body.astChildren.head shouldBe a[Return]
     publicModifier.modifierType shouldBe ModifierTypes.PUBLIC

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
@@ -78,7 +78,7 @@ class TypeDeclTests extends JavaSrcCodeToCpgFixture {
   "should contain a type decl for `foo` with correct fields" in {
     val List(x) = cpg.typeDecl.name("Bar").l
     x.name shouldBe "Bar"
-    x.code shouldBe "Bar"
+    x.code shouldBe "class Bar"
     x.fullName shouldBe "a.b.c.d.Bar"
     x.isExternal shouldBe false
     x.inheritsFromTypeFullName should contain theSameElementsAs List("a.b.c.d.Woo")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
@@ -1,10 +1,11 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.{JavaSrcCode2CpgFixture, JavaSrcCodeToCpgFixture}
-import io.shiftleft.codepropertygraph.generated.nodes.Identifier
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.UnresolvedConstants
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import io.shiftleft.semanticcpg.language._
-import org.scalatest.Ignore
 
 class NewTypeTests extends JavaSrcCode2CpgFixture {
   "processing wildcard types should not crash (smoke test)" when {
@@ -56,6 +57,79 @@ class NewTypeTests extends JavaSrcCode2CpgFixture {
       cpg.call.name("newInstance").head.signature shouldBe "java.lang.Object()"
     }
   }
+
+  "methods with varargs" should {
+    val cpg = code("""
+        |class Foo {
+        |  public static String[] foo(boolean b, String... items) {
+        |    return b ? items : new String[1];
+        |  }
+        |
+        |  public void test(boolean b, String item1, String item2) {
+        |    String[] items = foo(b, item1, item2);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "use an array type to represent varargs in the method signature" in {
+      cpg.method.name("foo").l match {
+        case fooMethod :: Nil =>
+          fooMethod.fullName shouldBe "Foo.foo:java.lang.String[](boolean,java.lang.String[])"
+          fooMethod.signature shouldBe "java.lang.String[](boolean,java.lang.String[])"
+
+        case result => fail(s"Expected single foo method but got $result")
+      }
+    }
+
+    "create an array parameter node to represent varargs" in {
+      def fooMethods = cpg.method.name("foo").l
+      fooMethods.size shouldBe 1
+      fooMethods.parameter.l match {
+        case bParam :: itemsParam :: Nil =>
+          bParam.typeFullName shouldBe "boolean"
+          bParam.name shouldBe "b"
+          bParam.code shouldBe "boolean b"
+
+          itemsParam.typeFullName shouldBe "java.lang.String[]"
+          itemsParam.name shouldBe "items"
+          itemsParam.code shouldBe "String... items"
+
+        case result => fail(s"Expected 2 parameters for foo method but got $result")
+      }
+    }
+
+    "use an array type to represent varargs in the call signature" in {
+      cpg.call.name("foo").l match {
+        case fooCall :: Nil =>
+          fooCall.methodFullName shouldBe "Foo.foo:java.lang.String[](boolean,java.lang.String[])"
+          fooCall.signature shouldBe "java.lang.String[](boolean,java.lang.String[])"
+
+        case result => fail(s"Expected single foo call but got $result")
+      }
+    }
+
+    "use an arrayInitializer call node to represent varargs in the call AST" in {
+      def call = cpg.call.name("foo")
+      call.size shouldBe 1
+      call.argument.l match {
+        case List(_: Identifier, varargs: Call) =>
+          varargs.methodFullName shouldBe Operators.arrayInitializer
+          varargs.typeFullName shouldBe "java.lang.String[]"
+          varargs.argument.l match {
+            case List(item1: Identifier, item2: Identifier) =>
+              item1.name shouldBe "item1"
+              item1.typeFullName shouldBe "java.lang.String"
+
+              item2.name shouldBe "item2"
+              item2.typeFullName shouldBe "java.lang.String"
+
+            case result => fail(s"Expected array initializer args matching 2 items but got $result")
+          }
+
+        case result => fail(s"Expected identifier and arrayInitializer arguments but got $result")
+      }
+    }
+  }
 }
 
 class TypeTests extends JavaSrcCodeToCpgFixture {
@@ -83,8 +157,6 @@ class TypeTests extends JavaSrcCodeToCpgFixture {
       |   static void bar(int[] xs) {}
       |
       |   static void baz(Foo[] fs) {}
-      |
-      |   static void bak(Foo... fs) {}
       | }
       |
       | class Bar extends A<B<C>> {
@@ -154,10 +226,10 @@ class TypeTests extends JavaSrcCodeToCpgFixture {
     x.name shouldBe "y"
   }
 
-  "should default to ANY with a matching type node for unresolved types" in {
-    val List(x)    = cpg.typ("ANY").l
+  "should default to <unresolvedType> with a matching type node for unresolved types" in {
+    val List(x)    = cpg.typ(UnresolvedConstants.UnresolvedType).l
     val List(node) = cpg.identifier.name("UnknownType").l
-    node.typeFullName shouldBe "ANY"
+    node.typeFullName shouldBe UnresolvedConstants.UnresolvedType
     node.typ.headOption shouldBe Some(x)
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
@@ -1,7 +1,7 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.{JavaSrcCode2CpgFixture, JavaSrcCodeToCpgFixture}
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.UnresolvedConstants
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
@@ -227,9 +227,9 @@ class TypeTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should default to <unresolvedType> with a matching type node for unresolved types" in {
-    val List(x)    = cpg.typ(UnresolvedConstants.UnresolvedType).l
+    val List(x)    = cpg.typ(TypeConstants.UnresolvedType).l
     val List(node) = cpg.identifier.name("UnknownType").l
-    node.typeFullName shouldBe UnresolvedConstants.UnresolvedType
+    node.typeFullName shouldBe TypeConstants.UnresolvedType
     node.typ.headOption shouldBe Some(x)
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
@@ -26,7 +26,7 @@ class VarDeclTests extends JavaSrcCode2CpgFixture {
     local.name shouldBe "x"
     local.order shouldBe 1
 
-    assig.code shouldBe "x = 1"
+    assig.code shouldBe "int x = 1"
     assig.order shouldBe 2
   }
 
@@ -111,7 +111,7 @@ class VarDeclTests extends JavaSrcCode2CpgFixture {
     localZ.name shouldBe "z"
     localZ.order shouldBe 3
 
-    assigY.code shouldBe "y = 4"
+    assigY.code shouldBe "int y = 4"
     assigY.order shouldBe 4
     assigX.code shouldBe "x = 1"
     assigX.order shouldBe 5
@@ -143,16 +143,16 @@ class VarDeclTests extends JavaSrcCode2CpgFixture {
     localY.name shouldBe "y"
     localY.order shouldBe 2
 
-    assigY.code shouldBe "y = 2"
+    assigY.code shouldBe "int y = 2"
     assigY.order shouldBe 3
 
     localZ.name shouldBe "z"
     localZ.order shouldBe 4
 
-    assigZ.code shouldBe "z = 3"
+    assigZ.code shouldBe "int z = 3"
     assigZ.order shouldBe 5
 
-    assigX.code shouldBe "x = 1"
+    assigX.code shouldBe "w = 1"
     assigX.order shouldBe 6
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
@@ -152,7 +152,7 @@ class VarDeclTests extends JavaSrcCode2CpgFixture {
     assigZ.code shouldBe "int z = 3"
     assigZ.order shouldBe 5
 
-    assigX.code shouldBe "w = 1"
+    assigX.code shouldBe "x = 1"
     assigX.order shouldBe 6
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ArrayTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ArrayTests.scala
@@ -140,15 +140,12 @@ class ArrayTests extends JavaDataflowFixture {
 
   it should "find a path if sink is in a `FOREACH` loop over `MALICIOUS` array" in {
     val (source, sink) = getConstSourceSink("test9")
-    // The behaviour of javasrc2cpg currently matches c2cpg (neither of which find a path here.
-    // TODO: Fix dataflow through foreach constructs for both this and c2cpg
-    sink.reachableBy(source).size shouldBe 0
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "find a path if `MALICIOUS` is added to an accumulator in a loop" in {
     val (source, sink) = getConstSourceSink("test10")
-    // TODO: Fix dataflow through foreach constructs for both this and c2cpg
-    sink.reachableBy(source).size shouldBe 0
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "find a path if `MALICIOUS` is assigned to safe array and printed" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/LambdaTests.scala
@@ -1,0 +1,36 @@
+package io.joern.javasrc2cpg.querying.dataflow
+
+import io.joern.dataflowengineoss.language._
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+
+class LambdaTests extends JavaSrcCode2CpgFixture {
+
+  "dataflow through a simple lambda call should be found" in {
+    val cpg = code("""
+        |import java.util.function.Consumer;
+        |
+        |public class Foo {
+        |
+        |    public static void sink(String s) {}
+        |
+        |    public static Consumer<String> getConsumer() {
+        |        return input -> sink(input);
+        |    }
+        |
+        |    public static void test(String input) {
+        |        Consumer<String> consumer = getConsumer();
+        |        consumer.accept(input);
+        |    }
+        |}
+        |""".stripMargin)
+
+    def source = cpg.method.name("test").parameter.name("input")
+    def sink   = cpg.method.name("sink").parameter.name("s")
+
+    pendingUntilFixed {
+      sink.reachableBy(source).isEmpty shouldBe false
+    }
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -1,8 +1,16 @@
 package io.joern.javasrc2cpg.testfixtures
 
+import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
+import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, CodeToCpgFixture, LanguageFrontend}
+import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.utils.ProjectRoot
+import overflowdb.traversal.Traversal
 
 import java.io.File
 
@@ -18,4 +26,52 @@ class JavaSrcFrontend extends LanguageFrontend {
 
 class JavaSrcCodeToCpgFixture extends CodeToCpgFixture(new JavaSrcFrontend) {}
 
-class JavaSrcCode2CpgFixture extends Code2CpgFixture(new JavaSrcFrontend)
+class JavaSrcCode2CpgFixture(withOssDataflow: Boolean = false) extends Code2CpgFixture(new JavaSrcFrontend) {
+
+  val semanticsFile: String            = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
+  lazy val defaultSemantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFile))
+  implicit val resolver: ICallResolver = NoResolve
+  implicit lazy val engineContext: EngineContext = EngineContext(defaultSemantics, EngineConfig(maxCallDepth = 4))
+
+  override def applyPasses(cpg: Cpg): Unit = {
+    super.applyPasses(cpg)
+
+    if (withOssDataflow) {
+      val context = new LayerCreatorContext(cpg)
+      val options = new OssDataFlowOptions()
+      new OssDataFlow(options).run(context)
+    }
+  }
+
+  def getConstSourceSink(
+    cpg: Cpg,
+    methodName: String,
+    sourceCode: String = "\"MALICIOUS\"",
+    sinkPattern: String = ".*println.*"
+  ): (Traversal[Literal], Traversal[Expression]) = {
+    getMultiFnSourceSink(cpg, methodName, methodName, sourceCode, sinkPattern)
+  }
+
+  def getMultiFnSourceSink(
+    cpg: Cpg,
+    sourceMethodName: String,
+    sinkMethodName: String,
+    sourceCode: String = "\"MALICIOUS\"",
+    sinkPattern: String = ".*println.*"
+  ): (Traversal[Literal], Traversal[Expression]) = {
+    val sourceMethod = cpg.method(s".*$sourceMethodName.*").head
+    val sinkMethod   = cpg.method(s".*$sinkMethodName.*").head
+    def source       = sourceMethod.literal.code(sourceCode)
+    def sink         = sinkMethod.call.name(sinkPattern).argument(1).ast.collectAll[Expression]
+
+    // If either of these fail, then the testcase was written incorrectly or the AST was created incorrectly.
+    if (source.size <= 0) {
+      fail(s"Could not find source $sourceCode in method $sourceMethodName")
+    }
+    if (sink.size <= 0) {
+      fail(s"Could not find sink $sinkPattern for method $sinkMethodName")
+    }
+
+    (source, sink)
+  }
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/SourceFilesPickerTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/SourceFilesPickerTests.scala
@@ -8,7 +8,7 @@ import org.scalatest.BeforeAndAfterAll
 
 class SourceFilesPickerTests extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   "SourceFilesPicker" - {
-   "should not filter out fileNames ending in `build.gradle`" in {
+    "should not filter out fileNames ending in `build.gradle`" in {
       val inFileName = "/path/does/not/exist/build.gradle"
       SourceFilesPicker.shouldFilter(inFileName) shouldBe false
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/SourceFilesPickerTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/SourceFilesPickerTests.scala
@@ -8,7 +8,7 @@ import org.scalatest.BeforeAndAfterAll
 
 class SourceFilesPickerTests extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   "SourceFilesPicker" - {
-    "should not filter out fileNames ending in `build.gradle`" in {
+   "should not filter out fileNames ending in `build.gradle`" in {
       val inFileName = "/path/does/not/exist/build.gradle"
       SourceFilesPicker.shouldFilter(inFileName) shouldBe false
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
@@ -8,6 +8,13 @@ import io.shiftleft.passes.{KeyPool, SimpleCpgPass}
   */
 class TypeNodePass(usedTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] = None)
     extends SimpleCpgPass(cpg, "types", keyPool) {
+
+  // Lambda typeDecl type names fit the structure
+  // `a.b.c.d.ClassName.lambda$method$name:returnType(paramTypes)`
+  // so this regex works by greedily matching the package and class names
+  // at the start and cutting off the matched group before the signature.
+  private val lambdaTypeRegex = raw".*\.(.*):.*\(.*\)".r
+
   override def run(diffGraph: DiffGraphBuilder): Unit = {
 
     diffGraph.addNode(
@@ -18,7 +25,10 @@ class TypeNodePass(usedTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] =
     )
 
     usedTypes.sorted.foreach { typeName =>
-      val shortName = typeName.split('.').lastOption.getOrElse(typeName)
+      val shortName = typeName match {
+        case lambdaTypeRegex(methodName) => methodName
+        case _                           => typeName.split('.').lastOption.getOrElse(typeName)
+      }
       val node = NewType()
         .name(shortName)
         .fullName(typeName)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
@@ -1,5 +1,6 @@
 package io.joern.x2cpg.passes.frontend
 
+import io.joern.x2cpg.passes.frontend.TypeNodePass.fullToShortName
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewType
 import io.shiftleft.passes.{KeyPool, SimpleCpgPass}
@@ -8,12 +9,6 @@ import io.shiftleft.passes.{KeyPool, SimpleCpgPass}
   */
 class TypeNodePass(usedTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] = None)
     extends SimpleCpgPass(cpg, "types", keyPool) {
-
-  // Lambda typeDecl type names fit the structure
-  // `a.b.c.d.ClassName.lambda$method$name:returnType(paramTypes)`
-  // so this regex works by greedily matching the package and class names
-  // at the start and cutting off the matched group before the signature.
-  private val lambdaTypeRegex = raw".*\.(.*):.*\(.*\)".r
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
 
@@ -25,15 +20,27 @@ class TypeNodePass(usedTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] =
     )
 
     usedTypes.sorted.foreach { typeName =>
-      val shortName = typeName match {
-        case lambdaTypeRegex(methodName) => methodName
-        case _                           => typeName.split('.').lastOption.getOrElse(typeName)
-      }
+      val shortName = fullToShortName(typeName)
       val node = NewType()
         .name(shortName)
         .fullName(typeName)
         .typeDeclFullName(typeName)
       diffGraph.addNode(node)
+    }
+  }
+}
+
+object TypeNodePass {
+  // Lambda typeDecl type names fit the structure
+  // `a.b.c.d.ClassName.lambda$method$name:returnType(paramTypes)`
+  // so this regex works by greedily matching the package and class names
+  // at the start and cutting off the matched group before the signature.
+  private val lambdaTypeRegex = raw".*\.(.*):.*\(.*\)".r
+
+  def fullToShortName(typeName: String): String = {
+    typeName match {
+      case lambdaTypeRegex(methodName) => methodName
+      case _                           => typeName.split('.').lastOption.getOrElse(typeName)
     }
   }
 }


### PR DESCRIPTION
This is effectively a full re-write of lambda support for javasrc2cpg. It adds a `TYPE_DECL` corresponding to the lambda method (and inheriting from the implemented functional interface) and bindings to the implemented method, all of which were missing with the previous implementation.

It relies heavily on the `ExpectedType` information to create correct signatures for the lambda method node and bindings, so in cases where we don't know the expected type, these are left as `java.lang.Object`, even if JavaParser could resolve the lambda type. In cases where neither the expected type nor the lambda type could be resolved, the results will be effectively useless. In this case we don't know which method the lambda implements, so the relevant bindings aren't created at all.

A specific case where JavaParser could resolve the lambda but where we don't know the expected type occurs in the example:
```
import java.util.List;
import java.util.stream.Collectors;

public class Foo {
  public List<String> method(List<String> list) {
    return list.stream().map(string -> string).collect(Collectors.toList());
  }
}
```
In this case, we know `string -> string` implements `Function<T,R>` since it could be resolved, but don't know that the type parameters map to `String` in this context.

# Update on 20.06.22 revision

__PR for codescience dataflow tests:__ https://github.com/ShiftLeftSecurity/codescience/pull/6200

This PR is now no longer a WIP. but ended up adding a fair amount of stuff. These can be roughly categorized as:

## Lambda re-implementation
Lambda support was effectively rewritten entirely. Dataflow through lambdas using the OSS dataflow engine doesn't work, probably due to the open source call linker not being able to link the lambda call to the `$lambda$X` method created for the implementation. Closed source dataflow is now on par with `java2cpg`, at least as far as covered by the closed source dataflow tests. A PR to fix expected flows for those tests will follow once this has been merged. 

Since java lambdas (conceptually) create a class implementing an interface method, a fair amount of type information is needed for lambdas to work. If that type information is not available (e.g. due to using a dependency that couldn't be fetched), this implementation will give unusable results. It may be possible to use some heuristics to figure out some of this type information, but in my opinion the effort is not worth it.

## ForEach re-implemenation
The only other big change included in this PR. To fix dataflow through foreach loops, javasrc now represents a foreach loop more similarly to java bytecode. Specifically, for foreach loops over native arrays:
```
// ex1
for (int x : xs) { ... }
// where xs has type int[] is represented as
for (int idx = 0; idx < xs.length; idx++) {
  int x = xs[idx];
}

// ex2
for (int x : new int[] {1, 2 }) { ... }
// is represented as
int[] tmpIterable = new int[] {1, 2}
for (int idx = 0; idx < tmpIterable.length; idx++) {
  int x = tmpIterable[idx];
  ...
}
```

whereas for foreach loops over collections:
```
for (Integer x : xs) { ... }
// where xs has type List<Integer> is represented as
Iterator tmpIterator = xs.iterator
while (tmpIterator.hasNext()) {
  Integer x = tmpIterator.next();
  ...
}
```

## Fixed varargs handling
Before, varargs were treated as regular arguments. This led to crashes in the worst case and potentially missing dataflows otherwise. With this PR, varargs are now treated as arrays, similar to compiled Java. Variadic parameters are given an array type, while variadic arguments are treated as `arrayInitializationExpressions`. For example:
```
public static void foo(String... inputs) {}
public static void bar() {
  foo("Hello", "world");
}

// is now represented as
public static void foo(String[] inputs) {}
public static void bar() {
  foo(new String[] {"Hello", "world"});
}
```

## Missing modifiers and other misc additions
This adds some missing method and typeDecl modifiers and improves the code fields. Most notably, this no longer uses a simple `toString` for the code for method calls, since lambdas in the scope of the call could make this code field incredibly long.