### PR TITLE
Apply data flow semantics at generation time

### DIFF
--- a/benchmarks/src/test/scala/io/joern/benchmarks/testfixtures/BenchmarkFixture.scala
+++ b/benchmarks/src/test/scala/io/joern/benchmarks/testfixtures/BenchmarkFixture.scala
@@ -152,7 +152,9 @@ class BenchmarkCpgContext {
     applyDefaultOverlays(cpg.get)
     val context = new LayerCreatorContext(cpg.get)
     val options = new OssDataFlowOptions()
-    new OssDataFlow(options).run(context)
+    val semanticsFile: String            = ProjectRoot.relativise("benchmarks/src/test/resources/default.semantics")
+    lazy val defaultSemantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFile))
+    new OssDataFlow(options)(defaultSemantics).run(context)
     cpg.get
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -1,6 +1,7 @@
 package io.joern.dataflowengineoss.layers.dataflows
 
 import io.joern.dataflowengineoss.passes.reachingdef.ReachingDefPass
+import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
 object OssDataFlow {
@@ -12,7 +13,7 @@ object OssDataFlow {
 
 class OssDataFlowOptions(var maxNumberOfDefinitions: Int = 4000) extends LayerCreatorOptions {}
 
-class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
+class OssDataFlow(opts: OssDataFlowOptions)(implicit s: Semantics) extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
@@ -1,0 +1,47 @@
+package io.joern.dataflowengineoss.passes.reachingdef
+
+import io.joern.dataflowengineoss.queryengine.Engine.isOutputArgOfInternalMethod
+import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, Expression, StoredNode}
+import io.shiftleft.semanticcpg.language._
+import io.joern.dataflowengineoss.language._
+import overflowdb.traversal._
+
+object EdgeValidator {
+
+  /** Determines whether the edge from `parentNode`to `childNode` is valid, according to the given semantics.
+    */
+  def isValidEdge(childNode: CfgNode, parentNode: CfgNode)(implicit semantics: Semantics): Boolean = {
+    (childNode, parentNode) match {
+      case (childNode: Expression, parentNode)
+          if (isCallRetval(parentNode) || !isValidEdgeToExpression(parentNode, childNode)) =>
+        false
+      case (_: Expression, _: Expression)                    => true
+      case (childNode: Expression, _) if !(childNode.isUsed) => false
+      case (_: Expression, _)                                => true
+      case (_, parentNode)                                   => !isCallRetval(parentNode)
+    }
+  }
+
+  private def isValidEdgeToExpression(parNode: CfgNode, curNode: Expression)(implicit semantics: Semantics): Boolean = {
+    parNode match {
+      case parentNode: Expression =>
+        val sameCallSite = parentNode.inCall.l == curNode.start.inCall.l
+        !(sameCallSite && isOutputArgOfInternalMethod(parentNode)) &&
+        (sameCallSite && parentNode.isUsed && curNode.isDefined || !sameCallSite && curNode.isUsed)
+      case _ =>
+        curNode.isUsed
+    }
+  }
+
+  private def isCallRetval(parentNode: StoredNode)(implicit semantics: Semantics): Boolean = {
+    parentNode match {
+      case call: Call =>
+        val sem = semantics.forMethod(call.methodFullName)
+        sem.isDefined && !sem.get.mappings.map(_._2).contains(-1)
+      case _ =>
+        false
+    }
+  }
+
+}

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -1,5 +1,6 @@
 package io.joern.dataflowengineoss.passes.reachingdef
 
+import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.passes.ForkJoinParallelCpgPass
@@ -10,7 +11,8 @@ import scala.collection.mutable
 
 /** A pass that calculates reaching definitions ("data dependencies").
   */
-class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends ForkJoinParallelCpgPass[Method](cpg) {
+class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000)(implicit s: Semantics)
+    extends ForkJoinParallelCpgPass[Method](cpg) {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
@@ -25,7 +27,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Fork
     }
 
     val solution     = new DataFlowSolver().calculateMopSolutionForwards(problem)
-    val ddgGenerator = new DdgGenerator()
+    val ddgGenerator = new DdgGenerator(s)
     ddgGenerator.addReachingDefEdges(dstGraph, problem, solution)
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -122,26 +122,17 @@ object Engine {
     * @param path
     *   the path that has been expanded to reach the `curNode`
     */
-  def expandIn(curNode: CfgNode, path: Vector[PathElement], edgeProvider: (CfgNode => Vector[Edge]) = null)(implicit
-    semantics: Semantics
-  ): Vector[PathElement] = {
-
-    val parentNodes = if (edgeProvider == null) {
-      ddgInE(curNode, path)
-    } else {
-      edgeProvider(curNode)
-    }
-
+  def expandIn(curNode: CfgNode, path: Vector[PathElement])(implicit semantics: Semantics): Vector[PathElement] = {
     curNode match {
       case argument: Expression =>
-        val (arguments, nonArguments) = parentNodes.partition(_.outNode().isInstanceOf[Expression])
+        val (arguments, nonArguments) = ddgInE(curNode, path).partition(_.outNode().isInstanceOf[Expression])
         val elemsForArguments = arguments.flatMap { e =>
           elemForArgument(e, argument)
         }
         val elems = elemsForArguments ++ nonArguments.flatMap(edgeToPathElement)
         elems
       case _ =>
-        parentNodes.flatMap(edgeToPathElement)
+        ddgInE(curNode, path).flatMap(edgeToPathElement)
     }
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -122,17 +122,26 @@ object Engine {
     * @param path
     *   the path that has been expanded to reach the `curNode`
     */
-  def expandIn(curNode: CfgNode, path: Vector[PathElement])(implicit semantics: Semantics): Vector[PathElement] = {
+  def expandIn(curNode: CfgNode, path: Vector[PathElement], edgeProvider: (CfgNode => Vector[Edge]) = null)(implicit
+    semantics: Semantics
+  ): Vector[PathElement] = {
+
+    val parentNodes = if (edgeProvider == null) {
+      ddgInE(curNode, path)
+    } else {
+      edgeProvider(curNode)
+    }
+
     curNode match {
       case argument: Expression =>
-        val (arguments, nonArguments) = ddgInE(curNode, path).partition(_.outNode().isInstanceOf[Expression])
+        val (arguments, nonArguments) = parentNodes.partition(_.outNode().isInstanceOf[Expression])
         val elemsForArguments = arguments.flatMap { e =>
           elemForArgument(e, argument)
         }
         val elems = elemsForArguments ++ nonArguments.flatMap(edgeToPathElement)
         elems
       case _ =>
-        ddgInE(curNode, path).flatMap(edgeToPathElement)
+        parentNodes.flatMap(edgeToPathElement)
     }
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -175,14 +175,10 @@ object Engine {
       .inE(EdgeTypes.REACHING_DEF)
       .asScala
       .filter { e =>
-        if (node.isInstanceOf[Block]) {
-          !e.outNode().isInstanceOf[Method]
-        } else {
-          e.outNode() match {
-            case srcNode: CfgNode =>
-              !srcNode.isInstanceOf[Method] && !path.map(_.node).contains(srcNode) && !isCallRetval(srcNode)
-            case _ => false
-          }
+        e.outNode() match {
+          case srcNode: CfgNode =>
+            !srcNode.isInstanceOf[Method] && !path.map(_.node).contains(srcNode) && !isCallRetval(srcNode)
+          case _ => false
         }
       }
       .toVector

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/dotgenerator/DotDdgGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/dotgenerator/DotDdgGeneratorTests.scala
@@ -23,7 +23,7 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       inside(cpg.method.name("foo").dotDdg(semantics).l) { case List(elem) =>
         val lines = elem.split("\n")
         lines.head should startWith("digraph \"foo\"")
-        lines.count(x => x.contains("->")) shouldBe 32
+        lines.count(x => x.contains("->")) shouldBe 31
         lines.last should startWith("}")
       }
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -12,7 +12,7 @@ class DataFlowCodeToCpgSuite extends CCodeToCpgSuite {
 
   private val semanticsFilename: String = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
 
-  protected val semantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
+  implicit protected val semantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
 
   protected implicit val context: EngineContext = EngineContext(semantics)
 

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/DataFlowBinToCpgSuite.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/DataFlowBinToCpgSuite.scala
@@ -21,7 +21,7 @@ class DataFlowBinToCpgSuite extends GhidraBinToCpgSuite {
 
   var semanticsFilename =
     ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
-  var semantics: Semantics            = _
+  implicit var semantics: Semantics            = _
   implicit var context: EngineContext = _
 
   override def beforeAll(): Unit = {

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/DataFlowTests.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/DataFlowTests.scala
@@ -13,6 +13,11 @@ import io.shiftleft.utils.ProjectRoot
 
 class DataFlowTests extends GhidraBinToCpgSuite {
 
+  implicit val resolver: ICallResolver = NoResolve
+  val semanticsFilename               = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
+  implicit val semantics: Semantics            = Semantics.fromList(new Parser().parseFile(semanticsFilename))
+  implicit var context: EngineContext = EngineContext(semantics)
+
   override def passes(cpg: Cpg): Unit = {
     applyDefaultOverlays(cpg)
     val context = new LayerCreatorContext(cpg)
@@ -25,11 +30,6 @@ class DataFlowTests extends GhidraBinToCpgSuite {
     buildCpgForBin("linux/mips/t1_to_t9")
   }
 
-  implicit val resolver: ICallResolver = NoResolve
-
-  val semanticsFilename               = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
-  val semantics: Semantics            = Semantics.fromList(new Parser().parseFile(semanticsFilename))
-  implicit var context: EngineContext = EngineContext(semantics)
 
   "should find flows through `add*` instructions" in {
     def source = cpg.call.code("li t1,0x2a").argument(1)

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/DataFlowThroughLoHiRegistersTests.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/mips/DataFlowThroughLoHiRegistersTests.scala
@@ -37,7 +37,7 @@ class DataFlowThroughLoHiRegistersTests extends GhidraBinToCpgSuite {
        |"<operator>.incBy" 1->1 2->1 3->1 4->1
        |"<operator>.rotateRight" 2->1
        |""".stripMargin
-  val semantics: Semantics            = Semantics.fromList(new Parser().parse(customSemantics))
+  implicit val semantics: Semantics            = Semantics.fromList(new Parser().parse(customSemantics))
   implicit val context: EngineContext = EngineContext(semantics)
 
   "should find flows through `div*` instructions" in {

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/x86/DataFlowTests.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/querying/x86/DataFlowTests.scala
@@ -13,6 +13,11 @@ import io.shiftleft.utils.ProjectRoot
 
 class DataFlowTests extends GhidraBinToCpgSuite {
 
+  implicit val resolver: ICallResolver = NoResolve
+  val semanticsFilename                = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
+  implicit val semantics: Semantics             = Semantics.fromList(new Parser().parseFile(semanticsFilename))
+  implicit var context: EngineContext  = EngineContext(semantics)
+
   override def passes(cpg: Cpg): Unit = {
     val context = new LayerCreatorContext(cpg)
     new Base().run(context)
@@ -30,11 +35,6 @@ class DataFlowTests extends GhidraBinToCpgSuite {
   }
 
   "The data flow should contain " in {
-    implicit val resolver: ICallResolver = NoResolve
-    val semanticsFilename                = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
-    val semantics: Semantics             = Semantics.fromList(new Parser().parseFile(semanticsFilename))
-    implicit var context: EngineContext  = EngineContext(semantics)
-
     def source = cpg.method.name("dataflow").call.argument.code("1")
     def sink =
       cpg.method

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -2,8 +2,10 @@ package io.joern.javasrc2cpg
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, writeCodeToFile}
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.utils.ProjectRoot
 
 import java.io.{File, PrintWriter}
 import java.nio.file.Files
@@ -23,8 +25,10 @@ class JavaSrc2CpgTestContext {
       val cpg = javaSrc2Cpg.createCpg(config)
       applyDefaultOverlays(cpg.get)
       if (runDataflow) {
-        val context = new LayerCreatorContext(cpg.get)
-        val options = new OssDataFlowOptions()
+        val context                       = new LayerCreatorContext(cpg.get)
+        val options                       = new OssDataFlowOptions()
+        val semanticsFilename             = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
+        implicit val semantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
         new OssDataFlow(options).run(context)
       }
       buildResult = Some(cpg.get)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -30,9 +30,9 @@ class JavaSrcCodeToCpgFixture extends CodeToCpgFixture(new JavaSrcFrontend(delom
 class JavaSrcCode2CpgFixture(withOssDataflow: Boolean = false, delombokMode: String = "default")
     extends Code2CpgFixture(new JavaSrcFrontend(delombokMode)) {
 
-  val semanticsFile: String            = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
-  lazy val defaultSemantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFile))
-  implicit val resolver: ICallResolver = NoResolve
+  val semanticsFile: String = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
+  implicit lazy val defaultSemantics: Semantics  = Semantics.fromList(new Parser().parseFile(semanticsFile))
+  implicit val resolver: ICallResolver           = NoResolve
   implicit lazy val engineContext: EngineContext = EngineContext(defaultSemantics, EngineConfig(maxCallDepth = 4))
 
   override def applyPasses(cpg: Cpg): Unit = {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/Jimple2CpgTestContext.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/Jimple2CpgTestContext.scala
@@ -1,10 +1,14 @@
 package io.joern.jimple2cpg
 
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.joern.dataflowengineoss.queryengine.EngineContext
+import io.joern.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
 import io.shiftleft.semanticcpg.layers._
+import io.shiftleft.utils.ProjectRoot
 
 import java.io.{File, PrintWriter}
 import java.nio.file.Files
@@ -24,6 +28,9 @@ class Jimple2CpgTestContext {
       if (runDataflow) {
         val context = new LayerCreatorContext(cpg)
         val options = new OssDataFlowOptions()
+
+        val semanticsFilename             = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
+        implicit val semantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
         new OssDataFlow(options).run(context)
       }
       buildResult = Some(cpg)

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -10,9 +10,8 @@ import io.shiftleft.utils.ProjectRoot
 
 class DataFlowCodeToCpgSuite extends JsSrc2CpgSuite {
 
-  val semanticsFilename: String = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
-
-  var semantics: Semantics = _
+  val semanticsFilename: String     = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
+  implicit var semantics: Semantics = _
 
   implicit var context: EngineContext = _
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -30,7 +30,7 @@ class KotlinFrontend(withTestResourcePaths: Boolean = false) extends LanguageFro
 class KotlinCode2CpgFixture(withOssDataflow: Boolean = false, withDefaultJars: Boolean = false)
     extends Code2CpgFixture(new KotlinFrontend(withTestResourcePaths = withDefaultJars)) {
 
-  val defaultSemantics = {
+  implicit val defaultSemantics = {
     val semanticsFilename: String = ProjectRoot.relativise("joern-cli/src/main/resources/default.semantics")
     Semantics.fromList(new Parser().parseFile(semanticsFilename))
   }

--- a/joern-cli/src/main/scala/io/joern/joerncli/CpgBasedTool.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/CpgBasedTool.scala
@@ -2,6 +2,7 @@ package io.joern.joerncli
 
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoaderConfig
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
@@ -22,7 +23,7 @@ object CpgBasedTool {
 
   /** Add the data flow layer to the CPG if it does not exist yet.
     */
-  def addDataFlowOverlayIfNonExistent(cpg: Cpg): Unit = {
+  def addDataFlowOverlayIfNonExistent(cpg: Cpg)(implicit s: Semantics): Unit = {
     if (!cpg.metaData.overlays.exists(_ == OssDataFlow.overlayName)) {
       System.err.println("CPG does not have dataflow overlay. Calculating.")
       val opts    = new OssDataFlowOptions()

--- a/joern-cli/src/main/scala/io/joern/joerncli/DefaultOverlays.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/DefaultOverlays.scala
@@ -1,6 +1,8 @@
 package io.joern.joerncli
 
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.joern.joerncli.console.JoernWorkspaceLoader
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers._
@@ -18,8 +20,12 @@ object DefaultOverlays {
   def create(storeFilename: String, maxNumberOfDefinitions: Int = defaultMaxNumberOfDefinitions): Cpg = {
     val cpg = CpgBasedTool.loadFromOdb(storeFilename)
     applyDefaultOverlays(cpg)
-    val context = new LayerCreatorContext(cpg)
-    val options = new OssDataFlowOptions(maxNumberOfDefinitions)
+    val context                       = new LayerCreatorContext(cpg)
+    val options                       = new OssDataFlowOptions(maxNumberOfDefinitions)
+    implicit val semantics: Semantics = JoernWorkspaceLoader.defaultSemantics
+    if (semantics.elements.isEmpty) {
+      System.err.println("Warning: semantics are empty.")
+    }
     new OssDataFlow(options).run(context)
     cpg
   }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -5,7 +5,9 @@ import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows._
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.joern.joerncli.CpgBasedTool.{exitIfInvalid, exitWithError}
+import io.joern.joerncli.console.Joern.semantics
 import io.joern.joerncli.console.JoernWorkspaceLoader
+import io.joern.joerncli.console.JoernWorkspaceLoader.defaultSemantics
 import io.joern.x2cpg.layers._
 import io.shiftleft.semanticcpg.layers._
 import overflowdb.Graph
@@ -59,15 +61,15 @@ object JoernExport extends App {
     exitIfInvalid(config.outDir, config.cpgFileName)
 
     Using.resource(CpgBasedTool.loadFromOdb(config.cpgFileName)) { cpg =>
-      CpgBasedTool.addDataFlowOverlayIfNonExistent(cpg)
-      val context = new LayerCreatorContext(cpg)
-
-      mkdir(File(config.outDir))
       implicit val semantics: Semantics = JoernWorkspaceLoader.defaultSemantics
       if (semantics.elements.isEmpty) {
         System.err.println("Warning: semantics are empty.")
       }
 
+      CpgBasedTool.addDataFlowOverlayIfNonExistent(cpg)
+      val context = new LayerCreatorContext(cpg)
+
+      mkdir(File(config.outDir))
       (config.repr, config.format) match {
         case (Representation.ast, Format.dot) =>
           new DumpAst(AstDumpOptions(config.outDir)).create(context)


### PR DESCRIPTION
Previously, we did not apply data flow semantics at DDG generation time, but only at query-time. While that's enough for reachableBy queries and is the most flexible solution, it means that raw exports of the graph will show a lot of `REACHING_DEF` edges that shouldn't exist. Since a lot of people seem to be interested in exporting the raw graph, I want to make sure they don't mistakenly believe that we don't honor data flow semantics. Therefore, semantics are now also applied at generation time.