### PR TITLE
Include BLOCK nodes in the CFG and enable tracking for them

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DdgGenerator.scala
@@ -59,8 +59,7 @@ class DdgGenerator {
   }
 
   private def shouldBeDisplayed(v: Node): Boolean = !(
-    v.isInstanceOf[Block] ||
-      v.isInstanceOf[ControlStructure] ||
+    v.isInstanceOf[ControlStructure] ||
       v.isInstanceOf[JumpTarget]
   )
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
@@ -1,7 +1,5 @@
 package io.joern.dataflowengineoss.passes.reachingdef
 
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
-
 /** A general data flow problem, formulated as in the Dragon Book, Second Edition on page 626, with mild modifications.
   * In particular, instead of allowing only for the specification of a boundary, we allow initialization of IN and OUT.
   */

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -1,7 +1,5 @@
 package io.joern.dataflowengineoss.passes.reachingdef
 
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
-
 import scala.collection.mutable
 
 class DataFlowSolver {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -209,7 +209,6 @@ class DdgGenerator {
       case _: FieldIdentifier  => false
       case _: JumpTarget       => false
       case _: MethodReturn     => false
-      case _: Block            => false
       case _                   => true
     }
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -102,7 +102,10 @@ class DdgGenerator {
             val edgesToAdd = in(node).toList.flatMap { inDef =>
               numberToNode.get(inDef) match {
                 case Some(identifier: Identifier) => Some(identifier)
-                case _                            => None
+                case Some(call: Call) if call.name != Operators.fieldAccess =>
+                  Some(call)
+                case _ =>
+                  None
               }
             }
             edgesToAdd.foreach { inNode =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -107,9 +107,8 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
 
     val res = curNode match {
       // Case 1: we have reached a source => return result and continue traversing
-      case x if sources.contains(x.asInstanceOf[NodeType]) => {
+      case x if sources.contains(x.asInstanceOf[NodeType]) =>
         Vector(ReachableByResult(path, table, callSiteStack)) ++ deduplicate(computeResultsForParents())
-      }
       // Case 1.5: the second node on the path is a METHOD_RETURN and its a source. This clumsy check is necessary because
       // for method returns, the derived tasks we create in TaskCreator jump immediately to the RETURN statements in
       // order to only pick up values that actually propagate via a RETURN and don't just flow to METHOD_RETURN because
@@ -118,6 +117,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
           if path.size > 1 && path(1).node
             .isInstanceOf[MethodReturn] && sources.contains(path(1).node.asInstanceOf[NodeType]) =>
         Vector(ReachableByResult(path.drop(1), table, callSiteStack)) ++ deduplicate(computeResultsForParents())
+
       // Case 2: we have reached a method parameter (that isn't a source) => return partial result and stop traversing
       case _: MethodParameterIn =>
         Vector(ReachableByResult(path, table, callSiteStack, partial = true))
@@ -129,6 +129,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
             path
           ) =>
         createPartialResultForOutputArgOrRet()
+
       // Case 4: we have reached an argument to an internal method without semantic (output argument) and
       // this isn't the start node nor is it the argument for the parameter we just expanded => return partial result and stop traversing
       case arg: Expression
@@ -136,11 +137,11 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
             isCallToInternalMethodWithoutSemantic(c)
           ) && !arg.inCall.headOption.exists(x => isArgOrRetOfMethodWeCameFrom(x, path)) =>
         createPartialResultForOutputArgOrRet()
+
       // All other cases: expand into parents
       case _ =>
         deduplicate(computeResultsForParents())
     }
-
     table.add(curNode, res)
     res
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -57,7 +57,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows from identifiers to return values of `flow`" in {
       val source = cpg.identifier
       val sink   = cpg.method.name("flow").methodReturn
-      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 9
+      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 8
     }
 
     "find flows from z to method returns of flow" in {
@@ -1524,7 +1524,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows from identifiers to return values of `flow`" in {
       val source = cpg.identifier
       val sink   = cpg.method.name("flow").methodReturn
-      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 9
+      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 8
     }
 
     "find flows from z to method returns of flow" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -554,4 +554,14 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     sink.reachableBy(src).size shouldBe 1
   }
 
