### PR TITLE
make console config configurable

### DIFF
--- a/joern-cli/src/main/scala/io/joern/joerncli/console/JoernConsole.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/JoernConsole.scala
@@ -43,7 +43,7 @@ class JoernWorkspaceLoader extends WorkspaceLoader[JoernProject] {
 
 class JoernConsole extends Console[JoernProject](JoernAmmoniteExecutor, new JoernWorkspaceLoader) {
 
-  override def config: ConsoleConfig = JoernConsole.config
+  override val config: ConsoleConfig = JoernConsole.defaultConfig
 
   implicit def semantics: Semantics = context.semantics
 
@@ -80,13 +80,13 @@ class JoernConsole extends Console[JoernProject](JoernAmmoniteExecutor, new Joer
 
 object JoernConsole {
 
-  def config: ConsoleConfig = new ConsoleConfig()
+  def defaultConfig: ConsoleConfig = new ConsoleConfig()
 
   def runScriptTest(scriptName: String, params: Map[String, String], cpg: Cpg): Any = {
     class TempConsole(workspaceDir: String) extends JoernConsole {
       override def context: EngineContext =
         EngineContext(Semantics.fromList(new Parser().parseFile(JoernWorkspaceLoader.defaultSemanticsFile)))
-      override def config = new ConsoleConfig(
+      override val config = new ConsoleConfig(
         install = new InstallConfig(Map("SHIFTLEFT_CONSOLE_INSTALL_DIR" -> workspaceDir))
       )
     }

--- a/joern-cli/src/test/scala/io/joern/joerncli/ConsoleTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/ConsoleTests.scala
@@ -15,7 +15,7 @@ class MyImportCode[T <: Project](console: Console[T]) extends ImportCode(console
 }
 
 class TestJoernConsole(workspaceDir: String) extends JoernConsole {
-  override def config = new ConsoleConfig(
+  override val config = new ConsoleConfig(
     install = new InstallConfig(Map("SHIFTLEFT_CONSOLE_INSTALL_DIR" -> workspaceDir))
   )
   override val importCode = new MyImportCode(this)


### PR DESCRIPTION
driven by a user question in
https://discord.com/channels/832209896089976854/832214243230744626/986545250497597510
: hard wiring xdg-open to open images works for most, but not all
users. That's why it was already defined as a `var`, but that didn't
have any effect because config itself was a `def`.

If this gets approval, I'll also update the docs (incl. discussing
`predef.sc`) and ocular.