### PR TITLE
jssrc2cpg: Fix export names

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
@@ -279,13 +279,19 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
         |var bar = 2;
         |export = foo;
         |export = bar;
+        |export = function func(param) {};
+        |export = class ClassA {};
         |""".stripMargin) { cpg =>
-      cpg.local.code.l shouldBe List("foo", "bar")
+      cpg.local.code.l shouldBe List("foo", "bar", "func")
+      cpg.typeDecl.name.l should contain allElementsOf List("func", "ClassA", "ClassA<meta>")
       cpg.call(Operators.assignment).code.l shouldBe List(
         "foo = 1",
         "bar = 2",
         "exports.foo = foo",
-        "exports.bar = bar"
+        "exports.bar = bar",
+        "function func = function func(param) {}",
+        "exports.func = func",
+        "exports.ClassA = ClassA"
       )
     }
 


### PR DESCRIPTION
Typescript allows to export almost anything: https://www.typescriptlang.org/docs/handbook/modules.html

If the exported entity does not provide a name itself (anonymous functions and classes) we derive one from the generated AST.

Supersedes: https://github.com/joernio/joern/pull/1594