### PR TITLE
jssrc2cpg: link dependencies and imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.570"
+val cpgVersion = "1.3.572"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -403,8 +403,8 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     } else {
       val specs = impDecl.json("specifiers").arr.toList
       val depNodes = specs.map { importSpecifier =>
-        val importedName = importSpecifier("local")("name").str
-        val importNode = createImportNodeAndAttachToAst(impDecl, source, importedName)
+        val importedName   = importSpecifier("local")("name").str
+        val importNode     = createImportNodeAndAttachToAst(impDecl, source, importedName)
         val dependencyNode = createDependencyNode(importedName, source, IMPORT_KEYWORD)
         diffGraph.addEdge(importNode, dependencyNode, EdgeTypes.IMPORTS)
         dependencyNode

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -9,7 +9,7 @@ import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.Stack._
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{IdentifierBase, NewNamespaceBlock, TypeRefBase}
+import io.shiftleft.codepropertygraph.generated.nodes.{IdentifierBase, NewImport, NewNamespaceBlock, TypeRefBase}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import ujson.Value
 
@@ -269,8 +269,10 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       case _             => List(code(lhs))
     }
     names.foreach { name =>
-      diffGraph.addNode(createDependencyNode(name, groupId, REQUIRE_KEYWORD))
-      createImportNodeAndAttachToAst(declarator, groupId, name)
+      val dependencyNode = createDependencyNode(name, groupId, REQUIRE_KEYWORD)
+      diffGraph.addNode(dependencyNode)
+      val importNode = createImportNodeAndAttachToAst(declarator, groupId, name)
+      diffGraph.addEdge(importNode, dependencyNode, EdgeTypes.IMPORTS)
     }
   }
 
@@ -331,8 +333,10 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       case TSExternalModuleReference => referenceNode.json("expression")("value").str
       case _                         => referenceNode.code
     }
-    diffGraph.addNode(createDependencyNode(name, referenceName, IMPORT_KEYWORD))
-    createImportNodeAndAttachToAst(impDecl, referenceName, name)
+    val dependencyNode = createDependencyNode(name, referenceName, IMPORT_KEYWORD)
+    diffGraph.addNode(dependencyNode)
+    val importNode = createImportNodeAndAttachToAst(impDecl, referenceName, name)
+    diffGraph.addEdge(importNode, dependencyNode, EdgeTypes.IMPORTS)
     astForRequireCallFromImport(name, None, referenceName, isImportN = false, impDecl)
   }
 
