### PR TITLE
jssrc2cpg: fix static/non-static class member handling

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
 
 trait AstForFunctionsCreator { this: AstCreator =>
 
-  case class MethodAst(ast: Ast, methodNode: NewMethod)
+  case class MethodAst(ast: Ast, methodNode: NewMethod, methodAst: Ast)
 
   private def handleRestInParameters(
     elementNodeInfo: BabelNodeInfo,
@@ -407,9 +407,9 @@ trait AstForFunctionsCreator { this: AstCreator =>
 
     methodRefNode match {
       case Some(ref) if callAst.nodes.isEmpty =>
-        MethodAst(Ast(ref), methodNode)
+        MethodAst(Ast(ref), methodNode, mAst)
       case _ =>
-        MethodAst(callAst, methodNode)
+        MethodAst(callAst, methodNode, mAst)
     }
   }
 


### PR DESCRIPTION
Static class members with initialization are now correctly attached to the `<clinit>` method. Non-static class members with initialization are now correctly attached to the `<constructor>` method.