+  "Flow through object given via object notation" in {
+    val cpg: Cpg = code("""
+        |const x = new Foo(y);
+        |""".stripMargin)
+
+    val sink = cpg.call.l
+    val src  = cpg.identifier("y").l
+    println(sink.reachableByFlows(src).p)
+  }
+
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -559,9 +559,9 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
         |const x = new Foo(y);
         |""".stripMargin)
 
-    val sink = cpg.call.l
+    val sink = cpg.identifier("x").l
     val src  = cpg.identifier("y").l
-    println(sink.reachableByFlows(src).p)
+    sink.reachableBy(src).size shouldBe 1
   }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -554,7 +554,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     sink.reachableBy(src).size shouldBe 1
   }
 
-  "Flow through object given via object notation" in {
+  "Flow through constructor" in {
     val cpg: Cpg = code("""
         |const x = new Foo(y);
         |""".stripMargin)
@@ -562,6 +562,28 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val sink = cpg.identifier("x").l
     val src  = cpg.identifier("y").l
     sink.reachableBy(src).size shouldBe 1
+  }
+
+  "Flow through constructor and object notation" in {
+    val cpg: Cpg = code("""
+                          |const x = new Foo({ z : y } );
+                          |""".stripMargin)
+
+    val sink = cpg.identifier("x").l
+    val src  = cpg.identifier("y").l
+    sink.reachableBy(src).size shouldBe 1
+  }
+
+  "Flow from field via object notation" in {
+    val cpg: Cpg = code("""
+                          |const x = { p : a.y } ;
+                          |""".stripMargin)
+
+    val sink = cpg.identifier("x").l
+    val src  = cpg.fieldAccess.where(_.fieldIdentifier.canonicalName("y")).l
+    src.size shouldBe 1
+    sink.size shouldBe 1
+    println(sink.reachableBy(src).l)
   }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/DependencyCfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/DependencyCfgCreationPassTest.scala
@@ -8,15 +8,13 @@ class DependencyCfgCreationPassTest extends AbstractCfgPassTest {
     "be correct for JSON.parse" in CfgFixture("""JSON.parse("foo");""") { implicit cpg =>
       succOf(":program") shouldBe expected((""""foo"""", AlwaysEdge))
       succOf(""""foo"""") shouldBe expected(("""JSON.parse("foo")""", AlwaysEdge))
-      succOf("""JSON.parse("foo")""") shouldBe expected(("<empty>", AlwaysEdge))
-      succOf("""<empty>""") shouldBe expected(("RET", AlwaysEdge))
+      succOf("""JSON.parse("foo")""") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "have correct structure for JSON.stringify" in CfgFixture("""JSON.stringify(foo);""") { implicit cpg =>
       succOf(":program") shouldBe expected(("foo", AlwaysEdge))
       succOf("foo") shouldBe expected(("JSON.stringify(foo)", AlwaysEdge))
-      succOf("JSON.stringify(foo)") shouldBe expected(("<empty>", AlwaysEdge))
-      succOf("<empty>") shouldBe expected(("RET", AlwaysEdge))
+      succOf("JSON.stringify(foo)") shouldBe expected(("RET", AlwaysEdge))
     }
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/DependencyCfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/DependencyCfgCreationPassTest.scala
@@ -8,13 +8,15 @@ class DependencyCfgCreationPassTest extends AbstractCfgPassTest {
     "be correct for JSON.parse" in CfgFixture("""JSON.parse("foo");""") { implicit cpg =>
       succOf(":program") shouldBe expected((""""foo"""", AlwaysEdge))
       succOf(""""foo"""") shouldBe expected(("""JSON.parse("foo")""", AlwaysEdge))
-      succOf("""JSON.parse("foo")""") shouldBe expected(("RET", AlwaysEdge))
+      succOf("""JSON.parse("foo")""") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("""<empty>""") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "have correct structure for JSON.stringify" in CfgFixture("""JSON.stringify(foo);""") { implicit cpg =>
       succOf(":program") shouldBe expected(("foo", AlwaysEdge))
       succOf("foo") shouldBe expected(("JSON.stringify(foo)", AlwaysEdge))
-      succOf("JSON.stringify(foo)") shouldBe expected(("RET", AlwaysEdge))
+      succOf("JSON.stringify(foo)") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("<empty>") shouldBe expected(("RET", AlwaysEdge))
     }
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/JsClassesCfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/JsClassesCfgCreationPassTest.scala
@@ -14,7 +14,8 @@ class JsClassesCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("MyClass") shouldBe expected(("_tmp_0", 1, AlwaysEdge))
       succOf("_tmp_0", 1) shouldBe expected(("new MyClass()", AlwaysEdge))
       succOf("new MyClass()", NodeTypes.CALL) shouldBe expected(("_tmp_0", 2, AlwaysEdge))
-      succOf("_tmp_0", 2) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 2) shouldBe expected(("new MyClass()", AlwaysEdge))
+      succOf("new MyClass()") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for simple new with arguments" in CfgFixture("new MyClass(arg1, arg2)") { implicit cpg =>
@@ -27,7 +28,8 @@ class JsClassesCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("arg1") shouldBe expected(("arg2", AlwaysEdge))
       succOf("arg2") shouldBe expected(("new MyClass(arg1, arg2)", AlwaysEdge))
       succOf("new MyClass(arg1, arg2)", NodeTypes.CALL) shouldBe expected(("_tmp_0", 2, AlwaysEdge))
-      succOf("_tmp_0", 2) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 2) shouldBe expected(("new MyClass(arg1, arg2)", AlwaysEdge))
+      succOf("new MyClass(arg1, arg2)") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for new with access path" in CfgFixture("new foo.bar.MyClass()") { implicit cpg =>
@@ -42,7 +44,8 @@ class JsClassesCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("foo.bar.MyClass") shouldBe expected(("_tmp_0", 1, AlwaysEdge))
       succOf("_tmp_0", 1) shouldBe expected(("new foo.bar.MyClass()", AlwaysEdge))
       succOf("new foo.bar.MyClass()", NodeTypes.CALL) shouldBe expected(("_tmp_0", 2, AlwaysEdge))
-      succOf("_tmp_0", 2) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 2) shouldBe expected(("new foo.bar.MyClass()", AlwaysEdge))
+      succOf("new foo.bar.MyClass()") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be structure for throw new exceptions" in CfgFixture("function foo() { throw new Foo() }") { implicit cpg =>
@@ -53,7 +56,8 @@ class JsClassesCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("Foo") shouldBe expected(("_tmp_0", 1, AlwaysEdge))
       succOf("_tmp_0", 1) shouldBe expected(("new Foo()", AlwaysEdge))
       succOf("new Foo()", NodeTypes.CALL) shouldBe expected(("_tmp_0", 2, AlwaysEdge))
-      succOf("_tmp_0", 2) shouldBe expected(("throw new Foo()", AlwaysEdge))
+      succOf("_tmp_0", 2) shouldBe expected(("new Foo()", AlwaysEdge))
+      succOf("new Foo()") shouldBe expected(("throw new Foo()", AlwaysEdge))
       succOf("throw new Foo()") shouldBe expected(("RET", AlwaysEdge))
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/MixedCfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/MixedCfgCreationPassTest.scala
@@ -25,7 +25,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("b", 1) shouldBe expected(("_tmp_0.b", AlwaysEdge))
       succOf("_tmp_0.b") shouldBe expected(("b = _tmp_0.b", AlwaysEdge))
       succOf("b = _tmp_0.b") shouldBe expected(("_tmp_0", 3, AlwaysEdge))
-      succOf("_tmp_0", 3) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 3) shouldBe expected(("{a, b}", AlwaysEdge))
+      succOf("{a, b}") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for object destruction assignment with declaration and ternary init" in CfgFixture(
@@ -52,7 +53,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("b", 1) shouldBe expected(("_tmp_0.b", AlwaysEdge))
       succOf("_tmp_0.b") shouldBe expected(("b = _tmp_0.b", AlwaysEdge))
       succOf("b = _tmp_0.b") shouldBe expected(("_tmp_0", 3, AlwaysEdge))
-      succOf("_tmp_0", 3) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 3) shouldBe expected(("{ a, b }", AlwaysEdge))
+      succOf("{ a, b }") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for object destruction assignment with reassignment" in CfgFixture("var {a: n, b: m} = x") {
@@ -73,7 +75,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
         succOf("b") shouldBe expected(("_tmp_0.b", AlwaysEdge))
         succOf("_tmp_0.b") shouldBe expected(("m = _tmp_0.b", AlwaysEdge))
         succOf("m = _tmp_0.b") shouldBe expected(("_tmp_0", 3, AlwaysEdge))
-        succOf("_tmp_0", 3) shouldBe expected(("RET", AlwaysEdge))
+        succOf("_tmp_0", 3) shouldBe expected(("{a: n, b: m}", AlwaysEdge))
+        succOf("{a: n, b: m}") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for object destruction assignment with reassignment and defaults" in CfgFixture(
@@ -119,7 +122,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
         expected(("m = _tmp_0.b === void 0 ? 2 : _tmp_0.b", AlwaysEdge))
       succOf("m = _tmp_0.b === void 0 ? 2 : _tmp_0.b") shouldBe
         expected(("_tmp_0", 5, AlwaysEdge))
-      succOf("_tmp_0", 5) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 5) shouldBe expected(("{a: n = 1, b: m = 2}", AlwaysEdge))
+      succOf("{a: n = 1, b: m = 2}") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for object destruction assignment with rest" in CfgFixture("var {a, ...rest} = x") { implicit cpg =>
@@ -140,7 +144,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("_tmp_0.rest") shouldBe expected(("rest = _tmp_0.rest", AlwaysEdge))
       succOf("rest = _tmp_0.rest") shouldBe expected(("_tmp_0", 3, AlwaysEdge))
 
-      succOf("_tmp_0", 3) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 3) shouldBe expected(("{a, ...rest}", AlwaysEdge))
+      succOf("{a, ...rest}") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for object destruction assignment with computed property name" ignore CfgFixture(
@@ -161,7 +166,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
         ("param1_0", 1, FalseEdge)
       )
       succOf("param1_0", 1) shouldBe expected(("param1_0 === void 0 ? {} : param1_0", AlwaysEdge))
-      succOf("_tmp_0") shouldBe expected(("param1_0 === void 0 ? {} : param1_0", AlwaysEdge))
+      succOf("_tmp_0") shouldBe expected(("{}", AlwaysEdge))
+      succOf("{}") shouldBe expected(("param1_0 === void 0 ? {} : param1_0", AlwaysEdge))
       succOf("param1_0 === void 0 ? {} : param1_0") shouldBe expected(
         ("_tmp_1 = param1_0 === void 0 ? {} : param1_0", AlwaysEdge)
       )
@@ -175,7 +181,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
         ("_tmp_2", TrueEdge), // holds {}
         ("_tmp_1", 2, FalseEdge)
       )
-      succOf("_tmp_2") shouldBe expected(("_tmp_1.id === void 0 ? {} : _tmp_1.id", AlwaysEdge))
+      succOf("_tmp_2") shouldBe expected(("{}", AlwaysEdge))
+      succOf("{}", 1) shouldBe expected(("_tmp_1.id === void 0 ? {} : _tmp_1.id", AlwaysEdge))
       succOf("_tmp_1", 2) shouldBe expected(("id", 2, AlwaysEdge))
 
       succOf("_tmp_1.id === void 0 ? {} : _tmp_1.id") shouldBe expected(
@@ -190,7 +197,9 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("b", 1) shouldBe expected(("_tmp_1.b", AlwaysEdge))
       succOf("_tmp_1.b") shouldBe expected(("b = _tmp_1.b", AlwaysEdge))
       succOf("b = _tmp_1.b") shouldBe expected(("_tmp_1", 4, AlwaysEdge))
-      succOf("_tmp_1", 4) shouldBe expected(("id", 3, AlwaysEdge))
+      succOf("_tmp_1", 4) shouldBe expected(("{id = {}, b}", AlwaysEdge))
+      succOf("{id = {}, b}") shouldBe expected(("id", AlwaysEdge))
+
     }
 
     "be correct for object destruction assignment as parameter" in CfgFixture("""
