### PR TITLE
jimple2cpg: Descriptive TypeDecl Modifiers

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -62,9 +62,10 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
   }
 
   /** Creates a list of all inherited classes and implemented interfaces. If there are none then a list with a single
-    * element 'java.lang.Object' is returned by default.
+    * element 'java.lang.Object' is returned by default. Returns two lists in the form of (List[Super Classes],
+    * List[Interfaces]).
     */
-  private def listOfSuperClasses(clazz: SootClass): List[String] = {
+  private def inheritedAndImplementedClasses(clazz: SootClass): (List[String], List[String]) = {
     val implementsTypeFullName = clazz.getInterfaces.asScala.map { (i: SootClass) =>
       registerType(i.getType.toQuotedString)
     }.toList
@@ -75,7 +76,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
         List(registerType("java.lang.Object"))
       } else List()
 
-    inheritsFromTypeFullName ++ implementsTypeFullName
+    (inheritsFromTypeFullName, implementsTypeFullName)
   }
 
   /** Creates the AST root for type declarations and acts as the entry point for method generation.
@@ -83,14 +84,32 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
   private def astForTypeDecl(typ: RefType, namespaceBlockFullName: String): Ast = {
     val fullName  = registerType(typ.toQuotedString)
     val shortName = typ.getSootClass.getShortJavaStyleName
+    val clz       = typ.getSootClass
+    val code      = new mutable.StringBuilder()
+
+    if (clz.isPublic) code.append("public ")
+    else if (clz.isPrivate) code.append("private ")
+    if (clz.isStatic) code.append("static ")
+    if (clz.isFinal) code.append("final ")
+    if (clz.isInterface) code.append("interface ")
+    else if (clz.isAbstract) code.append("abstract ")
+    if (clz.isEnum) code.append("enum ")
+    if (!clz.isInterface) code.append(s"class $shortName")
+    else code.append(shortName)
+
+    val modifiers                = astsForModifiers(clz)
+    val (inherited, implemented) = inheritedAndImplementedClasses(typ.getSootClass)
+
+    if (inherited.nonEmpty) code.append(s" extends ${inherited.mkString(", ")}")
+    if (implemented.nonEmpty) code.append(s" implements ${implemented.mkString(", ")}")
 
     val typeDecl = NewTypeDecl()
       .name(shortName)
       .fullName(fullName)
       .order(1) // Jimple always has 1 class per file
       .filename(filename)
-      .code(shortName)
-      .inheritsFromTypeFullName(listOfSuperClasses(typ.getSootClass))
+      .code(code.toString())
+      .inheritsFromTypeFullName(inherited ++ implemented)
       .astParentType(NodeTypes.NAMESPACE_BLOCK)
       .astParentFullName(namespaceBlockFullName)
     val methodAsts = withOrder(typ.getSootClass.getMethods.asScala.toList.sortWith((x, y) => x.getName > y.getName)) {
@@ -109,6 +128,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
     Ast(typeDecl)
       .withChildren(memberAsts)
       .withChildren(methodAsts)
+      .withChildren(modifiers)
   }
 
   private def astForField(field: SootField, order: Int): Ast = {
@@ -1019,6 +1039,23 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
         Some(ModifierTypes.VIRTUAL)
       else None,
       if (methodDeclaration.isSynchronized) Some("SYNCHRONIZED") else None
+    ).flatten.map { modifier =>
+      Ast(NewModifier().modifierType(modifier).code(modifier.toLowerCase))
+    }
+  }
+
+  private def astsForModifiers(classDeclaration: SootClass): Seq[Ast] = {
+    Seq(
+      if (classDeclaration.isStatic) Some(ModifierTypes.STATIC) else None,
+      if (classDeclaration.isPublic) Some(ModifierTypes.PUBLIC) else None,
+      if (classDeclaration.isProtected) Some(ModifierTypes.PROTECTED) else None,
+      if (classDeclaration.isPrivate) Some(ModifierTypes.PRIVATE) else None,
+      if (classDeclaration.isAbstract) Some(ModifierTypes.ABSTRACT) else None,
+      if (classDeclaration.isInterface) Some("INTERFACE") else None,
+      if (!classDeclaration.isFinal && !classDeclaration.isStatic && classDeclaration.isPublic)
+        Some(ModifierTypes.VIRTUAL)
+      else None,
+      if (classDeclaration.isSynchronized) Some("SYNCHRONIZED") else None
     ).flatten.map { modifier =>
       Ast(NewModifier().modifierType(modifier).code(modifier.toLowerCase))
     }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ImplementsInterfaceTests.scala
@@ -12,7 +12,7 @@ class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
     """
         |import java.io.Serializable;
         |
-        |class Foo implements Serializable {
+        |final class Foo implements Serializable {
         |
         |   public int add(int x, int y) {
         |     return x + y;
@@ -24,7 +24,7 @@ class ImplementsInterfaceTests extends JimpleCodeToCpgFixture {
   "should contain a type decl for `Foo` with correct fields" in {
     val List(x) = cpg.typeDecl.name("Foo").l
     x.name shouldBe "Foo"
-    x.code shouldBe "Foo"
+    x.code shouldBe "final class Foo implements java.io.Serializable"
     x.fullName shouldBe "Foo"
     x.isExternal shouldBe false
     x.inheritsFromTypeFullName shouldBe List("java.io.Serializable")

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
@@ -39,7 +39,7 @@ class InterfaceTests extends JimpleCodeToCpgFixture {
   }
 
   "should contain the correct modifier(s)" in {
-    val List(x) = cpg.typeDecl.name("Foo").l
+    val List(x)      = cpg.typeDecl.name("Foo").l
     val List(m1, m2) = x.modifier.l
     m1.modifierType shouldBe ModifierTypes.ABSTRACT
     m2.modifierType shouldBe "INTERFACE"

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/InterfaceTests.scala
@@ -1,5 +1,6 @@
 package io.joern.jimple2cpg.querying
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.semanticcpg.language._
 
 import java.io.File
@@ -18,7 +19,7 @@ class InterfaceTests extends JimpleCodeToCpgFixture {
   "should contain a type decl for `Foo` with correct fields" in {
     val List(x) = cpg.typeDecl.name("Foo").l
     x.name shouldBe "Foo"
-    x.code shouldBe "Foo"
+    x.code shouldBe "interface Foo extends java.lang.Object"
     x.fullName shouldBe "Foo"
     x.isExternal shouldBe false
     x.inheritsFromTypeFullName shouldBe List("java.lang.Object")
@@ -35,6 +36,13 @@ class InterfaceTests extends JimpleCodeToCpgFixture {
     x.fullName shouldBe "Foo.add:int(int,int)"
     x.isExternal shouldBe false
     x.order shouldBe 1
+  }
+
+  "should contain the correct modifier(s)" in {
+    val List(x) = cpg.typeDecl.name("Foo").l
+    val List(m1, m2) = x.modifier.l
+    m1.modifierType shouldBe ModifierTypes.ABSTRACT
+    m2.modifierType shouldBe "INTERFACE"
   }
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/TypeDeclTests.scala
@@ -1,6 +1,7 @@
 package io.joern.jimple2cpg.querying
 
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 
@@ -11,7 +12,7 @@ class TypeDeclTests extends JimpleCodeToCpgFixture {
   override val code: String =
     """
       | package Foo;
-      | class Bar extends Woo {
+      | abstract class Bar extends Woo {
       |   int x;
       |   int method () { return 1; }
       | };
@@ -21,7 +22,7 @@ class TypeDeclTests extends JimpleCodeToCpgFixture {
   "should contain a type decl for `foo` with correct fields" in {
     val List(x) = cpg.typeDecl.name("Bar").l
     x.name shouldBe "Bar"
-    x.code shouldBe "Bar"
+    x.code shouldBe "abstract class Bar extends Foo.Woo"
     x.fullName shouldBe "Foo.Bar"
     x.isExternal shouldBe false
     x.inheritsFromTypeFullName shouldBe List("Foo.Woo")
@@ -43,6 +44,12 @@ class TypeDeclTests extends JimpleCodeToCpgFixture {
     x.aliasTypeFullName shouldBe None
     x.order shouldBe -1
     x.filename shouldBe FileTraversal.UNKNOWN
+  }
+
+  "should contain the correct modifier(s)" in {
+    val List(x) = cpg.typeDecl.name("Bar").l
+    val List(m) = x.modifier.l
+    m.modifierType shouldBe ModifierTypes.ABSTRACT
   }
 
 }


### PR DESCRIPTION
- Improved the `code` property of `TypeDecl` nodes to include modifiers and superclasses/interfaces
- Added `Modifier` nodes to `TypeDecl`

Note: I have added an unofficial `INTERFACE` modifier type accompanied by `ABSTRACT` (since interfaces are implicitly abstract). Let me know if this is okay or not.