### PR TITLE
Fix ast of JS arrow functions

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -7,7 +7,7 @@ import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.Stack._
 import io.shiftleft.codepropertygraph.generated.nodes.{Identifier => _, _}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, ModifierTypes}
-import ujson.{Arr, Value}
+import ujson.Value
 
 import scala.collection.mutable
 
@@ -339,9 +339,9 @@ trait AstForFunctionsCreator { this: AstCreator =>
 
     methodAstParentStack.push(methodNode)
 
-    val blockJson                 = func.json("body")
-    val blockNodeInfo             = createBabelNodeInfo(blockJson)
-    val blockNode                 = createBlockNode(blockNodeInfo)
+    val bodyJson                  = func.json("body")
+    val bodyNodeInfo              = createBabelNodeInfo(bodyJson)
+    val blockNode                 = createBlockNode(bodyNodeInfo)
     val blockAst                  = Ast(blockNode)
     val additionalBlockStatements = mutable.ArrayBuffer.empty[Ast]
 
@@ -360,8 +360,16 @@ trait AstForFunctionsCreator { this: AstCreator =>
     val paramNodes = handleParameters(func.json("params").arr.toSeq, additionalBlockStatements)
 
     val bodyStmtAsts = func.node match {
-      case ArrowFunctionExpression => createBlockStatementAsts(Arr(blockJson))
-      case _                       => createBlockStatementAsts(blockJson("body"))
+      case ArrowFunctionExpression =>
+        bodyNodeInfo.node match {
+          case BlockStatement =>
+            // when body contains more than one statement, use bodyJson("body")) to avoid double Block node
+            createBlockStatementAsts(bodyJson("body"))
+          case _ =>
+            // when body is just one expression like const foo = () => 42, generate a Return node
+            createReturnAst(createReturnNode(bodyNodeInfo), List(astForNode(bodyJson))) :: Nil
+        }
+      case _ => createBlockStatementAsts(bodyJson("body"))
     }
     setIndices(methodBlockContent ++ additionalBlockStatements.toList ++ bodyStmtAsts)
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1,15 +1,24 @@
 package io.joern.jssrc2cpg.passes.ast
 
-import io.joern.jssrc2cpg.passes.AbstractPassTest
+import io.joern.jssrc2cpg.passes.{AbstractPassTest, Defines, EcmaBuiltins}
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import io.joern.jssrc2cpg.passes.Defines
-import io.joern.jssrc2cpg.passes.EcmaBuiltins
 
 class SimpleAstCreationPassTest extends AbstractPassTest {
 
   "AST generation for simple fragments" should {
+
+    "have return node for arrow functions" in AstFixture("const foo = () => 42;") { cpg =>
+      // Return node is necessary data flow
+      val methodBlock = cpg.method("anonymous").astChildren.isBlock
+      val literal     = methodBlock.astChildren.isReturn.astChildren.isLiteral.head
+      literal.code shouldBe "42"
+    }
+
+    "have only 1 Block Node for arrow functions" in AstFixture("const foo = () => {return 42;}") { cpg =>
+      cpg.method("anonymous").ast.isBlock.size shouldBe 1
+    }
 
     "have correct structure for FILENAME property" in AstFixture("let x = 1;") { cpg =>
       cpg.namespaceBlock.filenameExact("code.js").size shouldBe 1


### PR DESCRIPTION
For `const foo = () => 42`, there should be a ```Return``` node for the data flow algrithm.
<img width="820" alt="image" src="https://user-images.githubusercontent.com/16919236/199506042-8d0049fa-ec35-4f03-a9c1-fd7789aa1434.png">
For `const foo = () => {return 42;}`, there should be only one ```Block``` node.
<img width="824" alt="image" src="https://user-images.githubusercontent.com/16919236/199506069-720f0ea7-56df-42fb-85f3-b27da5f118e7.png">

