### PR TITLE
jssrc2cpg: Link anonymous function exports

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CallLinkerPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CallLinkerPassTest.scala
@@ -24,6 +24,7 @@ class CallLinkerPassTest extends DataFlowCodeToCpgSuite {
 
       inside(cpg.method("sayhi").callIn(NoResolve).l) { case List(call) =>
         call.code shouldBe "sayhi()"
+        call.methodFullName should endWith(".js::program:sayhi")
       }
     }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CallLinkerPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CallLinkerPassTest.scala
@@ -28,6 +28,57 @@ class CallLinkerPassTest extends DataFlowCodeToCpgSuite {
       }
     }
 
+    "link exported anonymous functions across file boundaries correctly" in {
+      val cpg: Cpg = code(
+        """
+          |const bar = require('./bar.js');
+          |const baz = require('./baz.js');
+          |
+          |bar.sayhi();
+          |baz.sayhowdy();
+          |""".stripMargin,
+        "foo.js"
+      ).moreCode(
+        """
+          |module.exports = {
+          |  sayhi: function() {            // this will be called anonymous
+          |    console.log("Hello World!");
+          |  },
+          |  saybye: function() {           // this will be called anonymous1
+          |    console.log("Good-bye!");
+          |  }
+          |}
+          |""".stripMargin,
+        "bar.js"
+      ).moreCode(
+        """
+          |module.exports = {
+          |  sayhowdy: function() {       // this will be called anonymous
+          |    console.log("Howdy World!");
+          |  }
+          |}
+          |""".stripMargin, "baz.js")
+
+      inside(cpg.method.fullNameExact("bar.js::program:anonymous").l) { case List(m) =>
+        m.name shouldBe "anonymous"
+        m.fullName shouldBe "bar.js::program:anonymous"
+      }
+
+      inside(cpg.method.fullNameExact("bar.js::program:anonymous").callIn(NoResolve).l) { case List(call) =>
+        call.code shouldBe "bar.sayhi()"
+        call.methodFullName shouldBe "bar.js::program:anonymous"
+      }
+
+      inside(cpg.method.fullNameExact("baz.js::program:anonymous").l) { case List(m) =>
+        m.name shouldBe "anonymous"
+        m.fullName shouldBe "baz.js::program:anonymous"
+      }
+
+      inside(cpg.method.fullNameExact("baz.js::program:anonymous").callIn(NoResolve).l) { case List(call) =>
+        call.code shouldBe "baz.sayhowdy()"
+        call.methodFullName shouldBe "baz.js::program:anonymous"
+      }
+    }
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/JavascriptCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/JavascriptCallLinker.scala
@@ -2,7 +2,7 @@ package io.joern.x2cpg.passes.frontend
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.passes.SimpleCpgPass
@@ -78,13 +78,19 @@ class JavascriptCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
       if (call.dispatchType == DispatchTypes.STATIC_DISPATCH) {
         methodsByFullName
           .get(call.methodFullName)
-          .foreach(diffGraph.addEdge(call, _, EdgeTypes.CALL))
+          .foreach { method =>
+            diffGraph.addEdge(call, method, EdgeTypes.CALL)
+            diffGraph.setNodeProperty(call, PropertyNames.METHOD_FULL_NAME, method.fullName)
+          }
       } else {
         getReceiverIdentifierName(call).foreach { name =>
           for (
             file   <- call.file.headOption;
             method <- methodsByNameAndFile.get((file.name, name))
-          ) { diffGraph.addEdge(call, method, EdgeTypes.CALL) }
+          ) {
+            diffGraph.addEdge(call, method, EdgeTypes.CALL)
+            diffGraph.setNodeProperty(call, PropertyNames.METHOD_FULL_NAME, method.fullName)
+          }
         }
       }
     }


### PR DESCRIPTION
There is a disconnect with `module.export` functions where the key is named and there is a lambda on the right (no name present). For example, calls to the following will not be successfully linked:

```javascript
module.exports = {
  sayhi: function() {            // this will be called anonymous
   console.log("Hello World!");
 },
  saybye: function() {           // this will be called anonymous1
   console.log("Good-bye!");
 }
}
```

The above is example can be found in test cases and the following changes are made:
- Set `methodFullName` property on call nodes when they are linked
- Set `typeFullName` of identifier receiving the result of require to the path with `<export>::` prefix
- Using details from the above, will be able to resolve an exported function without an identifier

Resolves #1914 