### PR TITLE
fix scaladoc warning

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/CfgDominator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/CfgDominator.scala
@@ -28,9 +28,8 @@ class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
     val dominators = Array.fill(indexOf.size)(UNDEFINED)
     dominators(indexOf(cfgEntry)) = indexOf(cfgEntry)
 
-    /** Retrieve index of immediate dominator for node with given index. If the index is `UNDEFINED`, UNDEFINED is
-      * returned.
-      */
+    /* Retrieve index of immediate dominator for node with given index. If the index is `UNDEFINED`, UNDEFINED is
+     * returned. */
     def safeDominators(index: Int): Int = {
       if (index != UNDEFINED) {
         dominators(index)


### PR DESCRIPTION
the warning comes up because this looks like scaladoc, but since it's on a method inside a method, it'll never end up in scaladoc

not really critical, but to avoid further confusion as in
https://github.com/joernio/joern/pull/1925#discussion_r1011382480