### PR TITLE
Introduce DynamicCallUnknownFallName define.

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -43,8 +43,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
         callName,
         DispatchTypes.DYNAMIC_DISPATCH,
         callExpr.lineNumber,
-        callExpr.columnNumber,
-        fullName = Some("")
+        callExpr.columnNumber
       )
     createCallAst(callNode, args, Some(Ast(receiverNode)), Some(Ast(baseNode)))
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -3,6 +3,7 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.datastructures.MethodScope
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
+import io.joern.x2cpg
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
@@ -294,12 +295,13 @@ trait AstNodeBuilder { this: AstCreator =>
     callName: String,
     dispatchType: String,
     line: Option[Integer],
-    column: Option[Integer],
-    fullName: Option[String] = None
+    column: Option[Integer]
   ): NewCall = NewCall()
     .code(code)
     .name(callName)
-    .methodFullName(fullName.getOrElse(callName))
+    .methodFullName(
+      if (dispatchType == DispatchTypes.STATIC_DISPATCH) callName else x2cpg.Defines.DynamicCallUnknownFallName
+    )
     .dispatchType(dispatchType)
     .lineNumber(line)
     .columnNumber(column)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -1,6 +1,7 @@
 package io.joern.pysrc2cpg
 
-import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, nodes}
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, nodes}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 class NodeBuilder(diffGraph: DiffGraphBuilder) {
@@ -15,7 +16,7 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .NewCall()
       .code(code)
       .name(name)
-      .methodFullName(name)
+      .methodFullName(if (dispatchType == DispatchTypes.STATIC_DISPATCH) name else Defines.DynamicCallUnknownFallName)
       .dispatchType(dispatchType)
       .typeFullName(Constants.ANY)
       .lineNumber(lineAndColumn.line)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Defines.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Defines.scala
@@ -21,4 +21,8 @@ object Defines {
 
   // Name of the constructor.
   val ConstructorMethodName = "<init>"
+
+  // In some languages like Javascript dynamic calls do not provide any statically known
+  // method/function interface information. In those cases please use this value.
+  val DynamicCallUnknownFallName = "<unknownFullName>"
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -1,5 +1,6 @@
 package io.joern.x2cpg.passes.base
 
+import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, NodeTypes}
@@ -26,7 +27,7 @@ class MethodStubCreator(cpg: Cpg) extends SimpleCpgPass(cpg) {
       methodFullNameToNode.put(method.fullName, method)
     }
 
-    for (call <- cpg.call if call.methodFullName.nonEmpty) {
+    for (call <- cpg.call if call.methodFullName != Defines.DynamicCallUnknownFallName) {
       methodToParameterCount.put(NameAndSignature(call.name, call.signature, call.methodFullName), call.argument.size)
     }
 


### PR DESCRIPTION
This value should by used for dynamically typed languages for dynamic
call method full name properties since they cannot provide any
meaningful method/function interface guarantees like we e.g. have in
Java where a dynamically dispatched call always has a certain
method/function interface guaranteed.