### PR TITLE
Display element in flow if it is a source element

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -43,7 +43,7 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
         if (first.isDefined && !first.get.visible && !sources.contains(first.get.node)) {
           None
         } else {
-          val visiblePathElements = result.path.filter(_.visible)
+          val visiblePathElements = result.path.filter(x => sources.contains(x.node) || x.visible)
           Some(Path(removeConsecutiveDuplicates(visiblePathElements.map(_.node))))
         }
       }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
@@ -1864,7 +1864,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
                      |""".stripMargin)
 
     "find a flow where the first element is a literal" in {
-      val source           = cpg.literal.code(".*firstName.*").l
+      val source           = cpg.literal.code(".*firstName.*")
       val sink             = cpg.call.methodFullName(".*log.*").l
       val List(flow)       = sink.reachableByFlows(source).l
       val literal: Literal = flow.elements.head.asInstanceOf[Literal]

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
@@ -1851,6 +1851,27 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
 
   }
+
+  "DataFlowTests69" should {
+    val cpg = code("""
+                     |char *foo() {
+                     |  return "abc" + "firstName";
+                     |}
+                     |
+                     |void bar() {
+                     | log(foo());
+                     |}
+                     |""".stripMargin)
+
+    "find a flow where the first element is a literal" in {
+      val source           = cpg.literal.code(".*firstName.*").l
+      val sink             = cpg.call.methodFullName(".*log.*").l
+      val List(flow)       = sink.reachableByFlows(source).l
+      val literal: Literal = flow.elements.head.asInstanceOf[Literal]
+      literal.code shouldBe "\"firstName\""
+    }
+  }
+
 }
 
 class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
@@ -2109,27 +2130,4 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
       freeArg.reachableByFlows(freeArg).count(path => path.elements.size > 1) shouldBe 1
     }
   }
-
-  "DataFlowTests69" should {
-
-    val cpg = code("""
-        |char *foo() {
-        |  return "abc" + "firstName";
-        |}
-        |
-        |void bar() {
-        | log(foo());
-        |}
-        |""".stripMargin)
-
-    "find a flow where the first element is a literal" in {
-      val source           = cpg.literal.code(".*firstName.*").l
-      val sink             = cpg.call.methodFullName(".*log.*").l
-      val List(flow)       = sink.reachableByFlows(source).l
-      val literal: Literal = flow.elements.head.asInstanceOf[Literal]
-      literal.code shouldBe "firstName"
-    }
-
-  }
-
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/DataFlowTests.scala
@@ -4,7 +4,7 @@ import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.Identifier
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.toNodeTraversal
 
@@ -2107,6 +2107,27 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
     "find flow for maxCallDepth = -1" in {
       def freeArg = cpg.call("free").argument(1)
       freeArg.reachableByFlows(freeArg).count(path => path.elements.size > 1) shouldBe 1
+    }
+  }
+
+  "DataFlowTests69" should {
+
+    val cpg = code("""
+        |char *foo() {
+        |  return "abc" + "firstName";
+        |}
+        |
+        |void bar() {
+        | log(foo());
+        |}
+        |""".stripMargin)
+
+    "find a flow where the first element is a literal" in {
+      val source           = cpg.literal.code(".*firstName.*").l
+      val sink             = cpg.call.methodFullName(".*log.*").l
+      val List(flow)       = sink.reachableByFlows(source).l
+      val literal: Literal = flow.elements.head.asInstanceOf[Literal]
+      literal.code shouldBe "firstName"
     }
 
   }


### PR DESCRIPTION
Before return flows, we do a bit of filtering to remove invisible elements. However, when the source is an invisible element, we should report it. Because we did not, flows from literals were often incomplete before, starting at the surrounding call.