### PR TITLE
kotlin2cpg: tweak ASTs around local declarations 

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -364,7 +364,7 @@ trait KtPsiToAst {
     val explicitTypeName  = Option(ktFn.getTypeReference).map(_.getText).getOrElse(TypeConstants.any)
     val typeFullName      = registerType(typeInfoProvider.returnType(ktFn, explicitTypeName))
     val _methodReturnNode = methodReturnNode(typeFullName, None, Some(line(ktFn)), Some(column(ktFn)))
-    Seq(methodAst(_methodNode, parameters, bodyAst, _methodReturnNode)) ++ otherBodyAsts
+    Seq(methodAst(_methodNode, parameters, bodyAst, _methodReturnNode).withChildren(otherBodyAsts))
   }
 
   def astsForBlock(
@@ -387,11 +387,7 @@ trait KtPsiToAst {
       case fn: KtNamedFunction         => fn
       case classOrObj: KtClassOrObject => classOrObj
     }
-    val declarationAsts = declarations.flatMap(astsForDeclaration)
-    declarationAsts.foreach { declAst =>
-      nestedDeclarationQueue.prepend(NestedDeclaration(methodAstParentStack.head, declAst.root.get))
-    }
-
+    val declarationAsts          = declarations.flatMap(astsForDeclaration)
     val allStatementsButLast     = statements.dropRight(1)
     val allStatementsButLastAsts = allStatementsButLast.map(astsForExpression(_, None)).flatten
     val lastStatementAsts =

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreator.scala
@@ -30,7 +30,6 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
   protected val bindingInfoQueue: mutable.ArrayBuffer[BindingInfo]             = mutable.ArrayBuffer.empty
   protected val lambdaAstQueue: mutable.ArrayBuffer[Ast]                       = mutable.ArrayBuffer.empty
   protected val lambdaBindingInfoQueue: mutable.ArrayBuffer[BindingInfo]       = mutable.ArrayBuffer.empty
-  protected val nestedDeclarationQueue: mutable.ArrayBuffer[NestedDeclaration] = mutable.ArrayBuffer.empty
   protected val methodAstParentStack: Stack[NewNode]                           = new Stack()
 
   protected val lambdaKeyPool   = new IntervalKeyPool(first = 1, last = Long.MaxValue)
@@ -75,15 +74,6 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
       _ = diffGraph.addNode(bindingInfo.node)
       (src, dst, label) <- bindingInfo.edgeMeta
     } diffGraph.addEdge(src, dst, label)
