### PR TITLE
server mode: capture reported output, instead of (only) printing on the server

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: 1.11
       - name: Check formatting
         run: sbt ++2.13.8 scalafmtCheck test:scalafmtCheck
-      - run: echo "Previous step failed because code is not formatted. Run 'sbt scalafmt'"
+      - run: echo "Previous step failed because code is not formatted. Run 'sbt scalafmt Test/scalafmt'"
         if: ${{ failure() }}
   test-scripts:
     runs-on: ubuntu-20.04

--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -380,9 +380,7 @@ trait PluginHandling {
 
 }
 
-trait ServerHandling {
-
-  this: BridgeBase =>
+trait ServerHandling { this: BridgeBase =>
 
   protected def startHttpServer(config: Config): Unit = {
     val predef   = predefPlus(additionalImportCode(config))

--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -1,10 +1,10 @@
 package io.joern.console
 
-import os.{Path, pwd}
 import ammonite.util.{Colors, Res}
 import better.files._
 import io.joern.console.cpgqlserver.CPGQLServer
 import io.joern.console.embammonite.EmbeddedAmmonite
+import os.{Path, pwd}
 
 case class Config(
   scriptFile: Option[Path] = None,
@@ -154,6 +154,7 @@ trait BridgeBase extends ScriptExecution with PluginHandling with ServerHandling
       config.scriptFile match {
         case None =>
           if (config.server) {
+            GlobalReporting.enable()
             startHttpServer(config)
           } else if (config.pluginToRun.isDefined) {
             runPlugin(config, slProduct.name)

--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -2,19 +2,18 @@ package io.joern.console
 
 import better.files.Dsl._
 import better.files.File
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.joern.console.cpgcreation.ImportCode
 import io.joern.console.scripting.{AmmoniteExecutor, ScriptManager}
 import io.joern.console.workspacehandling.{Project, WorkspaceLoader, WorkspaceManager}
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.Overlays
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
 import overflowdb.traversal.help.Doc
 
-import java.io.OutputStream
 import scala.sys.process.Process
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
@@ -22,8 +21,7 @@ import scala.util.{Failure, Success, Try}
 class Console[T <: Project](
   executor: AmmoniteExecutor,
   loader: WorkspaceLoader[T],
-  baseDir: File = File.currentWorkingDirectory,
-  val reportOutStream: OutputStream = System.err
+  baseDir: File = File.currentWorkingDirectory
 ) extends ScriptManager(executor) with Reporting {
 
   import Console._

--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -14,6 +14,7 @@ import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
 import overflowdb.traversal.help.Doc
 
+import java.io.OutputStream
 import scala.sys.process.Process
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
@@ -21,8 +22,9 @@ import scala.util.{Failure, Success, Try}
 class Console[T <: Project](
   executor: AmmoniteExecutor,
   loader: WorkspaceLoader[T],
-  baseDir: File = File.currentWorkingDirectory
-) extends ScriptManager(executor) {
+  baseDir: File = File.currentWorkingDirectory,
+  val reportOutStream: OutputStream = System.err
+) extends ScriptManager(executor) with Reporting {
 
   import Console._
 
@@ -473,12 +475,9 @@ class Console[T <: Project](
     projectName
   }
 
-  def report(string: String): Unit = Console.report(string)
-
 }
 
 object Console {
-  def report(string: String): Unit = System.err.println(string)
   val nameOfLegacyCpgInProject     = "cpg.bin.zip"
 
   def deriveNameFromInputPath[T <: Project](inputPath: String, workspace: WorkspaceManager[T]): String = {

--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -22,7 +22,8 @@ class Console[T <: Project](
   executor: AmmoniteExecutor,
   loader: WorkspaceLoader[T],
   baseDir: File = File.currentWorkingDirectory
-) extends ScriptManager(executor) with Reporting {
+) extends ScriptManager(executor)
+    with Reporting {
 
   import Console._
 
@@ -476,7 +477,7 @@ class Console[T <: Project](
 }
 
 object Console {
-  val nameOfLegacyCpgInProject     = "cpg.bin.zip"
+  val nameOfLegacyCpgInProject = "cpg.bin.zip"
 
   def deriveNameFromInputPath[T <: Project](inputPath: String, workspace: WorkspaceManager[T]): String = {
     val name    = File(inputPath).name

--- a/console/src/main/scala/io/joern/console/Reporting.scala
+++ b/console/src/main/scala/io/joern/console/Reporting.scala
@@ -1,11 +1,43 @@
 package io.joern.console
 
 import java.io.OutputStream
+import scala.collection.mutable
 
 trait Reporting {
-  // TODO in scala3, make this a trait parameter (rather than abstract member)
-  def reportOutStream: OutputStream
 
-  def report(string: String): Unit =
+  def reportOutStream: OutputStream = System.err
+
+  def report(string: String): Unit = {
     reportOutStream.write(string.getBytes("UTF-8"))
+    GlobalReporting.appendToGlobalStdOut(string)
+  }
+}
+
+/** A dirty hack to capture the reported output for the server-mode.
+ * Context: server mode is a bit tricky, because the reporting happens inside the repl, but we want to retrieve it
+ * from the context _outside_ the repl, and the two have separate classloaders.
+ * There's probably a cleaner way, but for now this serves our needs.
+ *
+ * Note that this convolutes the output from concurrently-running jobs - so we should not run UserRunnables concurrently.
+ *  */
+object GlobalReporting {
+  private var enabled = false
+
+  def enable(): Unit =
+    enabled = true
+
+  def disable(): Unit =
+    enabled = false
+
+  private val globalStdOut = new mutable.StringBuilder
+
+  def appendToGlobalStdOut(s: String): Unit = {
+    if (enabled) globalStdOut.append(s + System.lineSeparator())
+  }
+
+  def getAndClearGlobalStdOut(): String = {
+    val result = globalStdOut.result()
+    globalStdOut.clear()
+    result
+  }
 }

--- a/console/src/main/scala/io/joern/console/Reporting.scala
+++ b/console/src/main/scala/io/joern/console/Reporting.scala
@@ -1,0 +1,11 @@
+package io.joern.console
+
+import java.io.OutputStream
+
+trait Reporting {
+  // TODO in scala3, make this a trait parameter (rather than abstract member)
+  def reportOutStream: OutputStream
+
+  def report(string: String): Unit =
+    reportOutStream.write(string.getBytes("UTF-8"))
+}

--- a/console/src/main/scala/io/joern/console/Reporting.scala
+++ b/console/src/main/scala/io/joern/console/Reporting.scala
@@ -13,13 +13,13 @@ trait Reporting {
   }
 }
 
-/** A dirty hack to capture the reported output for the server-mode.
- * Context: server mode is a bit tricky, because the reporting happens inside the repl, but we want to retrieve it
- * from the context _outside_ the repl, and the two have separate classloaders.
- * There's probably a cleaner way, but for now this serves our needs.
- *
- * Note that this convolutes the output from concurrently-running jobs - so we should not run UserRunnables concurrently.
- *  */
+/** A dirty hack to capture the reported output for the server-mode. Context: server mode is a bit tricky, because the
+  * reporting happens inside the repl, but we want to retrieve it from the context _outside_ the repl, and the two have
+  * separate classloaders. There's probably a cleaner way, but for now this serves our needs.
+  *
+  * Note that this convolutes the output from concurrently-running jobs - so we should not run UserRunnables
+  * concurrently.
+  */
 object GlobalReporting {
   private var enabled = false
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -1,16 +1,19 @@
 package io.joern.console.cpgcreation
 
 import better.files.File
-import io.joern.console.{ConsoleException, FrontendConfig}
+import io.joern.console.{ConsoleException, FrontendConfig, Reporting}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.console.workspacehandling.Project
 import overflowdb.traversal.help.Table
 
+import java.io.OutputStream
 import java.nio.file.Path
 import scala.util.{Failure, Success, Try}
 
-class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
+class ImportCode[T <: Project](
+  console: io.joern.console.Console[T],
+  val reportOutStream: OutputStream = System.err) extends Reporting {
   import io.joern.console.Console._
 
   private val config             = console.config

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -1,19 +1,16 @@
 package io.joern.console.cpgcreation
 
 import better.files.File
+import io.joern.console.workspacehandling.Project
 import io.joern.console.{ConsoleException, FrontendConfig, Reporting}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.joern.console.workspacehandling.Project
 import overflowdb.traversal.help.Table
 
-import java.io.OutputStream
 import java.nio.file.Path
 import scala.util.{Failure, Success, Try}
 
-class ImportCode[T <: Project](
-  console: io.joern.console.Console[T],
-  val reportOutStream: OutputStream = System.err) extends Reporting {
+class ImportCode[T <: Project](console: io.joern.console.Console[T]) extends Reporting {
   import io.joern.console.Console._
 
   private val config             = console.config

--- a/console/src/main/scala/io/joern/console/embammonite/UserRunnable.scala
+++ b/console/src/main/scala/io/joern/console/embammonite/UserRunnable.scala
@@ -1,5 +1,6 @@
 package io.joern.console.embammonite
 
+import io.joern.console.GlobalReporting
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.io.{BufferedReader, PrintWriter}
@@ -25,7 +26,8 @@ class UserRunnable(queue: BlockingQueue[Job], writer: PrintWriter, reader: Buffe
         } else {
           sendQueryToAmmonite(job)
           val stdoutPair = stdOutUpToMarker()
-          val stdOutput  = stdoutPair.get
+          val stdOutput  = GlobalReporting.getAndClearGlobalStdOut() + stdoutPair.get
+
           val errOutput  = exhaustStderr()
           val result     = new QueryResult(stdOutput, errOutput, job.uuid)
           job.observer(result)

--- a/console/src/main/scala/io/joern/console/embammonite/UserRunnable.scala
+++ b/console/src/main/scala/io/joern/console/embammonite/UserRunnable.scala
@@ -28,8 +28,8 @@ class UserRunnable(queue: BlockingQueue[Job], writer: PrintWriter, reader: Buffe
           val stdoutPair = stdOutUpToMarker()
           val stdOutput  = GlobalReporting.getAndClearGlobalStdOut() + stdoutPair.get
 
-          val errOutput  = exhaustStderr()
-          val result     = new QueryResult(stdOutput, errOutput, job.uuid)
+          val errOutput = exhaustStderr()
+          val result    = new QueryResult(stdOutput, errOutput, job.uuid)
           job.observer(result)
         }
       }

--- a/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
+++ b/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
@@ -2,12 +2,14 @@ package io.joern.console.workspacehandling
 
 import better.files.Dsl._
 import better.files._
+import io.joern.console.Reporting
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import org.json4s.DefaultFormats
 import org.json4s.native.Serialization.{write => jsonWrite}
 import overflowdb.Config
 
+import java.io.OutputStream
 import java.net.URLEncoder
 import java.nio.file.Path
 import scala.collection.mutable.ListBuffer
@@ -24,7 +26,10 @@ object DefaultLoader extends WorkspaceLoader[Project] {
   * @param path
   *   path to to workspace.
   */
-class WorkspaceManager[ProjectType <: Project](path: String, loader: WorkspaceLoader[ProjectType] = DefaultLoader) {
+class WorkspaceManager[ProjectType <: Project](
+  path: String,
+  loader: WorkspaceLoader[ProjectType] = DefaultLoader,
+  val reportOutStream: OutputStream = System.err) extends Reporting {
 
   def getPath: String = path
 
@@ -413,7 +418,5 @@ object WorkspaceManager {
       .toList
       .sortBy(_.name)
   }
-
-  def report(str: String): Unit = System.err.println(str)
 
 }

--- a/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
+++ b/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
@@ -29,7 +29,8 @@ object DefaultLoader extends WorkspaceLoader[Project] {
 class WorkspaceManager[ProjectType <: Project](
   path: String,
   loader: WorkspaceLoader[ProjectType] = DefaultLoader,
-  val reportOutStream: OutputStream = System.err) extends Reporting {
+  val reportOutStream: OutputStream = System.err
+) extends Reporting {
 
   def getPath: String = path
 

--- a/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
+++ b/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
@@ -26,11 +26,8 @@ object DefaultLoader extends WorkspaceLoader[Project] {
   * @param path
   *   path to to workspace.
   */
-class WorkspaceManager[ProjectType <: Project](
-  path: String,
-  loader: WorkspaceLoader[ProjectType] = DefaultLoader,
-  val reportOutStream: OutputStream = System.err
-) extends Reporting {
+class WorkspaceManager[ProjectType <: Project](path: String, loader: WorkspaceLoader[ProjectType] = DefaultLoader)
+    extends Reporting {
 
   def getPath: String = path
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/AmmoniteBridge.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/AmmoniteBridge.scala
@@ -6,10 +6,34 @@ object AmmoniteBridge extends App with BridgeBase {
 
   runAmmonite(parseConfig(args), JoernProduct)
 
+
   /** Code that is executed when starting the shell
     */
   override def predefPlus(lines: List[String]): String = {
-    lines.foldLeft(Predefined.forInteractiveShell) { case (res, line) => res + s"\n$line" }
+    // TODO cleanup, find simple solution, e.g. `def isServer` or `def reportOutStream` in BridgeBase
+    println("XXXXXXXX1")
+    // lines.foldLeft(Predefined.forInteractiveShell) { case (res, line) => res + s"\n$line" }
+    Predefined.forInteractiveShell) { case (res, line) => res + s"\n$line" }
+    s"""
+      |import io.joern.console.{`package` => _, _}
+      |import io.joern.joerncli.console.JoernConsole._
+      |import io.shiftleft.codepropertygraph.Cpg
+      |import io.shiftleft.codepropertygraph.Cpg.docSearchPackages
+      |import io.shiftleft.codepropertygraph.cpgloading._
+      |import io.shiftleft.codepropertygraph.generated._
+      |import io.shiftleft.codepropertygraph.generated.nodes._
+      |import io.shiftleft.codepropertygraph.generated.edges._
+      |import io.joern.dataflowengineoss.language.{`package` => _, _}
+      |import io.shiftleft.semanticcpg.language.{`package` => _, _}
+      |import overflowdb.{`package` => _, _}
+      |import overflowdb.traversal.{`package` => _, help => _, _}
+      |import scala.jdk.CollectionConverters._
+      |implicit val resolver: ICallResolver = NoResolve
+      |implicit val finder: NodeExtensionFinder = DefaultNodeExtensionFinder
+      |import io.joern.joerncli.console.Joern._
+      |def script(x: String) : Any = console.runScript(x, Map(), cpg)
+      |${lines.mkString("\n")}
+    """.stripMargin
   }
 
   override def promptStr(): String = "joern> "

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/AmmoniteBridge.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/AmmoniteBridge.scala
@@ -6,34 +6,12 @@ object AmmoniteBridge extends App with BridgeBase {
 
   runAmmonite(parseConfig(args), JoernProduct)
 
-
   /** Code that is executed when starting the shell
     */
   override def predefPlus(lines: List[String]): String = {
-    // TODO cleanup, find simple solution, e.g. `def isServer` or `def reportOutStream` in BridgeBase
-    println("XXXXXXXX1")
-    // lines.foldLeft(Predefined.forInteractiveShell) { case (res, line) => res + s"\n$line" }
-    Predefined.forInteractiveShell) { case (res, line) => res + s"\n$line" }
-    s"""
-      |import io.joern.console.{`package` => _, _}
-      |import io.joern.joerncli.console.JoernConsole._
-      |import io.shiftleft.codepropertygraph.Cpg
-      |import io.shiftleft.codepropertygraph.Cpg.docSearchPackages
-      |import io.shiftleft.codepropertygraph.cpgloading._
-      |import io.shiftleft.codepropertygraph.generated._
-      |import io.shiftleft.codepropertygraph.generated.nodes._
-      |import io.shiftleft.codepropertygraph.generated.edges._
-      |import io.joern.dataflowengineoss.language.{`package` => _, _}
-      |import io.shiftleft.semanticcpg.language.{`package` => _, _}
-      |import overflowdb.{`package` => _, _}
-      |import overflowdb.traversal.{`package` => _, help => _, _}
-      |import scala.jdk.CollectionConverters._
-      |implicit val resolver: ICallResolver = NoResolve
-      |implicit val finder: NodeExtensionFinder = DefaultNodeExtensionFinder
-      |import io.joern.joerncli.console.Joern._
-      |def script(x: String) : Any = console.runScript(x, Map(), cpg)
-      |${lines.mkString("\n")}
-    """.stripMargin
+    s"""${Predefined.forInteractiveShell}
+       |${lines.mkString("\n")}
+       |""".stripMargin
   }
 
   override def promptStr(): String = "joern> "

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/Joern.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/Joern.scala
@@ -1,3 +1,3 @@
 package io.joern.joerncli.console
 
-object Joern extends JoernConsole {}
+object Joern extends JoernConsole

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/Predefined.scala
@@ -40,6 +40,15 @@ object Predefined {
       """.stripMargin +
       dynamicPredef()
 
+  val forServer: String =
+    shared +
+      """
+        |val joernConsole = new io.joern.joerncli.console.JoernConsole(reportOutStream(System.err))
+        |import joernConsole._
+        |
+      """.stripMargin +
+      dynamicPredef()
+
   def dynamicPredef(): String = {
     Run.codeForRunCommand() +
       Help.codeForHelpCommand(classOf[io.joern.joerncli.console.JoernConsole])

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/Predefined.scala
@@ -43,8 +43,12 @@ object Predefined {
   val forServer: String =
     shared +
       """
-        |val joernConsole = new io.joern.joerncli.console.JoernConsole(reportOutStream(System.err))
-        |import joernConsole._
+        |import io.joern.joerncli.console.Joern._
+        |def script(x: String) : Any = console.runScript(x, Map(), cpg)
+        |println("in forServer...")
+        |val stdOutFile = new java.io.FileOutputStream("stdout.txt")
+        |stdOutFile.write("i was here".getBytes("UTF-8"))
+        |stdOutFile.flush()
         |
       """.stripMargin +
       dynamicPredef()

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/Predefined.scala
@@ -40,19 +40,6 @@ object Predefined {
       """.stripMargin +
       dynamicPredef()
 
-  val forServer: String =
-    shared +
-      """
-        |import io.joern.joerncli.console.Joern._
-        |def script(x: String) : Any = console.runScript(x, Map(), cpg)
-        |println("in forServer...")
-        |val stdOutFile = new java.io.FileOutputStream("stdout.txt")
-        |stdOutFile.write("i was here".getBytes("UTF-8"))
-        |stdOutFile.flush()
-        |
-      """.stripMargin +
-      dynamicPredef()
-
   def dynamicPredef(): String = {
     Run.codeForRunCommand() +
       Help.codeForHelpCommand(classOf[io.joern.joerncli.console.JoernConsole])


### PR DESCRIPTION
A dirty hack to capture the reported output for the server-mode. Context: server mode is a bit tricky, because the
reporting happens inside the repl, but we want to retrieve it from the context _outside_ the repl, and the two have
separate classloaders. There's probably a cleaner way, but for now this serves our needs.

Note that this convolutes the output from concurrently-running jobs - so we should not run UserRunnables
concurrently.

I'll revisit this when we upgrade to scala3-repl, and hopefully make it less hacky.