### PR TITLE
c2cpg: clean-up from the latest two refactorings

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/AstCreationPassTests.scala
@@ -481,7 +481,6 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with Inside with As
           call.order shouldBe 2
           call.methodFullName shouldBe Operators.fieldAccess
           call.argument(2).code shouldBe "value"
-          val ca = call.argument(1)
           inside(call.argument(1)) { case fa: Call =>
             fa.code shouldBe "decltype(local)"
             fa.methodFullName shouldBe "<operator>.typeOf"


### PR DESCRIPTION
Came in via https://github.com/joernio/joern/pull/1658 and https://github.com/joernio/joern/pull/1659 without merge from master.