### PR TITLE
Fix a bug in the static call linker

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
@@ -12,13 +12,18 @@ import scala.collection.mutable
 class StaticCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
 
   import StaticCallLinker._
-  private val methodFullNameToNode = mutable.Map.empty[String, StoredNode]
+  private val methodFullNameToNode = mutable.Map.empty[String, List[Method]]
 
   /** Main method of enhancement - to be implemented by child class
     */
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     cpg.method.foreach { method =>
-      methodFullNameToNode.put(method.fullName, method)
+      methodFullNameToNode.get(method.fullName) match {
+        case Some(l) =>
+          methodFullNameToNode.put(method.fullName, method :: l)
+        case None =>
+          methodFullNameToNode.put(method.fullName, List(method))
+      }
     }
 
     cpg.call.foreach { call =>
@@ -44,7 +49,9 @@ class StaticCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
   private def linkStaticCall(call: Call, dstGraph: DiffGraphBuilder): Unit = {
     val resolvedMethodOption = methodFullNameToNode.get(call.methodFullName)
     if (resolvedMethodOption.isDefined) {
-      dstGraph.addEdge(call, resolvedMethodOption.get, EdgeTypes.CALL)
+      resolvedMethodOption.get.foreach { dst =>
+        dstGraph.addEdge(call, dst, EdgeTypes.CALL)
+      }
     } else {
       logger.info(
         s"Unable to link static CALL with METHOD_FULL_NAME ${call.methodFullName}, NAME ${call.name}, " +

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
@@ -19,10 +19,8 @@ class StaticCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     cpg.method.foreach { method =>
       methodFullNameToNode.get(method.fullName) match {
-        case Some(l) =>
-          methodFullNameToNode.put(method.fullName, method :: l)
-        case None =>
-          methodFullNameToNode.put(method.fullName, List(method))
+        case Some(l) => methodFullNameToNode.put(method.fullName, method :: l)
+        case None    => methodFullNameToNode.put(method.fullName, List(method))
       }
     }
 


### PR DESCRIPTION
In cases where multiple methods with the same full name exist, we only linked to one of them. For C/C++, this meant that if there was both a prototype and a function definition, we would sometimes end up only linking to the prototype. This PR fixes this by linking to all methods with the given full name rather than just one.