### PR TITLE
javasrc: Fix relative path crash during config file creation

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
@@ -43,13 +43,10 @@ class ConfigFileCreationPass(projectDir: String, cpg: Cpg) extends ConcurrentWri
   }
 
   private def configFileName(configFile: File): String = {
-    Try(Paths.get(projectDir)) match {
-      case Success(basePath) =>
-        basePath.relativize(configFile.path).toString
-
-      case Failure(_) =>
-        configFile.name
-    }
+    Try(Paths.get(projectDir).toAbsolutePath)
+      .map(_.relativize(configFile.path.toAbsolutePath).toString)
+      .orElse(Try(configFile.pathAsString))
+      .getOrElse(configFile.name)
   }
 
   private def extensionFilter(extension: String)(file: File): Boolean = {


### PR DESCRIPTION
Before these changes, the frontend would crash if the frontend was invoked with a relative path to the java project. This fixes the absoluteness of the paths and is just more robust in general.