### PR TITLE
A call linker for python

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -1,6 +1,8 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
+import io.joern.x2cpg.passes.frontend.PythonCallLinker
+import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.Path
 
@@ -20,4 +22,9 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
 
   override def isAvailable: Boolean =
     command.toFile.exists
+
+  override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
+    new PythonCallLinker(cpg).createAndApply()
+    cpg
+  }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -5,12 +5,10 @@ import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOpti
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.pysrc2cpg.Py2CpgOnFileSystem.buildCpg
 import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.passes.frontend.PythonCallLinker
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
-
-import java.io.File
-import java.nio.file.Paths
 
 trait PythonFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".py"
@@ -34,6 +32,7 @@ class PySrcTestCpg extends TestCpg with PythonFrontend {
 
   override def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
+    new PythonCallLinker(this).createAndApply()
 
     if (_withOssDataflow) {
       val context = new LayerCreatorContext(this)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -3,8 +3,9 @@ package io.joern.pysrc2cpg
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.pysrc2cpg.Py2CpgOnFileSystem.buildCpg
-import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
+import io.joern.x2cpg.passes.frontend.PythonCallLinker
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
+import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
@@ -16,7 +17,9 @@ trait PythonFrontend extends LanguageFrontend {
 
   override def execute(sourceCodeFile: File): Cpg = {
     val config = Py2CpgOnFileSystemConfig(Paths.get(X2CpgConfig.defaultOutputPath), sourceCodeFile.toPath, None)
-    buildCpg(config)
+    val cpg    = buildCpg(config)
+    new PythonCallLinker(cpg).createAndApply()
+    cpg
   }
 }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -1,22 +1,22 @@
 package io.joern.pysrc2cpg
 
+import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.pysrc2cpg.Py2CpgOnFileSystem.buildCpg
+import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.passes.frontend.PythonCallLinker
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
-import io.joern.x2cpg.{X2Cpg, X2CpgConfig}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
-
-import java.io.File
-import java.nio.file.Paths
 
 trait PythonFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".py"
 
-  override def execute(sourceCodeFile: File): Cpg = {
-    val config = Py2CpgOnFileSystemConfig(Paths.get(X2CpgConfig.defaultOutputPath), sourceCodeFile.toPath, None)
+  override def execute(sourceCodePath: java.io.File): Cpg = {
+    val cpgOutFile = File.newTemporaryFile(suffix = "cpg.bin")
+    cpgOutFile.deleteOnExit()
+    val config = Py2CpgOnFileSystemConfig(cpgOutFile.path, sourceCodePath.toPath, None)
     val cpg    = buildCpg(config)
     new PythonCallLinker(cpg).createAndApply()
     cpg

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -7,15 +7,43 @@ import io.shiftleft.semanticcpg.language._
 
 class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
 
-  val cpg: Cpg = code("""
+  "call test 1" in {
+    val cpg: Cpg = code("""
       |a = 42
       |c = foo(a, b)
       |print(c)
       |""".stripMargin)
+    def source = cpg.literal("42")
+    def sink   = cpg.call("print")
+    sink.reachableByFlows(source).size shouldBe 1
+  }
 
-  "first test" in {
-    val source = cpg.literal("42")
-    val sink   = cpg.call.code("print.*").argument
+  "call test 2" in {
+    val cpg: Cpg = code("""
+      |def foo():
+      |    return 42
+      |bar = foo()
+      |print(bar)
+      |""".stripMargin)
+    def source = cpg.literal("42")
+    def sink   = cpg.call("print")
+    sink.reachableByFlows(source).size shouldBe 1
+  }
+
+  "call test 3" in {
+    val cpg: Cpg = code("""
+        |def foo(input):
+        |    sink(input)
+        |
+        |def main():
+        |    source = 42
+        |    foo(source)
+        |
+        |""".stripMargin)
+
+    def source = cpg.literal("42")
+    def sink   = cpg.call("sink")
+
     sink.reachableByFlows(source).size shouldBe 1
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -13,8 +13,6 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
       |c = foo(a, b)
       |print(c)
       |""".stripMargin)
-
-  "first test" in {
     val source = cpg.literal("42")
     val sink   = cpg.call.code("print.*").argument
     sink.reachableByFlows(source).size shouldBe 1
@@ -28,42 +26,31 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
       |""".stripMargin)
     def source = cpg.literal("42")
     def sink   = cpg.call("sink").argument
-    source.size shouldBe 1
-    sink.size shouldBe 1
     sink.reachableByFlows(source).size shouldBe 1
   }
-    "call test 2" in {
-      val cpg: Cpg = code(
-        """
-          |def foo():
-          |    return 42
-          |bar = foo()
-          |print(bar)
-          |""".stripMargin)
 
-      def source = cpg.literal("42")
+  "inter procedural call 1" in {
+    val cpg: Cpg = code("""
+      |def foo():
+      |    return 42
+      |bar = foo()
+      |print(bar)
+      |""".stripMargin)
+    def source = cpg.literal("42")
+    def sink   = cpg.call("print")
+    sink.reachableByFlows(source).size shouldBe 1
+  }
 
-      def sink = cpg.call("print")
-
-      sink.reachableByFlows(source).size shouldBe 1
-    }
-
-    "call test 3" in {
-      val cpg: Cpg = code(
-        """
-          |def foo(input):
-          |    sink(input)
-          |
-          |def main():
-          |    source = 42
-          |    foo(source)
-          |
-          |""".stripMargin)
-
-      def source = cpg.literal("42")
-
-      def sink = cpg.call("sink")
-
-      sink.reachableByFlows(source).size shouldBe 1
-    }
+  "inter procedural call 2" in {
+    val cpg: Cpg = code("""
+      |def foo(input):
+      |    sink(input)
+      |def main():
+      |    source = 42
+      |    foo(source)
+      |""".stripMargin)
+    def source = cpg.literal("42")
+    def sink   = cpg.call("sink")
+    sink.reachableByFlows(source).size shouldBe 1
+  }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -43,7 +43,6 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
 
     def source = cpg.literal("42")
     def sink   = cpg.call("sink")
-
     sink.reachableByFlows(source).size shouldBe 1
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonCallLinker.scala
@@ -1,0 +1,55 @@
+package io.joern.x2cpg.passes.frontend
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
+import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.semanticcpg.language._
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.mutable
+
+// link python calls to methods only by their name(not full name)
+class PythonCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
+
+  import PythonCallLinker._
+
+  private val methodNameToNode = mutable.Map.empty[String, List[Method]]
+
+  override def run(dstGraph: DiffGraphBuilder): Unit = {
+
+    cpg.method.foreach { method =>
+      methodNameToNode.updateWith(method.name) {
+        case Some(l) => Some(method :: l)
+        case None    => Some(List(method))
+      }
+    }
+
+    cpg.call.foreach { call =>
+      try {
+        linkCallOnlyByShortName(call, dstGraph)
+      } catch {
+        case exception: Exception =>
+          throw new RuntimeException(exception)
+      }
+    }
+  }
+
+  private def linkCallOnlyByShortName(call: Call, dstGraph: DiffGraphBuilder): Unit = {
+    val resolvedMethodOption = methodNameToNode.get(call.name)
+    if (resolvedMethodOption.isDefined) {
+      resolvedMethodOption.get.foreach { dst =>
+        dstGraph.addEdge(call, dst, EdgeTypes.CALL)
+      }
+    } else {
+      logger.info(
+        s"Unable to link CALL with METHOD_NAME ${call.name}, NAME ${call.name}, " +
+          s"SIGNATURE ${call.signature}, CODE ${call.code}"
+      )
+    }
+  }
+
+}
+object PythonCallLinker {
+  private val logger: Logger = LoggerFactory.getLogger(classOf[PythonCallLinker])
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonCallLinker.scala
@@ -2,52 +2,19 @@ package io.joern.x2cpg.passes.frontend
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.passes.SimpleCpgPass
 import io.shiftleft.semanticcpg.language._
-import org.slf4j.{Logger, LoggerFactory}
-
-import scala.collection.mutable
 
 // link python calls to methods only by their name(not full name)
 class PythonCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
 
-  import PythonCallLinker._
-
-  private val methodNameToNode = mutable.Map.empty[String, List[Method]]
-
   override def run(dstGraph: DiffGraphBuilder): Unit = {
-    cpg.method.foreach { method =>
-      methodNameToNode.updateWith(method.name) {
-        case Some(l) => Some(method :: l)
-        case None    => Some(List(method))
-      }
-    }
-    cpg.call.foreach { call =>
-      try {
-        linkCallOnlyByShortName(call, dstGraph)
-      } catch {
-        case exception: Exception =>
-          throw new RuntimeException(exception)
-      }
-    }
+    val methodNameToNode = cpg.method.toList.groupBy(_.name)
+    for {
+      call    <- cpg.call
+      methods <- methodNameToNode.get(call.name)
+      method  <- methods
+    } dstGraph.addEdge(call, method, EdgeTypes.CALL)
   }
 
-  private def linkCallOnlyByShortName(call: Call, dstGraph: DiffGraphBuilder): Unit = {
-    val resolvedMethodOption = methodNameToNode.get(call.name)
-    if (resolvedMethodOption.isDefined) {
-      resolvedMethodOption.get.foreach { dst =>
-        dstGraph.addEdge(call, dst, EdgeTypes.CALL)
-      }
-    } else {
-      logger.info(
-        s"Unable to link CALL with METHOD_NAME ${call.name}, NAME ${call.name}, " +
-          s"SIGNATURE ${call.signature}, CODE ${call.code}"
-      )
-    }
-  }
-
-}
-object PythonCallLinker {
-  private val logger: Logger = LoggerFactory.getLogger(classOf[PythonCallLinker])
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonCallLinker.scala
@@ -17,14 +17,12 @@ class PythonCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
   private val methodNameToNode = mutable.Map.empty[String, List[Method]]
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
-
     cpg.method.foreach { method =>
       methodNameToNode.updateWith(method.name) {
         case Some(l) => Some(method :: l)
         case None    => Some(List(method))
       }
     }
-
     cpg.call.foreach { call =>
       try {
         linkCallOnlyByShortName(call, dstGraph)


### PR DESCRIPTION
This PR introduce a call linker for python.
The linker links ```calls``` and ```methods``` only by their **name**(not full name), because it's hard to decide thier full name in a dynamic language.
Though this will result in wrong edges, it will make interprocedural data flow analysis work for the moment.
