### PR TITLE
Add PHP global and use stmts

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
@@ -5,10 +5,13 @@ import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.{Scope => X2CpgScope}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewLocal, NewMethod, NewNamespaceBlock, NewNode, NewTypeDecl}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 
 class Scope extends X2CpgScope[String, NewNode, NewNode] {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   private var localStack: List[mutable.ArrayBuffer[NewLocal]]     = Nil
   private var constAndStaticInits: List[mutable.ArrayBuffer[Ast]] = Nil
@@ -16,13 +19,21 @@ class Scope extends X2CpgScope[String, NewNode, NewNode] {
 
   override def pushNewScope(scopeNode: NewNode): Unit = {
     scopeNode match {
-      case _: NewMethod => localStack = mutable.ArrayBuffer[NewLocal]() :: localStack
+      case _: NewMethod =>
+        localStack = mutable.ArrayBuffer[NewLocal]() :: localStack
+        super.pushNewScope(scopeNode)
+
       case _: NewTypeDecl =>
         constAndStaticInits = mutable.ArrayBuffer[Ast]() :: constAndStaticInits
         fieldInits = mutable.ArrayBuffer[Ast]() :: fieldInits
-      case _ => // Nothing to do here
+        super.pushNewScope(scopeNode)
+
+      case _: NewNamespaceBlock =>
+        super.pushNewScope(scopeNode)
+
+      case invalid =>
+        logger.warn(s"pushNewScope called with invalid node $invalid. Ignoring!")
     }
-    super.pushNewScope(scopeNode)
   }
 
   override def popScope(): Option[NewNode] = {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
@@ -636,4 +636,20 @@ class OperatorTests extends PhpCode2CpgFixture {
       }
     }
   }
+
+  "global calls should handle simple and non-simple args" in {
+    val cpg = code("<?php\nglobal $a, $$b")
+
+    inside(cpg.call.l) { case List(globalCall) =>
+      globalCall.name shouldBe "global"
+      globalCall.methodFullName shouldBe "global"
+      globalCall.code shouldBe "global $a, $$b"
+      globalCall.lineNumber shouldBe Some(2)
+
+      inside(globalCall.argument.l) { case List(aArg: Identifier, bArg: Identifier) =>
+        aArg.name shouldBe "a"
+        bArg.name shouldBe "b"
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/UseTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/UseTests.scala
@@ -1,0 +1,75 @@
+package io.joern.php2cpg.querying
+
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+
+class UseTests extends PhpCode2CpgFixture {
+
+  "normal use statements without aliases should be represented correctly" in {
+    val cpg = code("<?php\nuse A\\B;")
+
+    inside(cpg.imports.l) { case List(importStmt) =>
+      importStmt.code shouldBe "use A\\B"
+      importStmt.importedEntity should contain("A\\B")
+      importStmt.importedAs.isEmpty shouldBe true
+    }
+  }
+
+  "normal use statements including multiple namespaces should be enclosed in a block" in {
+    val cpg = code("<?php\nuse A, B;")
+
+    inside(cpg.imports.l.sortBy(_.code)) { case List(aImport, bImport) =>
+      aImport.code shouldBe "use A"
+      aImport.importedEntity should contain("A")
+      aImport.importedAs.isEmpty shouldBe true
+
+      bImport.code shouldBe "use B"
+      bImport.importedEntity should contain("B")
+      bImport.importedAs.isEmpty shouldBe true
+    }
+  }
+
+  "use statements with aliases should be correctly represented" in {
+    val cpg = code("<?php\nuse A\\B as C;")
+
+    inside(cpg.imports.l) { case List(importStmt) =>
+      importStmt.code shouldBe "use A\\B as C"
+      importStmt.importedEntity should contain("A\\B")
+      importStmt.importedAs should contain("C")
+    }
+  }
+
+  "function uses should have the correct code field" in {
+    val cpg = code("<?php\nuse function foo\\bar;")
+
+    inside(cpg.imports.l) { case List(importStmt) =>
+      importStmt.code shouldBe "use function foo\\bar"
+      importStmt.importedEntity should contain("foo\\bar")
+      importStmt.importedAs.isEmpty shouldBe true
+    }
+  }
+
+  "const uses should have the correct code field" in {
+    val cpg = code("<?php\nuse const foo\\BAR;")
+
+    inside(cpg.imports.l) { case List(importStmt) =>
+      importStmt.code shouldBe "use const foo\\BAR"
+      importStmt.importedEntity should contain("foo\\BAR")
+      importStmt.importedAs.isEmpty shouldBe true
+    }
+  }
+
+  "group uses should have the correct names for all elements in the group" in {
+    val cpg = code("<?php\nuse A\\{B\\C, D}")
+
+    inside(cpg.imports.l.sortBy(_.code)) { case List(aImport, bImport) =>
+      aImport.code shouldBe "use A\\B\\C"
+      aImport.importedEntity should contain("A\\B\\C")
+      aImport.importedAs.isEmpty shouldBe true
+
+      bImport.code shouldBe "use A\\D"
+      bImport.importedEntity should contain("A\\D")
+      bImport.importedAs.isEmpty shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
The use implementation here is not complete. It does include the information one needs to figure out function names and such with queries, but ideally the frontend should do this by itself. This would require interaction with includes and is still a TODO.