### PR TITLE
Simplified ExternalCommand

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -6,19 +6,16 @@ import scala.util.{Failure, Success, Try}
 import scala.jdk.CollectionConverters._
 
 object ExternalCommand {
-
-  private val IS_WIN: Boolean =
-    scala.util.Properties.isWin
-
-  private val shellPrefix: Seq[String] =
-    if (IS_WIN) "cmd" :: "/c" :: Nil else "sh" :: "-c" :: Nil
-
-  def run(command: String, cwd: String, separateStdErr: Boolean = false): Try[Seq[String]] = {
+  def run(
+    command: String,
+    cwd: String,
+    separateStdErr: Boolean = false,
+    extraEnv: Map[String, String] = Map.empty
+  ): Try[Seq[String]] = {
     val stdOutOutput  = new ConcurrentLinkedQueue[String]
     val stdErrOutput  = if (separateStdErr) new ConcurrentLinkedQueue[String] else stdOutOutput
     val processLogger = ProcessLogger(stdOutOutput.add, stdErrOutput.add)
-
-    Process(shellPrefix :+ command, new java.io.File(cwd)).!(processLogger) match {
+    Process(command, new java.io.File(cwd), extraEnv.toList: _*).!(processLogger) match {
       case 0 =>
         Success(stdOutOutput.asScala.toSeq)
       case _ =>


### PR DESCRIPTION
No need to run it through the platform-specific shell. scala.sys.process.Process can handle that itself.

Also in this PR: added `extraEnv: Map[String, String]` parameter to `ExternalCommand.run` to pass additional env variables.