### PR TITLE
jssrc2cpg: use "<operator>.new" as NAME for constructor calls

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -143,7 +143,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
 
     val receiverNode = astForNodeWithFunctionReference(callee)
     Ast.storeInDiffGraph(receiverNode, diffGraph)
-    
+
     // TODO: place "<operator>.new" into the schema
     val callNode = handleCallNodeArgs(newExpr, receiverNode.nodes.head, tmpAllocNode2, callName = "<operator>.new")
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -31,10 +31,21 @@ trait AstForExpressionsCreator { this: AstCreator =>
     createCallAst(callNode, argAsts)
   }
 
-  private def handleCallNodeArgs(callExpr: BabelNodeInfo, receiverNode: NewNode, baseNode: NewNode): Ast = {
+  private def handleCallNodeArgs(
+    callExpr: BabelNodeInfo,
+    receiverNode: NewNode,
+    baseNode: NewNode,
+    callName: String = ""
+  ): Ast = {
     val args = astForNodes(callExpr.json("arguments").arr.toList)
     val callNode =
-      createCallNode(callExpr.code, "", DispatchTypes.DYNAMIC_DISPATCH, callExpr.lineNumber, callExpr.columnNumber)
+      createCallNode(
+        callExpr.code,
+        callName,
+        DispatchTypes.DYNAMIC_DISPATCH,
+        callExpr.lineNumber,
+        callExpr.columnNumber
+      )
     createCallAst(callNode, args, Some(Ast(receiverNode)), Some(Ast(baseNode)))
   }
 
@@ -132,7 +143,9 @@ trait AstForExpressionsCreator { this: AstCreator =>
 
     val receiverNode = astForNodeWithFunctionReference(callee)
     Ast.storeInDiffGraph(receiverNode, diffGraph)
-    val callNode = handleCallNodeArgs(newExpr, receiverNode.nodes.head, tmpAllocNode2)
+    
+    // TODO: place "<operator>.new" into the schema
+    val callNode = handleCallNodeArgs(newExpr, receiverNode.nodes.head, tmpAllocNode2, callName = "<operator>.new")
 
     val tmpAllocReturnNode = Ast(createIdentifierNode(tmpAllocName, newExpr))
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
@@ -106,6 +106,7 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       allocCall.code shouldBe ".alloc"
 
       val List(constructorCall) = newCallBlock.astChildren.isCall.codeExact("new MyClass()").l
+      constructorCall.name shouldBe "<operator>.new"
       constructorCall.astChildren.isIdentifier.nameExact("MyClass").size shouldBe 1
 
       val List(receiver) = constructorCall.receiver.isIdentifier.nameExact("MyClass").l
@@ -194,7 +195,9 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       allocCall.code shouldBe ".alloc"
 
       val List(constructorCall) = newCallBlock.astChildren.isCall.codeExact("new foo.bar.MyClass()").l
-      val List(path)            = constructorCall.astChildren.isCall.codeExact("foo.bar.MyClass").l
+      constructorCall.name shouldBe "<operator>.new"
+
+      val List(path) = constructorCall.astChildren.isCall.codeExact("foo.bar.MyClass").l
       path.name shouldBe Operators.fieldAccess
 
       val List(receiver) = constructorCall.receiver.isCall.codeExact("foo.bar.MyClass").l
@@ -236,6 +239,7 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       allocCall.code shouldBe ".alloc"
 
       val List(constructorCall) = newCallBlock.astChildren.isCall.codeExact("new Foo()").l
+      constructorCall.name shouldBe "<operator>.new"
       constructorCall.astChildren.isIdentifier.nameExact("Foo").size shouldBe 1
 
       val List(receiver) = constructorCall.receiver.isIdentifier.nameExact("Foo").l


### PR DESCRIPTION
This is for: https://github.com/joernio/joern/issues/1688