### PR TITLE
Simplifiy FlowGraph trait.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,3 @@ are:
 For more instructions on how to run benchmarks individually head over to the `benchmarks` subproject. If you would
 like the benchmark results to be written to a file instead of printed to STDOUT, set the path to the environment 
 variable `JOERN_BENCHMARK_RESULT_FILE`.
-

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
@@ -18,8 +18,6 @@ class DataFlowProblem[Node, V](
   * wrapper that takes care of these minor discrepancies.
   */
 trait FlowGraph[Node] {
-  val entryNode: Node
-  val exitNode: Node
   val allNodesReversePostOrder: List[Node]
   val allNodesPostOrder: List[Node]
   val succ: Map[Node, List[Node]]

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
@@ -20,8 +20,8 @@ class DataFlowProblem[Node, V](
 trait FlowGraph[Node] {
   val allNodesReversePostOrder: List[Node]
   val allNodesPostOrder: List[Node]
-  val succ: Map[Node, List[Node]]
-  val pred: Map[Node, List[Node]]
+  def succ(node: Node): IterableOnce[Node]
+  def pred(node: Node): IterableOnce[Node]
 }
 
 /** This is actually a function family consisting of one transfer function for each node of the flow graph. Each

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -28,6 +28,7 @@ class DdgGenerator(semantics: Semantics) {
     */
   def addReachingDefEdges(
     dstGraph: DiffGraphBuilder,
+    method: Method,
     problem: DataFlowProblem[StoredNode, mutable.BitSet],
     solution: Solution[StoredNode, mutable.BitSet]
   ): Unit = {
@@ -37,7 +38,6 @@ class DdgGenerator(semantics: Semantics) {
     val in           = solution.in
     val gen          = solution.problem.transferFunction.asInstanceOf[ReachingDefTransferFunction].gen
 
-    val method        = problem.flowGraph.entryNode.asInstanceOf[Method]
     val allNodes      = in.keys.toList
     val usageAnalyzer = new UsageAnalyzer(problem, in)
 
@@ -149,9 +149,8 @@ class DdgGenerator(semantics: Semantics) {
     /** This is part of the Lone-identifier optimization: as we remove lone identifiers from `gen` sets, we must now
       * retrieve them and create an edge from each lone identifier to the exit node.
       */
-    def addEdgesFromLoneIdentifiersToExit(): Unit = {
+    def addEdgesFromLoneIdentifiersToExit(method: Method): Unit = {
       val numberToNode     = problem.flowGraph.asInstanceOf[ReachingDefFlowGraph].numberToNode
-      val method           = problem.flowGraph.entryNode.asInstanceOf[Method]
       val exitNode         = method.methodReturn
       val transferFunction = solution.problem.transferFunction.asInstanceOf[OptimizedReachingDefTransferFunction]
       val genOnce          = transferFunction.loneIdentifiers
@@ -171,7 +170,7 @@ class DdgGenerator(semantics: Semantics) {
       case _                            =>
     }
     addEdgesToExitNode(method.methodReturn)
-    addEdgesFromLoneIdentifiersToExit()
+    addEdgesFromLoneIdentifiersToExit(method)
   }
 
   private def addEdge(fromNode: StoredNode, toNode: StoredNode, variable: String = "")(implicit

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -21,22 +21,21 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000)(implicit s: 
   override def runOnPart(dstGraph: DiffGraphBuilder, method: Method): Unit = {
     logger.info("Calculating reaching definitions for: {} in {}", method.fullName, method.filename)
     val problem = ReachingDefProblem.create(method)
-    if (shouldBailOut(problem)) {
+    if (shouldBailOut(method, problem)) {
       logger.warn("Skipping.")
       return
     }
 
     val solution     = new DataFlowSolver().calculateMopSolutionForwards(problem)
     val ddgGenerator = new DdgGenerator(s)
-    ddgGenerator.addReachingDefEdges(dstGraph, problem, solution)
+    ddgGenerator.addReachingDefEdges(dstGraph, method, problem, solution)
   }
 
   /** Before we start propagating definitions in the graph, which is the bulk of the work, we check how many definitions
     * were are dealing with in total. If a threshold is reached, we bail out instead, leaving reaching definitions
     * uncalculated for the method in question. Users can increase the threshold if desired.
     */
-  private def shouldBailOut(problem: DataFlowProblem[StoredNode, mutable.BitSet]): Boolean = {
-    val method           = problem.flowGraph.entryNode.asInstanceOf[Method]
+  private def shouldBailOut(method: Method, problem: DataFlowProblem[StoredNode, mutable.BitSet]): Boolean = {
     val transferFunction = problem.transferFunction.asInstanceOf[ReachingDefTransferFunction]
     // For each node, the `gen` map contains the list of definitions it generates
     // We add up the sizes of these lists to obtain the total number of definitions

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -62,8 +62,16 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph[StoredNode] {
 
   val allNodesPostOrder: List[StoredNode] = allNodesReversePostOrder.reverse
 
-  val succ: Map[StoredNode, List[StoredNode]] = initSucc(allNodesReversePostOrder)
-  val pred: Map[StoredNode, List[StoredNode]] = initPred(allNodesReversePostOrder, method)
+  private val _succ: Map[StoredNode, List[StoredNode]] = initSucc(allNodesReversePostOrder)
+  private val _pred: Map[StoredNode, List[StoredNode]] = initPred(allNodesReversePostOrder, method)
+
+  override def succ(node: StoredNode): IterableOnce[StoredNode] = {
+    _succ.apply(node)
+  }
+
+  override def pred(node: StoredNode): IterableOnce[StoredNode] = {
+    _pred.apply(node)
+  }
 
   /** Create a map that allows CFG successors to be retrieved for each node
     */


### PR DESCRIPTION
Remove entryNode and exitNode. Those are not required by
DataFlowProblem and DataFlowSolver and where so far only used
to piggy back the method node onto the data flow problem for the
using codes sake.
Now the using code handles the method node itself and on top we avoid
casting.

Also: Made succ and pred functions.
This enables implementors to choose how they want to implement those
to relations and are not forced to use a Map.