### PR TITLE
Workaround for dependency resolution issue

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -31,6 +31,9 @@ libraryDependencies ++= Seq(
   "org.scalatest"        %% "scalatest"         % Versions.scalatest % Test
 )
 
+// A temporary (hopefully) workaround for https://github.com/eclipse-equinox/equinox.bundles/issues/54
+dependencyOverrides += "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.9.100"
+
 Test / packageBin / publishArtifact := true
 
 scalacOptions ++= Seq(

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -13,6 +13,9 @@ libraryDependencies ++= Seq(
   "org.scalatest"           %% "scalatest"         % Versions.scalatest % Test
 )
 
+// A temporary (hopefully) workaround for https://github.com/eclipse-equinox/equinox.bundles/issues/54
+dependencyOverrides += "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.9.100"
+
 enablePlugins(UniversalPlugin)
 enablePlugins(JavaAppPackaging)
 //wildcard import from staged `lib` dir, for simplicity and also to avoid `line too long` error on windows

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -13,6 +13,9 @@ libraryDependencies ++= Seq(
   "org.scalatest"           %% "scalatest"                  % Versions.scalatest % Test
 )
 
+// A temporary (hopefully) workaround for https://github.com/eclipse-equinox/equinox.bundles/issues/54
+dependencyOverrides += "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.9.100"
+
 Test / packageBin / publishArtifact := true
 
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)

--- a/querydb/build.sbt
+++ b/querydb/build.sbt
@@ -19,6 +19,9 @@ libraryDependencies ++= Seq(
   "org.scalatest"        %% "scalatest"    % Versions.scalatest % Test
 )
 
+// A temporary (hopefully) workaround for https://github.com/eclipse-equinox/equinox.bundles/issues/54
+dependencyOverrides += "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.9.100"
+
 topLevelDirectory := Some(name.value)
 
 lazy val createDistribution = taskKey[File]("Create binary distribution of extension")


### PR DESCRIPTION
Right now `master` does not build because of:

```
Error:  sbt.librarymanagement.ResolveException: Error downloading org.osgi.service:org.osgi.service.prefs:[1.1.0,1.2.0)
```

It's a workaround for https://github.com/eclipse-equinox/equinox.bundles/issues/54