### PR TITLE
bring back js2cpg frontend as a fallback, if jssrc isn't available

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
@@ -1,0 +1,23 @@
+package io.joern.console.cpgcreation
+
+import io.joern.console.FrontendConfig
+
+import java.nio.file.Path
+
+case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+  private lazy val command: Path = if (isWin) rootPath.resolve("js2cpg.bat") else rootPath.resolve("js2cpg.sh")
+
+  /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
+    */
+  override def generate(
+    inputPath: String,
+    outputPath: String = "cpg.bin.zip",
+    namespaces: List[String] = List()
+  ): Option[String] = {
+    val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean =
+    command.toFile.exists
+}

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -16,19 +16,23 @@ package object cpgcreation {
     rootPath: Path,
     args: List[String]
   ): Option[CpgGenerator] = {
+    lazy val conf = config.withArgs(args)
     language match {
-      case Languages.CSHARP                       => Some(CSharpCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.C | Languages.NEWC           => Some(CCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.LLVM                         => Some(LlvmCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.GOLANG                       => Some(GoCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.JAVA                         => Some(JavaCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.JAVASRC                      => Some(JavaSrcCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.JSSRC | Languages.JAVASCRIPT => Some(JsSrcCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.PYTHONSRC                    => Some(PythonSrcCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.PHP                          => Some(PhpCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.GHIDRA                       => Some(GhidraCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.KOTLIN                       => Some(KotlinCpgGenerator(config.withArgs(args), rootPath))
-      case _                                      => None
+      case Languages.CSHARP             => Some(CSharpCpgGenerator(conf, rootPath))
+      case Languages.C | Languages.NEWC => Some(CCpgGenerator(conf, rootPath))
+      case Languages.LLVM               => Some(LlvmCpgGenerator(conf, rootPath))
+      case Languages.GOLANG             => Some(GoCpgGenerator(conf, rootPath))
+      case Languages.JAVA               => Some(JavaCpgGenerator(conf, rootPath))
+      case Languages.JAVASRC            => Some(JavaSrcCpgGenerator(conf, rootPath))
+      case Languages.JSSRC | Languages.JAVASCRIPT =>
+        val jssrc = JsSrcCpgGenerator(conf, rootPath)
+        if (jssrc.isAvailable) Some(jssrc)
+        else Some(JsCpgGenerator(conf, rootPath))
+      case Languages.PYTHONSRC => Some(PythonSrcCpgGenerator(conf, rootPath))
+      case Languages.PHP       => Some(PhpCpgGenerator(conf, rootPath))
+      case Languages.GHIDRA    => Some(GhidraCpgGenerator(conf, rootPath))
+      case Languages.KOTLIN    => Some(KotlinCpgGenerator(conf, rootPath))
+      case _                   => None
     }
   }
 


### PR DESCRIPTION
* still required by ocular...
* partial revert of https://github.com/joernio/joern/pull/1563/files#diff-ae06dd079f8134c67a12684b24f703f9cdbb25ec59aa327ca3af32819831a646R26