### PR TITLE
Lower log level for dependency resolver

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -32,11 +32,11 @@ object DependencyResolver {
       GradleDependencies.get(projectDir, gradleProjectName, gradleConfiguration) match {
         case Some(deps) => Some(deps)
         case None =>
-          logger.info(s"Could not download Gradle dependencies for project at path `$projectDir`")
+          logger.warn(s"Could not download Gradle dependencies for project at path `$projectDir`")
           None
       }
     } else {
-      logger.info(s"Could not find a supported build tool setup at path `$projectDir`")
+      logger.warn(s"Could not find a supported build tool setup at path `$projectDir`")
       None
     }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -32,11 +32,11 @@ object DependencyResolver {
       GradleDependencies.get(projectDir, gradleProjectName, gradleConfiguration) match {
         case Some(deps) => Some(deps)
         case None =>
-          logger.warn(s"Could not download Gradle dependencies for project at path `$projectDir`")
+          logger.info(s"Could not download Gradle dependencies for project at path `$projectDir`")
           None
       }
     } else {
-      logger.error(s"Could not find a supported build tool setup at path `$projectDir`")
+      logger.info(s"Could not find a supported build tool setup at path `$projectDir`")
       None
     }
   }


### PR DESCRIPTION
For Java projects without maven/gradle build files, the dependency resolver will fail, logging an error. However, errors should only be reported when it's not possible to continue analysis, which isn't true in this case. Lowered to `warn`.