### PR TITLE
kotlin2cpg: fix parsing of nop lambdas 

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -406,11 +406,12 @@ trait KtPsiToAst {
     val declarationAsts          = declarations.flatMap(astsForDeclaration)
     val allStatementsButLast     = statements.dropRight(1)
     val allStatementsButLastAsts = allStatementsButLast.map(astsForExpression(_, None)).flatten
+
     val lastStatementAsts =
-      if (implicitReturnAroundLastStatement) {
+      if (implicitReturnAroundLastStatement && statements.nonEmpty) {
         val _returnNode = returnNode(Constants.retCode, line(statements.last), column(statements.last))
         Seq(returnAst(_returnNode, astsForExpression(statements.last, Some(1))))
-      } else if (statements.size > 0) astsForExpression(statements.last, None)
+      } else if (statements.nonEmpty) astsForExpression(statements.last, None)
       else Seq()
 
     if (pushToScope) scope.popScope()

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -158,7 +158,6 @@ trait KtPsiToAst {
         methodNode(Constants.init, fullName, signature, relativizedPath, line(ctor), column(ctor))
       scope.pushNewScope(secondaryCtorMethodNode)
 
-      val typeFullName = registerType(typeInfoProvider.typeFullName(ctor, TypeConstants.any))
       val ctorThisParam = methodParameterNode(Constants.this_, classFullName)
         .dynamicTypeHintFullName(Seq(classFullName))
         .order(0)
@@ -252,7 +251,6 @@ trait KtPsiToAst {
         memberSetCallAst(ctorParam, classFullName)
     }
 
-    val typeFullName = typeInfoProvider.typeFullName(ktClass.getPrimaryConstructor, TypeConstants.any)
     val constructorMethodReturn = methodReturnNode(
       TypeConstants.void,
       None,

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -414,4 +414,16 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
       cpg.method.fullName(".*lambda.*2.*").block.astChildren.isLocal.size shouldBe 2
     }
   }
+
+  "CPG for code with lambda with no statements in its block" should {
+    val cpg = code("""
+        |package mypkg
+        |fun nopnopnopnopnopnopnopnop() {
+        |    1.let { _ -> }
+        |}
+        |""".stripMargin)
+    "contain a METHOD node for the lambda" in {
+      cpg.method.fullName(".*lambda.*").l should not be empty
+    }
+  }
 }


### PR DESCRIPTION
without this change, generating a CPG for a project containing a lambda
with no statements in its block crashes with a `NoSuchElementException`:
```
2022-08-10 11:44:33.325 INFO shutdown finished
java.util.NoSuchElementException: last of empty list
 at scala.collection.immutable.Nil$.last(List.scala:665)
 at scala.collection.immutable.Nil$.last(List.scala:661)
 at io.joern.kotlin2cpg.ast.KtPsiToAst.astsForBlock(KtPsiToAst.scala:411)
 at io.joern.kotlin2cpg.ast.KtPsiToAst.astsForBlock$(KtPsiToAst.scala:386)
 at io.joern.kotlin2cpg.passes.AstCreator.astsForBlock(AstCreator.scala:25)
 at io.joern.kotlin2cpg.ast.KtPsiToAst.$anonfun$astForLambda$4(KtPsiToAst.scala:530)

```