### PR TITLE
Introduce a pass to handle `const foo = (x,y) => { }`

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -21,6 +21,7 @@ import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.utils.HashUtil
 import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.passes.frontend.JavascriptCallLinker
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
@@ -74,6 +75,6 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
 object JsSrc2Cpg {
 
   def postProcessingPasses(cpg: Cpg): List[CpgPassBase] =
-    List(new RequirePass(cpg), new ConstClosurePass(cpg))
+    List(new RequirePass(cpg), new ConstClosurePass(cpg), new JavascriptCallLinker(cpg))
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -7,6 +7,7 @@ import io.joern.jssrc2cpg.passes.{
   AstCreationPass,
   BuiltinTypesPass,
   ConfigPass,
+  ConstClosurePass,
   DependenciesPass,
   JsMetaDataPass,
   PrivateKeyFilePass,
@@ -73,6 +74,6 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
 object JsSrc2Cpg {
 
   def postProcessingPasses(cpg: Cpg): List[CpgPassBase] =
-    List(new RequirePass(cpg))
+    List(new RequirePass(cpg), new ConstClosurePass(cpg))
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
@@ -1,0 +1,11 @@
+package io.joern.jssrc2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.passes.SimpleCpgPass
+import overflowdb.BatchedUpdate
+
+/** A pass that identifies assignments of closures to constants and updates `METHOD` nodes accordingly.
+  */
+class ConstClosurePass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+  override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit = {}
+}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
@@ -3,9 +3,22 @@ package io.joern.jssrc2cpg.passes
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.SimpleCpgPass
 import overflowdb.BatchedUpdate
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal._
 
 /** A pass that identifies assignments of closures to constants and updates `METHOD` nodes accordingly.
   */
 class ConstClosurePass(cpg: Cpg) extends SimpleCpgPass(cpg) {
-  override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit = {}
+  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+    for {
+      assignment      <- cpg.assignment
+      name            <- assignment.filter(_.code.startsWith("const ")).target.isIdentifier.name
+      method          <- assignment.start.source.isMethodRef.referencedMethod
+      enclosingMethod <- assignment.start.method.fullName
+    } {
+      diffGraph.setNodeProperty(method, "NAME", name)
+      diffGraph.setNodeProperty(method, "FULL_NAME", s"$enclosingMethod:$name")
+    }
+
+  }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
@@ -10,10 +10,8 @@ import overflowdb.traversal.{NodeOps, Traversal}
 
 import java.nio.file.Paths
 
-/**
-  * This pass enhances the call graph and call nodes by interpreting
-  * assignments of the form `foo = require("module")`.
-  * */
+/** This pass enhances the call graph and call nodes by interpreting assignments of the form `foo = require("module")`.
+  */
 class RequirePass(cpg: Cpg) extends SimpleCpgPass(cpg) {
 
   private val codeRoot = cpg.metaData.root.headOption.getOrElse("")

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
@@ -10,6 +10,10 @@ import overflowdb.traversal.{NodeOps, Traversal}
 
 import java.nio.file.Paths
 
+/**
+  * This pass enhances the call graph and call nodes by interpreting
+  * assignments of the form `foo = require("module")`.
+  * */
 class RequirePass(cpg: Cpg) extends SimpleCpgPass(cpg) {
 
   private val codeRoot = cpg.metaData.root.headOption.getOrElse("")

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -599,7 +599,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
 
   "Flow into method defined as lambda and assigned to constant" in {
     val cpg: Cpg = code("""
-        | const foo = <A>(x, y) => {
+        | const foo = (x, y) => {
         |   sink(x);
         | };
         |
@@ -610,6 +610,12 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val src  = cpg.literal.code("1").l
     sink.size shouldBe 1
     src.size shouldBe 1
+    // TODO While `const foo = (x,y) => { ... }` ends up as a METHOD
+    // in the CPG, its fullName is just `file::program:anonymous` and
+    // its name is `anonymous`, and so, we don't know that it can be
+    // referred to as `foo`.  There is also no assignment visible
+    // in the CPG, so, the relation between the constant `foo` and
+    // the anonymous function is not visible in the CPG
     sink.reachableBy(src).size shouldBe 1
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -597,4 +597,20 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     sink.reachableBy(src).size shouldBe 1
   }
 
+  "Flow into method defined as lambda and assigned to constant" in {
+    val cpg: Cpg = code("""
+        | const foo = <A>(x, y) => {
+        |   sink(x);
+        | };
+        |
+        | foo(1, 2);
+        |""".stripMargin)
+
+    val sink = cpg.call("sink").l
+    val src  = cpg.literal.code("1").l
+    sink.size shouldBe 1
+    src.size shouldBe 1
+    sink.reachableBy(src).size shouldBe 1
+  }
+
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -610,12 +610,6 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val src  = cpg.literal.code("1").l
     sink.size shouldBe 1
     src.size shouldBe 1
-    // TODO While `const foo = (x,y) => { ... }` ends up as a METHOD
-    // in the CPG, its fullName is just `file::program:anonymous` and
-    // its name is `anonymous`, and so, we don't know that it can be
-    // referred to as `foo`.  There is also no assignment visible
-    // in the CPG, so, the relation between the constant `foo` and
-    // the anonymous function is not visible in the CPG
     sink.reachableBy(src).size shouldBe 1
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
@@ -1,0 +1,5 @@
+package io.joern.jssrc2cpg.passes
+
+import io.joern.jssrc2cpg.testfixtures.DataFlowCodeToCpgSuite
+
+class ConstClosurePassTests extends DataFlowCodeToCpgSuite {}

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
@@ -1,5 +1,20 @@
 package io.joern.jssrc2cpg.passes
 
 import io.joern.jssrc2cpg.testfixtures.DataFlowCodeToCpgSuite
+import io.shiftleft.semanticcpg.language._
 
-class ConstClosurePassTests extends DataFlowCodeToCpgSuite {}
+class ConstClosurePassTests extends DataFlowCodeToCpgSuite {
+
+  "should return method `foo` via `cpg.method`" in {
+    val cpg = code("""
+         const foo = (x,y) => {
+           return x + y;
+         }
+      """.stripMargin)
+
+    val List(m) = cpg.method.name("foo").l
+    m.name shouldBe "foo"
+    m.fullName.endsWith("program:foo") shouldBe true
+  }
+
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/CallGraph.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/CallGraph.scala
@@ -14,13 +14,7 @@ object CallGraph {
   def defaultOpts         = new LayerCreatorOptions()
 
   def passes(cpg: Cpg): Iterator[CpgPassBase] = {
-    val languageSpecificPasses = cpg.metaData.language.lastOption match {
-      case Some(Languages.JSSRC)      => Iterator[CpgPassBase](new JavascriptCallLinker(cpg))
-      case Some(Languages.JAVASCRIPT) => Iterator[CpgPassBase](new JavascriptCallLinker(cpg))
-      case _                          => Iterator[CpgPassBase]()
-    }
-    languageSpecificPasses ++
-      Iterator(new MethodRefLinker(cpg), new StaticCallLinker(cpg), new DynamicCallLinker(cpg))
+    Iterator(new MethodRefLinker(cpg), new StaticCallLinker(cpg), new DynamicCallLinker(cpg))
   }
 
 }


### PR DESCRIPTION
Fixes #1870