### PR TITLE
refactor dsl: tighten return types, use generated steps rather than graph-generic dsl, ...

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
@@ -1,79 +1,39 @@
 package io.shiftleft.semanticcpg.language
 
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import overflowdb.traversal._
 
 class TagTraversal(val traversal: Traversal[Tag]) extends AnyVal {
 
   def member: Traversal[Member] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.MEMBER)
-      .sortBy(_.id)
-      .cast[Member]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Member]
 
   def method: Traversal[Method] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.METHOD)
-      .sortBy(_.id)
-      .cast[Method]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Method]
 
   def methodReturn: Traversal[MethodReturn] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.METHOD_RETURN)
-      .sortBy(_.id)
-      .cast[MethodReturn]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodReturn]
 
   def parameter: Traversal[MethodParameterIn] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
-      .sortBy(_.id)
-      .cast[MethodParameterIn]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodParameterIn]
 
   def parameterOut: Traversal[MethodParameterOut] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.METHOD_PARAMETER_OUT)
-      .sortBy(_.id)
-      .cast[MethodParameterOut]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodParameterOut]
 
   def call: Traversal[Call] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.CALL)
-      .sortBy(_.id)
-      .cast[Call]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Call]
 
   def identifier: Traversal[Identifier] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.IDENTIFIER)
-      .sortBy(_.id)
-      .cast[Identifier]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Identifier]
 
   def literal: Traversal[Literal] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.LITERAL)
-      .sortBy(_.id)
-      .cast[Literal]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Literal]
 
   def local: Traversal[Local] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.LOCAL)
-      .sortBy(_.id)
-      .cast[Local]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Local]
 
   def file: Traversal[File] =
-    traversal
-      .in(EdgeTypes.TAGGED_BY)
-      .hasLabel(NodeTypes.FILE)
-      .sortBy(_.id)
-      .cast[File]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[File]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
@@ -3,37 +3,21 @@ package io.shiftleft.semanticcpg.language
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes._
 import overflowdb.traversal._
+import scala.reflect.ClassTag
 
 class TagTraversal(val traversal: Traversal[Tag]) extends AnyVal {
 
-  def member: Traversal[Member] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Member].sortBy(_.id)
+  def member: Traversal[Member]                   = tagged[Member]
+  def method: Traversal[Method]                   = tagged[Method]
+  def methodReturn: Traversal[MethodReturn]       = tagged[MethodReturn]
+  def parameter: Traversal[MethodParameterIn]     = tagged[MethodParameterIn]
+  def parameterOut: Traversal[MethodParameterOut] = tagged[MethodParameterOut]
+  def call: Traversal[Call]                       = tagged[Call]
+  def identifier: Traversal[Identifier]           = tagged[Identifier]
+  def literal: Traversal[Literal]                 = tagged[Literal]
+  def local: Traversal[Local]                     = tagged[Local]
+  def file: Traversal[File]                       = tagged[File]
 
-  def method: Traversal[Method] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Method].sortBy(_.id)
-
-  def methodReturn: Traversal[MethodReturn] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodReturn].sortBy(_.id)
-
-  def parameter: Traversal[MethodParameterIn] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodParameterIn].sortBy(_.id)
-
-  def parameterOut: Traversal[MethodParameterOut] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodParameterOut].sortBy(_.id)
-
-  def call: Traversal[Call] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Call].sortBy(_.id)
-
-  def identifier: Traversal[Identifier] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Identifier].sortBy(_.id)
-
-  def literal: Traversal[Literal] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Literal].sortBy(_.id)
-
-  def local: Traversal[Local] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Local].sortBy(_.id)
-
-  def file: Traversal[File] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[File].sortBy(_.id)
-
+  private def tagged[A <: StoredNode: ClassTag]: Traversal[A] =
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[A].sortBy(_.id)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
@@ -7,33 +7,33 @@ import overflowdb.traversal._
 class TagTraversal(val traversal: Traversal[Tag]) extends AnyVal {
 
   def member: Traversal[Member] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Member]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Member].sortBy(_.id)
 
   def method: Traversal[Method] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Method]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Method].sortBy(_.id)
 
   def methodReturn: Traversal[MethodReturn] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodReturn]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodReturn].sortBy(_.id)
 
   def parameter: Traversal[MethodParameterIn] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodParameterIn]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodParameterIn].sortBy(_.id)
 
   def parameterOut: Traversal[MethodParameterOut] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodParameterOut]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[MethodParameterOut].sortBy(_.id)
 
   def call: Traversal[Call] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Call]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Call].sortBy(_.id)
 
   def identifier: Traversal[Identifier] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Identifier]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Identifier].sortBy(_.id)
 
   def literal: Traversal[Literal] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Literal]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Literal].sortBy(_.id)
 
   def local: Traversal[Local] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Local]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[Local].sortBy(_.id)
 
   def file: Traversal[File] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[File]
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[File].sortBy(_.id)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/MethodTraversal.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.semanticcpg.language.bindingextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Method, TypeDecl}
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
@@ -15,5 +14,5 @@ class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
   /** Traverse to bindings which reference to this method.
     */
   def referencingBinding: Traversal[Binding] =
