### PR TITLE
jssrc2cpg: added NAMEs for CALLs

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -32,21 +32,28 @@ trait AstForExpressionsCreator { this: AstCreator =>
 
   private def handleCallNodeArgs(
     callExpr: BabelNodeInfo,
-    receiverNode: NewNode,
+    receiverAst: Ast,
     baseNode: NewNode,
     callName: Option[String] = None
   ): Ast = {
+    val name = callName.getOrElse {
+      nameOf(receiverAst.nodes.head) match {
+        case Operators.fieldAccess => nameOf(receiverAst.nodes(2))
+        case _                     => nameOf(receiverAst.nodes.head)
+      }
+    }
+
     val args = astForNodes(callExpr.json("arguments").arr.toList)
     val callNode =
       createCallNode(
         callExpr.code,
-        callName.getOrElse(nameOf(receiverNode)),
+        name,
         DispatchTypes.DYNAMIC_DISPATCH,
         callExpr.lineNumber,
         callExpr.columnNumber,
         fullName = Some("")
       )
-    createCallAst(callNode, args, Some(Ast(receiverNode)), Some(Ast(baseNode)))
+    createCallAst(callNode, args, Some(Ast(receiverAst.nodes.head)), Some(Ast(baseNode)))
   }
 
   protected def astForCallExpression(callExpr: BabelNodeInfo): Ast = {
@@ -99,7 +106,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
           scope.addVariableReference(thisNode.name, thisNode)
           (receiverAst, thisNode)
       }
-      handleCallNodeArgs(callExpr, receiverAst.nodes.head, baseNode)
+      handleCallNodeArgs(callExpr, receiverAst, baseNode)
     }
     callNode
   }
@@ -146,7 +153,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
 
     // TODO: place "<operator>.new" into the schema
     val callNode =
-      handleCallNodeArgs(newExpr, receiverNode.nodes.head, tmpAllocNode2, callName = Some("<operator>.new"))
+      handleCallNodeArgs(newExpr, receiverNode, tmpAllocNode2, callName = Some("<operator>.new"))
 
     val tmpAllocReturnNode = Ast(createIdentifierNode(tmpAllocName, newExpr))
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -243,6 +243,13 @@ trait AstNodeBuilder { this: AstCreator =>
     case _                => ""
   }
 
