### PR TITLE
jssrc2cpg: Added ConfigPass and file filtering

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -2,6 +2,9 @@ package io.joern.jssrc2cpg
 
 import better.files.File
 import io.joern.jssrc2cpg.passes.{AstCreationPass, BuiltinTypesPass, CallLinkerPass, JsMetaDataPass, TypeNodePass}
+import io.joern.jssrc2cpg.passes.ConfigPass
+import io.joern.jssrc2cpg.passes.DependenciesPass
+import io.joern.jssrc2cpg.passes.PrivateKeyFilePass
 import io.joern.jssrc2cpg.utils.AstGenRunner
 import io.joern.jssrc2cpg.utils.AstGenRunner.AstGenRunnerResult
 import io.joern.jssrc2cpg.utils.Report
@@ -9,6 +12,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.utils.HashUtil
+import io.joern.x2cpg.SourceFiles
 
 import java.nio.file.Path
 import scala.util.Try
@@ -17,14 +21,17 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
 
   private val report: Report = new Report()
 
+  private def configFiles(config: Config, extensions: Set[String]): Seq[File] =
+    SourceFiles.determine(config.inputPath, extensions).map(File(_))
+
   def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config) { (cpg, config) =>
       File.usingTemporaryDirectory("jssrc2cpgOut") { tmpDir =>
-        val partialResult = AstGenRunner.execute(File(config.inputPath), tmpDir)
+        val partialResult = AstGenRunner.execute(config, tmpDir)
         val astgenResult =
           AstGenRunnerResult(parsedFiles = partialResult.parsedFiles, skippedFiles = partialResult.skippedFiles)
 
-        val hash = HashUtil.sha256(astgenResult.parsedFiles.map { case (_, file) => Path.of(file) }.toSeq)
+        val hash = HashUtil.sha256(astgenResult.parsedFiles.map { case (_, file) => Path.of(file) })
 
         val astCreationPass = new AstCreationPass(cpg, astgenResult, config, report)
         astCreationPass.createAndApply()
@@ -32,6 +39,15 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
         new CallLinkerPass(cpg).createAndApply()
         new JsMetaDataPass(cpg, hash, config.inputPath).createAndApply()
         new BuiltinTypesPass(cpg).createAndApply()
+        new DependenciesPass(cpg, config).createAndApply()
+        new ConfigPass(
+          cpg,
+          configFiles(config, Set(".json", ".config.js", ".conf.js", ".vue", ".html")),
+          config,
+          report
+        ).createAndApply()
+        new PrivateKeyFilePass(cpg, configFiles(config, Set(".key")), config, report).createAndApply()
+
         report.print()
       }
     }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
@@ -6,8 +6,24 @@ import io.joern.x2cpg.X2CpgConfig
 import io.joern.x2cpg.X2CpgMain
 import scopt.OParser
 
