### PR TITLE
Make `--optimize-dependencies` the default for `js2cpg`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion    = "1.3.540"
-val js2cpgVersion = "0.2.147"
+val cpgVersion    = "1.3.542"
+val js2cpgVersion = "0.2.158"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/src/universal/js2cpg.sh
+++ b/joern-cli/src/universal/js2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml --optimize-dependencies "$@"


### PR DESCRIPTION
`js2cpg` recently introduced the `--optimize-dependencies` flag. When used, `js2cpg` will be more selective about downloading dependencies, which significantly reduces CPG construction time. While the flag is not enabled by default for `js2cpg` runs, I am making it the default for `joern`. It is expected that it will be the default in a few months, at which point we do not need to specify the flag manually anymore.