### PR TITLE
jssrc2cpg: add `IMPORT` nodes for `require` statements

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1264,4 +1264,17 @@ class MixedAstCreationPassTest extends AbstractPassTest {
     }
   }
 
+  "AST generation for import/require" should {
+    "make available `import` statements via cpg.imports" in AstFixture("import {x} from \"foo\";") { cpg =>
+      val List(imp) = cpg.imports.l
+      imp.code shouldBe "import {x} from \"foo\""
+      imp.importedEntity shouldBe Some("foo")
+    }
+
+    "make available `require` statements via cpg.imports" in AstFixture("const x = require(\"foo\")") { cpg =>
+      val List(imp) = cpg.imports.l
+
+    }
+
+  }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1269,11 +1269,14 @@ class MixedAstCreationPassTest extends AbstractPassTest {
       val List(imp) = cpg.imports.l
       imp.code shouldBe "import {x} from \"foo\""
       imp.importedEntity shouldBe Some("foo")
+      imp.importedAs shouldBe Some("x")
     }
 
     "make available `require` statements via cpg.imports" in AstFixture("const x = require(\"foo\")") { cpg =>
       val List(imp) = cpg.imports.l
-
+      imp.code shouldBe "x = require(\"foo\")"
+      imp.importedEntity shouldBe Some("foo")
+      imp.importedAs shouldBe Some("x")
     }
 
   }


### PR DESCRIPTION
Previously, we only added `IMPORT` nodes for `import` statements while `require` calls were only accessible via `cpg.call("require")`. With this PR, it doesn't matter whether modules are imported via `import` or `require`, in both cases, we create `IMPORT` nodes.