### PR TITLE
Fix `success` field for CPG server

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgqlserver/CPGQLServer.scala
+++ b/console/src/main/scala/io/joern/console/cpgqlserver/CPGQLServer.scala
@@ -148,11 +148,11 @@ abstract class WebServiceWithWebSocket[T <: HasUUID](
   }
 
   def returnResult(result: T): Unit = {
-    resultMap.put(result.uuid, (result, false))
+    resultMap.put(result.uuid, (result, true))
     openConnections.foreach { connection =>
       connection.send(cask.Ws.Text(result.uuid.toString))
     }
-    Response(ujson.Obj("success" -> false, "uuid" -> result.uuid.toString), 200)
+    Response(ujson.Obj("success" -> true, "uuid" -> result.uuid.toString), 200)
   }
 
   def resultToJson(result: T, b: Boolean): Obj

--- a/console/src/test/scala/io/joern/console/cpgqlserver/CPGQLServerTests.scala
+++ b/console/src/test/scala/io/joern/console/cpgqlserver/CPGQLServerTests.scala
@@ -193,7 +193,7 @@ class CPGQLServerTests extends AnyWordSpec with Matchers {
         resp.obj.keySet should contain("stderr")
         resp.obj.keySet should not contain "err"
 
-        resp("success").bool shouldBe false
+        resp("success").bool shouldBe true
         resp("uuid").str shouldBe wsMsg
         resp("stdout").str shouldBe ""
         resp("stderr").str.length should not be 0
@@ -224,7 +224,7 @@ class CPGQLServerTests extends AnyWordSpec with Matchers {
           resp.obj.keySet should contain("stderr")
           resp.obj.keySet should not contain "err"
 
-          resp("success").bool shouldBe false
+          resp("success").bool shouldBe true
           resp("uuid").str shouldBe wsMsg
           resp("stdout").str shouldBe ""
           resp("stderr").str.length should not be 0


### PR DESCRIPTION
Looks to me like the `success` field is always false even if the query was actually executed without problems. This PR changes that.