### PR TITLE
Add PHP switch statements and fix variable code

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -52,6 +52,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case contStmt: PhpContinueStmt => astForContinueStmt(contStmt)
       case whileStmt: PhpWhileStmt   => astForWhileStmt(whileStmt)
       case ifStmt: PhpIfStmt         => astForIfStmt(ifStmt)
+      case switchStmt: PhpSwitchStmt => astForSwitchStmt(switchStmt)
 
       case unhandled =>
         logger.warn(s"Unhandled stmt: $unhandled")
@@ -185,6 +186,10 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       .lineNumber(line(ifStmt))
 
     controlStructureAst(ifNode, Some(condition), thenAst :: elseAst)
+  }
+
+  private def astForSwitchStmt(stmt: PhpSwitchStmt): Ast = {
+
   }
 
   private def astForFunctionCall(call: PhpFuncCall): Ast = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -109,8 +109,10 @@ object Domain {
   ) extends PhpStmt
   final case class PhpElseIfStmt(cond: PhpExpr, stmts: List[PhpStmt], attributes: PhpAttributes) extends PhpStmt
   final case class PhpElseStmt(stmts: List[PhpStmt], attributes: PhpAttributes)                  extends PhpStmt
-  final case class PhpSwitchStmt(condition: PhpExpr, cases: List[PhpCaseStmt], attributes: PhpAttributes) extends PhpStmt
-  final case class PhpCaseStmt(condition: Option[PhpExpr], stmts: List[PhpStmt], attributes: PhpAttributes) extends PhpStmt
+  final case class PhpSwitchStmt(condition: PhpExpr, cases: List[PhpCaseStmt], attributes: PhpAttributes)
+      extends PhpStmt
+  final case class PhpCaseStmt(condition: Option[PhpExpr], stmts: List[PhpStmt], attributes: PhpAttributes)
+      extends PhpStmt
 
   final case class PhpMethodDecl(
     name: String,
@@ -331,14 +333,14 @@ object Domain {
 
   private def readSwitch(json: Value): PhpSwitchStmt = {
     val condition = readExpr(json("cond"))
-    val cases = json("cases").arr.map(readCase).toList
+    val cases     = json("cases").arr.map(readCase).toList
 
     PhpSwitchStmt(condition, cases, PhpAttributes(json))
   }
 
   private def readCase(json: Value): PhpCaseStmt = {
     val condition = Option.unless(json("cond").isNull)(readExpr(json("cond")))
-    val stmts = json("stmts").arr.map(readStmt).toList
+    val stmts     = json("stmts").arr.map(readStmt).toList
 
     PhpCaseStmt(condition, stmts, PhpAttributes(json))
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
@@ -26,7 +26,7 @@ class OperatorTests extends PhpCode2CpgFixture {
       assignment.argument.l match {
         case List(target: Identifier, source: Literal) =>
           target.name shouldBe "a"
-          target.code shouldBe "a"
+          target.code shouldBe "$a"
           target.argumentIndex shouldBe 1
 
           source.code shouldBe "2"
@@ -77,7 +77,7 @@ class OperatorTests extends PhpCode2CpgFixture {
       addition.argument.l match {
         case List(expr: Identifier) =>
           expr.name shouldBe "a"
-          expr.code shouldBe "a"
+          expr.code shouldBe "$a"
           expr.argumentIndex shouldBe 1
 
         case result => s"Found unexpected call args $result"
@@ -118,7 +118,7 @@ class OperatorTests extends PhpCode2CpgFixture {
       addition.argument.l match {
         case List(target: Identifier, source: Literal) =>
           target.name shouldBe "a"
-          target.code shouldBe "a"
+          target.code shouldBe "$a"
           target.argumentIndex shouldBe 1
 
           source.code shouldBe "2"
@@ -178,8 +178,7 @@ class OperatorTests extends PhpCode2CpgFixture {
       }
 
       cast.typeFullName shouldBe "int"
-      // TODO Still need to fix variable code
-      cast.code shouldBe "(int) a"
+      cast.code shouldBe "(int) $a"
       cast.lineNumber shouldBe Some(2)
       cast.argument.l match {
         case List(typeRef: TypeRef, expr: Identifier) =>


### PR DESCRIPTION
Switch statements felt like a good candidate for a common x2cpg method, but at least from comparing php2cpg and javasrc2cpg, it looks like actually extracting shared code will be difficult to do without adding just as much preprocessing code back in. 