### PR TITLE
alternative fix for CfgCreator complexity class woes

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/CfgCreationPassTests.scala
@@ -266,7 +266,10 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
       succOf("x") shouldBe expected(("x", AlwaysEdge))
     }
 
-    "be correct with empty condition with empty block" in new CpgCfgFixture("for (;;) ;") {
+    "use UB to skip empty condition with empty block" in new CpgCfgFixture("for (;;) ;") {
+      //Non-terminating loops without side-effects are undefined behavior.
+      //So we can emit whatever CFG we want, it can't be wrong.
+      //However, gcc and clang both emit the loop without using the liberty granted by the C standard to spawn bats
       succOf("RET func ()") shouldBe expected(("RET", AlwaysEdge))
     }
 
@@ -401,7 +404,7 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
 
     "be correct for nested switch" in new CpgCfgFixture("switch (x) { case 1: switch(y) { default: z; } }") {
       succOf("RET func ()") shouldBe expected(("x", AlwaysEdge))
-      succOf("x") shouldBe expected(("case 1:", CaseEdge), ("default:", CaseEdge))
+      succOf("x") shouldBe expected(("case 1:", CaseEdge), ("RET", AlwaysEdge))
       succOf("case 1:") shouldBe expected(("1", AlwaysEdge))
       succOf("1") shouldBe expected(("y", AlwaysEdge))
       succOf("y") shouldBe expected(("default:", CaseEdge))

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/CfgCreationPassTests.scala
@@ -413,7 +413,7 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
     "be correct for nested switch" in
       new CfgFixture("switch (x) { case 1: switch(y) { default: z; } }") {
         succOf("RET func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("default:", CaseEdge))
+        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("RET", AlwaysEdge))
         succOf("case 1:") shouldBe expected(("y", AlwaysEdge))
         succOf("y") shouldBe expected(("default:", CaseEdge))
         succOf("default:") shouldBe expected(("z", AlwaysEdge))

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CfgCreationPassTest.scala
@@ -336,7 +336,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("y", TrueEdge), ("c", FalseEdge))
         succOf("y") shouldBe expected(("break;", TrueEdge), ("a", FalseEdge))
-        succOf("break;") shouldBe expected(("a", AlwaysEdge), ("c", AlwaysEdge))
+        succOf("break;", 0) shouldBe expected(("a", AlwaysEdge))
         succOf("a") shouldBe expected(("break;", 1, AlwaysEdge))
         succOf("break;", 1) shouldBe expected(("c", AlwaysEdge))
         succOf("c") shouldBe expected(("RET", AlwaysEdge))
@@ -358,8 +358,8 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("y", TrueEdge), ("n", FalseEdge))
         succOf("y") shouldBe expected(("break;", TrueEdge), ("z", FalseEdge))
-        succOf("break;") shouldBe expected(("n", AlwaysEdge))
-        succOf("break;", 1) shouldBe expected(("x", AlwaysEdge), ("n", AlwaysEdge))
+        succOf("break;", 0) shouldBe expected(("n", AlwaysEdge))
+        succOf("break;", 1) shouldBe expected(("x", AlwaysEdge))
         succOf("z") shouldBe expected(("break;", 1, TrueEdge), ("x", FalseEdge))
         succOf("n") shouldBe expected(("RET", AlwaysEdge))
       }
@@ -414,7 +414,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("y", TrueEdge), ("c", FalseEdge))
         succOf("y") shouldBe expected(("break;", TrueEdge), ("z", FalseEdge))
-        succOf("break;") shouldBe expected(("x", 1, AlwaysEdge), ("z", AlwaysEdge), ("c", AlwaysEdge))
+        succOf("break;") shouldBe expected(("z", AlwaysEdge))
         succOf("z") shouldBe expected(("x", 1, AlwaysEdge))
         succOf("x", 1) shouldBe expected(("1", AlwaysEdge))
         succOf("1") shouldBe expected(("x < 1", AlwaysEdge))
@@ -427,7 +427,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
       new CfgFixture("while(x) { do { break; } while (y) } o;") {
         succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("break;", TrueEdge), ("o", FalseEdge))
-        succOf("break;") shouldBe expected(("x", AlwaysEdge), ("o", AlwaysEdge))
+        succOf("break;") shouldBe expected(("x", AlwaysEdge))
         succOf("o") shouldBe expected(("RET", AlwaysEdge))
       }
     }
@@ -437,7 +437,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf(":program") shouldBe expected(("y", AlwaysEdge))
         succOf("y") shouldBe expected(("z", TrueEdge), ("RET", FalseEdge))
         succOf("z") shouldBe expected(("break;", TrueEdge), ("y", FalseEdge))
-        succOf("break;") shouldBe expected(("y", AlwaysEdge), ("RET", AlwaysEdge))
+        succOf("break;") shouldBe expected(("y", AlwaysEdge))
       }
     }
 


### PR DESCRIPTION
This is an alternative to https://github.com/joernio/joern/pull/1455

This does change behavior: We generated a lot of incorrect CFGs. Generally speaking, I would very much appreciate a source-code comment if we test for known incorrect behavior. Such tests are still valuable for documenting known shortcomings, but a comment (like e.g. below wrt empty loops) makes life much easier when testing.

@fabsx00 -- are you happy with readability?