### PR TITLE
Fixing file extension check

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -94,7 +94,7 @@ object ProgramHandlingUtil {
           zip
             .entries()
             .asScala
-            .filter(f => !f.isDirectory && f.getName.contains(".class"))
+            .filter(f => !f.isDirectory && f.getName.endsWith(".class"))
             .flatMap(entry => {
               val sourceCodePathFile = new File(sourceCodePath)
               // Handle the case if the input source code path is an archive itself


### PR DESCRIPTION
`com.facebook.presto.spark.classloader_interface.IPrestoSparkServiceFactory` is passing `f.getName.contains(".class")`, `endsWith` should fix this.

Example input: [presto.zip](https://github.com/joernio/joern/files/9899376/presto.zip)