### PR TITLE
StoredNode.tag|tagList: deduplicate and refactor

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1,6 +1,5 @@
 package io.joern.jssrc2cpg.passes.ast
 
-import better.files.File
 import io.joern.jssrc2cpg.passes.AbstractPassTest
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -108,9 +108,9 @@ class NodeSteps[NodeType <: StoredNode](val traversal: Traversal[NodeType]) exte
   }
 
   @Doc(info = "Tags attached to this node")
-  def tagList: List[List[TagBase]] =
+  def tagList: List[List[Tag]] =
     traversal.map { taggedNode =>
-      taggedNode.tagList.l
+      taggedNode.tag.l
     }.l
 
   @Doc(info = "Tags attached to this node")

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
@@ -9,22 +9,12 @@ import scala.jdk.CollectionConverters._
 
 class StoredNodeMethods(val node: StoredNode) extends AnyVal with NodeExtension {
   def tag: Traversal[Tag] = {
-    node._taggedByOut.asScala.map(_.asInstanceOf[Tag]).to(Traversal)
+    node._taggedByOut.asScala
+      .map(_.asInstanceOf[Tag])
+      .distinctBy(tag => (tag.name, tag.value))
+      .to(Traversal)
   }
 
   def file: Traversal[File] =
     Traversal.fromSingle(node).file
-
-  def tagList: Traversal[NewTag] = {
-    node._taggedByOut.asScala
-      .map { case tagNode: HasName with HasValue =>
-        (tagNode.name, Option(tagNode.value))
-      }
-      .distinct
-      .collect { case (name, Some(value)) =>
-        NewTag()
-          .name(name)
-          .value(value)
-      }
-  }
 }


### PR DESCRIPTION
Both `.tag` and `.tagList` did essentially the same thing, but tagList
deferred from our naming convention and unnecessarily instantiated
a `NewTag` for each existing `Tag` node.

Successor of https://github.com/joernio/joern/pull/1602