### PR TITLE
Add PHP anonymous functions

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
@@ -16,6 +16,7 @@ class Scope extends X2CpgScope[String, NewNode, NewNode] {
   private var localStack: List[mutable.ArrayBuffer[NewLocal]]     = Nil
   private var constAndStaticInits: List[mutable.ArrayBuffer[Ast]] = Nil
   private var fieldInits: List[mutable.ArrayBuffer[Ast]]          = Nil
+  private val anonymousMethods                                    = mutable.ArrayBuffer[Ast]()
 
   override def pushNewScope(scopeNode: NewNode): Unit = {
     scopeNode match {
@@ -63,6 +64,14 @@ class Scope extends X2CpgScope[String, NewNode, NewNode] {
       case _ => // Nothing to do here
     }
     super.addToScope(identifier, variable)
+  }
+
+  def addAnonymousMethod(methodAst: Ast): Unit = anonymousMethods.addOne(methodAst)
+
+  def getAndClearAnonymousMethods: List[Ast] = {
+    val methods = anonymousMethods.toList
+    anonymousMethods.clear()
+    methods
   }
 
   def getEnclosingNamespaceName: Option[String] =

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/CfgCreationPassTests.scala
@@ -36,7 +36,7 @@ class CfgCreationPassTests extends CfgTestFixture(() => new PhpCfgTestCpg) {
           |  }
           |}
           |""".stripMargin)
-      succOf("break(2)") shouldBe expected(("ANY", AlwaysEdge))
+      succOf("break(2)") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for continue with level 1" in {
@@ -82,7 +82,7 @@ class CfgCreationPassTests extends CfgTestFixture(() => new PhpCfgTestCpg) {
           |  } while ($j < 1);
           |} while ($i < 1);
           |""".stripMargin)
-      succOf("break(2)") shouldBe expected(("ANY", AlwaysEdge))
+      succOf("break(2)") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for continue with level 1" in {
@@ -128,7 +128,7 @@ class CfgCreationPassTests extends CfgTestFixture(() => new PhpCfgTestCpg) {
           |  }
           |}
           |""".stripMargin)
-      succOf("break(2)") shouldBe expected(("ANY", AlwaysEdge))
+      succOf("break(2)") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for continue with level 1" in {
@@ -180,7 +180,7 @@ class CfgCreationPassTests extends CfgTestFixture(() => new PhpCfgTestCpg) {
           |    $k;
           |}
           |""".stripMargin)
-      succOf("break(2)") shouldBe expected(("ANY", AlwaysEdge))
+      succOf("break(2)") shouldBe expected(("RET", AlwaysEdge))
     }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
