### PR TITLE
Execute post-processing passes automatically for `joern-parse`/`ImportCode`

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -9,7 +9,7 @@ val CirceVersion          = "0.14.2"
 val AmmoniteVersion       = "2.5.3"
 val ZeroturnaroundVersion = "1.15"
 
-dependsOn(Projects.semanticcpg, Projects.macros, Projects.c2cpg % Test, Projects.x2cpg % "compile->compile;test->test")
+dependsOn(Projects.semanticcpg, Projects.macros, Projects.jssrc2cpg, Projects.c2cpg % Test, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
   "io.shiftleft"         %% "codepropertygraph" % Versions.cpg,

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -1,6 +1,7 @@
 package io.joern.console.cpgcreation
 
 import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
 
 import scala.sys.process._
 
@@ -33,6 +34,10 @@ abstract class CpgGenerator() {
       System.err.println(s"Error running shell command: $cmd")
       None
     }
+  }
+
+  def applyPostProcessingPasses(cpg: Cpg): Cpg = {
+    cpg
   }
 
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -55,13 +55,13 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
   def languageIsKnown(language: String): Boolean = CpgGeneratorFactory.KNOWN_LANGUAGES.contains(language)
 
   def runGenerator(
-    frontend: CpgGenerator,
+    generator: CpgGenerator,
     inputPath: String,
     outputPath: String,
     namespaces: List[String] = List()
   ): Option[Path] = {
     val outputFileOpt: Option[File] =
-      frontend.generate(inputPath, outputPath, namespaces).map(File(_))
+      generator.generate(inputPath, outputPath, namespaces).map(File(_))
     outputFileOpt.map { outFile =>
       val parentPath = outFile.parent.path.toAbsolutePath
       if (isZipFile(outFile)) {

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -1,6 +1,8 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
+import io.joern.jssrc2cpg.JsSrc2Cpg
+import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.Path
 
@@ -20,4 +22,10 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
 
   override def isAvailable: Boolean =
     command.toFile.exists
+
+  override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
+    JsSrc2Cpg.postProcessingPasses(cpg).foreach(_.createAndApply())
+    cpg
+  }
+
 }

--- a/console/src/test/scala/io/joern/console/cpgqlserver/CPGQLServerTests.scala
+++ b/console/src/test/scala/io/joern/console/cpgqlserver/CPGQLServerTests.scala
@@ -115,7 +115,6 @@ class CPGQLServerTests extends AnyWordSpec with Matchers {
         getResultResponse.obj.keySet should contain("success")
         getResultResponse("uuid").str shouldBe queryResultWSMessage
         getResultResponse("stdout").str shouldBe "res0: Int = 1\n"
-        getResultResponse("stderr").str shouldBe ""
       }
 
       "disallow fetching the result of a completed query with an invalid auth header" in Fixture() { host =>
@@ -166,7 +165,6 @@ class CPGQLServerTests extends AnyWordSpec with Matchers {
           getResultResponse.obj.keySet should not contain "err"
           getResultResponse("uuid").str shouldBe queryResultWSMessage
           getResultResponse("stdout").str shouldBe "res0: Int = 1\n"
-          getResultResponse("stderr").str shouldBe ""
       }
 
       "write a well-formatted message to a websocket connection when a query failed evaluation" in Fixture() { host =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
@@ -72,7 +72,7 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
         |import {c} from "";
         |import * as d from "depD";
         |""".stripMargin) { cpg =>
-      val List(a, b, c, d) = cpg.staticImport.l
+      val List(a, b, c, d) = cpg.imports.l
       a.code shouldBe "import {a} from \"depA\""
       a.importedEntity shouldBe Some("depA")
       a.importedAs shouldBe Some("a")

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
@@ -43,7 +43,7 @@ class TsAstCreationPassTest extends AbstractPassTest {
       modelsDep.name shouldBe "models"
       modelsDep.dependencyGroupId shouldBe Some("../models/index")
 
-      val List(fs, models) = cpg.staticImport.l
+      val List(fs, models) = cpg.imports.l
       fs.code shouldBe "import fs = require('fs')"
       fs.importedEntity shouldBe Some("fs")
       fs.importedAs shouldBe Some("fs")

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
@@ -168,7 +168,7 @@ class VueJsDomAstCreationPassTest extends AbstractDomPassTest {
         helloWorld.code shouldBe "HelloWorld"
       }
 
-      inside(cpg.staticImport.l) { case List(component, prop, vue) =>
+      inside(cpg.imports.l) { case List(component, prop, vue) =>
         component.importedAs shouldBe Some("Component")
         component.importedEntity shouldBe Some("vue-property-decorator")
         component.code shouldBe "import { Component, Prop, Vue } from 'vue-property-decorator'"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ImportTests.scala
@@ -18,11 +18,11 @@ class ImportTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
         |""".stripMargin)
 
     "should contain the correct number of IMPORT nodes" in {
-      cpg.staticImport.size should not be 0
+      cpg.imports.size should not be 0
     }
 
     "should contain IMPORT node for `listOf` entry with the correct properties set" in {
-      val List(imp) = cpg.staticImport.code(".*listOf.*").l
+      val List(imp) = cpg.imports.code(".*listOf.*").l
       imp.code shouldBe "import kotlin.io.collections.listOf"
       imp.importedEntity shouldBe Some("kotlin.io.collections.listOf")
       imp.lineNumber shouldBe Some(4)
@@ -32,7 +32,7 @@ class ImportTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     }
 
     "should contain IMPORT node for wildcard `comparisons` entry with the correct properties set" in {
-      val List(imp) = cpg.staticImport.code(".*comparisons.*").l
+      val List(imp) = cpg.imports.code(".*comparisons.*").l
       imp.code shouldBe "import kotlin.comparisons.*"
       imp.importedEntity shouldBe Some("kotlin.comparisons.*")
       imp.lineNumber shouldBe Some(5)
@@ -52,7 +52,7 @@ class ImportTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
         |""".stripMargin)
 
     "should not contain any IMPORT nodes" in {
-      cpg.staticImport.size shouldBe 0
+      cpg.imports.size shouldBe 0
     }
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -252,8 +252,8 @@ class NodeTypeStarters(cpg: Cpg) extends TraversalSource(cpg.graph) {
   def ret(code: String): Traversal[Return] =
     ret.code(code)
 
-  @Doc(info = "All static imports")
-  def staticImport: Traversal[Import] =
+  @Doc(info = "All imports")
+  def imports: Traversal[Import] =
     InitialTraversal.from[Import](cpg.graph, NodeTypes.IMPORT)
 
   @Doc(info = "All switch blocks (`ControlStructure` nodes)")


### PR DESCRIPTION
This is a follow-up for https://github.com/joernio/joern/pull/1804 - the post processing passes (e.g., `RequirePass`) are now executed automatically when using `joern-parse` and `ImportCode`.