### PR TITLE
joern-export: SplitByMethod

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -3,7 +3,6 @@ name := "joern-cli"
 dependsOn(Projects.console, Projects.console % "test->test", Projects.c2cpg, Projects.dataflowengineoss, Projects.x2cpg)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft"            %% "overflowdb-formats"   % "1.149+2-c2953d40",
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,
   "com.lihaoyi"             %% "requests"          % "0.7.1",
   "com.github.scopt"        %% "scopt"             % "4.1.0",

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -3,6 +3,7 @@ name := "joern-cli"
 dependsOn(Projects.console, Projects.console % "test->test", Projects.c2cpg, Projects.dataflowengineoss, Projects.x2cpg)
 
 libraryDependencies ++= Seq(
+  "io.shiftleft"            %% "overflowdb-formats"   % "1.148+1-5199fb50",
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,
   "com.lihaoyi"             %% "requests"          % "0.7.1",
   "com.github.scopt"        %% "scopt"             % "4.1.0",

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -3,7 +3,7 @@ name := "joern-cli"
 dependsOn(Projects.console, Projects.console % "test->test", Projects.c2cpg, Projects.dataflowengineoss, Projects.x2cpg)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft"            %% "overflowdb-formats"   % "1.148+2-a01c4aa2",
+  "io.shiftleft"            %% "overflowdb-formats"   % "1.149+2-c2953d40",
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,
   "com.lihaoyi"             %% "requests"          % "0.7.1",
   "com.github.scopt"        %% "scopt"             % "4.1.0",

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -3,7 +3,7 @@ name := "joern-cli"
 dependsOn(Projects.console, Projects.console % "test->test", Projects.c2cpg, Projects.dataflowengineoss, Projects.x2cpg)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft"            %% "overflowdb-formats"   % "1.148+1-5199fb50",
+  "io.shiftleft"            %% "overflowdb-formats"   % "1.148+2-a01c4aa2",
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,
   "com.lihaoyi"             %% "requests"          % "0.7.1",
   "com.github.scopt"        %% "scopt"             % "4.1.0",

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -33,7 +33,7 @@ object JoernExport extends App {
   /** Choose from either a subset of the graph, or the entire graph (all).
     */
   object Representation extends Enumeration {
-    val Ast, Cfg, Ddg, Cdg, Pdg, Cpg14, All, SplitByMethod = Value
+    val Ast, Cfg, Ddg, Cdg, Pdg, Cpg14, Cpg, All = Value
 
     lazy val byNameLowercase: Map[String, Value] =
       values.map { value =>
@@ -128,7 +128,7 @@ object JoernExport extends App {
     val ExportResult(nodeCount, edgeCount, _, additionalInfo) = repr match {
       case Representation.All =>
         exporter.runExport(cpg.graph, outDir)
-      case Representation.SplitByMethod =>
+      case Representation.Cpg =>
         splitByMethod(cpg).iterator.map { subGraph =>
           val name = subGraph.name
           val sanitizedFileName =

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -5,17 +5,17 @@ import better.files.File
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.layers.dataflows._
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.joerncli.CpgBasedTool.{exitIfInvalid, exitWithError}
+import io.joern.joerncli.CpgBasedTool.exitIfInvalid
 import io.joern.x2cpg.layers._
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language.{toAstNodeMethods, toNodeTypeStarters}
 import io.shiftleft.semanticcpg.layers._
-import overflowdb.Graph
 import overflowdb.formats.ExportResult
-import overflowdb.formats.dot.DotExporter
-import overflowdb.formats.graphml.GraphMLExporter
 import overflowdb.formats.neo4jcsv.Neo4jCsvExporter
-import overflowdb.formats.graphson.GraphSONExporter
+import overflowdb.{Edge, Node}
 
 import java.nio.file.Paths
+import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.util.Using
 
 object JoernExport extends App {
@@ -23,17 +23,34 @@ object JoernExport extends App {
   case class Config(
     cpgFileName: String = "cpg.bin",
     outDir: String = "out",
-    repr: Representation.Value = Representation.cpg14,
-    format: Format.Value = Format.dot
+    repr: Representation.Value = Representation.Cpg14,
+    format: Format.Value = Format.Dot
   )
 
   /** Choose from either a subset of the graph, or the entire graph (all).
     */
   object Representation extends Enumeration {
-    val ast, cfg, ddg, cdg, pdg, cpg14, all = Value
+    val Ast, Cfg, Ddg, Cdg, Pdg, Cpg14, All, SplitByMethod = Value
+
+    lazy val byNameLowercase: Map[String, Value] =
+      values.map { value =>
+        value.toString.toLowerCase -> value
+      }.toMap
+
+    def withNameIgnoreCase(s: String): Value =
+      byNameLowercase.getOrElse(s, throw new NoSuchElementException(s"No value found for '$s'"))
+
   }
   object Format extends Enumeration {
-    val dot, neo4jcsv, graphml, graphson = Value
+    val Dot, Neo4jCsv, Graphml, Graphson = Value
+
+    lazy val byNameLowercase: Map[String, Value] =
+      values.map { value =>
+        value.toString.toLowerCase -> value
+      }.toMap
+
+    def withNameIgnoreCase(s: String): Value =
+      byNameLowercase.getOrElse(s, throw new NoSuchElementException(s"No value found for '$s'"))
   }
 
   private def parseConfig: Option[Config] =
@@ -49,12 +66,12 @@ object JoernExport extends App {
         .action((x, c) => c.copy(outDir = x))
       opt[String]("repr")
         .text(
-          s"representation to extract: [${Representation.values.toSeq.sorted.mkString("|")}] - defaults to `${Representation.cpg14}`"
+          s"representation to extract: [${Representation.values.toSeq.map(_.toString.toLowerCase).sorted.mkString("|")}] - defaults to `${Representation.Cpg14}`"
         )
-        .action((x, c) => c.copy(repr = Representation.withName(x)))
+        .action((x, c) => c.copy(repr = Representation.withNameIgnoreCase(x)))
       opt[String]("format")
-        .action((x, c) => c.copy(format = Format.withName(x)))
-        .text(s"export format, one of [${Format.values.toSeq.sorted.mkString("|")}] - defaults to `${Format.dot}`")
+        .action((x, c) => c.copy(format = Format.withNameIgnoreCase(x)))
+        .text(s"export format, one of [${Format.values.toSeq.map(_.toString.toLowerCase).sorted.mkString("|")}] - defaults to `${Format.Dot}`")
     }.parse(args, Config())
 
   parseConfig.foreach { config =>
@@ -70,38 +87,69 @@ object JoernExport extends App {
       val context = new LayerCreatorContext(cpg)
 
       mkdir(File(config.outDir))
-      (config.repr, config.format) match {
-        case (Representation.ast, Format.dot) =>
-          new DumpAst(AstDumpOptions(config.outDir)).create(context)
-        case (Representation.cfg, Format.dot) =>
-          new DumpCfg(CfgDumpOptions(config.outDir)).create(context)
-        case (Representation.ddg, Format.dot) =>
-          new DumpDdg(DdgDumpOptions(config.outDir)).create(context)
-        case (Representation.cdg, Format.dot) =>
-          new DumpCdg(CdgDumpOptions(config.outDir)).create(context)
-        case (Representation.pdg, Format.dot) =>
-          new DumpPdg(PdgDumpOptions(config.outDir)).create(context)
-        case (Representation.cpg14, Format.dot) =>
-          new DumpCpg14(Cpg14DumpOptions(config.outDir)).create(context)
-        case (Representation.all, Format.neo4jcsv) =>
-          overflowdbExport(cpg.graph, config.outDir, Neo4jCsvExporter)
-        case (Representation.all, Format.graphml) =>
-          overflowdbExport(cpg.graph, config.outDir, GraphMLExporter)
-        case (Representation.all, Format.dot) =>
-          overflowdbExport(cpg.graph, config.outDir, DotExporter)
-        case (Representation.all, Format.graphson) =>
-          overflowdbExport(cpg.graph, config.outDir, GraphSONExporter)
-        case (repr, format) =>
-          exitWithError(s"combination of repr=$repr and format=$format not (yet) supported")
+      config.format match {
+        case Format.Dot =>
+          exportDot(config.repr, config.outDir, context)
+        case Format.Neo4jCsv =>
+          exportWithOdbFormat(cpg, config.repr, config.outDir, Neo4jCsvExporter)
+//        case (Representation.all, Format.graphml) =>
+//          exportWithOdbFormat(cpg.graph, config.outDir, GraphMLExporter)
+//        case (Representation.all, Format.dot) =>
+//          exportWithOdbFormat(cpg.graph, config.outDir, DotExporter)
+//        case (Representation.all, Format.graphson) =>
+//          exportWithOdbFormat(cpg.graph, config.outDir, GraphSONExporter)
+//        case (repr, format) =>
+//          exitWithError(s"combination of repr=$repr and format=$format not (yet) supported")
       }
     }
   }
 
-  private def overflowdbExport(graph: Graph, outDir: String, exporter: overflowdb.formats.Exporter): Unit = {
-    val outDirPath                                                = Paths.get(outDir).toAbsolutePath
-    val ExportResult(nodeCount, edgeCount, files, additionalInfo) = exporter.runExport(graph, outDirPath)
+  private def exportDot(repr: Representation.Value, outDir: String, context: LayerCreatorContext): Unit = {
+    import Representation._
+    repr match {
+      case Ast => new DumpAst(AstDumpOptions(outDir)).create(context)
+      case Cfg => new DumpCfg(CfgDumpOptions(outDir)).create(context)
+      case Ddg => new DumpDdg(DdgDumpOptions(outDir)).create(context)
+      case Cdg => new DumpCdg(CdgDumpOptions(outDir)).create(context)
+      case Pdg => new DumpPdg(PdgDumpOptions(outDir)).create(context)
+      case Cpg14 => new DumpCpg14(Cpg14DumpOptions(outDir)).create(context)
+    }
+  }
+
+  private def exportWithOdbFormat(cpg: Cpg, repr: Representation.Value, outDir: String, exporter: overflowdb.formats.Exporter): Unit = {
+    val outDirPath = Paths.get(outDir).toAbsolutePath
+    val ExportResult(nodeCount, edgeCount, _, additionalInfo) = repr match {
+      case Representation.All =>
+        exporter.runExport(cpg.graph, outDirPath)
+      case Representation.SplitByMethod =>
+        splitByMethod(cpg).iterator.foreach { subGraph =>
+          exporter.runExport(subGraph.nodes, subGraph.edges, outDirPath.resolve(subGraph.name))
+        }
+    }
+
     println(s"exported $nodeCount nodes, $edgeCount edges into $outDirPath")
     additionalInfo.foreach(println)
   }
 
+  /**
+   * for each method in the cpg:
+   *  recursively traverse all AST edges to get the subgraph of nodes within this method
+   *  add the method and this subgraph to the export
+   *  add all edges between all of these nodes to the export
+   */
+  private def splitByMethod(cpg: Cpg): IterableOnce[SubGraph] = {
+    cpg.method.map { method =>
+      SubGraph(method.fullName, method.ast.toSet)
+    }
+  }
+
+  case class SubGraph(name: String, nodes: Set[Node]) {
+    def edges: Set[Edge] = {
+      for {
+        node <- nodes
+        edge <- node.bothE.asScala
+        if nodes.contains(edge.inNode) && nodes.contains(edge.outNode)
+      } yield edge
+    }
+  }
 }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -175,10 +175,8 @@ object JoernExport extends App {
     windowsFilenameDeduplicationHelper: mutable.Set[String]
   ): String = {
     val sanitizedMethodName = methodName.replaceAll("[^a-zA-Z0-9-_\\.]", "_")
-    val isWindows           = System.getProperty("os.name").toLowerCase.contains("win")
-
     val sanitizedFilename =
-      if (isWindows) {
+      if (scala.util.Properties.isWin) {
         // windows has some quirks in it's file system, e.g. we need to ensure paths aren't too long - so we're using a
         // different strategy to sanitize windows file names: first occurrence of a given method uses the method name
         // any methods with the same name afterwards get a `_` suffix

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -130,8 +130,11 @@ object JoernExport extends App {
         exporter.runExport(cpg.graph, outDir)
       case Representation.SplitByMethod =>
         splitByMethod(cpg).iterator.map { subGraph =>
-          val sanitizedFilename = subGraph.name.replaceAll("[^a-zA-Z0-9-_\\.]", "_")
-          val outFileName = outDir.resolve(sanitizedFilename)
+          val name = subGraph.name
+          val sanitizedName =
+            if (name.startsWith("/")) s"_root_/$name"
+            else name
+          val outFileName = outDir.resolve(sanitizedName)
           exporter.runExport(subGraph.nodes, subGraph.edges, outFileName)
         }.reduce(plus)
     }
@@ -148,7 +151,11 @@ object JoernExport extends App {
    */
   private def splitByMethod(cpg: Cpg): IterableOnce[SubGraph] = {
     cpg.method.map { method =>
-      SubGraph(method.fullName, method.ast.toSet)
+      val sanitizedMethodName = method.name.replaceAll("[^a-zA-Z0-9-_\\.]", "_")
+      SubGraph(
+        name = s"${method.filename}/$sanitizedMethodName",
+        nodes = method.ast.toSet
+      )
     }
   }
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -86,11 +86,11 @@ object JoernExport extends App {
     mkdir(File(outDir))
 
     Using.resource(CpgBasedTool.loadFromOdb(config.cpgFileName)) { cpg =>
-      export(cpg, config.repr, config.format, Paths.get(outDir).toAbsolutePath)
+      exportCpg(cpg, config.repr, config.format, Paths.get(outDir).toAbsolutePath)
     }
   }
 
-  def export(cpg: Cpg, representation: Representation.Value, format: Format.Value, outDir: Path): Unit = {
+  def exportCpg(cpg: Cpg, representation: Representation.Value, format: Format.Value, outDir: Path): Unit = {
     implicit val semantics: Semantics = DefaultSemantics()
     if (semantics.elements.isEmpty) {
       System.err.println("Warning: semantics are empty.")

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -131,10 +131,11 @@ object JoernExport extends App {
       case Representation.SplitByMethod =>
         splitByMethod(cpg).iterator.map { subGraph =>
           val name = subGraph.name
-          val sanitizedName =
+          val sanitizedFileName =
             if (name.startsWith("/")) s"_root_/$name"
             else name
-          val outFileName = outDir.resolve(sanitizedName)
+          val extension = exporter.defaultFileExtension
+          val outFileName = outDir.resolve(s"$sanitizedFileName.$extension")
           exporter.runExport(subGraph.nodes, subGraph.edges, outFileName)
         }.reduce(plus)
     }

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
@@ -15,7 +15,14 @@ class JoernExportTests extends AnyWordSpec with Matchers with AbstractJoernCliTe
       val tempDir = os.temp.dir(prefix = "joern-export-test")
       JoernExport.exportCpg(cpg, Representation.Cpg, JoernExport.Format.Graphson, tempDir.toNIO)
       val exportedFiles = os.walk(tempDir).filter(_.toIO.isFile)
-      exportedFiles.size should be >= 100
+
+      // c frontend creates a different cpg on windows - not sure about the details, but purely for the export it doesn't
+      // really matter...
+      if (scala.util.Properties.isWin) {
+        exportedFiles.size should be >= 5
+      } else {
+        exportedFiles.size should be >= 100
+      }
     }
   }
 

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
@@ -1,0 +1,22 @@
+package io.joern.joerncli
+
+import better.files.File
+import io.joern.joerncli.JoernExport.Representation
+import io.shiftleft.codepropertygraph.Cpg
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class JoernExportTests extends AnyWordSpec with Matchers with AbstractJoernCliTest {
+
+  "export to graphson, for example code 'testcode/free'" should withTestCpg(
+    File(getClass.getClassLoader.getResource("testcode/free"))
+  ) { case (cpg: Cpg, _) =>
+    "split output by method" in {
+      val tempDir = os.temp.dir(prefix = "joern-export-test")
+      JoernExport.export(cpg, Representation.SplitByMethod, JoernExport.Format.Graphson, tempDir.toNIO)
+      val exportedFiles = os.walk(tempDir).filter(_.toIO.isFile)
+      exportedFiles.size should be >= 100
+    }
+  }
+
+}

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
@@ -15,14 +15,7 @@ class JoernExportTests extends AnyWordSpec with Matchers with AbstractJoernCliTe
       val tempDir = os.temp.dir(prefix = "joern-export-test")
       JoernExport.exportCpg(cpg, Representation.Cpg, JoernExport.Format.Graphson, tempDir.toNIO)
       val exportedFiles = os.walk(tempDir).filter(_.toIO.isFile)
-
-      // c frontend creates a different cpg on windows - not sure about the details, but purely for the export it doesn't
-      // really matter...
-      if (scala.util.Properties.isWin) {
-        exportedFiles.size should be >= 5
-      } else {
-        exportedFiles.size should be >= 100
-      }
+      exportedFiles.size shouldBe 6
     }
   }
 

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
@@ -13,7 +13,7 @@ class JoernExportTests extends AnyWordSpec with Matchers with AbstractJoernCliTe
   ) { case (cpg: Cpg, _) =>
     "split output by method" in {
       val tempDir = os.temp.dir(prefix = "joern-export-test")
-      JoernExport.export(cpg, Representation.Cpg, JoernExport.Format.Graphson, tempDir.toNIO)
+      JoernExport.exportCpg(cpg, Representation.Cpg, JoernExport.Format.Graphson, tempDir.toNIO)
       val exportedFiles = os.walk(tempDir).filter(_.toIO.isFile)
       exportedFiles.size should be >= 100
     }

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
@@ -13,7 +13,7 @@ class JoernExportTests extends AnyWordSpec with Matchers with AbstractJoernCliTe
   ) { case (cpg: Cpg, _) =>
     "split output by method" in {
       val tempDir = os.temp.dir(prefix = "joern-export-test")
-      JoernExport.export(cpg, Representation.SplitByMethod, JoernExport.Format.Graphson, tempDir.toNIO)
+      JoernExport.export(cpg, Representation.Cpg, JoernExport.Format.Graphson, tempDir.toNIO)
       val exportedFiles = os.walk(tempDir).filter(_.toIO.isFile)
       exportedFiles.size should be >= 100
     }


### PR DESCRIPTION
implements https://github.com/joernio/joern/issues/1893
depends on https://github.com/ShiftLeftSecurity/overflowdb/pull/331 and https://github.com/ShiftLeftSecurity/overflowdb/pull/332 - won't compile until upgrade train has completed

Also includes some refactorings - most notably: Representation|Format: changed to uppercase 
(as per Scala convention and support in match clauses), but match on name ignore case when parsing config