### PR TITLE
jssrc2cpg: uniform handling for string literals

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -30,15 +30,10 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   protected def astForNullLiteral(nullLiteral: BabelNodeInfo): Ast =
     Ast(createLiteralNode(nullLiteral.code, Some(Defines.NULL.label), nullLiteral.lineNumber, nullLiteral.columnNumber))
 
-  protected def astForStringLiteral(stringLiteral: BabelNodeInfo): Ast =
-    Ast(
-      createLiteralNode(
-        stringLiteral.code,
-        Some(Defines.STRING.label),
-        stringLiteral.lineNumber,
-        stringLiteral.columnNumber
-      )
-    )
+  protected def astForStringLiteral(stringLiteral: BabelNodeInfo): Ast = {
+    val code = s"\"${stringLiteral.json("value").str}\""
+    Ast(createLiteralNode(code, Some(Defines.STRING.label), stringLiteral.lineNumber, stringLiteral.columnNumber))
+  }
 
   protected def astForSpreadElement(spreadElement: BabelNodeInfo): Ast = {
     val ast = astForNode(spreadElement.json("argument"))
@@ -131,24 +126,28 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     val quasis      = templateLiteral.json("quasis").arr.toList.filterNot(_("tail").bool)
     val quasisTail  = templateLiteral.json("quasis").arr.toList.filter(_("tail").bool).head
 
-    val callName = "__Runtime.TO_STRING"
-    val argsCodes = expressions.zip(quasis).flatMap { case (expression, quasi) =>
-      List(s"\"${quasi("value")("raw").str}\"", code(expression))
-    }
-    val callCode = s"$callName${(argsCodes :+ s"\"${quasisTail("value")("raw").str}\"").mkString("(", ", ", ")")}"
-    val templateCall =
-      createCallNode(
-        callCode,
-        callName,
-        DispatchTypes.STATIC_DISPATCH,
-        templateLiteral.lineNumber,
-        templateLiteral.columnNumber
-      )
+    if (expressions.isEmpty && quasis.isEmpty) {
+      astForTemplateElement(createBabelNodeInfo(quasisTail))
+    } else {
+      val callName = "__Runtime.TO_STRING"
+      val argsCodes = expressions.zip(quasis).flatMap { case (expression, quasi) =>
+        List(s"\"${quasi("value")("raw").str}\"", code(expression))
+      }
+      val callCode = s"$callName${(argsCodes :+ s"\"${quasisTail("value")("raw").str}\"").mkString("(", ", ", ")")}"
+      val templateCall =
+        createCallNode(
+          callCode,
+          callName,
+          DispatchTypes.STATIC_DISPATCH,
+          templateLiteral.lineNumber,
+          templateLiteral.columnNumber
+        )
 
-    val argumentAsts = expressions.zip(quasis).flatMap { case (expression, quasi) =>
-      List(astForNode(quasi), astForNode(expression))
+      val argumentAsts = expressions.zip(quasis).flatMap { case (expression, quasi) =>
+        List(astForNode(quasi), astForNode(expression))
+      }
+      val argAsts = argumentAsts :+ astForNode(quasisTail)
+      createCallAst(templateCall, argAsts)
     }
-    val argAsts = argumentAsts :+ astForNode(quasisTail)
-    createCallAst(templateCall, argAsts)
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -187,6 +187,32 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       argument3.argumentIndex shouldBe 3
     }
 
+    "have correct structure for different string literals" in AstFixture("""
+        |var keyA = "AAA";
+        |var keyB = 'BBB';
+        |var keyC = `CCC`;
+        |var keyD = `DDD"`;
+        |var keyE = "EE EE E";
+        |var keyF = "F-FF-F";
+        |""".stripMargin) { cpg =>
+      cpg.literal.code.l shouldBe List(
+        """"AAA"""",
+        """"BBB"""",
+        """"CCC"""",
+        """"DDD""""",
+        """"EE EE E"""",
+        """"F-FF-F""""
+      )
+      cpg.call.code.l shouldBe List(
+        """var keyA = "AAA"""",
+        """var keyB = 'BBB'""",
+        """var keyC = `CCC`""",
+        """var keyD = `DDD"`""",
+        """var keyE = "EE EE E"""",
+        """var keyF = "F-FF-F""""
+      )
+    }
+
     "have correct structure for try" in AstFixture("""
        |try {
        | open()


### PR DESCRIPTION
String literals should look the same no matter if they are written with ", ', or ` (e.g., useful for easy secrets detection).