### PR TITLE
Fix some javaparser and javasrc2cpg crashes

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -141,6 +141,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewMethodReturn,
   NewModifier,
   NewNamespaceBlock,
+  NewNode,
   NewReturn,
   NewTypeDecl,
   NewTypeRef,
@@ -1335,31 +1336,38 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .withRefEdge(idxIdentifierArg, idxLocal)
   }
 
-  private def nativeForEachCompareAst(lineNo: Option[Integer], iterableLocal: NodeTypeInfo, idxLocal: NewLocal): Ast = {
+  private def nativeForEachCompareAst(
+    lineNo: Option[Integer],
+    iterableSource: NodeTypeInfo,
+    idxLocal: NewLocal
+  ): Ast = {
     val idxName = idxLocal.name
 
     val compareNode = operatorCallNode(
       Operators.lessThan,
-      code = s"$idxName < ${iterableLocal.name}.length",
+      code = s"$idxName < ${iterableSource.name}.length",
       typeFullName = Some(TypeConstants.Boolean),
       line = lineNo
     )
     val comparisonIdxIdentifier = identifierNode(idxName, idxLocal.typeFullName, lineNo)
     val comparisonFieldAccess = operatorCallNode(
       Operators.fieldAccess,
-      code = s"${iterableLocal.name}.length",
+      code = s"${iterableSource.name}.length",
       typeFullName = Some(TypeConstants.Int),
       line = lineNo
     )
-    val fieldAccessIdentifier      = identifierNode(iterableLocal.name, iterableLocal.typeFullName, lineNo)
+    val fieldAccessIdentifier      = identifierNode(iterableSource.name, iterableSource.typeFullName, lineNo)
     val fieldAccessFieldIdentifier = fieldIdentifierNode("length", lineNo)
     val fieldAccessArgs            = List(fieldAccessIdentifier, fieldAccessFieldIdentifier).map(Ast(_))
     val fieldAccessAst             = callAst(comparisonFieldAccess, fieldAccessArgs)
     val compareArgs                = List(Ast(comparisonIdxIdentifier), fieldAccessAst)
 
+    // TODO: This is a workaround for a crash when looping over statically imported members. Handle those properly.
+    val iterableSourceNode = localParamOrMemberFromNode(iterableSource)
+
     callAst(compareNode, compareArgs)
       .withRefEdge(comparisonIdxIdentifier, idxLocal)
-      .withRefEdge(fieldAccessIdentifier, iterableLocal.node)
+      .withRefEdges(fieldAccessIdentifier, iterableSourceNode.toList)
   }
 
   private def nativeForEachIncrementAst(lineNo: Option[Integer], idxLocal: NewLocal): Ast = {
@@ -1407,6 +1415,14 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
   }
 
+  private def localParamOrMemberFromNode(nodeTypeInfo: NodeTypeInfo): Option[NewNode] = {
+    nodeTypeInfo.node match {
+      case localNode: NewLocal                 => Some(localNode)
+      case memberNode: NewMember               => Some(memberNode)
+      case parameterNode: NewMethodParameterIn => Some(parameterNode)
+      case _                                   => None
+    }
+  }
   private def variableAssignForNativeForEachBody(
     variableLocal: NewLocal,
     idxLocal: NewLocal,
@@ -1430,10 +1446,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val indexAccessArgsAsts = List(indexAccessIdentifier, indexAccessIndex).map(Ast(_))
     val indexAccessAst      = callAst(indexAccess, indexAccessArgsAsts)
 
+    val iterableSourceNode = localParamOrMemberFromNode(iterable)
+
     val assignArgsAsts = List(Ast(targetNode), indexAccessAst)
     callAst(varAssignNode, assignArgsAsts)
       .withRefEdge(targetNode, variableLocal)
-      .withRefEdge(indexAccessIdentifier, iterable.node)
+      .withRefEdges(indexAccessIdentifier, iterableSourceNode.toList)
       .withRefEdge(indexAccessIndex, idxLocal)
   }
 
@@ -2249,8 +2267,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val maybeResolvedExpr = Try(expr.resolve())
     val argumentAsts      = argAstsForCall(expr, maybeResolvedExpr, expr.getArguments)
 
-    val typeFullName = typeInfoCalc
-      .fullName(expr.getType)
+    val typeFullName = tryWithSafeStackOverflow(typeInfoCalc.fullName(expr.getType)).toOption.flatten
       .orElse(scopeStack.lookupVariableType(expr.getTypeAsString))
       .orElse(expectedType.map(_.fullName))
       .getOrElse(TypeConstants.UnresolvedType)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
@@ -5,7 +5,6 @@ import io.joern.javasrc2cpg.util.NameConstants
 import io.shiftleft.codepropertygraph.generated.edges.Ref
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{
-  Binding,
   Block,
   Call,
   ControlStructure,
@@ -16,6 +15,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   Return
 }
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.toNodeTraversal
 
 import scala.jdk.CollectionConverters._
 


### PR DESCRIPTION
This fixes 2 crashes that occurred during cpg generation for https://github.com/dsolonenko/financisto. The first was another stack overflow resulting from a "getType" call, while the second was due to an invalid REF edge that was created when looping over a statically imported member in a foreach loop. TODOs from this are to implement proper static import handling, and to fix the javaparser crash, although that would be part of a much larger JavaParser fixing effort.

