### PR TITLE
Add PHP locals and for loops

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -250,8 +250,13 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     val bodyAst = stmtBlockAst(stmt.bodyStmts, line(stmt))
 
-    val forNode = NewControlStructure().controlStructureType(ControlStructureTypes.FOR).lineNumber(lineNumber)
-    // TODO Create locals on first use of variable
+    val initCode      = initAsts.map(rootCode(_)).mkString(",")
+    val conditionCode = conditionAsts.map(rootCode(_)).mkString(",")
+    val loopExprCode  = loopExprAsts.map(rootCode(_)).mkString(",")
+    val forCode       = s"for ($initCode;$conditionCode;$loopExprCode)"
+
+    val forNode =
+      NewControlStructure().controlStructureType(ControlStructureTypes.FOR).lineNumber(lineNumber).code(forCode)
     forAst(forNode, Nil, initAsts, conditionAsts, loopExprAsts, bodyAst)
   }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
@@ -1,0 +1,44 @@
+package io.joern.php2cpg.datastructures
+
+import io.joern.x2cpg.datastructures.{Scope => X2CpgScope}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewLocal, NewMethod, NewNode}
+
+import scala.collection.mutable
+
+class Scope extends X2CpgScope[String, NewNode, NewNode] {
+
+  private var localStack: List[mutable.ArrayBuffer[NewLocal]] = Nil
+
+  override def pushNewScope(scopeNode: NewNode): Unit = {
+    scopeNode match {
+      case _: NewMethod => localStack = mutable.ArrayBuffer[NewLocal]() :: localStack
+      case _            => // Nothing to do here
+    }
+    super.pushNewScope(scopeNode)
+  }
+
+  override def popScope(): Option[NewNode] = {
+    val poppedScope = super.popScope()
+
+    poppedScope match {
+      case Some(_: NewMethod) =>
+        // TODO This is unsafe to catch errors for now.
+        localStack = localStack.tail
+      case _ => // Nothing to do here
+    }
+
+    poppedScope
+  }
+
+  override def addToScope(identifier: String, variable: NewNode): NewNode = {
+    variable match {
+      case local: NewLocal =>
+        // TODO This is unsafe to catch errors for now.
+        localStack.head.addOne(local)
+      case _ => // Nothing to do here
+    }
+    super.addToScope(identifier, variable)
+  }
+
+  def getLocalsInScope: List[NewLocal] = localStack.headOption.map(_.toList).toList.flatten
+}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -101,6 +101,7 @@ object Domain {
   final case class PhpContinueStmt(num: Option[Int], attributes: PhpAttributes)                 extends PhpStmt
   final case class PhpWhileStmt(cond: PhpExpr, stmts: List[PhpStmt], attributes: PhpAttributes) extends PhpStmt
   final case class PhpDoStmt(cond: PhpExpr, stmts: List[PhpStmt], attributes: PhpAttributes)    extends PhpStmt
+  final case class PhpForStmt(inits: List[PhpExpr], conditions: List[PhpExpr], loopExprs: List[PhpExpr], bodyStmts: List[PhpStmt], attributes: PhpAttributes) extends PhpStmt
   final case class PhpIfStmt(
     cond: PhpExpr,
     stmts: List[PhpStmt],
@@ -296,6 +297,7 @@ object Domain {
       case "Stmt_Continue"   => readContinue(json)
       case "Stmt_While"      => readWhile(json)
       case "Stmt_Do"         => readDo(json)
+      case "Stmt_For"        => readFor(json)
       case "Stmt_If"         => readIf(json)
       case "Stmt_Switch"     => readSwitch(json)
       case unhandled =>
@@ -333,6 +335,15 @@ object Domain {
     val cond  = readExpr(json("cond"))
     val stmts = json("stmts").arr.toList.map(readStmt)
     PhpDoStmt(cond, stmts, PhpAttributes(json))
+  }
+
+  private def readFor(json: Value): PhpForStmt = {
+    val inits = json("init").arr.map(readExpr).toList
+    val conditions = json("cond").arr.map(readExpr).toList
+    val loopExprs = json("cond").arr.map(readExpr).toList
+    val bodyStmts = json("stmts").arr.map(readStmt).toList
+
+    PhpForStmt(inits, conditions, loopExprs, bodyStmts, PhpAttributes(json))
   }
 
   private def readIf(json: Value): PhpIfStmt = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -346,7 +346,7 @@ object Domain {
   private def readFor(json: Value): PhpForStmt = {
     val inits      = json("init").arr.map(readExpr).toList
     val conditions = json("cond").arr.map(readExpr).toList
-    val loopExprs  = json("cond").arr.map(readExpr).toList
+    val loopExprs  = json("loop").arr.map(readExpr).toList
     val bodyStmts  = json("stmts").arr.map(readStmt).toList
 
     PhpForStmt(inits, conditions, loopExprs, bodyStmts, PhpAttributes(json))

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -101,7 +101,13 @@ object Domain {
   final case class PhpContinueStmt(num: Option[Int], attributes: PhpAttributes)                 extends PhpStmt
   final case class PhpWhileStmt(cond: PhpExpr, stmts: List[PhpStmt], attributes: PhpAttributes) extends PhpStmt
   final case class PhpDoStmt(cond: PhpExpr, stmts: List[PhpStmt], attributes: PhpAttributes)    extends PhpStmt
-  final case class PhpForStmt(inits: List[PhpExpr], conditions: List[PhpExpr], loopExprs: List[PhpExpr], bodyStmts: List[PhpStmt], attributes: PhpAttributes) extends PhpStmt
+  final case class PhpForStmt(
+    inits: List[PhpExpr],
+    conditions: List[PhpExpr],
+    loopExprs: List[PhpExpr],
+    bodyStmts: List[PhpStmt],
+    attributes: PhpAttributes
+  ) extends PhpStmt
   final case class PhpIfStmt(
     cond: PhpExpr,
     stmts: List[PhpStmt],
@@ -338,10 +344,10 @@ object Domain {
   }
 
   private def readFor(json: Value): PhpForStmt = {
-    val inits = json("init").arr.map(readExpr).toList
+    val inits      = json("init").arr.map(readExpr).toList
     val conditions = json("cond").arr.map(readExpr).toList
-    val loopExprs = json("cond").arr.map(readExpr).toList
-    val bodyStmts = json("stmts").arr.map(readStmt).toList
+    val loopExprs  = json("cond").arr.map(readExpr).toList
+    val bodyStmts  = json("stmts").arr.map(readStmt).toList
 
     PhpForStmt(inits, conditions, loopExprs, bodyStmts, PhpAttributes(json))
   }
@@ -464,7 +470,11 @@ object Domain {
       case Obj(value) if value.get("nodeType").map(_.str).contains("Name_FullyQualified") =>
         val name = value("parts").arr.map(_.str).mkString(FullyQualifiedNameDelimiter)
         PhpNameExpr(name, PhpAttributes(json))
-      case _ => ??? // TODO: other matches are possible?
+      case Obj(value) if value.get("nodeType").map(_.str).contains("Expr_Variable") =>
+        readVariable(value)
+      case unhandled =>
+        logger.error(s"Found unhandled name type $unhandled")
+        ??? // TODO: other matches are possible?
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/LocalTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/LocalTests.scala
@@ -1,0 +1,65 @@
+package io.joern.php2cpg.querying
+
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+
+class LocalTests extends PhpCode2CpgFixture {
+
+  "locals for methods" should {
+    "be created for methods with assigns" in {
+      val cpg = code("""<?php
+          |function foo() {
+          |  $x = 0;
+          |  $y = 1;
+          |  $x = 2;
+          |}""".stripMargin)
+
+      inside(cpg.method.name("foo").local.sortBy(_.name).toList) { case List(xLocal, yLocal) =>
+        xLocal.name shouldBe "x"
+        xLocal.code shouldBe "$x"
+
+        yLocal.name shouldBe "y"
+        yLocal.code shouldBe "$y"
+      }
+    }
+
+    "have ref edges from uses" in {
+      val cpg = code("""<?php
+          |function foo() {
+          |  $x = bar();
+          |  $x();
+          |}
+          |""".stripMargin)
+
+      inside(cpg.method.name("foo").ast.isIdentifier.name("x").l) { case List(xIdent1, xIdent2) =>
+        xIdent1._localViaRefOut.map(_.name) should contain("x")
+        xIdent2._localViaRefOut.map(_.name) should contain("x")
+      }
+    }
+
+    "not be created if the variable matches a parameter type" in {
+      val cpg = code("""<?php
+          |function foo($x) {
+          |  $x = 12;
+          |}
+          |""".stripMargin)
+
+      cpg.method.name("foo").local.isEmpty shouldBe true
+    }
+
+    "create a local when it is first used if not defined in an assign" in {
+      val cpg = code("""<?php
+          |function foo() {
+          |  if ($x) {
+          |    echo "Hello, world";
+          |  }
+          |}
+          |""".stripMargin)
+
+      inside(cpg.method.name("foo").local.l) { case List(xLocal) =>
+        xLocal.name shouldBe "x"
+        xLocal.code shouldBe "$x"
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/PocTest.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/PocTest.scala
@@ -39,9 +39,8 @@ class PocTest extends PhpCode2CpgFixture {
     }
 
     "have the correct method ast for the printHello method" in {
-      cpg.method.internal.l match {
+      cpg.method.internal.name("printHello").l match {
         case method :: Nil =>
-          method.name shouldBe "printHello"
           val List(param) = method.parameter.l
           param.name shouldBe "name"
           param.code shouldBe "name"

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -137,7 +137,14 @@ abstract class AstCreatorBase(filename: String) {
     }
   }
 
-  def forAst(forNode: NewControlStructure, locals: Seq[Ast], initAsts: Seq[Ast], conditionAsts: Seq[Ast], updateAsts: Seq[Ast], bodyAst: Ast): Ast = {
+  def forAst(
+    forNode: NewControlStructure,
+    locals: Seq[Ast],
+    initAsts: Seq[Ast],
+    conditionAsts: Seq[Ast],
+    updateAsts: Seq[Ast],
+    bodyAst: Ast
+  ): Ast = {
     val lineNumber = forNode.lineNumber
     Ast(forNode)
       .withChildren(locals)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -127,6 +127,27 @@ abstract class AstCreatorBase(filename: String) {
     }
   }
 
+  def wrapMultipleInBlock(asts: Seq[Ast], lineNumber: Option[Integer]): Ast = {
+    asts.toList match {
+      case Nil => blockAst(NewBlock().lineNumber(lineNumber))
+
+      case ast :: Nil => ast
+
+      case asts => blockAst(NewBlock().lineNumber(lineNumber), asts)
+    }
+  }
+
+  def forAst(forNode: NewControlStructure, locals: Seq[Ast], initAsts: Seq[Ast], conditionAsts: Seq[Ast], updateAsts: Seq[Ast], bodyAst: Ast): Ast = {
+    val lineNumber = forNode.lineNumber
+    Ast(forNode)
+      .withChildren(locals)
+      .withChild(wrapMultipleInBlock(initAsts, lineNumber))
+      .withChild(wrapMultipleInBlock(conditionAsts, lineNumber))
+      .withChild(wrapMultipleInBlock(updateAsts, lineNumber))
+      .withChild(bodyAst)
+      .withConditionEdges(forNode, conditionAsts.flatMap(_.root).toList)
+  }
+
   /** For a given block node and statement ASTs, create an AST that represents the block. The main purpose of this
     * method is to increase the readability of the code which creates block asts.
     */

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -156,9 +156,13 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     */
   protected def cfgForBreakStatement(node: ControlStructure): Cfg = {
     node.astChildren.find(_.order == 1) match {
-      case Some(jumpLabel) =>
-        val labelName = jumpLabel.asInstanceOf[JumpLabel].name
+      case Some(jumpLabel: JumpLabel) =>
+        val labelName = jumpLabel.name
         Cfg(entryNode = Some(node), jumpsToLabel = List((node, labelName)))
+      case Some(_: Literal) =>
+        // TODO: PHP breaks take an integer argument which determines how many blocks should be broken out of. Creating
+        //  the CFG for that correctly is still a TODO, but this prevents crashes.
+        Cfg(entryNode = Some(node), breaks = List(node))
       case None =>
         Cfg(entryNode = Some(node), breaks = List(node))
     }
@@ -166,9 +170,13 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
 
   protected def cfgForContinueStatement(node: ControlStructure): Cfg = {
     node.astChildren.find(_.order == 1) match {
-      case Some(jumpLabel) =>
-        val labelName = jumpLabel.asInstanceOf[JumpLabel].name
+      case Some(jumpLabel: JumpLabel) =>
+        val labelName = jumpLabel.name
         Cfg(entryNode = Some(node), jumpsToLabel = List((node, labelName)))
+      case Some(_: Literal) =>
+        // TODO: PHP breaks take an integer argument which determines how many blocks should be broken out of. Creating
+        //  the CFG for that correctly is still a TODO, but this prevents crashes.
+        Cfg(entryNode = Some(node), breaks = List(node))
       case None =>
         Cfg(entryNode = Some(node), continues = List(node))
     }


### PR DESCRIPTION
Notes:
* Locals for a method are always added to the start of the method. This is to keep code simple by avoiding having to return a sequence of ASTs at any point. I also think this makes as much sense as putting them anywhere else, since PHP doesn't have variable declarations or shadowing.
* This also adds a global typeDecl/method similar to C to avoid any issues that arise from the assumption that locals belong to a specific method.
* This does not handle global variables yet (specifically that the `global` keyword is required to bring global variables into local scope). This will be fixed when adding support for `global`.