### PR TITLE
jssrc2cpg: performance fix for file reading

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelJsonParser.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelJsonParser.scala
@@ -1,6 +1,6 @@
 package io.joern.jssrc2cpg.parser
 
-import io.shiftleft.utils.IOUtils
+import io.joern.jssrc2cpg.utils.JsIOUtils
 import ujson.Value.Value
 
 import java.nio.file.Path
@@ -11,12 +11,11 @@ object BabelJsonParser {
   case class ParseResult(filename: String, fullPath: String, json: Value, fileContent: String)
 
   def readFile(rootPath: Path, file: Path): ParseResult = {
-    val jsonContent       = IOUtils.readLinesInFile(file).mkString
-    val json              = ujson.read(jsonContent)
-    val filename          = json("relativeName").str
-    val fullPath          = Paths.get(rootPath.toString, filename)
-    val sourceFileContent = IOUtils.readLinesInFile(fullPath).mkString("", "\n", "\n")
-    ParseResult(filename, fullPath.toString, json, sourceFileContent)
+    val json     = ujson.read(file)
+    val filename = json("relativeName").str
+    val fullPath = Paths.get(rootPath.toString, filename)
+    val result   = JsIOUtils.readFile(fullPath)
+    ParseResult(filename, fullPath.toString, json, result)
   }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -6,6 +6,7 @@ import io.joern.jssrc2cpg.utils.Report
 import io.joern.jssrc2cpg.utils.TimeUtils
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.utils.AstGenRunner.AstGenRunnerResult
+import io.joern.jssrc2cpg.utils.JsIOUtils
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.shiftleft.utils.IOUtils
@@ -35,7 +36,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
     astGenRunnerResult.skippedFiles.foreach { skippedFile =>
       val (rootPath, fileName) = skippedFile
       val filePath             = Paths.get(rootPath, fileName)
-      val fileLOC              = IOUtils.readLinesInFile(filePath).size
+      val fileLOC              = JsIOUtils.countLinesInFile(filePath)
       report.addReportInfo(fileName, fileLOC)
     }
   }
@@ -44,7 +45,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
     val (rootPath, jsonFilename) = input
     val ((gotCpg, filename), duration) = TimeUtils.time {
       val parseResult = BabelJsonParser.readFile(Paths.get(rootPath), Paths.get(jsonFilename))
-      val fileLOC     = IOUtils.readLinesInFile(Paths.get(parseResult.fullPath)).size
+      val fileLOC     = JsIOUtils.countLinesInFile(Paths.get(parseResult.fullPath))
       report.addReportInfo(parseResult.filename, fileLOC, parsed = true)
       Try {
         val localDiff = new AstCreator(config, parseResult, usedTypes).createAst()

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/JsIOUtils.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/JsIOUtils.scala
@@ -1,0 +1,21 @@
+package io.joern.jssrc2cpg.utils
+
+import java.nio.file.Path
+
+object JsIOUtils {
+
+  def readFile(path: Path): String = {
+    val bufferedSource = scala.io.Source.fromFile(path.toFile)
+    val result         = bufferedSource.getLines().mkString("", "\n", "\n")
+    bufferedSource.close()
+    result
+  }
+
+  def countLinesInFile(path: Path): Int = {
+    val bufferedSource = scala.io.Source.fromFile(path.toFile)
+    val result         = bufferedSource.getLines().size
+    bufferedSource.close()
+    result
+  }
+
+}


### PR DESCRIPTION
Massively improves performance for larger JS/TS projects (e.g., https://github.com/appsmithorg/appsmith 40 sec -> 10 sec)
by using scala.io.Source.fromFile instead of our own IOUtils from x2cpg.
Have to figure out why.