### PR TITLE
jimple2cpg: fix name of annotation

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -270,7 +270,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
 
   private def astsForAnnotations(annotation: AnnotationTag, order: Int, methodDeclaration: AbstractHost): Ast = {
     val annoType = registerType(parseAsmType(annotation.getType))
-    val name     = if (annoType.contains('.')) annoType.substring(annoType.indexOf('.'), annoType.length) else annoType
+    val name     = annoType.split('.').last
     val elementNodes = withOrder(annotation.getElems.asScala) { case (a, order) =>
       astForAnnotationElement(a, order, methodDeclaration)
     }


### PR DESCRIPTION
<img width="582" alt="image" src="https://user-images.githubusercontent.com/16919236/201709428-359cfd68-a09b-4357-99bf-394ae1d67578.png">

Shouled be ```RequestMapping``` to stay the same with ```javasrc2cpg```.