### PR TITLE
jssrc2cpg: fixes for duplicated AST node storage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion    = "1.3.545"
+val cpgVersion    = "1.3.547"
 val js2cpgVersion = "0.2.158"
 
 lazy val joerncli          = Projects.joerncli

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -347,11 +347,9 @@ trait AstForDeclarationsCreator {
     val lhsAst = nodeInfo.node match {
       case BabelAst.ObjectPattern =>
         val sourceAst = astForNodeWithFunctionReference(createBabelNodeInfo(rhsElement).json)
-        Ast.storeInDiffGraph(sourceAst, diffGraph)
         astForDeconstruction(nodeInfo, sourceAst)
       case BabelAst.ArrayPattern =>
         val sourceAst = astForNodeWithFunctionReference(createBabelNodeInfo(rhsElement).json)
-        Ast.storeInDiffGraph(sourceAst, diffGraph)
         astForDeconstruction(nodeInfo, sourceAst)
       case _ => astForNode(lhsElement)
     }
@@ -407,11 +405,9 @@ trait AstForDeclarationsCreator {
     val lhsAst = nodeInfo.node match {
       case BabelAst.ObjectPattern =>
         val sourceAst = astForNodeWithFunctionReference(createBabelNodeInfo(rhsElement).json)
-        Ast.storeInDiffGraph(sourceAst, diffGraph)
         astForDeconstruction(nodeInfo, sourceAst)
       case BabelAst.ArrayPattern =>
         val sourceAst = astForNodeWithFunctionReference(createBabelNodeInfo(rhsElement).json)
-        Ast.storeInDiffGraph(sourceAst, diffGraph)
         astForDeconstruction(nodeInfo, sourceAst)
       case _ => astForNode(lhsElement)
     }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -55,7 +55,7 @@ trait AstForDeclarationsCreator {
     } else {
       createFieldAccessCallAst(
         createIdentifierNode(exportName, declaration),
-        createIdentifierNode(name, declaration),
+        createFieldIdentifierNode(name, declaration.lineNumber, declaration.columnNumber),
         declaration.lineNumber,
         declaration.columnNumber
       )
@@ -124,7 +124,6 @@ trait AstForDeclarationsCreator {
           declaration.lineNumber,
           declaration.columnNumber
         )
-      Ast.storeInDiffGraph(destAst, diffGraph)
       Ast.storeInDiffGraph(sourceAst, diffGraph)
       assigmentCallAst
     }
@@ -251,10 +250,8 @@ trait AstForDeclarationsCreator {
       val nodeInfo = createBabelNodeInfo(id.json)
       nodeInfo.node match {
         case BabelAst.ObjectPattern =>
-          Ast.storeInDiffGraph(sourceAst, diffGraph)
           astForDeconstruction(nodeInfo, sourceAst)
         case BabelAst.ArrayPattern =>
-          Ast.storeInDiffGraph(sourceAst, diffGraph)
           astForDeconstruction(nodeInfo, sourceAst)
         case _ =>
           val destAst = astForNode(id.json)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -171,19 +171,13 @@ trait AstForExpressionsCreator {
     val memberNodeInfo   = createBabelNodeInfo(memberExpr.json("property"))
     val memberNode =
       if (memberIsComputed) {
-        astForNode(memberNodeInfo.json)
+        val node = astForNode(memberNodeInfo.json)
+        Ast.storeInDiffGraph(node, diffGraph)
+        node
       } else {
         Ast(createFieldIdentifierNode(memberNodeInfo.code, memberNodeInfo.lineNumber, memberNodeInfo.columnNumber))
       }
-    Ast.storeInDiffGraph(memberNode, diffGraph)
-    val accessAst =
-      createFieldAccessCallAst(
-        baseAst.nodes.head,
-        memberNode.nodes.head,
-        memberExpr.lineNumber,
-        memberExpr.columnNumber
-      )
-    accessAst
+    createFieldAccessCallAst(baseAst.nodes.head, memberNode.nodes.head, memberExpr.lineNumber, memberExpr.columnNumber)
   }
 
   protected def astForAssignmentExpression(assignment: BabelNodeInfo): Ast = {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -207,7 +207,6 @@ trait AstForExpressionsCreator {
     nodeInfo.node match {
       case BabelAst.ObjectPattern | BabelAst.ArrayPattern =>
         val rhsAst = astForNodeWithFunctionReference(assignment.json("right"))
-        Ast.storeInDiffGraph(rhsAst, diffGraph)
         astForDeconstruction(nodeInfo, rhsAst)
       case _ =>
         val lhsAst = astForNode(assignment.json("left"))

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -81,16 +81,24 @@ trait AstNodeBuilder {
   protected def setIndices(asts: List[Ast], receiver: Option[Ast] = None): Unit = {
     var currIndex = 1
     var currOrder = 1
-    asts.foreach { a =>
+
+    val remainingAsts = asts match {
+      case head :: rest
+          if head.root.exists(x => x.isInstanceOf[NewIdentifier] && x.asInstanceOf[NewIdentifier].code == "this") =>
+        val x = head.root.get.asInstanceOf[NewIdentifier]
+        x.argumentIndex = 0
+        x.order = 1
+        currOrder = currOrder + 1
+        rest
+      case others => others
+    }
+
+    remainingAsts.foreach { a =>
       a.root match {
-        case Some(x: ExpressionNew) if x.code != "this" || x.isInstanceOf[NewLiteral] =>
+        case Some(x: ExpressionNew) =>
           x.argumentIndex = currIndex
           x.order = currOrder
           currIndex = currIndex + 1
-          currOrder = currOrder + 1
-        case Some(x: ExpressionNew) =>
-          x.argumentIndex = 0
-          x.order = 1
           currOrder = currOrder + 1
         case _ =>
           currIndex = currIndex + 1

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/AstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/AstCreationPassTest.scala
@@ -4760,12 +4760,27 @@ class AstCreationPassTest extends AbstractPassTest {
 
   "AST generation for exports" should {
     "have correct structure for simple names and aliases" in AstFixture("""
+        |var name1, name2, name3, name6;
+        |var variable4, variable5;
         |export { name1, name2, name3 };
         |export { variable4 as name4, variable5 as name5, name6 };
         |export let name7, name8, name9;
         |export let name10 = "10", name11 = "11", name12;
         |""".stripMargin) { cpg =>
-      cpg.local.code.l shouldBe List("name7", "name8", "name9", "name10", "name11", "name12")
+      cpg.local.code.l shouldBe List(
+        "name1",
+        "name2",
+        "name3",
+        "name6",
+        "variable4",
+        "variable5",
+        "name7",
+        "name8",
+        "name9",
+        "name10",
+        "name11",
+        "name12"
+      )
       cpg.call(Operators.assignment).code.l shouldBe List(
         "exports.name1 = name1",
         "exports.name2 = name2",
@@ -4785,11 +4800,12 @@ class AstCreationPassTest extends AbstractPassTest {
     }
 
     "have correct structure for defaults" in AstFixture("""
+        |var name1;
         |export { name1 as default };
         |export default name2 = "2";
         |export default function foo(param) {};
         |""".stripMargin) { cpg =>
-      cpg.local.code.l shouldBe List("foo", "name2")
+      cpg.local.code.l shouldBe List("name1", "foo", "name2")
       cpg.call(Operators.assignment).code.l shouldBe List(
         "exports[\"default\"] = name1",
         "name2 = \"2\"",

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TsAstCreationPassTest.scala
@@ -88,10 +88,9 @@ class TsAstCreationPassTest extends AbstractPassTest with Inside {
     "have correct modifier" in AstFixture("""
         |abstract class Greeter {
         |  static a: string;
-        |  #b: string;
-        |  private c: string;
-        |  public d: string;
-        |  protected e: string;
+        |  private b: string;
+        |  public c: string;
+        |  protected d: string;
         |}
         |""".stripMargin) { cpg =>
       inside(cpg.typeDecl.name("Greeter.*").l) { case List(greeter, greeterMeta) =>
@@ -99,9 +98,9 @@ class TsAstCreationPassTest extends AbstractPassTest with Inside {
         greeter.name shouldBe "Greeter"
         cpg.typeDecl.isAbstract.head shouldBe greeter
         greeterMeta.member.isStatic.head shouldBe greeterMeta.member.name("a").head
-        greeter.member.isPrivate.l shouldBe List(greeter.member.name("b").head, greeter.member.name("c").head)
-        greeter.member.isPublic.head shouldBe greeter.member.name("d").head
-        greeter.member.isProtected.head shouldBe greeter.member.name("e").head
+        greeter.member.isPrivate.head shouldBe greeter.member.name("b").head
+        greeter.member.isPublic.head shouldBe greeter.member.name("c").head
+        greeter.member.isProtected.head shouldBe greeter.member.name("d").head
       }
     }
 


### PR DESCRIPTION
This PR together with https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1642
enables joern imports of JS/TS projects containing template code.

_TODO_: update cpg version here once https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1642 is released.