-    traversal.in(EdgeTypes.REF).where(_.hasLabel(NodeTypes.BINDING)).cast[Binding]
+    traversal.flatMap(_._bindingViaRefIn)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/TypeDeclTraversal.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.language.bindingextension
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Method, TypeDecl}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
@@ -15,6 +14,6 @@ class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
   /** Traverse to the method bindings of this type declaration.
     */
   def methodBinding: Traversal[Binding] =
-    traversal.canonicalType.out(EdgeTypes.BINDS).cast[Binding]
+    traversal.canonicalType.flatMap(_.bindsOut)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
@@ -65,6 +65,6 @@ class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
     */
   @Doc(info = "Call sites (outgoing calls)")
   def call: Traversal[Call] =
-    traversal.out(EdgeTypes.CONTAINS).collectAll[Call]
+    traversal.flatMap(_._callViaContainsOut)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -71,7 +71,7 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
     } yield paramIn
 
   def typ: Traversal[Type] = {
-    Traversal(node._evalTypeOut).cast[Type]
+    node._evalTypeOut.cast[Type]
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -1,15 +1,7 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.Implicits.JavaIteratorDeco
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  AstNode,
-  Call,
-  CallRepr,
-  Expression,
-  Local,
-  MethodParameterIn,
-  Type
-}
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.ICallResolver
@@ -43,19 +35,19 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
   }
 
   def expressionUp: Traversal[Expression] = {
-    Traversal(node._astIn.asScala.filterNot(_.isInstanceOf[Local])).cast[Expression]
+    node._astIn.filterNot(_.isInstanceOf[Local]).cast[Expression]
   }
 
   def expressionDown: Traversal[Expression] = {
-    Traversal(node._astOut.asScala.filterNot(_.isInstanceOf[Local])).cast[Expression]
+    node._astOut.filterNot(_.isInstanceOf[Local]).cast[Expression]
   }
 
   def receivedCall: Traversal[Call] = {
-    Traversal(node._receiverIn.asScala).cast[Call]
+    node._receiverIn.cast[Call]
   }
 
   def isArgument: Traversal[Expression] = {
-    Traversal(node._argumentIn.asScala).cast[Expression]
+    node._argumentIn.cast[Expression]
   }
 
   def inCall: Traversal[Call] = {
@@ -70,8 +62,7 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
       if paramIn.index == node.argumentIndex
     } yield paramIn
 
-  def typ: Traversal[Type] = {
+  def typ: Traversal[Type] =
     node._evalTypeOut.cast[Type]
-  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -66,7 +66,7 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
     for {
       call          <- node._argumentIn.asScala
       calledMethods <- callResolver.getCalledMethods(call.asInstanceOf[CallRepr])
-      paramIn       <- calledMethods._astOut.asScala.collect { case node: MethodParameterIn => node }
+      paramIn       <- calledMethods._astOut.asScala.collectAll[MethodParameterIn]
       if paramIn.index == node.argumentIndex
     } yield paramIn
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,15 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  Annotation,
-  Block,
-  CfgNode,
-  ControlStructure,
-  Local,
-  Method,
-  NewLocation,
-  TypeDecl
-}
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.{Traversal, jIteratortoTraversal}
@@ -22,7 +13,7 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
     method._annotationViaAstOut
 
   def local: Traversal[Local] =
