### PR TITLE
jssrc2cpg: ignore node_modules folder + refactorings

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -10,7 +10,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.utils.HashUtil
-import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.passes.frontend.JavascriptCallLinker
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
@@ -20,9 +19,6 @@ import scala.util.Try
 class JsSrc2Cpg extends X2CpgFrontend[Config] {
 
   private val report: Report = new Report()
-
-  private def configFiles(config: Config, extensions: Set[String]): Seq[File] =
-    SourceFiles.determine(config.inputPath, extensions).map(File(_))
 
   def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config) { (cpg, config) =>
@@ -37,13 +33,8 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
         new JsMetaDataPass(cpg, hash, config.inputPath).createAndApply()
         new BuiltinTypesPass(cpg).createAndApply()
         new DependenciesPass(cpg, config).createAndApply()
-        new ConfigPass(
-          cpg,
-          configFiles(config, Set(".json", ".config.js", ".conf.js", ".vue", ".html")),
-          config,
-          report
-        ).createAndApply()
-        new PrivateKeyFilePass(cpg, configFiles(config, Set(".key")), config, report).createAndApply()
+        new ConfigPass(cpg, config, report).createAndApply()
+        new PrivateKeyFilePass(cpg, config, report).createAndApply()
 
         report.print()
       }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -105,7 +105,7 @@ class AstCreator(
 
     methodAstParentStack.push(programMethod)
 
-    val blockNode = NewBlock().typeFullName("ANY")
+    val blockNode = NewBlock().typeFullName(Defines.ANY)
 
     scope.pushNewMethodScope(fullName, name, blockNode, None)
     localAstParentStack.push(blockNode)
@@ -119,7 +119,7 @@ class AstCreator(
     val methodReturn = NewMethodReturn()
       .code("RET")
       .evaluationStrategy(EvaluationStrategies.BY_VALUE)
-      .typeFullName(Defines.ANY.label)
+      .typeFullName(Defines.ANY)
 
     localAstParentStack.pop()
     scope.popScope()

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -236,7 +236,7 @@ trait AstCreatorHelper { this: AstCreator =>
                   case None =>
                     val methodScopeNode = methodScope.scopeNode
                     val localNode =
-                      createLocalNode(origin.variableName, Defines.ANY.label, Some(closureBindingIdProperty))
+                      createLocalNode(origin.variableName, Defines.ANY, Some(closureBindingIdProperty))
                     diffGraph.addEdge(methodScopeNode, localNode, EdgeTypes.AST)
                     val closureBindingNode = createClosureBindingNode(closureBindingIdProperty, origin.variableName)
                     methodScope.capturingRefId.foreach(ref =>
@@ -268,7 +268,7 @@ trait AstCreatorHelper { this: AstCreator =>
     methodScopeNodeId: NewNode,
     variableName: String
   ): (NewNode, ScopeType) = {
-    val local = createLocalNode(variableName, Defines.ANY.label)
+    val local = createLocalNode(variableName, Defines.ANY)
     diffGraph.addEdge(methodScopeNodeId, local, EdgeTypes.AST)
     (local, MethodScope)
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -50,12 +50,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     val exportCallAst = if (name == DEFAULTS_KEY) {
       createIndexAccessCallAst(
         createIdentifierNode(exportName, declaration),
-        createLiteralNode(
-          s"\"$DEFAULTS_KEY\"",
-          Some(Defines.STRING.label),
-          declaration.lineNumber,
-          declaration.columnNumber
-        ),
+        createLiteralNode(s"\"$DEFAULTS_KEY\"", Some(Defines.STRING), declaration.lineNumber, declaration.columnNumber),
         declaration.lineNumber,
         declaration.columnNumber
       )
@@ -113,7 +108,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     } else {
       val strippedCode = cleanImportName(fromName).stripPrefix("_")
       val id           = createIdentifierNode(s"_$strippedCode", declaration)
-      val localNode    = createLocalNode(id.code, Defines.ANY.label)
+      val localNode    = createLocalNode(id.code, Defines.ANY)
       scope.addVariable(id.code, localNode, BlockScope)
       diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
 
@@ -284,7 +279,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       case Some(f @ BabelNodeInfo(_: FunctionLike, _, _, _, _, _, _)) =>
         val (_, methodFullName) = calcMethodNameAndFullName(f)
         methodFullName
-      case _ => init.map(typeFor).getOrElse(Defines.ANY.label)
+      case _ => init.map(typeFor).getOrElse(Defines.ANY)
     }
 
     val localNode = createLocalNode(id.code, typeFullName)
@@ -349,7 +344,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
   ): Ast = {
     val destName  = alias.getOrElse(name)
     val destNode  = createIdentifierNode(destName, nodeInfo)
-    val localNode = createLocalNode(destName, Defines.ANY.label)
+    val localNode = createLocalNode(destName, Defines.ANY)
     scope.addVariable(destName, localNode, BlockScope)
     diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
 
@@ -466,7 +461,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     Ast.storeInDiffGraph(valueAst, diffGraph)
     val fieldAccessTmpNode = createIdentifierNode(localTmpName, element)
     val keyNode =
-      createLiteralNode(index.toString, Some(Defines.NUMBER.label), element.lineNumber, element.columnNumber)
+      createLiteralNode(index.toString, Some(Defines.NUMBER), element.lineNumber, element.columnNumber)
     val accessAst = createIndexAccessCallAst(fieldAccessTmpNode, keyNode, element.lineNumber, element.columnNumber)
     Ast.storeInDiffGraph(accessAst, diffGraph)
     createAssignmentCallAst(
@@ -500,7 +495,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     val testAst = {
       val fieldAccessTmpNode = createIdentifierNode(localTmpName, element)
       val keyNode =
-        createLiteralNode(index.toString, Some(Defines.NUMBER.label), element.lineNumber, element.columnNumber)
+        createLiteralNode(index.toString, Some(Defines.NUMBER), element.lineNumber, element.columnNumber)
       val accessAst =
         createIndexAccessCallAst(fieldAccessTmpNode, keyNode, element.lineNumber, element.columnNumber)
       Ast.storeInDiffGraph(accessAst, diffGraph)
@@ -511,7 +506,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     val falseAst = {
       val fieldAccessTmpNode = createIdentifierNode(localTmpName, element)
       val keyNode =
-        createLiteralNode(index.toString, Some(Defines.NUMBER.label), element.lineNumber, element.columnNumber)
+        createLiteralNode(index.toString, Some(Defines.NUMBER), element.lineNumber, element.columnNumber)
       createIndexAccessCallAst(fieldAccessTmpNode, keyNode, element.lineNumber, element.columnNumber)
     }
     Ast.storeInDiffGraph(falseAst, diffGraph)
@@ -616,7 +611,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     scope.pushNewBlockScope(blockNode)
     localAstParentStack.push(blockNode)
 
-    val localNode = createLocalNode(localTmpName, Defines.ANY.label)
+    val localNode = createLocalNode(localTmpName, Defines.ANY)
     diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
 
     val tmpNode = createIdentifierNode(localTmpName, pattern)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -105,7 +105,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     Ast(
       createLiteralNode(
         thisExpr.code,
-        dynamicInstanceTypeStack.headOption.orElse(Some(Defines.ANY.label)),
+        dynamicInstanceTypeStack.headOption.orElse(Some(Defines.ANY)),
         thisExpr.lineNumber,
         thisExpr.columnNumber
       )
@@ -119,7 +119,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     localAstParentStack.push(blockNode)
 
     val tmpAllocName      = generateUnusedVariableName(usedVariableNames, "_tmp")
-    val localTmpAllocNode = createLocalNode(tmpAllocName, Defines.ANY.label)
+    val localTmpAllocNode = createLocalNode(tmpAllocName, Defines.ANY)
     diffGraph.addEdge(localAstParentStack.head, localTmpAllocNode, EdgeTypes.AST)
 
     val tmpAllocNode1 = createIdentifierNode(tmpAllocName, newExpr)
@@ -374,7 +374,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
       localAstParentStack.push(blockNode)
 
       val tmpName      = generateUnusedVariableName(usedVariableNames, "_tmp")
-      val localTmpNode = createLocalNode(tmpName, Defines.ANY.label)
+      val localTmpNode = createLocalNode(tmpName, Defines.ANY)
       diffGraph.addEdge(localAstParentStack.head, localTmpNode, EdgeTypes.AST)
 
       val tmpArrayNode = createIdentifierNode(tmpName, arrExpr)
@@ -451,7 +451,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     localAstParentStack.push(blockNode)
 
     val tmpName   = generateUnusedVariableName(usedVariableNames, "_tmp")
-    val localNode = createLocalNode(tmpName, Defines.ANY.label)
+    val localNode = createLocalNode(tmpName, Defines.ANY)
     diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
 
     val propertiesAsts = objExpr.json("properties").arr.toList.map { property =>
@@ -476,7 +476,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
             .getOrElse {
               if (defaultName.isEmpty) {
                 val tmpName   = generateUnusedVariableName(usedVariableNames, "_tmp")
-                val localNode = createLocalNode(tmpName, Defines.ANY.label)
+                val localNode = createLocalNode(tmpName, Defines.ANY)
                 diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
                 tmpName
               } else { defaultName.get }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -39,7 +39,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
       .getOrElse {
         if (defaultName.isEmpty) {
           val tmpName   = generateUnusedVariableName(usedVariableNames, "_tmp")
-          val localNode = createLocalNode(tmpName, Defines.ANY.label)
+          val localNode = createLocalNode(tmpName, Defines.ANY)
           diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
           tmpName
         } else { defaultName.get }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -12,9 +12,9 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     val name      = ident.json("name").str
     val identNode = createIdentifierNode(name, ident)
     val tpe = typeFullName match {
-      case Some(Defines.ANY.label) => typeFor(ident)
-      case Some(otherType)         => otherType
-      case None                    => typeFor(ident)
+      case Some(Defines.ANY) => typeFor(ident)
+      case Some(otherType)   => otherType
+      case None              => typeFor(ident)
     }
     identNode.typeFullName = tpe
     scope.addVariableReference(name, identNode)
@@ -28,11 +28,11 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     Ast(createIdentifierNode("import", importKeyword))
 
   protected def astForNullLiteral(nullLiteral: BabelNodeInfo): Ast =
-    Ast(createLiteralNode(nullLiteral.code, Some(Defines.NULL.label), nullLiteral.lineNumber, nullLiteral.columnNumber))
+    Ast(createLiteralNode(nullLiteral.code, Some(Defines.NULL), nullLiteral.lineNumber, nullLiteral.columnNumber))
 
   protected def astForStringLiteral(stringLiteral: BabelNodeInfo): Ast = {
     val code = s"\"${stringLiteral.json("value").str}\""
-    Ast(createLiteralNode(code, Some(Defines.STRING.label), stringLiteral.lineNumber, stringLiteral.columnNumber))
+    Ast(createLiteralNode(code, Some(Defines.STRING), stringLiteral.lineNumber, stringLiteral.columnNumber))
   }
 
   protected def astForSpreadElement(spreadElement: BabelNodeInfo): Ast = {
@@ -45,7 +45,7 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     Ast(
       createLiteralNode(
         s"\"${templateElement.json("value")("raw").str}\"",
-        Some(Defines.STRING.label),
+        Some(Defines.STRING),
         templateElement.lineNumber,
         templateElement.columnNumber
       )
@@ -53,39 +53,22 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   protected def astForRegExpLiteral(regExpLiteral: BabelNodeInfo): Ast =
     Ast(
-      createLiteralNode(
-        regExpLiteral.code,
-        Some(Defines.STRING.label),
-        regExpLiteral.lineNumber,
-        regExpLiteral.columnNumber
-      )
+      createLiteralNode(regExpLiteral.code, Some(Defines.STRING), regExpLiteral.lineNumber, regExpLiteral.columnNumber)
     )
 
   protected def astForRegexLiteral(regexLiteral: BabelNodeInfo): Ast =
-    Ast(
-      createLiteralNode(
-        regexLiteral.code,
-        Some(Defines.STRING.label),
-        regexLiteral.lineNumber,
-        regexLiteral.columnNumber
-      )
-    )
+    Ast(createLiteralNode(regexLiteral.code, Some(Defines.STRING), regexLiteral.lineNumber, regexLiteral.columnNumber))
 
   protected def astForNumberLiteral(numberLiteral: BabelNodeInfo): Ast =
     Ast(
-      createLiteralNode(
-        numberLiteral.code,
-        Some(Defines.NUMBER.label),
-        numberLiteral.lineNumber,
-        numberLiteral.columnNumber
-      )
+      createLiteralNode(numberLiteral.code, Some(Defines.NUMBER), numberLiteral.lineNumber, numberLiteral.columnNumber)
     )
 
   protected def astForNumericLiteral(numericLiteral: BabelNodeInfo): Ast =
     Ast(
       createLiteralNode(
         numericLiteral.code,
-        Some(Defines.NUMBER.label),
+        Some(Defines.NUMBER),
         numericLiteral.lineNumber,
         numericLiteral.columnNumber
       )
@@ -95,7 +78,7 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     Ast(
       createLiteralNode(
         decimalLiteral.code,
-        Some(Defines.NUMBER.label),
+        Some(Defines.NUMBER),
         decimalLiteral.lineNumber,
         decimalLiteral.columnNumber
       )
@@ -103,19 +86,14 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   protected def astForBigIntLiteral(bigIntLiteral: BabelNodeInfo): Ast =
     Ast(
-      createLiteralNode(
-        bigIntLiteral.code,
-        Some(Defines.NUMBER.label),
-        bigIntLiteral.lineNumber,
-        bigIntLiteral.columnNumber
-      )
+      createLiteralNode(bigIntLiteral.code, Some(Defines.NUMBER), bigIntLiteral.lineNumber, bigIntLiteral.columnNumber)
     )
 
   protected def astForBooleanLiteral(booleanLiteral: BabelNodeInfo): Ast =
     Ast(
       createLiteralNode(
         booleanLiteral.code,
-        Some(Defines.BOOLEAN.label),
+        Some(Defines.BOOLEAN),
         booleanLiteral.lineNumber,
         booleanLiteral.columnNumber
       )

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -132,7 +132,7 @@ trait AstForStatementsCreator { this: AstCreator =>
       .map { test =>
         astForNode(Obj(test))
       }
-      .getOrElse(Ast(createLiteralNode("true", Some(Defines.BOOLEAN.label), forStmt.lineNumber, forStmt.columnNumber)))
+      .getOrElse(Ast(createLiteralNode("true", Some(Defines.BOOLEAN), forStmt.lineNumber, forStmt.columnNumber)))
     val updateAst = safeObj(forStmt.json, "update")
       .map { update =>
         astForNode(Obj(update))
@@ -265,7 +265,7 @@ trait AstForStatementsCreator { this: AstCreator =>
 
     // _iterator assignment:
     val iteratorName      = generateUnusedVariableName(usedVariableNames, "_iterator")
-    val iteratorLocalNode = createLocalNode(iteratorName, Defines.ANY.label)
+    val iteratorLocalNode = createLocalNode(iteratorName, Defines.ANY)
     diffGraph.addEdge(localAstParentStack.head, iteratorLocalNode, EdgeTypes.AST)
 
     val iteratorNode = createIdentifierNode(iteratorName, forInOfStmt)
@@ -326,7 +326,7 @@ trait AstForStatementsCreator { this: AstCreator =>
 
     // _result:
     val resultName      = generateUnusedVariableName(usedVariableNames, "_result")
-    val resultLocalNode = createLocalNode(resultName, Defines.ANY.label)
+    val resultLocalNode = createLocalNode(resultName, Defines.ANY)
     diffGraph.addEdge(localAstParentStack.head, resultLocalNode, EdgeTypes.AST)
     val resultNode = createIdentifierNode(resultName, forInOfStmt)
 
@@ -337,7 +337,7 @@ trait AstForStatementsCreator { this: AstCreator =>
       case _                   => code(nodeInfo.json)
     }
 
-    val loopVariableLocalNode = createLocalNode(loopVariableName, Defines.ANY.label)
+    val loopVariableLocalNode = createLocalNode(loopVariableName, Defines.ANY)
     diffGraph.addEdge(localAstParentStack.head, loopVariableLocalNode, EdgeTypes.AST)
     val loopVariableNode = createIdentifierNode(loopVariableName, forInOfStmt)
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -38,10 +38,7 @@ trait AstForTypesCreator { this: AstCreator =>
     seenAliasTypes.add(aliasTypeDeclNode)
 
     val typeDeclNodeAst =
-      if (
-        !Defines.values
-          .exists { case typeName: Defines.Tpe => typeName.label == name } && !seenAliasTypes.exists(_.name == name)
-      ) {
+      if (!Defines.JSTYPES.contains(name) && !seenAliasTypes.exists(_.name == name)) {
         val (typeName, typeFullName) = calcTypeNameAndFullName(alias, Some(name))
         val typeDeclNode = createTypeDeclNode(
           typeName,
@@ -230,12 +227,8 @@ trait AstForTypesCreator { this: AstCreator =>
     if (calls.isEmpty) {
       Ast(typeDeclNode).withChildren(member)
     } else {
-      val init = staticInitMethodAst(
-        calls,
-        s"$typeFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}",
-        None,
-        Defines.ANY.label
-      )
+      val init =
+        staticInitMethodAst(calls, s"$typeFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}", None, Defines.ANY)
       Ast(typeDeclNode).withChildren(member).withChild(init)
     }
   }
@@ -327,7 +320,7 @@ trait AstForTypesCreator { this: AstCreator =>
         staticMemberInitCalls ++ staticInitBlockAsts,
         s"$typeFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}",
         None,
-        Defines.ANY.label
+        Defines.ANY
       )
       Ast.storeInDiffGraph(init, diffGraph)
       diffGraph.addEdge(typeDeclNode, init.nodes.head, EdgeTypes.AST)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -185,7 +185,7 @@ trait AstNodeBuilder { this: AstCreator =>
       .evaluationStrategy(EvaluationStrategies.BY_VALUE)
       .lineNumber(line)
       .columnNumber(column)
-      .typeFullName(tpe.getOrElse(Defines.ANY.label))
+      .typeFullName(tpe.getOrElse(Defines.ANY))
     scope.addVariable(name, param, MethodScope)
     param
   }
@@ -217,7 +217,7 @@ trait AstNodeBuilder { this: AstCreator =>
     NewMember()
       .code(code)
       .name(name)
-      .typeFullName(Defines.ANY.label)
+      .typeFullName(Defines.ANY)
       .dynamicTypeHintFullName(dynamicTypeOption.toList)
 
   protected def createMethodNode(methodName: String, methodFullName: String, func: BabelNodeInfo): NewMethod = {
@@ -305,7 +305,7 @@ trait AstNodeBuilder { this: AstCreator =>
     .dispatchType(dispatchType)
     .lineNumber(line)
     .columnNumber(column)
-    .typeFullName(Defines.ANY.label)
+    .typeFullName(Defines.ANY)
 
   protected def createVoidCallNode(line: Option[Integer], column: Option[Integer]): NewCall =
     createCallNode("void 0", "<operator>.void", DispatchTypes.STATIC_DISPATCH, line, column)
@@ -328,7 +328,7 @@ trait AstNodeBuilder { this: AstCreator =>
   ): NewLiteral =
     NewLiteral()
       .code(code)
-      .typeFullName(Defines.ANY.label)
+      .typeFullName(Defines.ANY)
       .lineNumber(line)
       .columnNumber(column)
       .dynamicTypeHintFullName(dynamicTypeOption.toList)
@@ -359,14 +359,10 @@ trait AstNodeBuilder { this: AstCreator =>
 
   protected def createIdentifierNode(name: String, node: BabelNodeInfo): NewIdentifier = {
     val dynamicInstanceTypeOption = name match {
-      case "this" =>
-        dynamicInstanceTypeStack.headOption
-      case "console" =>
-        Some(Defines.CONSOLE.label)
-      case "Math" =>
-        Some(Defines.MATH.label)
-      case _ =>
-        None
+      case "this"    => dynamicInstanceTypeStack.headOption
+      case "console" => Some(Defines.CONSOLE)
+      case "Math"    => Some(Defines.MATH)
+      case _         => None
     }
     createIdentifierNode(name, dynamicInstanceTypeOption, node.lineNumber, node.columnNumber)
   }
@@ -381,7 +377,7 @@ trait AstNodeBuilder { this: AstCreator =>
     .code(name)
     .lineNumber(line)
     .columnNumber(column)
-    .typeFullName(Defines.ANY.label)
+    .typeFullName(Defines.ANY)
     .dynamicTypeHintFullName(dynamicTypeOption.toList)
 
   protected def createStaticCallNode(
@@ -398,7 +394,7 @@ trait AstNodeBuilder { this: AstCreator =>
     .signature("")
     .lineNumber(line)
     .columnNumber(column)
-    .typeFullName(Defines.ANY.label)
+    .typeFullName(Defines.ANY)
 
   protected def createLocalNode(name: String, typeFullName: String, closureBindingId: Option[String] = None): NewLocal =
     NewLocal().code(name).name(name).typeFullName(typeFullName).closureBindingId(closureBindingId).order(0)
@@ -425,7 +421,7 @@ trait AstNodeBuilder { this: AstCreator =>
 
   protected def createBlockNode(node: BabelNodeInfo): NewBlock =
     NewBlock()
-      .typeFullName(Defines.ANY.label)
+      .typeFullName(Defines.ANY)
       .code(node.code)
       .lineNumber(node.lineNumber)
       .columnNumber(node.columnNumber)
@@ -449,7 +445,7 @@ trait AstNodeBuilder { this: AstCreator =>
         methodName,
         astParentType = astParentType,
         astParentFullName = astParentFullName
-      ).inheritsFromTypeFullName(List(Defines.ANY.label))
+      ).inheritsFromTypeFullName(List(Defines.ANY))
 
     // Problem for https://github.com/ShiftLeftSecurity/codescience/issues/3626 here.
     // As the type (thus, the signature) of the function node is unknown (i.e., ANY*)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -17,82 +17,82 @@ trait TypeHelper { this: AstCreator =>
   }
 
   private def typeForFlowType(flowType: BabelNodeInfo): String = flowType.node match {
-    case AnyTypeAnnotation            => Defines.ANY.label
+    case AnyTypeAnnotation            => Defines.ANY
     case ArrayTypeAnnotation          => code(flowType.json)
-    case BooleanTypeAnnotation        => Defines.BOOLEAN.label
+    case BooleanTypeAnnotation        => Defines.BOOLEAN
     case BooleanLiteralTypeAnnotation => code(flowType.json)
     case NullLiteralTypeAnnotation    => code(flowType.json)
-    case ExistsTypeAnnotation         => Defines.ANY.label
-    case FunctionTypeAnnotation       => Defines.ANY.label
+    case ExistsTypeAnnotation         => Defines.ANY
+    case FunctionTypeAnnotation       => Defines.ANY
     case GenericTypeAnnotation        => code(flowType.json("id"))
-    case InterfaceTypeAnnotation      => Defines.ANY.label
-    case IntersectionTypeAnnotation   => Defines.ANY.label
-    case MixedTypeAnnotation          => Defines.ANY.label
-    case EmptyTypeAnnotation          => Defines.ANY.label
+    case InterfaceTypeAnnotation      => Defines.ANY
+    case IntersectionTypeAnnotation   => Defines.ANY
+    case MixedTypeAnnotation          => Defines.ANY
+    case EmptyTypeAnnotation          => Defines.ANY
     case NullableTypeAnnotation =>
       typeForTypeAnnotation(createBabelNodeInfo(flowType.json(TYPE_ANNOTATION_KEY)))
     case NumberLiteralTypeAnnotation => code(flowType.json)
-    case NumberTypeAnnotation        => Defines.NUMBER.label
-    case ObjectTypeAnnotation        => Defines.OBJECT.label
+    case NumberTypeAnnotation        => Defines.NUMBER
+    case ObjectTypeAnnotation        => Defines.OBJECT
     case StringLiteralTypeAnnotation => code(flowType.json)
-    case StringTypeAnnotation        => Defines.STRING.label
-    case SymbolTypeAnnotation        => Defines.SYMBOL.label
+    case StringTypeAnnotation        => Defines.STRING
+    case SymbolTypeAnnotation        => Defines.SYMBOL
     case ThisTypeAnnotation =>
-      dynamicInstanceTypeStack.headOption.getOrElse(Defines.ANY.label)
-    case TupleTypeAnnotation       => Defines.ANY.label
-    case TypeofTypeAnnotation      => Defines.ANY.label
-    case UnionTypeAnnotation       => Defines.ANY.label
-    case VoidTypeAnnotation        => Defines.ANY.label
-    case IndexedAccessType         => Defines.ANY.label
-    case OptionalIndexedAccessType => Defines.ANY.label
+      dynamicInstanceTypeStack.headOption.getOrElse(Defines.ANY)
+    case TupleTypeAnnotation       => Defines.ANY
+    case TypeofTypeAnnotation      => Defines.ANY
+    case UnionTypeAnnotation       => Defines.ANY
+    case VoidTypeAnnotation        => Defines.ANY
+    case IndexedAccessType         => Defines.ANY
+    case OptionalIndexedAccessType => Defines.ANY
     case _ =>
       notHandledYet(flowType, TYPE_NOT_HANDLED_TEXT)
-      Defines.ANY.label
+      Defines.ANY
   }
 
   private def typeForTsType(tsType: BabelNodeInfo): String = tsType.node match {
-    case TSAnyKeyword       => Defines.ANY.label
-    case TSBooleanKeyword   => Defines.BOOLEAN.label
-    case TSBigIntKeyword    => Defines.NUMBER.label
+    case TSAnyKeyword       => Defines.ANY
+    case TSBooleanKeyword   => Defines.BOOLEAN
+    case TSBigIntKeyword    => Defines.NUMBER
     case TSIntrinsicKeyword => code(tsType.json)
-    case TSNeverKeyword     => Defines.ANY.label
-    case TSNullKeyword      => Defines.NULL.label
-    case TSNumberKeyword    => Defines.NUMBER.label
-    case TSObjectKeyword    => Defines.OBJECT.label
-    case TSStringKeyword    => Defines.STRING.label
-    case TSSymbolKeyword    => Defines.SYMBOL.label
-    case TSUndefinedKeyword => Defines.ANY.label
-    case TSUnknownKeyword   => Defines.ANY.label
-    case TSVoidKeyword      => Defines.ANY.label
+    case TSNeverKeyword     => Defines.ANY
+    case TSNullKeyword      => Defines.NULL
+    case TSNumberKeyword    => Defines.NUMBER
+    case TSObjectKeyword    => Defines.OBJECT
+    case TSStringKeyword    => Defines.STRING
+    case TSSymbolKeyword    => Defines.SYMBOL
+    case TSUndefinedKeyword => Defines.ANY
+    case TSUnknownKeyword   => Defines.ANY
+    case TSVoidKeyword      => Defines.ANY
     case TSThisType =>
-      dynamicInstanceTypeStack.headOption.getOrElse(Defines.ANY.label)
-    case TSFunctionType    => Defines.ANY.label
-    case TSConstructorType => Defines.ANY.label
+      dynamicInstanceTypeStack.headOption.getOrElse(Defines.ANY)
+    case TSFunctionType    => Defines.ANY
+    case TSConstructorType => Defines.ANY
     case TSTypeReference   => code(tsType.json)
-    case TSTypePredicate   => Defines.ANY.label
-    case TSTypeQuery       => Defines.ANY.label
-    case TSTypeLiteral     => Defines.ANY.label
+    case TSTypePredicate   => Defines.ANY
+    case TSTypeQuery       => Defines.ANY
+    case TSTypeLiteral     => Defines.ANY
     case TSArrayType       => code(tsType.json)
-    case TSTupleType       => Defines.ANY.label
+    case TSTupleType       => Defines.ANY
     case TSOptionalType =>
       typeForTypeAnnotation(createBabelNodeInfo(tsType.json(TYPE_ANNOTATION_KEY)))
     case TSRestType =>
       typeForTypeAnnotation(createBabelNodeInfo(tsType.json(TYPE_ANNOTATION_KEY)))
-    case TSUnionType        => Defines.ANY.label
-    case TSIntersectionType => Defines.ANY.label
-    case TSConditionalType  => Defines.ANY.label
-    case TSInferType        => Defines.ANY.label
+    case TSUnionType        => Defines.ANY
+    case TSIntersectionType => Defines.ANY
+    case TSConditionalType  => Defines.ANY
+    case TSInferType        => Defines.ANY
     case TSParenthesizedType =>
       typeForTypeAnnotation(createBabelNodeInfo(tsType.json(TYPE_ANNOTATION_KEY)))
-    case TSTypeOperator                => Defines.ANY.label
-    case TSIndexedAccessType           => Defines.ANY.label
-    case TSMappedType                  => Defines.ANY.label
-    case TSLiteralType                 => Defines.ANY.label
-    case TSExpressionWithTypeArguments => Defines.ANY.label
-    case TSImportType                  => Defines.ANY.label
+    case TSTypeOperator                => Defines.ANY
+    case TSIndexedAccessType           => Defines.ANY
+    case TSMappedType                  => Defines.ANY
+    case TSLiteralType                 => Defines.ANY
+    case TSExpressionWithTypeArguments => Defines.ANY
+    case TSImportType                  => Defines.ANY
     case _ =>
       notHandledYet(tsType, TYPE_NOT_HANDLED_TEXT)
-      Defines.ANY.label
+      Defines.ANY
   }
 
   private def typeForTypeAnnotation(typeAnnotation: BabelNodeInfo): String = typeAnnotation.node match {
@@ -102,7 +102,7 @@ trait TypeHelper { this: AstCreator =>
     case _: TSType        => typeForTsType(createBabelNodeInfo(typeAnnotation.json))
     case _ =>
       notHandledYet(typeAnnotation, TYPE_NOT_HANDLED_TEXT)
-      Defines.ANY.label
+      Defines.ANY
   }
 
   protected def typeFor(node: BabelNodeInfo): String =
@@ -112,7 +112,7 @@ trait TypeHelper { this: AstCreator =>
         registerType(tpe, tpe)
         tpe
       case None =>
-        Defines.ANY.label
+        Defines.ANY
     }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -29,7 +29,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   override def generateParts(): Array[(String, String)] = astGenRunnerResult.parsedFiles.toArray
 
   def allUsedTypes(): List[(String, String)] =
-    usedTypes.keys().asScala.filterNot { case (typeName, _) => typeName == Defines.ANY.label }.toList
+    usedTypes.keys().asScala.filterNot { case (typeName, _) => typeName == Defines.ANY }.toList
 
   override def finish(): Unit = {
     astGenRunnerResult.skippedFiles.foreach { skippedFile =>

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPass.scala
@@ -16,18 +16,16 @@ class BuiltinTypesPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
 
     diffGraph.addNode(namespaceBlock)
 
-    Defines.values.zipWithIndex.map { case (typeName: Defines.Tpe, index) =>
-      val typeNameLabel = typeName.label
-
+    Defines.JSTYPES.zipWithIndex.map { case (typeName: String, index) =>
       val tpe = NewType()
-        .name(typeNameLabel)
-        .fullName(typeNameLabel)
-        .typeDeclFullName(typeNameLabel)
+        .name(typeName)
+        .fullName(typeName)
+        .typeDeclFullName(typeName)
       diffGraph.addNode(tpe)
 
       val typeDecl = NewTypeDecl()
-        .name(typeNameLabel)
-        .fullName(typeNameLabel)
+        .name(typeName)
+        .fullName(typeName)
         .isExternal(false)
         .astParentType(NodeTypes.NAMESPACE_BLOCK)
         .astParentFullName(Defines.GLOBAL_NAMESPACE)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConfigPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConfigPass.scala
@@ -4,21 +4,32 @@ import better.files.File
 import io.joern.jssrc2cpg.utils.Report
 import io.joern.jssrc2cpg.utils.TimeUtils
 import io.joern.jssrc2cpg.Config
+import io.joern.x2cpg.SourceFiles
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile
 import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
-class ConfigPass(cpg: Cpg, files: Seq[File], config: Config, report: Report = new Report())
-    extends ConcurrentWriterCpgPass[File](cpg) {
+class ConfigPass(cpg: Cpg, config: Config, report: Report = new Report()) extends ConcurrentWriterCpgPass[File](cpg) {
 
   private val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  override def generateParts(): Array[File] = files.toArray
+  protected val allExtensions: Set[String]      = Set(".json", ".js", ".vue", ".html")
+  protected val selectedExtensions: Set[String] = Set(".json", ".config.js", ".conf.js", ".vue", ".html")
+
+  override def generateParts(): Array[File] =
+    configFiles(config, allExtensions).toArray
 
   protected def fileContent(file: File): Seq[String] =
     IOUtils.readLinesInFile(file.path)
+
+  protected def configFiles(config: Config, extensions: Set[String]): Seq[File] =
+    SourceFiles
+      .determine(config.inputPath, extensions)
+      .filterNot(_.contains(Defines.NODE_MODULES_FOLDER))
+      .filter(f => selectedExtensions.exists(f.endsWith))
+      .map(File(_))
 
   override def runOnPart(diffGraph: DiffGraphBuilder, file: File): Unit = {
     val path = File(config.inputPath).path.toAbsolutePath.relativize(file.path).toString

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/Defines.scala
@@ -1,24 +1,19 @@
 package io.joern.jssrc2cpg.passes
 
-class DefineTypes extends Enumeration {
-  type Defines = Value
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
-  val ANY: Tpe     = Tpe("ANY")
-  val NUMBER: Tpe  = Tpe("__ecma.Number")
-  val STRING: Tpe  = Tpe("__ecma.String")
-  val BOOLEAN: Tpe = Tpe("__ecma.Boolean")
-  val NULL: Tpe    = Tpe("__ecma.Null")
-  val MATH: Tpe    = Tpe("__ecma.Math")
-  val SYMBOL: Tpe  = Tpe("__ecma.Symbol")
-  val CONSOLE: Tpe = Tpe("__whatwg.console")
-  val OBJECT: Tpe  = Tpe("object")
+object Defines {
+  val ANY: String                 = "ANY"
+  val NUMBER: String              = "__ecma.Number"
+  val STRING: String              = "__ecma.String"
+  val BOOLEAN: String             = "__ecma.Boolean"
+  val NULL: String                = "__ecma.Null"
+  val MATH: String                = "__ecma.Math"
+  val SYMBOL: String              = "__ecma.Symbol"
+  val CONSOLE: String             = "__whatwg.console"
+  val OBJECT: String              = "object"
+  val NODE_MODULES_FOLDER: String = "node_modules"
+  val GLOBAL_NAMESPACE: String    = NamespaceTraversal.globalNamespaceName
 
-  val GLOBAL_NAMESPACE = "<global>"
-
-  class Tpe(val label: String) extends super.Val
-  private object Tpe {
-    def apply(label: String): Tpe = new Tpe(label)
-  }
+  val JSTYPES: List[String] = List(ANY, NUMBER, STRING, BOOLEAN, NULL, MATH, SYMBOL, CONSOLE, OBJECT)
 }
-
-object Defines extends DefineTypes

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
@@ -14,6 +14,7 @@ class DependenciesPass(cpg: Cpg, config: Config) extends SimpleCpgPass(cpg) {
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val packagesJsons = SourceFiles
       .determine(config.inputPath, Set(".json"))
+      .filterNot(_.contains(Defines.NODE_MODULES_FOLDER))
       .filter(f =>
         f.endsWith(PackageJsonParser.PACKAGE_JSON_FILENAME) || f.endsWith(PackageJsonParser.PACKAGE_JSON_LOCK_FILENAME)
       )

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/PrivateKeyFilePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/PrivateKeyFilePass.scala
@@ -8,15 +8,20 @@ import io.shiftleft.utils.IOUtils
 
 import scala.util.matching.Regex
 
-class PrivateKeyFilePass(cpg: Cpg, files: Seq[File], config: Config, report: Report = new Report())
-    extends ConfigPass(cpg, files, config, report) {
+class PrivateKeyFilePass(cpg: Cpg, config: Config, report: Report = new Report())
+    extends ConfigPass(cpg, config, report) {
 
   private val PRIVATE_KEY: Regex = """.*RSA\sPRIVATE\sKEY.*""".r
+
+  override val allExtensions: Set[String]      = Set(".key")
+  override val selectedExtensions: Set[String] = Set(".key")
 
   override def fileContent(file: File): Seq[String] =
     Seq("Content omitted for security reasons.")
 
   override def generateParts(): Array[File] =
-    super.generateParts().filter(p => IOUtils.readLinesInFile(p.path).exists(PRIVATE_KEY.matches))
+    configFiles(config, selectedExtensions).toArray.filter(p =>
+      IOUtils.readLinesInFile(p.path).exists(PRIVATE_KEY.matches)
+    )
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/TypeNodePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/TypeNodePass.scala
@@ -7,7 +7,7 @@ import io.shiftleft.passes.SimpleCpgPass
 class TypeNodePass(usedTypes: List[(String, String)], cpg: Cpg) extends SimpleCpgPass(cpg, "types") {
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val filteredTypes = usedTypes.filterNot { case (name, _) =>
-      name == "ANY" || Defines.values.map { case typeName: Defines.Tpe => typeName.label }.contains(name)
+      name == Defines.ANY || Defines.JSTYPES.contains(name)
     }
 
     filteredTypes.sortBy(_._2).foreach { case (name, fullName) =>

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/Environment.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/Environment.scala
@@ -5,7 +5,6 @@ import java.nio.file.Paths
 
 object Environment {
 
-  val IS_WIN: Boolean   = scala.util.Properties.isWin
   val IS_MAC: Boolean   = scala.util.Properties.isMac
   val IS_LINUX: Boolean = scala.util.Properties.isLinux
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPassTest.scala
@@ -14,17 +14,16 @@ class BuiltinTypesPassTest extends AbstractPassTest {
     }
 
     "create types and type decls correctly" in {
-      Defines.values.foreach { case typeName: Defines.Tpe =>
-        val typeNameLabel      = typeName.label
-        val List(typeDeclNode) = cpg.typeDecl(typeNameLabel).l
-        typeDeclNode.fullName shouldBe typeNameLabel
+      Defines.JSTYPES.foreach { typeName: String =>
+        val List(typeDeclNode) = cpg.typeDecl(typeName).l
+        typeDeclNode.fullName shouldBe typeName
         typeDeclNode.isExternal shouldBe false
         typeDeclNode.filename shouldBe "builtintypes"
 
         cpg.namespaceBlock.astChildren.l should contain(typeDeclNode)
 
-        val List(typeNode) = cpg.typ(typeNameLabel).l
-        typeNode.fullName shouldBe typeNameLabel
+        val List(typeNode) = cpg.typ(typeName).l
+        typeNode.fullName shouldBe typeName
       }
     }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -642,28 +642,28 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
     "have correct structure for empty method" in AstFixture("function method(x) {}") { cpg =>
       val List(method) = cpg.method.nameExact("method").l
       method.astChildren.isBlock.size shouldBe 1
-      method.methodReturn.typeFullName shouldBe Defines.ANY.label
-      method.parameter.index(0).nameExact("this").typeFullName(Defines.ANY.label).size shouldBe 1
-      method.parameter.index(1).nameExact("x").typeFullName(Defines.ANY.label).size shouldBe 1
+      method.methodReturn.typeFullName shouldBe Defines.ANY
+      method.parameter.index(0).nameExact("this").typeFullName(Defines.ANY).size shouldBe 1
+      method.parameter.index(1).nameExact("x").typeFullName(Defines.ANY).size shouldBe 1
     }
 
     "have correct structure for empty method with rest parameter" in AstFixture("function method(x, ...args) {}") {
       cpg =>
         val List(method) = cpg.method.nameExact("method").l
-        method.methodReturn.typeFullName shouldBe Defines.ANY.label
+        method.methodReturn.typeFullName shouldBe Defines.ANY
 
         val List(t, x, args) = method.parameter.l
         t.index shouldBe 0
         t.name shouldBe "this"
-        t.typeFullName shouldBe Defines.ANY.label
+        t.typeFullName shouldBe Defines.ANY
         x.index shouldBe 1
         x.name shouldBe "x"
-        x.typeFullName shouldBe Defines.ANY.label
+        x.typeFullName shouldBe Defines.ANY
         args.index shouldBe 2
         args.name shouldBe "args"
         args.code shouldBe "...args"
         args.isVariadic shouldBe true
-        args.typeFullName shouldBe Defines.ANY.label
+        args.typeFullName shouldBe Defines.ANY
     }
 
     "have correct structure for decl assignment" in AstFixture("function foo(x) { var local = 1; }") { cpg =>
@@ -673,10 +673,10 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(t, x) = method.parameter.l
       t.index shouldBe 0
       t.name shouldBe "this"
-      t.typeFullName shouldBe Defines.ANY.label
+      t.typeFullName shouldBe Defines.ANY
       x.index shouldBe 1
       x.name shouldBe "x"
-      x.typeFullName shouldBe Defines.ANY.label
+      x.typeFullName shouldBe Defines.ANY
 
       val List(local) = block.astChildren.isLocal.l
       local.name shouldBe "local"
@@ -695,10 +695,10 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(t, x) = method.parameter.l
       t.index shouldBe 0
       t.name shouldBe "this"
-      t.typeFullName shouldBe Defines.ANY.label
+      t.typeFullName shouldBe Defines.ANY
       x.index shouldBe 1
       x.name shouldBe "x"
-      x.typeFullName shouldBe Defines.ANY.label
+      x.typeFullName shouldBe Defines.ANY
 
       val List(local) = block.astChildren.isLocal.l
       local.name shouldBe "local"
@@ -718,13 +718,13 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(t, x, y) = method.parameter.l
       t.index shouldBe 0
       t.name shouldBe "this"
-      t.typeFullName shouldBe Defines.ANY.label
+      t.typeFullName shouldBe Defines.ANY
       x.index shouldBe 1
       x.name shouldBe "x"
-      x.typeFullName shouldBe Defines.ANY.label
+      x.typeFullName shouldBe Defines.ANY
       y.index shouldBe 2
       y.name shouldBe "y"
-      y.typeFullName shouldBe Defines.ANY.label
+      y.typeFullName shouldBe Defines.ANY
 
       val List(firstLocal, secondLocal) = block.astChildren.isLocal.l
       firstLocal.name shouldBe "local1"
@@ -1345,7 +1345,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       program.astChildren.isBlock.size shouldBe 1
       val blockMethodReturn = program.methodReturn
       blockMethodReturn.code shouldBe "RET"
-      blockMethodReturn.typeFullName shouldBe Defines.ANY.label
+      blockMethodReturn.typeFullName shouldBe Defines.ANY
     }
 
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
@@ -86,12 +86,12 @@ class TsAstCreationPassTest extends AbstractPassTest {
         callZ.argument(1).code shouldBe "boolean"
         callZ.argument(2).code shouldBe "true"
       }
-      cpg.local("x").typeFullName.l shouldBe List(Defines.STRING.label)
-      cpg.identifier("x").typeFullName.l shouldBe List(Defines.STRING.label)
+      cpg.local("x").typeFullName.l shouldBe List(Defines.STRING)
+      cpg.identifier("x").typeFullName.l shouldBe List(Defines.STRING)
       cpg.local("y").typeFullName.l shouldBe List("int")
       cpg.identifier("y").typeFullName.l shouldBe List("int")
-      cpg.local("z").typeFullName.l shouldBe List(Defines.BOOLEAN.label)
-      cpg.identifier("z").typeFullName.l shouldBe List(Defines.BOOLEAN.label)
+      cpg.local("z").typeFullName.l shouldBe List(Defines.BOOLEAN)
+      cpg.identifier("z").typeFullName.l shouldBe List(Defines.BOOLEAN)
     }
 
     "have correct structure for import assignments" in AstFixture(
@@ -130,7 +130,7 @@ class TsAstCreationPassTest extends AbstractPassTest {
       func.fullName shouldBe "code.ts::program:foo"
       val List(_, arg) = cpg.method("foo").parameter.l
       arg.name shouldBe "arg"
-      arg.typeFullName shouldBe Defines.STRING.label
+      arg.typeFullName shouldBe Defines.STRING
       arg.code shouldBe "arg: string"
       arg.index shouldBe 1
       val List(parentTypeDecl) = cpg.typeDecl.name(":program").l

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
@@ -12,7 +12,7 @@ class TSTypesTest extends AbstractPassTest {
     inside(cpg.identifier.l) { case List(x, y) =>
       x.name shouldBe "x"
       x.code shouldBe "x"
-      x.typeFullName shouldBe Defines.STRING.label
+      x.typeFullName shouldBe Defines.STRING
       y.name shouldBe "y"
       y.code shouldBe "y"
       y.typeFullName shouldBe "Foo"
@@ -37,7 +37,7 @@ class TSTypesTest extends AbstractPassTest {
     inside(cpg.method("foo").parameter.l) { case List(_, a, b) =>
       a.name shouldBe "a"
       a.code shouldBe "a: string"
-      a.typeFullName shouldBe Defines.STRING.label
+      a.typeFullName shouldBe Defines.STRING
       b.name shouldBe "b"
       b.code shouldBe "b: Foo"
       b.typeFullName shouldBe "Foo"
@@ -118,7 +118,7 @@ class TSTypesTest extends AbstractPassTest {
       |type Alias = string
       |""".stripMargin) { cpg =>
     cpg.typeDecl("string").l shouldBe empty
-    cpg.typeDecl(Defines.STRING.label).size shouldBe 1
+    cpg.typeDecl(Defines.STRING).size shouldBe 1
     inside(cpg.typeDecl("Alias").l) { case List(alias) =>
       alias.fullName shouldBe "code.ts::program:Alias"
       alias.code shouldBe "type Alias = string"


### PR DESCRIPTION
- content in node_modules folder is now ignored (for all config files)
- simplified io.joern.jssrc2cpg.passes.Defines (simple strings are sufficient here)