### PR TITLE
Publish test artifacts for all projects.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,3 +90,5 @@ publish / skip := true // don't publish the root project
 lazy val root = project
   .in(file("."))
   .aggregate(aggregatedProjects: _*)
+
+ThisBuild / Test / packageBin / publishArtifact := true

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -31,8 +31,6 @@ libraryDependencies ++= Seq(
   "org.scalatest"        %% "scalatest"         % Versions.scalatest % Test
 )
 
-Test / packageBin / publishArtifact := true
-
 scalacOptions ++= Seq(
   "-deprecation", // Emit warning and location for usages of deprecated APIs.
   "-encoding",

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -13,8 +13,6 @@ libraryDependencies ++= Seq(
   "org.scalatest"           %% "scalatest"                  % Versions.scalatest % Test
 )
 
-Test / packageBin / publishArtifact := true
-
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)
 
 scalacOptions ++= Seq() ++ (

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -14,8 +14,6 @@ libraryDependencies ++= Seq(
   "org.scalatest"             %% "scalatest"         % Versions.scalatest % Test
 )
 
-Test / packageBin / publishArtifact := true
-
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)
 
 scalacOptions ++= Seq() ++ (

--- a/joern-cli/frontends/x2cpg/build.sbt
+++ b/joern-cli/frontends/x2cpg/build.sbt
@@ -11,8 +11,6 @@ libraryDependencies ++= Seq(
   "org.scalatest"           %% "scalatest"          % Versions.scalatest     % Test
 )
 
-Test / packageBin / publishArtifact := true
-
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)
 
 scalacOptions ++= Seq() ++ (

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -23,5 +23,3 @@ scalacOptions ++= Seq() ++ (
 )
 
 enablePlugins(JavaAppPackaging)
-
-Test / packageBin / publishArtifact := true

--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -11,4 +11,3 @@ libraryDependencies ++= Seq(
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)
 
 compile / javacOptions ++= Seq("-g") //debug symbols
-Test / packageBin / publishArtifact := true


### PR DESCRIPTION
Some of the code we have under tests is or will be reused in other
projects. Mainly our test fixtures will be reused but creating
individual projects which just test utilities for each already existing
project seem overkill.