### PR TITLE
querydb/Test: change test archetype in preparation for scala3

### DIFF
--- a/querydb/src/test/scala/io/joern/scanners/android/AndroidMisconfigurationsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/android/AndroidMisconfigurationsTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.android
 
 import io.joern.suites.AndroidQueryTestSuite
 
-class AndroidMisconfigurationsTests extends AndroidQueryTestSuite {
-
-  override def queryBundle = AndroidMisconfigurations
+class AndroidMisconfigurationsTests extends AndroidQueryTestSuite(AndroidMisconfigurations) {
 
   "the `manifestXmlBackupEnabled` query" when {
 

--- a/querydb/src/test/scala/io/joern/scanners/android/AndroidUnprotectedAppPartsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/android/AndroidUnprotectedAppPartsTests.scala
@@ -6,8 +6,7 @@ import io.joern.suites.KotlinQueryTestSuite
 import overflowdb.traversal.iterableToTraversal
 import io.shiftleft.semanticcpg.language._
 
-class AndroidUnprotectedAppPartsTests extends KotlinQueryTestSuite {
-  override def queryBundle = AndroidUnprotectedAppParts
+class AndroidUnprotectedAppPartsTests extends KotlinQueryTestSuite(AndroidUnprotectedAppParts) {
 
   "should match all positive examples" in {
     val query = queryBundle.intentRedirection()

--- a/querydb/src/test/scala/io/joern/scanners/android/RootDetectionTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/android/RootDetectionTests.scala
@@ -6,10 +6,8 @@ import io.joern.suites.{KotlinQueryTestSuite}
 import io.shiftleft.semanticcpg.language._
 import io.joern.dataflowengineoss.language._
 
-class RootDetectionTests extends KotlinQueryTestSuite {
+class RootDetectionTests extends KotlinQueryTestSuite(RootDetection) {
   implicit val engineContext: EngineContext = EngineContext(Semantics.empty)
-
-  override def queryBundle = RootDetection
 
   "the `rootDetectionViaFileChecks` query" when {
     "should match on all multi-file positive examples" in {

--- a/querydb/src/test/scala/io/joern/scanners/android/UnsafeReflectionTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/android/UnsafeReflectionTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.android
 
 import io.joern.suites.AndroidQueryTestSuite
 
-class UnsafeReflectionTests extends AndroidQueryTestSuite {
-
-  override def queryBundle = UnsafeReflection
+class UnsafeReflectionTests extends AndroidQueryTestSuite(UnsafeReflection) {
 
   private def makeBuildGradle(targetSdk: Int): String = {
     s"""

--- a/querydb/src/test/scala/io/joern/scanners/c/CopyLoopTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/CopyLoopTests.scala
@@ -5,9 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.joern.console.scan._
 
-class CopyLoopTests extends CQueryTestSuite {
-
-  override def queryBundle = CopyLoops
+class CopyLoopTests extends CQueryTestSuite(CopyLoops) {
 
   "find indexed buffer assignment targets in loops where index is incremented" in {
     queryBundle.isCopyLoop()(cpg).map(_.evidence) match {

--- a/querydb/src/test/scala/io/joern/scanners/c/CredentialDropTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/CredentialDropTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.c
 
 import io.joern.suites.CQueryTestSuite
 
-class CredentialDropTests extends CQueryTestSuite {
-
-  override def queryBundle = CredentialDrop
+class CredentialDropTests extends CQueryTestSuite(CredentialDrop) {
 
   "find cases where user changes are not preceded by calls to set*gid and setgroups" in {
     val query   = queryBundle.userCredDrop()

--- a/querydb/src/test/scala/io/joern/scanners/c/DangerousFunctionsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/DangerousFunctionsTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.c
 
 import io.joern.suites.CQueryTestSuite
 
-class DangerousFunctionsTests extends CQueryTestSuite {
-
-  override def queryBundle = DangerousFunctions
+class DangerousFunctionsTests extends CQueryTestSuite(DangerousFunctions) {
 
   "find insecure gets() function usage" in {
     val query   = queryBundle.getsUsed()

--- a/querydb/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/FileOpRaceTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.c
 
 import io.joern.suites.CQueryTestSuite
 
-class FileOpRaceTests extends CQueryTestSuite {
-
-  override def queryBundle = FileOpRace
+class FileOpRaceTests extends CQueryTestSuite(FileOpRace) {
 
   "should flag function `insecure_race` only" in {
     val query   = queryBundle.fileOperationRace()

--- a/querydb/src/test/scala/io/joern/scanners/c/HeapBasedOverflowTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/HeapBasedOverflowTests.scala
@@ -4,9 +4,7 @@ import io.joern.suites.CQueryTestSuite
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.console.scan._
 
-class HeapBasedOverflowTests extends CQueryTestSuite {
-
-  override def queryBundle = HeapBasedOverflow
+class HeapBasedOverflowTests extends CQueryTestSuite(HeapBasedOverflow) {
 
   "find calls to malloc/memcpy system with different expressions in arguments" in {
     val x = queryBundle.mallocMemcpyIntOverflow()

--- a/querydb/src/test/scala/io/joern/scanners/c/IntegerTruncationsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/IntegerTruncationsTests.scala
@@ -5,9 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.joern.console.scan._
 
-class IntegerTruncationsTests extends CQueryTestSuite {
-
-  override def queryBundle = IntegerTruncations
+class IntegerTruncationsTests extends CQueryTestSuite(IntegerTruncations) {
 
   "find truncation in assignment of `strlen` to `int`" in {
     queryBundle.strlenAssignmentTruncations()(cpg) match {

--- a/querydb/src/test/scala/io/joern/scanners/c/MetricsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/MetricsTests.scala
@@ -4,9 +4,7 @@ import io.joern.suites.CQueryTestSuite
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.console.scan._
 
-class MetricsTests extends CQueryTestSuite {
-
-  override def queryBundle = Metrics
+class MetricsTests extends CQueryTestSuite(Metrics) {
 
   "find functions with too many parameters" in {
     queryBundle.tooManyParameters()(cpg).map(_.evidence) match {

--- a/querydb/src/test/scala/io/joern/scanners/c/NullTerminationTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/NullTerminationTests.scala
@@ -5,9 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.joern.console.scan._
 
-class NullTerminationTests extends CQueryTestSuite {
-
-  override def queryBundle = NullTermination
+class NullTerminationTests extends CQueryTestSuite(NullTermination) {
 
   "should find the bad code and not report the good" in {
     val query = queryBundle.strncpyNoNullTerm()

--- a/querydb/src/test/scala/io/joern/scanners/c/RetvalChecksTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/RetvalChecksTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.c
 
 import io.joern.suites.CQueryTestSuite
 
-class RetvalChecksTests extends CQueryTestSuite {
-
-  override def queryBundle = RetvalChecks
+class RetvalChecksTests extends CQueryTestSuite(RetvalChecks) {
 
   "should find unchecked read and not flag others" in {
     val query   = queryBundle.uncheckedReadRecvMalloc()

--- a/querydb/src/test/scala/io/joern/scanners/c/SignedLeftShiftTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/SignedLeftShiftTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.c
 
 import io.joern.suites.CQueryTestSuite
 
-class SignedLeftShiftTests extends CQueryTestSuite {
-
-  override def queryBundle = SignedLeftShift
+class SignedLeftShiftTests extends CQueryTestSuite(SignedLeftShift) {
 
   "find signed left shift" in {
     val query   = queryBundle.signedLeftShift()

--- a/querydb/src/test/scala/io/joern/scanners/c/SocketApiTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/SocketApiTests.scala
@@ -3,9 +3,7 @@ package io.joern.scanners.c
 import io.joern.suites.CQueryTestSuite
 import io.joern.x2cpg.testfixtures.TestCpg
 
-class SocketApiTests extends CQueryTestSuite {
-
-  override def queryBundle = SocketApi
+class SocketApiTests extends CQueryTestSuite(SocketApi) {
 
   override val cpg: TestCpg = code("""
       |void return_not_checked(int sockfd, void *buf, size_t len, int flags) {

--- a/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreePostUsage.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreePostUsage.scala
@@ -6,9 +6,7 @@ import io.joern.console.scan._
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.iterableToTraversal
 
-class UseAfterFreePostUsage extends CQueryTestSuite {
-
-  override def queryBundle = UseAfterFree
+class UseAfterFreePostUsage extends CQueryTestSuite(UseAfterFree) {
 
   "should flag functions `bad` and `false_positive` only" in {
     val x = queryBundle.freePostDominatesUsage()

--- a/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreeReturnTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreeReturnTests.scala
@@ -6,9 +6,7 @@ import io.joern.console.scan._
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.iterableToTraversal
 
-class UseAfterFreeReturnTests extends CQueryTestSuite {
-
-  override def queryBundle = UseAfterFree
+class UseAfterFreeReturnTests extends CQueryTestSuite(UseAfterFree) {
 
   "should flag `bad` function only" in {
     val x = queryBundle.freeReturnedValue()

--- a/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreeTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreeTests.scala
@@ -3,9 +3,7 @@ package io.joern.scanners.c
 import io.joern.suites.CQueryTestSuite
 import io.joern.x2cpg.testfixtures.TestCpg
 
-class UseAfterFreeTests extends CQueryTestSuite {
-
-  override def queryBundle = UseAfterFree
+class UseAfterFreeTests extends CQueryTestSuite(UseAfterFree) {
 
   override val cpg: TestCpg = code("""
     |void good(a_struct_type *a_struct) {

--- a/querydb/src/test/scala/io/joern/scanners/ghidra/DangerousFunctionsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/ghidra/DangerousFunctionsTests.scala
@@ -2,9 +2,8 @@ package io.joern.scanners.ghidra
 
 import io.joern.suites.GhidraQueryTestSuite
 
-class DangerousFunctionsTests extends GhidraQueryTestSuite {
-  override def queryBundle = DangerousFunctions
-
+class DangerousFunctionsTests extends GhidraQueryTestSuite(DangerousFunctions) {
+  
   "find insecure strcpy" in {
     buildCpgForBin("dangerous_functions.o")
 

--- a/querydb/src/test/scala/io/joern/scanners/ghidra/DangerousFunctionsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/ghidra/DangerousFunctionsTests.scala
@@ -3,7 +3,7 @@ package io.joern.scanners.ghidra
 import io.joern.suites.GhidraQueryTestSuite
 
 class DangerousFunctionsTests extends GhidraQueryTestSuite(DangerousFunctions) {
-  
+
   "find insecure strcpy" in {
     buildCpgForBin("dangerous_functions.o")
 

--- a/querydb/src/test/scala/io/joern/scanners/ghidra/UserInputIntoDangerousFunctionsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/ghidra/UserInputIntoDangerousFunctionsTests.scala
@@ -2,8 +2,7 @@ package io.joern.scanners.ghidra
 
 import io.joern.suites.GhidraQueryTestSuite
 
-class UserInputIntoDangerousFunctionsTests extends GhidraQueryTestSuite {
-  override def queryBundle = UserInputIntoDangerousFunctions
+class UserInputIntoDangerousFunctionsTests extends GhidraQueryTestSuite(UserInputIntoDangerousFunctions) {
 
   "getenvToStrcpy query" when {
     def query = queryBundle.getenvToStrcpy()

--- a/querydb/src/test/scala/io/joern/scanners/java/CryptographyMisuseTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/java/CryptographyMisuseTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.java
 
 import io.joern.suites.JavaQueryTestSuite
 
-class CryptographyMisuseTests extends JavaQueryTestSuite {
-
-  override def queryBundle = CryptographyMisuse
+class CryptographyMisuseTests extends JavaQueryTestSuite(CryptographyMisuse) {
 
   "the `unsafeHashAlgo` query" when {
     "find the use of the MD5 hash algorithm" in {

--- a/querydb/src/test/scala/io/joern/scanners/kotlin/NetworkCommunicationTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/kotlin/NetworkCommunicationTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.kotlin
 
 import io.joern.suites.KotlinQueryTestSuite
 
-class NetworkCommunicationTests extends KotlinQueryTestSuite {
-
-  override def queryBundle = NetworkCommunication
+class NetworkCommunicationTests extends KotlinQueryTestSuite(NetworkCommunication) {
 
   "should match on all multi-file positive examples" in {
     val q = queryBundle.nopTrustManagerUsed()

--- a/querydb/src/test/scala/io/joern/scanners/kotlin/NetworkProtocolsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/kotlin/NetworkProtocolsTests.scala
@@ -5,9 +5,7 @@ import io.joern.suites.KotlinQueryTestSuite
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 import overflowdb.traversal.iterableToTraversal
 
-class NetworkProtocolsTests extends KotlinQueryTestSuite {
-
-  override def queryBundle = NetworkProtocols
+class NetworkProtocolsTests extends KotlinQueryTestSuite(NetworkProtocols) {
 
   "should find calls relevant to insecure network protocol usage" in {
     val query = queryBundle.usageOfInsecureProtocol()

--- a/querydb/src/test/scala/io/joern/scanners/kotlin/PathTraversalsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/kotlin/PathTraversalsTests.scala
@@ -2,9 +2,7 @@ package io.joern.scanners.kotlin
 
 import io.joern.suites.KotlinQueryTestSuite
 
-class PathTraversalsTests extends KotlinQueryTestSuite {
-
-  override def queryBundle = PathTraversals
+class PathTraversalsTests extends KotlinQueryTestSuite(PathTraversals) {
 
   "should match on all multi-file positive examples" in {
     val q = queryBundle.unzipDirectoryTraversal()

--- a/querydb/src/test/scala/io/joern/suites/AndroidQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/AndroidQueryTestSuite.scala
@@ -8,7 +8,8 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.ConfigFile
 import io.shiftleft.semanticcpg.language._
 
-class AndroidQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends KotlinCode2CpgFixture(withOssDataflow = true, withDefaultJars = true) {
+class AndroidQueryTestSuite[QB <: QueryBundle](val queryBundle: QB)
+    extends KotlinCode2CpgFixture(withOssDataflow = true, withDefaultJars = true) {
 
   val argumentProvider = new QDBArgumentProvider(3)
 

--- a/querydb/src/test/scala/io/joern/suites/AndroidQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/AndroidQueryTestSuite.scala
@@ -8,11 +8,9 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.ConfigFile
 import io.shiftleft.semanticcpg.language._
 
-class AndroidQueryTestSuite extends KotlinCode2CpgFixture(withOssDataflow = true, withDefaultJars = true) {
+class AndroidQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends KotlinCode2CpgFixture(withOssDataflow = true, withDefaultJars = true) {
 
   val argumentProvider = new QDBArgumentProvider(3)
-
-  def queryBundle: QueryBundle = QueryUtil.EmptyBundle
 
   def allQueries: List[Query] = QueryUtil.allQueries(queryBundle, argumentProvider)
 

--- a/querydb/src/test/scala/io/joern/suites/CQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/CQueryTestSuite.scala
@@ -9,11 +9,9 @@ import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.x2cpg.testfixtures.TestCpg
 import io.shiftleft.semanticcpg.language._
 
-class CQueryTestSuite extends DataFlowCodeToCpgSuite {
+class CQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends DataFlowCodeToCpgSuite {
 
   private val argumentProvider = new QDBArgumentProvider(3)
-
-  def queryBundle: QueryBundle = QueryUtil.EmptyBundle
 
   def allQueries: List[Query] = QueryUtil.allQueries(queryBundle, argumentProvider)
 

--- a/querydb/src/test/scala/io/joern/suites/GhidraQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/GhidraQueryTestSuite.scala
@@ -10,11 +10,9 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.utils.ProjectRoot
 import overflowdb.traversal.iterableToTraversal
 
-class GhidraQueryTestSuite extends DataFlowBinToCpgSuite {
+class GhidraQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends DataFlowBinToCpgSuite {
   val argumentProvider              = new QDBArgumentProvider(3)
   override val binDirectory: String = ProjectRoot.relativise("querydb/src/test/resources/testbinaries")
-
-  protected def queryBundle: QueryBundle = QueryUtil.EmptyBundle
 
   protected def allQueries: List[Query] = QueryUtil.allQueries(queryBundle, argumentProvider)
 

--- a/querydb/src/test/scala/io/joern/suites/JavaQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/JavaQueryTestSuite.scala
@@ -8,7 +8,8 @@ import io.joern.x2cpg.testfixtures.TestCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Method, StoredNode}
 
-class JavaQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
+class JavaQueryTestSuite[QB <: QueryBundle](val queryBundle: QB)
+    extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
   val argumentProvider = new QDBArgumentProvider(3)
 
   override def beforeAll(): Unit = {

--- a/querydb/src/test/scala/io/joern/suites/JavaQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/JavaQueryTestSuite.scala
@@ -8,14 +8,12 @@ import io.joern.x2cpg.testfixtures.TestCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Method, StoredNode}
 
-class JavaQueryTestSuite extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
+class JavaQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
   val argumentProvider = new QDBArgumentProvider(3)
 
   override def beforeAll(): Unit = {
     super.beforeAll()
   }
-
-  def queryBundle: QueryBundle = QueryUtil.EmptyBundle
 
   def allQueries: List[Query] = QueryUtil.allQueries(queryBundle, argumentProvider)
 

--- a/querydb/src/test/scala/io/joern/suites/KotlinQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/KotlinQueryTestSuite.scala
@@ -9,14 +9,12 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.joern.console.scan._
 import io.shiftleft.utils.ProjectRoot
 
-class KotlinQueryTestSuite extends KotlinCode2CpgFixture(withOssDataflow = true) {
+class KotlinQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends KotlinCode2CpgFixture(withOssDataflow = true) {
   val argumentProvider = new QDBArgumentProvider(3)
 
   override def beforeAll(): Unit = {
     super.beforeAll()
   }
-
-  def queryBundle: QueryBundle = QueryUtil.EmptyBundle
 
   def allQueries: List[Query] = QueryUtil.allQueries(queryBundle, argumentProvider)
 

--- a/querydb/src/test/scala/io/joern/suites/KotlinQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/KotlinQueryTestSuite.scala
@@ -9,7 +9,8 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.joern.console.scan._
 import io.shiftleft.utils.ProjectRoot
 
-class KotlinQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends KotlinCode2CpgFixture(withOssDataflow = true) {
+class KotlinQueryTestSuite[QB <: QueryBundle](val queryBundle: QB)
+    extends KotlinCode2CpgFixture(withOssDataflow = true) {
   val argumentProvider = new QDBArgumentProvider(3)
 
   override def beforeAll(): Unit = {


### PR DESCRIPTION
context: Scala3 is stricter on deriving the type of an inherited method, specifically:
```
trait A
object A1 extends A {
  def onlyInA1 = 42
}

trait B {
  def a: A
}

class B1 extends B {
  override def a = A1

  def fun = a.onlyInA1
}
```
fails with
```
[error] 31 |    def fun = a.onlyInA1
[error]    |              ^^^^^^^^^^
[error]    |       value onlyInA1 is not a member of io.joern.scanners.android.Foo.A
```

One fix is to annotate `def a` with the specific type in each subclass,
but in our use case I found it more natural to pass the QueryBundle to
the parent and use a type parameter.