@@ -226,7 +235,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("1") shouldBe expected(("_tmp_0[1]", AlwaysEdge))
       succOf("_tmp_0[1]") shouldBe expected(("b = _tmp_0[1]", AlwaysEdge))
       succOf("b = _tmp_0[1]") shouldBe expected(("_tmp_0", 3, AlwaysEdge))
-      succOf("_tmp_0", 3) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 3) shouldBe expected(("[a, b]", AlwaysEdge))
+      succOf("[a, b]") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for array destruction assignment without declaration" in CfgFixture("[a, b] = x") { implicit cpg =>
@@ -247,7 +257,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("1") shouldBe expected(("_tmp_0[1]", AlwaysEdge))
       succOf("_tmp_0[1]") shouldBe expected(("b = _tmp_0[1]", AlwaysEdge))
       succOf("b = _tmp_0[1]") shouldBe expected(("_tmp_0", 3, AlwaysEdge))
-      succOf("_tmp_0", 3) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 3) shouldBe expected(("[a, b]", AlwaysEdge))
+      succOf("[a, b]") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for array destruction assignment with defaults" in CfgFixture("var [a = 1, b = 2] = x") {
@@ -291,8 +302,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
           ("b = _tmp_0[1] === void 0 ? 2 : _tmp_0[1]", AlwaysEdge)
         )
         succOf("b = _tmp_0[1] === void 0 ? 2 : _tmp_0[1]") shouldBe expected(("_tmp_0", 5, AlwaysEdge))
