### PR TITLE
write resourcefile efficiently

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/CompilerAPI.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/CompilerAPI.scala
@@ -56,7 +56,7 @@ object CompilerAPI {
           val tempFile = File.createTempFile("kotlin2cpgDependencies", "", new File("./"))
           tempFile.deleteOnExit()
           val outStream = new FileOutputStream(tempFile)
-          val buffer = new Array[Byte](4096)
+          val buffer    = new Array[Byte](4096)
 
           while (resourceStream.available > 0) {
             val readBytes = resourceStream.read(buffer)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/CompilerAPI.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/CompilerAPI.scala
@@ -56,10 +56,15 @@ object CompilerAPI {
           val tempFile = File.createTempFile("kotlin2cpgDependencies", "", new File("./"))
           tempFile.deleteOnExit()
           val outStream = new FileOutputStream(tempFile)
+          val buffer = new Array[Byte](4096)
 
-          val bytes =
-            LazyList.continually(resourceStream.read).takeWhile(_ != -1).map(_.toByte).toArray
-          outStream.write(bytes)
+          while (resourceStream.available > 0) {
+            val readBytes = resourceStream.read(buffer)
+            outStream.write(buffer, 0, readBytes)
+          }
+          outStream.flush()
+          outStream.close()
+
           config.add(CLIConfigurationKeys.CONTENT_ROOTS, new JvmClasspathRoot(tempFile))
           logger.debug("Added dependency from resources `" + path.path + "`.")
         } else {


### PR DESCRIPTION
Previously we'd allocate a new `LazyList:Cons` for each byte that we
read from the resource, which ended up being the biggest memory consumer
on the heap (only on a 1g heap, but still)...

This was uncovered by a OutOfMemory issues during `kotlin2cpg/test` as part of https://github.com/joernio/joern/pull/1451, but it's semantically different enough that it deserves a separate PR.
It doesn't entirely fix the OOM issues in the linked PR though.