### PR TITLE
javasrc: Add field initializers to constructors

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
@@ -120,7 +120,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
 
     "test annotation node properties" in {
       import scala.jdk.CollectionConverters._
-      val annotationNode = cpg.method.nameExact("SomeClass").annotation.head
+      val annotationNode = cpg.method.nameExact("<init>").annotation.head
       annotationNode.code shouldBe "@MarkerAnnotation()"
       annotationNode.name shouldBe "MarkerAnnotation"
       annotationNode.fullName shouldBe "some.MarkerAnnotation"

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -435,7 +435,7 @@ class CallTests extends JavaSrcCodeToCpgFixture {
 
     argument.name shouldBe Operators.fieldAccess
     argument.typeFullName shouldBe "test.MyObject"
-    argument.code shouldBe "obj"
+    argument.code shouldBe "this.obj"
     argument.order shouldBe 2
     argument.argumentIndex shouldBe 1
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -36,7 +36,7 @@ class NewConstructorInvocationTests extends JavaSrcCode2CpgFixture {
         |}
         |""".stripMargin)
     "create the correct Ast for the constructor" in {
-      fooCpg.method.name("Foo").l match {
+      fooCpg.typeDecl.name("Foo").method.nameExact("<init>").l match {
         case List(cons: Method) =>
           cons.fullName shouldBe "Foo.<init>:void(int)"
           cons.signature shouldBe "void(int)"
@@ -107,7 +107,7 @@ class ConstructorInvocationTests extends JavaSrcCodeToCpgFixture {
 
   "it should create correct method nodes for constructors" in {
 
-    cpg.method.name("Bar").l match {
+    cpg.typeDecl.name("Bar").method.nameExact("<init>").l match {
       case List(cons1: Method, cons2: Method) =>
         cons1.fullName shouldBe "Bar.<init>:void(int)"
         cons1.signature shouldBe "void(int)"

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
@@ -1,10 +1,241 @@
 package io.joern.javasrc2cpg.querying
 
-import io.joern.javasrc2cpg.testfixtures.JavaSrcCodeToCpgFixture
+import io.joern.javasrc2cpg.testfixtures.{JavaSrcCode2CpgFixture, JavaSrcCodeToCpgFixture}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, ModifierTypes, Operators, PropertyNames}
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier, Member}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier, Literal, Member}
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.Ignore
+
+class NewMemberTests extends JavaSrcCode2CpgFixture {
+  "non-static member initializers" should {
+    "be added to the default constructor in classes with no constructor" in {
+      val cpg = code("""
+			 |class Foo {
+             |    int x = 1;
+             |}""".stripMargin)
+
+      val constructor = cpg.method.nameExact("<init>").l match {
+        case constructor :: Nil => constructor
+        case result             => fail(s"Expected single constructor method but found $result")
+      }
+
+      constructor.fullName shouldBe "Foo.<init>:void()"
+      val xAssign = constructor.body.astChildren.l match {
+        case List(xAssign: Call) => xAssign
+        case result              => fail(s"Expected xAssign in constructor but found $result")
+      }
+
+      xAssign.name shouldBe Operators.assignment
+      xAssign.methodFullName shouldBe Operators.assignment
+
+      xAssign.argument.l match {
+        case List(fieldAccess: Call, value: Literal) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.argument.l match {
+            case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              identifier.name shouldBe "this"
+              identifier.typeFullName shouldBe "Foo"
+              fieldIdentifier.canonicalName shouldBe "x"
+
+            case result => fail(s"Expected field identifier args but got $result")
+          }
+
+          value.code shouldBe "1"
+          value.typeFullName shouldBe "int"
+          value.argumentIndex shouldBe 2
+
+        case result => fail(s"Expected field assign args but got $result")
+      }
+    }
+
+    "be added to an empty constructor" in {
+      val cpg = code("""
+             |class Foo {
+             |    int x = 1;
+             |    public Foo() {}
+             |}""".stripMargin)
+      val constructor = cpg.method.nameExact("<init>").l match {
+        case constructor :: Nil => constructor
+        case result             => fail(s"Expected single constructor method but found $result")
+      }
+
+      constructor.fullName shouldBe "Foo.<init>:void()"
+      val xAssign = constructor.body.astChildren.l match {
+        case List(xAssign: Call) => xAssign
+        case result              => fail(s"Expected xAssign in constructor but found $result")
+      }
+
+      xAssign.name shouldBe Operators.assignment
+      xAssign.methodFullName shouldBe Operators.assignment
+
+      xAssign.argument.l match {
+        case List(fieldAccess: Call, value: Literal) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.argument.l match {
+            case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              identifier.name shouldBe "this"
+              identifier.typeFullName shouldBe "Foo"
+              fieldIdentifier.canonicalName shouldBe "x"
+
+            case result => fail(s"Expected field identifier args but got $result")
+          }
+
+          value.code shouldBe "1"
+          value.typeFullName shouldBe "int"
+          value.argumentIndex shouldBe 2
+
+        case result => fail(s"Expected field assign args but got $result")
+      }
+    }
+
+    "be added to a not-empty constructor without an explicit constructor invocation" in {
+      val cpg = code("""
+			 |class Foo {
+			 |    int x = 1;
+			 |    int y;
+			 |
+			 |    public Foo(int y) {
+			 |      this.y = y;
+			 |    }
+			 |}""".stripMargin)
+
+      val constructor = cpg.method.nameExact("<init>").l match {
+        case constructor :: Nil => constructor
+        case result             => fail(s"Expected single constructor method but found $result")
+      }
+
+      constructor.fullName shouldBe "Foo.<init>:void(int)"
+      val (xAssign, yAssign) = constructor.body.astChildren.l match {
+        case List(xAssign: Call, yAssign: Call) => (xAssign, yAssign)
+        case result                             => fail(s"Expected two assigns in constructor but found $result")
+      }
+
+      xAssign.name shouldBe Operators.assignment
+      xAssign.methodFullName shouldBe Operators.assignment
+
+      xAssign.argument.l match {
+        case List(fieldAccess: Call, value: Literal) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.argument.l match {
+            case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              identifier.name shouldBe "this"
+              identifier.typeFullName shouldBe "Foo"
+              fieldIdentifier.canonicalName shouldBe "x"
+
+            case result => fail(s"Expected field identifier args but got $result")
+          }
+
+          value.code shouldBe "1"
+          value.typeFullName shouldBe "int"
+          value.argumentIndex shouldBe 2
+
+        case result => fail(s"Expected field assign args but got $result")
+      }
+
+      yAssign.name shouldBe Operators.assignment
+      yAssign.methodFullName shouldBe Operators.assignment
+
+      yAssign.argument.l match {
+        case List(fieldAccess: Call, value: Identifier) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.argument.l match {
+            case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              identifier.name shouldBe "this"
+              identifier.typeFullName shouldBe "Foo"
+              fieldIdentifier.canonicalName shouldBe "y"
+
+            case result => fail(s"Expected field identifier args but got $result")
+          }
+
+          value.name shouldBe "y"
+          value.code shouldBe "y"
+          value.typeFullName shouldBe "int"
+          value.argumentIndex shouldBe 2
+
+        case result => fail(s"Expected field assign args but got $result")
+      }
+    }
+
+    "not be added to a constructor containing an explicit constructor invocation" in {
+      val cpg = code("""
+			 |class Foo {
+			 |    int x = 1;
+			 |    int y;
+			 |
+			 |    public Foo(int y) {
+			 |        this.y = y;
+			 |    }
+			 |
+			 |    public Foo() {
+			 |        this(42);
+			 |    }
+			 |}""".stripMargin)
+
+      val constructorWithParam = cpg.method.fullNameExact("Foo.<init>:void(int)").l match {
+        case constructor :: Nil => constructor
+        case result             => fail(s"Expected single constructor method but found $result")
+      }
+
+      val (xAssign, yAssign) = constructorWithParam.body.astChildren.l match {
+        case List(xAssign: Call, yAssign: Call) => (xAssign, yAssign)
+        case result                             => fail(s"Expected two assigns in constructor but found $result")
+      }
+
+      xAssign.name shouldBe Operators.assignment
+      xAssign.methodFullName shouldBe Operators.assignment
+
+      xAssign.argument.l match {
+        case List(fieldAccess: Call, value: Literal) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.argument.l match {
+            case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              identifier.name shouldBe "this"
+              identifier.typeFullName shouldBe "Foo"
+              fieldIdentifier.canonicalName shouldBe "x"
+
+            case result => fail(s"Expected field identifier args but got $result")
+          }
+
+          value.code shouldBe "1"
+          value.typeFullName shouldBe "int"
+          value.argumentIndex shouldBe 2
+
+        case result => fail(s"Expected field assign args but got $result")
+      }
+
+      yAssign.name shouldBe Operators.assignment
+      yAssign.methodFullName shouldBe Operators.assignment
+
+      yAssign.argument.l match {
+        case List(fieldAccess: Call, value: Identifier) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.argument.l match {
+            case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              identifier.name shouldBe "this"
+              identifier.typeFullName shouldBe "Foo"
+              fieldIdentifier.canonicalName shouldBe "y"
+
+            case result => fail(s"Expected field identifier args but got $result")
+          }
+
+          value.name shouldBe "y"
+          value.code shouldBe "y"
+          value.typeFullName shouldBe "int"
+          value.argumentIndex shouldBe 2
+
+        case result => fail(s"Expected field assign args but got $result")
+      }
+
+      val ctorWithExplInvocation = cpg.method.fullNameExact("Foo.<init>:void()")
+      ctorWithExplInvocation.body.astChildren.l match {
+        case List(explConsInvocation: Call) =>
+          explConsInvocation.methodFullName shouldBe "Foo.<init>:void(int)"
+
+        case result => fail(s"Expected single explicit constructor invocation call but found $result")
+      }
+    }
+  }
+}
 
 class MemberTests extends JavaSrcCodeToCpgFixture {
 


### PR DESCRIPTION
This PR fixes https://github.com/joernio/joern/issues/1757 by adding member initializers to constructors. For consistency with java bytecode, the initializers are added to the start of every constructor body, except if that body contains a `this(...)` call. All of the assignments are also assignments to a `fieldAccess` (e.g. `int x = 12` would be represented as `this.x = 12`), again for consistency with bytecode.