### PR TITLE
Fix `astgen` invocation

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -28,8 +28,8 @@ object AstGenRunner {
 
   private val EXECUTABLE_DIR: String = {
     val dir      = AstGenRunner.getClass.getProtectionDomain.getCodeSource.getLocation.toString
-    val fixedDir = new java.io.File(dir.substring("file:".length, dir.indexOf("jssrc2cpg"))).toString
-    Paths.get(fixedDir, "jssrc2cpg/bin/astgen").toAbsolutePath.toString
+    val fixedDir = new java.io.File(dir.substring("file:".length, dir.lastIndexOf("lib"))).toString
+    Paths.get(fixedDir, "/bin/astgen").toAbsolutePath.toString
   }
 
   private val TYPE_DEFINITION_FILE_EXTENSIONS = List(".t.ts.json", ".d.ts.json")

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -27,8 +27,18 @@ object AstGenRunner {
   }
 
   private val EXECUTABLE_DIR: String = {
-    val dir      = AstGenRunner.getClass.getProtectionDomain.getCodeSource.getLocation.toString
-    val fixedDir = new java.io.File(dir.substring("file:".length, dir.lastIndexOf("lib"))).toString
+    val dir        = AstGenRunner.getClass.getProtectionDomain.getCodeSource.getLocation.toString
+    val indexOfLib = dir.lastIndexOf("lib")
+    val fixedDir = if (indexOfLib != -1) {
+      new java.io.File(dir.substring("file:".length, indexOfLib)).toString
+    } else {
+      val indexOfTarget = dir.lastIndexOf("target")
+      if (indexOfTarget != -1) {
+        new java.io.File(dir.substring("file:".length, indexOfTarget)).toString
+      } else {
+        new java.io.File(dir.substring("file:".length, dir.length)).toString
+      }
+    }
     Paths.get(fixedDir, "/bin/astgen").toAbsolutePath.toString
   }
 


### PR DESCRIPTION
When `jssrc2cpg` is used as a library in an extension, then the current code for resolving the location of `astgen` fails because it is looking for a directory called `jssrc2cpg` in the staging directory. When searching the path backwards for `lib`, it works in the normal setting and when used in an extension.