### PR TITLE
joern-export: graphson support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-
 val cpgVersion = "1.3.568"
-
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -1,12 +1,11 @@
 package io.joern.joerncli
 
 import better.files.Dsl._
-import better.files.{DefaultBufferSize, File}
+import better.files.File
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.layers.dataflows._
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.joern.joerncli.CpgBasedTool.{exitIfInvalid, exitWithError}
-import io.joern.joerncli.console.JoernWorkspaceLoader
 import io.joern.x2cpg.layers._
 import io.shiftleft.semanticcpg.layers._
 import overflowdb.Graph
@@ -14,7 +13,9 @@ import overflowdb.formats.ExportResult
 import overflowdb.formats.dot.DotExporter
 import overflowdb.formats.graphml.GraphMLExporter
 import overflowdb.formats.neo4jcsv.Neo4jCsvExporter
+import overflowdb.formats.graphson.GraphSONExporter
 
+import java.nio.file.Paths
 import scala.util.Using
 
 object JoernExport extends App {
@@ -32,7 +33,7 @@ object JoernExport extends App {
     val ast, cfg, ddg, cdg, pdg, cpg14, all = Value
   }
   object Format extends Enumeration {
-    val dot, neo4jcsv, graphml = Value
+    val dot, neo4jcsv, graphml, graphson = Value
   }
 
   private def parseConfig: Option[Config] =
@@ -88,6 +89,8 @@ object JoernExport extends App {
           overflowdbExport(cpg.graph, config.outDir, GraphMLExporter)
         case (Representation.all, Format.dot) =>
           overflowdbExport(cpg.graph, config.outDir, DotExporter)
+        case (Representation.all, Format.graphson) =>
+          overflowdbExport(cpg.graph, config.outDir, GraphSONExporter)
         case (repr, format) =>
           exitWithError(s"combination of repr=$repr and format=$format not (yet) supported")
       }
@@ -95,8 +98,9 @@ object JoernExport extends App {
   }
 
   private def overflowdbExport(graph: Graph, outDir: String, exporter: overflowdb.formats.Exporter): Unit = {
-    val ExportResult(nodeCount, edgeCount, files, additionalInfo) = exporter.runExport(graph, outDir)
-    println(s"export completed successfully: $nodeCount nodes, $edgeCount edges in ${files.size} files")
+    val outDirPath = Paths.get(outDir).toAbsolutePath
+    val ExportResult(nodeCount, edgeCount, files, additionalInfo) = exporter.runExport(graph, outDirPath)
+    println(s"exported $nodeCount nodes, $edgeCount edges into $outDirPath")
     additionalInfo.foreach(println)
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.2


### PR DESCRIPTION
I also took the liberty to amend the success message - IMO it's more
informative now.

```
./joern-export --repr=all --format=graphson
exported 30570 nodes, 214486 edges into /home/mp/Projects/shiftleft/joern/out
```
