### PR TITLE
kotlin2cpg: `s/lazy val cpg/val cpg/g` in test suite

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnnotatedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnnotatedExpressionsTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class AnnotatedExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with two identical calls, one annotated and one not" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnonymousFunctionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnonymousFunctionsTests.scala
@@ -10,7 +10,7 @@ class AnonymousFunctionsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
   implicit val resolver = NoResolve
 
   "CPG for code with anonymous function as argument" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.collections.List

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArithmeticOperationsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArithmeticOperationsTests.scala
@@ -8,7 +8,7 @@ class ArithmeticOperationsTests extends KotlinCode2CpgFixture(withOssDataflow = 
 
   "CPG for code with simple arithmetic operations" should {
 
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |  println(1 + 2)
         |  println(1 - 2)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArrayAccessExprsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ArrayAccessExprsTests.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 class ArrayAccessExprsTests extends KotlinCode2CpgFixture(withOssDataflow = true) {
 
   "CPG for code with simple map construction and access" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main(args: Array<String>) {
@@ -40,7 +40,7 @@ class ArrayAccessExprsTests extends KotlinCode2CpgFixture(withOssDataflow = true
   }
 
   "CPG for code with simple array construction and access" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main(args: Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AssignmentTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AssignmentTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class AssignmentTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple assignments" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |  val x: Int = 5
         |  x += 1

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BooleanLogicTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/BooleanLogicTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class BooleanLogicTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple boolean op usage" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |  val w = true
         |  val x: Boolean = !w

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallGraphTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallGraphTests.scala
@@ -9,7 +9,7 @@ class CallGraphTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple function definition" should {
 
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun add(x: Int, y: Int): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -10,7 +10,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   implicit val resolver = NoResolve
 
   "CPG for code with two functions with the same name, but different params" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo(x: Int, y: Int): Int {
@@ -93,7 +93,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a class declaration " should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo {
@@ -150,7 +150,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a call to an implicitly imported stdlib fn " should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun doSome(x: String) {
@@ -176,7 +176,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with invocation of extension function from stdlib" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main() {
@@ -194,7 +194,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a simple method call to decl of Java's stdlib" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |fun foo(x: String): Int {
@@ -213,7 +213,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a simple call to class from Java's stdlib imported with _as_" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import java.io.File as MyFile
@@ -233,7 +233,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a simple call with unknown identifier imported via _as_" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import no.such.CaseClass as MyCaseClass
@@ -267,7 +267,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with call which has parenthesized expression as receiver" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallableReferenceTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallableReferenceTests.scala
@@ -7,7 +7,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
 
   "CPG for code with simple callback usage" should {
 
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun isOdd(x: Int) = x % 2 != 0
         |
         |fun firstOdd(x: Int): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallbackTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallbackTests.scala
@@ -9,7 +9,7 @@ class CallbackTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   implicit val resolver = NoResolve
 
   "CPG for code with callback and additional parameter" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun withCallback(p: String, callback: (String) -> Unit) {
@@ -49,7 +49,7 @@ class CallbackTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with simple callback usage" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |fun withCallback(fn: (String)->Unit) {
@@ -71,7 +71,7 @@ class CallbackTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with simple callback inside class method" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |class AClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToConstructorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToConstructorTests.scala
@@ -10,7 +10,7 @@ class CallsToConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = fa
   implicit val resolver = NoResolve
 
   "CPG for code with call to constructor of Java stdlib object inside declaration" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import java.io.File
@@ -82,7 +82,7 @@ class CallsToConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = fa
   }
 
   "CPG for code with call to constructor of Java stdlib object inside QE" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import java.io.File
@@ -146,7 +146,7 @@ class CallsToConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = fa
   }
 
   "CPG for code with call to simple constructor of user-defined class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass(val x: String) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 
 class CallsToFieldAccessTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with class method referencing member in a call" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass(private val x: String) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CfgTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CfgTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class CfgTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple structures" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun sink(p: Int): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ClassLiteralTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ClassLiteralTests.scala
@@ -8,7 +8,7 @@ class ClassLiteralTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple class literals" should {
 
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Bar {}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CollectionAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CollectionAccessTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class CollectionAccessTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple list access" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |import kotlin.collections.mutableListOf
         |
         |fun main(args : Array<String>) {
@@ -27,7 +27,7 @@ class CollectionAccessTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with simple map access" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |import kotlin.collections.mutableMapOf
         |
         |fun main(args : Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CompanionObjectTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CompanionObjectTests.scala
@@ -9,7 +9,7 @@ import io.shiftleft.semanticcpg.language._
 class CompanionObjectTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple unnamed companion object" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass {
@@ -68,7 +68,7 @@ class CompanionObjectTests extends KotlinCode2CpgFixture(withOssDataflow = false
   }
 
   "CPG for code with simple named companion object" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ComparisonOperatorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ComparisonOperatorTests.scala
@@ -8,7 +8,7 @@ class ComparisonOperatorTests extends KotlinCode2CpgFixture(withOssDataflow = fa
 
   "CPG for code with simple comparison operator usage" should {
 
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>): Int {
         | val x: Int = 1
         | val y: Int = 2

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ComplexExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ComplexExpressionsTests.scala
@@ -8,7 +8,7 @@ import overflowdb.traversal.jIteratortoTraversal
 
 class ComplexExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with _and_/_or_ operator and try-catch as one of the arguments" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -54,7 +54,7 @@ class ComplexExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
   }
 
   "CPG for code with _and_ operator and let inside it" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Config {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ConstructorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ConstructorTests.scala
@@ -10,7 +10,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   implicit val resolver = NoResolve
 
   "CPG for a class declaration with an implicit constructor" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo
@@ -26,7 +26,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with class with param in its primary constructor" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass(x: String)
@@ -43,7 +43,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with class which defines member in its primary constructor" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass(val x: String)
@@ -109,7 +109,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for a class declaration with an implicit constructor with parameters" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo(bar: String) {
@@ -126,7 +126,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for a class declaration with an explicit constructor with parameters" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo constructor(bar: String) {
@@ -143,7 +143,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for a class declaration with secondary constructor" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo(foo: String) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 
 class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple if-else" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo(x: Int): Int {
@@ -24,7 +24,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with `when` statement with assignment in its conditional" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -48,7 +48,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with multiple control structures" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |import kotlin.random.Random
         |
         |class ClassFoo {
@@ -113,7 +113,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with simple `for`-statements" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -134,7 +134,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with simple `if`-statement" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main() {
@@ -158,7 +158,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with try-catch-finally statement" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |fun main() {
@@ -186,7 +186,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with try-catch statement" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |fun main() {
@@ -211,7 +211,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with `for-in` loop which has a simple variable loop parameter" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main() {
@@ -320,7 +320,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with `for-in` loop which has a destructuring declaration loop parameter" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |data class AClass(val x: String, val y: Int)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DataClassTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DataClassTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class DataClassTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple data class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |data class Result(val p: Int, val q: String)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DefaultContentRootsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DefaultContentRootsTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDefaultJars = true) {
 
   "CPG for code with a simple function definition with parameters of stdlib types, but not fully specified" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun add1mul(x: Int, y: Int): Int {
@@ -29,7 +29,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code with a simple class definition" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo {
@@ -54,7 +54,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code with type alias of a stdlib type" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |typealias FooList = List<Int>
         |
         |fun foo() {
@@ -70,7 +70,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code with array access" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun foo(): Int {
         |  val x = listOf(1, 2, 3)
         |  return x[0]
@@ -84,7 +84,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code with `this` expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo {
@@ -102,7 +102,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code with a class definition" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo: Object {
@@ -121,7 +121,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code with Java stdlib" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo(cmd: String) {
@@ -147,7 +147,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code using the Javalin web framework" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import io.javalin.Javalin
@@ -218,7 +218,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code using the http4k framework" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package com.example
         |
         |import org.http4k.core.HttpHandler
@@ -281,7 +281,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
   }
 
   "CPG for code with addition of aliased type and its original" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |typealias MyInt = Int

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DelegatedPropertiesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DelegatedPropertiesTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 class DelegatedPropertiesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple delegated properties" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class MyClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
@@ -10,7 +10,7 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   implicit val resolver = NoResolve
 
   "CPG for code with destructuring declaration and a variable as RHS" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package main
         |
         |data class AClass(val a: String, val b: Int)
@@ -83,7 +83,7 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with destructuring declaration and a variable as RHS, plus one `_`" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package main
         |
         |data class AClass(val a: String, val b: Int)
@@ -108,7 +108,7 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with destructuring expression with a ctor-invocation RHS" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package main
         |
         |data class AClass(val a: String, val b: Int)
@@ -229,7 +229,7 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with destructuring expression with a ctor-invocation RHS and an `_`" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package main
         |
         |data class AClass(val a: String, val b: Int)
@@ -254,7 +254,7 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with destructuring expression with a non-ctor-call RHS" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |data class AClass(val a: String, val b: Int)
@@ -364,7 +364,7 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with destructuring expression with a non-ctor-call RHS and an `_`" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |data class AClass(val a: String, val b: Int)
@@ -395,7 +395,7 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with destructuring expression with a DQE call RHS" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |data class AClass(val a: String, val b: Int)
@@ -518,7 +518,7 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with destructuring expression with a DQE call RHS and an `_`" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |data class AClass(val a: String, val b: Int)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/EnumTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/EnumTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 class EnumTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple enum definition" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |enum class Direction {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
@@ -8,7 +8,7 @@ class ExtensionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple extension function definitions" should {
     implicit val resolver = NoResolve
 
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Example {
@@ -38,7 +38,7 @@ class ExtensionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     // TODO: add test cases after the lowering is clear:
     //   --> right now we cannot differentiate between the fn definitions at different scopes
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun String.hash() = "HASH_PLACEHOLDER_1: $this"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FieldAccessTests.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 class FieldAccessTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple filed access of user-defined class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FileTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FileTests.scala
@@ -9,7 +9,7 @@ import java.io.File
 class FileTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple class definition and one method" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg.bar
         |
         |class Foo {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/GenericsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/GenericsTests.scala
@@ -8,7 +8,7 @@ class GenericsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   implicit val resolver = NoResolve
 
   "CPG for code with simple user-defined fn using generics" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |
         |package mypkg
         |
@@ -54,7 +54,7 @@ class GenericsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with simple user-defined fn using generics and a type parameter subclassed from user-defined fn" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IdentifierTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IdentifierTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class IdentifierTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with two simple methods" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun add(x: Int, y: Int): Int {
         |  return x + y
         |}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IfExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/IfExpressionsTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 
 class IfExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple `if`-expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package baz
         |
         |fun main(argc: Int): Int {
@@ -46,7 +46,7 @@ class IfExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with `if`-expression with `else-if`" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -85,7 +85,7 @@ class IfExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `if`-expression with fn calls in branches" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun some1(): Int {
@@ -135,7 +135,7 @@ class IfExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with `if`-expression as receiver of a DQE" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -157,7 +157,7 @@ class IfExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `if`-expression with DQEs in branches" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -211,7 +211,7 @@ class IfExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `if`-expression with enum in branches" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -258,7 +258,7 @@ class IfExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `if`-expression inside method" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ImportTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 class ImportTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with a stdlib import" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.io.collections.listOf
@@ -43,7 +43,7 @@ class ImportTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code without explicit imports" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main(args : Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InnerClassesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InnerClassesTests.scala
@@ -10,7 +10,7 @@ class InnerClassesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   implicit val resolver = NoResolve
 
   "CPG for code with a simple inner class definition" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         | class Outer {
         |     private val bar: Int = 1
         |     inner class Inner {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LabeledExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LabeledExpressionsTests.scala
@@ -8,7 +8,7 @@ class LabeledExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
   implicit val resolver = NoResolve
 
   "CPG for code with simple call to `println` prefixed by a label" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -10,7 +10,7 @@ import overflowdb.traversal.jIteratortoTraversal
 
 class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDefaultJars = true) {
   "CPG for code with a simple lambda which captures a method parameter" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |// TODO: test with `fun foo(x: String, y: String): Int {`
@@ -43,7 +43,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with a simple lambda which captures a local" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.collections.List
@@ -82,7 +82,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with a list iterator lambda" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo(x: String): Int {
@@ -163,7 +163,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with a scope function lambda" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun throughTakeIf(x: String): String? {
@@ -229,7 +229,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with a lambda mapping values of a collection" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun mappedListWith(p: String): List<String> {
@@ -301,7 +301,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with destructuring inside lambda" should {
-    lazy val cpg = code("""
+    val cpg = code("""
        |package mypkg
        |
        |fun main(args: Array<String>) {
@@ -316,7 +316,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with a simple lambda which captures a method parameter inside method" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass {
@@ -340,7 +340,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with a simple lambda which captures a method parameter, nested twice" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |fun foo(x: String): Int {
@@ -374,7 +374,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with call with lambda inside method definition" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -407,7 +407,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
   }
 
   "CPG for code with nested lambdas" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun doSomething(p: String): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LazyBlocksTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LazyBlocksTests.scala
@@ -9,7 +9,7 @@ class LazyBlocksTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   // TODO: add test cases for lazy properties as well
 
   "CPG for code with simple lazy blocks" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import java.nio.file.Files

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 class LiteralTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code simple literal declarations with explicit types" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |  val a: Int = 1
         |  val b: Boolean = true
@@ -36,7 +36,7 @@ class LiteralTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code simple literal declarations without explicit types" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |  val a = 1
         |  val b = true

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class LocalTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code simple local declarations" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main() {
         |  val x: Int = 1
         |  val y = 2

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MemberTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 class MemberTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple member" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |class Foo {
         |  val bar: Int = 1
         |}
@@ -29,7 +29,7 @@ class MemberTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with member defined in primary constructor" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |class AClass(private val x: String) {
@@ -52,7 +52,7 @@ class MemberTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with member which gets its init from constructor arg" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |class Foo(p: String) {
         |  val bar: Int = p
         |}
@@ -77,7 +77,7 @@ class MemberTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with member which gets its init from constructor arg with expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |class Foo(p: String) {
         |  val bar: Int = p + "baz"
         |}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MetaDataTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MetaDataTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class MetaDataTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
-  lazy val cpg = code("""
+  val cpg = code("""
       |class ClassFoo {}
       |""".stripMargin)
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodParameterTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 class MethodParameterTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with a simple function definition" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun add1mul(x: Int, y: Int): Int {
@@ -38,7 +38,7 @@ class MethodParameterTests extends KotlinCode2CpgFixture(withOssDataflow = false
   }
 
   "CPG for code with a simple class definition" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodReturnTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class MethodReturnTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple method with two parameters" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |fun foo(x: Int, y: Double): Int {
       |  return x * 2
       |}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class MethodTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple method defined at package-level" should {
-    lazy val cpg = code("""
+    val cpg = code("""
        |fun double(x: Int): Int {
        |  return x * 2
        |}
@@ -64,7 +64,7 @@ class MethodTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with simple class declaration" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package com.test.pkg
         |
         |class Foo {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/NamespaceBlockTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/NamespaceBlockTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class NamespaceBlockTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple namespace declaration" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package com.test.PackageFoo
         |
         |class ClassFoo {
@@ -51,7 +51,7 @@ class NamespaceBlockTests extends KotlinCode2CpgFixture(withOssDataflow = false)
   }
 
   "CPG for code with imports of simple Android packages" should {
-    lazy val cpg = code("""
+    val cpg = code("""
        |package mypkg
        |
        |import android.content.Intent

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectDeclarationsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectDeclarationsTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class ObjectDeclarationsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple object declaration" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |object Foo {
@@ -57,7 +57,7 @@ class ObjectDeclarationsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
   }
 
   "CPG for code with complex object declaration" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import android.content.Context

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple object expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun foo() {
         |  val bar = object {
         |    override val baz = 1
@@ -25,7 +25,7 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with simple object expression with apply called after it" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package main
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ParenthesizedExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ParenthesizedExpressionTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class ParenthesizedExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple paranthesized expression " should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -27,7 +27,7 @@ class ParenthesizedExpressionTests extends KotlinCode2CpgFixture(withOssDataflow
   }
 
   "CPG for code with a paranthesized expression as part of a dot-qualified expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/QualifiedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/QualifiedExpressionsTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class QualifiedExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with qualified expression with QE as a receiver" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main(args: Array<String>) {
@@ -27,7 +27,7 @@ class QualifiedExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = 
   }
 
   "CPG for code with qualified expression with CALL as a receiver" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun getHashMap(): HashMap<String,String> {
@@ -60,7 +60,7 @@ class QualifiedExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = 
   }
 
   "CPG for code with qualified expression with `when` as receiver" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.random.Random
@@ -84,7 +84,7 @@ class QualifiedExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = 
   }
 
   "CPG for code with qualified expression in which the receiver is a call to array access" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ResolutionErrorsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ResolutionErrorsTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 
 class ResolutionErrorsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with QE of receiver for which the type cannot be inferred" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main() {
@@ -26,7 +26,7 @@ class ResolutionErrorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with simple stdlib fns" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.collections.HashMap
@@ -55,7 +55,7 @@ class ResolutionErrorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with stdlib mutable list of items of class without type info available" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import com.intellij.ide.util.projectWizard.importSources.DetectedProjectRoot
@@ -81,7 +81,7 @@ class ResolutionErrorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with QE expression without type info" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |object AClass {
@@ -117,7 +117,7 @@ class ResolutionErrorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with extension fn defined on unresolvable type " should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import com.intellij.openapi.editor.*
@@ -138,7 +138,7 @@ class ResolutionErrorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with extension fn defined on resolvable type with unresolvable subtypes" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import com.intellij.openapi.editor.*
@@ -160,7 +160,7 @@ class ResolutionErrorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with `containsKey` call on collection of elements without corresponding imported class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import io.no.SuchPackage

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SafeQualifiedExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SafeQualifiedExpressionsTests.scala
@@ -8,7 +8,7 @@ class SafeQualifiedExpressionsTests extends KotlinCode2CpgFixture(withOssDataflo
   implicit val resolver = NoResolve
 
   "CPG for code with safe qualified expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ScopeFunctionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ScopeFunctionTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code call to `also` scope function without an explicitly-defined parameter" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -20,7 +20,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code call to `apply` scope function without an explicitly-defined parameter" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -35,7 +35,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code call to `let` scope function without an explicitly-defined parameter" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -50,7 +50,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code call to `run` scope function without an explicitly-defined parameter" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -65,7 +65,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `let` scope function" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -98,7 +98,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `run` scope function" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -132,7 +132,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `also` scope function" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -166,7 +166,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with `with` scope function" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo(x: String): Int {
@@ -187,7 +187,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `apply` scope function" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Bar(p: String)
@@ -203,7 +203,7 @@ class ScopeFunctionTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
   }
 
   "CPG for code with simple `takeIf` scope function" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SpecialOperatorsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SpecialOperatorsTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with _safe call_ operator" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |    val b: String? = null
         |    println(b?.length)
@@ -25,7 +25,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with _as_ operator" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |    val b = "PLACEHOLDER" as String
         |    println(b)
@@ -42,7 +42,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with `notNullAssert` operator" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun foo(x : Int) {
         | val p = x!!
         | println(p)
@@ -55,7 +55,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with _notNullAssert_ operator inside dot-qualified expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun foo() {
         |    val bar = " PLACEHOLDER "!!.trim()
         |    println(bar)
@@ -72,7 +72,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with _is_ expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |packge mypkg
         |
         |fun main() {
@@ -99,7 +99,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with range expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |packge mypkg
         |
         |fun main() {
@@ -124,7 +124,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with simple usage of _elvis_ operator" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main(args: Array<String>) {
@@ -150,7 +150,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with _elvis_ operator usage and subexpression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package main
         |
         |fun main() {
@@ -167,7 +167,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with _notIn_ operator" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main(args: Array<String>) {
@@ -187,7 +187,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   "CPG for code with _in_ operator" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun main(args: Array<String>) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StdLibTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StdLibTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class StdLibTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with call to `takeIf`" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |  package mypkg
         |
         |  import kotlin.random.Random
@@ -35,7 +35,7 @@ class StdLibTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a single call to println and a corresponding import" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import kotlin.io.println
@@ -52,7 +52,7 @@ class StdLibTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a single call to println, a corresponding import and a locally defined println method" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun println(baz: String) {
@@ -71,7 +71,7 @@ class StdLibTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a call to static class method of imported class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -95,7 +95,7 @@ class StdLibTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a chained call to static class method of imported class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -110,7 +110,7 @@ class StdLibTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with a call to infix fn `to`" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun foo() {
@@ -134,7 +134,7 @@ class StdLibTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     }
 
     "CPG for code with calls to stdlib's `split`s" should {
-      lazy val cpg = code("""
+      val cpg = code("""
           |package mypkg
           |
           |fun main() {
@@ -153,7 +153,7 @@ class StdLibTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     }
 
     "CPG for code with calls to stdlib's `trim`s" should {
-      lazy val cpg = code("""
+      val cpg = code("""
           |package mypkg
           |
           |fun trimParam(p: String): String {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StringInterpolationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/StringInterpolationTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class StringInterpolationTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with basic string interpolation" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |  val name = "Peter"
         |  val age = 34

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SuperTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SuperTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class SuperTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple call using _super_" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |open class BClass {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ThisTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ThisTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class ThisTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with calls to functions of same name, but different scope" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun bar() { println("Top-level function") }
@@ -39,7 +39,7 @@ class ThisTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with call that has _this_ as argument" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun bar(x: Any) { println(x) }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TopLevelPropertiesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TopLevelPropertiesTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class TopLevelPropertiesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with top-level property" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |const val CSRF_SESSION_KEY = "_csrf"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 
 class TryExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple `try`-expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun doSomething(x: Int): Int {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeAliasTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeAliasTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class TypeAliasTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDefaultJars = true) {
   "CPG for code with simple typealias to Int" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |typealias MyInt = Int
@@ -32,7 +32,7 @@ class TypeAliasTests extends KotlinCode2CpgFixture(withOssDataflow = false, with
   // _seemingly_ because adding the springframework jar to the classpath will give the
   // compiler enough information to detect that there is no recursion in the typealias definition
   "CPG for code with seemingly-recursive type alias" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |import org.springframework.data.annotation.Id
         |actual typealias Id = Id
@@ -50,7 +50,7 @@ class TypeAliasTests extends KotlinCode2CpgFixture(withOssDataflow = false, with
   }
 
   "CPG for code with typealias containing other type alias in its RHS" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |
@@ -82,7 +82,7 @@ class TypeAliasTests extends KotlinCode2CpgFixture(withOssDataflow = false, with
   }
 
   "CPG for code with simple typealias to ListInt" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |typealias Foo = List<Int>
@@ -107,7 +107,7 @@ class TypeAliasTests extends KotlinCode2CpgFixture(withOssDataflow = false, with
   }
 
   "CPG for code with typealias of type from external library" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package org.http4k.core.body
         |
         |import org.http4k.core.Parameters
@@ -123,7 +123,7 @@ class TypeAliasTests extends KotlinCode2CpgFixture(withOssDataflow = false, with
   }
 
   "CPG for code with call to ctor of typealiased user-defined class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class AClass(val x: String)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeDeclTests.scala
@@ -9,7 +9,7 @@ import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 class TypeDeclTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for simple class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import java.lang.Object
@@ -60,7 +60,7 @@ class TypeDeclTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with user-defined class which has no specific superclasses" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package main
         |
         |class AClass
@@ -78,7 +78,7 @@ class TypeDeclTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "class with multiple initializers" ignore {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package baz
         |
         |import kotlin.io.println
@@ -107,7 +107,7 @@ class TypeDeclTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with simple class declaration and usage" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |class Foo {
@@ -131,7 +131,7 @@ class TypeDeclTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with usage of setter of simple user-defined class" should {
-    lazy val cpg = code("""
+    val cpg = code("""
       |package mypkg
       |
       |class Simple {
@@ -160,7 +160,7 @@ class TypeDeclTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with class defined inside user-defined function" should {
-    lazy val cpg = code("""
+    val cpg = code("""
        |package mypkg
        |
        |fun doSomething(x: String): String {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 class TypeTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with simple class with one method and one member" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package com.test.PackageFoo
         |
         |class Foo {
@@ -66,7 +66,7 @@ class TypeTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   }
 
   "CPG for code with call to a static method from Java's stdlib with a return type different from its receiver type " should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |import javax.crypto.Cipher

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/UnaryOpTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/UnaryOpTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class UnaryOpTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   "CPG for code with calls to unary operators" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |fun main(args : Array<String>) {
         |  val x: Int = 5
         |  val y: Boolean = true

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/WhenExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/WhenExpressionTests.scala
@@ -4,7 +4,7 @@ import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
 
 class WhenExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with simple `when`-expression" should {
-    lazy val cpg = code("""
+    val cpg = code("""
         |package mypkg
         |
         |fun myfun() {


### PR DESCRIPTION
done semi-manually via CLI foo
```
find . -name "*scala" | xargs -I{} sed -i -e 's|lazy val cpg|val cpg|g' {}
```