-    method._blockViaContainsOut.flatMap(_._localViaAstOut)
+    method._blockViaContainsOut.local
 
   /** All control structures of this method
     */
@@ -60,17 +51,16 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
 
   /** The type declaration associated with this method, e.g., the class it is defined in.
     */
-  def definingTypeDecl: Traversal[TypeDecl] =
-    Traversal.fromSingle(method).definingTypeDecl
+  def definingTypeDecl: Option[TypeDecl] =
+    Traversal.fromSingle(method).definingTypeDecl.headOption
 
   /** The type declaration associated with this method, e.g., the class it is defined in. Alias for 'definingTypeDecl'
     */
-  def typeDecl: Traversal[TypeDecl] = definingTypeDecl
+  def typeDecl: Option[TypeDecl] = definingTypeDecl
 
   /** Traverse to method body (alias for `block`) */
-  // TODO MP: return a `Block` rather than `Traversal[Block]` - it's guaranteed to be there and exactly one...
-  def body: Traversal[Block] =
-    Traversal.fromSingle(method.block)
+  def body: Block =
+    method.block
 
   override def location: NewLocation = {
     LocationCreator(method, method.name, method.label, method.lineNumber, method)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodReturn, NewLocation, Type}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, _}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal.{Traversal, iterableToTraversal}
 
 class MethodReturnMethods(val node: MethodReturn) extends AnyVal with NodeExtension with HasLocation {
   override def location: NewLocation = {
@@ -17,7 +17,7 @@ class MethodReturnMethods(val node: MethodReturn) extends AnyVal with NodeExtens
     // return type to CallRepr would lead to a break in the API aka
     // the DSL steps which are subsequently allowed to be called. Before
     // we addressed this we can only return Call instances.
-    Traversal.from(callsites.filter(_.isInstanceOf[Call])).cast[Call]
+    callsites.collectAll[Call]
   }
 
   def typ: Traversal[Type] = node.evalTypeOut

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
@@ -9,11 +9,10 @@ class AssignmentMethods(val assignment: OpNodes.Assignment) extends AnyVal {
   def target: Expression = assignment.argument(1)
 
   def source: Expression = {
-    val numberOfArguments = assignment.argument.size
-    numberOfArguments match {
+    assignment.argument.size match {
       case 1 => assignment.argument(1)
       case 2 => assignment.argument(2)
-      case _ => throw new RuntimeException(s"Assignment statement with $numberOfArguments arguments")
+      case numberOfArguments => throw new RuntimeException(s"Assignment statement with $numberOfArguments arguments")
     }
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
@@ -10,8 +10,8 @@ class AssignmentMethods(val assignment: OpNodes.Assignment) extends AnyVal {
 
   def source: Expression = {
     assignment.argument.size match {
-      case 1 => assignment.argument(1)
-      case 2 => assignment.argument(2)
+      case 1                 => assignment.argument(1)
+      case 2                 => assignment.argument(2)
       case numberOfArguments => throw new RuntimeException(s"Assignment statement with $numberOfArguments arguments")
     }
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
@@ -1,17 +1,9 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  Call,
-  Expression,
-  FieldIdentifier,
-  Identifier,
-  Literal,
-  Member,
-  TypeDecl
-}
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
-import overflowdb.traversal.{NodeOps, Traversal, jIteratortoTraversal}
+import overflowdb.traversal.{NodeOps, Traversal}
 
 class FieldAccessMethods(val arrayAccess: OpNodes.FieldAccess) extends AnyVal {
 
@@ -28,6 +20,7 @@ class FieldAccessMethods(val arrayAccess: OpNodes.FieldAccess) extends AnyVal {
 
   def fieldIdentifier: Traversal[FieldIdentifier] = arrayAccess.start.argument(2).isFieldIdentifier
 
-  def member: Option[Member] = arrayAccess._refOut.to(Traversal).collectAll[Member].headOption
+  def member: Option[Member] =
+    arrayAccess.referencedMember.headOption
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -4,7 +4,6 @@ import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.{OpNodes, allArrayAccessTypes}
-import overflowdb.traversal.Traversal
 
 class TargetMethods(val expr: Expression) extends AnyVal {
 
@@ -13,12 +12,9 @@ class TargetMethods(val expr: Expression) extends AnyVal {
       .collectFirst { case x if allArrayAccessTypes.contains(x.name) => x }
       .map(new OpNodes.ArrayAccess(_))
 
-  // TODO MP: return an `Option[Expression]` rather than `Traversal[Expression]`
-  def pointer: Traversal[Expression] = {
-    expr match {
-      case call: Call if call.name == Operators.indirection => Traversal.fromSingle(call.argument(1))
-      case _                                                => Traversal()
+  def pointer: Option[Expression] =
+    Option(expr).collect {
+      case call: Call if call.name == Operators.indirection => call.argument(1)
     }
-  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
@@ -39,8 +38,6 @@ class CallTraversal(val traversal: Traversal[Call]) extends AnyVal {
   def toMethodReturn(implicit callResolver: ICallResolver): Traversal[MethodReturn] =
     traversal
       .flatMap(callResolver.getCalledMethodsAsTraversal)
-      .out(EdgeTypes.AST)
-      .hasLabel(NodeTypes.METHOD_RETURN)
-      .cast[MethodReturn]
+      .flatMap(_.methodReturn)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -16,7 +16,7 @@ class ControlStructureTraversal(val traversal: Traversal[ControlStructure]) exte
 
   @Doc(info = "The condition associated with this control structure")
   def condition: Traversal[Expression] =
-    traversal.out(EdgeTypes.CONDITION).cast[Expression]
+    traversal.flatMap(_.conditionOut).collectAll[Expression]
 
   @Doc(info = "Control structures where condition.code matches regex")
   def condition(regex: String): Traversal[ControlStructure] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTraversal.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Identifier}
 import overflowdb.traversal._
 
@@ -10,7 +9,8 @@ class IdentifierTraversal(val traversal: Traversal[Identifier]) extends AnyVal {
 
   /** Traverse to all declarations of this identifier
     */
-  def refsTo: Traversal[Declaration] =
-    traversal.out(EdgeTypes.REF).cast[Declaration]
+  def refsTo: Traversal[Declaration] = {
+    traversal.flatMap(_.refOut).cast[Declaration]
+  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -12,8 +12,9 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
   /** Nodes of the AST rooted in this node, including the node itself.
     */
   @Doc(info = "All nodes of the abstract syntax tree")
-  def ast: Traversal[AstNode] =
+  def ast: Traversal[AstNode] = {
     traversal.repeat(_.out(EdgeTypes.AST))(_.emit).cast[AstNode]
+  }
 
   /** All nodes of the abstract syntax tree rooted in this node, which match `predicate`. Equivalent of `match` in the
     * original CPG paper.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
@@ -64,6 +64,6 @@ class ExpressionTraversal[NodeType <: Expression](val traversal: Traversal[NodeT
   /** Traverse to expression evaluation type
     */
   def typ: Traversal[Type] =
-    traversal.out(EdgeTypes.EVAL_TYPE).cast[Type]
+    traversal.flatMap(_._evalTypeOut).cast[Type]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
@@ -17,7 +17,7 @@ class EvalTypeAccessors[A <: AstNode](val traversal: Traversal[A]) extends AnyVa
     if (regexes.isEmpty) Traversal.empty
     else {
       val regexes0 = regexes.map(_.r).toSet
-      traversal.where(evalType(_).filter( value => regexes0.exists(_.matches(value))))
+      traversal.where(evalType(_).filter(value => regexes0.exists(_.matches(value))))
     }
 
   def evalTypeExact(value: String): Traversal[A] =
@@ -37,7 +37,7 @@ class EvalTypeAccessors[A <: AstNode](val traversal: Traversal[A]) extends AnyVa
     if (regexes.isEmpty) Traversal.empty
     else {
       val regexes0 = regexes.map(_.r).toSet
-      traversal.where(evalType(_).filter( value => !regexes0.exists(_.matches(value))))
+      traversal.where(evalType(_).filter(value => !regexes0.exists(_.matches(value))))
     }
 
   private def evalType(traversal: Traversal[A]): Traversal[String] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
@@ -1,69 +1,46 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Properties}
+import io.shiftleft.codepropertygraph.generated.Properties
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode
 import overflowdb.traversal._
-import overflowdb.traversal.filter.P
-import overflowdb.{Node, toPropertyKeyOps}
 
-class EvalTypeAccessors[A <: Node](val traversal: Traversal[A]) extends AnyVal {
+class EvalTypeAccessors[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {
 
   def evalType: Traversal[String] =
-    traversal.out(EdgeTypes.EVAL_TYPE).out(EdgeTypes.REF).property(Properties.FULL_NAME)
+    evalType(traversal)
 
-  def evalType(regex: String): Traversal[A] =
-    traversal.where(
-      _.out(EdgeTypes.EVAL_TYPE)
-        .out(EdgeTypes.REF)
-        .has(Properties.FULL_NAME.where(_.matches(regex)))
-    )
+  def evalType(regex: String): Traversal[A] = {
+    traversal.where(evalType(_).filter(_.matches(regex)))
+  }
 
-  def evalType(values: String*): Traversal[A] =
-    if (values.isEmpty) Traversal.empty
+  def evalType(regexes: String*): Traversal[A] =
+    if (regexes.isEmpty) Traversal.empty
     else {
-      val regexes0 = values.map(_.r).toSet
-      traversal.where(
-        _.out(EdgeTypes.EVAL_TYPE)
-          .out(EdgeTypes.REF)
-          .has(Properties.FULL_NAME.where { value =>
-            regexes0.exists(_.matches(value))
-          })
-      )
+      val regexes0 = regexes.map(_.r).toSet
+      traversal.where(evalType(_).filter( value => regexes0.exists(_.matches(value))))
     }
 
   def evalTypeExact(value: String): Traversal[A] =
-    traversal.where(
-      _.out(EdgeTypes.EVAL_TYPE)
-        .out(EdgeTypes.REF)
-        .has(Properties.FULL_NAME, value)
-    )
+    traversal.where(evalType(_).filter(_ == value))
 
   def evalTypeExact(values: String*): Traversal[A] =
     if (values.isEmpty) Traversal.empty
     else {
-      traversal.where(
-        _.out(EdgeTypes.EVAL_TYPE)
-          .out(EdgeTypes.REF)
-          .has(Properties.FULL_NAME.where(P.within(values.to(Set))))
-      )
+      val valuesSet = values.to(Set)
+      traversal.where(evalType(_).filter(valuesSet.contains))
     }
 
-  def evalTypeNot(value: String): Traversal[A] =
-    traversal.where(
-      _.out(EdgeTypes.EVAL_TYPE)
-        .out(EdgeTypes.REF)
-        .hasNot(Properties.FULL_NAME.where(_.matches(value)))
-    )
+  def evalTypeNot(regex: String): Traversal[A] =
+    traversal.where(evalType(_).filterNot(_.matches(regex)))
 
   def evalTypeNot(regexes: String*): Traversal[A] =
     if (regexes.isEmpty) Traversal.empty
     else {
       val regexes0 = regexes.map(_.r).toSet
-      traversal.where(
-        _.out(EdgeTypes.EVAL_TYPE)
-          .out(EdgeTypes.REF)
-          .hasNot(Properties.FULL_NAME.where { value =>
-            regexes0.exists(_.matches(value))
-          })
-      )
+      traversal.where(evalType(_).filter( value => !regexes0.exists(_.matches(value))))
     }
+
+  private def evalType(traversal: Traversal[A]): Traversal[String] =
+    traversal.flatMap(_._evalTypeOut).flatMap(_._refOut).property(Properties.FULL_NAME)
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ModifierAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ModifierAccessors.scala
@@ -1,7 +1,8 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.codepropertygraph.generated.nodes.Modifier
-import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes, Properties}
+import io.shiftleft.codepropertygraph.generated.traversal.toModifierTraversalExtGen
 import overflowdb._
 import overflowdb.traversal._
 
@@ -40,10 +41,10 @@ class ModifierAccessors[A <: Node](val traversal: Traversal[A]) extends AnyVal {
     hasModifier(ModifierTypes.VIRTUAL)
 
   def hasModifier(modifier: String): Traversal[A] =
-    traversal.where(_.out.hasLabel(NodeTypes.MODIFIER).has(Properties.MODIFIER_TYPE -> modifier))
+    traversal.where(_.out.collectAll[Modifier].modifierType(modifier))
 
   /** Traverse to modifiers, e.g., "static", "public".
     */
   def modifier: Traversal[Modifier] =
-    traversal.out.hasLabel(NodeTypes.MODIFIER).cast[Modifier]
+    traversal.out.collectAll[Modifier]
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationParameterAssignTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationParameterAssignTraversal.scala
@@ -1,23 +1,22 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes._
 import overflowdb.traversal.Traversal
 
 /** An annotation parameter-assignment, e.g., `foo=value` in @Test(foo=value)
   */
-class AnnotationParameterAssignTraversal(val traversal: Traversal[nodes.AnnotationParameterAssign]) extends AnyVal {
+class AnnotationParameterAssignTraversal(val traversal: Traversal[AnnotationParameterAssign]) extends AnyVal {
 
   /** Traverse to all annotation parameters
     */
-  def parameter: Traversal[nodes.AnnotationParameter] =
-    traversal
-      .flatMap(_._annotationParameterViaAstOut)
+  def parameter: Traversal[AnnotationParameter] =
+    traversal.flatMap(_._annotationParameterViaAstOut)
 
   /** Traverse to all values of annotation parameters
     */
-  def value: Traversal[nodes.Expression] =
+  def value: Traversal[Expression] =
     traversal
       .flatMap(_.astOut)
-      .filterNot(_.isInstanceOf[nodes.AnnotationParameter])
-      .cast[nodes.Expression]
+      .filterNot(_.isInstanceOf[AnnotationParameter])
+      .cast[Expression]
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/FileTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/FileTraversal.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import overflowdb.traversal._
 
 /** A compilation unit
@@ -9,12 +8,10 @@ import overflowdb.traversal._
 class FileTraversal(val traversal: Traversal[File]) extends AnyVal {
 
   def namespace: Traversal[Namespace] =
-    traversal.in(EdgeTypes.SOURCE_FILE).hasLabel(NodeTypes.NAMESPACE_BLOCK).out(EdgeTypes.REF).cast[Namespace]
+    traversal.flatMap(_.namespaceBlock).flatMap(_._namespaceViaRefOut)
 
 }
 
 object FileTraversal {
-
   val UNKNOWN = "<unknown>"
-
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/ImportTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/ImportTraversal.scala
@@ -1,14 +1,11 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Import, NamespaceBlock}
 import overflowdb.traversal._
 
 class ImportTraversal(val traversal: Traversal[Import]) extends AnyVal {
 
-  def namespaceBlock: Traversal[NamespaceBlock] = traversal
-    .in(EdgeTypes.AST)
-    .collect { case x: NamespaceBlock => x }
-    .cast[NamespaceBlock]
+  def namespaceBlock: Traversal[NamespaceBlock] =
+    traversal.flatMap(_.astIn).collectAll[NamespaceBlock]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTraversal.scala
@@ -16,6 +16,6 @@ class MemberTraversal(val traversal: Traversal[Member]) extends AnyVal {
   /** Places where
     */
   def ref: Traversal[Call] =
-    traversal.in(EdgeTypes.REF).cast[Call]
+    traversal.flatMap(_._callViaRefIn)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
@@ -11,7 +10,7 @@ class MethodReturnTraversal(val traversal: Traversal[MethodReturn]) extends AnyV
 
   @Doc(info = "traverse to parent method")
   def method: Traversal[Method] =
-    traversal.in(EdgeTypes.AST).cast[Method]
+    traversal.flatMap(_._methodViaAstIn)
 
   def returnUser(implicit callResolver: ICallResolver): Traversal[Call] =
     traversal.flatMap(_.returnUser)
@@ -20,7 +19,7 @@ class MethodReturnTraversal(val traversal: Traversal[MethodReturn]) extends AnyV
     */
   @Doc(info = "traverse to last expressions in CFG (can be multiple)")
   def cfgLast: Traversal[CfgNode] =
-    traversal.in(EdgeTypes.CFG).cast[Expression]
+    traversal.flatMap(_.cfgIn)
 
   /** Traverse to return type
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -112,15 +112,14 @@ class MethodTraversal(val iterableOnce: IterableOnce[Method]) extends AnyVal {
   /** Traverse to external methods, that is, methods not present but only referenced in the CPG.
     */
   @Doc(info = "External methods (called, but no body available)")
-  def external: Traversal[Method] = {
-    traversal.has(Properties.IS_EXTERNAL -> true)
-  }
+  def external: Traversal[Method] =
+    traversal.isExternal(true)
 
   /** Traverse to internal methods, that is, methods for which code is included in this CPG.
     */
   @Doc(info = "Internal methods, i.e., a body is available")
   def internal: Traversal[Method] =
-    traversal.has(Properties.IS_EXTERNAL -> false)
+    traversal.isExternal(false)
 
   /** Traverse to the methods local variables
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlockTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlockTraversal.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import overflowdb.traversal._
 
 class NamespaceBlockTraversal(val traversal: Traversal[NamespaceBlock]) extends AnyVal {
@@ -9,19 +8,13 @@ class NamespaceBlockTraversal(val traversal: Traversal[NamespaceBlock]) extends 
   /** Namespaces for namespace blocks.
     */
   def namespace: Traversal[Namespace] =
-    traversal.out(EdgeTypes.REF).cast[Namespace]
+    traversal.flatMap(_.refOut)
 
   /** The type declarations defined in this namespace
     */
   def typeDecl: Traversal[TypeDecl] =
-    traversal
-      .out(EdgeTypes.AST)
-      .hasLabel(NodeTypes.TYPE_DECL)
-      .cast[TypeDecl]
+    traversal.flatMap(_._typeDeclViaAstOut)
 
   def method: Traversal[Method] =
-    traversal
-      .out(EdgeTypes.AST)
-      .hasLabel(NodeTypes.METHOD)
-      .cast[Method]
+    traversal.flatMap(_._methodViaAstOut)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{Traversal, toElementTraversal, toNodeTraversal}
+import overflowdb.traversal.Traversal
 
 /** A namespace, e.g., Java package or C# namespace
   */
@@ -12,20 +11,12 @@ class NamespaceTraversal(val traversal: Traversal[Namespace]) extends AnyVal {
   /** The type declarations defined in this namespace
     */
   def typeDecl: Traversal[TypeDecl] =
-    traversal
-      .in(EdgeTypes.REF)
-      .out(EdgeTypes.AST)
-      .hasLabel(NodeTypes.TYPE_DECL)
-      .cast[TypeDecl]
+    traversal.flatMap(_.refIn).flatMap(_._typeDeclViaAstOut)
 
   /** Methods defined in this namespace
     */
   def method: Traversal[Method] =
-    traversal
-      .in(EdgeTypes.REF)
-      .out(EdgeTypes.AST)
-      .hasLabel(NodeTypes.METHOD)
-      .cast[Method]
+    traversal.flatMap(_.refIn).flatMap(_._methodViaAstOut)
 
   /** External namespaces - any namespaces which contain one or more external type.
     */
@@ -40,7 +31,5 @@ class NamespaceTraversal(val traversal: Traversal[Namespace]) extends AnyVal {
 }
 
 object NamespaceTraversal {
-
   val globalNamespaceName = "<global>"
-
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -19,31 +19,27 @@ class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
   /** Types referencing to this type declaration.
     */
   def referencingType: Traversal[Type] =
-    traversal.in(EdgeTypes.REF).cast[Type]
+    traversal.flatMap(_.refIn)
 
   /** Namespace in which this type declaration is defined
     */
   def namespace: Traversal[Namespace] =
-    traversal
-      .in(EdgeTypes.AST)
-      .hasLabel(NodeTypes.NAMESPACE_BLOCK)
-      .out(EdgeTypes.REF)
-      .cast[Namespace]
+    traversal.flatMap(_.namespaceBlock).namespace
 
   /** Methods defined as part of this type
     */
   def method: Traversal[Method] =
-    canonicalType.out(EdgeTypes.AST).hasLabel(NodeTypes.METHOD).cast[Method]
+    canonicalType.flatMap(_._methodViaAstOut)
 
   /** Filter for type declarations contained in the analyzed code.
     */
   def internal: Traversal[TypeDecl] =
-    canonicalType.has(Properties.IS_EXTERNAL -> false)
+    canonicalType.isExternal(false)
 
   /** Filter for type declarations not contained in the analyzed code.
     */
   def external: Traversal[TypeDecl] =
-    canonicalType.has(Properties.IS_EXTERNAL -> true)
+    canonicalType.isExternal(true)
 
   /** Member variables
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, Properties, nodes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb._
-import overflowdb.traversal.{Traversal, toElementTraversal, toNodeTraversal}
+import overflowdb.traversal.Traversal
 
 /** Type declaration - possibly a template that requires instantiation
   */
@@ -44,12 +43,12 @@ class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
   /** Member variables
     */
   def member: Traversal[Member] =
-    canonicalType.out.hasLabel(NodeTypes.MEMBER).cast[Member]
+    canonicalType.flatMap(_._memberViaAstOut)
 
   /** Direct base types in the inheritance graph.
     */
   def baseType: Traversal[Type] =
-    canonicalType.out(EdgeTypes.INHERITS_FROM).cast[Type]
+    canonicalType.flatMap(_._typeViaInheritsFromOut)
 
   /** Direct base type declaration.
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{Traversal, toElementTraversal, toNodeTraversal}
+import overflowdb.traversal.Traversal
 
 class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
 
@@ -60,7 +60,7 @@ class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
   /** Type declarations which derive from this type.
     */
   def derivedTypeDecl: Traversal[TypeDecl] =
-    traversal.in(EdgeTypes.INHERITS_FROM).cast[TypeDecl]
+    traversal.flatMap(_.inheritsFromIn)
 
   /** Direct alias types.
     */
@@ -73,30 +73,23 @@ class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
     traversal.repeat(_.aliasType)(_.emitAllButFirst)
 
   def localOfType: Traversal[Local] =
-    traversal.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[Local]
+    traversal.flatMap(_._localViaEvalTypeIn)
 
   def memberOfType: Traversal[Member] =
-    traversal.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.MEMBER).cast[Member]
+    traversal.flatMap(_.evalTypeIn).collectAll[Member]
 
   @deprecated("Please use `parameterOfType`")
   def parameter: Traversal[MethodParameterIn] = parameterOfType
 
   def parameterOfType: Traversal[MethodParameterIn] =
-    traversal
-      .in(EdgeTypes.EVAL_TYPE)
-      .collectAll[MethodParameterIn]
+    traversal.flatMap(_.evalTypeIn).collectAll[MethodParameterIn]
 
   def methodReturnOfType: Traversal[MethodReturn] =
-    traversal
-      .in(EdgeTypes.EVAL_TYPE)
-      .hasLabel(NodeTypes.METHOD_RETURN)
-      .cast[MethodReturn]
+    traversal.flatMap(_.evalTypeIn).collectAll[MethodReturn]
 
   def expressionOfType: Traversal[Expression] = expression
 
   def expression: Traversal[Expression] =
-    traversal
-      .in(EdgeTypes.EVAL_TYPE)
-      .collectAll[Expression]
+    traversal.flatMap(_.evalTypeIn).collectAll[Expression]
 
 }


### PR DESCRIPTION
Mostly refactoring, but one noteworthy change: in `TagTraversal` I dropped the `.sort` because it's a bad default: it only works if the entire traversal is in memory