-
-    nestedDeclarationQueue.foreach { case NestedDeclaration(parent, child) =>
-      child match {
-        case _: NewMethod =>
-        case _: NewTypeDecl =>
-          diffGraph.addEdge(parent, child, EdgeTypes.AST)
-        case _ =>
-      }
-    }
 
     closureBindingDefQueue.foreach { case ClosureBindingDef(node, captureEdgeTo, refEdgeTo) =>
       diffGraph.addNode(node)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallGraphTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallGraphTests.scala
@@ -7,7 +7,7 @@ class CallGraphTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   implicit val resolver = NoResolve
 
-  "CPG for code with simple function definition" should {
+  "CPG for code with simple function declaration" should {
 
     val cpg = code("""
         |package mypkg

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DefaultContentRootsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DefaultContentRootsTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDefaultJars = true) {
 
-  "CPG for code with a simple function definition with parameters of stdlib types, but not fully specified" should {
+  "CPG for code with a simple function declaration with parameters of stdlib types, but not fully specified" should {
     val cpg = code("""
         |package mypkg
         |
@@ -76,7 +76,7 @@ class DefaultContentRootsTests extends KotlinCode2CpgFixture(withOssDataflow = f
     }
   }
 
-  "CPG for code with a class definition" should {
+  "CPG for code with a class declaration" should {
     val cpg = code("""
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/EnumTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/EnumTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 class EnumTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
-  "CPG for code with simple enum definition" should {
+  "CPG for code with simple enum declaration" should {
     val cpg = code("""
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 
 class ExtensionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
-  "CPG for code with simple extension function definitions" should {
+  "CPG for code with simple extension function declarations" should {
     implicit val resolver = NoResolve
 
     val cpg = code("""
@@ -37,7 +37,7 @@ class ExtensionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     implicit val resolver = NoResolve
 
     // TODO: add test cases after the lowering is clear:
-    //   --> right now we cannot differentiate between the fn definitions at different scopes
+    //   --> right now we cannot differentiate between the fn declarations at different scopes
     val cpg = code("""
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FileTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FileTests.scala
@@ -8,7 +8,7 @@ import java.io.File
 
 class FileTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
-  "CPG for code with simple class definition and one method" should {
+  "CPG for code with simple class declaration and one method" should {
     val cpg = code("""
         |package mypkg.bar
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InnerClassesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InnerClassesTests.scala
@@ -9,7 +9,7 @@ class InnerClassesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   implicit val resolver = NoResolve
 
-  "CPG for code with a simple inner class definition" should {
+  "CPG for code with a simple inner class declaration" should {
     val cpg = code("""
         | class Outer {
         |     private val bar: Int = 1

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -359,7 +359,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
     }
   }
 
-  "CPG for code with call with lambda inside method definition" should {
+  "CPG for code with call with lambda inside method declaration" should {
     val cpg = code("""
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalClassesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalClassesTests.scala
@@ -1,0 +1,66 @@
+package io.joern.kotlin2cpg.querying
+
+import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.{Method, TypeDecl}
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.{iterableToTraversal}
+
+class LocalClassesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
+
+  implicit val resolver = NoResolve
+
+  "CPG for code with a simple local fn definition" should {
+    val cpg = code("""
+        |package mypkg
+        |
+        |fun sink(x: String) = println(x)
+        |fun main() {
+        |    class AClass {
+        |        fun printQ(q: String) = sink(q)
+        |    }
+        |    val a = AClass()
+        |    a.printQ("AMESSAGE")
+        |}
+        |""".stripMargin)
+
+    "contain a TYPE_DECL node for the local class with the correct PROPS set" in {
+      val List(td: TypeDecl) = cpg.typeDecl.nameExact("AClass").l
+      td.fullName shouldBe "mypkg.main.AClass"
+      td.method.filterNot { m => m.fullName.startsWith("mypkg.main.AClass") }.fullName.l shouldBe List()
+      td.inheritsFromTypeFullName.l shouldBe List("java.lang.Object")
+    }
+  }
+
+  "CPG for code with a deeply-nested local class definition" should {
+    val cpg = code("""
+        |package mypkg
+        |fun sink(x: String) = println(x)
+        |fun f1(p: String) {
+        |    class AClass {
+        |        fun doSomething(r: String) {
+        |            class BClass {
+        |                fun doSomethingElse(s: String) {
+        |                    sink(s)
+        |                }
+        |            }
+        |            val bClass = BClass()
+        |            bClass.doSomethingElse(r)
+        |        }
+        |    }
+        |    val aClass = AClass()
+        |    aClass.doSomething(p)
+        |}
+        |
+        |""".stripMargin)
+
+    "contain a TYPE_DECL node for the deeply-nested local class with the correct PROPS set" in {
+      val List(td: TypeDecl) = cpg.typeDecl.nameExact("BClass").l
+      td.fullName shouldBe "mypkg.f1.AClass.doSomething.BClass"
+      td.method
+        .filterNot { m => m.fullName.startsWith("mypkg.f1.AClass.doSomething.BClass") }
+        .fullName
+        .l shouldBe List()
+      td.inheritsFromTypeFullName.l shouldBe List("java.lang.Object")
+    }
+  }
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalClassesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalClassesTests.scala
@@ -9,7 +9,7 @@ class LocalClassesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   implicit val resolver = NoResolve
 
-  "CPG for code with a simple local fn definition" should {
+  "CPG for code with a simple local fn declaration" should {
     val cpg = code("""
         |package mypkg
         |
@@ -31,7 +31,7 @@ class LocalClassesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     }
   }
 
-  "CPG for code with a deeply-nested local class definition" should {
+  "CPG for code with a deeply-nested local class declaration" should {
     val cpg = code("""
         |package mypkg
         |fun sink(x: String) = println(x)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalFunctionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalFunctionsTests.scala
@@ -8,7 +8,7 @@ class LocalFunctionsTests extends KotlinCode2CpgFixture(withOssDataflow = false)
 
   implicit val resolver = NoResolve
 
-  "CPG for code with a simple local fn definition" should {
+  "CPG for code with a simple local fn declaration" should {
     val cpg = code("""
         |package mypkg
         |
@@ -30,7 +30,7 @@ class LocalFunctionsTests extends KotlinCode2CpgFixture(withOssDataflow = false)
     }
   }
 
-  "CPG for code with deeply-nested local fn definitions" should {
+  "CPG for code with deeply-nested local fn declarations" should {
     val cpg = code("""
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalFunctionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalFunctionsTests.scala
@@ -20,13 +20,62 @@ class LocalFunctionsTests extends KotlinCode2CpgFixture(withOssDataflow = false)
         |}
         |""".stripMargin)
 
-    "should contain a METHOD node for the local function with the correct PROPS set" in {
+    "contain a METHOD node for the local function with the correct PROPS set" in {
       val List(m: Method) = cpg.method.nameExact("f2").l
       m.fullName shouldBe "mypkg.f1.f2:void(java.lang.String)"
       m.signature shouldBe "void(java.lang.String)"
       m.parameter.size shouldBe 1
       m.block.size shouldBe 1
       m.block.expressionDown.size shouldBe 1
+    }
+  }
+
+  "CPG for code with deeply-nested local fn definitions" should {
+    val cpg = code("""
+        |package mypkg
+        |
+        |fun f1(p: String) {
+        |    fun f2(q: String) {
+        |        fun f3(r: String) {
+        |            fun f4(s: String) {
+        |                println(s)
+        |            }
+        |            f4(r)
+        |        }
+        |        f3(q)
+        |    }
+        |    f2(p)
+        |}
+        |""".stripMargin)
+
+    "contain METHOD nodes for the local fns with the correct props set" in {
+      val List(m1: Method) = cpg.method.nameExact("f1").l
+      m1.fullName shouldBe "mypkg.f1:void(java.lang.String)"
+      m1.signature shouldBe "void(java.lang.String)"
+      m1.parameter.size shouldBe 1
+      m1.block.size shouldBe 1
+      m1.block.expressionDown.size shouldBe 1
+
+      val List(m2: Method) = cpg.method.nameExact("f2").l
+      m2.fullName shouldBe "mypkg.f1.f2:void(java.lang.String)"
+      m2.signature shouldBe "void(java.lang.String)"
+      m2.parameter.size shouldBe 1
+      m2.block.size shouldBe 1
+      m2.block.expressionDown.size shouldBe 1
+
+      val List(m3: Method) = cpg.method.nameExact("f3").l
+      m3.fullName shouldBe "mypkg.f1.f2.f3:void(java.lang.String)"
+      m3.signature shouldBe "void(java.lang.String)"
+      m3.parameter.size shouldBe 1
+      m3.block.size shouldBe 1
+      m3.block.expressionDown.size shouldBe 1
+
+      val List(m4: Method) = cpg.method.nameExact("f4").l
+      m4.fullName shouldBe "mypkg.f1.f2.f3.f4:void(java.lang.String)"
+      m4.signature shouldBe "void(java.lang.String)"
+      m4.parameter.size shouldBe 1
+      m4.block.size shouldBe 1
+      m4.block.expressionDown.size shouldBe 1
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodParameterTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class MethodParameterTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
-  "CPG for code with a simple function definition" should {
+  "CPG for code with a simple function declaration" should {
     val cpg = code("""
         |package mypkg
         |
@@ -38,7 +38,7 @@ class MethodParameterTests extends KotlinCode2CpgFixture(withOssDataflow = false
     }
   }
 
-  "CPG for code with a simple class definition" should {
+  "CPG for code with a simple class declaration" should {
     val cpg = code("""
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeAliasTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeAliasTests.scala
@@ -30,7 +30,7 @@ class TypeAliasTests extends KotlinCode2CpgFixture(withOssDataflow = false, with
   }
 
   // _seemingly_ because adding the springframework jar to the classpath will give the
-  // compiler enough information to detect that there is no recursion in the typealias definition
+  // compiler enough information to detect that there is no recursion in the typealias declaration
   "CPG for code with seemingly-recursive type alias" should {
     val cpg = code("""
         |package mypkg

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeDeclTests.scala
@@ -300,7 +300,7 @@ class TypeDeclTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     "should contain a TYPE_DECL node for the class with the correct props set" in {
       val List(td) = cpg.typeDecl.nameExact("AClass").l
       td.isExternal shouldBe false
-      td.fullName shouldBe "mypkg.AClass$doSomething"
+      td.fullName shouldBe "mypkg.doSomething.AClass"
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/NestedDeclarationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/NestedDeclarationTests.scala
@@ -1,0 +1,118 @@
+package io.joern.kotlin2cpg.validation
+
+import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.edges.Ast
+import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Method, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.jIteratortoTraversal
+
+class NestedDeclarationsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
+  "CPG for code with a simple local fn definition" should {
+    val cpg = code("""
+        |package mypkg
+        |
+        |fun f1(p: String) {
+        |    fun f2(q: String) {
+        |        println(q)
+        |    }
+        |    f2(p)
+        |}
+        |""".stripMargin)
+
+    "contain METHODs node for the local fns with the correct `astParent`s set" in {
+      val List(m: Method)         = cpg.method.nameExact("f2").l
+      val List(astParent: Method) = m.astIn.l
+      astParent.fullName shouldBe cpg.method.nameExact("f1").fullName.head
+    }
+  }
+
+  "CPG for code with deeply-nested local fn definitions" should {
+    val cpg = code("""
+        |package mypkg
+        |
+        |fun f1(p: String) {
+        |    fun f2(q: String) {
+        |        fun f3(r: String) {
+        |            fun f4(s: String) {
+        |                println(s)
+        |            }
+        |            f4(r)
+        |        }
+        |        f3(q)
+        |    }
+        |    f2(p)
+        |}
+        |""".stripMargin)
+
+    "contain METHOD nodes for the local fns with the correct `astParent`s set" in {
+      val List(m2: Method)         = cpg.method.nameExact("f2").l
+      val List(astParent2: Method) = m2.astIn.l
+      astParent2.fullName shouldBe cpg.method.nameExact("f1").fullName.head
+
+      val List(m3: Method)         = cpg.method.nameExact("f3").l
+      val List(astParent3: Method) = m3.astIn.l
+      astParent3.fullName shouldBe cpg.method.nameExact("f2").fullName.head
+
+      val List(m4: Method)         = cpg.method.nameExact("f4").l
+      val List(astParent4: Method) = m4.astIn.l
+      astParent4.fullName shouldBe cpg.method.nameExact("f3").fullName.head
+    }
+  }
+
+  "CPG for code with a simple local class definition" should {
+    val cpg = code("""
+        |package mypkg
+        |
+        |fun sink(x: String) = println(x)
+        |fun main() {
+        |    class AClass {
+        |        fun printQ(q: String) = sink(q)
+        |    }
+        |    val a = AClass()
+        |    a.printQ("AMESSAGE")
+        |}
+        |""".stripMargin)
+
+    "contain TYPE_DECL nodes for the local classes with the correct `astParent`s set" in {
+      val List(td: TypeDecl)      = cpg.typeDecl.nameExact("AClass").l
+      val List(astParent: Method) = td.astIn.l
+      astParent.fullName shouldBe cpg.method.nameExact("main").fullName.head
+    }
+  }
+
+  "CPG for code with deeply nested local class definitions" should {
+    val cpg = code("""
+        |package mypkg
+        |
+        |fun sink(x: String) = println(x)
+        |fun f1(p: String) {
+        |    class AClass {
+        |        fun doSomething(r: String) {
+        |            class BClass {
+        |                fun doSomethingElse(s: String) {
+        |                    sink(s)
+        |                }
+        |            }
+        |            val bClass = BClass()
+        |            bClass.doSomethingElse(r)
+        |        }
+        |    }
+        |    val aClass = AClass()
+        |    aClass.doSomething(p)
+        |}
+        |""".stripMargin)
+
+    "contain TYPE_DECL nodes for the local classes with the correct `astParent`s set" in {
+      val List(td: TypeDecl)      = cpg.typeDecl.nameExact("AClass").l
+      val List(astParent: Method) = td.astIn.l
+      astParent.fullName shouldBe cpg.method.nameExact("f1").fullName.head
+
+      val List(td2: TypeDecl)      = cpg.typeDecl.nameExact("BClass").l
+      val List(astParent2: Method) = td2.astIn.l
+      astParent2.fullName shouldBe cpg.method.nameExact("doSomething").fullName.head
+    }
+  }
+
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/NestedDeclarationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/NestedDeclarationTests.scala
@@ -9,7 +9,7 @@ import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.jIteratortoTraversal
 
 class NestedDeclarationsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
-  "CPG for code with a simple local fn definition" should {
+  "CPG for code with a simple local fn declaration" should {
     val cpg = code("""
         |package mypkg
         |
@@ -28,7 +28,7 @@ class NestedDeclarationsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
     }
   }
 
-  "CPG for code with deeply-nested local fn definitions" should {
+  "CPG for code with deeply-nested local fn declarations" should {
     val cpg = code("""
         |package mypkg
         |
@@ -61,7 +61,7 @@ class NestedDeclarationsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
     }
   }
 
-  "CPG for code with a simple local class definition" should {
+  "CPG for code with a simple local class declaration" should {
     val cpg = code("""
         |package mypkg
         |
@@ -82,7 +82,7 @@ class NestedDeclarationsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
     }
   }
 
-  "CPG for code with deeply nested local class definitions" should {
+  "CPG for code with deeply nested local class declarations" should {
     val cpg = code("""
         |package mypkg
         |

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/validation/ValidationTests.scala
@@ -368,7 +368,7 @@ class ValidationTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     }
   }
 
-  "CPG for code with call with lambda inside method definition" should {
+  "CPG for code with call with lambda inside method declaration" should {
     lazy val cpg = code("""
         |package mypkg
         |


### PR DESCRIPTION
mostly contains fixes for deeply-nested declarations