### PR TITLE
Add remaining PHP language constructs to Domain with placeholder implemenations

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -118,6 +118,8 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case globalStmt: PhpGlobalStmt       => astForGlobalStmt(globalStmt)
       case useStmt: PhpUseStmt             => astForUseStmt(useStmt)
       case groupUseStmt: PhpGroupUseStmt   => astForGroupUseStmt(groupUseStmt)
+      case foreachStmt: PhpForeachStmt     => astForForeachStmt(foreachStmt)
+      case traitUseStmt: PhpTraitUseStmt   => astforTraitUseStmt(traitUseStmt)
       case null =>
         logger.warn("stmt was null")
         ???
@@ -257,6 +259,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case newExpr: PhpNewExpr       => astForNewExpr(newExpr)
       case matchExpr: PhpMatchExpr   => astForMatchExpr(matchExpr)
       case yieldExpr: PhpYieldExpr   => astForYieldExpr(yieldExpr)
+      case closure: PhpClosureExpr   => astForClosureExpr(closure)
 
       case yieldFromExpr: PhpYieldFromExpr             => astForYieldFromExpr(yieldFromExpr)
       case classConstFetchExpr: PhpClassConstFetchExpr => astForClassConstFetchExpr(classConstFetchExpr)
@@ -267,6 +270,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case propertyFetchExpr: PhpPropertyFetchExpr     => astForPropertyFetchExpr(propertyFetchExpr)
       case includeExpr: PhpIncludeExpr                 => astForIncludeExpr(includeExpr)
       case shellExecExpr: PhpShellExecExpr             => astForShellExecExpr(shellExecExpr)
+      case arrowFunction: PhpArrowFunction             => astForArrowFunc(arrowFunction)
 
       case null =>
         logger.warn("expr was null")
@@ -528,6 +532,16 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val groupPrefix = s"${stmt.prefix.name}\\"
     val imports     = stmt.uses.map(astForUseUse(_, groupPrefix))
     wrapMultipleInBlock(imports, line(stmt))
+  }
+
+  private def astForForeachStmt(stmt: PhpForeachStmt): Ast = {
+    // TODO Actually implement this
+    Ast()
+  }
+
+  private def astforTraitUseStmt(stmt: PhpTraitUseStmt): Ast = {
+    // TODO Actually implement this
+    Ast()
   }
 
   private def astForUseUse(stmt: PhpUseUse, namePrefix: String = ""): Ast = {
@@ -1260,6 +1274,16 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     Ast(yieldNode)
       .withChildren(maybeKey.toList)
       .withChildren(maybeVal.toList)
+  }
+
+  private def astForClosureExpr(expr: PhpClosureExpr): Ast = {
+    // TODO Actually implement this (with uses)
+    Ast()
+  }
+
+  private def astForArrowFunc(expr: PhpArrowFunction): Ast = {
+    // TODO Actually implement this
+    Ast()
   }
 
   private def astForYieldFromExpr(expr: PhpYieldFromExpr): Ast = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -483,7 +483,7 @@ object Domain {
 
   final case class PhpConstFetchExpr(name: PhpNameExpr, attributes: PhpAttributes) extends PhpExpr
 
-  final case class PhpArrayExpr(items: List[PhpArrayItem], attributes: PhpAttributes) extends PhpExpr
+  final case class PhpArrayExpr(items: List[Option[PhpArrayItem]], attributes: PhpAttributes) extends PhpExpr
   final case class PhpArrayItem(
     key: Option[PhpExpr],
     value: PhpExpr,
@@ -784,7 +784,9 @@ object Domain {
   }
 
   private def readArray(json: Value): PhpArrayExpr = {
-    val items = json("items").arr.map(readArrayItem).toList
+    val items = json("items").arr.map { item =>
+      Option.unless(item.isNull)(readArrayItem(item))
+    }.toList
     PhpArrayExpr(items, PhpAttributes(json))
   }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -25,7 +25,7 @@ class AstCreationPass(inputPath: String, cpg: Cpg) extends ConcurrentWriterCpgPa
         diffGraph.absorb(new AstCreator(filename, parseResult, global).createAst())
 
       case None =>
-        logger.error(s"Could not parse file $filename. Results will be missing!")
+        logger.warn(s"Could not parse file $filename. Results will be missing!")
     }
   }
 


### PR DESCRIPTION
With this PR, the frontend no longer crashes on larger projects (tested with a couple of trending PHP projects on github). The implementation for foreach loops, trait use statements and anonymous functions/classes are still TODO, but this should unblock further work on the security side for PHP for now.