### PR TITLE
Clean up `kotlin2cpg`'s AstCreator a bit more

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -899,7 +899,8 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     val assignmentNode =
       operatorCallNode(Operators.assignment, tmpName + " = " + initExpr.getText, None)
     val assignmentAst = callAst(assignmentNode, List(assignmentLhsAst, assignmentRhsAst))
-    val returnType    = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
+    registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
+
     val assignmentsForEntries =
       nonUnderscoreEntries(expr).zipWithIndex.map { entryWithIdx =>
         val entry             = entryWithIdx._1
@@ -2053,7 +2054,8 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
       }.flatten
 
     val fullNameWithSig = typeInfoProvider.fullNameWithSignature(expr, (TypeConstants.any, TypeConstants.any))
-    val returnType      = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
+    registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
+
     val initCallNode =
       callNode(
         expr.getText,

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -376,11 +376,10 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
         val orderAfterCtorParams = constructorParamsAsts.size + 1
 
         val ctorMethodBlockAst =
-          if (secondaryCtor.getBodyExpression != null) {
-            Seq(astForBlock(secondaryCtor.getBodyExpression, orderAfterCtorParams))
-          } else {
-            Seq()
-          }
+          Option(secondaryCtor.getBodyExpression)
+            .map(astForBlock(_, orderAfterCtorParams))
+            .map(Seq(_))
+            .getOrElse(Seq())
         scope.popScope()
 
         val ctorMethodReturnNode =


### PR DESCRIPTION
- improve readability
- add more idiomatic Scala code
- use fns from `x2cpg`

 