### PR TITLE
Add ConfigFile nodes to javasrc2cpg ASTs

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -1,7 +1,7 @@
 package io.joern.javasrc2cpg
 
 import better.files.File
-import io.joern.javasrc2cpg.passes.AstCreationPass
+import io.joern.javasrc2cpg.passes.{AstCreationPass, ConfigFileCreationPass}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
@@ -36,6 +36,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
 
       val astCreator = new AstCreationPass(sourcesDir, sourceFileNames, config, cpg)
       astCreator.createAndApply()
+      new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
         .createAndApply()
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
@@ -10,8 +10,7 @@ import org.slf4j.LoggerFactory
 import java.nio.file.Paths
 import scala.util.{Failure, Success, Try}
 
-class ConfigFileCreationPass(projectDir: String, cpg: Cpg)
-  extends ConcurrentWriterCpgPass[File](cpg) {
+class ConfigFileCreationPass(projectDir: String, cpg: Cpg) extends ConcurrentWriterCpgPass[File](cpg) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -32,8 +31,8 @@ class ConfigFileCreationPass(projectDir: String, cpg: Cpg)
   override def runOnPart(diffGraph: DiffGraphBuilder, file: File): Unit = {
     Try(IOUtils.readLinesInFile(file.path)) match {
       case Success(fileContentsLines) =>
-        val name = configFileName(file)
-        val content = fileContentsLines.mkString("\n")
+        val name       = configFileName(file)
+        val content    = fileContentsLines.mkString("\n")
         val configNode = NewConfigFile().name(name).content(content)
         logger.debug(s"Adding config file $name")
         diffGraph.addNode(configNode)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
@@ -1,0 +1,96 @@
+package io.joern.javasrc2cpg.passes
+
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.utils.IOUtils
+import org.slf4j.LoggerFactory
+
+import java.nio.file.Paths
+import scala.util.{Failure, Success, Try}
+
+class ConfigFileCreationPass(projectDir: String, cpg: Cpg)
+  extends ConcurrentWriterCpgPass[File](cpg) {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def generateParts(): Array[File] = {
+    Try(File(projectDir)) match {
+      case Success(file) if file.isDirectory =>
+        file.listRecursively
+          .filter(isConfigFile)
+          .toArray
+
+      case Success(file) if isConfigFile(file) =>
+        Array(file)
+
+      case _ => Array.empty
+    }
+  }
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, file: File): Unit = {
+    Try(IOUtils.readLinesInFile(file.path)) match {
+      case Success(fileContentsLines) =>
+        val name = configFileName(file)
+        val content = fileContentsLines.mkString("\n")
+        val configNode = NewConfigFile().name(name).content(content)
+        logger.debug(s"Adding config file $name")
+        diffGraph.addNode(configNode)
+
+      case Failure(error) =>
+        logger.warn(s"Unable to create config file node for ${file.canonicalPath}: $error")
+    }
+  }
+
+  private def configFileName(configFile: File): String = {
+    Try(Paths.get(projectDir)) match {
+      case Success(basePath) =>
+        basePath.relativize(configFile.path).toString
+
+      case Failure(_) =>
+        configFile.name
+    }
+  }
+
+  private def extensionFilter(extension: String)(file: File): Boolean = {
+    file.extension.contains(extension)
+  }
+
+  private def pathEndFilter(pathEnd: String)(file: File): Boolean = {
+    file.canonicalPath.endsWith(pathEnd)
+  }
+
+  private def mybatisFilter(file: File): Boolean = {
+    file.canonicalPath.contains("batis") && file.extension.contains(".xml")
+  }
+
+  private val configFileFilters: List[File => Boolean] = List(
+    // JAVA_INTERNAL
+    extensionFilter(".properties"),
+    // JSP
+    extensionFilter(".jsp"),
+    // Velocity files, see https://velocity.apache.org
+    extensionFilter(".vm"),
+    // For Terraform secrets
+    extensionFilter(".tf"),
+    extensionFilter(".tfvars"),
+    // PLAY
+    pathEndFilter("routes"),
+    pathEndFilter("application.conf"),
+    // SERVLET
+    pathEndFilter("web.xml"),
+    // JSF
+    pathEndFilter("faces-config.xml"),
+    // STRUTS
+    pathEndFilter("struts.xml"),
+    // DIRECT WEB REMOTING
+    pathEndFilter("dwr.xml"),
+    // MYBATIS
+    mybatisFilter
+  )
+
+  private def isConfigFile(file: File): Boolean = {
+    configFileFilters.exists(predicate => predicate(file))
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/application.conf
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/application.conf
@@ -1,0 +1,1 @@
+basic conf

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.jsp
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.jsp
@@ -1,0 +1,1 @@
+basic jsp

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.properties
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.properties
@@ -1,0 +1,1 @@
+key=value

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.tf
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.tf
@@ -1,0 +1,1 @@
+basic tf

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.tfvars
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.tfvars
@@ -1,0 +1,1 @@
+basic tfvars

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.vm
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.vm
@@ -1,0 +1,1 @@
+basic velocity

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/batis/conf.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/batis/conf.xml
@@ -1,0 +1,1 @@
+basic batis conf

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/dwr.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/dwr.xml
@@ -1,0 +1,1 @@
+basic dwr

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/faces-config.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/faces-config.xml
@@ -1,0 +1,1 @@
+basic jsf

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/nested/nested.properties
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/nested/nested.properties
@@ -1,0 +1,1 @@
+basic nested properties

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/no-conf-1.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/no-conf-1.xml
@@ -1,0 +1,1 @@
+should not find

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/no-conf-2.conf
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/no-conf-2.conf
@@ -1,0 +1,1 @@
+should not find

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/routes
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/routes
@@ -1,0 +1,1 @@
+basic routes

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/struts.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/struts.xml
@@ -1,0 +1,1 @@
+basic struts

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/web.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/web.xml
@@ -1,0 +1,1 @@
+basic xml

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -8,10 +8,11 @@ import io.shiftleft.utils.ProjectRoot
 
 class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
 
-  private val testConfigDir: String = ProjectRoot.relativise("joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests")
+  private val testConfigDir: String =
+    ProjectRoot.relativise("joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests")
 
   "it should find the correct config files" in {
-    val foundFiles = new ConfigFileCreationPass(testConfigDir, new Cpg()).generateParts().map(_.canonicalPath)
+    val foundFiles        = new ConfigFileCreationPass(testConfigDir, new Cpg()).generateParts().map(_.canonicalPath)
     val absoluteConfigDir = File(testConfigDir).canonicalPath
     foundFiles should contain theSameElementsAs Array(
       s"$absoluteConfigDir/application.conf",
@@ -26,7 +27,7 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
       s"$absoluteConfigDir/faces-config.xml",
       s"$absoluteConfigDir/nested/nested.properties",
       s"$absoluteConfigDir/struts.xml",
-      s"$absoluteConfigDir/web.xml",
+      s"$absoluteConfigDir/web.xml"
     )
   }
 
@@ -34,10 +35,7 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
     val cpg = code("""
         |public class Foo{}
 	    |""".stripMargin)
-      .moreCode(
-        code = "key=value",
-        fileName = "config.properties"
-      )
+      .moreCode(code = "key=value", fileName = "config.properties")
 
     cpg.typeDecl.name("Foo").nonEmpty shouldBe true
     cpg.configFile.l match {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -1,0 +1,52 @@
+package io.joern.javasrc2cpg.passes
+
+import better.files.File
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.utils.ProjectRoot
+
+class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
+
+  private val testConfigDir: String = ProjectRoot.relativise("joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests")
+
+  "it should find the correct config files" in {
+    val foundFiles = new ConfigFileCreationPass(testConfigDir, new Cpg()).generateParts().map(_.canonicalPath)
+    val absoluteConfigDir = File(testConfigDir).canonicalPath
+    foundFiles should contain theSameElementsAs Array(
+      s"$absoluteConfigDir/application.conf",
+      s"$absoluteConfigDir/basic.jsp",
+      s"$absoluteConfigDir/basic.properties",
+      s"$absoluteConfigDir/routes",
+      s"$absoluteConfigDir/basic.tf",
+      s"$absoluteConfigDir/basic.tfvars",
+      s"$absoluteConfigDir/basic.vm",
+      s"$absoluteConfigDir/batis/conf.xml",
+      s"$absoluteConfigDir/dwr.xml",
+      s"$absoluteConfigDir/faces-config.xml",
+      s"$absoluteConfigDir/nested/nested.properties",
+      s"$absoluteConfigDir/struts.xml",
+      s"$absoluteConfigDir/web.xml",
+    )
+  }
+
+  "it should populate config files correctly" in {
+    val cpg = code("""
+        |public class Foo{}
+	    |""".stripMargin)
+      .moreCode(
+        code = "key=value",
+        fileName = "config.properties"
+      )
+
+    cpg.typeDecl.name("Foo").nonEmpty shouldBe true
+    cpg.configFile.l match {
+      case List(configFile) =>
+        configFile.name shouldBe "config.properties"
+        configFile.content shouldBe "key=value"
+
+      case result => fail(s"Expected single config file but got $result")
+    }
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -6,6 +6,8 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.utils.ProjectRoot
 
+import java.nio.file.Paths
+
 class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
 
   private val testConfigDir: String =
@@ -15,19 +17,19 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
     val foundFiles        = new ConfigFileCreationPass(testConfigDir, new Cpg()).generateParts().map(_.canonicalPath)
     val absoluteConfigDir = File(testConfigDir).canonicalPath
     foundFiles should contain theSameElementsAs Array(
-      s"$absoluteConfigDir/application.conf",
-      s"$absoluteConfigDir/basic.jsp",
-      s"$absoluteConfigDir/basic.properties",
-      s"$absoluteConfigDir/routes",
-      s"$absoluteConfigDir/basic.tf",
-      s"$absoluteConfigDir/basic.tfvars",
-      s"$absoluteConfigDir/basic.vm",
-      s"$absoluteConfigDir/batis/conf.xml",
-      s"$absoluteConfigDir/dwr.xml",
-      s"$absoluteConfigDir/faces-config.xml",
-      s"$absoluteConfigDir/nested/nested.properties",
-      s"$absoluteConfigDir/struts.xml",
-      s"$absoluteConfigDir/web.xml"
+      Paths.get(absoluteConfigDir, "application.conf").toString,
+      Paths.get(absoluteConfigDir, "basic.jsp").toString,
+      Paths.get(absoluteConfigDir, "basic.properties").toString,
+      Paths.get(absoluteConfigDir, "routes").toString,
+      Paths.get(absoluteConfigDir, "basic.tf").toString,
+      Paths.get(absoluteConfigDir, "basic.tfvars").toString,
+      Paths.get(absoluteConfigDir, "basic.vm").toString,
+      Paths.get(absoluteConfigDir, "batis", "conf.xml").toString,
+      Paths.get(absoluteConfigDir, "dwr.xml").toString,
+      Paths.get(absoluteConfigDir, "faces-config.xml").toString,
+      Paths.get(absoluteConfigDir, "nested", "nested.properties").toString,
+      Paths.get(absoluteConfigDir, "struts.xml").toString,
+      Paths.get(absoluteConfigDir, "web.xml").toString
     )
   }
 


### PR DESCRIPTION
The list of config file filters is based on that used by `java2cpg` in [ConfigFile.java](https://github.com/ShiftLeftSecurity/java2cpg/blob/master/java2cpg/src/main/java/io/shiftleft/java2cpg/configfiles/ConfigFile.java). 