### PR TITLE
kotlin2cpg: Refactor N°8

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -103,7 +103,7 @@ trait KtPsiToAst {
     typeInfoProvider: TypeInfoProvider
   ): Seq[Ast] = {
     parameters.zipWithIndex.map { case (valueParam, idx) =>
-      val typeFullName  = registerType(typeInfoProvider.typeFullName(valueParam, TypeConstants.any))
+      val typeFullName = registerType(typeInfoProvider.typeFullName(valueParam, TypeConstants.any))
 
       val thisParam       = methodParameterNode(Constants.this_, typeDecl.fullName).order(0)
       val thisIdentifier  = identifierNode(Constants.this_, typeDecl.fullName)
@@ -116,10 +116,10 @@ trait KtPsiToAst {
         List(returnAst(returnNode(Constants.ret), List(fieldAccessCallAst)))
       )
 
-      val componentIdx = idx + 1
+      val componentIdx  = idx + 1
       val componentName = s"${Constants.componentNPrefix}$componentIdx"
-      val signature = s"$typeFullName()"
-      val fullName = s"${typeDecl.fullName}.$componentName:$signature"
+      val signature     = s"$typeFullName()"
+      val fullName      = s"${typeDecl.fullName}.$componentName:$signature"
       methodAst(
         methodNode(componentName, fullName, signature, relativizedPath),
         Seq(thisParam),

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -832,9 +832,7 @@ trait KtPsiToAst {
         }.flatten
       case typedExpr: KtNameReferenceExpression =>
         val argIdx = if (isStaticCall) 1 else 2
-        val node =
-          fieldIdentifierNode(typedExpr.getText)
-            .argumentIndex(argIdx)
+        val node = fieldIdentifierNode(typedExpr.getText).argumentIndex(argIdx)
         List(Ast(node))
       case _ =>
         List()

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -346,7 +346,7 @@ trait KtPsiToAst {
   }
 
   def astForReturnExpression(expr: KtReturnExpression)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val children = astsForExpression(expr.getReturnedExpression, Some(1))
+    val children = astsForExpression(expr.getReturnedExpression, None)
     returnAst(returnNode(expr.getText, line(expr), column(expr)), children.toList)
   }
 
@@ -354,8 +354,8 @@ trait KtPsiToAst {
     typeInfoProvider: TypeInfoProvider
   ): Ast = {
     registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
-    val args = astsForExpression(expr.getLeftHandSide, Some(1)) ++
-      Seq(astForTypeReference(expr.getTypeReference, Some(2)))
+    val args = astsForExpression(expr.getLeftHandSide, None) ++
+      Seq(astForTypeReference(expr.getTypeReference, None))
     val node = operatorCallNode(Operators.is, expr.getText, None, line(expr), column(expr))
     callAst(withArgumentIndex(node, argIdx), args.toList)
   }
@@ -364,7 +364,7 @@ trait KtPsiToAst {
     typeInfoProvider: TypeInfoProvider
   ): Ast = {
     registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
-    val args = astsForExpression(expr.getLeft, Some(1)) ++ Seq(astForTypeReference(expr.getRight, Some(2)))
+    val args = astsForExpression(expr.getLeft, None) ++ Seq(astForTypeReference(expr.getRight, None))
     val node = operatorCallNode(Operators.cast, expr.getText, None, line(expr), column(expr))
     callAst(withArgumentIndex(node, argIdx), args.toList)
   }
@@ -563,7 +563,7 @@ trait KtPsiToAst {
     val assignmentLhsAst  = Ast(assignmentLhsNode).withRefEdge(assignmentLhsNode, localForTmpNode)
 
     val assignmentNode   = operatorCallNode(Operators.assignment, s"$tmpName = ${initExpr.getText}", None)
-    val assignmentRhsAst = astsForExpression(initExpr, Some(2)).head
+    val assignmentRhsAst = astsForExpression(initExpr, None).head
     val assignmentAst    = callAst(assignmentNode, List(assignmentLhsAst, assignmentRhsAst))
     registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
 
@@ -1243,9 +1243,9 @@ trait KtPsiToAst {
   def astForIfAsExpression(expr: KtIfExpression, argIdx: Option[Int])(implicit
     typeInfoProvider: TypeInfoProvider
   ): Ast = {
-    val conditionAsts = astsForExpression(expr.getCondition, Some(1))
-    val thenAsts      = astsForExpression(expr.getThen, Some(2))
-    val elseAsts      = astsForExpression(expr.getElse, Some(3))
+    val conditionAsts = astsForExpression(expr.getCondition, None)
+    val thenAsts      = astsForExpression(expr.getThen, None)
+    val elseAsts      = astsForExpression(expr.getElse, None)
 
     val returnTypeFullName = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
     val node = operatorCallNode(Operators.conditional, expr.getText, Some(returnTypeFullName), line(expr), column(expr))

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -686,7 +686,6 @@ trait KtPsiToAst {
       line(entry),
       column(entry)
     )
-      .argumentIndex(2)
 
     val componentNIdentifierAst = astWithRefEdgeMaybe(componentNIdentifierNode.name, componentNIdentifierNode)
     val componentNAst = Ast(componentNCallNode)
@@ -998,7 +997,6 @@ trait KtPsiToAst {
       Constants.javaUtilIterator,
       DispatchTypes.DYNAMIC_DISPATCH
     )
-      .argumentIndex(2)
 
     val iteratorAssignmentRhsAst = Ast(iteratorAssignmentRhs)
       .withChild(Ast(iteratorAssignmentRhsIdentifier))
@@ -1047,7 +1045,7 @@ trait KtPsiToAst {
       s"${TypeConstants.javaLangObject}()",
       TypeConstants.javaLangObject,
       DispatchTypes.DYNAMIC_DISPATCH
-    ).argumentIndex(2)
+    )
     val iteratorNextCallAst = Ast(iteratorNextCall)
       .withChild(iteratorNextIdentifierAst)
       .withArgEdge(iteratorNextCall, iteratorNextIdentifier)
@@ -1106,7 +1104,6 @@ trait KtPsiToAst {
       Constants.javaUtilIterator,
       DispatchTypes.DYNAMIC_DISPATCH
     )
-      .argumentIndex(2)
 
     val iteratorAssignmentRhsAst = Ast(iteratorAssignmentRhs)
       .withChild(Ast(iteratorAssignmentRhsIdentifier))
@@ -1161,7 +1158,7 @@ trait KtPsiToAst {
       s"${TypeConstants.javaLangObject}()",
       TypeConstants.javaLangObject,
       DispatchTypes.DYNAMIC_DISPATCH
-    ).argumentIndex(2)
+    )
 
     val iteratorNextCallAst = Ast(iteratorNextCall)
       .withChild(iteratorNextIdentifierAst)
@@ -1292,7 +1289,6 @@ trait KtPsiToAst {
       line(expr),
       column(expr)
     )
-      .argumentIndex(2)
     val initCallAst = Ast(initCallNode)
       .withChildren(List(initReceiverAst) ++ argAsts)
       .withArgEdges(initCallNode, Seq(initReceiverNode) ++ argAsts.flatMap(_.root))

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -933,7 +933,7 @@ trait KtPsiToAst {
       typeInfoProvider.expressionType(expr.getTryBlock.getStatements.asScala.last, TypeConstants.any)
     )
     val tryBlockAst = astsForExpression(expr.getTryBlock, None).headOption.getOrElse(Ast())
-    val clauseAsts = withIndex(expr.getCatchClauses.asScala.toSeq) { (entry, idx) =>
+    val clauseAsts = expr.getCatchClauses.asScala.toSeq.map { entry =>
       astsForExpression(entry.getCatchBody, None)
     }.flatten
     val node = operatorCallNode(Operators.tryCatch, expr.getText, Some(typeFullName), line(expr), column(expr))

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -103,12 +103,7 @@ trait KtPsiToAst {
     typeInfoProvider: TypeInfoProvider
   ): Seq[Ast] = {
     parameters.zipWithIndex.map { case (valueParam, idx) =>
-      val componentIdx = idx + 1
-
       val typeFullName  = registerType(typeInfoProvider.typeFullName(valueParam, TypeConstants.any))
-      val componentName = s"${Constants.componentNPrefix}$componentIdx"
-      val signature     = s"$typeFullName()"
-      val fullName      = s"${typeDecl.fullName}.$componentName:$signature"
 
       val thisParam       = methodParameterNode(Constants.this_, typeDecl.fullName).order(0)
       val thisIdentifier  = identifierNode(Constants.this_, typeDecl.fullName)
@@ -120,6 +115,11 @@ trait KtPsiToAst {
         blockNode(fieldAccessCall.code, typeFullName),
         List(returnAst(returnNode(Constants.ret), List(fieldAccessCallAst)))
       )
+
+      val componentIdx = idx + 1
+      val componentName = s"${Constants.componentNPrefix}$componentIdx"
+      val signature = s"$typeFullName()"
+      val fullName = s"${typeDecl.fullName}.$componentName:$signature"
       methodAst(
         methodNode(componentName, fullName, signature, relativizedPath),
         Seq(thisParam),

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -802,18 +802,10 @@ trait KtPsiToAst {
         List(Ast(node))
       case _ => List()
     }
-
-    val astDerivedMethodFullName = Operators.fieldAccess
-    val astDerivedSignature      = ""
-    val (fullName, signature) =
-      typeInfoProvider.fullNameWithSignature(expr, (astDerivedMethodFullName, astDerivedSignature))
     registerType(typeInfoProvider.containingDeclType(expr, TypeConstants.any))
-    val retType      = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
-    val methodName   = Operators.fieldAccess
-    val dispatchType = DispatchTypes.STATIC_DISPATCH
+    val retType = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
 
-    val _callNode =
-      callNode(expr.getText, methodName, fullName, signature, retType, dispatchType, line(expr), column(expr))
+    val _callNode    = operatorCallNode(Operators.fieldAccess, expr.getText, Some(retType), line(expr), column(expr))
     val root         = Ast(withArgumentIndex(_callNode, argIdx))
     val receiverNode = receiverAst.root.get
     val ast = root

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -510,7 +510,7 @@ trait KtPsiToAst {
       }
     )
     val typeFullName = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
-    val args = List(astsForExpression(expr.getBaseExpression, Some(1)).headOption.getOrElse(Ast()))
+    val args = List(astsForExpression(expr.getBaseExpression, None).headOption.getOrElse(Ast()))
       .filterNot(_.root == null)
     val node = operatorCallNode(operatorType, expr.getText, Some(typeFullName), line(expr), column(expr))
     callAst(withArgumentIndex(node, argIdx), args)
@@ -527,7 +527,7 @@ trait KtPsiToAst {
       }
     )
     val typeFullName = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
-    val args = List(astsForExpression(expr.getBaseExpression, Some(1)).headOption.getOrElse(Ast()))
+    val args = List(astsForExpression(expr.getBaseExpression, None).headOption.getOrElse(Ast()))
       .filterNot(_.root == null)
     val node = operatorCallNode(operatorType, expr.getText, Some(typeFullName), line(expr), column(expr))
     callAst(withArgumentIndex(node, argIdx), args)
@@ -914,14 +914,14 @@ trait KtPsiToAst {
   }
 
   private def astForTryAsStatement(expr: KtTryExpression)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val tryAstOption = astsForExpression(expr.getTryBlock, Some(1)).headOption
+    val tryAstOption = astsForExpression(expr.getTryBlock, None).headOption
       .getOrElse(Ast())
     val clauseAsts = withIndex(expr.getCatchClauses.asScala.toSeq) { (entry, idx) =>
-      astsForExpression(entry.getCatchBody, Some(idx + 1))
+      astsForExpression(entry.getCatchBody, None)
     }.flatten
     val finallyAsts = Option(expr.getFinallyBlock)
       .map(_.getFinalExpression)
-      .map(astsForExpression(_, Some(clauseAsts.size + 2)))
+      .map(astsForExpression(_, None))
       .getOrElse(Seq())
     val node = controlStructureNode(expr.getText, ControlStructureTypes.TRY, line(expr), column(expr))
     controlStructureAst(node, None, tryAstOption :: (clauseAsts ++ finallyAsts).toList)
@@ -934,9 +934,9 @@ trait KtPsiToAst {
       // TODO: remove the `last`
       typeInfoProvider.expressionType(expr.getTryBlock.getStatements.asScala.last, TypeConstants.any)
     )
-    val tryBlockAst = astsForExpression(expr.getTryBlock, Some(1)).headOption.getOrElse(Ast())
+    val tryBlockAst = astsForExpression(expr.getTryBlock, None).headOption.getOrElse(Ast())
     val clauseAsts = withIndex(expr.getCatchClauses.asScala.toSeq) { (entry, idx) =>
-      astsForExpression(entry.getCatchBody, Some(idx + 1))
+      astsForExpression(entry.getCatchBody, None)
     }.flatten
     val node = operatorCallNode(Operators.tryCatch, expr.getText, Some(typeFullName), line(expr), column(expr))
     callAst(withArgumentIndex(node, argIdx), List(tryBlockAst) ++ clauseAsts)
@@ -949,15 +949,15 @@ trait KtPsiToAst {
   }
 
   def astForWhile(expr: KtWhileExpression)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val conditionAst = astsForExpression(expr.getCondition, Some(1)).headOption
-    val stmtAsts     = astsForExpression(expr.getBody, Some(2))
+    val conditionAst = astsForExpression(expr.getCondition, None).headOption
+    val stmtAsts     = astsForExpression(expr.getBody, None)
     val node         = controlStructureNode(expr.getText, ControlStructureTypes.WHILE, line(expr), column(expr))
     controlStructureAst(node, conditionAst, stmtAsts.toList)
   }
 
   def astForDoWhile(expr: KtDoWhileExpression)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val conditionAst = astsForExpression(expr.getCondition, Some(2)).headOption
-    val stmtAsts     = astsForExpression(expr.getBody, Some(1))
+    val conditionAst = astsForExpression(expr.getCondition, None).headOption
+    val stmtAsts     = astsForExpression(expr.getBody, None)
     val node         = controlStructureNode(expr.getText, ControlStructureTypes.DO, line(expr), column(expr))
     controlStructureAst(node, conditionAst, stmtAsts.toList, true)
   }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -924,20 +924,9 @@ trait KtPsiToAst {
       else DispatchTypes.STATIC_DISPATCH
 
     val receiverAst = astsForExpression(expr.getReceiverExpression, Some(argIdxForReceiver)).head
-    val argAsts = expr.getSelectorExpression match {
-      case selectorExpression: KtCallExpression =>
-        withIndex(selectorExpression.getValueArguments.asScala.toSeq) { case (arg, idx) =>
-          val selectorArgIndex = if (isStaticCall) idx else argIdxForReceiver + idx
-          astsForExpression(arg.getArgumentExpression, Some(selectorArgIndex))
-        }.flatten
-      case typedExpr: KtNameReferenceExpression =>
-        val argIdx = if (isStaticCall) 1 else 2
-        val node   = fieldIdentifierNode(typedExpr.getText).argumentIndex(argIdx)
-        List(Ast(node))
-      case _ => List()
-    }
+    val argAsts     = selectorExpressionArgAsts(expr)
 
-    val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts.toList)
+    val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
     val (fullName, signature) =
       typeInfoProvider.fullNameWithSignature(expr, (astDerivedMethodFullName, astDerivedSignature))
     registerType(typeInfoProvider.containingDeclType(expr, TypeConstants.any))

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -805,15 +805,12 @@ trait KtPsiToAst {
     registerType(typeInfoProvider.containingDeclType(expr, TypeConstants.any))
     val retType = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
 
-    val _callNode    = operatorCallNode(Operators.fieldAccess, expr.getText, Some(retType), line(expr), column(expr))
-    val root         = Ast(withArgumentIndex(_callNode, argIdx))
-    val receiverNode = receiverAst.root.get
-    val ast = root
-      .withChild(receiverAst)
-      .withArgEdge(_callNode, receiverNode)
-      .withChildren(argAsts)
-      .withArgEdges(_callNode, argAsts.map(_.root.get))
-    ast.withReceiverEdge(_callNode, receiverNode)
+    val node = operatorCallNode(Operators.fieldAccess, expr.getText, Some(retType), line(expr), column(expr))
+    val nodeWithIdx = argIdx match {
+      case Some(idx) => node.argumentIndex(idx)
+      case None      => node
+    }
+    callAst(nodeWithIdx, List(receiverAst) ++ argAsts.toList)
   }
 
   private def astDerivedFullNameWithSignature(expr: KtQualifiedExpression, argAsts: List[Ast])(implicit

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CompanionObjectTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CompanionObjectTests.scala
@@ -52,6 +52,7 @@ class CompanionObjectTests extends KotlinCode2CpgFixture(withOssDataflow = false
       c.methodFullName shouldBe "<operator>.fieldAccess"
       c.name shouldBe "<operator>.fieldAccess"
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      c.argument.code.l shouldBe List("AClass", "m")
 
       val List(firstArg: Call, secondArg: FieldIdentifier) = c.argument.l
       firstArg.code shouldBe "AClass"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
@@ -157,6 +157,10 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       allocAssignmentRhs.argumentIndex shouldBe 2
 
       val List(tmpInitCall) = cpg.call.code(".*init.*").l
+      tmpInitCall.code shouldBe "<init>"
+      tmpInitCall.methodFullName shouldBe "main.AClass.<init>:void(java.lang.String,int)"
+      tmpInitCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      tmpInitCall.argument.code.l shouldBe List("tmp_1", "aMessage", "41414141")
 
       val List(initCallFirstArg: Identifier, initCallSecondArg: Identifier, initCallThirdArg: Literal) =
         tmpInitCall.argument.l


### PR DESCRIPTION
- remove unnecessary ARG_IDX sets
- make fns more readable