### PR TITLE
Recursively search for Maven project roots when fetching dependencies

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -44,7 +44,9 @@ object DependencyResolver {
   }
 
   def isMavenBuild(codeDir: Path): Boolean = {
-    Files.exists(codeDir.resolve("pom.xml"))
+    Files
+      .walk(codeDir)
+      .anyMatch(file => file.toString.endsWith("pom.xml"))
   }
 
   def isGradleBuild(codeDir: Path): Boolean = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -1,5 +1,6 @@
 package io.joern.x2cpg.utils.dependency
 
+import better.files.File
 import io.joern.x2cpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 
@@ -9,37 +10,52 @@ import scala.util.{Failure, Success}
 object MavenDependencies {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private[dependency] def get(projectDir: Path): List[String] = {
-    // we can't use -Dmdep.outputFile because that keeps overwriting its own output for each sub-project it's running for
-    val lines = ExternalCommand.run(
-      s"mvn -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out",
-      projectDir.toString
-    ) match {
-      case Success(lines) => lines
-      case Failure(exception) =>
-        logger.warn(
-          s"Retrieval of compile class path via maven return with error.\n" +
-            "The compile class path may be missing or partial.\n" +
-            "Results will suffer from poor type information.\n\n" +
-            exception.getMessage
-        )
-        // exception message is the program output - and we still want to look for potential partial results
-        exception.getMessage.linesIterator.toSeq
+  private def findMavenProjectRoots(currentDir: File): List[Path] = {
+    val (childDirectories, childFiles) = currentDir.children.partition(_.isDirectory)
+    childFiles.find(_.name == "pom.xml") match {
+      case Some(pomFile) => pomFile.parent.path :: Nil
+
+      case None if childDirectories.isEmpty => Nil
+
+      case None => childDirectories.flatMap(findMavenProjectRoots).toList
+
     }
+  }
 
-    var classPathNext = false
-    val deps = lines
-      .flatMap { line =>
-        val isClassPathNow = classPathNext
-        classPathNext = line.endsWith("Dependencies classpath:")
-
-        if (isClassPathNow) line.split(':') else Array.empty[String]
+  private[dependency] def get(projectDir: Path): List[String] = {
+    val combinedDeps = findMavenProjectRoots(projectDir).flatMap { projectRoot =>
+      // we can't use -Dmdep.outputFile because that keeps overwriting its own output for each sub-project it's running for
+      val lines = ExternalCommand.run(
+        s"mvn -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out",
+        projectRoot.toString
+      ) match {
+        case Success(lines) => lines
+        case Failure(exception) =>
+          logger.warn(
+            s"Retrieval of compile class path via maven return with error.\n" +
+              "The compile class path may be missing or partial.\n" +
+              "Results will suffer from poor type information.\n\n" +
+              exception.getMessage
+          )
+          // exception message is the program output - and we still want to look for potential partial results
+          exception.getMessage.linesIterator.toSeq
       }
-      .distinct
-      .toList
-    logger.info("got {} Maven dependencies", deps.size)
 
-    deps
+      var classPathNext = false
+      val deps = lines
+        .flatMap { line =>
+          val isClassPathNow = classPathNext
+          classPathNext = line.endsWith("Dependencies classpath:")
+
+          if (isClassPathNow) line.split(':') else Array.empty[String]
+        }
+        .distinct
+        .toList
+
+      deps
+    }
+    logger.info("got {} Maven dependencies", combinedDeps.size)
+    combinedDeps
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
@@ -36,6 +36,7 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
       } else {
         File.usingTemporaryDirectory("DependencyResolverTests") { tmpDir =>
           val outFile = tmpDir / fileName
+          outFile.createIfNotExists(createParents = true)
           outFile.write(content)
           val dependenciesResult = DependencyResolver.getDependencies(tmpDir.path, params)
           testFunc(dependenciesResult)
@@ -194,7 +195,7 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
         |    </dependencies>
         |</project>
         |""".stripMargin,
-      "pom.xml"
+      "subdir/pom.xml"
     )
 
     fixture.test { dependenciesResult =>


### PR DESCRIPTION
With these changes, the DependencyResolver will recursively search for all Maven project roots, starting at the given project directory, and will then sequentially fetch dependencies for all project roots found this way. I considered a parallel implementation, but decided against it for a couple of reasons:
- the main use-case for this is to still fetch dependencies when the given input directory is not actually the maven root directory, but rather a parent. In this case we're still just fetching dependencies for a single project so it doesn't matter either way.
- fetching dependencies in parallel might result in duplicate dependencies being downloaded twice, instead of using the cached version for the second run.