### PR TITLE
remove unnecessary usage of `implicit Node -> Traversal`

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
@@ -8,7 +8,7 @@ case class Path(elements: List[CfgNode]) {
   def resultPairs(): List[(String, Option[Integer])] = {
     val pairs = elements.map {
       case point: MethodParameterIn =>
-        val method      = point.method.head
+        val method      = point.method
         val method_name = method.name
         val code        = s"$method_name(${method.parameter.l.sortBy(_.order).map(_.code).mkString(", ")})"
         (code, point.lineNumber)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -318,7 +318,7 @@ private class UsageAnalyzer(problem: DataFlowProblem[mutable.BitSet], in: Map[St
       case param: MethodParameterIn =>
         nodeToString(use).contains(param.name)
       case call: Call if indirectionAccessSet.contains(call.name) =>
-        call.argument(1).headOption.exists(x => nodeToString(use).contains(x.code))
+        call.argumentOption(1).exists(x => nodeToString(use).contains(x.code))
       case call: Call =>
         nodeToString(use).contains(call.code)
       case identifier: Identifier => nodeToString(use).contains(identifier.code)

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
@@ -552,12 +552,12 @@ class AstCreationPassTests
           call.order shouldBe 2
           call.methodFullName shouldBe Operators.fieldAccess
           call.argument(2).code shouldBe "value"
-          inside(call.argument(1).l) { case List(fa: Call) =>
+          val ca = call.argument(1)
+          inside(call.argument(1)) { case fa: Call =>
             fa.code shouldBe "decltype(local)"
             fa.methodFullName shouldBe "<operator>.typeOf"
             fa.argument(1).code shouldBe "local"
           }
-
         }
       }
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -131,7 +131,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
           fallbackClosureBinding.outE.collectAll[Ref].map(_.inNode()).l match {
             case List(capturedParam: MethodParameterIn) =>
               capturedParam.name shouldBe "fallback"
-              capturedParam.method.head.fullName shouldBe "Foo.test1:void(java.lang.String,java.lang.String)"
+              capturedParam.method.fullName shouldBe "Foo.test1:void(java.lang.String,java.lang.String)"
             case result => fail(s"Expected single capturedParam but got $result")
           }
 
@@ -564,7 +564,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
           capturedClosureBinding.outE.collectAll[Ref].map(_.inNode()).l match {
             case List(capturedParam: MethodParameterIn) =>
               capturedParam.name shouldBe "captured"
-              capturedParam.method.head.fullName shouldBe "TestClass.test:Foo(java.lang.String)"
+              capturedParam.method.fullName shouldBe "TestClass.test:Foo(java.lang.String)"
             case result => fail(s"Expected single capturedParam but got $result")
           }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/SynchronizedTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/SynchronizedTests.scala
@@ -1,10 +1,8 @@
 package io.joern.jimple2cpg.querying
 
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
-import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
 
 class SynchronizedTests extends JimpleCodeToCpgFixture {
 
@@ -31,7 +29,7 @@ class SynchronizedTests extends JimpleCodeToCpgFixture {
     method.astChildren.size shouldBe 7
     val List("STATIC", "PUBLIC", "SYNCHRONIZED") = method.modifier.map(_.modifierType).l
     val List(param)                              = method.parameter.l
-    val List(body)                               = method.block.l
+    val body                                     = method.block
     param.code shouldBe "java.lang.String s"
     body.astChildren.head shouldBe a[Return]
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -455,7 +455,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(receiver)       = barCall.receiver.isCall.l
       val List(receiverViaAst) = barCall.astChildren.isCall.l
 
-      receiver.head shouldBe receiverViaAst.head
+      receiver shouldBe receiverViaAst
       receiver.code shouldBe "(_tmp_0 = x.foo(y)).bar"
       receiver.name shouldBe Operators.fieldAccess
       receiver.order shouldBe 0
@@ -537,7 +537,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
     "have local variable for function with correct type full name" in AstFixture("function method(x) {}") { cpg =>
       val List(method) = cpg.method.nameExact(":program").l
-      val List(block)  = method.block.l
+      val block        = method.block
       val localFoo     = block.local.head
       localFoo.name shouldBe "method"
       localFoo.typeFullName should endWith("code.js::program:method")
@@ -778,7 +778,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(method)      = cpg.method.nameExact(":program").l
       val List(methodBlock) = method.astChildren.isBlock.l
       val List(loopBlock)   = methodBlock.astChildren.isBlock.l
-      checkForInOrOf(loopBlock.head)
+      checkForInOrOf(loopBlock)
     }
 
     "be correct for for-loop with for-of" in AstFixture("""
@@ -789,7 +789,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(method)      = cpg.method.nameExact(":program").l
       val List(methodBlock) = method.astChildren.isBlock.l
       val List(loopBlock)   = methodBlock.astChildren.isBlock.l
-      checkForInOrOf(loopBlock.head)
+      checkForInOrOf(loopBlock)
     }
 
     "be correct for for-loop with empty test" in AstFixture("for(;;){}") { cpg =>
@@ -1249,7 +1249,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
     "be correct for empty method" in AstFixture("function method() {}") { cpg =>
       val List(program) = cpg.method.nameExact("method").l
       program.astChildren.isBlock.size shouldBe 1
-      val List(blockMethodReturn) = program.methodReturn.l
+      val blockMethodReturn = program.methodReturn
       blockMethodReturn.code shouldBe "RET"
       blockMethodReturn.typeFullName shouldBe Defines.ANY.label
     }
@@ -1315,7 +1315,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
     objectKeysCall.code shouldBe "Object.keys(arr)"
     objectKeysCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
-    val List(objectKeysCallArg: Identifier) = objectKeysCall.argument(1).l
+    val objectKeysCallArg = objectKeysCall.argument(1).asInstanceOf[Identifier]
     objectKeysCallArg.name shouldBe "arr"
     objectKeysCallArg.order shouldBe 1
 
@@ -1381,19 +1381,19 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
     pushCallReceiver.name shouldBe Operators.fieldAccess
     pushCallReceiver.argumentIndex shouldBe 0
 
-    val List(pushCallReceiverBase: Identifier) = pushCallReceiver.argument(1).l
+    val pushCallReceiverBase = pushCallReceiver.argument(1).asInstanceOf[Identifier]
     pushCallReceiverBase.name shouldBe "_tmp_0"
     pushCallReceiverBase.order shouldBe 1
 
-    val List(pushCallReceiverMember: FieldIdentifier) = pushCallReceiver.argument(2).l
+    val pushCallReceiverMember = pushCallReceiver.argument(2).asInstanceOf[FieldIdentifier]
     pushCallReceiverMember.canonicalName shouldBe "push"
     pushCallReceiverMember.order shouldBe 2
 
-    val List(pushCallThis: Identifier) = pushCall.argument(1).l
+    val pushCallThis = pushCall.argument(1).asInstanceOf[Identifier]
     pushCallThis.name shouldBe "_tmp_0"
     pushCallThis.order shouldBe 1
 
-    val List(pushCallArg: Literal) = pushCall.argument(2).l
+    val pushCallArg = pushCall.argument(2).asInstanceOf[Literal]
     pushCallArg.code shouldBe element.toString
     pushCallArg.order shouldBe 2
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
@@ -16,8 +16,8 @@ class TsAstCreationPassTest extends AbstractPassTest {
       "code.ts"
     ) { cpg =>
       inside(cpg.call(Operators.cast).l) { case List(call) =>
-        call.argument(1).head.code shouldBe "string"
-        call.argument(2).head.code shouldBe "\"foo\""
+        call.argument(1).code shouldBe "string"
+        call.argument(2).code shouldBe "\"foo\""
       }
     }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ConstructorTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ConstructorTests.scala
@@ -21,7 +21,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       m.fullName shouldBe "mypkg.Foo.<init>:void()"
       m.name shouldBe "<init>"
       m.parameter.size shouldBe 1
-      m.block.size shouldBe 1
+      Option(m.block).isDefined shouldBe true
     }
   }
 
@@ -37,7 +37,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       m.fullName shouldBe "mypkg.AClass.<init>:void(java.lang.String)"
       m.name shouldBe "<init>"
       m.parameter.size shouldBe 2
-      m.block.size shouldBe 1
+      Option(m.block).isDefined shouldBe true
       m.block.expressionDown.size shouldBe 0
     }
   }
@@ -65,7 +65,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       m.fullName shouldBe "mypkg.AClass.<init>:void(java.lang.String)"
       m.name shouldBe "<init>"
       m.parameter.size shouldBe 2
-      m.block.size shouldBe 1
+      Option(m.block).isDefined shouldBe true
 
       val List(firstParam: MethodParameterIn, secondParam: MethodParameterIn) = m.parameter.l
       firstParam.name shouldBe "this"
@@ -121,7 +121,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       m.fullName shouldBe "mypkg.Foo.<init>:void(java.lang.String)"
       m.name shouldBe "<init>"
       m.parameter.size shouldBe 2
-      m.block.size shouldBe 1
+      Option(m.block).isDefined shouldBe true
     }
   }
 
@@ -138,7 +138,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       m.fullName shouldBe "mypkg.Foo.<init>:void(java.lang.String)"
       m.name shouldBe "<init>"
       m.parameter.size shouldBe 2
-      m.block.size shouldBe 1
+      Option(m.block).isDefined shouldBe true
     }
   }
 
@@ -177,7 +177,6 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       m.methodReturn.lineNumber shouldBe Some(4)
       m.methodReturn.columnNumber shouldBe Some(9)
 
-      m.block.size shouldBe 1
       m.block.astChildren.size shouldBe 0
     }
 
@@ -191,7 +190,6 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       m.methodReturn.lineNumber shouldBe Some(6)
       m.methodReturn.columnNumber shouldBe Some(4)
 
-      m.block.size shouldBe 1
       m.block.astChildren.map(_.code).l shouldBe List("this.bar = bar")
 
       val List(mThisParam: MethodParameterIn, firstParam: MethodParameterIn, secondParam: MethodParameterIn) =
@@ -200,7 +198,7 @@ class ConstructorTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       firstParam.name shouldBe "foo"
       secondParam.name shouldBe "bar"
 
-      val List(b)                     = m.block.l
+      val b                           = m.block
       val List(firstBlockChild: Call) = b.astChildren.l
       firstBlockChild.methodFullName shouldBe Operators.assignment
       firstBlockChild.code shouldBe "this.bar = bar"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
@@ -235,7 +235,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
       iteratorLocal.typeFullName shouldBe "ANY"
 
       // TODO: add test for the block in here
-      val List(iteratorAssignment: Call) = cpg.call.code("iterator.*itera.*").head.l
+      val iteratorAssignment = cpg.call.code("iterator.*itera.*").head
       iteratorAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       iteratorAssignment.name shouldBe Operators.assignment
       iteratorAssignment.methodFullName shouldBe Operators.assignment
@@ -259,7 +259,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
       iteratorAssignmentRhsArg.argumentIndex shouldBe 0
       iteratorAssignmentRhsArg.typeFullName shouldBe "java.util.List"
 
-      val List(controlStructure: ControlStructure) = cpg.controlStructure.head.l
+      val controlStructure = cpg.controlStructure.head
       controlStructure.controlStructureType shouldBe ControlStructureTypes.WHILE
       controlStructure.order shouldBe 3
       controlStructure.condition.size shouldBe 1
@@ -350,7 +350,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
       iteratorLocal.typeFullName shouldBe "ANY"
 
       // TODO: add test for the block in here
-      val List(iteratorAssignment: Call) = cpg.call.code("iterator.*itera.*").head.l
+      val iteratorAssignment = cpg.call.code("iterator.*itera.*").head
       iteratorAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       iteratorAssignment.name shouldBe Operators.assignment
       iteratorAssignment.methodFullName shouldBe Operators.assignment
@@ -374,7 +374,7 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
       iteratorAssignmentRhsArg.argumentIndex shouldBe 0
       iteratorAssignmentRhsArg.typeFullName shouldBe "java.util.List"
 
-      val List(controlStructure: ControlStructure) = cpg.controlStructure.head.l
+      val controlStructure = cpg.controlStructure.head
       controlStructure.controlStructureType shouldBe ControlStructureTypes.WHILE
       controlStructure.order shouldBe 3
       controlStructure.condition.size shouldBe 1

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DataClassTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DataClassTests.scala
@@ -22,12 +22,12 @@ class DataClassTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       firstMethod.name shouldBe "component1"
       firstMethod.fullName shouldBe "mypkg.Result.component1:int()"
       firstMethod.signature shouldBe "int()"
-      firstMethod.block.size shouldBe 1
+      Option(firstMethod.block).isDefined shouldBe true
 
       secondMethod.name shouldBe "component2"
       secondMethod.fullName shouldBe "mypkg.Result.component2:java.lang.String()"
       secondMethod.signature shouldBe "java.lang.String()"
-      secondMethod.block.size shouldBe 1
+      Option(secondMethod.block).isDefined shouldBe true
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
@@ -40,11 +40,11 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       firstDestructAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       firstDestructAssignment.methodFullName shouldBe Operators.assignment
 
-      val List(firstDestructLHSIdentifier: Identifier) = firstDestructAssignment.argument(1).l
+      val firstDestructLHSIdentifier = firstDestructAssignment.argument(1).asInstanceOf[Identifier]
       firstDestructLHSIdentifier.name shouldBe "myA"
       firstDestructLHSIdentifier.typeFullName shouldBe "java.lang.String"
 
-      val List(firstDestructRHSCall: Call) = firstDestructAssignment.argument(2).l
+      val firstDestructRHSCall = firstDestructAssignment.argument(2).asInstanceOf[Call]
       firstDestructRHSCall.code shouldBe "aClass.component1()"
       firstDestructRHSCall.name shouldBe "component1"
       firstDestructRHSCall.methodFullName shouldBe "main.AClass.component1:java.lang.String()"
@@ -63,11 +63,11 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       secondDestructAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       secondDestructAssignment.methodFullName shouldBe Operators.assignment
 
-      val List(secondDestructLHSIdentifier: Identifier) = secondDestructAssignment.argument(1).l
+      val secondDestructLHSIdentifier = secondDestructAssignment.argument(1).asInstanceOf[Identifier]
       secondDestructLHSIdentifier.name shouldBe "myB"
       secondDestructLHSIdentifier.typeFullName shouldBe "int"
 
-      val List(secondDestructRHSCall: Call) = secondDestructAssignment.argument(2).l
+      val secondDestructRHSCall = secondDestructAssignment.argument(2).asInstanceOf[Call]
       secondDestructRHSCall.code shouldBe "aClass.component2()"
       secondDestructRHSCall.methodFullName shouldBe "main.AClass.component2:int()"
       secondDestructRHSCall.signature shouldBe "int()"
@@ -184,11 +184,11 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       firstDestructAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       firstDestructAssignment.methodFullName shouldBe Operators.assignment
 
-      val List(firstDestructLHSIdentifier: Identifier) = firstDestructAssignment.argument(1).l
+      val firstDestructLHSIdentifier = firstDestructAssignment.argument(1).asInstanceOf[Identifier]
       firstDestructLHSIdentifier.name shouldBe "myA"
       firstDestructLHSIdentifier.typeFullName shouldBe "java.lang.String"
 
-      val List(firstDestructRHSCall: Call) = firstDestructAssignment.argument(2).l
+      val firstDestructRHSCall = firstDestructAssignment.argument(2).asInstanceOf[Call]
       firstDestructRHSCall.code should startWith("tmp_")
       firstDestructRHSCall.code should endWith("component1()")
       firstDestructRHSCall.name shouldBe "component1"
@@ -207,11 +207,11 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       secondDestructAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       secondDestructAssignment.methodFullName shouldBe Operators.assignment
 
-      val List(secondDestructLHSIdentifier: Identifier) = secondDestructAssignment.argument(1).l
+      val secondDestructLHSIdentifier = secondDestructAssignment.argument(1).asInstanceOf[Identifier]
       secondDestructLHSIdentifier.name shouldBe "myB"
       secondDestructLHSIdentifier.typeFullName shouldBe "int"
 
-      val List(secondDestructRHSCall: Call) = secondDestructAssignment.argument(2).l
+      val secondDestructRHSCall = secondDestructAssignment.argument(2).asInstanceOf[Call]
       secondDestructRHSCall.code should startWith("tmp_")
       secondDestructRHSCall.code should endWith("component2()")
       secondDestructRHSCall.name shouldBe "component2"
@@ -319,11 +319,11 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       firstDestructAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       firstDestructAssignment.methodFullName shouldBe Operators.assignment
 
-      val List(firstDestructLHSIdentifier: Identifier) = firstDestructAssignment.argument(1).l
+      val firstDestructLHSIdentifier = firstDestructAssignment.argument(1).asInstanceOf[Identifier]
       firstDestructLHSIdentifier.name shouldBe "myA"
       firstDestructLHSIdentifier.typeFullName shouldBe "java.lang.String"
 
-      val List(firstDestructRHSCall: Call) = firstDestructAssignment.argument(2).l
+      val firstDestructRHSCall = firstDestructAssignment.argument(2).asInstanceOf[Call]
       firstDestructRHSCall.code should startWith("tmp_")
       firstDestructRHSCall.code should endWith("component1()")
       firstDestructRHSCall.name shouldBe "component1"
@@ -342,11 +342,11 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       secondDestructAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       secondDestructAssignment.methodFullName shouldBe Operators.assignment
 
-      val List(secondDestructLHSIdentifier: Identifier) = secondDestructAssignment.argument(1).l
+      val secondDestructLHSIdentifier = secondDestructAssignment.argument(1).asInstanceOf[Identifier]
       secondDestructLHSIdentifier.name shouldBe "myB"
       secondDestructLHSIdentifier.typeFullName shouldBe "int"
 
-      val List(secondDestructRHSCall: Call) = secondDestructAssignment.argument(2).l
+      val secondDestructRHSCall = secondDestructAssignment.argument(2).asInstanceOf[Call]
       secondDestructRHSCall.code should startWith("tmp_")
       secondDestructRHSCall.code should endWith("component2()")
       secondDestructRHSCall.name shouldBe "component2"
@@ -471,11 +471,11 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       firstDestructAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       firstDestructAssignment.methodFullName shouldBe Operators.assignment
 
-      val List(firstDestructLHSIdentifier: Identifier) = firstDestructAssignment.argument(1).l
+      val firstDestructLHSIdentifier = firstDestructAssignment.argument(1).asInstanceOf[Identifier]
       firstDestructLHSIdentifier.name shouldBe "myA"
       firstDestructLHSIdentifier.typeFullName shouldBe "java.lang.String"
 
-      val List(firstDestructRHSCall: Call) = firstDestructAssignment.argument(2).l
+      val firstDestructRHSCall = firstDestructAssignment.argument(2).asInstanceOf[Call]
       firstDestructRHSCall.code should startWith("tmp_")
       firstDestructRHSCall.code should endWith("component1()")
       firstDestructRHSCall.name shouldBe "component1"
@@ -494,11 +494,11 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
       secondDestructAssignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       secondDestructAssignment.methodFullName shouldBe Operators.assignment
 
-      val List(secondDestructLHSIdentifier: Identifier) = secondDestructAssignment.argument(1).l
+      val secondDestructLHSIdentifier = secondDestructAssignment.argument(1).asInstanceOf[Identifier]
       secondDestructLHSIdentifier.name shouldBe "myB"
       secondDestructLHSIdentifier.typeFullName shouldBe "int"
 
-      val List(secondDestructRHSCall: Call) = secondDestructAssignment.argument(2).l
+      val secondDestructRHSCall = secondDestructAssignment.argument(2).asInstanceOf[Call]
       secondDestructRHSCall.code should startWith("tmp_")
       secondDestructRHSCall.code should endWith("component2()")
       secondDestructRHSCall.name shouldBe "component2"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -134,7 +134,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
       td.isExternal shouldBe false
       td.code shouldBe "LAMBDA_TYPE_DECL"
       td.inheritsFromTypeFullName shouldBe Seq("kotlin.Function1")
-      td.astParent.size shouldBe 1
+      Option(td.astParent).isDefined shouldBe true
 
       val List(bm) = cpg.typeDecl.fullName(".*lambda.*").boundMethod.l
       bm.fullName shouldBe "mypkg.<lambda><f_Test0.kt_no1>:java.lang.Object(java.lang.Object)"
@@ -203,7 +203,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
       val List(td) = cpg.typeDecl.fullName(".*lambda.*").l
       td.isExternal shouldBe false
       td.code shouldBe "LAMBDA_TYPE_DECL"
-      td.astParent.size shouldBe 1
+      Option(td.astParent).isDefined shouldBe true
 
       val List(bm) = cpg.typeDecl.fullName(".*lambda.*").boundMethod.l
       bm.fullName shouldBe "mypkg.<lambda><f_Test0.kt_no1>:java.lang.Object(java.lang.Object)"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
@@ -1,7 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 
 class MethodTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
@@ -22,7 +21,6 @@ class MethodTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     "should contain method nodes with the correct fields" in {
       val List(x) = cpg.method.name("double").isExternal(false).l
-      x.size shouldBe 1
       x.fullName shouldBe "double:int(int)"
       x.code shouldBe "double"
       x.signature shouldBe "int(int)"
@@ -32,7 +30,6 @@ class MethodTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       x.filename.endsWith(".kt") shouldBe true
 
       val List(y) = cpg.method.name("main").isExternal(false).l
-      y.size shouldBe 1
       y.fullName shouldBe "main:void(kotlin.Array)"
       y.code shouldBe "main"
       y.signature shouldBe "void(kotlin.Array)"
@@ -76,7 +73,6 @@ class MethodTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     "should contain a METHOD node for `bar` with the props set" in {
       val List(m) = cpg.method.name("bar").l
-      m.size shouldBe 1
       m.name shouldBe "bar"
       m.fullName shouldBe "com.test.pkg.Foo.bar:int(int)"
       m.code shouldBe "bar"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SpecialOperatorsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/SpecialOperatorsTests.scala
@@ -144,8 +144,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
     }
 
     "should contain an IDENTIFIER node for  " in {
-      val List(i) = cpg.identifier.nameExact("foo").head.l
-      i.typeFullName shouldBe "int"
+      cpg.identifier.nameExact("foo").head.typeFullName shouldBe "int"
     }
   }
 
@@ -161,8 +160,7 @@ class SpecialOperatorsTests extends KotlinCode2CpgFixture(withOssDataflow = fals
         |""".stripMargin)
 
     "should contain an IDENTIFIER node for the result of the elvis operator call with the correct TYPE_FULL_NAME set" in {
-      val List(i) = cpg.identifier.nameExact("isValid").head.l
-      i.typeFullName shouldBe "boolean"
+      cpg.identifier.nameExact("isValid").head.typeFullName shouldBe "boolean"
     }
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TryExpressionsTests.scala
@@ -37,7 +37,7 @@ class TryExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false)
       firstArg.order shouldBe 1
       secondArg.order shouldBe 2
 
-      val List(firstAstChildOfFirstArg: Identifier) = firstArg.astChildren.head.l
+      val firstAstChildOfFirstArg = firstArg.astChildren.head.asInstanceOf[Identifier]
       firstAstChildOfFirstArg.order shouldBe 1
       firstAstChildOfFirstArg.name shouldBe "x"
       firstAstChildOfFirstArg.code shouldBe "x"
@@ -45,7 +45,7 @@ class TryExpressionsTests extends KotlinCode2CpgFixture(withOssDataflow = false)
       firstAstChildOfFirstArg.lineNumber shouldBe Some(7)
       firstAstChildOfFirstArg.columnNumber shouldBe Some(8)
 
-      val List(firstAstChildOfSecondArg: Call) = secondArg.astChildren.head.l
+      val firstAstChildOfSecondArg = secondArg.astChildren.head.asInstanceOf[Call]
       firstAstChildOfSecondArg.order shouldBe 1
       firstAstChildOfSecondArg.name shouldBe "toInt"
       firstAstChildOfSecondArg.code shouldBe "r.toInt()"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/PrimitiveArrayTypeMappingTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/PrimitiveArrayTypeMappingTests.scala
@@ -18,8 +18,7 @@ class PrimitiveArrayTypeMappingTests extends KotlinCode2CpgFixture(withOssDatafl
         |""".stripMargin)
 
     "should contain an IDENTIFIER node with a TYPE_FULL_NAME of its mapped type" in {
-      val List(i) = cpg.identifier.nameExact("nums").head.l
-      i.typeFullName shouldBe "boolean[]"
+      cpg.identifier.nameExact("nums").head.typeFullName shouldBe "boolean[]"
     }
   }
 
@@ -37,8 +36,7 @@ class PrimitiveArrayTypeMappingTests extends KotlinCode2CpgFixture(withOssDatafl
         |""".stripMargin)
 
     "should contain an IDENTIFIER node with a TYPE_FULL_NAME of its mapped type" in {
-      val List(i) = cpg.identifier.nameExact("nums").head.l
-      i.typeFullName shouldBe "byte[]"
+      cpg.identifier.nameExact("nums").head.typeFullName shouldBe "byte[]"
     }
   }
 
@@ -73,8 +71,7 @@ class PrimitiveArrayTypeMappingTests extends KotlinCode2CpgFixture(withOssDatafl
         |""".stripMargin)
 
     "should contain an IDENTIFIER node with a TYPE_FULL_NAME of its mapped type" in {
-      val List(i) = cpg.identifier.nameExact("nums").head.l
-      i.typeFullName shouldBe "char[]"
+      cpg.identifier.nameExact("nums").head.typeFullName shouldBe "char[]"
     }
   }
 
@@ -92,8 +89,7 @@ class PrimitiveArrayTypeMappingTests extends KotlinCode2CpgFixture(withOssDatafl
         |""".stripMargin)
 
     "should contain an IDENTIFIER node with a TYPE_FULL_NAME of its mapped type" in {
-      val List(i) = cpg.identifier.nameExact("nums").head.l
-      i.typeFullName shouldBe "double[]"
+      cpg.identifier.nameExact("nums").head.typeFullName shouldBe "double[]"
     }
   }
 
@@ -111,8 +107,7 @@ class PrimitiveArrayTypeMappingTests extends KotlinCode2CpgFixture(withOssDatafl
         |""".stripMargin)
 
     "should contain an IDENTIFIER node with a TYPE_FULL_NAME of its mapped type" in {
-      val List(i) = cpg.identifier.nameExact("nums").head.l
-      i.typeFullName shouldBe "float[]"
+      cpg.identifier.nameExact("nums").head.typeFullName shouldBe "float[]"
     }
   }
 
@@ -130,8 +125,7 @@ class PrimitiveArrayTypeMappingTests extends KotlinCode2CpgFixture(withOssDatafl
         |""".stripMargin)
 
     "should contain an IDENTIFIER node with a TYPE_FULL_NAME of its mapped type" in {
-      val List(i) = cpg.identifier.nameExact("nums").head.l
-      i.typeFullName shouldBe "int[]"
+      cpg.identifier.nameExact("nums").head.typeFullName shouldBe "int[]"
     }
   }
 
@@ -149,8 +143,7 @@ class PrimitiveArrayTypeMappingTests extends KotlinCode2CpgFixture(withOssDatafl
         |""".stripMargin)
 
     "should contain an IDENTIFIER node with a TYPE_FULL_NAME of its mapped type" in {
-      val List(i) = cpg.identifier.nameExact("nums").head.l
-      i.typeFullName shouldBe "long[]"
+      cpg.identifier.nameExact("nums").head.typeFullName shouldBe "long[]"
     }
   }
 
@@ -168,8 +161,7 @@ class PrimitiveArrayTypeMappingTests extends KotlinCode2CpgFixture(withOssDatafl
         |""".stripMargin)
 
     "should contain an IDENTIFIER node with a TYPE_FULL_NAME of its mapped type" in {
-      val List(i) = cpg.identifier.nameExact("nums").head.l
-      i.typeFullName shouldBe "short[]"
+      cpg.identifier.nameExact("nums").head.typeFullName shouldBe "short[]"
     }
   }
 }