-
-        succOf("_tmp_0", 5) shouldBe expected(("RET", AlwaysEdge))
+        succOf("_tmp_0", 5) shouldBe expected(("[a = 1, b = 2]", AlwaysEdge))
+        succOf("[a = 1, b = 2]") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for array destruction assignment with ignores" in CfgFixture("var [a, , b] = x") { implicit cpg =>
@@ -313,7 +324,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("2") shouldBe expected(("_tmp_0[2]", AlwaysEdge))
       succOf("_tmp_0[2]") shouldBe expected(("b = _tmp_0[2]", AlwaysEdge))
       succOf("b = _tmp_0[2]") shouldBe expected(("_tmp_0", 3, AlwaysEdge))
-      succOf("_tmp_0", 3) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 3) shouldBe expected(("[a, , b]", AlwaysEdge))
+      succOf("[a, , b]") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for array destruction assignment with rest" in CfgFixture("var [a, ...rest] = x") { implicit cpg =>
@@ -334,7 +346,8 @@ class MixedCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("1") shouldBe expected(("_tmp_0[1]", AlwaysEdge))
       succOf("_tmp_0[1]") shouldBe expected(("rest = _tmp_0[1]", AlwaysEdge))
       succOf("rest = _tmp_0[1]") shouldBe expected(("_tmp_0", 3, AlwaysEdge))
