### PR TITLE
Make Code2CpgFixture more flexible.

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
@@ -3,12 +3,11 @@ package io.joern.c2cpg.testfixtures
 import better.files.File
 import io.joern.c2cpg.{C2Cpg, Config}
 import io.joern.c2cpg.parser.FileDefaults
-import io.joern.x2cpg.testfixtures.Code2CpgFixture
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend}
 import io.shiftleft.codepropertygraph.Cpg
-import io.joern.x2cpg.testfixtures.LanguageFrontend
 import org.scalatest.Inside
 
-class C2CpgFrontend(override val fileSuffix: String = FileDefaults.C_EXT) extends LanguageFrontend {
+trait C2CpgFrontend extends LanguageFrontend {
   def execute(sourceCodePath: java.io.File): Cpg = {
     val cpgOutFile = File.newTemporaryFile("c2cpg.bin")
     cpgOutFile.deleteOnExit()
@@ -23,6 +22,8 @@ class C2CpgFrontend(override val fileSuffix: String = FileDefaults.C_EXT) extend
   }
 }
 
+class DefaultTestCpgWithC(val fileSuffix: String) extends DefaultTestCpg with C2CpgFrontend
+
 class CCodeToCpgSuite(fileSuffix: String = FileDefaults.C_EXT)
-    extends Code2CpgFixture(new C2CpgFrontend(fileSuffix))
+    extends Code2CpgFixture(() => new DefaultTestCpgWithC(fileSuffix))
     with Inside

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -1,19 +1,28 @@
 package io.joern.c2cpg.testfixtures
 
+import io.joern.c2cpg.parser.FileDefaults
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.shiftleft.codepropertygraph.Cpg
+import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, TestCpg}
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
-class DataFlowCodeToCpgSuite extends CCodeToCpgSuite {
+class DataFlowTestCpg extends TestCpg with C2CpgFrontend {
+  override val fileSuffix: String = FileDefaults.C_EXT
+
+  override protected def applyPasses(): Unit = {
+    X2Cpg.applyDefaultOverlays(this)
+
+    val context = new LayerCreatorContext(this)
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
+  }
+}
+
+class DataFlowCodeToCpgSuite extends Code2CpgFixture(() => new DataFlowTestCpg()) {
 
   protected implicit val context: EngineContext = EngineContext()
-
-  override def applyPasses(cpg: Cpg): Unit = {
-    super.applyPasses(cpg)
-    new OssDataFlow(new OssDataFlowOptions()).run(new LayerCreatorContext(cpg))
-  }
 
   protected implicit def int2IntegerOption(x: Int): Option[Integer] = Some(x)
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -1,21 +1,30 @@
 package io.joern.jssrc2cpg.testfixtures
 
-import io.shiftleft.codepropertygraph.Cpg
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.jssrc2cpg.JsSrc2Cpg
+import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, TestCpg}
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
-class DataFlowCodeToCpgSuite extends JsSrc2CpgSuite {
+class DataFlowTestCpg extends TestCpg with JsSrc2CpgFrontend {
+  override val fileSuffix: String = ".js"
+
+  override def applyPasses(): Unit = {
+    X2Cpg.applyDefaultOverlays(this)
+
+    val context = new LayerCreatorContext(this)
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
+    JsSrc2Cpg.postProcessingPasses(this).foreach(_.createAndApply())
+  }
+
+}
+
+class DataFlowCodeToCpgSuite extends Code2CpgFixture(() => new DataFlowTestCpg()) {
 
   implicit var context: EngineContext = EngineContext()
-
-  override def applyPasses(cpg: Cpg): Unit = {
-    super.applyPasses(cpg)
-    new OssDataFlow(new OssDataFlowOptions()).run(new LayerCreatorContext(cpg))
-    JsSrc2Cpg.postProcessingPasses(cpg).foreach(_.createAndApply())
-  }
 
   protected def flowToResultPairs(path: Path): List[(String, Integer)] =
     path.resultPairs().collect { case (firstElement: String, secondElement: Option[Integer]) =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
@@ -4,10 +4,10 @@ import better.files.File
 import io.joern.jssrc2cpg.JsSrc2Cpg
 import io.joern.jssrc2cpg.Config
 import io.shiftleft.codepropertygraph.Cpg
-import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend}
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend}
 import org.scalatest.Inside
 
-class JsSrc2CpgFrontend(override val fileSuffix: String = ".js") extends LanguageFrontend {
+trait JsSrc2CpgFrontend extends LanguageFrontend {
   def execute(sourceCodePath: java.io.File): Cpg = {
     val cpgOutFile = File.newTemporaryFile(suffix = "cpg.bin")
     cpgOutFile.deleteOnExit()
@@ -17,4 +17,8 @@ class JsSrc2CpgFrontend(override val fileSuffix: String = ".js") extends Languag
   }
 }
 
-class JsSrc2CpgSuite(fileSuffix: String = ".js") extends Code2CpgFixture(new JsSrc2CpgFrontend(fileSuffix)) with Inside
+class DefaultTestCpgWithJsSrc(val fileSuffix: String) extends DefaultTestCpg with JsSrc2CpgFrontend
+
+class JsSrc2CpgSuite(fileSuffix: String = ".js")
+    extends Code2CpgFixture(() => new DefaultTestCpgWithJsSrc(fileSuffix))
+    with Inside

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/testfixtures/PhpCode2CpgFixture.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/testfixtures/PhpCode2CpgFixture.scala
@@ -2,13 +2,13 @@ package io.joern.php2cpg.testfixtures
 
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.php2cpg.{Config, Php2Cpg}
-import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend}
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
 
 import java.io.File
 
-class PhpFrontend extends LanguageFrontend {
+trait PhpFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".php"
 
   override def execute(sourceCodeFile: File): Cpg = {
@@ -17,7 +17,9 @@ class PhpFrontend extends LanguageFrontend {
   }
 }
 
-class PhpCode2CpgFixture extends Code2CpgFixture(new PhpFrontend()) {
+class DefaultTestCpgWithPhp extends DefaultTestCpg with PhpFrontend
+
+class PhpCode2CpgFixture extends Code2CpgFixture(() => new DefaultTestCpgWithPhp) {
   implicit val resolver: ICallResolver           = NoResolve
   implicit lazy val engineContext: EngineContext = EngineContext()
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -3,15 +3,15 @@ package io.joern.pysrc2cpg
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.pysrc2cpg.Py2CpgOnFileSystem.buildCpg
-import io.joern.x2cpg.X2CpgConfig
-import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend}
+import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
 import java.io.File
 import java.nio.file.Paths
 
-class PythonFrontend() extends LanguageFrontend {
+trait PythonFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".py"
 
   override def execute(sourceCodeFile: File): Cpg = {
@@ -20,18 +20,28 @@ class PythonFrontend() extends LanguageFrontend {
   }
 }
 
-class PySrc2CpgFixture(withOssDataflow: Boolean = false) extends Code2CpgFixture(new PythonFrontend()) {
+class PySrcTestCpg extends TestCpg with PythonFrontend {
+  private var _withOssDataflow = false
 
-  implicit val context: EngineContext = EngineContext()
+  def withOssDataflow(value: Boolean = true): this.type = {
+    _withOssDataflow = value
+    this
+  }
 
-  override def applyPasses(cpg: Cpg): Unit = {
-    super.applyPasses(cpg)
+  override def applyPasses(): Unit = {
+    X2Cpg.applyDefaultOverlays(this)
 
-    if (withOssDataflow) {
-      val context = new LayerCreatorContext(cpg)
+    if (_withOssDataflow) {
+      val context = new LayerCreatorContext(this)
       val options = new OssDataFlowOptions()
       new OssDataFlow(options).run(context)
     }
   }
+}
+
+class PySrc2CpgFixture(withOssDataflow: Boolean = false)
+    extends Code2CpgFixture(() => new PySrcTestCpg().withOssDataflow(withOssDataflow)) {
+
+  implicit val context: EngineContext = EngineContext()
 
 }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/Code2CpgFixture.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/Code2CpgFixture.scala
@@ -1,34 +1,35 @@
 package io.joern.x2cpg.testfixtures
 
-import io.joern.x2cpg.X2Cpg
-import io.shiftleft.codepropertygraph.Cpg
 import org.scalatest.{BeforeAndAfterAll, Inside}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.mutable
 
-class Code2CpgFixture(val frontend: LanguageFrontend)
+// Fixture class from which all tests which require a code to CPG translation step
+// should either directly or indirectly use. The intended way is to derive from
+// this class, thereby specifying the testCpgFactory parameter and than use the
+// derived class in tests.
+// The testCpgFactory() and code() methods return a type T deriving from TestCpg
+// in order to allow further cpg and language frontend configuration methods to
+// be defined as needed for the individual test cases.
+class Code2CpgFixture[T <: TestCpg](testCpgFactory: () => T)
     extends AnyWordSpec
     with Matchers
     with BeforeAndAfterAll
     with Inside {
   private val cpgs = mutable.ArrayBuffer.empty[TestCpg]
 
-  def code(code: String): TestCpg = {
-    val newCpg = new TestCpg(frontend, this).moreCode(code)
+  def code(code: String): T = {
+    val newCpg = testCpgFactory().moreCode(code)
     cpgs.append(newCpg)
     newCpg
   }
 
-  def code(code: String, fileName: String): TestCpg = {
-    val newCpg = new TestCpg(frontend, this).moreCode(code, fileName)
+  def code(code: String, fileName: String): T = {
+    val newCpg = testCpgFactory().moreCode(code, fileName)
     cpgs.append(newCpg)
     newCpg
-  }
-
-  def applyPasses(cpg: Cpg): Unit = {
-    X2Cpg.applyDefaultOverlays(cpg)
   }
 
   override def afterAll(): Unit = {

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/DefaultTestCpg.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/DefaultTestCpg.scala
@@ -1,0 +1,9 @@
+package io.joern.x2cpg.testfixtures
+
+import io.joern.x2cpg.X2Cpg
+
+abstract class DefaultTestCpg extends TestCpg {
+  override protected def applyPasses(): Unit = {
+    X2Cpg.applyDefaultOverlays(this)
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/LanguageFrontend.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/LanguageFrontend.scala
@@ -6,7 +6,7 @@ import java.io.File
 
 /** LanguageFrontend encapsulates the logic that translates the source code directory into CPGs
   */
-abstract class LanguageFrontend {
+trait LanguageFrontend {
 
   /** A standard file extension for the source code files of the given language. E.g. `.c` for C language
     */

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/TestCpg.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/TestCpg.scala
@@ -9,18 +9,22 @@ import java.util.Comparator
 import scala.collection.mutable
 
 // Lazily populated test CPG which is created upon first access to the underlying graph.
-class TestCpg(frontend: LanguageFrontend, fixture: Code2CpgFixture) extends Cpg() {
+// The trait LanguageFrontend is mixed in and not property/field of this class in order
+// to allow the configuration of language frontend specific properties on the CPG object.
+abstract class TestCpg extends Cpg() with LanguageFrontend {
   private var _graph            = Option.empty[Graph]
   private val codeFileNamePairs = mutable.ArrayBuffer.empty[(String, Path)]
   private var fileNameCounter   = 0
 
-  def moreCode(code: String): TestCpg = {
-    val result = moreCode(code, s"Test$fileNameCounter${frontend.fileSuffix}")
+  protected def applyPasses(): Unit
+
+  def moreCode(code: String): this.type = {
+    moreCode(code, s"Test$fileNameCounter${fileSuffix}")
     fileNameCounter += 1
-    result
+    this
   }
 
-  def moreCode(code: String, fileName: String): TestCpg = {
+  def moreCode(code: String, fileName: String): this.type = {
     checkGraphEmpty()
     codeFileNamePairs.append((code, Paths.get(fileName)))
     this
@@ -55,8 +59,8 @@ class TestCpg(frontend: LanguageFrontend, fixture: Code2CpgFixture) extends Cpg(
     if (_graph.isEmpty) {
       val codeDir = codeToFileSystem()
       try {
-        _graph = Some(frontend.execute(codeDir.toFile).graph)
-        fixture.applyPasses(this)
+        _graph = Some(execute(codeDir.toFile).graph)
+        applyPasses()
       } finally {
         deleteDir(codeDir)
       }

--- a/querydb/src/test/scala/io/joern/suites/AndroidQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/AndroidQueryTestSuite.scala
@@ -3,7 +3,7 @@ package io.joern.suites
 import io.joern.util.QueryUtil
 import io.joern.console.{CodeSnippet, Query, QueryBundle}
 import io.joern.kotlin2cpg.{Config, Kotlin2Cpg}
-import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend}
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.utils.ProjectRoot
 import io.joern.console.scan._
@@ -12,7 +12,9 @@ import io.shiftleft.semanticcpg.language._
 
 import java.io.File
 
-class Kotlin2CpgFrontend(override val fileSuffix: String = ".kt") extends LanguageFrontend {
+trait Kotlin2CpgFrontend extends LanguageFrontend {
+  override val fileSuffix: String = ".kt"
+
   def execute(sourceCodePath: File): Cpg = {
     val cpgFile = File.createTempFile("kt2cpg", ".zip")
     cpgFile.deleteOnExit()
@@ -22,7 +24,9 @@ class Kotlin2CpgFrontend(override val fileSuffix: String = ".kt") extends Langua
   }
 }
 
-class AndroidQueryTestSuite extends Code2CpgFixture(new Kotlin2CpgFrontend()) {
+class DefaultTestCpgWithKotlin extends DefaultTestCpg with Kotlin2CpgFrontend
+
+class AndroidQueryTestSuite extends Code2CpgFixture(() => new DefaultTestCpgWithKotlin()) {
 
   val argumentProvider = new QDBArgumentProvider(3)
 


### PR DESCRIPTION
This enables the reused of Code2CpgFixture also in tests setups where
additional configuration values are need for either the language
frontend or the CPG passes.

We achieve this by basically making the TestCpg a combo object where the
LangaugeFrontend trait is mixed in. By then deriving from TestCpg,
arbitrary additional configuration methods can be added.