### PR TITLE
Fix for flows when dealing with member variables

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -1,14 +1,6 @@
 package io.joern.dataflowengineoss.language
 
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  CfgNode,
-  Expression,
-  FieldIdentifier,
-  Identifier,
-  Literal,
-  Member,
-  TypeDecl
-}
+import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Expression, Identifier, Literal, Member, TypeDecl}
 import io.joern.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement, ReachableByResult}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.Cpg
@@ -16,6 +8,8 @@ import overflowdb.traversal._
 import io.shiftleft.semanticcpg.language._
 
 import scala.collection.mutable
+
+case class StartingPointWithSource(startingPoint: CfgNode, source: CfgNode)
 
 /** Base class for nodes that can occur in data flows
   */
@@ -38,22 +32,24 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
   def reachableBy[NodeType <: CfgNode](
     sourceTravs: Traversal[NodeType]*
   )(implicit context: EngineContext): Traversal[NodeType] = {
-    val reachedSources = reachableByInternal(sourceTravsToStartingPoints(sourceTravs)).map(_.source)
+    val reachedSources =
+      reachableByInternal(sourceTravsToStartingPoints(sourceTravs)).map(_.startingPoint)
     Traversal.from(reachedSources).cast[NodeType]
   }
 
   def reachableByFlows[A <: CfgNode](sourceTravs: Traversal[A]*)(implicit context: EngineContext): Traversal[Path] = {
-    val sources = sourceTravsToStartingPoints(sourceTravs)
+    val sources        = sourceTravsToStartingPoints(sourceTravs)
+    val startingPoints = sources.map(_.startingPoint)
     val paths = reachableByInternal(sources)
       .map { result =>
         // We can get back results that start in nodes that are invisible
         // according to the semantic, e.g., arguments that are only used
         // but not defined. We filter these results here prior to returning
         val first = result.path.headOption
-        if (first.isDefined && !first.get.visible && !sources.contains(first.get.node)) {
+        if (first.isDefined && !first.get.visible && !startingPoints.contains(first.get.node)) {
           None
         } else {
-          val visiblePathElements = result.path.filter(x => sources.contains(x.node) || x.visible)
+          val visiblePathElements = result.path.filter(x => startingPoints.contains(x.node) || x.visible)
           Some(Path(removeConsecutiveDuplicates(visiblePathElements.map(_.node))))
         }
       }
@@ -73,12 +69,23 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     l.headOption.map(x => x :: l.sliding(2).collect { case Seq(a, b) if a != b => b }.toList).getOrElse(List())
   }
 
-  private def reachableByInternal(sources: List[CfgNode])(implicit context: EngineContext): List[ReachableByResult] = {
+  private def reachableByInternal(
+    startingPointsWithSources: List[StartingPointWithSource]
+  )(implicit context: EngineContext): List[ReachableByResult] = {
     val sinks  = traversal.dedup.toList.sortBy(_.id)
     val engine = new Engine(context)
-    val result = engine.backwards(sinks, sources)
+    val result = engine.backwards(sinks, startingPointsWithSources.map(_.startingPoint))
+
     engine.shutdown()
-    result
+    val sources               = startingPointsWithSources.map(_.source)
+    val startingPointToSource = startingPointsWithSources.map { x => x.startingPoint -> x.source }.toMap
+    result.map { r =>
+      if (sources.contains(r.startingPoint)) {
+        r
+      } else {
+        r.copy(path = PathElement(startingPointToSource(r.startingPoint)) +: r.path)
+      }
+    }
   }
 
   /** The code below deals with static member variables in Java, and specifically with the situation where literals that
@@ -96,7 +103,9 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     }
   }
 
-  def sourceTravsToStartingPoints[NodeType <: CfgNode](sourceTravs: Seq[Traversal[NodeType]]): List[CfgNode] = {
+  def sourceTravsToStartingPoints[NodeType <: CfgNode](
+    sourceTravs: Seq[Traversal[NodeType]]
+  ): List[StartingPointWithSource] = {
     val sources = sourceTravs
       .flatMap(_.toList)
       .collect { case n: CfgNode => n }
@@ -104,7 +113,7 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
       .toList
       .sortBy(_.id)
     sources.flatMap { src =>
-      sourceToStartingPoints(src)
+      sourceToStartingPoints(src).map(s => StartingPointWithSource(s, src))
     }
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -69,7 +69,7 @@ case class ReachableByResult(
   callDepth: Int = 0,
   partial: Boolean = false
 ) {
-  def source: CfgNode = path.head.node
+  def startingPoint: CfgNode = path.head.node
 
   /** If the result begins in an output argument, return it.
     */


### PR DESCRIPTION
I recently introduced tracking of member variables initialized by literals. To achieve this, I expanded literals to yield the member variables initialized by those literals, prior to data flow tracking. Unfortunately, I forgot to consider that this would mean that the flow would start in the member variable and not in the literal. This PR fixes that, appending the literal if it is the actual source.