### PR TITLE
jssrc2cpg: lowered import declarations

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -133,7 +133,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
         createAssignmentCallAst(
           destAst.nodes.head,
           sourceAst.nodes.head,
-          s"${codeOf(destAst.nodes.head)} = ${codeOf(sourceAst.nodes.head)}",
+          s"var ${codeOf(destAst.nodes.head)} = ${codeOf(sourceAst.nodes.head)}",
           declaration.lineNumber,
           declaration.columnNumber
         )
@@ -146,7 +146,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     val specifiers = declaration
       .json("specifiers")
       .arr
-      .toSeq
+      .toList
       .map { spec =>
         if (createBabelNodeInfo(spec).node == ExportNamespaceSpecifier) {
           val exported = createBabelNodeInfo(spec("exported"))
@@ -162,15 +162,10 @@ trait AstForDeclarationsCreator { this: AstCreator =>
         }
       }
 
-    val exportName = extractExportFromNameFromExportDecl(declaration)
-
-    val blockNode = createBlockNode(declaration)
-    scope.pushNewBlockScope(blockNode)
-    localAstParentStack.push(blockNode)
-
+    val exportName      = extractExportFromNameFromExportDecl(declaration)
     val fromAst         = createAstForFrom(exportName, declaration)
     val declAstAndNames = extractDeclarationsFromExportDecl(declaration, "declaration")
-    val declAsts = declAstAndNames.map { case (ast, names) =>
+    val declAsts = declAstAndNames.toList.map { case (ast, names) =>
       ast +: names.map { name =>
         if (exportName != EXPORT_KEYWORD)
           diffGraph.addNode(createDependencyNode(name, exportName.stripPrefix("_"), REQUIRE_KEYWORD))
@@ -191,20 +186,13 @@ trait AstForDeclarationsCreator { this: AstCreator =>
         createExportAssignmentCallAst(exportName, exportCallAst, declaration)
     }
 
-    val asts = fromAst +: (specifierAsts ++ declAsts.toSeq.flatten)
-    setIndices(asts.toList)
-    localAstParentStack.pop()
-    scope.popScope()
-    Ast(blockNode).withChildren(asts)
+    val asts = fromAst +: (specifierAsts ++ declAsts.flatten)
+    setIndices(asts)
+    blockAst(createBlockNode(declaration), asts)
   }
 
   protected def astForExportAssignment(assignment: BabelNodeInfo): Ast = {
     val expressionAstWithNames = extractDeclarationsFromExportDecl(assignment, "expression")
-
-    val blockNode = createBlockNode(assignment)
-    scope.pushNewBlockScope(blockNode)
-    localAstParentStack.push(blockNode)
-
     val declAsts = expressionAstWithNames.map { case (ast, names) =>
       ast +: names.map { name =>
         val exportCallAst = createExportCallAst(name, EXPORT_KEYWORD, assignment)
@@ -212,20 +200,14 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       }
     }
 
-    val asts = declAsts.toSeq.flatten
-    setIndices(asts.toList)
-    localAstParentStack.pop()
-    scope.popScope()
-    Ast(blockNode).withChildren(asts)
+    val asts = declAsts.toList.flatten
+    setIndices(asts)
+    blockAst(createBlockNode(assignment), asts)
   }
 
   protected def astForExportDefaultDeclaration(declaration: BabelNodeInfo): Ast = {
     val exportName      = extractExportFromNameFromExportDecl(declaration)
     val declAstAndNames = extractDeclarationsFromExportDecl(declaration, "declaration")
-
-    val blockNode = createBlockNode(declaration)
-    scope.pushNewBlockScope(blockNode)
-    localAstParentStack.push(blockNode)
 
     val declAsts = declAstAndNames.map { case (ast, names) =>
       ast +: names.map { name =>
@@ -234,11 +216,9 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       }
     }
 
-    val asts = declAsts.toSeq.flatten
-    setIndices(asts.toList)
-    localAstParentStack.pop()
-    scope.popScope()
-    Ast(blockNode).withChildren(asts)
+    val asts = declAsts.toList.flatten
+    setIndices(asts)
+    blockAst(createBlockNode(declaration), asts)
   }
 
   protected def astForExportAllDeclaration(declaration: BabelNodeInfo): Ast = {
@@ -249,10 +229,6 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       diffGraph.addNode(createDependencyNode(name, depGroupId, REQUIRE_KEYWORD))
     }
 
-    val blockNode = createBlockNode(declaration)
-    scope.pushNewBlockScope(blockNode)
-    localAstParentStack.push(blockNode)
-
     val fromCallAst   = createAstForFrom(exportName, declaration)
     val exportCallAst = createExportCallAst(name, EXPORT_KEYWORD, declaration)
     Ast.storeInDiffGraph(exportCallAst, diffGraph)
@@ -260,9 +236,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
 
     val asts = List(fromCallAst, exportCallAst, assignmentCallAst)
     setIndices(asts)
-    localAstParentStack.pop()
-    scope.popScope()
-    Ast(blockNode).withChildren(asts)
+    blockAst(createBlockNode(declaration), asts)
   }
 
   protected def astForVariableDeclaration(declaration: BabelNodeInfo): Ast = {
@@ -352,7 +326,35 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     }
     diffGraph.addNode(createDependencyNode(name, referenceName, IMPORT_KEYWORD))
     createImportNodeAndAttachToAst(impDecl, referenceName, name)
-    Ast()
+    astForRequireCallFromImport(name, referenceName, impDecl)
+  }
+
+  private def astForRequireCallFromImport(name: String, from: String, nodeInfo: BabelNodeInfo): Ast = {
+    val id        = createIdentifierNode(name, nodeInfo)
+    val localNode = createLocalNode(id.code, Defines.ANY.label)
+    scope.addVariable(id.code, localNode, BlockScope)
+    diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
+
+    val destAst           = Ast(id)
+    val sourceCallArgNode = createLiteralNode(s"\"$from\"", None, nodeInfo.lineNumber, nodeInfo.columnNumber)
+    val sourceCall = createCallNode(
+      s"$REQUIRE_KEYWORD(${sourceCallArgNode.code})",
+      REQUIRE_KEYWORD,
+      DispatchTypes.STATIC_DISPATCH,
+      nodeInfo.lineNumber,
+      nodeInfo.columnNumber
+    )
+    val sourceAst = createCallAst(sourceCall, List(Ast(sourceCallArgNode)))
+    val assigmentCallAst =
+      createAssignmentCallAst(
+        destAst.nodes.head,
+        sourceAst.nodes.head,
+        s"var ${codeOf(destAst.nodes.head)} = ${codeOf(sourceAst.nodes.head)}",
+        nodeInfo.lineNumber,
+        nodeInfo.columnNumber
+      )
+    Ast.storeInDiffGraph(sourceAst, diffGraph)
+    assigmentCallAst
   }
 
   protected def astForImportDeclaration(impDecl: BabelNodeInfo): Ast = {
@@ -362,15 +364,26 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     if (specifiers.isEmpty) {
       diffGraph.addNode(createDependencyNode(source, source, IMPORT_KEYWORD))
       createImportNodeAndAttachToAst(impDecl, source, source)
-      Ast()
+      astForRequireCallFromImport(source, source, impDecl)
     } else {
-      val depNodes = impDecl.json("specifiers").arr.map { importSpecifier =>
+      val specs = impDecl.json("specifiers").arr.toList
+      val depNodes = specs.map { importSpecifier =>
         val importedName = importSpecifier("local")("name").str
         createImportNodeAndAttachToAst(impDecl, source, importedName)
         createDependencyNode(importedName, source, IMPORT_KEYWORD)
       }
       depNodes.foreach(diffGraph.addNode)
-      Ast()
+      val requireCalls = specs.map { importSpecifier =>
+        val importedName = importSpecifier("local")("name").str
+        astForRequireCallFromImport(importedName, source, impDecl)
+      }
+      if (requireCalls.isEmpty) {
+        Ast()
+      } else if (requireCalls.size == 1) {
+        requireCalls.head
+      } else {
+        blockAst(createBlockNode(impDecl), requireCalls)
+      }
     }
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -27,14 +27,15 @@ trait AstForStatementsCreator { this: AstCreator =>
   private def sortBlockStatements(blockStatements: List[BabelNodeInfo]): List[BabelNodeInfo] =
     blockStatements.sortBy { nodeInfo =>
       nodeInfo.node match {
-        case FunctionDeclaration                                  => 0
-        case DeclareTypeAlias if isPlainTypeAlias(nodeInfo)       => 3
-        case TypeAlias if isPlainTypeAlias(nodeInfo)              => 3
-        case TSTypeAliasDeclaration if isPlainTypeAlias(nodeInfo) => 3
-        case DeclareTypeAlias                                     => 2
-        case TypeAlias                                            => 2
-        case TSTypeAliasDeclaration                               => 2
-        case _                                                    => 1
+        case ImportDeclaration                                    => 0
+        case FunctionDeclaration                                  => 1
+        case DeclareTypeAlias if isPlainTypeAlias(nodeInfo)       => 4
+        case TypeAlias if isPlainTypeAlias(nodeInfo)              => 4
+        case TSTypeAliasDeclaration if isPlainTypeAlias(nodeInfo) => 4
+        case DeclareTypeAlias                                     => 3
+        case TypeAlias                                            => 3
+        case TSTypeAliasDeclaration                               => 3
+        case _                                                    => 2
       }
     }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
@@ -182,18 +182,18 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
         "module-name"
       )
       cpg.assignment.code.l shouldBe List(
-        "var name = require(\"module-name\").name",
-        "var otherName = require(\"module-name\").otherName",
+        "var name = require(\"module-name\")",
+        "var otherName = require(\"module-name\")",
         "var member1 = require(\"module-name\").member1",
         "var alias1 = require(\"module-name\").member2",
         "var member3 = require(\"module-name\").member3",
         "var member4 = require(\"module-name\").member4",
         "var member5 = require(\"module-name\").member5",
         "var alias2 = require(\"module-name\").member6",
-        "var defaultMember1 = require(\"module-name\").defaultMember1",
-        "var alias3 = require(\"module-name\").alias3",
-        "var defaultMember2 = require(\"module-name\").defaultMember2",
-        "var module-name = require(\"module-name\").module-name"
+        "var defaultMember1 = require(\"module-name\")",
+        "var alias3 = require(\"module-name\")",
+        "var defaultMember2 = require(\"module-name\")",
+        "var module-name = require(\"module-name\")"
       )
 
       val List(

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
@@ -2,7 +2,6 @@ package io.joern.jssrc2cpg.passes.ast
 
 import io.joern.jssrc2cpg.passes.AbstractPassTest
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 
 class DependencyAstCreationPassTest extends AbstractPassTest {
@@ -168,6 +167,35 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
        |import defaultMember2 from "module-name";
        |import "module-name";
        |""".stripMargin) { cpg =>
+      cpg.local.code.l shouldBe List(
+        "name",
+        "otherName",
+        "member1",
+        "alias1",
+        "member3",
+        "member4",
+        "member5",
+        "alias2",
+        "defaultMember1",
+        "alias3",
+        "defaultMember2",
+        "module-name"
+      )
+      cpg.assignment.code.l shouldBe List(
+        "var name = require(\"module-name\")",
+        "var otherName = require(\"module-name\")",
+        "var member1 = require(\"module-name\")",
+        "var alias1 = require(\"module-name\")",
+        "var member3 = require(\"module-name\")",
+        "var member4 = require(\"module-name\")",
+        "var member5 = require(\"module-name\")",
+        "var alias2 = require(\"module-name\")",
+        "var defaultMember1 = require(\"module-name\")",
+        "var alias3 = require(\"module-name\")",
+        "var defaultMember2 = require(\"module-name\")",
+        "var module-name = require(\"module-name\")"
+      )
+
       val List(
         name,
         otherName,
@@ -256,7 +284,7 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
         "variable4",
         "variable5"
       )
-      cpg.call(Operators.assignment).code.l.sorted shouldBe List(
+      cpg.assignment.code.l.sorted shouldBe List(
         "exports.name1 = name1",
         "exports.name10 = name10",
         "exports.name11 = name11",
@@ -284,7 +312,7 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
         |""".stripMargin) { cpg =>
       cpg.local.code.l shouldBe List("foo", "bar", "func")
       cpg.typeDecl.name.l should contain allElementsOf List("func", "ClassA")
-      cpg.call(Operators.assignment).code.l shouldBe List(
+      cpg.assignment.code.l shouldBe List(
         "var foo = 1",
         "var bar = 2",
         "exports.foo = foo",
@@ -302,7 +330,7 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
         |export default function foo(param) {};
         |""".stripMargin) { cpg =>
       cpg.local.code.l shouldBe List("name1", "foo", "name2")
-      cpg.call(Operators.assignment).code.l shouldBe List(
+      cpg.assignment.code.l shouldBe List(
         "exports[\"default\"] = name1",
         "name2 = \"2\"",
         "exports[\"default\"] = name2",
@@ -334,12 +362,12 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
       bar.dependencyGroupId shouldBe Some("Bar")
       bar.version shouldBe "require"
 
-      cpg.call(Operators.assignment).code.l shouldBe List(
-        "_Foo = require(\"Foo\")",
+      cpg.assignment.code.l shouldBe List(
+        "var _Foo = require(\"Foo\")",
         "_Foo.name1 = import1",
         "_Foo.name2 = import2",
         "_Foo.name3 = name3",
-        "_Bar = require(\"Bar\")",
+        "var _Bar = require(\"Bar\")",
         "_Bar.bar = bar"
       )
     }
@@ -363,12 +391,12 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
       dep3.dependencyGroupId shouldBe Some("./some/Module")
       dep3.version shouldBe "require"
 
-      cpg.call(Operators.assignment).code.l shouldBe List(
-        "_Foo = require(\"Foo\")",
+      cpg.assignment.code.l shouldBe List(
+        "var _Foo = require(\"Foo\")",
         "exports.Foo = _Foo",
-        "_Bar = require(\"Bar\")",
+        "var _Bar = require(\"Bar\")",
         "exports.B = _Bar",
-        "_Module = require(\"./some/Module\")",
+        "var _Module = require(\"./some/Module\")",
         "exports.Module = _Module"
       )
     }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
@@ -182,18 +182,18 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
         "module-name"
       )
       cpg.assignment.code.l shouldBe List(
-        "var name = require(\"module-name\")",
-        "var otherName = require(\"module-name\")",
-        "var member1 = require(\"module-name\")",
-        "var alias1 = require(\"module-name\")",
-        "var member3 = require(\"module-name\")",
-        "var member4 = require(\"module-name\")",
-        "var member5 = require(\"module-name\")",
-        "var alias2 = require(\"module-name\")",
-        "var defaultMember1 = require(\"module-name\")",
-        "var alias3 = require(\"module-name\")",
-        "var defaultMember2 = require(\"module-name\")",
-        "var module-name = require(\"module-name\")"
+        "var name = require(\"module-name\").name",
+        "var otherName = require(\"module-name\").otherName",
+        "var member1 = require(\"module-name\").member1",
+        "var alias1 = require(\"module-name\").member2",
+        "var member3 = require(\"module-name\").member3",
+        "var member4 = require(\"module-name\").member4",
+        "var member5 = require(\"module-name\").member5",
+        "var alias2 = require(\"module-name\").member6",
+        "var defaultMember1 = require(\"module-name\").defaultMember1",
+        "var alias3 = require(\"module-name\").alias3",
+        "var defaultMember2 = require(\"module-name\").defaultMember2",
+        "var module-name = require(\"module-name\").module-name"
       )
 
       val List(

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
@@ -81,13 +81,13 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       d.code shouldBe "static d"
 
       val List(clInitMethod)         = classATypeDecl.method.nameExact(io.joern.x2cpg.Defines.StaticInitMethodName).l
-      val List(cInitCall, dInitCall) = clInitMethod.block.ast.isCall.nameExact(Operators.assignment).l
+      val List(cInitCall, dInitCall) = clInitMethod.block.assignment.l
       cInitCall.code shouldBe "static c = true"
       dInitCall.code shouldBe "this.d = false"
 
       val List(constructor) =
         cpg.typeDecl.nameExact("ClassA").method.nameExact(io.joern.x2cpg.Defines.ConstructorMethodName).l
-      val List(aInitCall, bInitCall) = constructor.block.ast.isCall.nameExact(Operators.assignment).l
+      val List(aInitCall, bInitCall) = constructor.block.assignment.l
       aInitCall.code shouldBe "a = 1"
       bInitCall.code shouldBe """b = "foo""""
     }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -634,10 +634,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
         destructionBlock.astChildren.isLocal.nameExact("_tmp_0").size shouldBe 1
         destructionBlock.astChildren.isCall.codeExact("_tmp_0 = x").size shouldBe 1
 
-        val List(assignmentToA) = destructionBlock.astChildren.isCall
-          .nameExact(Operators.assignment)
-          .codeExact("a = _tmp_0.a === void 0 ? 1 : _tmp_0.a")
-          .l
+        val List(assignmentToA) = destructionBlock.assignment.codeExact("a = _tmp_0.a === void 0 ? 1 : _tmp_0.a").l
         assignmentToA.astChildren.isIdentifier.size shouldBe 1
 
         val List(ifA) = assignmentToA.astChildren.isCall.codeExact("_tmp_0.a === void 0 ? 1 : _tmp_0.a").l
@@ -656,11 +653,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
         val List(falseBranchA) = ifA.astChildren.isCall.codeExact("_tmp_0.a").l
         falseBranchA.name shouldBe Operators.fieldAccess
 
-        val List(assignmentToB) =
-          destructionBlock.astChildren.isCall
-            .nameExact(Operators.assignment)
-            .codeExact("b = _tmp_0.b === void 0 ? 2 : _tmp_0.b")
-            .l
+        val List(assignmentToB) = destructionBlock.assignment.codeExact("b = _tmp_0.b === void 0 ? 2 : _tmp_0.b").l
         assignmentToB.astChildren.isIdentifier.size shouldBe 1
 
         val List(ifB) = assignmentToB.astChildren.isCall.codeExact("_tmp_0.b === void 0 ? 2 : _tmp_0.b").l
@@ -726,10 +719,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
       destructionBlock.astChildren.isLocal.nameExact("_tmp_0").size shouldBe 1
       destructionBlock.astChildren.isCall.codeExact("_tmp_0 = x").size shouldBe 1
 
-      val List(assignmentToN) = destructionBlock.astChildren.isCall
-        .nameExact(Operators.assignment)
-        .codeExact("n = _tmp_0.a === void 0 ? 1 : _tmp_0.a")
-        .l
+      val List(assignmentToN) = destructionBlock.assignment.codeExact("n = _tmp_0.a === void 0 ? 1 : _tmp_0.a").l
       assignmentToN.astChildren.isIdentifier.size shouldBe 1
 
       val List(ifA) = assignmentToN.astChildren.isCall.codeExact("_tmp_0.a === void 0 ? 1 : _tmp_0.a").l
@@ -748,10 +738,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
       val List(falseBranchA) = ifA.astChildren.isCall.codeExact("_tmp_0.a").l
       falseBranchA.name shouldBe Operators.fieldAccess
 
-      val List(assignmentToM) = destructionBlock.astChildren.isCall
-        .nameExact(Operators.assignment)
-        .codeExact("m = _tmp_0.b === void 0 ? 2 : _tmp_0.b")
-        .l
+      val List(assignmentToM) = destructionBlock.assignment.codeExact("m = _tmp_0.b === void 0 ? 2 : _tmp_0.b").l
       assignmentToN.astChildren.isIdentifier.size shouldBe 1
 
       val List(ifB) = assignmentToM.astChildren.isCall.codeExact("_tmp_0.b === void 0 ? 2 : _tmp_0.b").l
@@ -975,11 +962,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
         destructionBlock.astChildren.isLocal.nameExact("_tmp_0").size shouldBe 1
         destructionBlock.astChildren.isCall.codeExact("_tmp_0 = x").size shouldBe 1
 
-        val List(assignmentToA) = destructionBlock.astChildren.isCall
-          .nameExact(Operators.assignment)
-          .codeExact("a = _tmp_0[0] === void 0 ? 1 : _tmp_0[0]")
-          .l
-
+        val List(assignmentToA) = destructionBlock.assignment.codeExact("a = _tmp_0[0] === void 0 ? 1 : _tmp_0[0]").l
         assignmentToA.astChildren.isIdentifier.size shouldBe 1
 
         val List(ifA) = assignmentToA.astChildren.isCall.codeExact("_tmp_0[0] === void 0 ? 1 : _tmp_0[0]").l
@@ -998,10 +981,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
         val List(falseBranchA) = ifA.astChildren.isCall.codeExact("_tmp_0[0]").l
         falseBranchA.name shouldBe Operators.indexAccess
 
-        val List(assignmentToB) = destructionBlock.astChildren.isCall
-          .nameExact(Operators.assignment)
-          .codeExact("b = _tmp_0[1] === void 0 ? 2 : _tmp_0[1]")
-          .l
+        val List(assignmentToB) = destructionBlock.assignment.codeExact("b = _tmp_0[1] === void 0 ? 2 : _tmp_0[1]").l
         assignmentToB.astChildren.isIdentifier.size shouldBe 1
 
         val List(ifB) = assignmentToB.astChildren.isCall.codeExact("_tmp_0[1] === void 0 ? 2 : _tmp_0[1]").l
@@ -1170,7 +1150,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
       val List(delete) = program.astChildren.isBlock.astChildren.isCall.codeExact("delete foo.x").l
       delete.name shouldBe Operators.delete
 
-      val List(rhs) = delete.astChildren.isCall.nameExact(Operators.fieldAccess).l
+      val List(rhs) = delete.fieldAccess.l
       rhs.code shouldBe "foo.x"
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
@@ -17,11 +17,7 @@ class TsAstCreationPassTest extends AbstractPassTest {
         |""".stripMargin,
       "code.ts"
     ) { cpg =>
-      cpg.call(Operators.assignment).code.l shouldBe List(
-        "const x = \"foo\" as string",
-        "var y = 1 as int",
-        "let z = true as boolean"
-      )
+      cpg.assignment.code.l shouldBe List("const x = \"foo\" as string", "var y = 1 as int", "let z = true as boolean")
       inside(cpg.call(Operators.cast).l) { case List(callX, callY, callZ) =>
         callX.argument(1).code shouldBe "string"
         callX.argument(2).code shouldBe "\"foo\""
@@ -39,6 +35,8 @@ class TsAstCreationPassTest extends AbstractPassTest {
         |""".stripMargin,
       "code.ts"
     ) { cpg =>
+      cpg.assignment.code.l shouldBe List("var fs = require(\"fs\")", "var models = require(\"../models/index\")")
+      cpg.local.code.l shouldBe List("fs", "models")
       val List(fsDep, modelsDep) = cpg.dependency.l
       fsDep.name shouldBe "fs"
       fsDep.dependencyGroupId shouldBe Some("fs")

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
@@ -35,7 +35,10 @@ class TsAstCreationPassTest extends AbstractPassTest {
         |""".stripMargin,
       "code.ts"
     ) { cpg =>
-      cpg.assignment.code.l shouldBe List("var fs = require(\"fs\")", "var models = require(\"../models/index\")")
+      cpg.assignment.code.l shouldBe List(
+        "var fs = require(\"fs\").fs",
+        "var models = require(\"../models/index\").models"
+      )
       cpg.local.code.l shouldBe List("fs", "models")
       val List(fsDep, modelsDep) = cpg.dependency.l
       fsDep.name shouldBe "fs"

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
@@ -35,10 +35,7 @@ class TsAstCreationPassTest extends AbstractPassTest {
         |""".stripMargin,
       "code.ts"
     ) { cpg =>
-      cpg.assignment.code.l shouldBe List(
-        "var fs = require(\"fs\").fs",
-        "var models = require(\"../models/index\").models"
-      )
+      cpg.assignment.code.l shouldBe List("var fs = require(\"fs\")", "var models = require(\"../models/index\")")
       cpg.local.code.l shouldBe List("fs", "models")
       val List(fsDep, modelsDep) = cpg.dependency.l
       fsDep.name shouldBe "fs"

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
@@ -140,9 +140,15 @@ class VueJsDomAstCreationPassTest extends AbstractDomPassTest {
       "test.vue"
     ) { cpg =>
       cpg.file.name.l shouldBe List("test.vue")
-      cpg.call.code.l shouldBe List("exports[\"default\"]", "exports[\"default\"] = HelloWorld")
+      cpg.assignment.code.l shouldBe List(
+        "var Component = require(\"vue-property-decorator\")",
+        "var Prop = require(\"vue-property-decorator\")",
+        "var Vue = require(\"vue-property-decorator\")",
+        "exports[\"default\"] = HelloWorld"
+      )
+      cpg.local.code.l shouldBe List("Component", "Prop", "Vue", "msg")
 
-      inside(cpg.identifier.l) { case List(exports, msg, helloWorld) =>
+      inside(cpg.identifier.l) { case List(exports, msg, comp, prop, vue, helloWorld) =>
         exports.name shouldBe "exports"
         exports.code shouldBe "exports"
         msg.name shouldBe "msg"
@@ -153,6 +159,13 @@ class VueJsDomAstCreationPassTest extends AbstractDomPassTest {
         parentTemplateDom(parentTemplateDom(msg)).code shouldBe "<h1>{{ msg }}</h1>"
         helloWorld.name shouldBe "HelloWorld"
         helloWorld.code shouldBe "HelloWorld"
+
+        comp.name shouldBe "Component"
+        comp.code shouldBe "Component"
+        prop.name shouldBe "Prop"
+        prop.code shouldBe "Prop"
+        vue.name shouldBe "Vue"
+        vue.code shouldBe "Vue"
       }
 
       inside(cpg.staticImport.l) { case List(component, prop, vue) =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
@@ -148,7 +148,14 @@ class VueJsDomAstCreationPassTest extends AbstractDomPassTest {
       )
       cpg.local.code.l shouldBe List("Component", "Prop", "Vue", "msg")
 
-      inside(cpg.identifier.l) { case List(exports, msg, comp, prop, vue, helloWorld) =>
+      inside(cpg.identifier.l) { case List(exports, comp, prop, vue, msg, helloWorld) =>
+        comp.name shouldBe "Component"
+        comp.code shouldBe "Component"
+        prop.name shouldBe "Prop"
+        prop.code shouldBe "Prop"
+        vue.name shouldBe "Vue"
+        vue.code shouldBe "Vue"
+
         exports.name shouldBe "exports"
         exports.code shouldBe "exports"
         msg.name shouldBe "msg"
@@ -159,13 +166,6 @@ class VueJsDomAstCreationPassTest extends AbstractDomPassTest {
         parentTemplateDom(parentTemplateDom(msg)).code shouldBe "<h1>{{ msg }}</h1>"
         helloWorld.name shouldBe "HelloWorld"
         helloWorld.code shouldBe "HelloWorld"
-
-        comp.name shouldBe "Component"
-        comp.code shouldBe "Component"
-        prop.name shouldBe "Prop"
-        prop.code shouldBe "Prop"
-        vue.name shouldBe "Vue"
-        vue.code shouldBe "Vue"
       }
 
       inside(cpg.staticImport.l) { case List(component, prop, vue) =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
@@ -141,9 +141,9 @@ class VueJsDomAstCreationPassTest extends AbstractDomPassTest {
     ) { cpg =>
       cpg.file.name.l shouldBe List("test.vue")
       cpg.assignment.code.l shouldBe List(
-        "var Component = require(\"vue-property-decorator\")",
-        "var Prop = require(\"vue-property-decorator\")",
-        "var Vue = require(\"vue-property-decorator\")",
+        "var Component = require(\"vue-property-decorator\").Component",
+        "var Prop = require(\"vue-property-decorator\").Prop",
+        "var Vue = require(\"vue-property-decorator\").Vue",
         "exports[\"default\"] = HelloWorld"
       )
       cpg.local.code.l shouldBe List("Component", "Prop", "Vue", "msg")


### PR DESCRIPTION
Import declarations are now additionally lowered to good-old ES6 style require assignments. With this the CS require preprocessor does not need modifications.