### PR TITLE
Adjust to METHOD_PARAMETER_OUT now having an index property.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.564"
+val cpgVersion = "1.3.567"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -114,7 +114,7 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph[StoredNode] {
   }
 
   private def nextParamOutOrExit(paramOut: MethodParameterOut): List[StoredNode] = {
-    val nextParam = paramOut.method.parameter.index(paramOut.index.head + 1).asOutput.headOption
+    val nextParam = paramOut.method.parameter.index(paramOut.index + 1).asOutput.headOption
     if (nextParam.isDefined) { nextParam.toList }
     else { List(exitNode) }
   }
@@ -136,7 +136,7 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph[StoredNode] {
   }
 
   private def previousOutputParamOrLastNodeOfBody(paramOut: MethodParameterOut): List[StoredNode] = {
-    val prevParam = paramOut.method.parameter.index(paramOut.index.head - 1).asOutput.headOption
+    val prevParam = paramOut.method.parameter.index(paramOut.index - 1).asOutput.headOption
     if (prevParam.isDefined) { prevParam.toList }
     else { lastActualCfgNode.toList }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodDecoratorPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodDecoratorPass.scala
@@ -24,6 +24,7 @@ class MethodDecoratorPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
           .NewMethodParameterOut()
           .code(parameterIn.code)
           .order(parameterIn.order)
+          .index(parameterIn.index)
           .name(parameterIn.name)
           .evaluationStrategy(parameterIn.evaluationStrategy)
           .typeFullName(parameterIn.typeFullName)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -10,21 +10,19 @@ class MethodParameterOutTraversal(val traversal: Traversal[MethodParameterOut]) 
 
   def paramIn: Traversal[MethodParameterIn] = traversal.flatMap(_.parameterLinkIn.headOption)
 
-  def index: Traversal[Int] = paramIn.index
-
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def index(num: Int): Traversal[MethodParameterOut] =
-    traversal.filter(_.paramIn.index(num).nonEmpty)
+    traversal.filter { _.index == num }
 
   /* get all parameters from (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def indexFrom(num: Int): Traversal[MethodParameterOut] =
-    traversal.filter(_.parameterLinkIn.index.headOption.exists(_ >= num))
+    traversal.filter(_.index >= num)
 
   /* get all parameters up to (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def indexTo(num: Int): Traversal[MethodParameterOut] =
-    traversal.filter(_.parameterLinkIn.index.headOption.exists(_ <= num))
+    traversal.filter(_.index <= num)
 
   def argument: Traversal[Expression] =
     for {


### PR DESCRIPTION
This requires a small API change on METHOD_PARAMETER_OUT because
`parameter.index` now has type `Int` instead of `Traversal[Int]`.