### PR TITLE
Fix javasrc crash and hang bugs

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -52,7 +52,6 @@ class AstCreationPass(sourceInfo: SourceDirectoryInfo, config: Config, cpg: Cpg,
         diffGraph.absorb(new AstCreator(fileInfo.originalFileName, result, global, symbolResolver).createAst())
       case _ =>
         logger.warn("Failed to parse file " + fileInfo.analysisFileName)
-        Iterator()
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2901,7 +2901,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     if (maybeImplementedInterface.isEmpty) {
       val location = s"$filename:${line(expr)}:${column(expr)}"
-      logger.warn(
+      logger.debug(
         s"Could not resolve the interface implemented by a lambda. Type info may be missing: $location. Type info may be missing."
       )
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
@@ -62,7 +62,7 @@ class TypeInferencePass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
           diffGraph.setNodeProperty(call, PropertyNames.Signature, method.signature)
           diffGraph.setNodeProperty(call, PropertyNames.TypeFullName, method.methodReturn.typeFullName)
         } else {
-          logger.info(s"Found multiple matching internal methods for unresolved call ${call.methodFullName}")
+          logger.debug(s"Found multiple matching internal methods for unresolved call ${call.methodFullName}")
         }
 
       case None => // Call is to and unresolved external method, so we can't get any more information here.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -57,7 +57,16 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
       .map { substitutedType =>
         // substitutedType.isTypeVariable can crash with an UnsolvedSymbolException if it is an instance of LazyType,
         // in which case the type hasn't been successfully substituted.
-        !(substitutedType.isTypeVariable && substitutedType.asTypeParameter() == typeParamDecl)
+        val substitutionOccurred =
+          !(substitutedType.isTypeVariable && substitutedType.asTypeParameter() == typeParamDecl)
+        // There's a potential infinite loop that can occur when a type variable is subsituted with a wildcard type
+        // bounded by that type variable.
+        val isSimilarWildcardSubstition = substitutedType match {
+          case wc: ResolvedWildcard => wc.getBoundedType == substitutedType
+          case _                    => false
+        }
+
+        substitutionOccurred && !isSimilarWildcardSubstition
       }
       .getOrElse(false)
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -59,10 +59,10 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
         // in which case the type hasn't been successfully substituted.
         val substitutionOccurred =
           !(substitutedType.isTypeVariable && substitutedType.asTypeParameter() == typeParamDecl)
-        // There's a potential infinite loop that can occur when a type variable is subsituted with a wildcard type
+        // There's a potential infinite loop that can occur when a type variable is substituted with a wildcard type
         // bounded by that type variable.
         val isSimilarWildcardSubstition = substitutedType match {
-          case wc: ResolvedWildcard => wc.getBoundedType == substitutedType
+          case wc: ResolvedWildcard => Try(wc.getBoundedType.asTypeParameter()).toOption.contains(typeParamDecl)
           case _                    => false
         }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
@@ -24,7 +24,7 @@ object Util {
       case Success(ancestors) => ancestors.asScala.toSeq
 
       case Failure(exception) =>
-        logger.warn(s"Failed to get direct parents for typeDecl ${typeDecl.getQualifiedName}", exception)
+        logger.debug(s"Failed to get direct parents for typeDecl ${typeDecl.getQualifiedName}")
         Seq.empty
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
@@ -24,7 +24,7 @@ object Util {
       case Success(ancestors) => ancestors.asScala.toSeq
 
       case Failure(exception) =>
-        logger.debug(s"Failed to get direct parents for typeDecl ${typeDecl.getQualifiedName}")
+        logger.debug(s"Failed to get direct parents for typeDecl ${typeDecl.getQualifiedName}", exception)
         Seq.empty
     }
   }


### PR DESCRIPTION
This PR includes 2 fixes for issues found when creating a cpg for https://github.com/elastic/elasticsearch
* `typeDecl.getAncestors` throws an `IllegalArgumentException` for record types (at least when using the ReflectionTypeSolver), so catch that exception. This may be related to https://github.com/javaparser/javaparser/issues/3556
* It was possible to end up with an infinite recursive loop when substituting a type variable with a wildcard type bounded by that same type variable, so this adds a check to check if a "true" substitution occurred.

This also lowers the logging level for some warnings that are currently very noisy (and not particularly useful except for debugging) on elasticsearch.