### PR TITLE
jssrc2cpg: removed test resource files

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/broken/broken.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/broken/broken.js
@@ -1,1 +1,0 @@
-console.log("broken;

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/broken/good.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/broken/good.js
@@ -1,1 +1,0 @@
-console.log("good");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/closurebinding/foobar.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/closurebinding/foobar.js
@@ -1,7 +1,0 @@
-function foo()
-{
-    x = 1;
-    function bar() {
-        x = 2;
-    }
-}

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/closurebinding/nested/a.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/closurebinding/nested/a.js
@@ -1,7 +1,0 @@
-function a1()
-{
-    x = 1;
-    function a2() {
-        x = 2;
-    }
-}

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/closurebinding/nested/b.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/closurebinding/nested/b.js
@@ -1,7 +1,0 @@
-function b1()
-{
-    x = 1;
-    function b2() {
-        x = 2;
-    }
-}

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/.sub/e.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/.sub/e.js
@@ -1,1 +1,0 @@
-console.log("e.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/a.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/a.js
@@ -1,1 +1,0 @@
-console.log("a.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/a.min.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/a.min.js
@@ -1,1 +1,0 @@
-console.log("a.min.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/b-min.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/b-min.js
@@ -1,1 +1,0 @@
-console.log("b-min.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/c.spec.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/c.spec.js
@@ -1,1 +1,0 @@
-console.log("c-spec.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/d.chunk.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/d.chunk.js
@@ -1,1 +1,0 @@
-console.log("d.chunk.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/folder/b.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/folder/b.js
@@ -1,1 +1,0 @@
-console.log("folder/b.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/folder/c.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/folder/c.js
@@ -1,1 +1,0 @@
-console.log("folder/c.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/foo.bar/d.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/foo.bar/d.js
@@ -1,1 +1,0 @@
-console.log("foo.bar/d.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/index.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/index.js
@@ -1,1 +1,0 @@
-console.log("index.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/a.spec.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/a.spec.js
@@ -1,1 +1,0 @@
-console.log("tests/a.spec.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/b.mock.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/b.mock.js
@@ -1,1 +1,0 @@
-console.log("tests/b.mock.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/c.e2e.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/c.e2e.js
@@ -1,1 +1,0 @@
-console.log("tests/c.e2e.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/d.test.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/excludes/tests/d.test.js
@@ -1,1 +1,0 @@
-console.log("tests/d.test.js");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/rec/a.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/rec/a.js
@@ -1,1 +1,0 @@
-console.log("a");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/rec/b.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/rec/b.js
@@ -1,1 +1,0 @@
-console.log("b");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/rec/sub/c.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/rec/sub/c.js
@@ -1,1 +1,0 @@
-console.log("c");

--- a/joern-cli/frontends/jssrc2cpg/src/test/resources/rec/sub/d.js
+++ b/joern-cli/frontends/jssrc2cpg/src/test/resources/rec/sub/d.js
@@ -1,1 +1,0 @@
-console.log("d");

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTest.scala
@@ -9,12 +9,39 @@ import io.shiftleft.semanticcpg.language._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.BeforeAndAfterAll
 
 import java.util.regex.Pattern
 
-class ExcludeTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+class ExcludeTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks with BeforeAndAfterAll {
 
-  private val projectUnderTest = File(getClass.getResource("/excludes").toURI)
+  private val testFiles: List[String] = List(
+    ".sub/e.js",
+    "folder/b.js",
+    "folder/c.js",
+    "foo.bar/d.js",
+    "tests/a.spec.js",
+    "tests/b.mock.js",
+    "tests/c.e2e.js",
+    "tests/d.test.js",
+    "a.js",
+    "b-min.js",
+    "c.spec.js",
+    "d.chunk.js",
+    "index.js"
+  )
+
+  private val projectUnderTest: File = {
+    val dir = File.newTemporaryDirectory("jssrc2cpgTestsExludeTest")
+    testFiles.foreach { testFile =>
+      val file = dir / testFile
+      file.createIfNotExists(createParents = true)
+      file.write(s"""console.log("${file.canonicalPath}");""")
+    }
+    dir
+  }
+
+  override def afterAll(): Unit = projectUnderTest.delete(swallowIOExceptions = true)
 
   private def testWithArguments(exclude: Seq[String], excludeRegex: String, expectedFiles: Set[String]): Unit = {
     File.usingTemporaryDirectory("jssrc2cpgTests") { tmpDir =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ProjectParseTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ProjectParseTests.scala
@@ -8,16 +8,42 @@ import io.joern.jssrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
+import org.scalatest.BeforeAndAfterAll
 
-class ProjectParseTests extends JsSrc2CpgSuite {
+class ProjectParseTests extends JsSrc2CpgSuite with BeforeAndAfterAll {
+
+  private val projectWithSubfolders: File = {
+    val dir = File.newTemporaryDirectory("jssrc2cpgTestsSubfolders")
+    List("sub/c.js", "sub/d.js", "a.js", "b.js").foreach { testFile =>
+      val file = dir / testFile
+      file.createIfNotExists(createParents = true)
+      file.write(s"""console.log("${file.canonicalPath}");""")
+    }
+    dir
+  }
+
+  private val projectWithBrokenFile: File = {
+    val dir      = File.newTemporaryDirectory("jssrc2cpgTestsBroken")
+    val goodFile = dir / "good.js"
+    goodFile.createIfNotExists(createParents = true)
+    goodFile.write(s"""console.log("good");""")
+    val brokenFile = dir / "broken.js"
+    brokenFile.createIfNotExists(createParents = true)
+    brokenFile.write(s"""console.log("broken""")
+    dir
+  }
+
+  override def afterAll(): Unit = {
+    projectWithSubfolders.delete(swallowIOExceptions = true)
+    projectWithBrokenFile.delete(swallowIOExceptions = true)
+  }
 
   private object ProjectParseTestsFixture {
-    def apply(project: String)(f: Cpg => Unit): Unit = {
+    def apply(projectDir: File)(f: Cpg => Unit): Unit = {
       File.usingTemporaryDirectory("jssrc2cpgTests") { tmpDir =>
-        val dir          = File(getClass.getResource(s"/$project").toURI).copyToDirectory(tmpDir)
         val cpg          = newEmptyCpg()
-        val config       = Config(inputPath = dir.toString, outputPath = dir.toString)
-        val astgenResult = AstGenRunner.execute(config, dir)
+        val config       = Config(inputPath = projectDir.toString, outputPath = tmpDir.toString)
+        val astgenResult = AstGenRunner.execute(config, tmpDir)
         new AstCreationPass(cpg, astgenResult, config).createAndApply()
         f(cpg)
       }
@@ -26,7 +52,7 @@ class ProjectParseTests extends JsSrc2CpgSuite {
 
   "Parsing a project" should {
 
-    "generate correct filenames" in ProjectParseTestsFixture("rec") { cpg =>
+    "generate correct filenames" in ProjectParseTestsFixture(projectWithSubfolders) { cpg =>
       cpg.file.name.l should contain allElementsOf List(
         "a.js",
         "b.js",
@@ -35,8 +61,8 @@ class ProjectParseTests extends JsSrc2CpgSuite {
       )
     }
 
-    "recover from broken input file" in ProjectParseTestsFixture("broken") { cpg =>
-      cpg.file.name.l should (contain("good.js") and not contain ("broken.js"))
+    "recover from broken input file" in ProjectParseTestsFixture(projectWithBrokenFile) { cpg =>
+      cpg.file.name.l should (contain("good.js") and not contain "broken.js")
     }
 
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/AbstractPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/AbstractPassTest.scala
@@ -27,16 +27,6 @@ abstract class AbstractPassTest extends AnyWordSpec with Matchers with Inside {
         file.delete()
       }
     }
-
-    def apply(testFile: File)(f: Cpg => Unit): Unit = {
-      val file         = testFile
-      val dir          = file.parent
-      val cpg          = newEmptyCpg()
-      val config       = Config(inputPath = dir.toString(), outputPath = dir.toString())
-      val astgenResult = AstGenRunner.execute(config, dir)
-      new AstCreationPass(cpg, astgenResult, config).createAndApply()
-      f(cpg)
-    }
   }
 
   protected object CfgFixture extends Fixture {


### PR DESCRIPTION
Test files and their content that is required during jssrc2cpg tests is now generated on-the-fly.
This is way easier to maintain as the single point of truth is now directly visible in the test code.
Hence, we do not have to rely on external files any longer. Also, the handling of resource paths / URIs during testing within Intellij or a SBT shell is quite error prone.