### PR TITLE
rewrite `extends App` to `def main`

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
@@ -20,23 +20,25 @@ class ParsedArguments(arguments: Seq[String]) extends ScallopConf(arguments) {
   verify()
 }
 
-object Main extends App {
-  val parsedArguments = new ParsedArguments(args.toSeq)
+object Main {
+  def main(args: Array[String]) = {
+    val parsedArguments = new ParsedArguments(args.toSeq)
 
-  val ignoreVenvDir =
-    if (parsedArguments.ignoreVenvDir.toOption.get) {
-      parsedArguments.venvDir.toOption
-    } else {
-      None
-    }
+    val ignoreVenvDir =
+      if (parsedArguments.ignoreVenvDir.toOption.get) {
+        parsedArguments.venvDir.toOption
+      } else {
+        None
+      }
 
-  val py2CpgConfig =
-    Py2CpgOnFileSystemConfig(
-      Paths.get(parsedArguments.output.toOption.get),
-      Paths.get(parsedArguments.input.toOption.get),
-      ignoreVenvDir.map(Paths.get(_))
-    )
+    val py2CpgConfig =
+      Py2CpgOnFileSystemConfig(
+        Paths.get(parsedArguments.output.toOption.get),
+        Paths.get(parsedArguments.input.toOption.get),
+        ignoreVenvDir.map(Paths.get(_))
+      )
 
-  val cpg = Py2CpgOnFileSystem.buildCpg(py2CpgConfig)
-  cpg.close()
+    val cpg = Py2CpgOnFileSystem.buildCpg(py2CpgConfig)
+    cpg.close()
+  }
 }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernFlow.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernFlow.scala
@@ -20,9 +20,44 @@ case class FlowConfig(
   depth: Int = 1
 )
 
-object JoernFlow extends App {
+object JoernFlow {
+  def main(args: Array[String]) = {
+    parseConfig(args).foreach { config =>
+      def debugOut(msg: String): Unit = {
+        if (config.verbose) {
+          print(msg)
+        }
+      }
 
-  private def parseConfig: Option[FlowConfig] = {
+      debugOut("Loading graph... ")
+      val cpg = CpgBasedTool.loadFromOdb(config.cpgFileName)
+      debugOut("[DONE]\n")
+
+      implicit val resolver: ICallResolver = NoResolve
+      val sources                          = params(cpg, config.srcRegex, config.srcParam)
+      val sinks                            = params(cpg, config.dstRegex, config.dstParam)
+
+      debugOut(s"Number of sources: ${sources.size}\n")
+      debugOut(s"Number of sinks: ${sinks.size}\n")
+
+      implicit val semantics: Semantics = DefaultSemantics()
+      val engineConfig                  = EngineConfig(config.depth)
+      debugOut(s"Analysis depth: ${engineConfig.maxCallDepth}\n")
+      implicit val context: EngineContext = EngineContext(semantics, engineConfig)
+
+      debugOut("Determining flows...")
+      sinks.foreach { s =>
+        List(s).to(Traversal).reachableByFlows(sources.to(Traversal)).p.foreach(println)
+      }
+      debugOut("[DONE]")
+
+      debugOut("Closing graph... ")
+      cpg.close()
+      debugOut("[DONE]\n")
+    }
+  }
+
+  private def parseConfig(args: Array[String]): Option[FlowConfig] = {
     new scopt.OptionParser[FlowConfig]("joern-flow") {
       head("Find flows")
       help("help")
@@ -61,40 +96,6 @@ object JoernFlow extends App {
         .action((_, c) => c.copy(verbose = true))
     }
   }.parse(args, FlowConfig())
-
-  parseConfig.foreach { config =>
-    def debugOut(msg: String): Unit = {
-      if (config.verbose) {
-        print(msg)
-      }
-    }
-
-    debugOut("Loading graph... ")
-    val cpg = CpgBasedTool.loadFromOdb(config.cpgFileName)
-    debugOut("[DONE]\n")
-
-    implicit val resolver: ICallResolver = NoResolve
-    val sources                          = params(cpg, config.srcRegex, config.srcParam)
-    val sinks                            = params(cpg, config.dstRegex, config.dstParam)
-
-    debugOut(s"Number of sources: ${sources.size}\n")
-    debugOut(s"Number of sinks: ${sinks.size}\n")
-
-    implicit val semantics: Semantics = DefaultSemantics()
-    val engineConfig                  = EngineConfig(config.depth)
-    debugOut(s"Analysis depth: ${engineConfig.maxCallDepth}\n")
-    implicit val context: EngineContext = EngineContext(semantics, engineConfig)
-
-    debugOut("Determining flows...")
-    sinks.foreach { s =>
-      List(s).to(Traversal).reachableByFlows(sources.to(Traversal)).p.foreach(println)
-    }
-    debugOut("[DONE]")
-
-    debugOut("Closing graph... ")
-    cpg.close()
-    debugOut("[DONE]\n")
-  }
 
   private def params(cpg: Cpg, methodNameRegex: String, paramIndex: Option[Int]): List[MethodParameterIn] = {
     cpg

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
@@ -37,11 +37,16 @@ case class JoernScanConfig(
   listLanguages: Boolean = false
 )
 
-object JoernScan extends App with BridgeBase {
+object JoernScan extends BridgeBase {
 
   val implementationVersion = getClass.getPackage.getImplementationVersion
 
-  val (scanArgs, frontendArgs) = CpgBasedTool.splitArgs(args)
+  def main(args: Array[String]) = {
+    val (scanArgs, frontendArgs) = CpgBasedTool.splitArgs(args)
+    optionParser.parse(scanArgs, JoernScanConfig()).foreach { config =>
+      run(config, frontendArgs)
+    }
+  }
 
   val optionParser = new scopt.OptionParser[JoernScanConfig]("joern-scan") {
     head(
@@ -106,9 +111,7 @@ object JoernScan extends App with BridgeBase {
     note(s"Args specified after the ${CpgBasedTool.ARGS_DELIMITER} separator will be passed to the front-end verbatim")
   }
 
-  optionParser.parse(scanArgs, JoernScanConfig()).foreach(run)
-
-  private def run(config: JoernScanConfig): Unit = {
+  private def run(config: JoernScanConfig, frontendArgs: List[String]): Unit = {
     if (config.dump) {
       dumpQueriesAsJson(config.dumpDestination)
     } else if (config.listQueryNames) {
@@ -118,7 +121,7 @@ object JoernScan extends App with BridgeBase {
     } else if (config.updateQueryDb) {
       updateQueryDatabase(config.queryDbVersion)
     } else {
-      runScanPlugin(config)
+      runScanPlugin(config, frontendArgs)
     }
   }
 
@@ -143,7 +146,7 @@ object JoernScan extends App with BridgeBase {
     println(s.toString())
   }
 
-  private def runScanPlugin(config: JoernScanConfig): Unit = {
+  private def runScanPlugin(config: JoernScanConfig, frontendArgs: List[String]): Unit = {
 
     if (config.src == "") {
       println(optionParser.usage)

--- a/joern-cli/src/universal/schema-extender/schema/src/main/scala/CpgExtCodegen.scala
+++ b/joern-cli/src/universal/schema-extender/schema/src/main/scala/CpgExtCodegen.scala
@@ -5,23 +5,25 @@ import overflowdb.schema.Property.ValueType
 
 import java.io.File
 
-object CpgExtCodegen extends App {
-  val outputDir = args.headOption
-    .map(new File(_))
-    .getOrElse(throw new AssertionError("please pass outputDir as first parameter"))
+object CpgExtCodegen {
+  def main(args: Array[String]) = {
+    val outputDir = args.headOption
+      .map(new File(_))
+      .getOrElse(throw new AssertionError("please pass outputDir as first parameter"))
 
-  val builder   = new SchemaBuilder(domainShortName = "Cpg", basePackage = "io.shiftleft.codepropertygraph.generated")
-  val cpgSchema = new CpgSchema(builder)
+    val builder = new SchemaBuilder(domainShortName = "Cpg", basePackage = "io.shiftleft.codepropertygraph.generated")
+    val cpgSchema = new CpgSchema(builder)
 
-  // START extensions for this build - add your's here and remove the example properties
-  val exampleProperty =
-    builder.addProperty(name = "EXAMPLE_PROPERTY", valueType = ValueType.String, comment = "an example property")
+    // START extensions for this build - add your's here and remove the example properties
+    val exampleProperty =
+      builder.addProperty(name = "EXAMPLE_PROPERTY", valueType = ValueType.String, comment = "an example property")
 
-  val exampleNode =
-    builder.addNodeType(name = "EXAMPLE_NODE", comment = "an example node").addProperties(exampleProperty)
+    val exampleNode =
+      builder.addNodeType(name = "EXAMPLE_NODE", comment = "an example node").addProperties(exampleProperty)
 
-  cpgSchema.fs.file.addProperties(exampleProperty)
-  // END extensions for this build
+    cpgSchema.fs.file.addProperties(exampleProperty)
+    // END extensions for this build
 
-  new CodeGen(builder.build).run(outputDir)
+    new CodeGen(builder.build).run(outputDir)
+  }
 }

--- a/querydb/src/main/scala/io/joern/dumpq/Main.scala
+++ b/querydb/src/main/scala/io/joern/dumpq/Main.scala
@@ -6,9 +6,11 @@ import io.joern.dataflowengineoss.semanticsloader.Semantics
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.Serialization
 
-object Main extends App {
+object Main {
 
-  dumpQueries()
+  def main(args: Array[String]) = {
+    dumpQueries()
+  }
 
   def dumpQueries(): Unit = {
     implicit val engineContext: EngineContext = EngineContext(Semantics.empty)


### PR DESCRIPTION
Scala3 doesn't support the 'magic' DelayedInit trait which is used by
`extends App` - the recommended way for cross compilation is to use
regular `def main(args: Array[String])` methods instead.

See https://docs.scala-lang.org/scala3/book/methods-main-methods.html