### PR TITLE
ensure `cpg.id.outV` doesn't compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion    = "1.3.540"
+val cpgVersion    = "1.3.540+0-1cbb78b6+20220526-1412"
 val js2cpgVersion = "0.2.147"
 
 lazy val joerncli          = Projects.joerncli

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion    = "1.3.540+0-1cbb78b6+20220526-1412"
-val js2cpgVersion = "0.2.147"
+val cpgVersion    = "1.3.540"
+val js2cpgVersion = "0.2.158"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion    = "1.3.540"
+val cpgVersion    = "1.3.542"
 val js2cpgVersion = "0.2.158"
 
 lazy val joerncli          = Projects.joerncli

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/NodeTypeStartersTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/NodeTypeStartersTests.scala
@@ -113,7 +113,7 @@ class NodeTypeStartersTests extends CCodeToCpgSuite {
     val method2 = cpg.method.name("libfunc").head
 
     cpg.id(method1.id).l shouldBe Seq(method1)
-    cpg.id(Seq(method1.id, method2.id)).l shouldBe Seq(method1, method2)
+    cpg.ids(method1.id, method2.id).l shouldBe Seq(method1, method2)
   }
 
 }

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/querying/NodeTypeStartersTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/querying/NodeTypeStartersTests.scala
@@ -110,7 +110,7 @@ class NodeTypeStartersTests extends FuzzyCCodeToCpgSuite {
     val method2 = cpg.method.name("libfunc").head
 
     cpg.id(method1.id).l shouldBe Seq(method1)
-    cpg.id(Seq(method1.id, method2.id)).l shouldBe Seq(method1, method2)
+    cpg.ids(method1.id, method2.id).l shouldBe Seq(method1, method2)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -4,16 +4,17 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Properties}
 import overflowdb._
-import overflowdb.traversal.help.{Doc, TraversalSource}
-import overflowdb.traversal.{Traversal, jIteratortoTraversal, toElementTraversal}
+import overflowdb.traversal.help
+import overflowdb.traversal.help.Doc
+import overflowdb.traversal.{Traversal, TraversalSource, jIteratortoTraversal, toElementTraversal}
 
-@TraversalSource
-class NodeTypeStarters(cpg: Cpg) {
+@help.TraversalSource
+class NodeTypeStarters(cpg: Cpg) extends TraversalSource(cpg.graph) {
 
   /** Traverse to all nodes.
     */
   @Doc(info = "All nodes of the graph")
-  def all: Traversal[StoredNode] =
+  override def all: Traversal[StoredNode] =
     cpg.graph.nodes.cast[StoredNode]
 
   /** Traverse to all annotations
@@ -97,22 +98,11 @@ class NodeTypeStarters(cpg: Cpg) {
   def goto: Traversal[ControlStructure] =
     controlStructure.isGoto
 
-  /** Begin traversal at node with id.
-    */
-  def id[NodeType <: StoredNode](anId: Long): Traversal[NodeType] =
-    cpg.graph.nodes(anId).cast[NodeType]
-
   /** Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
     */
   @Doc(info = "All identifier usages")
   def identifier: Traversal[Identifier] =
     cpg.graph.nodes(NodeTypes.IDENTIFIER).cast[Identifier]
-
-  /** Begin traversal at set of nodes - specified by their ids
-    */
-  def id[NodeType <: StoredNode](ids: Seq[Long]): Traversal[NodeType] =
-    if (ids.isEmpty) Traversal.empty
-    else cpg.graph.nodes(ids: _*).cast[NodeType]
 
   /** Shorthand for `cpg.identifier.name(name)`
     */

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -337,4 +337,11 @@ class StepsTest extends AnyWordSpec with Matchers {
     method.head.modifier.modifierType.toSetMutable shouldBe Set("modifiertype")
   }
 
+  "id starter step" in {
+    // only verifying what compiles and what doesn't...
+    // if it compiles, :shipit:
+    assertCompiles("cpg.id(1).out")
+    assertDoesNotCompile("cpg.id(1).outV") // `.outV` is only available on Traversal[Edge]
+  }
+
 }


### PR DESCRIPTION
`.outV` is only valid on `Traversal[Edge]`, trying this now results in
a compiler error.

Depends on https://github.com/ShiftLeftSecurity/overflowdb/pull/307
Re https://github.com/joernio/joern/issues/1367