### PR TITLE
kotlin2cpg: bring back old impl of single fn

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -932,7 +932,10 @@ trait KtPsiToAst {
       callNode(expr.getText, methodName, fullName, signature, retType, dispatchType, line(expr), column(expr)),
       argIdx
     )
-    callAst(node, List(receiverAst) ++ argAsts)
+    Ast(node)
+      .withChild(receiverAst)
+      .withChildren(argAsts)
+      .withArgEdges(node, argAsts.map(_.root.get))
   }
 
   private def astForQualifiedExpressionWithReceiverEdge(


### PR DESCRIPTION
this specific fn, and other fns around _KtQualifiedExpressions_ are in dire need of refactoring.
bringing this change in _as is_ simply because of broken upstream data-flows