### PR TITLE
Fix data flow of js object notation

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -2,27 +2,11 @@ package io.joern.dataflowengineoss.passes.reachingdef
 
 import io.joern.dataflowengineoss.queryengine.AccessPathUsage.toTrackedBaseAndAccessPathSimple
 import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators, PropertyNames}
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  Block,
-  Call,
-  CfgNode,
-  ControlStructure,
-  Expression,
-  FieldIdentifier,
-  Identifier,
-  JumpTarget,
-  Method,
-  MethodParameterIn,
-  MethodParameterOut,
-  MethodReturn,
-  Return,
-  StoredNode,
-  Unknown
-}
 import io.shiftleft.semanticcpg.accesspath.MatchResult
-import overflowdb.BatchedUpdate.DiffGraphBuilder
 import io.shiftleft.semanticcpg.language._
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import scala.collection.{Set, mutable}
 
@@ -105,10 +89,8 @@ class DdgGenerator(semantics: Semantics) {
             val edgesToAdd = in(node).toList.flatMap { inDef =>
               numberToNode.get(inDef) match {
                 case Some(identifier: Identifier) => Some(identifier)
-                case Some(call: Call) if call.name != Operators.fieldAccess =>
-                  Some(call)
-                case _ =>
-                  None
+                case Some(call: Call)             => Some(call)
+                case _                            => None
               }
             }
             edgesToAdd.foreach { inNode =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -1,9 +1,9 @@
 package io.joern.jssrc2cpg.dataflow
 
-import io.joern.jssrc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.language._
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.joern.jssrc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
@@ -587,14 +587,13 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
   }
 
   "Flow from inside object notation to call argument" in {
-    val cpg: Cpg = code(
-      """
+    val cpg: Cpg = code("""
         |const a = { b : 47 } ;
         |fn(a);
         |""".stripMargin)
 
     val sink = cpg.call.nameExact("fn")
-    val src = cpg.literal("47")
+    val src  = cpg.literal("47")
     sink.reachableBy(src).nonEmpty shouldBe true
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -586,4 +586,16 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     println(sink.reachableBy(src).l)
   }
 
+  "Flow from inside object notation to call argument" in {
+    val cpg: Cpg = code(
+      """
+        |const a = { b : 47 } ;
+        |fn(a);
+        |""".stripMargin)
+
+    val sink = cpg.call.nameExact("fn")
+    val src = cpg.literal("47")
+    sink.reachableBy(src).nonEmpty shouldBe true
+  }
+
 }


### PR DESCRIPTION
https://github.com/joernio/joern/blob/518992dd540498b51f7acd1e66e57bb80c66be8a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala#L108

```
if call.name != Operators.fieldAccess
```
This line is blocking the data flow from inside object notation to outside. Here is the test case.
```
    val cpg: Cpg = code(
      """
        |const a = { b : 47 } ;
        |fn(a);
        |""".stripMargin)

    val sink = cpg.call.nameExact("fn")
    val src = cpg.literal("47")
    sink.reachableBy(src).nonEmpty shouldBe true
```