### PR TITLE
Fix handling of nested breaks, continues, and cases.

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/CfgCreationPassTests.scala
@@ -401,7 +401,7 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
 
     "be correct for nested switch" in new CpgCfgFixture("switch (x) { case 1: switch(y) { default: z; } }") {
       succOf("RET func ()") shouldBe expected(("x", AlwaysEdge))
-      succOf("x") shouldBe expected(("case 1:", CaseEdge), ("default:", CaseEdge))
+      succOf("x") shouldBe expected(("case 1:", CaseEdge), ("RET", AlwaysEdge))
       succOf("case 1:") shouldBe expected(("1", AlwaysEdge))
       succOf("1") shouldBe expected(("y", AlwaysEdge))
       succOf("y") shouldBe expected(("default:", CaseEdge))

--- a/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/fuzzyc2cpg/src/test/scala/io/joern/fuzzyc2cpg/passes/CfgCreationPassTests.scala
@@ -413,7 +413,7 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
     "be correct for nested switch" in
       new CfgFixture("switch (x) { case 1: switch(y) { default: z; } }") {
         succOf("RET func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("default:", CaseEdge))
+        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("RET", AlwaysEdge))
         succOf("case 1:") shouldBe expected(("y", AlwaysEdge))
         succOf("y") shouldBe expected(("default:", CaseEdge))
         succOf("default:") shouldBe expected(("z", AlwaysEdge))

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CfgCreationPassTest.scala
@@ -336,7 +336,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("y", TrueEdge), ("c", FalseEdge))
         succOf("y") shouldBe expected(("break;", TrueEdge), ("a", FalseEdge))
-        succOf("break;") shouldBe expected(("a", AlwaysEdge), ("c", AlwaysEdge))
+        succOf("break;", 0) shouldBe expected(("a", AlwaysEdge))
         succOf("a") shouldBe expected(("break;", 1, AlwaysEdge))
         succOf("break;", 1) shouldBe expected(("c", AlwaysEdge))
         succOf("c") shouldBe expected(("RET", AlwaysEdge))
@@ -358,8 +358,8 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("y", TrueEdge), ("n", FalseEdge))
         succOf("y") shouldBe expected(("break;", TrueEdge), ("z", FalseEdge))
-        succOf("break;") shouldBe expected(("n", AlwaysEdge))
-        succOf("break;", 1) shouldBe expected(("x", AlwaysEdge), ("n", AlwaysEdge))
+        succOf("break;", 0) shouldBe expected(("n", AlwaysEdge))
+        succOf("break;", 1) shouldBe expected(("x", AlwaysEdge))
         succOf("z") shouldBe expected(("break;", 1, TrueEdge), ("x", FalseEdge))
         succOf("n") shouldBe expected(("RET", AlwaysEdge))
       }
@@ -414,7 +414,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("y", TrueEdge), ("c", FalseEdge))
         succOf("y") shouldBe expected(("break;", TrueEdge), ("z", FalseEdge))
-        succOf("break;") shouldBe expected(("x", 1, AlwaysEdge), ("z", AlwaysEdge), ("c", AlwaysEdge))
+        succOf("break;") shouldBe expected(("z", AlwaysEdge))
         succOf("z") shouldBe expected(("x", 1, AlwaysEdge))
         succOf("x", 1) shouldBe expected(("1", AlwaysEdge))
         succOf("1") shouldBe expected(("x < 1", AlwaysEdge))
@@ -427,7 +427,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
       new CfgFixture("while(x) { do { break; } while (y) } o;") {
         succOf(":program") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("break;", TrueEdge), ("o", FalseEdge))
-        succOf("break;") shouldBe expected(("x", AlwaysEdge), ("o", AlwaysEdge))
+        succOf("break;") shouldBe expected(("x", AlwaysEdge))
         succOf("o") shouldBe expected(("RET", AlwaysEdge))
       }
     }
@@ -437,7 +437,7 @@ class CfgCreationPassTest extends AnyWordSpec with Matchers {
         succOf(":program") shouldBe expected(("y", AlwaysEdge))
         succOf("y") shouldBe expected(("z", TrueEdge), ("RET", FalseEdge))
         succOf("z") shouldBe expected(("break;", TrueEdge), ("y", FalseEdge))
-        succOf("break;") shouldBe expected(("y", AlwaysEdge), ("RET", AlwaysEdge))
+        succOf("break;") shouldBe expected(("y", AlwaysEdge))
       }
     }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -346,7 +346,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
         entryNode = if (bodyCfg != Cfg.empty) { bodyCfg.entryNode }
         else { conditionCfg.entryNode },
         edges = diffGraphs ++ bodyCfg.edges ++ conditionCfg.edges,
-        fringe = conditionCfg.fringe.withEdgeType(FalseEdge) ++ bodyCfg.breaks.map((_, AlwaysEdge))
+        fringe = conditionCfg.fringe.withEdgeType(FalseEdge) ++ bodyCfg.breaks.map((_, AlwaysEdge)),
+        breaks = List(),
+        continues = List()
       )
   }
 
@@ -368,7 +370,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
       .copy(
         entryNode = conditionCfg.entryNode,
         edges = diffGraphs ++ conditionCfg.edges ++ trueCfg.edges ++ falseCfg.edges,
-        fringe = conditionCfg.fringe.withEdgeType(FalseEdge) ++ trueCfg.breaks.map((_, AlwaysEdge)) ++ falseCfg.fringe
+        fringe = conditionCfg.fringe.withEdgeType(FalseEdge) ++ trueCfg.breaks.map((_, AlwaysEdge)) ++ falseCfg.fringe,
+        breaks = List(),
+        continues = List()
       )
   }
 
@@ -390,7 +394,8 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
           if (!hasDefaultCase) { conditionCfg.fringe.withEdgeType(FalseEdge) }
           else { List() }
         } ++ bodyCfg.breaks
-          .map((_, AlwaysEdge)) ++ bodyCfg.fringe
+          .map((_, AlwaysEdge)) ++ bodyCfg.fringe,
+        caseLabels = List()
       )
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -397,7 +397,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
           else { List() }
         } ++ bodyCfg.breaks
           .map((_, AlwaysEdge)) ++ bodyCfg.fringe,
-        caseLabels = List()
+        caseLabels = List(),
+        breaks = List(),
+        continues = List()
       )
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -323,7 +323,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
       .copy(
         entryNode = entryNode,
         edges = newEdges ++ initExprCfg.edges ++ innerCfg.edges,
-        fringe = conditionCfg.fringe.withEdgeType(FalseEdge) ++ bodyCfg.breaks.map((_, AlwaysEdge))
+        fringe = conditionCfg.fringe.withEdgeType(FalseEdge) ++ bodyCfg.breaks.map((_, AlwaysEdge)),
+        breaks = List(),
+        continues = List()
       )
   }
 


### PR DESCRIPTION
When a Cfg for a loop construct is done, we need to set `continues` and `breaks` to empty lists. Similarly, when the construction for a switch statement is done, we need to set `caseLabels` to an empty list.