### PR TITLE
Handle member variables

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -1,9 +1,19 @@
 package io.joern.dataflowengineoss.language
 
-import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Literal}
-import io.joern.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement, ReachableByResult, ResultTable}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  CfgNode,
+  Expression,
+  FieldIdentifier,
+  Identifier,
+  Literal,
+  Member,
+  TypeDecl
+}
+import io.joern.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement, ReachableByResult}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.codepropertygraph.Cpg
 import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language._
 
 import scala.collection.mutable
 
@@ -72,12 +82,75 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
   }
 
   def sourceTravsToList[NodeType <: CfgNode](sourceTravs: Seq[Traversal[NodeType]]): List[CfgNode] = {
-    sourceTravs
+    val startingPoints = sourceTravs
       .flatMap(_.toList)
       .collect { case n: CfgNode => n }
       .dedup
       .toList
       .sortBy(_.id)
+    sources(startingPoints)
+  }
+
+  /** The code below deals with static member variables in Java, and specifically with the situation where literals that
+    * initialize static members are passed to `reachableBy` as sources. In this case, we determine the first usages of
+    * this member in each method, traversing the AST from left to right. This isn't fool-proof, e.g., goto-statements
+    * would be problematic, but it works quite well in practice.
+    */
+  private def sources(startingPoints: List[CfgNode]): List[CfgNode] = {
+    startingPoints.flatMap {
+      case lit: Literal =>
+        List(lit) ++ usages(targetsToClassIdentifierPair(literalToInitializedMembers(lit)))
+      case member: Member =>
+        usages(targetsToClassIdentifierPair(memberToInitializedMembers(member)))
+      case x => List(x)
+    }
+  }
+
+  /** For a literal, determine if it is used in the initialization of any member variables. This is Javasrc-specific as
+    * it looks for a method called "<clinit>", which represents the implicitly defined class constructor.
+    */
+  private def literalToInitializedMembers(lit: Literal): List[Identifier] = {
+    lit.inAssignment.where(_.method.nameExact("<clinit>")).target.isIdentifier.l
+  }
+
+  private def memberToInitializedMembers(member: Member): List[Identifier] = {
+    member.typeDecl.method
+      .nameExact("<clinit>")
+      .ast
+      .isIdentifier
+      .nameExact(member.name)
+      .argumentIndex(1)
+      .where(_.inAssignment)
+      .l
+  }
+
+  private def usages(pairs: List[(TypeDecl, Identifier)]): List[CfgNode] = {
+    pairs.flatMap { case (typeDecl, identifier) =>
+      val cpg = Cpg(typeDecl.graph())
+      val usagesInSameClass =
+        typeDecl.method
+          .whereNot(_.nameExact("<clinit>"))
+          .flatMap { m =>
+            m.ast.isIdentifier.nameExact(identifier.name).takeWhile(notLeftHandOfAssignment)
+          }
+          .headOption
+      val usagesInOtherClasses = cpg.method.flatMap { m =>
+        m.fieldAccess
+          .where(_.argument(1).isIdentifier.typeFullNameExact(typeDecl.fullName))
+          .where(_.argument(2).isFieldIdentifier.canonicalNameExact(identifier.name))
+          .takeWhile(notLeftHandOfAssignment)
+          .headOption
+      }
+      usagesInSameClass ++ usagesInOtherClasses
+    }
+  }
+
+  private def notLeftHandOfAssignment(x: Expression): Boolean = {
+    !(x.argumentIndex == 1 && x.inAssignment.nonEmpty)
+  }
+
+  private def targetsToClassIdentifierPair(targets: List[Identifier]): List[(TypeDecl, Identifier)] = {
+    targets.flatMap(target => target.method.typeDecl.map { typeDecl => (typeDecl, target) })
   }
 
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
@@ -72,20 +72,18 @@ class StaticMemberTests extends JavaDataflowFixture {
     val source = getSources
     val sink   = cpg.method(".*test1.*").call.name(".*println.*").argument(1)
 
-    sink.reachableBy(source).size shouldBe 0
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "find a path for `MALICIOUS` data from a different class directly" in {
     val source = getSources
     val sink   = cpg.method(".*test2.*").call.name(".*println.*").argument(1)
-
-    sink.reachableBy(source).size shouldBe 0
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "not find a path for `SAFE` data directly" in {
     val source = getSources
     val sink   = cpg.method(".*test3.*").call.name(".*println.*").argument(1)
-
     sink.reachableBy(source).size shouldBe 0
   }
 
@@ -93,7 +91,7 @@ class StaticMemberTests extends JavaDataflowFixture {
     val source = getSources
     val sink   = cpg.method(".*test4.*").call.name(".*println.*").argument(1)
 
-    sink.reachableBy(source).size shouldBe 0
+    sink.reachableBy(source).size shouldBe 1
   }
 
   it should "not find a path for `SAFE` data in the same class" in {


### PR DESCRIPTION
There have long been a few tests for handling of static member variables in Java that we've left broken. This PR fixes those, albeit not in a fool-proof manner. The idea is to look up usages of member variables and take the first one as we traverse the AST from left to right, unless that first one is actually a reassignment of that member variable, in which case we skip.