### PR TITLE
frontends: remove duplication from helper fn

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
@@ -4,7 +4,19 @@ import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, MethodParameterI
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.help.Table
 
-case class Path(elements: List[CfgNode])
+case class Path(elements: List[CfgNode]) {
+  def resultPairs(): List[(String, Option[Integer])] = {
+    val pairs = elements.map {
+      case point: MethodParameterIn =>
+        val method      = point.method.head
+        val method_name = method.name
+        val code        = s"$method_name(${method.parameter.l.sortBy(_.order).map(_.code).mkString(", ")})"
+        (code, point.lineNumber)
+      case point => (point.statement.repr, point.lineNumber)
+    }
+    pairs.headOption.map(x => x :: pairs.sliding(2).collect { case Seq(a, b) if a != b => b }.toList).getOrElse(List())
+  }
+}
 
 object Path {
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -1,12 +1,10 @@
 package io.joern.c2cpg.testfixtures
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import io.shiftleft.utils.ProjectRoot
 
@@ -31,16 +29,5 @@ class DataFlowCodeToCpgSuite extends CCodeToCpgSuite {
 
   protected implicit def int2IntegerOption(x: Int): Option[Integer] = Some(x)
 
-  protected def flowToResultPairs(path: Path): List[(String, Option[Integer])] = {
-    val pairs = path.elements.map {
-      case point: MethodParameterIn =>
-        val method      = point.method.head
-        val method_name = method.name
-        val code        = s"$method_name(${method.parameter.l.sortBy(_.order).map(_.code).mkString(", ")})"
-        (code, point.lineNumber)
-      case point => (point.statement.repr, point.lineNumber)
-    }
-    pairs.headOption.map(x => x :: pairs.sliding(2).collect { case Seq(a, b) if a != b => b }.toList).getOrElse(List())
-  }
-
+  protected def flowToResultPairs(path: Path): List[(String, Option[Integer])] = path.resultPairs()
 }

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/GhidraBinToCpgSuite.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/GhidraBinToCpgSuite.scala
@@ -31,18 +31,5 @@ class GhidraFrontend extends LanguageFrontend {
 class GhidraBinToCpgSuite extends BinToCpgFixture(new GhidraFrontend) {
   override val binDirectory = ProjectRoot.relativise("joern-cli/frontends/ghidra2cpg/src/test/testbinaries/")
 
-  def flowToResultPairs(path: Path): List[String] = {
-    val pairs = path.elements.map {
-      case point: nodes.MethodParameterIn => {
-        val method      = point.method.head
-        val method_name = method.name
-        val code        = s"$method_name(${method.parameter.l.sortBy(_.order).map(_.code).mkString(", ")})"
-        code
-      }
-      case point => point.statement.repr
-    }
-    pairs.headOption
-      .map(x => x :: pairs.sliding(2).collect { case Seq(a, b) if a != b => b }.toList)
-      .getOrElse(List())
-  }
+  protected def flowToResultPairs(path: Path): List[String] = path.resultPairs().map(_._1)
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -2,14 +2,14 @@ package io.joern.javasrc2cpg.testfixtures
 
 import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Expression, FieldIdentifier, Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
+import io.joern.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import overflowdb.NodeRef
 import overflowdb.traversal.Traversal
 
 class JavaDataflowFixture extends AnyFlatSpec with Matchers {
@@ -51,4 +51,6 @@ class JavaDataflowFixture extends AnyFlatSpec with Matchers {
 
     (source, sink)
   }
+
+  protected def flowToResultPairs(path: Path): List[(String, Option[Integer])] = path.resultPairs()
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -1,12 +1,10 @@
 package io.joern.jssrc2cpg.testfixtures
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import io.shiftleft.utils.ProjectRoot
 
@@ -29,17 +27,8 @@ class DataFlowCodeToCpgSuite extends JsSrc2CpgSuite {
     new OssDataFlow(new OssDataFlowOptions()).run(new LayerCreatorContext(cpg))
   }
 
-  protected def flowToResultPairs(path: Path): List[(String, Integer)] = {
-    val pairs = path.elements.map {
-      case point: MethodParameterIn =>
-        val method      = point.method.head
-        val method_name = method.name
-        val code        = s"$method_name(${method.parameter.l.sortBy(_.order).map(_.code).mkString(", ")})"
-        (code, point.lineNumber.get)
-      case point =>
-        (point.statement.repr, point.lineNumber.get)
+  protected def flowToResultPairs(path: Path): List[(String, Integer)] =
+    path.resultPairs().collect { case (firstElement: String, secondElement: Option[Integer]) =>
+      (firstElement, secondElement.get)
     }
-    pairs.headOption.map(x => x :: pairs.sliding(2).collect { case Seq(a, b) if a != b => b }.toList).getOrElse(List())
-  }
-
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -46,15 +46,5 @@ class KotlinCode2CpgFixture(withOssDataflow: Boolean = false, withDefaultJars: B
     }
   }
 
-  protected def flowToResultPairs(path: Path): List[(String, Option[Integer])] = {
-    val pairs = path.elements.map {
-      case point: MethodParameterIn =>
-        val method      = point.method.head
-        val method_name = method.name
-        val code        = s"$method_name(${method.parameter.l.sortBy(_.order).map(_.code).mkString(", ")})"
-        (code, point.lineNumber)
-      case point => (point.statement.repr, point.lineNumber)
-    }
-    pairs.headOption.map(x => x :: pairs.sliding(2).collect { case Seq(a, b) if a != b => b }.toList).getOrElse(List())
-  }
+  protected def flowToResultPairs(path: Path): List[(String, Option[Integer])] = path.resultPairs()
 }


### PR DESCRIPTION
motivation: I wanted to compare dataflows for similar contructs in kotlin2cpg and javasrc2cpg, but no method for getting the points was available for the latter. so i went ahead and added it, and removed the duplication in the other frontends while at it