### PR TITLE
javasrc: Add skip-dependency-download option and enable for tests

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -31,8 +31,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       val sourceCodePath = config.inputPaths.head
       new MetaDataPass(cpg, language).createAndApply()
       val (sourcesDir, sourceFileNames) = getSourcesFromDir(sourceCodePath)
-      val inferencePaths                = config.inferenceJarPaths
-      val astCreator                    = new AstCreationPass(sourcesDir, sourceFileNames, inferencePaths, cpg)
+      val astCreator                    = new AstCreationPass(sourcesDir, sourceFileNames, config, cpg)
       astCreator.createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
         .createAndApply()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -9,7 +9,8 @@ import scopt.OParser
 final case class Config(
   inputPaths: Set[String] = Set.empty,
   outputPath: String = X2CpgConfig.defaultOutputPath,
-  inferenceJarPaths: Set[String] = Set.empty
+  inferenceJarPaths: Set[String] = Set.empty,
+  skipDependencyDownload: Boolean = false
 ) extends X2CpgConfig[Config] {
 
   override def withAdditionalInputPath(inputPath: String): Config =
@@ -28,7 +29,10 @@ private object Frontend {
       programName("javasrc2cpg"),
       opt[String]("inference-jar-paths")
         .text(s"extra jars used only for type information")
-        .action((path, c) => c.copy(inferenceJarPaths = c.inferenceJarPaths + path))
+        .action((path, c) => c.copy(inferenceJarPaths = c.inferenceJarPaths + path)),
+      opt[Unit]("skip-dependency-download")
+        .text("don't attempt to download dependency jars for type information")
+        .action((_, c) => c.copy(skipDependencyDownload = true))
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -18,7 +18,8 @@ class JavaSrc2CpgTestContext {
       val config = Config(
         inputPaths = Set(writeCodeToFile(code, "javasrc2cpgTest", ".java").getAbsolutePath),
         outputPath = "",
-        inferenceJarPaths = inferenceJarPaths
+        inferenceJarPaths = inferenceJarPaths,
+        skipDependencyDownload = true
       )
       val cpg = javaSrc2Cpg.createCpg(config)
       applyDefaultOverlays(cpg.get)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -11,7 +11,7 @@ class JavaSrcFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".java"
 
   override def execute(sourceCodeFile: File): Cpg = {
-    implicit val defaultConfig: Config = Config()
+    implicit val defaultConfig: Config = Config(skipDependencyDownload = true)
     new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
   }
 }


### PR DESCRIPTION
Having the option to disable dependency downloading is nice in general, but in particular dependency downloads failing created a lot of warnings when running tests (even though we don't expect a build system). This PR adds the `skip-dependency-download` option (still leaving dependency downloading as the default) and disables downloads for our unit test suites.