### PR TITLE
javasrc: New test fixture migration #1

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -141,7 +141,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewMethodReturn,
   NewModifier,
   NewNamespaceBlock,
-  NewNode,
   NewReturn,
   NewTypeDecl,
   NewTypeRef,

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
@@ -1,269 +1,285 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.{Annotation, AnnotationLiteral, ArrayInitializer}
 import io.shiftleft.semanticcpg.language._
 
-class AnnotationTestMethod1 extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.NormalAnnotation;
-      |public class SomeClass {
-      |
-      |  @NormalAnnotation(value = "classAnnotation")
-      |  void function() {
-      |
-      |  }
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    val annotationNode = cpg.method.name("function").annotation.head
-    annotationNode.code shouldBe "@NormalAnnotation(value = \"classAnnotation\")"
-    annotationNode.name shouldBe "NormalAnnotation"
-    annotationNode.fullName shouldBe "some.NormalAnnotation"
+class AnnotationTests extends JavaSrcCode2CpgFixture {
+  "normal value annotations" should {
+    lazy val cpg = code(
+      """
+        |import some.NormalAnnotation;
+        |public class SomeClass {
+        |
+        |  @NormalAnnotation(value = "classAnnotation")
+        |  void function() {
+        |
+        |  }
+        |}
+        |""".stripMargin
+    )
+
+    "test annotation node properties" in {
+      val annotationNode = cpg.method.name("function").annotation.head
+      annotationNode.code shouldBe "@NormalAnnotation(value = \"classAnnotation\")"
+      annotationNode.name shouldBe "NormalAnnotation"
+      annotationNode.fullName shouldBe "some.NormalAnnotation"
+    }
+
+    "test annotation node parameter assignment child" in {
+      val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
+      paramAssign.code shouldBe "value = \"classAnnotation\""
+      paramAssign.order shouldBe 1
+    }
+
+    "test annotation node parameter child" in {
+      val Seq(param) = cpg.method.name("function").annotation.parameterAssign.parameter.l
+      param.code shouldBe "value"
+      param.order shouldBe 1
+    }
+
+    "test annotation node parameter value" in {
+      val Seq(paramValue) = cpg.method.name("function").annotation.parameterAssign.value.l
+      paramValue.code shouldBe "classAnnotation"
+      paramValue.order shouldBe 2
+      paramValue.argumentIndex shouldBe 2
+    }
   }
 
-  "test annotation node parameter assignment child" in {
-    val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
-    paramAssign.code shouldBe "value = \"classAnnotation\""
-    paramAssign.order shouldBe 1
+  "single annotations" should {
+    lazy val cpg = code(
+      """
+        |import some.SingleAnnotation;
+        |public class SomeClass {
+        |
+        |  @SingleAnnotation("classAnnotation")
+        |  void function() {
+        |
+        |  }
+        |}
+        |""".stripMargin
+    )
+
+    "test annotation node properties" in {
+      val annotationNode = cpg.method.name("function").annotation.head
+      annotationNode.code shouldBe "@SingleAnnotation(\"classAnnotation\")"
+      annotationNode.name shouldBe "SingleAnnotation"
+      annotationNode.fullName shouldBe "some.SingleAnnotation"
+    }
+
+    "test annotation node parameter assignment child" in {
+      val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
+      paramAssign.code shouldBe "\"classAnnotation\""
+      paramAssign.order shouldBe 1
+    }
+
+    "test annotation node parameter child" in {
+      val Seq(param) = cpg.method.name("function").annotation.parameterAssign.parameter.l
+      param.code shouldBe "value"
+      param.order shouldBe 1
+    }
+
+    "test annotation node parameter value" in {
+      val Seq(paramValue) = cpg.method.name("function").annotation.parameterAssign.value.l
+      paramValue.code shouldBe "classAnnotation"
+      paramValue.order shouldBe 2
+      paramValue.argumentIndex shouldBe 2
+    }
   }
 
-  "test annotation node parameter child" in {
-    val Seq(param) = cpg.method.name("function").annotation.parameterAssign.parameter.l
-    param.code shouldBe "value"
-    param.order shouldBe 1
+  "function marker annotations" should {
+    lazy val cpg = code(
+      """
+        |import some.MarkerAnnotation;
+        |public class SomeClass {
+        |
+        |  @MarkerAnnotation()
+        |  void function() {
+        |
+        |  }
+        |}
+        |""".stripMargin
+    )
+    "test annotation node properties" in {
+      val annotationNode = cpg.method.name("function").annotation.head
+      annotationNode.code shouldBe "@MarkerAnnotation()"
+      annotationNode.name shouldBe "MarkerAnnotation"
+      annotationNode.fullName shouldBe "some.MarkerAnnotation"
+    }
+
+    "test annotation node parameter assignment child" in {
+      cpg.method.name("function").annotation.parameterAssign.isEmpty shouldBe true
+    }
   }
 
-  "test annotation node parameter value" in {
-    val Seq(paramValue) = cpg.method.name("function").annotation.parameterAssign.value.l
-    paramValue.code shouldBe "classAnnotation"
-    paramValue.order shouldBe 2
-    paramValue.argumentIndex shouldBe 2
-  }
-}
+  "class marker annotations" should {
+    lazy val cpg = code(
+      """
+        |import some.MarkerAnnotation;
+        |public class SomeClass {
+        |
+        |  @MarkerAnnotation()
+        |  public SomeClass() {
+        |
+        |  }
+        |}
+        |""".stripMargin
+    )
 
-class AnnotationTestMethod2 extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.SingleAnnotation;
-      |public class SomeClass {
-      |
-      |  @SingleAnnotation("classAnnotation")
-      |  void function() {
-      |
-      |  }
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    val annotationNode = cpg.method.name("function").annotation.head
-    annotationNode.code shouldBe "@SingleAnnotation(\"classAnnotation\")"
-    annotationNode.name shouldBe "SingleAnnotation"
-    annotationNode.fullName shouldBe "some.SingleAnnotation"
-  }
+    "test annotation node properties" in {
+      import scala.jdk.CollectionConverters._
+      val annotationNode = cpg.method.nameExact("SomeClass").annotation.head
+      annotationNode.code shouldBe "@MarkerAnnotation()"
+      annotationNode.name shouldBe "MarkerAnnotation"
+      annotationNode.fullName shouldBe "some.MarkerAnnotation"
+    }
 
-  "test annotation node parameter assignment child" in {
-    val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
-    paramAssign.code shouldBe "\"classAnnotation\""
-    paramAssign.order shouldBe 1
+    "test annotation node parameter assignment child" in {
+      cpg.method.name("function").annotation.parameterAssign.isEmpty shouldBe true
+    }
   }
 
-  "test annotation node parameter child" in {
-    val Seq(param) = cpg.method.name("function").annotation.parameterAssign.parameter.l
-    param.code shouldBe "value"
-    param.order shouldBe 1
+  "parameter annotations" should {
+    lazy val cpg = code(
+      """
+        |import some.MarkerAnnotation;
+        |public class SomeClass {
+        |
+        |  void function(@MarkerAnnotation int x) {
+        |
+        |  }
+        |}
+        |""".stripMargin
+    )
+    "test annotation node properties" in {
+      val annotationNode = cpg.method.name("function").parameter.name("x").annotation.head
+      annotationNode.code shouldBe "@MarkerAnnotation"
+      annotationNode.name shouldBe "MarkerAnnotation"
+      annotationNode.fullName shouldBe "some.MarkerAnnotation"
+    }
   }
 
-  "test annotation node parameter value" in {
-    val Seq(paramValue) = cpg.method.name("function").annotation.parameterAssign.value.l
-    paramValue.code shouldBe "classAnnotation"
-    paramValue.order shouldBe 2
-    paramValue.argumentIndex shouldBe 2
-  }
-}
+  "field annotations" should {
+    lazy val cpg = code(
+      """
+        |import some.MarkerAnnotation;
+        |public class SomeClass {
+        |  @MarkerAnnotation int x;
+        |}
+        |""".stripMargin
+    )
 
-class AnnotationTestMethod3 extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.MarkerAnnotation;
-      |public class SomeClass {
-      |
-      |  @MarkerAnnotation()
-      |  void function() {
-      |
-      |  }
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    val annotationNode = cpg.method.name("function").annotation.head
-    annotationNode.code shouldBe "@MarkerAnnotation()"
-    annotationNode.name shouldBe "MarkerAnnotation"
-    annotationNode.fullName shouldBe "some.MarkerAnnotation"
+    "test annotation node properties" in {
+      val annotationNode = cpg.typeDecl.name("SomeClass").member.name("x").annotation.head
+      annotationNode.code shouldBe "@MarkerAnnotation"
+      annotationNode.name shouldBe "MarkerAnnotation"
+      annotationNode.fullName shouldBe "some.MarkerAnnotation"
+    }
   }
 
-  "test annotation node parameter assignment child" in {
-    cpg.method.name("function").annotation.parameterAssign.isEmpty shouldBe true
-  }
-}
+  "function value annotations" should {
+    lazy val cpg = code(
+      """
+        |import some.NormalAnnotation;
+        |public class SomeClass {
+        |
+        |  @NormalAnnotation(value = 2)
+        |  void function() {
+        |
+        |  }
+        |}
+        |""".stripMargin
+    )
+    "test annotation node properties" in {
+      val annotationNode = cpg.method.name("function").annotation.head
+      annotationNode.code shouldBe "@NormalAnnotation(value = 2)"
+      annotationNode.name shouldBe "NormalAnnotation"
+      annotationNode.fullName shouldBe "some.NormalAnnotation"
+    }
 
-class AnnotationTestConstructor extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.MarkerAnnotation;
-      |public class SomeClass {
-      |
-      |  @MarkerAnnotation()
-      |  public SomeClass() {
-      |
-      |  }
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    import scala.jdk.CollectionConverters._
-    val annotationNode = cpg.method.nameExact("SomeClass").annotation.head
-    annotationNode.code shouldBe "@MarkerAnnotation()"
-    annotationNode.name shouldBe "MarkerAnnotation"
-    annotationNode.fullName shouldBe "some.MarkerAnnotation"
-  }
-
-  "test annotation node parameter assignment child" in {
-    cpg.method.name("function").annotation.parameterAssign.isEmpty shouldBe true
-  }
-}
-
-class AnnotationTestParameter extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.MarkerAnnotation;
-      |public class SomeClass {
-      |
-      |  void function(@MarkerAnnotation int x) {
-      |
-      |  }
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    val annotationNode = cpg.method.name("function").parameter.name("x").annotation.head
-    annotationNode.code shouldBe "@MarkerAnnotation"
-    annotationNode.name shouldBe "MarkerAnnotation"
-    annotationNode.fullName shouldBe "some.MarkerAnnotation"
-  }
-}
-
-class AnnotationTestField extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.MarkerAnnotation;
-      |public class SomeClass {
-      |  @MarkerAnnotation int x;
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    val annotationNode = cpg.typeDecl.name("SomeClass").member.name("x").annotation.head
-    annotationNode.code shouldBe "@MarkerAnnotation"
-    annotationNode.name shouldBe "MarkerAnnotation"
-    annotationNode.fullName shouldBe "some.MarkerAnnotation"
-  }
-}
-
-class AnnotationTestValue1 extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.NormalAnnotation;
-      |public class SomeClass {
-      |
-      |  @NormalAnnotation(value = 2)
-      |  void function() {
-      |
-      |  }
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    val annotationNode = cpg.method.name("function").annotation.head
-    annotationNode.code shouldBe "@NormalAnnotation(value = 2)"
-    annotationNode.name shouldBe "NormalAnnotation"
-    annotationNode.fullName shouldBe "some.NormalAnnotation"
+    "test annotation node parameter value" in {
+      val Seq(paramValue: AnnotationLiteral) = cpg.method.name("function").annotation.parameterAssign.value.l
+      paramValue.code shouldBe "2"
+      paramValue.order shouldBe 2
+      paramValue.argumentIndex shouldBe 2
+    }
   }
 
-  "test annotation node parameter value" in {
-    val Seq(paramValue: AnnotationLiteral) = cpg.method.name("function").annotation.parameterAssign.value.l
-    paramValue.code shouldBe "2"
-    paramValue.order shouldBe 2
-    paramValue.argumentIndex shouldBe 2
-  }
-}
+  "function value annotations with array initializers" should {
+    lazy val cpg = code(
+      """
+        |import some.NormalAnnotation;
+        |public class SomeClass {
+        |
+        |  @NormalAnnotation(value = {"aaa", "bbb"})
+        |  void function() {
+        |
+        |  }
+        |}
+        |""".stripMargin
+    )
+    "test annotation node properties" in {
+      val annotationNode = cpg.method.name("function").annotation.head
+      annotationNode.code shouldBe "@NormalAnnotation(value = { \"aaa\", \"bbb\" })"
+      annotationNode.name shouldBe "NormalAnnotation"
+      annotationNode.fullName shouldBe "some.NormalAnnotation"
+    }
 
-class AnnotationTestValue2 extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.NormalAnnotation;
-      |public class SomeClass {
-      |
-      |  @NormalAnnotation(value = {"aaa", "bbb"})
-      |  void function() {
-      |
-      |  }
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    val annotationNode = cpg.method.name("function").annotation.head
-    annotationNode.code shouldBe "@NormalAnnotation(value = { \"aaa\", \"bbb\" })"
-    annotationNode.name shouldBe "NormalAnnotation"
-    annotationNode.fullName shouldBe "some.NormalAnnotation"
-  }
+    "test annotation node parameter assignment child" in {
+      val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
+      paramAssign.code shouldBe "value = { \"aaa\", \"bbb\" }"
+      paramAssign.order shouldBe 1
+    }
 
-  "test annotation node parameter assignment child" in {
-    val Seq(paramAssign) = cpg.method.name("function").annotation.parameterAssign.l
-    paramAssign.code shouldBe "value = { \"aaa\", \"bbb\" }"
-    paramAssign.order shouldBe 1
-  }
+    "test annotation node parameter child" in {
+      val Seq(param) = cpg.method.name("function").annotation.parameterAssign.parameter.l
+      param.code shouldBe "value"
+      param.order shouldBe 1
+    }
 
-  "test annotation node parameter child" in {
-    val Seq(param) = cpg.method.name("function").annotation.parameterAssign.parameter.l
-    param.code shouldBe "value"
-    param.order shouldBe 1
-  }
+    "test annotation node parameter value" in {
+      val Seq(paramValue: ArrayInitializer) = cpg.method.name("function").annotation.parameterAssign.value.l
+      paramValue.code shouldBe "{ \"aaa\", \"bbb\" }"
+      paramValue.order shouldBe 2
+      paramValue.argumentIndex shouldBe 2
+    }
 
-  "test annotation node parameter value" in {
-    val Seq(paramValue: ArrayInitializer) = cpg.method.name("function").annotation.parameterAssign.value.l
-    paramValue.code shouldBe "{ \"aaa\", \"bbb\" }"
-    paramValue.order shouldBe 2
-    paramValue.argumentIndex shouldBe 2
-  }
-
-  "test annotation node array initializer children" in {
-    val children = cpg.method.name("function").annotation.parameterAssign.value.astChildren.isExpression.s
-    children.find(_.code == "aaa").map(_.order) shouldBe Some(1)
-    children.find(_.code == "aaa").map(_.argumentIndex) shouldBe Some(1)
-    children.find(_.code == "bbb").map(_.order) shouldBe Some(2)
-    children.find(_.code == "bbb").map(_.argumentIndex) shouldBe Some(2)
-  }
-}
-
-class AnnotationTestValue3 extends JavaSrcCodeToCpgFixture {
-  override val code =
-    """
-      |import some.NormalAnnotation;
-      |import some.OtherAnnotation;
-      |public class SomeClass {
-      |
-      |  @NormalAnnotation(value = @OtherAnnotation)
-      |  void function() {
-      |
-      |  }
-      |}
-      |""".stripMargin
-  "test annotation node properties" in {
-    val annotationNode = cpg.method.name("function").annotation.head
-    annotationNode.code shouldBe "@NormalAnnotation(value = @OtherAnnotation)"
-    annotationNode.name shouldBe "NormalAnnotation"
-    annotationNode.fullName shouldBe "some.NormalAnnotation"
+    "test annotation node array initializer children" in {
+      val children = cpg.method.name("function").annotation.parameterAssign.value.astChildren.isExpression.s
+      children.find(_.code == "aaa").map(_.order) shouldBe Some(1)
+      children.find(_.code == "aaa").map(_.argumentIndex) shouldBe Some(1)
+      children.find(_.code == "bbb").map(_.order) shouldBe Some(2)
+      children.find(_.code == "bbb").map(_.argumentIndex) shouldBe Some(2)
+    }
   }
 
-  "test annotation node parameter value" in {
-    val Seq(paramValue: Annotation) = cpg.method.name("function").annotation.parameterAssign.value.l
-    paramValue.code shouldBe "@OtherAnnotation"
-    paramValue.fullName shouldBe "some.OtherAnnotation"
-    paramValue.order shouldBe 2
+  "nested annotations" should {
+    lazy val cpg = code(
+      """
+        |import some.NormalAnnotation;
+        |import some.OtherAnnotation;
+        |public class SomeClass {
+        |
+        |  @NormalAnnotation(value = @OtherAnnotation)
+        |  void function() {
+        |
+        |  }
+        |}
+        |""".stripMargin
+    )
+
+    "test annotation node properties" in {
+      val annotationNode = cpg.method.name("function").annotation.head
+      annotationNode.code shouldBe "@NormalAnnotation(value = @OtherAnnotation)"
+      annotationNode.name shouldBe "NormalAnnotation"
+      annotationNode.fullName shouldBe "some.NormalAnnotation"
+    }
+
+    "test annotation node parameter value" in {
+      val Seq(paramValue: Annotation) = cpg.method.name("function").annotation.parameterAssign.value.l
+      paramValue.code shouldBe "@OtherAnnotation"
+      paramValue.fullName shouldBe "some.OtherAnnotation"
+      paramValue.order shouldBe 2
+    }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
@@ -6,8 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class AnnotationTests extends JavaSrcCode2CpgFixture {
   "normal value annotations" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.NormalAnnotation;
         |public class SomeClass {
         |
@@ -16,8 +15,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
         |
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
 
     "test annotation node properties" in {
       val annotationNode = cpg.method.name("function").annotation.head
@@ -47,8 +45,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
   }
 
   "single annotations" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.SingleAnnotation;
         |public class SomeClass {
         |
@@ -57,8 +54,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
         |
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
 
     "test annotation node properties" in {
       val annotationNode = cpg.method.name("function").annotation.head
@@ -88,8 +84,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
   }
 
   "function marker annotations" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.MarkerAnnotation;
         |public class SomeClass {
         |
@@ -98,8 +93,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
         |
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
     "test annotation node properties" in {
       val annotationNode = cpg.method.name("function").annotation.head
       annotationNode.code shouldBe "@MarkerAnnotation()"
@@ -113,8 +107,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
   }
 
   "class marker annotations" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.MarkerAnnotation;
         |public class SomeClass {
         |
@@ -123,8 +116,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
         |
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
 
     "test annotation node properties" in {
       import scala.jdk.CollectionConverters._
@@ -140,8 +132,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
   }
 
   "parameter annotations" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.MarkerAnnotation;
         |public class SomeClass {
         |
@@ -149,8 +140,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
         |
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
     "test annotation node properties" in {
       val annotationNode = cpg.method.name("function").parameter.name("x").annotation.head
       annotationNode.code shouldBe "@MarkerAnnotation"
@@ -160,14 +150,12 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
   }
 
   "field annotations" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.MarkerAnnotation;
         |public class SomeClass {
         |  @MarkerAnnotation int x;
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
 
     "test annotation node properties" in {
       val annotationNode = cpg.typeDecl.name("SomeClass").member.name("x").annotation.head
@@ -178,8 +166,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
   }
 
   "function value annotations" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.NormalAnnotation;
         |public class SomeClass {
         |
@@ -188,8 +175,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
         |
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
     "test annotation node properties" in {
       val annotationNode = cpg.method.name("function").annotation.head
       annotationNode.code shouldBe "@NormalAnnotation(value = 2)"
@@ -206,8 +192,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
   }
 
   "function value annotations with array initializers" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.NormalAnnotation;
         |public class SomeClass {
         |
@@ -216,8 +201,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
         |
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
     "test annotation node properties" in {
       val annotationNode = cpg.method.name("function").annotation.head
       annotationNode.code shouldBe "@NormalAnnotation(value = { \"aaa\", \"bbb\" })"
@@ -254,8 +238,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
   }
 
   "nested annotations" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import some.NormalAnnotation;
         |import some.OtherAnnotation;
         |public class SomeClass {
@@ -265,8 +248,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
         |
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
 
     "test annotation node properties" in {
       val annotationNode = cpg.method.name("function").annotation.head

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArithmeticOperationsTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArithmeticOperationsTests.scala
@@ -9,9 +9,7 @@ import io.shiftleft.semanticcpg.language._
 
 class ArithmeticOperationsTests extends JavaSrcCode2CpgFixture {
 
-
-  lazy val cpg: Cpg = code(
-    """
+  lazy val cpg: Cpg = code("""
       | class Foo {
       |   static void main(int argc, char argv) {
       |     int a = 1;
@@ -22,8 +20,7 @@ class ArithmeticOperationsTests extends JavaSrcCode2CpgFixture {
       |     int f = b / a;
       |   }
       | }
-      |""".stripMargin
-  )
+      |""".stripMargin)
 
   val vars = Seq(("a", "int"), ("b", "int"), ("c", "int"), ("d", "int"), ("e", "int"), ("f", "int"))
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArithmeticOperationsTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArithmeticOperationsTests.scala
@@ -1,17 +1,16 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
-import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve, toNodeTypeStarters}
+import io.shiftleft.semanticcpg.language.toNodeTypeStarters
 import io.shiftleft.semanticcpg.language._
-import org.scalatest.Ignore
 
-class ArithmeticOperationsTests extends JavaSrcCodeToCpgFixture {
+class ArithmeticOperationsTests extends JavaSrcCode2CpgFixture {
 
-  implicit val resolver: ICallResolver = NoResolve
 
-  override val code: String =
+  lazy val cpg: Cpg = code(
     """
       | class Foo {
       |   static void main(int argc, char argv) {
@@ -24,6 +23,7 @@ class ArithmeticOperationsTests extends JavaSrcCodeToCpgFixture {
       |   }
       | }
       |""".stripMargin
+  )
 
   val vars = Seq(("a", "int"), ("b", "int"), ("c", "int"), ("d", "int"), ("e", "int"), ("f", "int"))
 
@@ -45,7 +45,14 @@ class ArithmeticOperationsTests extends JavaSrcCodeToCpgFixture {
     val List(op)                           = cpg.call.nameExact(Operators.addition).l
     val List(a: Identifier, b: Identifier) = op.astOut.l
     a.name shouldBe "a"
+    a.code shouldBe "a"
+    a.typeFullName shouldBe "int"
+    a.argumentIndex shouldBe 1
+
     b.name shouldBe "b"
+    b.code shouldBe "b"
+    b.typeFullName shouldBe "int"
+    b.argumentIndex shouldBe 2
   }
 
   "should contain a call node for the subtraction operator" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArrayTests.scala
@@ -8,15 +8,13 @@ import io.shiftleft.semanticcpg.language._
 class ArrayTests extends JavaSrcCode2CpgFixture {
 
   "array initializer expressions" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |class Foo {
         |  public void foo() {
         |    int[] x = {0, 1, 2};
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
     "initialize array with constant initialization expression" in {
       def m = cpg.method(".*foo.*")
 
@@ -35,15 +33,13 @@ class ArrayTests extends JavaSrcCode2CpgFixture {
   }
 
   "array initializers without constant initialization expressions" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |class Foo {
         |  public void bar() {
         |    int[][] x = new int[5][2];
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
 
     "initialize an array with empty initialization expression" in {
       def m = cpg.method(".*bar.*")
@@ -60,8 +56,7 @@ class ArrayTests extends JavaSrcCode2CpgFixture {
   }
 
   "array index accesses" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |class Foo {
         |  public void baz() {
         |    int[] x = new int[2];
@@ -69,9 +64,7 @@ class ArrayTests extends JavaSrcCode2CpgFixture {
         |    x[1] = x[0] + 2;
         |  }
         |}
-        |""".stripMargin
-
-    )
+        |""".stripMargin)
 
     "be handled correctly" in {
       def m = cpg.method(".*baz.*")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArrayTests.scala
@@ -1,86 +1,102 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
-import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
 import io.shiftleft.semanticcpg.language._
 
-class ArrayTests extends JavaSrcCodeToCpgFixture {
+class ArrayTests extends JavaSrcCode2CpgFixture {
 
-  implicit val resolver: ICallResolver = NoResolve
+  "array initializer expressions" should {
+    lazy val cpg = code(
+      """
+        |class Foo {
+        |  public void foo() {
+        |    int[] x = {0, 1, 2};
+        |  }
+        |}
+        |""".stripMargin
+    )
+    "initialize array with constant initialization expression" in {
+      def m = cpg.method(".*foo.*")
 
-  override val code: String =
-    """
-      |class Foo {
-      |  public void foo() {
-      |    int[] x = {0, 1, 2};
-      |  }
-      |
-      |  public void bar() {
-      |    int[][] x = new int[5][2];
-      |  }
-      |
-      |  public void baz() {
-      |    int[] x = new int[2];
-      |    x[0] = 1;
-      |    x[1] = x[0] + 2;
-      |  }
-      |}
-      |""".stripMargin
+      val List(arg1: Identifier, arg2: Call) = m.assignment.argument.l
 
-  "should initialize array with constant initialization expression" in {
-    def m = cpg.method(".*foo.*")
-
-    val List(arg1: Identifier, arg2: Call) = m.assignment.argument.l
-
-    arg1.code shouldBe "x"
-    arg1.typeFullName shouldBe "int[]"
-
-    arg2.code shouldBe "{ 0, 1, 2 }"
-    arg2.methodFullName shouldBe "<operator>.arrayInitializer"
-    arg2.astChildren.zipWithIndex.foreach { case (arg, idx) =>
-      arg shouldBe a[Literal]
-      arg.code shouldBe idx.toString
-    }
-  }
-
-  "should initialize an array with empty initialization expression" in {
-    def m = cpg.method(".*bar.*")
-
-    val List(arg1: Identifier, arg2: Call) = m.assignment.argument.l
-
-    arg1.typeFullName shouldBe "int[][]"
-
-    arg2.code shouldBe "new int[5][2]"
-    val List(lvl1: Literal, lvl2: Literal) = arg2.argument.l
-    lvl1.code shouldBe "5"
-    lvl2.code shouldBe "2"
-  }
-
-  "should handle arrayIndexAccesses correctly" in {
-    def m = cpg.method(".*baz.*")
-
-    val List(_, lhsAccess, rhsAccess) = m.assignment.l
-
-    withClue("indexAccess on LHS of assignment") {
-      val List(indexAccess: Call, _: Literal) = lhsAccess.argument.l
-      indexAccess.name shouldBe Operators.indexAccess
-      indexAccess.methodFullName shouldBe Operators.indexAccess
-      val List(arg1: Identifier, arg2: Literal) = indexAccess.argument.l
       arg1.code shouldBe "x"
-      arg1.name shouldBe "x"
       arg1.typeFullName shouldBe "int[]"
-      arg2.code shouldBe "0"
-    }
 
-    withClue("indexAccess in expr on RHS of assignment") {
-      val List(_, add: Call)                           = rhsAccess.argument.l
-      val List(access: Call, _: Literal)               = add.argument.l
-      val List(identifier: Identifier, index: Literal) = access.argument.l
-      identifier.name shouldBe "x"
-      identifier.typeFullName shouldBe "int[]"
-      index.code shouldBe "0"
+      arg2.code shouldBe "{ 0, 1, 2 }"
+      arg2.methodFullName shouldBe "<operator>.arrayInitializer"
+      arg2.astChildren.zipWithIndex.foreach { case (arg, idx) =>
+        arg shouldBe a[Literal]
+        arg.code shouldBe idx.toString
+      }
+    }
+  }
+
+  "array initializers without constant initialization expressions" should {
+    lazy val cpg = code(
+      """
+        |class Foo {
+        |  public void bar() {
+        |    int[][] x = new int[5][2];
+        |  }
+        |}
+        |""".stripMargin
+    )
+
+    "initialize an array with empty initialization expression" in {
+      def m = cpg.method(".*bar.*")
+
+      val List(arg1: Identifier, arg2: Call) = m.assignment.argument.l
+
+      arg1.typeFullName shouldBe "int[][]"
+
+      arg2.code shouldBe "new int[5][2]"
+      val List(lvl1: Literal, lvl2: Literal) = arg2.argument.l
+      lvl1.code shouldBe "5"
+      lvl2.code shouldBe "2"
+    }
+  }
+
+  "array index accesses" should {
+    lazy val cpg = code(
+      """
+        |class Foo {
+        |  public void baz() {
+        |    int[] x = new int[2];
+        |    x[0] = 1;
+        |    x[1] = x[0] + 2;
+        |  }
+        |}
+        |""".stripMargin
+
+    )
+
+    "be handled correctly" in {
+      def m = cpg.method(".*baz.*")
+
+      val List(_, lhsAccess, rhsAccess) = m.assignment.l
+
+      withClue("indexAccess on LHS of assignment") {
+        val List(indexAccess: Call, _: Literal) = lhsAccess.argument.l
+        indexAccess.name shouldBe Operators.indexAccess
+        indexAccess.methodFullName shouldBe Operators.indexAccess
+        val List(arg1: Identifier, arg2: Literal) = indexAccess.argument.l
+        arg1.code shouldBe "x"
+        arg1.name shouldBe "x"
+        arg1.typeFullName shouldBe "int[]"
+        arg2.code shouldBe "0"
+      }
+
+      withClue("indexAccess in expr on RHS of assignment") {
+        val List(_, add: Call)                           = rhsAccess.argument.l
+        val List(access: Call, _: Literal)               = add.argument.l
+        val List(identifier: Identifier, index: Literal) = access.argument.l
+        identifier.name shouldBe "x"
+        identifier.typeFullName shouldBe "int[]"
+        index.code shouldBe "0"
+      }
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BindingTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BindingTests.scala
@@ -5,7 +5,7 @@ import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 
 class BindingTests extends JavaSrcCode2CpgFixture {
   "override for generic method" should {
-    val cpg = code("""
+    lazy val cpg = code("""
         |import java.util.function.Consumer;
         |
         |class SomeConsumer implements Consumer<Integer> {
@@ -27,7 +27,7 @@ class BindingTests extends JavaSrcCode2CpgFixture {
   }
 
   "override for generic method" should {
-    val cpg = code(
+    lazy val cpg = code(
       """
         |import java.util.function.Consumer;
         |

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
@@ -7,8 +7,7 @@ import io.shiftleft.semanticcpg.language._
 
 class BooleanOperationsTests extends JavaSrcCode2CpgFixture {
 
-  lazy val cpg = code(
-    """
+  lazy val cpg = code("""
       | public class Foo {
       |   public static void main(String[] args) {
       |     boolean a = 1 == 2;
@@ -24,8 +23,7 @@ class BooleanOperationsTests extends JavaSrcCode2CpgFixture {
       |     boolean k = true;
       |   }
       | }
-      |""".stripMargin
-  )
+      |""".stripMargin)
 
   val vars = Seq(
     ("a", "boolean"),

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
@@ -1,15 +1,13 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
 
-class BooleanOperationsTests extends JavaSrcCodeToCpgFixture {
+class BooleanOperationsTests extends JavaSrcCode2CpgFixture {
 
-  implicit val resolver: ICallResolver = NoResolve
-
-  override val code: String =
+  lazy val cpg = code(
     """
       | public class Foo {
       |   public static void main(String[] args) {
@@ -27,6 +25,7 @@ class BooleanOperationsTests extends JavaSrcCodeToCpgFixture {
       |   }
       | }
       |""".stripMargin
+  )
 
   val vars = Seq(
     ("a", "boolean"),

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallGraphTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallGraphTests.scala
@@ -6,8 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class CallGraphTests extends JavaSrcCode2CpgFixture {
 
-  lazy val cpg = code(
-    """
+  lazy val cpg = code("""
        |class Foo {
        | int add(int x, int y) {
        |  return x + y;
@@ -16,8 +15,7 @@ class CallGraphTests extends JavaSrcCode2CpgFixture {
        |  System.out.println(add(1+2, 3));
        | }
        |}
-    """.stripMargin
-  )
+    """.stripMargin)
 
   "should find that add is called by main" in {
     cpg.method.name("add").caller.name.toSetMutable shouldBe Set("main")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallGraphTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallGraphTests.scala
@@ -1,24 +1,23 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.semanticcpg.language.NoResolve
 import io.shiftleft.semanticcpg.language._
 
-class CallGraphTests extends JavaSrcCodeToCpgFixture {
+class CallGraphTests extends JavaSrcCode2CpgFixture {
 
-  implicit val resolver: ICallResolver = NoResolve
-
-  override val code = """
-       class Foo {
-        int add(int x, int y) {
-         return x + y;
-        }
-        int main(int argc, char argv) {
-         System.out.println(add(1+2, 3));
-        }
-       }
+  lazy val cpg = code(
     """
+       |class Foo {
+       | int add(int x, int y) {
+       |  return x + y;
+       | }
+       | int main(int argc, char argv) {
+       |  System.out.println(add(1+2, 3));
+       | }
+       |}
+    """.stripMargin
+  )
 
   "should find that add is called by main" in {
     cpg.method.name("add").caller.name.toSetMutable shouldBe Set("main")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 
 class NewCallTests extends JavaSrcCode2CpgFixture {
   "call to method in different class" should {
-    val cpg = code(
+    lazy val cpg = code(
       """
         |class Base {
         |  void method(int aaa) {}
@@ -35,7 +35,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
   }
 
   "call to method in same class" should {
-    val cpg = code(
+    lazy val cpg = code(
       """
         |class Base {
         |  void method(int aaa) {}
@@ -62,7 +62,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
 
   "code fields" should {
     "be correct for chained calls starting at a constructor invocation" in {
-      val cpg = code("""
+      lazy val cpg = code("""
           |class Foo {
           |  private String value;
           |
@@ -85,7 +85,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
     }
 
     "be correct for constructor invocations" in {
-      val cpg = code("""
+      lazy val cpg = code("""
           |class Foo {
           |
           |  public static void test() {
@@ -103,7 +103,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
   }
 
   "call to method with generic return type" should {
-    val cpg = code("""
+    lazy val cpg = code("""
         |class Foo {
         |  void method(java.util.function.Function<String, Integer> supplier) {
         |     supplier.apply("abc");
@@ -121,7 +121,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
   }
 
   "call to generic method of generic type" should {
-    val cpg = code("""
+    lazy val cpg = code("""
         |class Foo <T extends Number> {
         |  <S extends T> void foo(S i) {}
         |
@@ -138,7 +138,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
   }
 
   "call to method with generic array parameter" should {
-    val cpg = code("""
+    lazy val cpg = code("""
         |class Foo <T> {
         |  void foo(T[] aaa) {}
         |

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
@@ -1,11 +1,11 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
 
-class CfgTests extends JavaSrcCodeToCpgFixture {
+class CfgTests extends JavaSrcCode2CpgFixture {
 
-  override val code =
+  lazy val  cpg = code(
     """
       |class Foo {
       | int foo(int x, int y) {
@@ -19,6 +19,7 @@ class CfgTests extends JavaSrcCodeToCpgFixture {
       | }
       |}
     """.stripMargin
+  )
 
   "should find that sink is control dependent on condition" in {
     val controllers = cpg.call("sink").controlledBy.isCall.toSetMutable

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CfgTests.scala
@@ -5,8 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class CfgTests extends JavaSrcCode2CpgFixture {
 
-  lazy val  cpg = code(
-    """
+  lazy val cpg = code("""
       |class Foo {
       | int foo(int x, int y) {
       |  if (y < 10)
@@ -18,8 +17,7 @@ class CfgTests extends JavaSrcCode2CpgFixture {
       |  return 0;
       | }
       |}
-    """.stripMargin
-  )
+    """.stripMargin)
 
   "should find that sink is control dependent on condition" in {
     val controllers = cpg.call("sink").controlledBy.isCall.toSetMutable

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConditionalTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConditionalTests.scala
@@ -8,16 +8,14 @@ import io.shiftleft.semanticcpg.language._
 class ConditionalTests extends JavaSrcCode2CpgFixture {
 
   "should parse ternary expression" in {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |class Foo {
         |  public int foo(int x) {
         |    int y = (x > 5) ? 10 : 2 + 20;
         |    return y;
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
 
     val List(ternaryExpr: Call)                                  = cpg.method.name("foo").call(Operators.conditional).l
     val List(condition: Call, thenExpr: Literal, elseExpr: Call) = ternaryExpr.argument.l
@@ -33,16 +31,14 @@ class ConditionalTests extends JavaSrcCode2CpgFixture {
   }
 
   "should find unresolved field-access args" in {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |class Foo {
         |  public int[] bar(boolean allowNull) {
         |    int[] y = allowNull ? this.cache : this.cacheNoNull;
         |    return y;
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
     val List(conditional: Call) = cpg.method.name("bar").call(Operators.conditional).l
     val List(condition: Identifier, thenExpr: Call, elseExpr: Call) = conditional.argument.l
 
@@ -57,15 +53,13 @@ class ConditionalTests extends JavaSrcCode2CpgFixture {
   }
 
   "should be able to parse nested conditionals" in {
-    lazy val cpg = code(
-    """
+    lazy val cpg = code("""
       |class Foo {
       |  public int baz(int input) {
       |    return (input > 10) ? 55 : ((input < 15) ? 42 : 39);
       |  }
       |}
-      |""".stripMargin
-    )
+      |""".stripMargin)
     val method = cpg.method.name("baz").head
     method.call(Operators.conditional).size shouldBe 2
     val List(parentC: Call, childC: Call) = method.call(Operators.conditional).l

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConditionalTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConditionalTests.scala
@@ -1,34 +1,24 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
 
-class ConditionalTests extends JavaSrcCodeToCpgFixture {
-
-  implicit val resolver: ICallResolver = NoResolve
-
-  override val code: String =
-    """
-      |class Foo {
-      |  public int foo(int x) {
-      |    int y = (x > 5) ? 10 : 2 + 20;
-      |    return y;
-      |  }
-      |
-      |  public int[] bar(boolean allowNull) {
-      |    int[] y = allowNull ? this.cache : this.cacheNoNull;
-      |    return y;
-      |  }
-      |
-      |  public int baz(int input) {
-      |    return (input > 10) ? 55 : ((input < 15) ? 42 : 39);
-      |  }
-      |}
-      |""".stripMargin
+class ConditionalTests extends JavaSrcCode2CpgFixture {
 
   "should parse ternary expression" in {
+    lazy val cpg = code(
+      """
+        |class Foo {
+        |  public int foo(int x) {
+        |    int y = (x > 5) ? 10 : 2 + 20;
+        |    return y;
+        |  }
+        |}
+        |""".stripMargin
+    )
+
     val List(ternaryExpr: Call)                                  = cpg.method.name("foo").call(Operators.conditional).l
     val List(condition: Call, thenExpr: Literal, elseExpr: Call) = ternaryExpr.argument.l
 
@@ -43,6 +33,16 @@ class ConditionalTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should find unresolved field-access args" in {
+    lazy val cpg = code(
+      """
+        |class Foo {
+        |  public int[] bar(boolean allowNull) {
+        |    int[] y = allowNull ? this.cache : this.cacheNoNull;
+        |    return y;
+        |  }
+        |}
+        |""".stripMargin
+    )
     val List(conditional: Call) = cpg.method.name("bar").call(Operators.conditional).l
     val List(condition: Identifier, thenExpr: Call, elseExpr: Call) = conditional.argument.l
 
@@ -57,6 +57,15 @@ class ConditionalTests extends JavaSrcCodeToCpgFixture {
   }
 
   "should be able to parse nested conditionals" in {
+    lazy val cpg = code(
+    """
+      |class Foo {
+      |  public int baz(int input) {
+      |    return (input > 10) ? 55 : ((input < 15) ? 42 : 39);
+      |  }
+      |}
+      |""".stripMargin
+    )
     val method = cpg.method.name("baz").head
     method.call(Operators.conditional).size shouldBe 2
     val List(parentC: Call, childC: Call) = method.call(Operators.conditional).l

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -26,8 +26,7 @@ class NewConstructorInvocationTests extends JavaSrcCode2CpgFixture {
   }
 
   "a simple single argument constructor" should {
-    lazy val fooCpg = code(
-      """
+    lazy val fooCpg = code("""
         |class Foo {
         |  int x;
         |
@@ -35,8 +34,7 @@ class NewConstructorInvocationTests extends JavaSrcCode2CpgFixture {
         |    this.x = x;
         |  }
         |}
-        |""".stripMargin
-    )
+        |""".stripMargin)
     "create the correct Ast for the constructor" in {
       fooCpg.method.name("Foo").l match {
         case List(cons: Method) =>

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 
 class NewConstructorInvocationTests extends JavaSrcCode2CpgFixture {
   "constructor init method call" should {
-    val cpg = code("""
+    lazy val cpg = code("""
         |class Foo {
         |  Foo(long aaa) {
         |  }
@@ -22,6 +22,40 @@ class NewConstructorInvocationTests extends JavaSrcCode2CpgFixture {
       val initCall = cpg.call.nameExact("<init>").head
       initCall.signature shouldBe "void(long)"
       initCall.methodFullName shouldBe "Foo.<init>:void(long)"
+    }
+  }
+
+  "a simple single argument constructor" should {
+    lazy val fooCpg = code(
+      """
+        |class Foo {
+        |  int x;
+        |
+        |  public Foo(int x) {
+        |    this.x = x;
+        |  }
+        |}
+        |""".stripMargin
+    )
+    "create the correct Ast for the constructor" in {
+      fooCpg.method.name("Foo").l match {
+        case List(cons: Method) =>
+          cons.fullName shouldBe "Foo.<init>:void(int)"
+          cons.signature shouldBe "void(int)"
+          cons.code shouldBe "public Foo(int x)"
+          cons.parameter.size shouldBe 2
+          val objParam = cons.parameter.index(0).head
+          objParam.name shouldBe "this"
+          objParam.typeFullName shouldBe "Foo"
+          objParam.dynamicTypeHintFullName shouldBe Seq("Foo")
+          val otherParam = cons.parameter.index(1).head
+          otherParam.name shouldBe "x"
+          otherParam.typeFullName shouldBe "int"
+          otherParam.dynamicTypeHintFullName shouldBe Seq()
+
+        case res =>
+          fail(s"Expected single Foo constructor, but got $res")
+      }
     }
   }
 }
@@ -74,24 +108,6 @@ class ConstructorInvocationTests extends JavaSrcCodeToCpgFixture {
       |""".stripMargin
 
   "it should create correct method nodes for constructors" in {
-    cpg.method.name("Foo").l match {
-      case List(cons: Method) =>
-        cons.fullName shouldBe "Foo.<init>:void(int)"
-        cons.signature shouldBe "void(int)"
-        cons.code shouldBe "public Foo(int x)"
-        cons.parameter.size shouldBe 2
-        val objParam = cons.parameter.index(0).head
-        objParam.name shouldBe "this"
-        objParam.typeFullName shouldBe "Foo"
-        objParam.dynamicTypeHintFullName shouldBe Seq("Foo")
-        val otherParam = cons.parameter.index(1).head
-        otherParam.name shouldBe "x"
-        otherParam.typeFullName shouldBe "int"
-        otherParam.dynamicTypeHintFullName shouldBe Seq()
-
-      case res =>
-        fail(s"Expected single Foo constructor, but got $res")
-    }
 
     cpg.method.name("Bar").l match {
       case List(cons1: Method, cons2: Method) =>


### PR DESCRIPTION
This PR moves the first couple of test classes to the new `JavaSrcCode2CpgFixture`. In some cases I left the tests unchanged, using a single code block, since the tests themselves are very simple and, in my opinion, the effort of restructuring the tests outweighs the benefits of doing so. For more complex test suites (especially once I get to the dataflow tests) this will not be the case.