### PR TITLE
Fix NAMESPACE_BLOCK properties.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -294,10 +294,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val namespaceBlock = packageDecl match {
       case Some(decl) =>
         val packageName = decl.getName.toString
-        val name        = packageName.split("\\.").lastOption.getOrElse("")
+        val fullName    = filename + ":" + packageName
         NewNamespaceBlock()
-          .name(name)
-          .fullName(packageName)
+          .name(packageName)
+          .fullName(fullName)
       case None =>
         globalNamespaceBlock()
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/FileTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/FileTests.scala
@@ -32,7 +32,7 @@ class FileTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should allow traversing from file to its namespace blocks" in {
-    cpg.file.nameNot(FileTraversal.UNKNOWN).namespaceBlock.name.toSetMutable shouldBe Set("b")
+    cpg.file.nameNot(FileTraversal.UNKNOWN).namespaceBlock.name.toSetMutable shouldBe Set("a.b")
   }
 
   "should allow traversing from file to its methods via namespace block" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/NamespaceBlockTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/NamespaceBlockTests.scala
@@ -20,9 +20,9 @@ class NamespaceBlockTests extends JavaSrcCodeToCpgFixture {
 
   "should contain correct namespace block for known file" in {
     val List(x) = cpg.namespaceBlock.filename(".*.java").l
-    x.name shouldBe "bar"
+    x.name shouldBe "foo.bar"
     x.filename should not be ""
-    x.fullName shouldBe s"foo.bar"
+    x.fullName should endWith(":foo.bar")
     x.order shouldBe 1
   }
 
@@ -35,7 +35,7 @@ class NamespaceBlockTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should allow traversing from namespace block to namespace" in {
-    cpg.namespaceBlock.filename(".*java").namespace.name.l shouldBe List("bar")
+    cpg.namespaceBlock.filename(".*java").namespace.name.l shouldBe List("foo.bar")
   }
 
 }


### PR DESCRIPTION
NAMESPACE_BLOCK NAME actually need to be the full namespace identifier
and FULL_NAME need to be a unique identifier for the block itself.
This is at the moment contradicting the CPG docu but the docu is wrong
and will be updated shortly.