### PR TITLE
Remove path.size > 1 for this test case

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -125,8 +125,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
       // Case 3: we have reached a call to an internal method without semantic (return value) and
       // this isn't the start node => return partial result and stop traversing
       case call: Call
-          if path.size > 1
-            && isCallToInternalMethodWithoutSemantic(call)
+          if isCallToInternalMethodWithoutSemantic(call)
             && !isArgOrRetOfMethodWeCameFrom(call, path) =>
         createPartialResultForOutputArgOrRet()
 


### PR DESCRIPTION
```
  "DataFlowTest70" should {
    val cpg = code("""
        | int source() {
        |   return 42;
        | }
        | void main() {
        |   sink(source());
        | }
        | """.stripMargin)

    "Test Interprocedural" should {
      "have a flow from argument(which itself is a call) to return" in {
        val source = cpg.literal("42")
        val sink   = cpg.call("sink").argument
        sink.reachableByFlows(source).size shouldBe 1
      }
    }
  }
```