### PR TITLE
Run delombok by default when a lombok dependency is detected

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -8,8 +8,10 @@ import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
+import io.joern.x2cpg.utils.dependency.DependencyResolver
 import org.slf4j.LoggerFactory
 
+import java.nio.file.Paths
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 import scala.util.Try
 
@@ -29,14 +31,17 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
   def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
       new MetaDataPass(cpg, language, config.inputPath).createAndApply()
-      val sourcesInfo = getSourcesFromDir(config)
+      val dependencies        = getDependencyList(config)
+      val hasLombokDependency = dependencies.exists(_.contains("lombok"))
+      val sourcesInfo         = getSourcesFromDir(config, hasLombokDependency)
       if (sourcesInfo.sourceFiles.isEmpty) {
         logger.error(s"no source files found at path ${config.inputPath}")
       } else {
         logger.info(s"found ${sourcesInfo.sourceFiles.size} source files")
       }
 
-      val astCreator = new AstCreationPass(sourcesInfo.typeSolverSourceDir, sourcesInfo.sourceFiles, config, cpg)
+      val astCreator =
+        new AstCreationPass(sourcesInfo.typeSolverSourceDir, sourcesInfo.sourceFiles, config, cpg, dependencies)
       astCreator.createAndApply()
       new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
@@ -44,12 +49,31 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     }
   }
 
+  private def getDependencyList(config: Config): Seq[String] = {
+    val codeDir = config.inputPath
+    if (config.fetchDependencies) {
+      DependencyResolver.getDependencies(Paths.get(codeDir)) match {
+        case Some(deps) => deps.toSeq
+        case None =>
+          logger.warn(s"Could not fetch dependencies for project at path $codeDir")
+          Seq()
+      }
+    } else {
+      logger.info("dependency resolving disabled")
+      Seq()
+    }
+  }
+
   /** JavaParser requires that the input path is a directory and not a single source file. This is inconvenient for
     * small-scale testing, so if a single source file is created, copy it to a temp directory.
     */
