### PR TITLE
Add option to use delombok for javasrc2cpg type information only

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -59,18 +59,18 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       dir.pathAsString
     }
 
-    val delombokSourcesDir = Option.when(config.runDelombok || config.delombokTypesOnly) {
+    val delombokSourcesDir = Option.when(config.delombokFullAnalysis || config.delombokTypesOnly) {
       Delombok.run(originalSourcesDir, config.delombokJavaHome)
     }
 
     val analysisSourceFilePath =
-      if (config.runDelombok)
+      if (config.delombokFullAnalysis)
         delombokSourcesDir.get
       else
         originalSourcesDir
 
     val typeSourcesPath =
-      if (config.runDelombok || config.delombokTypesOnly)
+      if (config.delombokFullAnalysis || config.delombokTypesOnly)
         delombokSourcesDir.get
       else
         originalSourcesDir

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -13,7 +13,7 @@ final case class Config(
   fetchDependencies: Boolean = false,
   javaFeatureSetVersion: Option[String] = None,
   delombokJavaHome: Option[String] = None,
-  runDelombok: Boolean = false,
+  delombokFullAnalysis: Boolean = false,
   delombokTypesOnly: Boolean = false
 ) extends X2CpgConfig[Config] {
 
@@ -40,9 +40,9 @@ private object Frontend {
       opt[String]("delombok-java-home")
         .text("Optional override to set java home used to run Delombok. Java 17 is recommended for the best results.")
         .action((path, c) => c.copy(delombokJavaHome = Some(path))),
-      opt[Unit]("run-delombok")
+      opt[Unit]("delombok-full-analysis")
         .text("run delombok on source before scanning for more accurate methods and type results")
-        .action((_, c) => c.copy(runDelombok = true)),
+        .action((_, c) => c.copy(delombokFullAnalysis = true)),
       opt[Unit]("run-delombok-types-only")
         .text("run delombok on source but use output only for type information")
         .action((_, c) => c.copy(delombokTypesOnly = true))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -13,7 +13,8 @@ final case class Config(
   fetchDependencies: Boolean = false,
   javaFeatureSetVersion: Option[String] = None,
   delombokJavaHome: Option[String] = None,
-  runDelombok: Boolean = false
+  runDelombok: Boolean = false,
+  delombokTypesOnly: Boolean = false
 ) extends X2CpgConfig[Config] {
 
   override def withInputPath(inputPath: String): Config =
@@ -41,7 +42,10 @@ private object Frontend {
         .action((path, c) => c.copy(delombokJavaHome = Some(path))),
       opt[Unit]("run-delombok")
         .text("run delombok on source before scanning for more accurate methods and type results")
-        .action((_, c) => c.copy(runDelombok = true))
+        .action((_, c) => c.copy(runDelombok = true)),
+      opt[Unit]("run-delombok-types-only")
+        .text("run delombok on source but use output only for type information")
+        .action((_, c) => c.copy(delombokTypesOnly = true))
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
@@ -24,4 +24,38 @@ class LombokTests extends JavaSrcCode2CpgFixture(runDelombok = true) {
       case result => fail(s"Expected single getValue method but got $result")
     }
   }
+
+  "source with lombok annotations should have correct type information" in {
+    val cpg = code(
+      """
+		|import lombok.Getter;
+		|
+		|public class Foo {
+		|  @Getter
+		|  private String firstName;
+		|
+		|  public Foo() {
+		|    firstName = "WALLY";
+		|  }
+		|}""".stripMargin,
+      fileName = "Foo.java"
+    ).moreCode(
+      """
+	    |public class Bar {
+        |
+        |  public void printObject(Object o) {
+        |    System.out.println(o.toString());
+        |  }
+        |
+        |  public void bar() {
+        |    Foo f = new Foo();
+        |    printObject(f.getFirstName());
+        |  }
+        |}
+        |""".stripMargin,
+      fileName = "Bar.java"
+    )
+
+    cpg.call.name("getFirstName").methodFullName.head shouldBe "Foo.getFirstName:java.lang.String()"
+  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
@@ -1,9 +1,10 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
 import io.shiftleft.semanticcpg.language._
 
-class LombokTests extends JavaSrcCode2CpgFixture(runDelombok = true) {
+class LombokTests extends JavaSrcCode2CpgFixture(delombokFullAnalysis = true) {
 
   "source with lombok annotations should be successfully delomboked" in {
     val cpg = code(
@@ -28,8 +29,10 @@ class LombokTests extends JavaSrcCode2CpgFixture(runDelombok = true) {
   "source with lombok annotations should have correct type information" in {
     val cpg = code(
       """
+		|import lombok.extern.java.Log;
 		|import lombok.Getter;
 		|
+		|@Log
 		|public class Foo {
 		|  @Getter
 		|  private String firstName;
@@ -56,6 +59,92 @@ class LombokTests extends JavaSrcCode2CpgFixture(runDelombok = true) {
       fileName = "Bar.java"
     )
 
-    cpg.call.name("getFirstName").methodFullName.head shouldBe "Foo.getFirstName:java.lang.String()"
+    // Getter type should be resolved since the getter code is included in the delombok source.
+    cpg.call.name("getFirstName").head.methodFullName shouldBe "Foo.getFirstName:java.lang.String()"
+    // Member should be created since we're processing full delombok source.
+    cpg.member.name("log").head.typeFullName shouldBe "java.util.logging.Logger"
+  }
+}
+
+class LombokTypesOnlyTests extends JavaSrcCode2CpgFixture(delombokTypesOnly = true) {
+  "source with some lombok annotations should have correct type information" in {
+    val cpg = code(
+      """
+       |import lombok.Getter;
+       |import lombok.extern.java.Log;
+       |
+       |@Log
+       |public class Foo {
+       |  @Getter
+       |  private String firstName;
+       |
+       |  public Foo() {
+       |    firstName = "WALLY";
+       |  }
+       |}""".stripMargin,
+      fileName = "Foo.java"
+    ).moreCode(
+      """
+       |public class Bar {
+       |
+       |  public void printObject(Object o) {
+       |    System.out.println(o.toString());
+       |  }
+       |
+       |  public void bar() {
+       |    Foo f = new Foo();
+       |    printObject(f.getFirstName());
+       |  }
+       |}
+       |""".stripMargin,
+      fileName = "Bar.java"
+    )
+
+    // Getter type should be resolved since the getter code is included in the delombok source used for type info.
+    cpg.call.name("getFirstName").head.methodFullName shouldBe "Foo.getFirstName:java.lang.String()"
+    // Log member should not be found since it hasn't been generated in the source we scan.
+    cpg.member.name("log").isEmpty shouldBe true
+  }
+}
+
+class NoLombokTests extends JavaSrcCode2CpgFixture() {
+  "source with some lombok annotations should have correct type information" in {
+    val cpg = code(
+      """
+       |import lombok.Getter;
+       |import lombok.extern.java.Log;
+       |
+       |@Log
+       |public class Foo {
+       |  @Getter
+       |  private String firstName;
+       |
+       |  public Foo() {
+       |    firstName = "WALLY";
+       |  }
+       |}""".stripMargin,
+      fileName = "Foo.java"
+    ).moreCode(
+      """
+       |public class Bar {
+       |
+       |  public void printObject(Object o) {
+       |    System.out.println(o.toString());
+       |  }
+       |
+       |  public void bar() {
+       |    Foo f = new Foo();
+       |    printObject(f.getFirstName());
+       |  }
+       |}
+       |""".stripMargin,
+      fileName = "Bar.java"
+    )
+
+    // Getter type should be unresolved since it's not available in source processed or in type info source.
+    val unresolvedName = s"Foo.getFirstName:${TypeConstants.UnresolvedType}()"
+    cpg.call.name("getFirstName").head.methodFullName shouldBe unresolvedName
+    // Log member should not be found since it hasn't been generated in the source we scan.
+    cpg.member.name("log").isEmpty shouldBe true
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -14,20 +14,25 @@ import overflowdb.traversal.Traversal
 
 import java.io.File
 
-class JavaSrcFrontend(runDelombok: Boolean = false) extends LanguageFrontend {
+class JavaSrcFrontend(delombokFullAnalysis: Boolean = false, delombokTypesOnly: Boolean = false)
+    extends LanguageFrontend {
 
   override val fileSuffix: String = ".java"
 
   override def execute(sourceCodeFile: File): Cpg = {
-    implicit val defaultConfig: Config = Config(runDelombok = runDelombok)
+    implicit val defaultConfig: Config =
+      Config(delombokFullAnalysis = delombokFullAnalysis, delombokTypesOnly = delombokTypesOnly)
     new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
   }
 }
 
 class JavaSrcCodeToCpgFixture extends CodeToCpgFixture(new JavaSrcFrontend) {}
 
-class JavaSrcCode2CpgFixture(withOssDataflow: Boolean = false, runDelombok: Boolean = false)
-    extends Code2CpgFixture(new JavaSrcFrontend(runDelombok)) {
+class JavaSrcCode2CpgFixture(
+  withOssDataflow: Boolean = false,
+  delombokFullAnalysis: Boolean = false,
+  delombokTypesOnly: Boolean = false
+) extends Code2CpgFixture(new JavaSrcFrontend(delombokFullAnalysis, delombokTypesOnly)) {
 
   val semanticsFile: String            = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
   lazy val defaultSemantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFile))


### PR DESCRIPTION
This PR adds an option to use delomboked source code for type information while still using the original source with lombok annotations when creating the CPG. This gives better type information than the original source in some cases, and gives correct filenames and line numbers instead of information from the delomboked source. The unit tests added in this PR give a simple example of where this approach works and where it doesn't.