@@ -391,15 +395,18 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     val specifiers = impDecl.json("specifiers").arr
 
     if (specifiers.isEmpty) {
-      diffGraph.addNode(createDependencyNode(source, source, IMPORT_KEYWORD))
-      createImportNodeAndAttachToAst(impDecl, source, source)
+      val dependencyNode = createDependencyNode(source, source, IMPORT_KEYWORD)
+      diffGraph.addNode(dependencyNode)
+      val importNode = createImportNodeAndAttachToAst(impDecl, source, source)
+      diffGraph.addEdge(importNode, dependencyNode, EdgeTypes.IMPORTS)
       astForRequireCallFromImport(source, None, source, isImportN = false, impDecl)
     } else {
       val specs = impDecl.json("specifiers").arr.toList
       val depNodes = specs.map { importSpecifier =>
-        val importedName = importSpecifier("local")("name").str
-        createImportNodeAndAttachToAst(impDecl, source, importedName)
-        createDependencyNode(importedName, source, IMPORT_KEYWORD)
+        val importedName   = importSpecifier("local")("name").str
+        val importNode     = createImportNodeAndAttachToAst(impDecl, source, importedName)
+        val dependencyNode = createDependencyNode(importedName, source, IMPORT_KEYWORD)
+        diffGraph.addEdge(importNode, dependencyNode, EdgeTypes.IMPORTS)
       }
       depNodes.foreach(diffGraph.addNode)
       val requireCalls = specs.map { importSpecifier =>
@@ -429,11 +436,12 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     impDecl: BabelNodeInfo,
     importedEntity: String,
     importedAs: String
-  ): Unit = {
+  ): NewImport = {
     val impNode = createImportNode(impDecl, Some(importedEntity).filter(_.trim.nonEmpty), importedAs)
     methodAstParentStack.collectFirst { case namespaceBlockNode: NewNamespaceBlock =>
       diffGraph.addEdge(namespaceBlockNode, impNode, EdgeTypes.AST)
     }
+    impNode
   }
 
   private def convertDestructingObjectElement(element: BabelNodeInfo, key: BabelNodeInfo, localTmpName: String): Ast = {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -403,10 +403,11 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     } else {
       val specs = impDecl.json("specifiers").arr.toList
       val depNodes = specs.map { importSpecifier =>
-        val importedName   = importSpecifier("local")("name").str
-        val importNode     = createImportNodeAndAttachToAst(impDecl, source, importedName)
+        val importedName = importSpecifier("local")("name").str
+        val importNode = createImportNodeAndAttachToAst(impDecl, source, importedName)
         val dependencyNode = createDependencyNode(importedName, source, IMPORT_KEYWORD)
         diffGraph.addEdge(importNode, dependencyNode, EdgeTypes.IMPORTS)
+        dependencyNode
       }
       depNodes.foreach(diffGraph.addNode)
       val requireCalls = specs.map { importSpecifier =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1270,6 +1270,16 @@ class MixedAstCreationPassTest extends AbstractPassTest {
       imp.code shouldBe "import {x} from \"foo\""
       imp.importedEntity shouldBe Some("foo")
       imp.importedAs shouldBe Some("x")
+
+    }
+
+    "allow traversing from dependency to import from for `import` statements" in AstFixture(
+      "import {x} from \"foo\";"
+    ) { cpg =>
+      val List(imp)  = cpg.imports.l
+      val List(dep)  = cpg.dependency.l
+      val List(imp2) = dep.imports.l
+      imp shouldBe imp2
     }
 
     "make available `require` statements via cpg.imports" in AstFixture("const x = require(\"foo\")") { cpg =>
@@ -1277,6 +1287,15 @@ class MixedAstCreationPassTest extends AbstractPassTest {
       imp.code shouldBe "x = require(\"foo\")"
       imp.importedEntity shouldBe Some("foo")
       imp.importedAs shouldBe Some("x")
+    }
+
+    "allow traversing from dependency to import from for `require` statements" in AstFixture(
+      "const x = require(\"foo\")"
+    ) { cpg =>
+      val List(imp)  = cpg.imports.l
+      val List(dep)  = cpg.dependency.l
+      val List(imp2) = dep.imports.l
+      imp shouldBe imp2
     }
 
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1289,13 +1289,12 @@ class MixedAstCreationPassTest extends AbstractPassTest {
       imp.importedAs shouldBe Some("x")
     }
 
-    "allow traversing from dependency to import from for `require` statements" in AstFixture(
-      "const x = require(\"foo\")"
-    ) { cpg =>
-      val List(imp)  = cpg.imports.l
-      val List(dep)  = cpg.dependency.l
-      val List(imp2) = dep.imports.l
-      imp shouldBe imp2
+    "allow traversing from dependency to import for `require` statements" in AstFixture("const x = require(\"foo\")") {
+      cpg =>
+        val List(imp)  = cpg.imports.l
+        val List(dep)  = cpg.dependency.l
+        val List(imp2) = dep.imports.l
+        imp shouldBe imp2
     }
 
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -81,6 +81,12 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
   implicit def iterOnceToAnnotationTrav[A <: Annotation](a: IterableOnce[A]): AnnotationTraversal =
     new AnnotationTraversal(iterableToTraversal(a))
 
+  implicit def singleToDependencyTrav[A <: Dependency](a: A): DependencyTraversal =
+    new DependencyTraversal(Traversal.fromSingle(a))
+
+  implicit def iterToDependencyTrav[A <: Dependency](a: IterableOnce[A]): DependencyTraversal =
+    new DependencyTraversal(iterableToTraversal(a))
+
   implicit def singleToAnnotationParameterAssignTrav[A <: AnnotationParameterAssign](
     a: A
   ): AnnotationParameterAssignTraversal =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/DependencyTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/DependencyTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.Import
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class DependencyTraversal(val traversal: Traversal[nodes.Dependency]) extends AnyVal {
   def imports: Traversal[Import] = traversal.in(EdgeTypes.IMPORTS).cast[Import]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/DependencyTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/DependencyTraversal.scala
@@ -1,0 +1,9 @@
+package io.shiftleft.semanticcpg.language.types.structure
+
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.nodes.Import
+import overflowdb.traversal.Traversal
+
+class DependencyTraversal(val traversal: Traversal[nodes.Dependency]) extends AnyVal {
+  def imports: Traversal[Import] = traversal.in(EdgeTypes.IMPORTS).cast[Import]
+}


### PR DESCRIPTION
With this PR, `IMPORT` nodes are now connected to `DEPENDENCY` nodes via `IMPORTS` edges and it's possible to traverse from a dependency to an import via `cpg.dependency.imports.l`.
