### PR TITLE
Add a hacky call methodFullName resolution pass

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -1,7 +1,7 @@
 package io.joern.javasrc2cpg
 
 import better.files.File
-import io.joern.javasrc2cpg.passes.{AstCreationPass, ConfigFileCreationPass}
+import io.joern.javasrc2cpg.passes.{AstCreationPass, ConfigFileCreationPass, TypeInferencePass}
 import io.joern.javasrc2cpg.util.Delombok
 import io.joern.javasrc2cpg.util.Delombok.DelombokMode
 import io.shiftleft.codepropertygraph.Cpg
@@ -47,6 +47,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
         .createAndApply()
+      new TypeInferencePass(cpg).createAndApply()
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
@@ -1,0 +1,47 @@
+package io.joern.javasrc2cpg.passes
+
+import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Call.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language._
+import org.slf4j.LoggerFactory
+
+class TypeInferencePass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def generateParts(): Array[Call] = {
+    cpg.call.methodFullName(s".*${TypeConstants.UnresolvedType}.*").toArray
+  }
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, call: Call): Unit = {
+    val candidateMethods = cpg.method.internal.nameExact(call.name).l
+
+    candidateMethods match {
+      case Nil           => // Call is to an unresolved external method, so we can't get any more information here.
+      case method :: Nil =>
+        // This is probably the correct method if the number of arguments is correct.
+        if (method.parameter.size == call.argument.size) {
+          diffGraph.setNodeProperty(call, PropertyNames.MethodFullName, method.fullName)
+          diffGraph.setNodeProperty(call, PropertyNames.Signature, method.signature)
+
+        } else {
+          logger.info(
+            s"Found non-matching internal method for unresolved call: ${method.fullName} - ${call.methodFullName}"
+          )
+        }
+
+      case methods =>
+        methods.filter(_.parameter.size == call.argument.size) match {
+          case method :: Nil =>
+            diffGraph.setNodeProperty(call, PropertyNames.MethodFullName, method.fullName)
+            diffGraph.setNodeProperty(call, PropertyNames.Signature, method.signature)
+
+          case _ =>
+            logger.info(s"Found multiple matching internal methods for unresolved call ${call.methodFullName}")
+        }
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
@@ -40,7 +40,7 @@ class NewTypeInferenceTests extends JavaSrcCode2CpgFixture {
       method.fullName shouldBe "org.codeminers.thirdparty.ThirdParty.getSgClient:com.sendgrid.SendGrid()"
     }
 
-    "have the correct signature if the method parameter and return types can be inferred" ignore {
+    "have the correct signature if the method parameter and return types can be inferred" in {
       // This is the more complex case that relies on type information across compilation units.
       val methodFullName = cpg.call.name("getSgClient").head.methodFullName
       methodFullName shouldBe "org.codeminers.thirdparty.ThirdParty.getSgClient:com.sendgrid.SendGrid()"


### PR DESCRIPTION
There are situations where we can currently infer the typeFullName for method return and parameter types by using import information, but since JavaParser cannot resolve these methods, this type information is missing when these methods are called from classes in other files. This PR adds a very rough implementation to find the implementation for internal methods that are called from different files. It doesn't handle overloaded methods or inheritance well, but should give better results than not having it.