-      succOf("_tmp_0", 3) shouldBe expected(("RET", AlwaysEdge))
+      succOf("_tmp_0", 3) shouldBe expected(("[a, ...rest]", AlwaysEdge))
+      succOf("[a, ...rest]") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for array destruction assignment as parameter" in CfgFixture("""

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/SimpleCfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/SimpleCfgCreationPassTest.scala
@@ -16,7 +16,8 @@ class SimpleCfgCreationPassTest extends AbstractCfgPassTest {
       succOf("class Foo") shouldBe expected(("bar", AlwaysEdge))
       succOf("bar") shouldBe expected(("this", AlwaysEdge))
       succOf("this", NodeTypes.IDENTIFIER) shouldBe expected(("bar()", AlwaysEdge))
-      succOf("bar()") shouldBe expected(("let x = (class Foo {}, bar())", AlwaysEdge))
+      succOf("bar()") shouldBe expected(("(class Foo {}, bar())", AlwaysEdge))
+      succOf("(class Foo {}, bar())") shouldBe expected(("let x = (class Foo {}, bar())", AlwaysEdge))
       succOf("let x = (class Foo {}, bar())") shouldBe expected(("RET", AlwaysEdge))
     }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -106,7 +106,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
         cfgForConditionalExpression(call)
       case call: Call if call.dispatchType == DispatchTypes.INLINED =>
         cfgForInlinedCall(call)
-      case _: Call | _: FieldIdentifier | _: Identifier | _: Literal | _: Unknown =>
+      case _: Call | _: FieldIdentifier | _: Identifier | _: Literal | _: Block | _: Unknown =>
         cfgForChildren(node) ++ cfgForSingleNode(node.asInstanceOf[CfgNode])
       case _ =>
         cfgForChildren(node)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -106,6 +106,14 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
         cfgForConditionalExpression(call)
       case call: Call if call.dispatchType == DispatchTypes.INLINED =>
         cfgForInlinedCall(call)
+      case block: Block =>
+        // Only include block nodes that do not describe the entire
+        // method body or the bodies of control structures
+        if (block.astParent.isMethod || block.astParent.isControlStructure) {
+          cfgForChildren(block)
+        } else {
+          cfgForChildren(node) ++ cfgForSingleNode(node.asInstanceOf[CfgNode])
+        }
       case _: Call | _: FieldIdentifier | _: Identifier | _: Literal | _: Block | _: Unknown =>
         cfgForChildren(node) ++ cfgForSingleNode(node.asInstanceOf[CfgNode])
       case _ =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -109,7 +109,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
       case block: Block =>
         // Only include block nodes that do not describe the entire
         // method body or the bodies of control structures
-        if (block.astParent.isMethod || block.astParent.isControlStructure) {
+        if (block._astIn.hasNext && (block.astParent.isMethod || block.astParent.isControlStructure)) {
           cfgForChildren(block)
         } else {
           cfgForChildren(node) ++ cfgForSingleNode(node.asInstanceOf[CfgNode])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
@@ -89,7 +89,7 @@ package object testing {
       fileName: String = ""
     ): MockCpg =
       withCustom { (graph, _) =>
-        val retParam  = NewMethodReturn().typeFullName("int")
+        val retParam  = NewMethodReturn().typeFullName("int").order(10)
         val param     = NewMethodParameterIn().order(1).index(1).name("param1")
         val paramType = NewType().name("paramtype")
         val paramOut  = NewMethodParameterOut().name("param1").order(1)


### PR DESCRIPTION
With this PR, we now include `BLOCK` nodes in the control flow graph in order to enable data flow tracking through constructor calls and Javascript objects given in object notation, e.g., `{ a: b }`.