### PR TITLE
Generalize the DataFlowProblem and DataFlowSolver.

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
@@ -5,11 +5,11 @@ import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 /** A general data flow problem, formulated as in the Dragon Book, Second Edition on page 626, with mild modifications.
   * In particular, instead of allowing only for the specification of a boundary, we allow initialization of IN and OUT.
   */
-class DataFlowProblem[V](
-  val flowGraph: FlowGraph,
-  val transferFunction: TransferFunction[V],
+class DataFlowProblem[Node, V](
+  val flowGraph: FlowGraph[Node],
+  val transferFunction: TransferFunction[Node, V],
   val meet: (V, V) => V,
-  val inOutInit: InOutInit[V],
+  val inOutInit: InOutInit[Node, V],
   val forward: Boolean,
   val empty: V
 )
@@ -19,35 +19,35 @@ class DataFlowProblem[V](
   * parameters are not part of our normal control flow graph. By defining successors and predecessors, we provide a
   * wrapper that takes care of these minor discrepancies.
   */
-trait FlowGraph {
-  val entryNode: StoredNode
-  val exitNode: StoredNode
-  val allNodesReversePostOrder: List[StoredNode]
-  val allNodesPostOrder: List[StoredNode]
-  val succ: Map[StoredNode, List[StoredNode]]
-  val pred: Map[StoredNode, List[StoredNode]]
+trait FlowGraph[Node] {
+  val entryNode: Node
+  val exitNode: Node
+  val allNodesReversePostOrder: List[Node]
+  val allNodesPostOrder: List[Node]
+  val succ: Map[Node, List[Node]]
+  val pred: Map[Node, List[Node]]
 }
 
 /** This is actually a function family consisting of one transfer function for each node of the flow graph. Each
   * function maps from the analysis domain to the analysis domain, e.g., for reaching definitions, sets of definitions
   * are mapped to sets of definitions.
   */
-trait TransferFunction[V] {
-  def apply(n: StoredNode, x: V): V
+trait TransferFunction[Node, V] {
+  def apply(n: Node, x: V): V
 }
 
 /** As a practical optimization, OUT[N] is often initialized to GEN[N]. Moreover, we need a way of specifying boundary
   * conditions such as OUT[ENTRY] = {}. We achieve both by allowing the data flow problem to specify initializers for IN
   * and OUT.
   */
-trait InOutInit[V] {
+trait InOutInit[Node, V] {
 
-  def initIn: Map[StoredNode, V]
+  def initIn: Map[Node, V]
 
-  def initOut: Map[StoredNode, V]
+  def initOut: Map[Node, V]
 
 }
 
 /** The solution consists of `in` and `out` for each node of the flow graph. We also attach the problem.
   */
-case class Solution[T](in: Map[StoredNode, T], out: Map[StoredNode, T], problem: DataFlowProblem[T])
+case class Solution[Node, V](in: Map[Node, V], out: Map[Node, V], problem: DataFlowProblem[Node, V])

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -10,10 +10,10 @@ class DataFlowSolver {
     * and `out`. These maps associate all CFG nodes with the set of definitions at node entry and node exit
     * respectively.
     */
-  def calculateMopSolutionForwards[T <: Iterable[_]](problem: DataFlowProblem[T]): Solution[T] = {
-    var out: Map[StoredNode, T] = problem.inOutInit.initOut
-    var in                      = problem.inOutInit.initIn
-    val workList                = mutable.ListBuffer[StoredNode]()
+  def calculateMopSolutionForwards[Node, T <: Iterable[_]](problem: DataFlowProblem[Node, T]): Solution[Node, T] = {
+    var out: Map[Node, T] = problem.inOutInit.initOut
+    var in                = problem.inOutInit.initIn
+    val workList          = mutable.ListBuffer[Node]()
     workList ++= problem.flowGraph.allNodesReversePostOrder
 
     while (workList.nonEmpty) {
@@ -43,10 +43,10 @@ class DataFlowSolver {
     * and `out`. These maps associate all CFG nodes with the set of definitions at node entry and node exit
     * respectively.
     */
-  def calculateMopSolutionBackwards[T <: Iterable[_]](problem: DataFlowProblem[T]): Solution[T] = {
-    var out: Map[StoredNode, T] = problem.inOutInit.initOut
-    var in                      = problem.inOutInit.initIn
-    val workList                = mutable.ListBuffer[StoredNode]()
+  def calculateMopSolutionBackwards[Node, T <: Iterable[_]](problem: DataFlowProblem[Node, T]): Solution[Node, T] = {
+    var out: Map[Node, T] = problem.inOutInit.initOut
+    var in                = problem.inOutInit.initIn
+    val workList          = mutable.ListBuffer[Node]()
     workList ++= problem.flowGraph.allNodesPostOrder
 
     while (workList.nonEmpty) {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -41,8 +41,8 @@ class DdgGenerator {
     */
   def addReachingDefEdges(
     dstGraph: DiffGraphBuilder,
-    problem: DataFlowProblem[mutable.BitSet],
-    solution: Solution[mutable.BitSet]
+    problem: DataFlowProblem[StoredNode, mutable.BitSet],
+    solution: Solution[StoredNode, mutable.BitSet]
   ): Unit = {
     implicit val implicitDst: DiffGraphBuilder = dstGraph
     val numberToNode                           = problem.flowGraph.asInstanceOf[ReachingDefFlowGraph].numberToNode
@@ -225,7 +225,10 @@ class DdgGenerator {
   * `n` of the flow graph. This component determines those of the incoming definitions that are relevant as the value
   * they define is actually used by `n`.
   */
-private class UsageAnalyzer(problem: DataFlowProblem[mutable.BitSet], in: Map[StoredNode, Set[Definition]]) {
+private class UsageAnalyzer(
+  problem: DataFlowProblem[StoredNode, mutable.BitSet],
+  in: Map[StoredNode, Set[Definition]]
+) {
 
   val numberToNode                 = problem.flowGraph.asInstanceOf[ReachingDefFlowGraph].numberToNode
   private val allNodes             = in.keys.toList

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -33,7 +33,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Fork
     * were are dealing with in total. If a threshold is reached, we bail out instead, leaving reaching definitions
     * uncalculated for the method in question. Users can increase the threshold if desired.
     */
-  private def shouldBailOut(problem: DataFlowProblem[mutable.BitSet]): Boolean = {
+  private def shouldBailOut(problem: DataFlowProblem[StoredNode, mutable.BitSet]): Boolean = {
     val method           = problem.flowGraph.entryNode.asInstanceOf[Method]
     val transferFunction = problem.transferFunction.asInstanceOf[ReachingDefTransferFunction]
     // For each node, the `gen` map contains the list of definitions it generates

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -21,21 +21,21 @@ object Definition {
 }
 
 object ReachingDefProblem {
-  def create(method: Method): DataFlowProblem[mutable.BitSet] = {
+  def create(method: Method): DataFlowProblem[StoredNode, mutable.BitSet] = {
     val flowGraph = new ReachingDefFlowGraph(method)
     val transfer  = new OptimizedReachingDefTransferFunction(flowGraph)
     val init      = new ReachingDefInit(transfer.gen)
     def meet: (mutable.BitSet, mutable.BitSet) => mutable.BitSet =
       (x: mutable.BitSet, y: mutable.BitSet) => { x.union(y) }
 
-    new DataFlowProblem[mutable.BitSet](flowGraph, transfer, meet, init, true, mutable.BitSet())
+    new DataFlowProblem[StoredNode, mutable.BitSet](flowGraph, transfer, meet, init, true, mutable.BitSet())
   }
 
 }
 
 /** The control flow graph as viewed by the data flow solver.
   */
-class ReachingDefFlowGraph(val method: Method) extends FlowGraph {
+class ReachingDefFlowGraph(val method: Method) extends FlowGraph[StoredNode] {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
@@ -150,7 +150,8 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph {
 
 /** For each node of the graph, this transfer function defines how it affects the propagation of definitions.
   */
-class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph) extends TransferFunction[mutable.BitSet] {
+class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph)
+    extends TransferFunction[StoredNode, mutable.BitSet] {
 
   private val nodeToNumber = flowGraph.nodeToNumber
 
@@ -354,7 +355,7 @@ class OptimizedReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph)
   }
 }
 
-class ReachingDefInit(gen: Map[StoredNode, mutable.BitSet]) extends InOutInit[mutable.BitSet] {
+class ReachingDefInit(gen: Map[StoredNode, mutable.BitSet]) extends InOutInit[StoredNode, mutable.BitSet] {
   override def initIn: Map[StoredNode, mutable.BitSet] =
     Map
       .empty[StoredNode, mutable.BitSet]


### PR DESCRIPTION
This PR removes the tie DataFlowProblem and DataFlowSolver have to
StoredNode in order to make it reusable for other domains.