### PR TITLE
Fix missing javasrc sources bug for non-standard directory structures

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/SourceRootFinderTests.scala
@@ -27,7 +27,10 @@ class SourceRootFinderTests extends AnyFlatSpec with Matchers with BeforeAndAfte
       File(rootPath, "some", "nested", "directories", "src", "io"),
       File(rootPath, "some", "nested", "more", "directories", "src", "io"),
       File(rootPath, "some", "nested", "more", "directories", "test", "io"),
-      File(rootPath, "nosrc", "nested", "directories", "io")
+      File(rootPath, "nosrc", "nested", "directories", "io"),
+      File(rootPath, "code", "project", "src", "main"),
+      File(rootPath, "code", "project", "src", "random"),
+      File(rootPath, "code", "project", "src", "test")
     )
 
     directoriesToCreate.foreach { file =>
@@ -54,9 +57,14 @@ class SourceRootFinderTests extends AnyFlatSpec with Matchers with BeforeAndAfte
     sourceRoots.sorted shouldBe List(
       s"$stdRootPath/maven/mvn1/src/main/java",
       s"$stdRootPath/maven/mvn2/src/main/java",
+      // Over-approximate to avoid missing sources
+      s"$stdRootPath/maven/mvn1/src/main/resources",
+      s"$stdRootPath/maven/mvn1/src/main/scala",
       s"$stdRootPath/src",
       s"$stdRootPath/some/nested/directories/src",
-      s"$stdRootPath/some/nested/more/directories/src"
+      s"$stdRootPath/some/nested/more/directories/src",
+      s"$stdRootPath/code/project/src/main",
+      s"$stdRootPath/code/project/src/random"
     ).sorted
   }
 


### PR DESCRIPTION
Specifically, the non-standard directory structure of https://github.com/adobe/places-monitor-android revealed some logical bugs in the source root detection logic in javasrc2cpg.