### PR TITLE
Frontends only need to depend on dataflowengineoss for tests.

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/build.sbt
+++ b/joern-cli/frontends/ghidra2cpg/build.sbt
@@ -1,6 +1,6 @@
 name := "ghidra2cpg"
 
-dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
+dependsOn(Projects.dataflowengineoss % Test, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
   "com.github.scopt" %% "scopt"                    % "4.1.0",

--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -3,7 +3,7 @@ name := "javasrc2cpg"
 scalaVersion       := "2.13.8"
 crossScalaVersions := Seq("2.13.8", "3.1.3")
 
-dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
+dependsOn(Projects.dataflowengineoss % Test, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,

--- a/joern-cli/frontends/jimple2cpg/build.sbt
+++ b/joern-cli/frontends/jimple2cpg/build.sbt
@@ -3,7 +3,7 @@ name := "jimple2cpg"
 scalaVersion       := "2.13.8"
 crossScalaVersions := Seq("2.13.8", "3.1.3")
 
-dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
+dependsOn(Projects.dataflowengineoss % Test, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -2,7 +2,7 @@ name               := "jssrc2cpg"
 scalaVersion       := "2.13.8"
 crossScalaVersions := Seq("2.13.8", "3.1.3")
 
-dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
+dependsOn(Projects.dataflowengineoss % Test, Projects.x2cpg % "compile->compile;test->test")
 
 val astGenVersion = "2.2.0"
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -1,8 +1,6 @@
 package io.joern.jssrc2cpg
 
 import better.files.File
-import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
-import io.joern.jssrc2cpg.JsSrc2Cpg.postProcessingPasses
 import io.joern.jssrc2cpg.passes.{
   AstCreationPass,
   BuiltinTypesPass,
@@ -58,15 +56,6 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
 
         report.print()
       }
-    }
-  }
-
-  def createCpgWithAllOverlays(config: Config): Try[Cpg] = {
-    val maybeCpg = createCpgWithOverlays(config)
-    maybeCpg.map { cpg =>
-      new OssDataFlow(new OssDataFlowOptions()).run(new LayerCreatorContext(cpg))
-      postProcessingPasses(cpg).foreach(_.createAndApply())
-      cpg
     }
   }
 

--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -2,7 +2,7 @@ name := "kotlin2cpg"
 
 val kotlinVersion = "1.6.21"
 
-dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
+dependsOn(Projects.dataflowengineoss % Test, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
   "com.github.pathikrit"    %% "better-files"               % "3.9.1",

--- a/joern-cli/frontends/pysrc2cpg/build.sbt
+++ b/joern-cli/frontends/pysrc2cpg/build.sbt
@@ -2,7 +2,7 @@ name := "pysrc2cpg"
 
 scalaVersion := "2.13.8"
 
-dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
+dependsOn(Projects.dataflowengineoss % Test, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph"          % Versions.cpg,

--- a/querydb/build.sbt
+++ b/querydb/build.sbt
@@ -5,6 +5,7 @@ enablePlugins(JavaAppPackaging)
 dependsOn(
   Projects.console,
   Projects.macros,
+  Projects.dataflowengineoss,
   Projects.ghidra2cpg,
   Projects.ghidra2cpg % "test->test",
   Projects.c2cpg      % "test->test",


### PR DESCRIPTION
Also fixed up dependencies for querydb since it so far only got
dataflowengineoss transitively which is now not the case anymore.