### PR TITLE
Allow `maxCallDepth` to be configured

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -26,7 +26,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
     * list is returned. Otherwise, the task is solved and its results are returned.
     */
   override def call(): Vector[ReachableByResult] = {
-    if (task.callDepth > context.config.maxCallDepth) {
+    if (context.config.maxCallDepth != -1 && task.callDepth > context.config.maxCallDepth) {
       Vector()
     } else {
       implicit val sem: Semantics = context.semantics

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
@@ -14,9 +14,8 @@ class StaticCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
   import StaticCallLinker._
   private val methodFullNameToNode = mutable.Map.empty[String, List[Method]]
 
-  /** Main method of enhancement - to be implemented by child class
-    */
   override def run(dstGraph: DiffGraphBuilder): Unit = {
+
     cpg.method.foreach { method =>
       methodFullNameToNode.updateWith(method.fullName) {
         case Some(l) => Some(method :: l)

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/JoernConsole.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/JoernConsole.scala
@@ -49,7 +49,7 @@ class JoernConsole extends Console[JoernProject](JoernAmmoniteExecutor, new Joer
 
   implicit def context: EngineContext =
     workspace.getActiveProject
-      .map(x => EngineContext(x.asInstanceOf[JoernProject].context.semantics))
+      .map(x => x.asInstanceOf[JoernProject].context)
       .getOrElse(EngineContext(JoernWorkspaceLoader.defaultSemantics))
 
   def banner(): Unit = {


### PR DESCRIPTION
The `maxCallDepth` parameter of the OSS data flow engine is picked up by the engine via `config.context.maxCallDepth`. Previously, however, it was not possible to set this parameter on the shell due to a bug fixed in this PR. In addition, with this PR, when setting `maxCallDepth` to -1, the engine will expand as far as possible.