### PR TITLE
pysrc2cpg: Refactor Call Linkers

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -1,7 +1,7 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
-import io.joern.x2cpg.passes.frontend.{PythonDynamicCallLinker, PythonStaticCallLinker}
+import io.joern.x2cpg.passes.frontend.{PythonNaiveCallLinker, PythonModuleDefinedCallLinker}
 import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.Path
@@ -24,8 +24,8 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
     command.toFile.exists
 
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
-    new PythonStaticCallLinker(cpg).createAndApply()
-    new PythonDynamicCallLinker(cpg).createAndApply()
+    new PythonModuleDefinedCallLinker(cpg).createAndApply()
+    new PythonNaiveCallLinker(cpg).createAndApply()
     cpg
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -5,7 +5,7 @@ import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOpti
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.pysrc2cpg.Py2CpgOnFileSystem.buildCpg
 import io.joern.x2cpg.X2Cpg
-import io.joern.x2cpg.passes.frontend.{PythonDynamicCallLinker, PythonStaticCallLinker}
+import io.joern.x2cpg.passes.frontend.{PythonNaiveCallLinker, PythonModuleDefinedCallLinker}
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
@@ -33,8 +33,8 @@ class PySrcTestCpg extends TestCpg with PythonFrontend {
 
   override def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
-    new PythonStaticCallLinker(this).createAndApply()
-    new PythonDynamicCallLinker(this).createAndApply()
+    new PythonModuleDefinedCallLinker(this).createAndApply()
+    new PythonNaiveCallLinker(this).createAndApply()
 
     if (_withOssDataflow) {
       val context = new LayerCreatorContext(this)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
@@ -165,7 +165,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       val callNode = cpg.call.codeExact("func(a, b)").head
       callNode.name shouldBe "func"
       callNode.signature shouldBe ""
-      callNode.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       callNode.lineNumber shouldBe Some(5)
       callNode.methodFullName shouldBe "test.py:<module>.func"
     }
@@ -205,7 +205,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       val callNode = cpg.call.codeExact("foo_func(a, b)").head
       callNode.name shouldBe "foo_func"
       callNode.signature shouldBe ""
-      callNode.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       callNode.lineNumber shouldBe Some(6)
       callNode.methodFullName shouldBe "foo.py:<module>.foo_func"
     }
@@ -214,7 +214,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       val callNode = cpg.call.codeExact("bar_func(a, b)").head
       callNode.name shouldBe "bar_func"
       callNode.signature shouldBe ""
-      callNode.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       callNode.lineNumber shouldBe Some(7)
       callNode.methodFullName shouldBe Seq("foo", "bar", "__init__.py:<module>.bar_func").mkString(File.separator)
     }
@@ -223,7 +223,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       val callNode = cpg.call.codeExact("baz(a, b)").head
       callNode.name shouldBe "baz"
       callNode.signature shouldBe ""
-      callNode.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       callNode.lineNumber shouldBe Some(8)
       callNode.methodFullName shouldBe "foo.py:<module>.faz"
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonNaiveCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonNaiveCallLinker.scala
@@ -3,18 +3,18 @@ package io.joern.x2cpg.passes.frontend
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.passes.SimpleCpgPass
-import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.jIteratortoTraversal
 
-/** Link python calls to methods only by their name(not full name)
+/** Link remaining unlinked Python calls to methods only by their name (not full name)
   * @param cpg
   *   the target code property graph.
   */
-class PythonDynamicCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class PythonNaiveCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     val methodNameToNode = cpg.method.toList.groupBy(_.name)
-    def calls            = cpg.call.where(_.dispatchType(DispatchTypes.DYNAMIC_DISPATCH.name()))
+    def calls            = cpg.call.filter(_.outE(EdgeTypes.CALL).isEmpty)
     for {
       call    <- calls
       methods <- methodNameToNode.get(call.name)


### PR DESCRIPTION
- No longer change calls to STATIC_DISPATCH
- Renamed call linkers to `PythonModuleDefinedCallLinker` and `PythonNaiveCallLinker` to reflect their linking strategies