@@ -1,0 +1,54 @@
+package io.joern.php2cpg.querying
+
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, MethodRef}
+import io.shiftleft.semanticcpg.language._
+
+class ClosureTests extends PhpCode2CpgFixture {
+
+  "long-form closures without uses " should {
+    val cpg = code("""<?php
+     |$x = function($value) {
+     |  echo $value;
+     |};
+     |""".stripMargin)
+
+    "have the correct method AST" in {
+      val closureMethod = inside(cpg.method.name(".*closure.*").l) { case List(closureMethod) =>
+        closureMethod
+      }
+
+      closureMethod.name shouldBe "__closure0"
+      closureMethod.fullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+      closureMethod.code shouldBe "function __closure0($value)"
+      closureMethod.parameter.size shouldBe 1
+
+      inside(closureMethod.parameter.l) { case List(valueParam) =>
+        valueParam.name shouldBe "value"
+      }
+
+      inside(closureMethod.body.astChildren.l) { case List(echoCall: Call) =>
+        echoCall.code shouldBe "echo $value"
+      }
+    }
+
+    "have a correct MethodRef added to the AST where the closure is defined" in {
+      inside(cpg.assignment.argument.l) { case List(_: Identifier, methodRef: MethodRef) =>
+        methodRef.methodFullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+        methodRef.code shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+        methodRef.lineNumber shouldBe Some(2)
+      }
+    }
+  }
+
+  "long-form closures with uses " should {
+    val cpg = code("""<?php
+                    |$captured = "I'm CAPTURED"
+                    |$x = function($value) {
+                    |  echo $value;
+                    |};
+                    |""".stripMargin)
+
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
@@ -2,12 +2,12 @@ package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, MethodRef}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, ClosureBinding, Identifier, Local, MethodRef, Return}
 import io.shiftleft.semanticcpg.language._
 
 class ClosureTests extends PhpCode2CpgFixture {
 
-  "long-form closures without uses " should {
+  "long-form closures without uses " ignore {
     val cpg = code("""<?php
      |$x = function($value) {
      |  echo $value;
@@ -44,11 +44,81 @@ class ClosureTests extends PhpCode2CpgFixture {
 
   "long-form closures with uses " should {
     val cpg = code("""<?php
-                    |$captured = "I'm CAPTURED"
-                    |$x = function($value) {
+                    |$use1 = "FOO";
+                    |$x = function($value) use($use1, &$use2) {
                     |  echo $value;
                     |};
                     |""".stripMargin)
 
+    "have the correct method AST" in {
+      val closureMethod = inside(cpg.method.name(".*closure.*").l) { case List(closureMethod) =>
+        closureMethod
+      }
+
+      closureMethod.name shouldBe "__closure0"
+      closureMethod.fullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+      closureMethod.code shouldBe "function __closure0($value) use($use1, &$use2)"
+      closureMethod.parameter.size shouldBe 1
+
+      inside(closureMethod.parameter.l) { case List(valueParam) =>
+        valueParam.name shouldBe "value"
+      }
+
+      inside(closureMethod.body.astChildren.l) { case List(use1: Local, use2: Local, echoCall: Call) =>
+        use1.name shouldBe "use1"
+        use1.code shouldBe "$use1"
+        use1.closureBindingId.isEmpty shouldBe false
+        inside(cpg.all.collectAll[ClosureBinding].filter(_.closureBindingId == use1.closureBindingId).l) {
+          case List(closureBinding) =>
+            closureBinding.closureOriginalName shouldBe Some("use1")
+        }
+
+        use2.name shouldBe "use2"
+        use2.code shouldBe "&$use2"
+
+        echoCall.code shouldBe "echo $value"
+      }
+    }
+
+    "have a correct MethodRef added to the AST where the closure is defined" in {
+      inside(cpg.assignment.code(".*closure.*").argument.l) { case List(_: Identifier, methodRef: MethodRef) =>
+        methodRef.methodFullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+        methodRef.code shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+        methodRef.lineNumber shouldBe Some(3)
+      }
+    }
+  }
+
+  "arrow functions should be represented as closures with return statements" should {
+    val cpg = code("""<?php
+     |$x = fn ($value) => $value + 1;
+     |""".stripMargin)
+
+    "have the correct method AST" in {
+      val closureMethod = inside(cpg.method.name(".*closure.*").l) { case List(closureMethod) =>
+        closureMethod
+      }
+
+      closureMethod.name shouldBe "__closure0"
+      closureMethod.fullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+      closureMethod.code shouldBe "function __closure0($value)"
+      closureMethod.parameter.size shouldBe 1
+
+      inside(closureMethod.parameter.l) { case List(valueParam) =>
+        valueParam.name shouldBe "value"
+      }
+
+      inside(closureMethod.body.astChildren.l) { case List(methodReturn: Return) =>
+        methodReturn.code shouldBe "return $value + 1"
+      }
+    }
+
+    "have a correct MethodRef added to the AST where the closure is defined" in {
+      inside(cpg.assignment.argument.l) { case List(_: Identifier, methodRef: MethodRef) =>
+        methodRef.methodFullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+        methodRef.code shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+        methodRef.lineNumber shouldBe Some(2)
+      }
+    }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -1,11 +1,30 @@
 package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, Local}
 import io.shiftleft.semanticcpg.language._
 
 class MethodTests extends PhpCode2CpgFixture {
+
+  "method nodes should be created with the correct fields" in {
+    val cpg = code("""<?php
+     |function foo(): int {}
+     |""".stripMargin)
+
+    inside(cpg.method.name("foo").l) { case List(fooMethod) =>
+      fooMethod.fullName shouldBe s"foo:${Defines.UnresolvedSignature}(0)"
+      fooMethod.lineNumber shouldBe Some(2)
+      fooMethod.code shouldBe "function foo()"
+
+      inside(fooMethod.methodReturn.l) { case List(methodReturn) =>
+        methodReturn.typeFullName shouldBe "int"
+        methodReturn.code shouldBe "RET"
+        methodReturn.lineNumber shouldBe Some(2)
+      }
+    }
+  }
 
   "static variables without default values should be represented as the correct local nodes" in {
     val cpg = code("""<?php


### PR DESCRIPTION
This supports both the long-form syntax as well as arrow functions. Both are represented as a regular method belonging to the typeDecl they were defined in.