-  private def getSourcesFromDir(config: Config): SourceDirectoryInfo = {
+  private def getSourcesFromDir(config: Config, hasLombokDependency: Boolean): SourceDirectoryInfo = {
 
-    val inputPathAsFile = File(config.inputPath)
+    if (hasLombokDependency) {
+      logger.info(s"Analysing delomboked code as lombok dependency was found.")
+    }
+    val shouldAnalyzeDelombokedCode = config.delombokFullAnalysis || hasLombokDependency
+    val inputPathAsFile             = File(config.inputPath)
 
     val originalSourcesDir = if (inputPathAsFile.isDirectory) {
       config.inputPath
@@ -59,18 +83,18 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       dir.pathAsString
     }
 
-    val delombokSourcesDir = Option.when(config.delombokFullAnalysis || config.delombokTypesOnly) {
+    val delombokSourcesDir = Option.when(shouldAnalyzeDelombokedCode || config.delombokTypesOnly) {
       Delombok.run(originalSourcesDir, config.delombokJavaHome)
     }
 
     val analysisSourceFilePath =
-      if (config.delombokFullAnalysis)
+      if (shouldAnalyzeDelombokedCode)
         delombokSourcesDir.get
       else
         originalSourcesDir
 
     val typeSourcesPath =
-      if (config.delombokFullAnalysis || config.delombokTypesOnly)
+      if (shouldAnalyzeDelombokedCode || config.delombokTypesOnly)
         delombokSourcesDir.get
       else
         originalSourcesDir

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -3,6 +3,7 @@ package io.joern.javasrc2cpg
 import better.files.File
 import io.joern.javasrc2cpg.passes.{AstCreationPass, ConfigFileCreationPass}
 import io.joern.javasrc2cpg.util.Delombok
+import io.joern.javasrc2cpg.util.Delombok.DelombokMode
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
@@ -15,7 +16,8 @@ import java.nio.file.Paths
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 import scala.util.Try
 
-case class SourceDirectoryInfo(typeSolverSourceDir: String, sourceFiles: List[String])
+case class SourceDirectoryInfo(typeSolverSourceDir: String, sourceFiles: List[SourceFileInfo])
+case class SourceFileInfo(analysisFileName: String, originalFileName: String)
 object JavaSrc2Cpg {
   val language: String = Languages.JAVASRC
 
@@ -41,7 +43,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       }
 
       val astCreator =
-        new AstCreationPass(sourcesInfo.typeSolverSourceDir, sourcesInfo.sourceFiles, config, cpg, dependencies)
+        new AstCreationPass(sourcesInfo, config, cpg, dependencies)
       astCreator.createAndApply()
       new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
@@ -64,16 +66,35 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     }
   }
 
+  private def getDelombokMode(config: Config): DelombokMode = {
+    config.delombokMode.map(_.toLowerCase) match {
+      case None                 => DelombokMode.Default
+      case Some("no-delombok")  => DelombokMode.NoDelombok
+      case Some("default")      => DelombokMode.Default
+      case Some("types-only")   => DelombokMode.TypesOnly
+      case Some("run-delombok") => DelombokMode.RunDelombok
+      case Some(value) =>
+        logger.warn(s"Found unrecognised delombok mode `$value`. Using default instead.")
+        DelombokMode.Default
+    }
+  }
+
   /** JavaParser requires that the input path is a directory and not a single source file. This is inconvenient for
     * small-scale testing, so if a single source file is created, copy it to a temp directory.
     */
   private def getSourcesFromDir(config: Config, hasLombokDependency: Boolean): SourceDirectoryInfo = {
-
+    val delombokMode = getDelombokMode(config)
     if (hasLombokDependency) {
       logger.info(s"Analysing delomboked code as lombok dependency was found.")
     }
-    val shouldAnalyzeDelombokedCode = config.delombokFullAnalysis || hasLombokDependency
-    val inputPathAsFile             = File(config.inputPath)
+    val runDelombok = delombokMode match {
+      case DelombokMode.NoDelombok  => false
+      case DelombokMode.Default     => hasLombokDependency
+      case DelombokMode.RunDelombok => true
+      case DelombokMode.TypesOnly   => true
+    }
+
+    val inputPathAsFile = File(config.inputPath)
 
     val originalSourcesDir = if (inputPathAsFile.isDirectory) {
       config.inputPath
@@ -83,25 +104,35 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       dir.pathAsString
     }
 
-    val delombokSourcesDir = Option.when(shouldAnalyzeDelombokedCode || config.delombokTypesOnly) {
+    val delombokSourcesDir = Option.when(runDelombok) {
       Delombok.run(originalSourcesDir, config.delombokJavaHome)
     }
 
     val analysisSourceFilePath =
-      if (shouldAnalyzeDelombokedCode)
+      if (runDelombok && (delombokMode != DelombokMode.TypesOnly))
         delombokSourcesDir.get
       else
         originalSourcesDir
 
     val typeSourcesPath =
-      if (shouldAnalyzeDelombokedCode || config.delombokTypesOnly)
+      if (runDelombok)
         delombokSourcesDir.get
       else
         originalSourcesDir
 
     val sourceFileNames = SourceFiles.determine(analysisSourceFilePath, sourceFileExtensions)
+    val sourceFileInfo = delombokSourcesDir match {
+      case Some(delombokSourcesDir) =>
+        sourceFileNames.map { fileName =>
+          // Directory structure remains unchanged.
+          val originalFileName = fileName.replace(delombokSourcesDir, originalSourcesDir)
+          SourceFileInfo(fileName, originalFileName)
+        }
 
-    SourceDirectoryInfo(typeSourcesPath, sourceFileNames)
+      case None => sourceFileNames.map { filename => SourceFileInfo(filename, filename) }
+    }
+
+    SourceDirectoryInfo(typeSourcesPath, sourceFileInfo)
   }
 
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -42,8 +42,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
         logger.info(s"found ${sourcesInfo.sourceFiles.size} source files")
       }
 
-      val astCreator =
-        new AstCreationPass(sourcesInfo, config, cpg, dependencies)
+      val astCreator = new AstCreationPass(sourcesInfo, config, cpg, dependencies)
       astCreator.createAndApply()
       new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -83,12 +83,13 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     */
   private def getSourcesFromDir(config: Config, hasLombokDependency: Boolean): SourceDirectoryInfo = {
     val delombokMode = getDelombokMode(config)
-    if (hasLombokDependency) {
-      logger.info(s"Analysing delomboked code as lombok dependency was found.")
-    }
     val runDelombok = delombokMode match {
-      case DelombokMode.NoDelombok  => false
-      case DelombokMode.Default     => hasLombokDependency
+      case DelombokMode.NoDelombok => false
+      case DelombokMode.Default =>
+        if (hasLombokDependency) {
+          logger.info(s"Analysing delomboked code as lombok dependency was found.")
+        }
+        hasLombokDependency
       case DelombokMode.RunDelombok => true
       case DelombokMode.TypesOnly   => true
     }
@@ -113,11 +114,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       else
         originalSourcesDir
 
-    val typeSourcesPath =
-      if (runDelombok)
-        delombokSourcesDir.get
-      else
-        originalSourcesDir
+    val typeSourcesPath = delombokSourcesDir.getOrElse(originalSourcesDir)
 
     val sourceFileNames = SourceFiles.determine(analysisSourceFilePath, sourceFileExtensions)
     val sourceFileInfo = delombokSourcesDir match {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -41,7 +41,7 @@ private object Frontend {
         .action((path, c) => c.copy(delombokJavaHome = Some(path))),
       opt[String]("delombok-mode")
         .text("""Specifies how delombok should be executed. Options are
-				 | no-delombok => to not run delombok under any circumstances.
+				| no-delombok => to not run delombok under any circumstances.
                  | default => run delombok if a lombok dependency is found and analyse delomboked code.
                  | types-only => to run delombok, but use it for type information only
                  | run-delombok => to force run delombok and analyse delomboked code.""".stripMargin)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -13,8 +13,7 @@ final case class Config(
   fetchDependencies: Boolean = false,
   javaFeatureSetVersion: Option[String] = None,
   delombokJavaHome: Option[String] = None,
-  delombokFullAnalysis: Boolean = false,
-  delombokTypesOnly: Boolean = false
+  delombokMode: Option[String] = None
 ) extends X2CpgConfig[Config] {
 
   override def withInputPath(inputPath: String): Config =
@@ -40,12 +39,13 @@ private object Frontend {
       opt[String]("delombok-java-home")
         .text("Optional override to set java home used to run Delombok. Java 17 is recommended for the best results.")
         .action((path, c) => c.copy(delombokJavaHome = Some(path))),
-      opt[Unit]("delombok-full-analysis")
-        .text("run delombok on source before scanning for more accurate methods and type results")
-        .action((_, c) => c.copy(delombokFullAnalysis = true)),
-      opt[Unit]("run-delombok-types-only")
-        .text("run delombok on source but use output only for type information")
-        .action((_, c) => c.copy(delombokTypesOnly = true))
+      opt[String]("delombok-mode")
+        .text("""Specifies how delombok should be executed. Options are
+				 | no-delombok => to not run delombok under any circumstances.
+                 | default => run delombok if a lombok dependency is found and analyse delomboked code.
+                 | types-only => to run delombok, but use it for type information only
+                 | run-delombok => to force run delombok and analyse delomboked code.""".stripMargin)
+        .action((mode, c) => c.copy(delombokMode = Some(mode)))
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -22,7 +22,7 @@ import scala.jdk.OptionConverters.RichOptional
 import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}
 
-class AstCreationPass(codeDir: String, filenames: List[String], config: Config, cpg: Cpg)
+class AstCreationPass(codeDir: String, filenames: List[String], config: Config, cpg: Cpg, dependencies: Seq[String])
     extends ConcurrentWriterCpgPass[String](cpg) {
 
   val global: Global              = new Global()
@@ -89,20 +89,8 @@ class AstCreationPass(codeDir: String, filenames: List[String], config: Config, 
       combinedTypeSolver.add(javaParserTypeSolver)
     }
 
-    val resolvedDeps = if (config.fetchDependencies) {
-      DependencyResolver.getDependencies(Paths.get(codeDir)) match {
-        case Some(deps) => deps
-        case None =>
-          logger.warn(s"Could not fetch dependencies for project at path $codeDir")
-          Seq()
-      }
-    } else {
-      logger.info("dependency resolving disabled")
-      Seq()
-    }
-
     // Add solvers for inference jars
-    (jarsList ++ resolvedDeps)
+    (jarsList ++ dependencies)
       .flatMap { path =>
         Try(new JarTypeSolver(path)).toOption
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -11,7 +11,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.{
   JarTypeSolver,
   JavaParserTypeSolver
 }
-import io.joern.javasrc2cpg.Config
+import io.joern.javasrc2cpg.{Config, SourceDirectoryInfo, SourceFileInfo}
 import io.joern.javasrc2cpg.util.{CachingReflectionTypeSolver, SourceRootFinder}
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.utils.dependency.DependencyResolver
@@ -22,25 +22,25 @@ import scala.jdk.OptionConverters.RichOptional
 import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}
 
-class AstCreationPass(codeDir: String, filenames: List[String], config: Config, cpg: Cpg, dependencies: Seq[String])
-    extends ConcurrentWriterCpgPass[String](cpg) {
+class AstCreationPass(sourceInfo: SourceDirectoryInfo, config: Config, cpg: Cpg, dependencies: Seq[String])
+    extends ConcurrentWriterCpgPass[SourceFileInfo](cpg) {
 
   val global: Global              = new Global()
   private val logger              = LoggerFactory.getLogger(classOf[AstCreationPass])
   lazy private val symbolResolver = createSymbolSolver()
 
-  override def generateParts(): Array[String] = filenames.toArray
+  override def generateParts(): Array[SourceFileInfo] = sourceInfo.sourceFiles.toArray
 
-  override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
+  override def runOnPart(diffGraph: DiffGraphBuilder, fileInfo: SourceFileInfo): Unit = {
     val parserConfig =
       new ParserConfiguration().setSymbolResolver(symbolResolver)
     val parser      = new JavaParser(parserConfig)
-    val parseResult = parser.parse(new java.io.File(filename))
+    val parseResult = parser.parse(new java.io.File(fileInfo.analysisFileName))
 
     parseResult.getProblems.asScala.toList match {
       case Nil => // Just carry on as usual
       case problems =>
-        logger.warn(s"Encountered problems while parsing file $filename:")
+        logger.warn(s"Encountered problems while parsing file ${fileInfo.analysisFileName}:")
         problems.foreach { problem =>
           logger.warn(s"- ${problem.getMessage}")
         }
@@ -48,9 +48,9 @@ class AstCreationPass(codeDir: String, filenames: List[String], config: Config, 
 
     parseResult.getResult.toScala match {
       case Some(result) if result.getParsed == Parsedness.PARSED =>
-        diffGraph.absorb(new AstCreator(filename, result, global, symbolResolver).createAst())
+        diffGraph.absorb(new AstCreator(fileInfo.originalFileName, result, global, symbolResolver).createAst())
       case _ =>
-        logger.warn("Failed to parse file " + filename)
+        logger.warn("Failed to parse file " + fileInfo.analysisFileName)
         Iterator()
     }
   }
@@ -76,7 +76,7 @@ class AstCreationPass(codeDir: String, filenames: List[String], config: Config, 
   }
 
   private def createSymbolSolver(): JavaSymbolSolver = {
-
+    val codeDir = sourceInfo.typeSolverSourceDir
     SourceRootFinder.getSourceRoots(codeDir)
 
     val combinedTypeSolver   = new CombinedTypeSolver()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -8,6 +8,16 @@ import java.nio.file.Paths
 import scala.util.{Failure, Success, Try}
 
 object Delombok {
+
+  sealed trait DelombokMode
+  // Don't run delombok at all.
+  object DelombokMode {
+    case object NoDelombok  extends DelombokMode
+    case object Default     extends DelombokMode
+    case object TypesOnly   extends DelombokMode
+    case object RunDelombok extends DelombokMode
+  }
+
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   private def systemJavaPath: String = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
@@ -4,9 +4,9 @@ import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
 import io.shiftleft.semanticcpg.language._
 
-class LombokTests extends JavaSrcCode2CpgFixture(delombokFullAnalysis = true) {
+class LombokTests extends JavaSrcCode2CpgFixture(delombokMode = "run-delombok") {
 
-  "source with lombok annotations should be successfully delomboked" in {
+  "basic source with lombok annotations" should {
     val cpg = code(
       """
         |import lombok.Getter;
@@ -17,12 +17,19 @@ class LombokTests extends JavaSrcCode2CpgFixture(delombokFullAnalysis = true) {
       fileName = "Foo.java"
     )
 
-    cpg.method.name("getValue").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Foo.getValue:int()"
-        method.body.astChildren.size shouldBe 1
+    "delombok the source correctly" in {
+      cpg.method.name("getValue").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Foo.getValue:int()"
+          method.body.astChildren.size shouldBe 1
+          method.filename.contains("delombok") shouldBe false
 
-      case result => fail(s"Expected single getValue method but got $result")
+        case result => fail(s"Expected single getValue method but got $result")
+      }
+    }
+
+    "not give the delomboked filename" in {
+      cpg.typeDecl.name("Foo").filename.head.contains("lombok") shouldBe false
     }
   }
 
@@ -66,7 +73,7 @@ class LombokTests extends JavaSrcCode2CpgFixture(delombokFullAnalysis = true) {
   }
 }
 
-class LombokTypesOnlyTests extends JavaSrcCode2CpgFixture(delombokTypesOnly = true) {
+class LombokTypesOnlyTests extends JavaSrcCode2CpgFixture(delombokMode = "types-only") {
   "source with some lombok annotations should have correct type information" in {
     val cpg = code(
       """

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -14,25 +14,21 @@ import overflowdb.traversal.Traversal
 
 import java.io.File
 
-class JavaSrcFrontend(delombokFullAnalysis: Boolean = false, delombokTypesOnly: Boolean = false)
-    extends LanguageFrontend {
+class JavaSrcFrontend(delombokMode: String) extends LanguageFrontend {
 
   override val fileSuffix: String = ".java"
 
   override def execute(sourceCodeFile: File): Cpg = {
     implicit val defaultConfig: Config =
-      Config(delombokFullAnalysis = delombokFullAnalysis, delombokTypesOnly = delombokTypesOnly)
+      Config(delombokMode = Some(delombokMode))
     new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
   }
 }
 
-class JavaSrcCodeToCpgFixture extends CodeToCpgFixture(new JavaSrcFrontend) {}
+class JavaSrcCodeToCpgFixture extends CodeToCpgFixture(new JavaSrcFrontend(delombokMode = "default")) {}
 
-class JavaSrcCode2CpgFixture(
-  withOssDataflow: Boolean = false,
-  delombokFullAnalysis: Boolean = false,
-  delombokTypesOnly: Boolean = false
-) extends Code2CpgFixture(new JavaSrcFrontend(delombokFullAnalysis, delombokTypesOnly)) {
+class JavaSrcCode2CpgFixture(withOssDataflow: Boolean = false, delombokMode: String = "default")
+    extends Code2CpgFixture(new JavaSrcFrontend(delombokMode)) {
 
   val semanticsFile: String            = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
   lazy val defaultSemantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFile))


### PR DESCRIPTION
With these changes, `javasrc2cpg` will automatically run delombok and scan the delomboked code when a lombok dependency is found with `--fetch-dependencies`. This isn't a particularly clever default and can't be switched off as is (another `--no-delombok` option could be added, but at that point we'd pretty much need to add a decision tree picture to the documentation to make sense of delombok logic). I'm not convinced this is something we actually want to do, but is a way of getting better WebGoat results by default (at least in sptests which currently fetch dependencies by default).

Update: This also fixes filenames in the CPG when delombok is used, so the filenames will now match the original source file and not the temporary delomboked files.