### PR TITLE
Misc javasrc fixes

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1066,24 +1066,30 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     astForBlockStatement(catchClause.getBody)
   }
 
-  def astForTry(stmt: TryStmt): Ast = {
+  def astsForTry(stmt: TryStmt): Seq[Ast] = {
     val tryNode = NewControlStructure()
       .controlStructureType(ControlStructureTypes.TRY)
       .code("try")
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
 
+    val resources = stmt.getResources.asScala.flatMap(astsForExpression(_, expectedType = None)).toList
     val tryAst    = astForBlockStatement(stmt.getTryBlock, codeStr = "try")
     val catchAsts = stmt.getCatchClauses.asScala.map(astForCatchClause)
-    val catchBlock = Ast(NewBlock().code("catch"))
-      .withChildren(catchAsts)
+    val catchBlock = Option
+      .when(catchAsts.nonEmpty) {
+        Ast(NewBlock().code("catch")).withChildren(catchAsts)
+      }
+      .toList
     val finallyAst =
       stmt.getFinallyBlock.toScala.map(astForBlockStatement(_, "finally")).toList
 
-    Ast(tryNode)
+    val controlStructureAst = Ast(tryNode)
       .withChild(tryAst)
-      .withChild(catchBlock)
+      .withChildren(catchBlock)
       .withChildren(finallyAst)
+
+    resources.appended(controlStructureAst)
   }
 
   private def astsForStatement(statement: Statement): Seq[Ast] = {
@@ -1109,7 +1115,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case x: SwitchStmt       => Seq(astForSwitchStatement(x))
       case x: SynchronizedStmt => Seq(astForSynchronizedStatement(x))
       case x: ThrowStmt        => Seq(astForThrow(x))
-      case x: TryStmt          => Seq(astForTry(x))
+      case x: TryStmt          => astsForTry(x)
       case x: WhileStmt        => Seq(astForWhile(x))
       case x =>
         logger.warn(s"Attempting to generate AST for unknown statement $x")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ArrayTests.scala
@@ -7,15 +7,65 @@ import io.shiftleft.semanticcpg.language._
 
 class ArrayTests extends JavaSrcCode2CpgFixture {
 
-  "array initializer expressions" should {
-    lazy val cpg = code("""
-        |class Foo {
-        |  public void foo() {
-        |    int[] x = {0, 1, 2};
-        |  }
-        |}
-        |""".stripMargin)
-    "initialize array with constant initialization expression" in {
+  "constant array initializer expressions" should {
+    "take preference in separated declaration and initializations" in {
+      val cpg = code("""
+                       |class Foo {
+                       |  public static void foo() {
+                       |    int[] xs;
+                       |    xs = new int[] {1, 2, 3};
+                       |  }
+                       |}
+                       |""".stripMargin)
+
+      cpg.method.name("foo").assignment.argument.l match {
+        case List(target: Identifier, arrayInitializer: Call) =>
+          target.name shouldBe "xs"
+          target.code shouldBe "xs"
+          target.argumentIndex shouldBe 1
+          target.typeFullName shouldBe "int[]"
+
+          arrayInitializer.name shouldBe Operators.arrayInitializer
+          arrayInitializer.methodFullName shouldBe Operators.arrayInitializer
+          arrayInitializer.code shouldBe "new int[] { 1, 2, 3 }"
+          arrayInitializer.typeFullName shouldBe "int[]"
+
+        case result => fail(s"Expected array initializer assignment args but got $result")
+      }
+    }
+    "take preference in combined declaration and initializations" in {
+      val cpg = code("""
+                       |class Foo {
+                       |  public static void foo() {
+                       |    int[] xs = new int[] { 1, 2, 3 };
+                       |  }
+                       |}
+                       |""".stripMargin)
+
+      cpg.method.name("foo").assignment.argument.l match {
+        case List(target: Identifier, arrayInitializer: Call) =>
+          target.name shouldBe "xs"
+          target.code shouldBe "xs"
+          target.argumentIndex shouldBe 1
+          target.typeFullName shouldBe "int[]"
+
+          arrayInitializer.name shouldBe Operators.arrayInitializer
+          arrayInitializer.methodFullName shouldBe Operators.arrayInitializer
+          arrayInitializer.code shouldBe "new int[] { 1, 2, 3 }"
+          arrayInitializer.typeFullName shouldBe "int[]"
+
+        case result => fail(s"Expected array initializer assignment args but got $result")
+      }
+    }
+
+    "initialize arrays with constant initialization expression" in {
+      val cpg = code("""
+                       |class Foo {
+                       |  public void foo() {
+                       |    int[] x = {0, 1, 2};
+                       |	 }
+                       |}
+                       |""".stripMargin)
       def m = cpg.method(".*foo.*")
 
       val List(arg1: Identifier, arg2: Call) = m.assignment.argument.l
@@ -32,64 +82,62 @@ class ArrayTests extends JavaSrcCode2CpgFixture {
     }
   }
 
-  "array initializers without constant initialization expressions" should {
-    lazy val cpg = code("""
-        |class Foo {
-        |  public void bar() {
-        |    int[][] x = new int[5][2];
-        |  }
-        |}
-        |""".stripMargin)
+  "should initialize an array with empty initialization expression" in {
+    val cpg = code("""
+                     |public class Foo {
+                     |  public void bar() {
+                     |    int[][] x = new int[5][2];
+                     |  }
+                     |}
+                     |""".stripMargin)
 
-    "initialize an array with empty initialization expression" in {
-      def m = cpg.method(".*bar.*")
+    def m = cpg.method(".*bar.*")
 
-      val List(arg1: Identifier, arg2: Call) = m.assignment.argument.l
+    val List(arg1: Identifier, arg2: Call) = m.assignment.argument.l
 
-      arg1.typeFullName shouldBe "int[][]"
+    arg1.typeFullName shouldBe "int[][]"
 
-      arg2.code shouldBe "new int[5][2]"
-      val List(lvl1: Literal, lvl2: Literal) = arg2.argument.l
-      lvl1.code shouldBe "5"
-      lvl2.code shouldBe "2"
-    }
+    arg2.code shouldBe "new int[5][2]"
+    val List(lvl1: Literal, lvl2: Literal) = arg2.argument.l
+    lvl1.code shouldBe "5"
+    lvl2.code shouldBe "2"
   }
 
-  "array index accesses" should {
-    lazy val cpg = code("""
-        |class Foo {
-        |  public void baz() {
-        |    int[] x = new int[2];
-        |    x[0] = 1;
-        |    x[1] = x[0] + 2;
-        |  }
-        |}
-        |""".stripMargin)
+  "arrayIndexAccesses" should {
+    val cpg = code("""
+                     |class Foo {
+                     |  public void baz() {
+                     |    int[] x = new int[2];
+                     |    x[0] = 1;
+                     |    x[1] = x[0] + 2;
+                     |  }
+                     |}
+                     |""".stripMargin)
 
-    "be handled correctly" in {
-      def m = cpg.method(".*baz.*")
+    "be handled correctly on the LHS of an assignment" in {
+      def m                     = cpg.method(".*baz.*")
+      val List(_, lhsAccess, _) = m.assignment.l
 
-      val List(_, lhsAccess, rhsAccess) = m.assignment.l
+      val List(indexAccess: Call, _: Literal) = lhsAccess.argument.l
+      indexAccess.name shouldBe Operators.indexAccess
+      indexAccess.methodFullName shouldBe Operators.indexAccess
+      val List(arg1: Identifier, arg2: Literal) = indexAccess.argument.l
+      arg1.code shouldBe "x"
+      arg1.name shouldBe "x"
+      arg1.typeFullName shouldBe "int[]"
+      arg2.code shouldBe "0"
+    }
 
-      withClue("indexAccess on LHS of assignment") {
-        val List(indexAccess: Call, _: Literal) = lhsAccess.argument.l
-        indexAccess.name shouldBe Operators.indexAccess
-        indexAccess.methodFullName shouldBe Operators.indexAccess
-        val List(arg1: Identifier, arg2: Literal) = indexAccess.argument.l
-        arg1.code shouldBe "x"
-        arg1.name shouldBe "x"
-        arg1.typeFullName shouldBe "int[]"
-        arg2.code shouldBe "0"
-      }
+    "be handled correctly on the RHS of an assignment" in {
+      def m                     = cpg.method(".*baz.*")
+      val List(_, _, rhsAccess) = m.assignment.l
 
-      withClue("indexAccess in expr on RHS of assignment") {
-        val List(_, add: Call)                           = rhsAccess.argument.l
-        val List(access: Call, _: Literal)               = add.argument.l
-        val List(identifier: Identifier, index: Literal) = access.argument.l
-        identifier.name shouldBe "x"
-        identifier.typeFullName shouldBe "int[]"
-        index.code shouldBe "0"
-      }
+      val List(_, add: Call)                           = rhsAccess.argument.l
+      val List(access: Call, _: Literal)               = add.argument.l
+      val List(identifier: Identifier, index: Literal) = access.argument.l
+      identifier.name shouldBe "x"
+      identifier.typeFullName shouldBe "int[]"
+      index.code shouldBe "0"
     }
   }
 }


### PR DESCRIPTION
# Changes:
* flatten the AST for expressions like `new int[] {1, 2, 3}`, which were previously represented as an `<operator>.alloc` call with an `<operator>.arraiInitializer` call as a child. 
* add resource initialisers to the AST directly before the `try-with-resources` block in which they are defined.