### PR TITLE
c2cpg: disabled auto discovery of system header include paths

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -16,9 +16,8 @@ final case class Config(
   logProblems: Boolean = false,
   logPreprocessor: Boolean = false,
   printIfDefsOnly: Boolean = false,
-  includePathsAutoDiscovery: Boolean = true
+  includePathsAutoDiscovery: Boolean = false
 ) extends X2CpgConfig[Config] {
-
   override def withInputPath(inputPath: String): Config = copy(inputPath = inputPath)
   override def withOutputPath(x: String): Config        = copy(outputPath = x)
 }
@@ -48,8 +47,11 @@ private object Frontend {
         .text("header include paths")
         .action((incl, c) => c.copy(includePaths = c.includePaths + incl)),
       opt[Unit]("no-include-auto-discovery")
-        .text("disables auto discovery of header include paths")
-        .action((_, c) => c.copy(includePathsAutoDiscovery = false)),
+        .text("disables auto discovery of system header include paths")
+        .hidden(),
+      opt[Unit]("with-include-auto-discovery")
+        .text("enables auto discovery of system header include paths")
+        .action((_, c) => c.copy(includePathsAutoDiscovery = true)),
       opt[String]("define")
         .unbounded()
         .text("define a name")

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -54,21 +54,14 @@ object IncludeAutoDiscovery {
     val endIndex =
       if (IS_WIN) output.indexWhere(_.startsWith("End of search list.")) - 1
       else output.indexWhere(_.startsWith("COMPILER_PATH")) - 1
-    output
-      .slice(startIndex, endIndex)
-      .map { p =>
-        Paths.get(p.trim).toRealPath()
-      }
-      .toSet
+    output.slice(startIndex, endIndex).map(p => Paths.get(p.trim).toRealPath()).toSet
   }
 
-  private def discoverPaths(command: String): Set[Path] = {
-    ExternalCommand.run(command) match {
-      case Success(output) => extractPaths(output)
-      case Failure(exception) =>
-        logger.warn(s"Unable to discover system include paths. Running '$command' failed.", exception)
-        Set.empty
-    }
+  private def discoverPaths(command: String): Set[Path] = ExternalCommand.run(command) match {
+    case Success(output) => extractPaths(output)
+    case Failure(exception) =>
+      logger.warn(s"Unable to discover system include paths. Running '$command' failed.", exception)
+      Set.empty
   }
 
   def discoverIncludePathsC(config: Config): Set[Path] = {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
@@ -29,9 +29,8 @@ class PreprocessorPassTests extends AnyWordSpec with Matchers {
         val filename = "test.c"
         val file     = dir / filename
         file.write(code)
-        val config = Config(inputPath = dir.path.toString, includePathsAutoDiscovery = false)
-
-        val stmts = new PreprocessorPass(config).run().toList
+        val config = Config(inputPath = dir.path.toString)
+        val stmts  = new PreprocessorPass(config).run().toList
         stmts shouldBe List("SYMBOL", "FOO=true")
       }
     }
@@ -56,9 +55,8 @@ class PreprocessorPassTests extends AnyWordSpec with Matchers {
         val filename = "test.c"
         val file     = dir / filename
         file.write(code)
-        val config =
-          Config(inputPath = dir.path.toString, defines = Set("SYMBOL"), includePathsAutoDiscovery = false)
-        val stmts = new PreprocessorPass(config).run().toList
+        val config = Config(inputPath = dir.path.toString, defines = Set("SYMBOL"))
+        val stmts  = new PreprocessorPass(config).run().toList
         stmts shouldBe List("SYMBOL=true", "FOO=true")
       }
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AbstractPassTest.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AbstractPassTest.scala
@@ -19,7 +19,7 @@ abstract class AbstractPassTest extends AnyWordSpec with Matchers with Inside {
         val cpg  = newEmptyCpg()
         val file = dir / fileName
         file.write(code)
-        val config = Config(inputPath = dir.toString, includePathsAutoDiscovery = false, outputPath = dir.toString())
+        val config = Config(inputPath = dir.toString, outputPath = dir.toString())
         new AstCreationPass(cpg, AstCreationPass.SourceFiles, config).createAndApply()
         f(cpg)
         file.delete()
@@ -31,7 +31,7 @@ abstract class AbstractPassTest extends AnyWordSpec with Matchers with Inside {
       File.usingTemporaryDirectory("c2cpgtest") { dir =>
         val file = dir / "file.c"
         file.write(code)
-        val config = Config(inputPath = dir.toString, includePathsAutoDiscovery = false, outputPath = dir.toString())
+        val config = Config(inputPath = dir.toString, outputPath = dir.toString())
         new AstCreationPass(cpg, AstCreationPass.SourceFiles, config).createAndApply()
       }
       cpg

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
@@ -12,12 +12,8 @@ trait C2CpgFrontend extends LanguageFrontend {
     val cpgOutFile = File.newTemporaryFile("c2cpg.bin")
     cpgOutFile.deleteOnExit()
     val c2cpg = new C2Cpg()
-    val config = Config(
-      inputPath = sourceCodePath.getAbsolutePath,
-      outputPath = cpgOutFile.pathAsString,
-      includeComments = true,
-      includePathsAutoDiscovery = false
-    )
+    val config =
+      Config(inputPath = sourceCodePath.getAbsolutePath, outputPath = cpgOutFile.pathAsString, includeComments = true)
     c2cpg.createCpg(config).get
   }
 }


### PR DESCRIPTION
Can be activated with `--with-include-auto-discovery` now.