### PR TITLE
Revert "also set Xms to avoid potential clash with user-defined settings"

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,1 +1,1 @@
--J-Xms2G -J-Xmx2G
+-J-Xmx2G


### PR DESCRIPTION
Reverts joernio/joern#1464

Not sure what's going on, but github actions fails on `sbt scalafmtCheck +test` with 
![image](https://user-images.githubusercontent.com/506752/171484383-6f4f9d69-019f-4820-8ab8-184af5a515b1.png)

Not sure why that's happening, apparently there's a `-J` missing, but no idea where that's coming from. I can test this in PR builds, for now let's revert. 