### PR TITLE
Recursively search for a mix of Maven and Gradle projects when fetching dependencies

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -4,6 +4,7 @@ import io.joern.x2cpg.utils.dependency.GradleConfigKeys.GradleConfigKey
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters._
 
 object GradleConfigKeys extends Enumeration {
   type GradleConfigKey = Value
@@ -26,20 +27,32 @@ object DependencyResolver {
     if (isMavenBuild(projectDir)) {
       logger.info("resolving Maven dependencies at {}", projectDir)
       Some(MavenDependencies.get(projectDir))
-    } else if (isGradleBuild(projectDir)) {
-      logger.info("resolving Gradle dependencies at {}", projectDir)
-      val gradleProjectName = params.forGradle.getOrElse(GradleConfigKeys.ProjectName, defaultGradleProjectName)
-      val gradleConfiguration =
-        params.forGradle.getOrElse(GradleConfigKeys.ConfigurationName, defaultGradleConfigurationName)
-      GradleDependencies.get(projectDir, gradleProjectName, gradleConfiguration) match {
-        case Some(deps) => Some(deps)
-        case None =>
-          logger.warn(s"Could not download Gradle dependencies for project at path `$projectDir`")
-          None
-      }
     } else {
-      logger.warn(s"Could not find a supported build tool setup at path `$projectDir`")
-      None
+      getGradleProjects(projectDir) match {
+        case Nil => // Not a Gradle project
+          logger.warn(s"Could not find a supported build tool setup at path `$projectDir`")
+          None
+
+        case gradleProjectDirs =>
+          val combinedDependencies = gradleProjectDirs.flatMap(getDepsForGradleProject(params, _)).flatten
+          Option.when(combinedDependencies.nonEmpty) { combinedDependencies }
+      }
+    }
+  }
+
+  private def getDepsForGradleProject(
+    params: DependencyResolverParams,
+    projectDir: Path
+  ): Option[collection.Seq[String]] = {
+    logger.info("resolving Gradle dependencies at {}", projectDir)
+    val gradleProjectName = params.forGradle.getOrElse(GradleConfigKeys.ProjectName, defaultGradleProjectName)
+    val gradleConfiguration =
+      params.forGradle.getOrElse(GradleConfigKeys.ConfigurationName, defaultGradleConfigurationName)
+    GradleDependencies.get(projectDir, gradleProjectName, gradleConfiguration) match {
+      case Some(deps) => Some(deps)
+      case None =>
+        logger.warn(s"Could not download Gradle dependencies for project at path `$projectDir`")
+        None
     }
   }
 
@@ -49,9 +62,18 @@ object DependencyResolver {
       .anyMatch(file => file.toString.endsWith("pom.xml"))
   }
 
-  def isGradleBuild(codeDir: Path): Boolean = {
+  def getGradleProjects(codeDir: Path): List[Path] = {
     Files
       .walk(codeDir)
-      .anyMatch(file => file.toString.endsWith(".gradle") || file.toString.endsWith(".gradle.kts"))
+      .filter(isGradlePath)
+      .map(_.getParent)
+      .iterator()
+      .asScala
+      .toList
+  }
+
+  private def isGradlePath(path: Path): Boolean = {
+    val pathString = path.toString
+    pathString.endsWith(".gradle") || pathString.endsWith(".gradle.kts")
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -10,52 +10,36 @@ import scala.util.{Failure, Success}
 object MavenDependencies {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private def findMavenProjectRoots(currentDir: File): List[Path] = {
-    val (childDirectories, childFiles) = currentDir.children.partition(_.isDirectory)
-    childFiles.find(_.name == "pom.xml") match {
-      case Some(pomFile) => pomFile.parent.path :: Nil
-
-      case None if childDirectories.isEmpty => Nil
-
-      case None => childDirectories.flatMap(findMavenProjectRoots).toList
-
+  private[dependency] def get(projectDir: Path): Option[collection.Seq[String]] = {
+    // we can't use -Dmdep.outputFile because that keeps overwriting its own output for each sub-project it's running for
+    val lines = ExternalCommand.run(
+      s"mvn -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out",
+      projectDir.toString
+    ) match {
+      case Success(lines) => lines
+      case Failure(exception) =>
+        logger.warn(
+          s"Retrieval of compile class path via maven return with error.\n" +
+            "The compile class path may be missing or partial.\n" +
+            "Results will suffer from poor type information.\n\n" +
+            exception.getMessage
+        )
+        // exception message is the program output - and we still want to look for potential partial results
+        exception.getMessage.linesIterator.toSeq
     }
-  }
 
-  private[dependency] def get(projectDir: Path): List[String] = {
-    val combinedDeps = findMavenProjectRoots(projectDir).flatMap { projectRoot =>
-      // we can't use -Dmdep.outputFile because that keeps overwriting its own output for each sub-project it's running for
-      val lines = ExternalCommand.run(
-        s"mvn -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out",
-        projectRoot.toString
-      ) match {
-        case Success(lines) => lines
-        case Failure(exception) =>
-          logger.warn(
-            s"Retrieval of compile class path via maven return with error.\n" +
-              "The compile class path may be missing or partial.\n" +
-              "Results will suffer from poor type information.\n\n" +
-              exception.getMessage
-          )
-          // exception message is the program output - and we still want to look for potential partial results
-          exception.getMessage.linesIterator.toSeq
+    var classPathNext = false
+    val deps = lines
+      .flatMap { line =>
+        val isClassPathNow = classPathNext
+        classPathNext = line.endsWith("Dependencies classpath:")
+
+        if (isClassPathNow) line.split(':') else Array.empty[String]
       }
+      .distinct
+      .toList
 
-      var classPathNext = false
-      val deps = lines
-        .flatMap { line =>
-          val isClassPathNow = classPathNext
-          classPathNext = line.endsWith("Dependencies classpath:")
-
-          if (isClassPathNow) line.split(':') else Array.empty[String]
-        }
-        .distinct
-        .toList
-
-      deps
-    }
-    logger.info("got {} Maven dependencies", combinedDeps.size)
-    combinedDeps
+    logger.info("got {} Maven dependencies", deps.size)
+    Some(deps)
   }
-
 }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
@@ -72,6 +72,25 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
     }
   }
 
+  "test gradle dependency resolution for a simple `build.gradle` in a nested project" in {
+    val fixture = new Fixture(
+      """
+       |apply plugin: 'java'
+       |repositories { mavenCentral() }
+       |dependencies { implementation 'log4j:log4j:1.2.17' }
+       |""".stripMargin,
+      "project/build.gradle",
+      isRunningOnWindowsGithubAction
+    )
+
+    fixture.test { dependenciesResult =>
+      dependenciesResult should not be empty
+      val dependencyFiles = dependenciesResult.getOrElse(Seq())
+      dependencyFiles.find(_.endsWith("log4j-1.2.17.jar")) should not be empty
+    }
+
+  }
+
   "test gradle dependency resolution for a simple `build.gradle.kts`" in {
     val fixture = new Fixture(
       """


### PR DESCRIPTION
https://github.com/joernio/joern/pull/1679/files added recursive searching for multiple Maven projects, but not Gradle. This PR applies the same idea, but allows the dependency fetcher to recursively search for any mix of Maven and Gradle projects starting at the given root and will fetch the dependencies for these on a per-project basis.

This isn't necessarily useful functionality, but comes with the side effect that it would also support a single nested Maven or Gradle subproject.