--- a/querydb/src/main/scala/io/joern/scanners/android/AndroidUnprotectedAppParts.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/AndroidUnprotectedAppParts.scala
@@ -7,6 +7,7 @@ import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.joern.macros.QueryMacros._
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.Traversal
 
 object AndroidUnprotectedAppParts extends QueryBundle {
   implicit val engineContext: EngineContext = EngineContext(Semantics.empty)

--- a/querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
@@ -8,6 +8,7 @@ import io.shiftleft.semanticcpg.language._
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.macros.QueryMacros._
+import overflowdb.traversal.Traversal
 
 object UseAfterFree extends QueryBundle {
 
@@ -199,7 +200,7 @@ object UseAfterFree extends QueryBundle {
             val assignedPostDom = postDom.isIdentifier
               .where(_.inAssignment)
               .codeExact(freedIdentifierCode)
-              .flatMap(id => id ++ id.postDominatedBy)
+              .flatMap(id => Traversal.fromSingle(id) ++ id.postDominatedBy)
 
             postDom
               .removedAll(assignedPostDom)

--- a/querydb/src/main/scala/io/joern/scanners/java/CertificateChecks.scala
+++ b/querydb/src/main/scala/io/joern/scanners/java/CertificateChecks.scala
@@ -42,7 +42,7 @@ object CertificateChecks extends QueryBundle {
           case _ => false
         }
         def skipPrologue(node: nodes.CfgNode): Traversal[nodes.CfgNode] =
-          node.repeat(_.cfgNext)(_.until(_.filter(!isPrologue(_))))
+          Traversal.fromSingle(node).repeat(_.cfgNext)(_.until(_.filter(!isPrologue(_))))
 
         cpg.method
           .nameExact(validators.keys.toSeq: _*)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -102,7 +102,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     *   the traversal of this node if it passes through the included set.
     */
   def passes(included: Set[CfgNode]): Traversal[CfgNode] =
-    node.filter(_.postDominatedBy.exists(included.contains))
+    Traversal.fromSingle(node).filter(_.postDominatedBy.exists(included.contains))
 
   /** Using the post dominator tree, will determine if this node passes through the excluded set of nodes and filter it
     * out.
@@ -112,7 +112,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     *   the traversal of this node if it does not pass through the excluded set.
     */
   def passesNot(excluded: Set[CfgNode]): Traversal[CfgNode] =
-    node.filterNot(_.postDominatedBy.exists(excluded.contains))
+    Traversal.fromSingle(node).filterNot(_.postDominatedBy.exists(excluded.contains))
 
   private def expandExhaustively(expand: CfgNode => Iterator[StoredNode]): Traversal[CfgNode] = {
     var controllingNodes = List.empty[CfgNode]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LocalMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LocalMethods.scala
@@ -13,5 +13,5 @@ class LocalMethods(val local: Local) extends AnyVal with NodeExtension with HasL
   /** The method hosting this local variable
     */
   def method: Traversal[Method] =
-    toTraversal(local).method
+    Traversal.fromSingle(local).method
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -68,8 +68,9 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
   def typeDecl: Traversal[TypeDecl] = definingTypeDecl
 
   /** Traverse to method body (alias for `block`) */
+  // TODO MP: return a `Block` rather than `Traversal[Block]` - it's guaranteed to be there and exactly one...
   def body: Traversal[Block] =
-    method.block
+    Traversal.fromSingle(method.block)
 
   override def location: NewLocation = {
     LocationCreator(method, method.name, method.label, method.lineNumber, method)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -13,9 +13,10 @@ class TargetMethods(val expr: Expression) extends AnyVal {
       .collectFirst { case x if allArrayAccessTypes.contains(x.name) => x }
       .map(new OpNodes.ArrayAccess(_))
 
+  // TODO MP: return an `Option[Expression]` rather than `Traversal[Expression]`
   def pointer: Traversal[Expression] = {
     expr match {
-      case call: Call if call.name == Operators.indirection => call.argument(1)
+      case call: Call if call.name == Operators.indirection => Traversal.fromSingle(call.argument(1))
       case _                                                => Traversal()
     }
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -165,6 +165,12 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
   implicit def graphToInterproceduralDot(cpg: Cpg): InterproceduralNodeDot =
     new InterproceduralNodeDot(cpg)
 
+  /** Warning: implicitly lifting `Node -> Traversal` opens a broad space with a lot of accidental complexity and is
+    * considered a historical accident. We only keep it around because we want to preserve `reachableBy(Node*)`, which
+    * unfortunately (due to type erasure) can't be an overload of `reachableBy(Traversal*)`.
+    *
+    * In most places you should explicitly call `Traversal.fromSingle` instead of relying on this implicit.
+    */
   implicit def toTraversal[NodeType <: StoredNode](node: NodeType): Traversal[NodeType] =
     Traversal.fromSingle(node)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -29,9 +29,9 @@ class MethodParameterOutTraversal(val traversal: Traversal[MethodParameterOut]) 
   def argument: Traversal[Expression] =
     for {
       paramOut <- traversal
-      method   <- paramOut.method
-      call     <- method.callIn
-      arg      <- call.argumentOut.collectAll[Expression]
+      method = paramOut.method
+      call <- method.callIn
+      arg  <- call.argumentOut.collectAll[Expression]
       if paramOut.parameterLinkIn.index.headOption.contains(arg.argumentIndex)
     } yield arg
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
@@ -137,7 +137,7 @@ package object testing {
     def withCallInMethod(methodName: String, callName: String, code: Option[String] = None): MockCpg =
       withCustom { (graph, cpg) =>
         val methodNode = cpg.method.name(methodName).head
-        val blockNode  = methodNode.block.head
+        val blockNode  = methodNode.block
         val callNode   = NewCall().name(callName).code(code.getOrElse(callName))
         graph.addNode(callNode)
         graph.addEdge(blockNode, callNode, EdgeTypes.AST)
@@ -156,7 +156,7 @@ package object testing {
     def withLocalInMethod(methodName: String, localName: String): MockCpg =
       withCustom { (graph, cpg) =>
         val methodNode = cpg.method.name(methodName).head
-        val blockNode  = methodNode.block.head
+        val blockNode  = methodNode.block
         val typeNode   = NewType().name("alocaltype")
         val localNode  = NewLocal().name(localName).typeFullName("alocaltype")
         graph.addNode(localNode)
@@ -168,7 +168,7 @@ package object testing {
     def withLiteralArgument(callName: String, literalCode: String): MockCpg = {
       withCustom { (graph, cpg) =>
         val callNode    = cpg.call.name(callName).head
-        val methodNode  = callNode.method.head
+        val methodNode  = callNode.method
         val literalNode = NewLiteral().code(literalCode)
         val typeDecl = NewTypeDecl()
           .name("ATypeDecl")
@@ -189,7 +189,7 @@ package object testing {
 
     def withArgument(callName: String, newNode: NewNode): MockCpg = withCustom { (graph, cpg) =>
       val callNode   = cpg.call.name(callName).head
-      val methodNode = callNode.method.head
+      val methodNode = callNode.method
       val typeDecl   = NewTypeDecl().name("abc")
       graph.addEdge(callNode, newNode, EdgeTypes.AST)
       graph.addEdge(callNode, newNode, EdgeTypes.ARGUMENT)

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversalTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversalTests.scala
@@ -23,7 +23,7 @@ class CfgNodeTraversalTests extends AnyWordSpec with Matchers {
       graph.addEdge(method, call1, EdgeTypes.CFG)
       graph.addEdge(call1, call2, EdgeTypes.CFG)
       graph.addEdge(call2, call3, EdgeTypes.CFG)
-      graph.addEdge(call2, method.methodReturn.head, EdgeTypes.CFG)
+      graph.addEdge(call2, method.methodReturn, EdgeTypes.CFG)
     }
     .cpg
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversalTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversalTests.scala
@@ -19,7 +19,7 @@ class ExpressionTraversalTests extends AnyWordSpec with Matchers {
       val call2  = cpg.call.name("call2").head
       graph.addEdge(method, call1, EdgeTypes.CFG)
       graph.addEdge(call1, call2, EdgeTypes.CFG)
-      graph.addEdge(call2, method.methodReturn.head, EdgeTypes.CFG)
+      graph.addEdge(call2, method.methodReturn, EdgeTypes.CFG)
     }
     .cpg
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTests.scala
@@ -19,7 +19,7 @@ class MethodParameterTests extends AnyWordSpec with Matchers {
           cpg.method.name("foo").parameter.toList
 
         args.size shouldBe 1
-        args.sortBy(_.order).map(_.typ.head.name) shouldBe
+        args.sortBy(_.order).map(_.typ.name) shouldBe
           List("paramtype")
       }
 
@@ -35,21 +35,21 @@ class MethodParameterTests extends AnyWordSpec with Matchers {
             cpg.method.name("foo").parameter.index(1).toList
 
           args.size shouldBe 1
-          args.head.typ.head.name shouldBe "paramtype"
+          args.head.typ.name shouldBe "paramtype"
         }
 
         "specifying index >= x" in {
           val args: List[MethodParameterIn] =
             cpg.method.name("foo").parameter.indexFrom(1).toList
 
-          args.map(_.typ.head.name).toSet shouldBe Set("paramtype")
+          args.map(_.typ.name).toSet shouldBe Set("paramtype")
         }
 
         "specifying index <= x" in {
           val args: List[MethodParameterIn] =
             cpg.method.name("foo").parameter.indexTo(2).toList
 
-          args.map(_.typ.head.name).toSet shouldBe Set("paramtype")
+          args.map(_.typ.name).toSet shouldBe Set("paramtype")
         }
       }
     }


### PR DESCRIPTION
We have an `implicit Node -> Traversal` which I now believe was not
a good idea in the first place. This PR cleans up most of it's usage,
which are mostly completely unnecessary calls, like
`val List(sameNodeA) = someNodeA.l`

Unfortunately we can't drop the implicit, I added a comment there.

A follow up PR will tighten some of the return types - this is mostly
a refactoring.
