### PR TITLE
Make gradle dependency mandatory

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,
   "org.apache.logging.log4j" % "log4j-slf4j-impl"  % Versions.log4j % Runtime,
   "io.joern" % "javaparser-symbol-solver-core" % "3.24.3-SL3", // custom build of our fork, sources at https://github.com/mpollmeier/javaparser
-  "org.gradle"     % "gradle-tooling-api" % Versions.gradleTooling % Optional,
+  "org.gradle"     % "gradle-tooling-api" % Versions.gradleTooling,
   "org.scalatest" %% "scalatest"          % Versions.scalatest     % Test,
   "org.projectlombok" % "lombok" % "1.18.24"
 )

--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph"          % Versions.cpg,
   "org.apache.logging.log4j" % "log4j-slf4j-impl"           % Versions.log4j         % Runtime,
   "org.slf4j"                % "slf4j-api"                  % "1.7.35",
-  "org.gradle"               % "gradle-tooling-api"         % Versions.gradleTooling % Optional,
+  "org.gradle"               % "gradle-tooling-api"         % Versions.gradleTooling,
   "org.jetbrains.kotlin"     % "kotlin-stdlib-jdk8"         % kotlinVersion,
   "org.jetbrains.kotlin"     % "kotlin-stdlib"              % kotlinVersion,
   "org.jetbrains.kotlin"     % "kotlin-compiler-embeddable" % kotlinVersion,


### PR DESCRIPTION
Using `javasrc` in joern plugins fails when using gradle dependency resolution because the gradle tooling jars aren't present. I noticed that the dependencies were marked as optional. Now they are mandatory.