-final case class Config(inputPath: String = "", outputPath: String = X2CpgConfig.defaultOutputPath)
-    extends X2CpgConfig[Config] {
+import java.nio.file.Paths
+import scala.util.matching.Regex
+
+final case class Config(
+  inputPath: String = "",
+  outputPath: String = X2CpgConfig.defaultOutputPath,
+  ignoredFilesRegex: Regex = "".r,
+  ignoredFiles: Seq[String] = Seq.empty
+) extends X2CpgConfig[Config] {
+
+  def createPathForIgnore(ignore: String): String = {
+    val path = Paths.get(ignore)
+    if (path.isAbsolute) {
+      path.toString
+    } else {
+      Paths.get(inputPath, ignore).toAbsolutePath.normalize().toString
+    }
+  }
 
   override def withInputPath(inputPath: String): Config = copy(inputPath = inputPath)
   override def withOutputPath(x: String): Config        = copy(outputPath = x)
@@ -18,8 +34,17 @@ private object Frontend {
 
   val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
-    import builder.programName
-    OParser.sequence(programName("jssrc2cpg"))
+    import builder._
+    OParser.sequence(
+      programName("jssrc2cpg"),
+      opt[Seq[String]]("exclude")
+        .valueName("<file1>,<file2>,...")
+        .action((x, c) => c.copy(ignoredFiles = c.ignoredFiles ++ x.map(c.createPathForIgnore)))
+        .text("files or folders to exclude during CPG generation (paths relative to <input-dir> or absolute paths)"),
+      opt[String]("exclude-regex")
+        .action((x, c) => c.copy(ignoredFilesRegex = x.r))
+        .text("a regex specifying files to exclude during CPG generation (the absolute file path is matched)")
+    )
   }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -1,12 +1,12 @@
 package io.joern.jssrc2cpg.astcreation
 
 import io.joern.x2cpg.datastructures.Stack._
-import io.joern.jssrc2cpg.parser.BabelAst
-import io.joern.jssrc2cpg.parser.BabelJsonParser.ParseResult
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.datastructures.Scope
-import io.joern.jssrc2cpg.passes.Defines
+import io.joern.jssrc2cpg.parser.BabelAst
+import io.joern.jssrc2cpg.parser.BabelJsonParser.ParseResult
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
+import io.joern.jssrc2cpg.passes.Defines
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes}
 import overflowdb.BatchedUpdate.DiffGraphBuilder

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -1,8 +1,8 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.x2cpg.datastructures.Stack._
 import io.joern.jssrc2cpg.parser.BabelAst
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
+import io.joern.x2cpg.datastructures.Stack._
 import io.joern.jssrc2cpg.passes.Defines
 import io.joern.jssrc2cpg.passes.EcmaBuiltins
 import io.joern.jssrc2cpg.passes.GlobalBuiltins

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -1,9 +1,9 @@
 package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.datastructures.BlockScope
-import io.joern.x2cpg.datastructures.Stack._
 import io.joern.jssrc2cpg.parser.BabelAst
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
+import io.joern.x2cpg.datastructures.Stack._
 import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.EdgeTypes

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,8 +1,8 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.x2cpg.datastructures.Stack._
 import io.joern.jssrc2cpg.parser.BabelAst
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
+import io.joern.x2cpg.datastructures.Stack._
 import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
@@ -1,6 +1,7 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.jssrc2cpg.parser.{BabelAst, BabelNodeInfo}
+import io.joern.jssrc2cpg.parser.BabelAst
+import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.x2cpg.Ast
 import ujson.Obj
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -1,8 +1,8 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.x2cpg.datastructures.Stack._
 import io.joern.jssrc2cpg.parser.BabelAst
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
+import io.joern.x2cpg.datastructures.Stack._
 import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.EdgeTypes

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -1,6 +1,7 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.jssrc2cpg.parser.{BabelAst, BabelNodeInfo}
+import io.joern.jssrc2cpg.parser.BabelAst
+import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
 
 trait TypeHelper {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -1,10 +1,10 @@
 package io.joern.jssrc2cpg.passes
 
 import io.joern.jssrc2cpg.astcreation.AstCreator
-import io.joern.jssrc2cpg.parser.BabelJsonParser
 import io.joern.jssrc2cpg.utils.Report
 import io.joern.jssrc2cpg.utils.TimeUtils
 import io.joern.jssrc2cpg.Config
+import io.joern.jssrc2cpg.parser.BabelJsonParser
 import io.joern.jssrc2cpg.utils.AstGenRunner.AstGenRunnerResult
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConfigPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConfigPass.scala
@@ -1,0 +1,39 @@
+package io.joern.jssrc2cpg.passes
+
+import better.files.File
+import io.joern.jssrc2cpg.utils.Report
+import io.joern.jssrc2cpg.utils.TimeUtils
+import io.joern.jssrc2cpg.Config
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.utils.IOUtils
+import org.slf4j.{Logger, LoggerFactory}
+
+class ConfigPass(cpg: Cpg, files: Seq[File], config: Config, report: Report = new Report())
+    extends ConcurrentWriterCpgPass[File](cpg) {
+
+  private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  override def generateParts(): Array[File] = files.toArray
+
+  protected def fileContent(file: File): Seq[String] =
+    IOUtils.readLinesInFile(file.path)
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, file: File): Unit = {
+    val path = File(config.inputPath).path.toAbsolutePath.relativize(file.path).toString
+    logger.debug(s"Adding file '$path' as config.")
+    val (gotCpg, duration) = TimeUtils.time {
+      val localDiff  = new DiffGraphBuilder
+      val content    = fileContent(file)
+      val loc        = content.size
+      val configNode = NewConfigFile().name(path).content(content.mkString("\n"))
+      report.addReportInfo(path, loc, parsed = true)
+      localDiff.addNode(configNode)
+      localDiff
+    }
+    diffGraph.absorb(gotCpg)
+    report.updateReport(path, cpg = true, duration)
+  }
+
+}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
@@ -14,7 +14,6 @@ class DependenciesPass(cpg: Cpg, config: Config) extends SimpleCpgPass(cpg) {
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val packagesJsons = SourceFiles
       .determine(config.inputPath, Set(".json"))
-      .toSet
       .filter(f =>
         f.endsWith(PackageJsonParser.PACKAGE_JSON_FILENAME) || f.endsWith(PackageJsonParser.PACKAGE_JSON_LOCK_FILENAME)
       )

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/PrivateKeyFilePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/PrivateKeyFilePass.scala
@@ -1,0 +1,22 @@
+package io.joern.jssrc2cpg.passes
+
+import better.files.File
+import io.joern.jssrc2cpg.utils.Report
+import io.joern.jssrc2cpg.Config
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.utils.IOUtils
+
+import scala.util.matching.Regex
+
+class PrivateKeyFilePass(cpg: Cpg, files: Seq[File], config: Config, report: Report = new Report())
+    extends ConfigPass(cpg, files, config, report) {
+
+  private val PRIVATE_KEY: Regex = """.*RSA\sPRIVATE\sKEY.*""".r
+
+  override def fileContent(file: File): Seq[String] =
+    Seq("Content omitted for security reasons.")
+
+  override def generateParts(): Array[File] =
+    super.generateParts().filter(p => IOUtils.readLinesInFile(p.path).exists(PRIVATE_KEY.matches))
+
+}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -1,10 +1,12 @@
 package io.joern.jssrc2cpg.utils
 
 import better.files.File
+import io.joern.jssrc2cpg.Config
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 
+import java.nio.file.Paths
 import scala.util.Failure
 import scala.util.Success
 
@@ -15,11 +17,11 @@ object AstGenRunner {
   private val TYPE_DEFINITION_FILE_EXTENSIONS = List(".t.ts.json", ".d.ts.json")
 
   case class AstGenRunnerResult(
-    parsedFiles: Set[(String, String)] = Set.empty,
-    skippedFiles: Set[(String, String)] = Set.empty
+    parsedFiles: List[(String, String)] = List.empty,
+    skippedFiles: List[(String, String)] = List.empty
   )
 
-  private def skippedFiles(in: File, astgenOut: Set[String]): Set[String] = {
+  private def skippedFiles(in: File, astgenOut: List[String]): List[String] = {
     val skipped = astgenOut.collect {
       case out if !out.startsWith("Converted") =>
         val filename = out.substring(0, out.indexOf(" "))
@@ -33,19 +35,38 @@ object AstGenRunner {
     skipped.flatten
   }
 
-  private def filterFiles(files: List[String]): Set[String] = {
-    // We are not interested in JS / TS type definition files at this stage.
-    // TODO: maybe we can enable that later on and use the type definitions there
-    //  for enhancing the CPG with additional type information for functions
-    files.filterNot(f => TYPE_DEFINITION_FILE_EXTENSIONS.exists(f.endsWith)).toSet
+  private def shouldBeIgnoredByUserConfig(filePath: String, config: Config, out: File): Boolean = {
+    val resolvedFilePath = filePath.replace(out.pathAsString, config.inputPath)
+    val isInIgnoredFiles = config.ignoredFiles.exists {
+      case ignorePath if File(ignorePath).isDirectory => resolvedFilePath.startsWith(ignorePath)
+      case ignorePath                                 => resolvedFilePath == ignorePath
+    }
+    if (isInIgnoredFiles || config.ignoredFilesRegex.matches(resolvedFilePath)) {
+      logger.debug(s"'$filePath' ignored by user configuration")
+      true
+    } else {
+      false
+    }
   }
 
-  def execute(in: File, out: File): AstGenRunnerResult = {
+  private def filterFiles(files: List[String], config: Config, out: File): List[String] = {
+    files.filter {
+      case filePath if TYPE_DEFINITION_FILE_EXTENSIONS.exists(filePath.endsWith) =>
+        // We are not interested in JS / TS type definition files at this stage.
+        // TODO: maybe we can enable that later on and use the type definitions there
+        //  for enhancing the CPG with additional type information for functions
+        false
+      case filePath => !shouldBeIgnoredByUserConfig(filePath.stripSuffix(".json"), config, out)
+    }
+  }
+
+  def execute(config: Config, out: File): AstGenRunnerResult = {
+    val in = File(config.inputPath)
     logger.debug(s"\t+ Running astgen in '$in' ...")
     ExternalCommand.run(s"astgen -t ts -o $out", in.toString()) match {
       case Success(result) =>
-        val parsed  = filterFiles(SourceFiles.determine(out.toString(), Set(".json")))
-        val skipped = skippedFiles(in, result.toSet)
+        val parsed  = filterFiles(SourceFiles.determine(out.toString(), Set(".json")), config, out)
+        val skipped = skippedFiles(in, result.toList)
         AstGenRunnerResult(parsed.map((in.toString(), _)), skipped.map((in.toString(), _)))
       case Failure(f) =>
         logger.error("\t- running astgen failed!", f)

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/a.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/a.js
@@ -1,0 +1,1 @@
+console.log("a.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/folder/b.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/folder/b.js
@@ -1,0 +1,1 @@
+console.log("folder/b.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/folder/c.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/folder/c.js
@@ -1,0 +1,1 @@
+console.log("folder/c.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/foo.bar/d.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/foo.bar/d.js
@@ -1,0 +1,1 @@
+console.log("foo.bar/d.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/index.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/index.js
@@ -1,0 +1,1 @@
+console.log("index.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/a.spec.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/a.spec.js
@@ -1,0 +1,1 @@
+console.log("tests/a.spec.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/b.mock.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/b.mock.js
@@ -1,0 +1,1 @@
+console.log("tests/b.mock.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/c.e2e.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/c.e2e.js
@@ -1,0 +1,1 @@
+console.log("tests/c.e2e.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/d.test.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/d.test.js
@@ -1,0 +1,1 @@
+console.log("tests/d.test.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTest.scala
@@ -1,0 +1,125 @@
+package io.joern.jssrc2cpg.io
+
+import better.files.File
+import io.joern.jssrc2cpg.Config
+import io.joern.jssrc2cpg.JsSrc2Cpg
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.{NodeTypes, PropertyNames}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+import overflowdb.traversal._
+
+import java.util.regex.Pattern
+
+class ExcludeTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+
+  private val projectUnderTestPath = File(getClass.getResource("/excludes").toURI).pathAsString
+
+  private def fileNames(cpg: Cpg): List[String] =
+    TraversalSource(cpg.graph).label(NodeTypes.FILE).property(PropertyNames.NAME).toList
+
+  private def testWithArguments(exclude: Seq[String], excludeRegex: String, expectedFiles: Set[String]): Unit = {
+    var cpg = Cpg.emptyCpg
+    File.usingTemporaryFile("cpg", ".bin") { cpgFile =>
+      val jssrc2cpg = new JsSrc2Cpg()
+      val config    = Config(inputPath = projectUnderTestPath)
+      val finalConfig = config.copy(
+        outputPath = cpgFile.toString(),
+        ignoredFiles = exclude.map(config.createPathForIgnore),
+        ignoredFilesRegex = excludeRegex.r
+      )
+      cpg = jssrc2cpg.createCpg(finalConfig).get
+    }
+    fileNames(cpg) should contain theSameElementsAs expectedFiles.map(_.replace("/", java.io.File.separator))
+  }
+
+  "Using different excludes via program arguments" should {
+
+    val testInput = Table(
+      // -- Header for naming all test parameters
+      ("statement", "exclude", "excludeRegex", "expectedResult"),
+      // --
+      // Test for default:
+      (
+        "exclude nothing if no excludes are given",
+        Seq.empty[String],
+        "",
+        Set("index.js", "a.js", "folder/b.js", "folder/c.js", "foo.bar/d.js")
+      ),
+      // --
+      // Tests for --exclude only:
+      (
+        "exclude a file with --exclude with relative path",
+        Seq("index.js"),
+        "",
+        Set("a.js", "folder/b.js", "folder/c.js", "foo.bar/d.js")
+      ),
+      (
+        "exclude files with --exclude with relative paths",
+        Seq("index.js", "folder/b.js"),
+        "",
+        Set("a.js", "folder/c.js", "foo.bar/d.js")
+      ),
+      (
+        "exclude a file with --exclude with absolute path",
+        Seq(s"$projectUnderTestPath/index.js"),
+        "",
+        Set("a.js", "folder/b.js", "folder/c.js", "foo.bar/d.js")
+      ),
+      (
+        "exclude files with --exclude with absolute paths",
+        Seq(s"$projectUnderTestPath/index.js", s"$projectUnderTestPath/folder/b.js"),
+        "",
+        Set("a.js", "folder/c.js", "foo.bar/d.js")
+      ),
+      (
+        "exclude files with --exclude with mixed paths",
+        Seq("index.js", s"$projectUnderTestPath/folder/b.js"),
+        "",
+        Set("a.js", "folder/c.js", "foo.bar/d.js")
+      ),
+      (
+        "exclude a folder with --exclude with absolute path",
+        Seq(s"$projectUnderTestPath/folder/"),
+        "",
+        Set("a.js", "index.js", "foo.bar/d.js")
+      ),
+      (
+        "exclude a folder with --exclude with relative path",
+        Seq("folder/"),
+        "",
+        Set("a.js", "index.js", "foo.bar/d.js")
+      ),
+      // --
+      // Tests for --exclude-regex only:
+      (
+        "exclude a file with --exclude-regex",
+        Seq.empty,
+        ".*index\\..*",
+        Set("a.js", "folder/b.js", "folder/c.js", "foo.bar/d.js")
+      ),
+      ("exclude files with --exclude-regex", Seq.empty, ".*(index|b)\\..*", Set("a.js", "folder/c.js", "foo.bar/d.js")),
+      (
+        "exclude a complete folder with --exclude-regex",
+        Seq.empty,
+        s".*${Pattern.quote(java.io.File.separator)}folder${Pattern.quote(java.io.File.separator)}.*",
+        Set("index.js", "a.js", "foo.bar/d.js")
+      ),
+      // --
+      // Tests for mixed arguments
+      (
+        "exclude files with --exclude and --exclude-regex",
+        Seq("a.js"),
+        ".*(index|b)\\..*",
+        Set("folder/c.js", "foo.bar/d.js")
+      )
+    )
+
+    forAll(testInput) { (statement, exclude, excludeRegex, result) =>
+      s"$statement" in testWithArguments(exclude, excludeRegex, result)
+    }
+
+  }
+
+}

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ProjectParseTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ProjectParseTests.scala
@@ -1,4 +1,4 @@
-package io.joern.jssrc2cpg.parser
+package io.joern.jssrc2cpg.io
 
 import better.files.File
 import io.joern.jssrc2cpg.testfixtures.JsSrc2CpgFrontend

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConfigPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConfigPassTest.scala
@@ -1,0 +1,137 @@
+package io.joern.jssrc2cpg.passes
+
+import better.files.File
+import io.joern.jssrc2cpg.Config
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.ConfigFile
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import overflowdb.traversal.TraversalSource
+
+class ConfigPassTest extends AnyWordSpec with Matchers {
+
+  private def configFiles(cpg: Cpg): List[ConfigFile] = {
+    val result = TraversalSource(cpg.graph).label(NodeTypes.CONFIG_FILE).cast[ConfigFile].toList
+    result.size should not be 0
+    result
+  }
+
+  "ConfigPass for Vue files" should {
+
+    "generate ConfigFiles correctly for simply Vue project" in {
+      File.usingTemporaryDirectory("jssrc2cpgTest") { dir =>
+        val fileA = dir / "a.vue"
+        val fileB = dir / "b.vue"
+        fileA.write("someCodeA();")
+        fileB.write("someCodeB();")
+        val cpg       = Cpg.emptyCpg
+        val filenames = Seq(fileA, fileB)
+        new ConfigPass(cpg, filenames, Config(inputPath = dir.pathAsString)).createAndApply()
+
+        val allConfigFiles = configFiles(cpg)
+
+        val configFileA =
+          allConfigFiles.find(_.name == "a.vue").getOrElse(fail("ConfigFile 'a.vue' not found!"))
+        val configFileB =
+          allConfigFiles.find(_.name == "b.vue").getOrElse(fail("ConfigFile 'b.vue' not found!"))
+
+        configFileA.content shouldBe "someCodeA();"
+        configFileB.content shouldBe "someCodeB();"
+      }
+    }
+
+  }
+
+  "ConfigPass for other config files" should {
+
+    "generate ConfigFiles correctly for simple JS project" in {
+      File.usingTemporaryDirectory("jssrc2cpgTest") { dir =>
+        val fileA = dir / "a.conf.js"
+        val fileB = dir / "b.config.js"
+        val fileC = dir / "c.json"
+
+        fileA.write("a")
+        fileB.write("b")
+        fileC.write("c")
+
+        val cpg   = Cpg.emptyCpg
+        val files = Seq(fileA, fileB, fileC)
+        new ConfigPass(cpg, files, Config(inputPath = dir.pathAsString)).createAndApply()
+
+        val allConfigFiles = configFiles(cpg)
+
+        val configFileA =
+          allConfigFiles
+            .find(_.name == "a.conf.js")
+            .getOrElse(fail("ConfigFile 'a.conf.js' not found!"))
+        val configFileB =
+          allConfigFiles
+            .find(_.name == "b.config.js")
+            .getOrElse(fail("ConfigFile 'b.config.js' not found!"))
+        val configFileC =
+          allConfigFiles.find(_.name == "c.json").getOrElse(fail("ConfigFile 'c.json' not found!"))
+
+        configFileA.content shouldBe "a"
+        configFileB.content shouldBe "b"
+        configFileC.content shouldBe "c"
+      }
+    }
+
+  }
+
+  "ConfigPass for html files" should {
+
+    "generate ConfigFiles correctly for simple JS project with html files" in {
+      File.usingTemporaryDirectory("jssrc2cpgTest") { dir =>
+        val fileA = dir / "a.html"
+        val fileB = dir / "b.html"
+
+        fileA.write("a")
+        fileB.write("b")
+
+        val cpg   = Cpg.emptyCpg
+        val files = Seq(fileA, fileB)
+        new ConfigPass(cpg, files, Config(inputPath = dir.pathAsString)).createAndApply()
+
+        val allConfigFiles = configFiles(cpg)
+        val configFileA =
+          allConfigFiles
+            .find(_.name == "a.html")
+            .getOrElse(fail("ConfigFile 'a.html' not found!"))
+        val configFileB =
+          allConfigFiles
+            .find(_.name == "b.html")
+            .getOrElse(fail("ConfigFile 'b.html' not found!"))
+
+        configFileA.content shouldBe "a"
+        configFileB.content shouldBe "b"
+      }
+    }
+
+  }
+
+  "PrivateKeyFilePass" should {
+
+    "generate ConfigFiles correctly" in {
+      File.usingTemporaryDirectory("jssrc2cpgTest") { dir =>
+        val fileA = dir / "a.key"
+        fileA.write("-----BEGIN RSA PRIVATE KEY-----\n123456789\n-----END RSA PRIVATE KEY-----")
+        val fileB = dir / "b.key"
+        fileB.write("-----BEGIN SOME OTHER KEY-----\nthis is fine\n-----END SOME OTHER KEY-----")
+
+        val cpg   = Cpg.emptyCpg
+        val files = Seq(fileA, fileB)
+        new PrivateKeyFilePass(cpg, files, Config(inputPath = dir.pathAsString)).createAndApply()
+
+        val allConfigFiles = configFiles(cpg)
+        val configFileA =
+          allConfigFiles.find(_.name == "a.key").getOrElse(fail("ConfigFile 'a.key' not found!"))
+        configFileA.content shouldBe "Content omitted for security reasons."
+
+        allConfigFiles.find(_.name == "b.key") shouldBe empty
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
We had these config files in js2cpg already and they may carry information required for our internal codescience passes.

Also: file filtering / user defined excludes were supported by js2cpg - ported that over.