### PR TITLE
jssrc2cpg: fixed locals-blocks relation in classes

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -7,6 +7,8 @@ import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.NewNamespaceBlock
+import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
 import org.apache.commons.lang.StringUtils
 import ujson.Value
 
@@ -217,6 +219,11 @@ trait AstCreatorHelper { this: AstCreator =>
             Some(variableNodeId)
           } else {
             currentScope.flatMap {
+              case methodScope: MethodScopeElement
+                  if methodScope.scopeNode.isInstanceOf[NewTypeDecl] || methodScope.scopeNode
+                    .isInstanceOf[NewNamespaceBlock] =>
+                currentScope = Some(Scope.getEnclosingMethodScopeElement(currentScope))
+                None
               case methodScope: MethodScopeElement =>
                 // We have reached a MethodScope and still did not find a local variable to link to.
                 // For all non local references the CPG format does not allow us to link

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -287,8 +287,8 @@ trait AstForTypesCreator { this: AstCreator =>
     methodAstParentStack.push(typeDeclNode)
     dynamicInstanceTypeStack.push(typeFullName)
     typeRefIdStack.push(typeRefNode)
-    scope.pushNewMethodScope(typeFullName, typeName, typeDeclNode, None)
-    scope.pushNewBlockScope(typeDeclNode)
+
+    scope.pushNewMethodScope(typeFullName, typeName, localAstParentStack.head, None)
 
     val allClassMembers = classMembers(clazz, withConstructor = false).toList
 
@@ -320,7 +320,6 @@ trait AstForTypesCreator { this: AstCreator =>
     methodAstParentStack.pop()
     dynamicInstanceTypeStack.pop()
     typeRefIdStack.pop()
-    scope.popScope()
     scope.popScope()
 
     if (staticMemberInitCalls.nonEmpty || staticInitBlockAsts.nonEmpty) {
@@ -364,8 +363,8 @@ trait AstForTypesCreator { this: AstCreator =>
 
     methodAstParentStack.push(namespaceNode)
     dynamicInstanceTypeStack.push(fullName)
-    scope.pushNewMethodScope(fullName, name, namespaceNode, None)
-    scope.pushNewBlockScope(namespaceNode)
+
+    scope.pushNewMethodScope(fullName, name, localAstParentStack.head, None)
 
     val blockAst = if (hasKey(tsModuleDecl.json, "body")) {
       val nodeInfo = createBabelNodeInfo(tsModuleDecl.json("body"))
@@ -379,7 +378,6 @@ trait AstForTypesCreator { this: AstCreator =>
 
     methodAstParentStack.pop()
     dynamicInstanceTypeStack.pop()
-    scope.popScope()
     scope.popScope()
 
     Ast(namespaceNode).withChild(blockAst)
@@ -409,8 +407,8 @@ trait AstForTypesCreator { this: AstCreator =>
 
     methodAstParentStack.push(typeDeclNode)
     dynamicInstanceTypeStack.push(typeFullName)
-    scope.pushNewMethodScope(typeFullName, typeName, typeDeclNode, None)
-    scope.pushNewBlockScope(typeDeclNode)
+
+    scope.pushNewMethodScope(typeFullName, typeName, localAstParentStack.head, None)
 
     val constructorNode = interfaceConstructor(typeName, tsInterface)
     diffGraph.addEdge(constructorNode, NewModifier().modifierType(ModifierTypes.CONSTRUCTOR), EdgeTypes.AST)
@@ -454,7 +452,6 @@ trait AstForTypesCreator { this: AstCreator =>
 
     methodAstParentStack.pop()
     dynamicInstanceTypeStack.pop()
-    scope.popScope()
     scope.popScope()
 
     Ast(typeDeclNode)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -288,7 +288,7 @@ trait AstForTypesCreator { this: AstCreator =>
     dynamicInstanceTypeStack.push(typeFullName)
     typeRefIdStack.push(typeRefNode)
 
-    scope.pushNewMethodScope(typeFullName, typeName, localAstParentStack.head, None)
+    scope.pushNewMethodScope(typeFullName, typeName, typeDeclNode, None)
 
     val allClassMembers = classMembers(clazz, withConstructor = false).toList
 
@@ -364,7 +364,7 @@ trait AstForTypesCreator { this: AstCreator =>
     methodAstParentStack.push(namespaceNode)
     dynamicInstanceTypeStack.push(fullName)
 
-    scope.pushNewMethodScope(fullName, name, localAstParentStack.head, None)
+    scope.pushNewMethodScope(fullName, name, namespaceNode, None)
 
     val blockAst = if (hasKey(tsModuleDecl.json, "body")) {
       val nodeInfo = createBabelNodeInfo(tsModuleDecl.json("body"))
@@ -408,7 +408,7 @@ trait AstForTypesCreator { this: AstCreator =>
     methodAstParentStack.push(typeDeclNode)
     dynamicInstanceTypeStack.push(typeFullName)
 
-    scope.pushNewMethodScope(typeFullName, typeName, localAstParentStack.head, None)
+    scope.pushNewMethodScope(typeFullName, typeName, typeDeclNode, None)
 
     val constructorNode = interfaceConstructor(typeName, tsInterface)
     diffGraph.addEdge(constructorNode, NewModifier().modifierType(ModifierTypes.CONSTRUCTOR), EdgeTypes.AST)

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
@@ -23,10 +23,11 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
         |
         |function sink(par1) {}
         |""".stripMargin) { cpg =>
-      val List(x1, x2, x3) = cpg.local("x").l
+      val List(x1, x2) = cpg.local("x").l
       x1._blockViaAstIn should not be empty
+      x1.referencingIdentifiers.name.l shouldBe List("x")
       x2._blockViaAstIn should not be empty
-      x3._blockViaAstIn should not be empty
+      x2.referencingIdentifiers.name.l shouldBe List("x")
     }
 
     "have a TYPE_DECL for ClassA" in AstFixture("var x = class ClassA {}") { cpg =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
@@ -7,6 +7,28 @@ import io.shiftleft.semanticcpg.language._
 class JsClassesAstCreationPassTest extends AbstractPassTest {
 
   "AST generation for classes" should {
+
+    "have ast parent blocks for class locals" in AstFixture("""
+        |var x = source();
+        |
+        |class Foo {
+        |  func() {
+        |    sink(x);
+        |  }
+        |}
+        |
+        |function source() {
+        |  return 1;
+        |}
+        |
+        |function sink(par1) {}
+        |""".stripMargin) { cpg =>
+      val List(x1, x2, x3) = cpg.local("x").l
+      x1._blockViaAstIn should not be empty
+      x2._blockViaAstIn should not be empty
+      x3._blockViaAstIn should not be empty
+    }
+
     "have a TYPE_DECL for ClassA" in AstFixture("var x = class ClassA {}") { cpg =>
       cpg.typeDecl.nameExact("ClassA").fullNameExact("code.js::program:ClassA").size shouldBe 1
     }


### PR DESCRIPTION
Previously, some locals were generated without a parent block for JS classes. This PR fixes that.