### PR TITLE
Add missing symlinks to joern-install.sh

### DIFF
--- a/joern-install.sh
+++ b/joern-install.sh
@@ -180,6 +180,11 @@ else
 	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/c2cpg.sh "$JOERN_LINK_DIR" || true
 	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/ghidra2cpg "$JOERN_LINK_DIR" || true
 	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/jssrc2cpg.sh "$JOERN_LINK_DIR" || true
+	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/javasrc2cpg "$JOERN_LINK_DIR" || true
+	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/jimple2cpg "$JOERN_LINK_DIR" || true
+	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/kotlin2cpg "$JOERN_LINK_DIR" || true
+	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/php2cpg "$JOERN_LINK_DIR" || true
+	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/pysrc2cpg "$JOERN_LINK_DIR" || true
 	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/joern-export "$JOERN_LINK_DIR" || true
 	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/joern-flow "$JOERN_LINK_DIR" || true
 	    sudo ln -sf "$JOERN_INSTALL_DIR"/joern-cli/joern-scan "$JOERN_LINK_DIR" || true


### PR DESCRIPTION
Add symlinks for the Python, Java, Kotlin, PHP and Jimple CPG construction tools to joern-install.sh, so that these tools can be called without needing to specify the path in a script.

If these symlinks have been omitted on purpose, feel free to ignore this pull request.