+  protected def nameOf(node: NewNode): String = node match {
+    case node: NewCall            => node.name
+    case node: NewIdentifier      => node.name
+    case node: NewFieldIdentifier => node.canonicalName
+    case _                        => codeOf(node)
+  }
+
   protected def createIndexAccessCallAst(
     baseNode: NewNode,
     partNode: NewNode,
@@ -295,11 +302,12 @@ trait AstNodeBuilder { this: AstCreator =>
     callName: String,
     dispatchType: String,
     line: Option[Integer],
-    column: Option[Integer]
+    column: Option[Integer],
+    fullName: Option[String] = None
   ): NewCall = NewCall()
     .code(code)
     .name(callName)
-    .methodFullName(callName)
+    .methodFullName(fullName.getOrElse(callName))
     .dispatchType(dispatchType)
     .lineNumber(line)
     .columnNumber(column)
@@ -411,13 +419,13 @@ trait AstNodeBuilder { this: AstCreator =>
 
   protected def createStaticCallNode(
     code: String,
-    methodName: String,
+    callName: String,
     fullName: String,
     line: Option[Integer],
     column: Option[Integer]
   ): NewCall = NewCall()
     .code(code)
-    .name(methodName)
+    .name(callName)
     .methodFullName(fullName)
     .dispatchType(DispatchTypes.STATIC_DISPATCH)
     .signature("")

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1097,7 +1097,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
 
     "have correct structure for method spread argument" in AstFixture("foo(...args)") { cpg =>
       val List(fooCall) = cpg.call.codeExact("foo(...args)").l
-      fooCall.name shouldBe ""
+      fooCall.name shouldBe "foo"
       fooCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
       val List(receiver) = fooCall.receiver.isIdentifier.l
@@ -1115,7 +1115,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
 
     "have correct structure for complex method spread argument" in AstFixture("foo(...x.bar())") { cpg =>
       val List(fooCall) = cpg.call.codeExact("foo(...x.bar())").l
-      fooCall.name shouldBe ""
+      fooCall.name shouldBe "foo"
       fooCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
       val List(receiver) = fooCall.receiver.isIdentifier.l

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -470,7 +470,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(barCall) = block.astChildren.isCall.l
       barCall.code shouldBe "x.foo(y).bar(z)"
-      barCall.name shouldBe Operators.fieldAccess
+      barCall.name shouldBe "bar"
 
       val List(receiver)       = barCall.receiver.isCall.l
       val List(receiverViaAst) = barCall.astChildren.isCall.l
@@ -495,7 +495,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(barBaseTree) = tmpAssignment.astChildren.isCall.l
       barBaseTree.code shouldBe "x.foo(y)"
-      barBaseTree.name shouldBe Operators.fieldAccess
+      barBaseTree.name shouldBe "foo"
       barBaseTree.argumentIndex shouldBe 2
 
       // barBaseTree constructs is tested for in another test.
@@ -519,7 +519,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(fooCall) = block.astChildren.isCall.l
       fooCall.code shouldBe "x.foo()"
-      fooCall.name shouldBe Operators.fieldAccess
+      fooCall.name shouldBe "foo"
       fooCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
       val List(receiver) = fooCall.astChildren.isCall.l
@@ -543,7 +543,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(call) = block.astChildren.isCall.l
       call.code shouldBe "a.b(x)"
-      call.name shouldBe Operators.fieldAccess
+      call.name shouldBe "b"
       call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
       val List(receiver) = call.receiver.isCall.l
@@ -1229,7 +1229,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       identifierZ.name shouldBe "z"
 
       val List(right) = assignment.astChildren.isCall.l
-      right.name shouldBe Operators.fieldAccess
+      right.name shouldBe "c"
 
       val List(callToC) = right.astChildren.isCall.l
       callToC.methodFullName shouldBe Operators.fieldAccess

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -448,7 +448,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(fooCall) = block.astChildren.isCall.l
       fooCall.code shouldBe "foo(x)"
-      fooCall.name shouldBe ""
+      fooCall.name shouldBe "foo"
       fooCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
       val List(receiver) = fooCall.receiver.isIdentifier.l
@@ -470,7 +470,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(barCall) = block.astChildren.isCall.l
       barCall.code shouldBe "x.foo(y).bar(z)"
-      barCall.name shouldBe ""
+      barCall.name shouldBe Operators.fieldAccess
 
       val List(receiver)       = barCall.receiver.isCall.l
       val List(receiverViaAst) = barCall.astChildren.isCall.l
@@ -495,7 +495,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(barBaseTree) = tmpAssignment.astChildren.isCall.l
       barBaseTree.code shouldBe "x.foo(y)"
-      barBaseTree.name shouldBe ""
+      barBaseTree.name shouldBe Operators.fieldAccess
       barBaseTree.argumentIndex shouldBe 2
 
       // barBaseTree constructs is tested for in another test.
@@ -519,7 +519,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(fooCall) = block.astChildren.isCall.l
       fooCall.code shouldBe "x.foo()"
-      fooCall.name shouldBe ""
+      fooCall.name shouldBe Operators.fieldAccess
       fooCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
       val List(receiver) = fooCall.astChildren.isCall.l
@@ -543,7 +543,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(call) = block.astChildren.isCall.l
       call.code shouldBe "a.b(x)"
-      call.name shouldBe ""
+      call.name shouldBe Operators.fieldAccess
       call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
       val List(receiver) = call.receiver.isCall.l
@@ -1229,7 +1229,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       identifierZ.name shouldBe "z"
 
       val List(right) = assignment.astChildren.isCall.l
-      right.name shouldBe ""
+      right.name shouldBe Operators.fieldAccess
 
       val List(callToC) = right.astChildren.isCall.l
       callToC.methodFullName shouldBe Operators.fieldAccess
@@ -1431,7 +1431,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
     loopVarAssignmentCall.order shouldBe 1
 
     val List(fooCall) = whileLoopBlock.astChildren.isBlock.astChildren.isCall.codeExact("foo(i)").l
-    fooCall.name shouldBe ""
+    fooCall.name shouldBe "foo"
   }
 
   private def checkLiterals(node: Block, element: Int): Unit = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -26,7 +26,7 @@ class MethodStubCreator(cpg: Cpg) extends SimpleCpgPass(cpg) {
       methodFullNameToNode.put(method.fullName, method)
     }
 
-    for (call <- cpg.call) {
+    for (call <- cpg.call if call.methodFullName.nonEmpty) {
       methodToParameterCount.put(NameAndSignature(call.name, call.signature, call.methodFullName), call.argument.size)
     }
 


### PR DESCRIPTION
As we do not have proper full names this required filtering out empty full names in the MethodStubCreator.

For reference: https://github.com/joernio/joern/issues/1728