### PR TITLE
Remove `undo`

### DIFF
--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -237,29 +237,6 @@ class Console[T <: Project](
     }
   }
 
-  @Doc(
-    info = "undo effects of analyzer",
-    longInfo = """|Undo the last change, that is, unapply the last
-       |overlay applied to the active project.
-       |""",
-    example = "undo"
-  )
-  def undo: File = {
-    project.overlayDirs.lastOption
-      .map { dir =>
-        if (dir.isRegularFile) {
-          System.err.println("Detected undo information in old format. That's ok.")
-          CpgLoader.addDiffGraphs(List(dir.path.toString), cpg)
-        } else {
-          val zipFiles = dir.list.toList.sortWith(compareFiles).reverse.map(_.path.toString)
-          CpgLoader.addDiffGraphs(zipFiles, cpg)
-        }
-        Overlays.removeLastOverlayName(cpg)
-        dir.delete()
-      }
-      .getOrElse(throw new RuntimeException("No overlays present"))
-  }
-
   private def compareFiles(a: File, b: File): Boolean = {
     val splitA = a.name.split("_")
     val splitB = b.name.split("_")

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -363,69 +363,6 @@ class ConsoleTests extends AnyWordSpec with Matchers {
     override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {}
   }
 
-  "undo" should {
-    "remove layer from meta information" in ConsoleFixture() { (console, codeDir) =>
-      console.importCode(codeDir.toString)
-      console._runAnalyzer(new MockLayerCreator)
-      console.project.appliedOverlays shouldBe List(
-        Base.overlayName,
-        ControlFlow.overlayName,
-        TypeRelations.overlayName,
-        CallGraph.overlayName,
-        "fooname"
-      )
-      console.undo
-      console.project.appliedOverlays shouldBe List(
-        Base.overlayName,
-        ControlFlow.overlayName,
-        TypeRelations.overlayName,
-        CallGraph.overlayName
-      )
-      console.undo
-      console.undo
-      console.undo
-      console.undo
-      console.project.appliedOverlays shouldBe List()
-    }
-
-    "remove overlay file from project" in ConsoleFixture() { (console, codeDir) =>
-      console.importCode(codeDir.toString)
-      val overlayDir         = console.project.path.resolve("overlays")
-      val overlayFilesBefore = overlayDir.toFile.list.toSet
-      overlayFilesBefore shouldBe Set(
-        Base.overlayName,
-        ControlFlow.overlayName,
-        TypeRelations.overlayName,
-        CallGraph.overlayName
-      )
-      console.undo
-      console.undo
-      console.undo
-      console.undo
-      val overlayFilesAfter = overlayDir.toFile.list.toSet
-      overlayFilesAfter shouldBe Set()
-    }
-
-    "actually remove some nodes" in ConsoleFixture() { (console, codeDir) =>
-      console.importCode(codeDir.toString)
-      console.cpg.parameter.asOutput.l.size should be > 0
-      console.project.appliedOverlays shouldBe List(
-        Base.overlayName,
-        ControlFlow.overlayName,
-        TypeRelations.overlayName,
-        CallGraph.overlayName
-      )
-      console.undo
-      console.undo
-      console.undo
-      console.undo
-      console.project.appliedOverlays shouldBe List()
-      console.cpg.parameter.asOutput.l.size shouldBe 0
-      console._runAnalyzer(new Base)
-      console.cpg.parameter.asOutput.l.size should be > 0
-    }
-  }
-
   "save" should {
     "close and reopen projects" taggedAs NotInWindowsRunners in ConsoleFixture() { (console, codeDir) =>
       console.importCode(codeDir.toString, "project1")
@@ -469,8 +406,6 @@ class ConsoleTests extends AnyWordSpec with Matchers {
       Run.runCustomQuery(console, console.cpg.method.newTagNode("mytag"))
       console.cpg.tag.name("mytag").method.name.toSet should contain("main")
       console.cpg.metaData.map(_.overlays).head.last shouldBe "custom"
-      console.undo
-      console.cpg.metaData.map(_.overlays).head.last shouldBe "callgraph"
     }
   }
 


### PR DESCRIPTION
_undo_ was introduced at some point to allow for edits while using Joern as a platform. Because it's not been used very extensively, and in order to help with removing deprecated logic, we decided to remove it for now.