### PR TITLE
Fix some javasrc type bugs

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
@@ -120,7 +120,7 @@ class Scope extends X2CpgScope[String, NodeTypeInfo, ScopeType] {
       )
   }
 
-  def getWildcardType(identifier: String): Option[String] = {
+  private def getWildcardType(identifier: String): Option[String] = {
     lookupVariableType(WildcardImportName) map { importName =>
       s"$importName.$identifier"
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -242,7 +242,7 @@ object TypeInfoCalculator {
     val Class: String          = "java.lang.Class"
     val Iterator: String       = "java.util.Iterator"
     val Void: String           = "void"
-    val UnresolvedType: String = "<unresolvedType>"
+    val UnresolvedType: String = "codepropertygraph.Unresolved"
   }
 
   object TypeNameConstants {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -1,11 +1,9 @@
 package io.joern.javasrc2cpg.util
 
-import com.github.javaparser.ast.`type`.{PrimitiveType, Type, WildcardType}
+import com.github.javaparser.ast.`type`.{PrimitiveType, Type}
 import com.github.javaparser.resolution.SymbolResolver
 import com.github.javaparser.resolution.declarations.{
   ResolvedDeclaration,
-  ResolvedEnumConstantDeclaration,
-  ResolvedMethodDeclaration,
   ResolvedTypeDeclaration,
   ResolvedTypeParameterDeclaration
 }
@@ -232,25 +230,20 @@ object TypeInfoCalculator {
   }
 
   object TypeConstants {
-    val Byte: String                = "byte"
-    val Short: String               = "short"
-    val Int: String                 = "int"
-    val Long: String                = "long"
-    val Float: String               = "float"
-    val Double: String              = "double"
-    val Char: String                = "char"
-    val Boolean: String             = "boolean"
-    val Object: String              = "java.lang.Object"
-    val Class: String               = "java.lang.Class"
-    val Iterator: String            = "java.util.Iterator"
-    val Void: String                = "void"
-    val UnresolvedType: String      = "<unresolvedType>"
-    val UnresolvedSignature: String = "<unresolvedSignature>"
-    val UnresolvedReceiver: String  = "<unresolvedReceiverType>"
+    val Byte: String           = "byte"
+    val Short: String          = "short"
+    val Int: String            = "int"
+    val Long: String           = "long"
+    val Float: String          = "float"
+    val Double: String         = "double"
+    val Char: String           = "char"
+    val Boolean: String        = "boolean"
+    val Object: String         = "java.lang.Object"
+    val Class: String          = "java.lang.Class"
+    val Iterator: String       = "java.util.Iterator"
+    val Void: String           = "void"
+    val UnresolvedType: String = "<unresolvedType>"
   }
-
-  val unresolvedConstants =
-    List(TypeConstants.UnresolvedType, TypeConstants.UnresolvedSignature, TypeConstants.UnresolvedReceiver)
 
   object TypeNameConstants {
     val Object: String = "Object"
@@ -295,7 +288,7 @@ object TypeInfoCalculator {
 
   def apply(global: Global, symbolResolver: SymbolResolver): TypeInfoCalculator = {
     val typeInfoCalculator = new TypeInfoCalculator(global, symbolResolver)
-    unresolvedConstants.foreach(typeInfoCalculator.registerType)
+    typeInfoCalculator.registerType(TypeConstants.UnresolvedType)
     typeInfoCalculator
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
@@ -47,7 +47,7 @@ class InferenceJarTests extends AnyFreeSpec with Matchers {
 
     "it should fail to resolve the type for Deps" in {
       val call = cpg.method.name("test1").call.name("foo").head
-      call.methodFullName shouldBe s"${TypeConstants.UnresolvedReceiver}.foo:${TypeConstants.UnresolvedType}()"
+      call.methodFullName shouldBe s"${TypeConstants.UnresolvedType}.foo:${TypeConstants.UnresolvedType}()"
       call.signature shouldBe s"${TypeConstants.UnresolvedType}()"
       call.typeFullName shouldBe s"${TypeConstants.UnresolvedType}"
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
@@ -79,36 +79,36 @@ class NewTypeInferenceTests extends JavaSrcCode2CpgFixture {
 
   "type information for members" should {
     val cpg = code("""
-        |import org.slf4j.Logger;
-        |import org.slf4j.LoggerFactory;
-        |import org.springframework.core.env.Environment;
+        |import a.Logger;
+        |import a.LoggerFactory;
+        |import b.Environment;
         |
         |public class Foo {
         |  Environment env;
         |  private static Logger log = LoggerFactory.getLogger(Foo.class);
         |
         |  public void foo() {
-        |    log.info("UserName is {}", env.getProperty("sfdc.username"));
+        |    log.info("UserName is {}", env.getProperty("property"));
         |  }
         |}
         |""".stripMargin)
 
     "be inferred from imports" in {
-      cpg.member.name("env").typeFullName.head shouldBe "org.springframework.core.env.Environment"
-      cpg.member.name("log").typeFullName.head shouldBe "org.slf4j.Logger"
+      cpg.member.name("env").typeFullName.head shouldBe "b.Environment"
+      cpg.member.name("log").typeFullName.head shouldBe "a.Logger"
     }
 
     "be used in calls" in {
       cpg.call.name("info").methodFullName.l match {
         case List(fullName) =>
-          fullName shouldBe "org.slf4j.Logger.info:void(java.lang.String,<unresolvedType>)"
+          fullName shouldBe "a.Logger.info:void(java.lang.String,codepropertygraph.Unresolved)"
 
         case result => fail(s"Expected single call to info but got $result")
       }
 
       cpg.call.name("getProperty").methodFullName.l match {
         case List(fullName) =>
-          fullName shouldBe "org.springframework.core.env.Environment.getProperty:<unresolvedType>(java.lang.String)"
+          fullName shouldBe "b.Environment.getProperty:codepropertygraph.Unresolved(java.lang.String)"
 
         case result => fail(s"Expected single call to getProperty but got $result")
       }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
@@ -7,6 +7,114 @@ import io.shiftleft.semanticcpg.language._
 
 class NewTypeInferenceTests extends JavaSrcCode2CpgFixture {
 
+  "type information for constructor invocations" should {
+
+    "be found for constructor invocations at the start of a call chain" in {
+      val cpg = code("""
+          |import a.Bar;
+          |
+          |public class Foo {
+          |  public void foo() {
+          |    String s = new Bar().getValue();
+          |  }
+          |}
+          |""".stripMargin)
+
+      cpg.call.nameExact("<init>").methodFullName.l match {
+        case List(fullName) =>
+          fullName shouldBe "a.Bar.<init>:void()"
+
+        case result => fail(s"Expected single constructor invocation for Bar but found $result")
+      }
+
+      cpg.call.nameExact("getValue").methodFullName.l match {
+        case List(fullName) =>
+          fullName shouldBe "a.Bar.getValue:java.lang.String()"
+
+        case result => fail(s"Expected single call to getValue but found $result")
+      }
+    }
+
+    "be found for constructor invocations as arguments" in {
+      val cpg = code("""
+          |import a.Bar;
+          |
+          |public class Foo {
+          |
+          |  public static void foo() {
+          |    useBar(new Bar());
+          |  }
+          |
+          |  public static void useBar(Bar b) {}
+          |}
+          |""".stripMargin)
+
+      cpg.call.nameExact("<init>").methodFullName.l match {
+        case List(fullName) =>
+          fullName shouldBe "a.Bar.<init>:void()"
+
+        case result => fail(s"Expected single constructor invocation for Bar but found $result")
+      }
+    }
+
+    "be found for constructor invocations as return args" in {
+      val cpg = code("""
+          |import a.Bar;
+          |
+          |public class Foo {
+          |  public Bar getBar() {
+          |    return new Bar();
+          |  }
+          |}
+          |""".stripMargin)
+
+      cpg.call.nameExact("<init>").methodFullName.l match {
+        case List(fullName) =>
+          fullName shouldBe "a.Bar.<init>:void()"
+
+        case result => fail(s"Expected single constructor invocation for Bar but found $result")
+      }
+    }
+  }
+
+  "type information for members" should {
+    val cpg = code("""
+        |import org.slf4j.Logger;
+        |import org.slf4j.LoggerFactory;
+        |import org.springframework.core.env.Environment;
+        |
+        |public class Foo {
+        |  Environment env;
+        |  private static Logger log = LoggerFactory.getLogger(Foo.class);
+        |
+        |  public void foo() {
+        |    log.info("UserName is {}", env.getProperty("sfdc.username"));
+        |  }
+        |}
+        |""".stripMargin)
+
+    "be inferred from imports" in {
+      cpg.member.name("env").typeFullName.head shouldBe "org.springframework.core.env.Environment"
+      cpg.member.name("log").typeFullName.head shouldBe "org.slf4j.Logger"
+    }
+
+    "be used in calls" in {
+      cpg.call.name("info").methodFullName.l match {
+        case List(fullName) =>
+          fullName shouldBe "org.slf4j.Logger.info:void(java.lang.String,<unresolvedType>)"
+
+        case result => fail(s"Expected single call to info but got $result")
+      }
+
+      cpg.call.name("getProperty").methodFullName.l match {
+        case List(fullName) =>
+          fullName shouldBe "org.springframework.core.env.Environment.getProperty:<unresolvedType>(java.lang.String)"
+
+        case result => fail(s"Expected single call to getProperty but got $result")
+      }
+    }
+  }
+
   "constructors created from import info" should {
     val cpg = code("""
         |import a.b.c.Bar;


### PR DESCRIPTION
This PR fixes a couple of bugs where types in method full names for unresolvable calls were `<unresolved...>` even though there was enough type information available to use the actual types.

It also replaces the `<unresolvedReceiver>` and `<unresolvedSignature>` types with `<unresolvedType>` for the sake of uniformity. 