### PR TITLE
Ignore php setup and test for now

### DIFF
--- a/joern-cli/frontends/php2cpg/bin/php-parse
+++ b/joern-cli/frontends/php2cpg/bin/php-parse
@@ -1,1 +1,0 @@
-vendor/bin/php-parse

--- a/joern-cli/frontends/php2cpg/build.sbt
+++ b/joern-cli/frontends/php2cpg/build.sbt
@@ -21,25 +21,25 @@ scalacOptions ++= Seq(
   "-deprecation" // Emit warning and location for usages of deprecated APIs.
 )
 
-lazy val phpParseInstallTask = taskKey[Unit]("Install PHP-Parse using PHP Composer")
-phpParseInstallTask := {
-  val phpBinDir = baseDirectory.value / "bin"
-  val phpParseBinary = phpBinDir / "vendor" / "bin" / "php-parse"
-  if (!phpParseBinary.exists) {
-    val installSciptPath =
-      if (isWin)
-        (phpBinDir / "installdeps.bat").getPath
-      else
-        (phpBinDir / "installdeps.sh").getPath
-    Process(installSciptPath, phpBinDir) !
-  }
-
-  val distDir = (Universal / stagingDirectory).value / "bin"
-  distDir.mkdirs()
-  IO.copyDirectory(phpBinDir, distDir)
-}
-
-Compile / compile := ((Compile / compile) dependsOn phpParseInstallTask).value
+// lazy val phpParseInstallTask = taskKey[Unit]("Install PHP-Parse using PHP Composer")
+// phpParseInstallTask := {
+//   val phpBinDir = baseDirectory.value / "bin"
+//   val phpParseBinary = phpBinDir / "vendor" / "bin" / "php-parse"
+//   if (!phpParseBinary.exists) {
+//     val installSciptPath =
+//       if (isWin)
+//         (phpBinDir / "installdeps.bat").getPath
+//       else
+//         (phpBinDir / "installdeps.sh").getPath
+//     Process(installSciptPath, phpBinDir) !
+//   }
+// 
+//   val distDir = (Universal / stagingDirectory).value / "bin"
+//   distDir.mkdirs()
+//   IO.copyDirectory(phpBinDir, distDir)
+// }
+// 
+// Compile / compile := ((Compile / compile) dependsOn phpParseInstallTask).value
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/PocTest.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/PocTest.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 
 class PocTest extends PhpCode2CpgFixture {
 
-  "The CPG generated for a very simple example" should {
+  "The CPG generated for a very simple example" ignore {
     val cpg = code(
       """
         |<?php


### PR DESCRIPTION
This is causing integration tests to fail as php isn't available on the test runner. Ignoring these is fine at the moment since the frontend is very far from usable anyways.