### PR TITLE
Stop the taskSolver from going in a method visited before

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -22,8 +22,6 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
 
   import Engine._
 
-  implicit val implicitEngineContext: EngineContext = context
-
   /** Entry point of callable. First checks if the maximum call depth has been exceeded, in which case an empty result
     * list is returned. Otherwise, the task is solved and its results are returned.
     */

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/FunctionCallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/FunctionCallTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 class NewFunctionCallTests extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
   "Dataflow through function calls" should {
 
-    "can go in a method twice" in {
+    "do not go in a method twice" in {
       val cpg = code("""
           |class Foo{
           |    String name;

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/FunctionCallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/FunctionCallTests.scala
@@ -1,11 +1,33 @@
 package io.joern.javasrc2cpg.querying.dataflow
 
-import io.joern.javasrc2cpg.testfixtures.{JavaDataflowFixture, JavaSrcCode2CpgFixture}
 import io.joern.dataflowengineoss.language._
+import io.joern.javasrc2cpg.testfixtures.{JavaDataflowFixture, JavaSrcCode2CpgFixture}
 import io.shiftleft.semanticcpg.language._
 
 class NewFunctionCallTests extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
   "Dataflow through function calls" should {
+
+    "can go in a method twice" in {
+      val cpg = code("""
+          |class Foo{
+          |    String name;
+          |    String getName() {
+          |        return name;
+          |    }
+          |}
+          |class Main{
+          |    public void bar(Foo foo) {
+          |        check(foo.getName());
+          |        sink(foo.getName());
+          |    }
+          |}
+          |""".stripMargin)
+
+      def source = cpg.method("bar").parameter.name("foo")
+      def sink   = cpg.method("sink").parameter.index(1)
+      sink.reachableByFlows(source).p.foreach(println)
+      sink.reachableBy(source).size shouldBe 1
+    }
 
     "find a path directly via a function argument" in {
       val cpg = code("""


### PR DESCRIPTION
Another approach for #1855 

Test case failed before this PR
 ```
   "do not go in a method twice" in {
      val cpg = code("""
          |class Foo{
          |    String name;
          |    String getName() {
          |        return name;
          |    }
          |}
          |class Main{
          |    public void bar(Foo foo) {
          |        check(foo.getName());
          |        sink(foo.getName());
          |    }
          |}
          |""".stripMargin)

      def source = cpg.method("bar").parameter.name("foo")
      def sink   = cpg.method("sink").parameter.index(1)
      sink.reachableBy(source).size shouldBe 1
```
Cause: two ```call``` to the same ```method```, leading the algorithm to go in ```getName``` twice:
```
check(foo.getName());
sink(foo.getName());
```
When we reach ```sink(foo.getName())``` we go in ```getName``` once, and when we reach ```check(foo.getName());``` we don't need to go in ```getName``` again, beacaue we have searched ```getName``` and if we do go in
https://github.com/joernio/joern/blob/210e867fa1921fd036d6388d56eb4b8751f97fc7/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L189
is triggered, and the task will fail.