### PR TITLE
Fixed joern-cli distribution

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -121,11 +121,5 @@ generateScaladocs := {
 }
 
 Universal / packageBin / mappings ++= sbt.Path.directory(new File("joern-cli/src/main/resources/scripts"))
-Universal / packageBin / mappings ++= {
-  val astgenDir = new File("joern-cli/frontends/jssrc2cpg/bin/astgen/")
-  astgenDir.listFiles.toSeq.map { f =>
-    f -> ("frontends/jssrc2cpg/bin/astgen/" + f.getName)
-  }
-}
 
 maintainer := "fabs@shiftleft.io"

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -121,5 +121,11 @@ generateScaladocs := {
 }
 
 Universal / packageBin / mappings ++= sbt.Path.directory(new File("joern-cli/src/main/resources/scripts"))
+Universal / packageBin / mappings ++= {
+  val astgenDir = new File("joern-cli/frontends/jssrc2cpg/bin/astgen/")
+  astgenDir.listFiles.toSeq.map { f =>
+    f -> ("frontends/jssrc2cpg/bin/astgen/" + f.getName)
+  }
+}
 
 maintainer := "fabs@shiftleft.io"

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -65,5 +65,16 @@ Test / fork := true
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 
+lazy val astGenCopyTask = taskKey[Unit](s"Copy astgen binaries")
+
+astGenCopyTask := {
+  val to = target.value / "universal" / "stage" / "bin" / "astgen"
+  to.mkdirs()
+  val from = baseDirectory.value / "bin" / "astgen"
+  IO.copyDirectory(from, to)
+}
+
+stage := (stage dependsOn astGenCopyTask).value
+
 Universal / packageName       := name.value
 Universal / topLevelDirectory := None

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -4,7 +4,6 @@ import better.files.File
 import io.joern.jssrc2cpg.Config
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.utils.ExternalCommand
-import io.shiftleft.utils.ProjectRoot
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths
@@ -25,8 +24,11 @@ object AstGenRunner {
     "astgen-win.exe"
   }
 
-  private val EXECUTABLE_DIR: String =
-    Paths.get(ProjectRoot.relativise("joern-cli/frontends/jssrc2cpg/bin/astgen")).toAbsolutePath.toString
+  private val EXECUTABLE_DIR: String = {
+    val dir      = AstGenRunner.getClass.getProtectionDomain.getCodeSource.getLocation.toString
+    val fixedDir = new java.io.File(dir.substring("file:".length, dir.indexOf("jssrc2cpg"))).toString
+    Paths.get(fixedDir, "jssrc2cpg/bin/astgen").toAbsolutePath.toString
+  }
 
   private val TYPE_DEFINITION_FILE_EXTENSIONS = List(".t.ts.json", ".d.ts.json")
 

--- a/joern-cli/src/universal/joern-export.bat
+++ b/joern-cli/src/universal/joern-export.bat
@@ -1,0 +1,6 @@
+@echo off
+
+set "SCRIPT_ABS_DIR=%~dp0"
+set "SCRIPT=%SCRIPT_ABS_DIR%bin\joern-export.bat"
+
+"%SCRIPT%" "-J-XX:+UseG1GC" "-J-XX:CompressedClassSpaceSize=128m" "-Dlog4j.configurationFile=%SCRIPT_ABS_DIR%conf\log4j2.xml" %*

--- a/joern-cli/src/universal/joern-flow.bat
+++ b/joern-cli/src/universal/joern-flow.bat
@@ -1,0 +1,6 @@
+@echo off
+
+set "SCRIPT_ABS_DIR=%~dp0"
+set "SCRIPT=%SCRIPT_ABS_DIR%bin\joern-flow.bat"
+
+"%SCRIPT%" "-J-XX:+UseG1GC" "-J-XX:CompressedClassSpaceSize=128m" "-Dlog4j.configurationFile=%SCRIPT_ABS_DIR%conf\log4j2.xml" %*

--- a/joern-cli/src/universal/joern-parse.bat
+++ b/joern-cli/src/universal/joern-parse.bat
@@ -1,0 +1,6 @@
+@echo off
+
+set "SCRIPT_ABS_DIR=%~dp0"
+set "SCRIPT=%SCRIPT_ABS_DIR%bin\joern-parse.bat"
+
+"%SCRIPT%" "-J-XX:+UseG1GC" "-J-XX:CompressedClassSpaceSize=128m" "-Dlog4j.configurationFile=%SCRIPT_ABS_DIR%conf\log4j2.xml" %*

--- a/joern-cli/src/universal/joern-scan.bat
+++ b/joern-cli/src/universal/joern-scan.bat
@@ -1,0 +1,6 @@
+@echo off
+
+set "SCRIPT_ABS_DIR=%~dp0"
+set "SCRIPT=%SCRIPT_ABS_DIR%bin\joern-scan.bat"
+
+"%SCRIPT%" "-J-XX:+UseG1GC" "-J-XX:CompressedClassSpaceSize=128m" "-Dlog4j.configurationFile=%SCRIPT_ABS_DIR%conf\log4j2.xml" %*

--- a/joern-cli/src/universal/joern-stats.bat
+++ b/joern-cli/src/universal/joern-stats.bat
@@ -1,0 +1,6 @@
+@echo off
+
+set "SCRIPT_ABS_DIR=%~dp0"
+set "SCRIPT=%SCRIPT_ABS_DIR%bin\joern-stats.bat"
+
+"%SCRIPT%" "-J-XX:+UseG1GC" "-J-XX:CompressedClassSpaceSize=128m" "-Dlog4j.configurationFile=%SCRIPT_ABS_DIR%conf\log4j2.xml" %*

--- a/joern-cli/src/universal/joern.bat
+++ b/joern-cli/src/universal/joern.bat
@@ -1,0 +1,6 @@
+@echo off
+
+set "SCRIPT_ABS_DIR=%~dp0"
+set "SCRIPT=%SCRIPT_ABS_DIR%bin\ammonite-bridge.bat"
+
+"%SCRIPT%" "-J-XX:+UseG1GC" "-J-XX:CompressedClassSpaceSize=128m" "-Dlog4j.configurationFile=%SCRIPT_ABS_DIR%conf\log4j2.xml" %*


### PR DESCRIPTION
We actually need to copy the binaries of astgen required for jssrc2cpg to the final distribution.
Also added remaining missing .bat files for executing joern and joern-* under Windows.