### PR TITLE
Remove most order-dependence from dataflowengineoss

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
@@ -19,7 +19,7 @@ object Path {
 
         val trackedSymbol = cfgNode match {
           case _: MethodParameterIn =>
-            val paramsPretty = method.parameter.toList.sortBy(_.order).map(_.code).mkString(", ")
+            val paramsPretty = method.parameter.toList.sortBy(_.index).map(_.code).mkString(", ")
             s"$methodName($paramsPretty)"
           case _ => cfgNode.statement.repr
         }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
@@ -11,7 +11,7 @@ class ExpressionMethods[NodeType <: Expression](val node: NodeType) extends AnyV
     */
   def isUsed(implicit semantics: Semantics): Boolean = {
     val s = semanticsForCallByArg
-    s.isEmpty || s.exists(_.mappings.exists { case (srcIndex, _) => srcIndex == node.order })
+    s.isEmpty || s.exists(_.mappings.exists { case (srcIndex, _) => srcIndex == node.argumentIndex })
   }
 
   /** Determine whether evaluation of the call this argument is a part of results in definition of this argument.
@@ -20,7 +20,7 @@ class ExpressionMethods[NodeType <: Expression](val node: NodeType) extends AnyV
     val s = semanticsForCallByArg.l
     s.isEmpty || s.exists { semantic =>
       semantic.mappings.exists { case (_, dstIndex) =>
-        dstIndex == node.order
+        dstIndex == node.argumentIndex
       }
     }
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -46,7 +46,7 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph {
   private val firstParam       = params.headOption
   private val lastParam        = params.lastOption
   private val firstOutputParam = firstParam.flatMap(_.asOutput.headOption)
-  private val lastOutputParam  = method.parameter.sortBy(_.order).asOutput.lastOption
+  private val lastOutputParam  = method.parameter.sortBy(_.index).asOutput.lastOption
 
   private val lastActualCfgNode = exitNode._cfgIn.nextOption()
 


### PR DESCRIPTION
While working on removing explicit order setting in javasrc2cpg, I ran into some dataflow issues due to order and argumentIndex/index no longer being the same in all cases. There are still a few checks in the dataflow engine that use order instead of index/argumentIndex, but I think using the latter makes more sense. This PR removes all uses of the order field from dataflowengineoss, except for one case where arbitrary expressions are sorted so we won't necessarily have an argumentIndex field available.