### PR TITLE
Fix aliasing issue when adding static initializers to javasrc constructors

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
@@ -132,7 +132,15 @@ class Scope extends X2CpgScope[String, NodeTypeInfo, ScopeType] {
 
   def getMemberInitializers: Seq[Ast] = {
     memberInits match {
-      case currMembers :: _ => currMembers.toSeq
+      case currMembers :: _ =>
+        currMembers.toSeq.map { ast =>
+          ast.root match {
+            case Some(root: AstNodeNew) =>
+              ast.subTreeCopy(root)
+
+            case _ => Ast()
+          }
+        }
       case Nil =>
         logger.warn("Attemping to fetch initializers from scope with uninitialized memberInits. Inits may be missing.")
         Seq.empty

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
@@ -8,6 +8,20 @@ import org.scalatest.Ignore
 
 class NewMemberTests extends JavaSrcCode2CpgFixture {
   "non-static member initializers" should {
+    "only be added once per constructor" in {
+      val cpg = code("""
+                      |class Foo {
+                      |  int x = 1;
+                      |
+                      |  public Foo() {}
+                      |
+                      |  public Foo(int y) {
+                      |    this.x = y;
+                      |  }
+                      |}""".stripMargin)
+
+      cpg.method.fullNameExact("Foo.<init>:void()").assignment.astChildren.size shouldBe 2
+    }
     "be added to the default constructor in classes with no constructor" in {
       val cpg = code("""
 			 |class Foo {


### PR DESCRIPTION
Re-adding the same initializer asts to constructors led to issues where duplicate nodes and edges were being added to the CPG. Doing a deep copy fixes this.