### PR TITLE
Optimize javasrc2cpg type solving somewhat and add cache to TypeInferencePass

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -11,7 +11,8 @@ libraryDependencies ++= Seq(
   "io.joern" % "javaparser-symbol-solver-core" % "3.24.3-SL3", // custom build of our fork, sources at https://github.com/mpollmeier/javaparser
   "org.gradle"        % "gradle-tooling-api" % Versions.gradleTooling,
   "org.scalatest"    %% "scalatest"          % Versions.scalatest % Test,
-  "org.projectlombok" % "lombok"             % "1.18.24"
+  "org.projectlombok" % "lombok"             % "1.18.24",
+  "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
 )
 
 scalacOptions ++= Seq(

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -199,8 +199,8 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     val reflectionTypeSolver = new CachingReflectionTypeSolver()
     val sourceTypeSolver     = EagerSourceTypeSolver(typesAsts)
 
-    combinedTypeSolver.appendSolver(sourceTypeSolver)
-    combinedTypeSolver.appendSolver(reflectionTypeSolver)
+    combinedTypeSolver.add(sourceTypeSolver)
+    combinedTypeSolver.add(reflectionTypeSolver)
 
     // Add solvers for inference jars
     val jarsList = config.inferenceJarPaths.flatMap(recursiveJarsFromPath).toList
@@ -208,7 +208,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       .flatMap { path =>
         Try(new JarTypeSolver(path)).toOption
       }
-      .foreach { combinedTypeSolver.appendSolver(_) }
+      .foreach { combinedTypeSolver.add(_) }
 
     new JavaSymbolSolver(combinedTypeSolver)
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -120,7 +120,6 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
 
     val analysisAsts = analysisAstsMap.values.toList
     val typesAsts = typesSources.par.flatMap { sourceFilename =>
-      // Always want to usecombinedTypeSolver
       val sourceFileInfo = SourceFileInfo(sourceFilename, sourceFilename)
       analysisAstsMap
         .get(sourceFilename)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -1,10 +1,14 @@
 package io.joern.javasrc2cpg
 
 import better.files.File
-import com.github.javaparser.JavaParser
+import com.github.javaparser.ParserConfiguration.LanguageLevel
+import com.github.javaparser.{JavaParser, ParserConfiguration}
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.Node.Parsedness
+import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver
 import io.joern.javasrc2cpg.passes.{AstCreationPass, ConfigFileCreationPass, TypeInferencePass}
+import io.joern.javasrc2cpg.typesolvers.{CachingReflectionTypeSolver, SimpleCombinedTypeSolver, EagerSourceTypeSolver}
 import io.joern.javasrc2cpg.util.{Delombok, SourceRootFinder}
 import io.joern.javasrc2cpg.util.Delombok.DelombokMode
 import io.shiftleft.codepropertygraph.Cpg
@@ -19,22 +23,38 @@ import java.nio.file.{Path, Paths}
 import scala.collection.parallel.CollectionConverters._
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.Try
+import scala.util.{Success, Try}
 
 case class SourceDirectoryInfo(typeSolverSourceDirs: List[String], sourceFiles: List[SourceFileInfo])
-case class SourceFileInfo(analysisFileName: String, originalFilename: String)
 case class SplitDirectories(analysisSourceDir: String, typesSourceDir: String)
+case class SplitJpAsts(analysisAsts: List[JpAstWithMeta], typesAsts: List[JpAstWithMeta])
+case class SourceFileInfo(analysisFileName: String, originalFilename: String)
 case class JpAstWithMeta(fileInfo: SourceFileInfo, compilationUnit: CompilationUnit)
-case class SplitJpAsts(analysisAsts: List[JpAstWithMeta], typesAsts: List[CompilationUnit])
 
 object JavaSrc2Cpg {
   val language: String = Languages.JAVASRC
+  private val logger   = LoggerFactory.getLogger(this.getClass)
 
   val sourceFileExtensions: Set[String] = Set(".java")
-  def apply(): JavaSrc2Cpg = new NewJavaSrc2Cpg()
+  def apply(): JavaSrc2Cpg              = new JavaSrc2Cpg()
+
+  def getDependencyList(config: Config): Seq[String] = {
+    val codeDir = config.inputPath
+    if (config.fetchDependencies) {
+      DependencyResolver.getDependencies(Paths.get(codeDir)) match {
+        case Some(deps) => deps.toSeq
+        case None =>
+          logger.warn(s"Could not fetch dependencies for project at path $codeDir")
+          Seq()
+      }
+    } else {
+      logger.info("dependency resolving disabled")
+      Seq()
+    }
+  }
 }
 
-class NewJavaSrc2Cpg extends JavaSrc2Cpg {
+class JavaSrc2Cpg extends X2CpgFrontend[Config] {
   import JavaSrc2Cpg._
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -43,16 +63,42 @@ class NewJavaSrc2Cpg extends JavaSrc2Cpg {
       new MetaDataPass(cpg, language, config.inputPath).createAndApply()
 
       val sourceDirectories = getSourcePathsWithDelombok(config)
-      val javaparserAsts = getSplitJavaparserAsts(sourceDirectories, config)
+      val javaparserAsts    = getSplitJavaparserAsts(sourceDirectories, config)
+      val symbolSolver      = createSymbolSolver(javaparserAsts.typesAsts, config)
+      javaparserAsts.analysisAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
+
+      val astCreationPass = new AstCreationPass(javaparserAsts.analysisAsts, config, cpg, symbolSolver)
+      astCreationPass.createAndApply()
+      new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
+      new TypeNodePass(astCreationPass.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
+      new TypeInferencePass(cpg).createAndApply()
     }
   }
+
+  // private def populateCombinedTypeSolver(solver: CombinedTypeSolver, typesAsts: List[JpAstWithMeta], config: Config): Unit = {
+  //   val reflectionTypeSolver = new CachingReflectionTypeSolver()
+  //   val sourceTypeSolver = EagerSourceTypeSolver(typesAsts)
+
+  //   // Source type solver should be the fastest, so check that first.
+  //   solver.add(sourceTypeSolver)
+  //   solver.add(reflectionTypeSolver)
+
+  //   // Add solvers for inference jars
+  //   val jarsList = config.inferenceJarPaths.flatMap(recursiveJarsFromPath).toList
+  //   (jarsList ++ getDependencyList(config))
+  //     .flatMap { path =>
+  //       Try(new JarTypeSolver(path)).toOption
+  //     }
+  //     .foreach { solver.add(_) }
+  // }
 
   private def getSourcesFromDir(sourceDir: String): List[String] = {
     SourceRootFinder.getSourceRoots(sourceDir).flatMap(SourceFiles.determine(_, sourceFileExtensions))
   }
 
   private def parseFile(filename: String): Option[CompilationUnit] = {
-    val parseResult = new JavaParser().parse(new java.io.File(filename))
+    val config      = new ParserConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE)
+    val parseResult = new JavaParser(config).parse(new java.io.File(filename))
 
     parseResult.getProblems.asScala.toList match {
       case Nil => // Just carry on as usual
@@ -73,19 +119,25 @@ class NewJavaSrc2Cpg extends JavaSrc2Cpg {
 
   private def getSplitJavaparserAsts(sourceDirectories: SplitDirectories, config: Config): SplitJpAsts = {
     val analysisSources = getSourcesFromDir(sourceDirectories.analysisSourceDir)
-    val typesSources = getSourcesFromDir(sourceDirectories.typesSourceDir)
+    val typesSources    = getSourcesFromDir(sourceDirectories.typesSourceDir)
 
     val analysisAstsMap = analysisSources.par.flatMap { sourceFilename =>
       val originalFilename = sourceFilename.replaceAll(sourceDirectories.analysisSourceDir, config.inputPath)
-      val sourceFileInfo = SourceFileInfo(sourceFilename, originalFilename)
-      val maybeParsedFile = parseFile(sourceFilename)
+      val sourceFileInfo   = SourceFileInfo(sourceFilename, originalFilename)
+      val maybeParsedFile  = parseFile(sourceFilename)
 
       maybeParsedFile.map(cu => sourceFilename -> JpAstWithMeta(sourceFileInfo, cu))
     }.toMap
 
     val analysisAsts = analysisAstsMap.values.toList
     val typesAsts = typesSources.par.flatMap { sourceFilename =>
-      analysisAstsMap.get(sourceFilename).map(_.compilationUnit).orElse(parseFile(sourceFilename))
+      // Always want to usecombinedTypeSolver
+      val sourceFileInfo = SourceFileInfo(sourceFilename, sourceFilename)
+      analysisAstsMap
+        .get(sourceFilename)
+        .map(_.compilationUnit)
+        .orElse(parseFile(sourceFilename))
+        .map(cu => JpAstWithMeta(sourceFileInfo, cu))
     }.toList
 
     SplitJpAsts(analysisAsts, typesAsts)
@@ -99,89 +151,20 @@ class NewJavaSrc2Cpg extends JavaSrc2Cpg {
     lazy val delombokDir    = Delombok.run(originalSourcesDir, config.delombokJavaHome)
 
     delombokMode match {
-      case DelombokMode.Default if hasLombokDependency=>
+      case DelombokMode.Default if hasLombokDependency =>
         logger.info(s"Analysing delomboked code as lombok dependency was found.")
         SplitDirectories(delombokDir, delombokDir)
 
       case DelombokMode.RunDelombok =>
         SplitDirectories(delombokDir, delombokDir)
 
-      case DelombokMode.TypesOnly   =>
+      case DelombokMode.TypesOnly =>
         SplitDirectories(originalSourcesDir, delombokDir)
 
       case _ => SplitDirectories(originalSourcesDir, originalSourcesDir)
     }
   }
 
-  private def getDependencyList(config: Config): Seq[String] = {
-    val codeDir = config.inputPath
-    if (config.fetchDependencies) {
-      DependencyResolver.getDependencies(Paths.get(codeDir)) match {
-        case Some(deps) => deps.toSeq
-        case None =>
-          logger.warn(s"Could not fetch dependencies for project at path $codeDir")
-          Seq()
-      }
-    } else {
-      logger.info("dependency resolving disabled")
-      Seq()
-    }
-  }
-  private def getDelombokMode(config: Config): DelombokMode = {
-    config.delombokMode.map(_.toLowerCase) match {
-      case None                 => DelombokMode.Default
-      case Some("no-delombok")  => DelombokMode.NoDelombok
-      case Some("default")      => DelombokMode.Default
-      case Some("types-only")   => DelombokMode.TypesOnly
-      case Some("run-delombok") => DelombokMode.RunDelombok
-      case Some(value) =>
-        logger.warn(s"Found unrecognised delombok mode `$value`. Using default instead.")
-        DelombokMode.Default
-    }
-  }
-}
-
-class JavaSrc2Cpg extends X2CpgFrontend[Config] {
-  import JavaSrc2Cpg._
-  private val logger = LoggerFactory.getLogger(getClass)
-
-
-  def createCpg(config: Config): Try[Cpg] = {
-    withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
-      new MetaDataPass(cpg, language, config.inputPath).createAndApply()
-      val dependencies        = getDependencyList(config)
-      val hasLombokDependency = dependencies.exists(_.contains("lombok"))
-      val sourcesInfo         = getSourcesFromDir(config, hasLombokDependency)
-      if (sourcesInfo.sourceFiles.isEmpty) {
-        logger.error(s"no source files found at path ${config.inputPath}")
-      } else {
-        logger.info(s"found ${sourcesInfo.sourceFiles.size} source files")
-      }
-
-      val astCreator = new AstCreationPass(sourcesInfo, config, cpg, dependencies)
-      astCreator.createAndApply()
-      new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
-      new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg)
-        .createAndApply()
-      new TypeInferencePass(cpg).createAndApply()
-    }
-  }
-
-  private def getDependencyList(config: Config): Seq[String] = {
-    val codeDir = config.inputPath
-    if (config.fetchDependencies) {
-      DependencyResolver.getDependencies(Paths.get(codeDir)) match {
-        case Some(deps) => deps.toSeq
-        case None =>
-          logger.warn(s"Could not fetch dependencies for project at path $codeDir")
-          Seq()
-      }
-    } else {
-      logger.info("dependency resolving disabled")
-      Seq()
-    }
-  }
-
   private def getDelombokMode(config: Config): DelombokMode = {
     config.delombokMode.map(_.toLowerCase) match {
       case None                 => DelombokMode.Default
@@ -195,62 +178,39 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     }
   }
 
-  /** JavaParser requires that the input path is a directory and not a single source file. This is inconvenient for
-    * small-scale testing, so if a single source file is created, copy it to a temp directory.
-    */
-  private def getSourcesFromDir(config: Config, hasLombokDependency: Boolean): SourceDirectoryInfo = {
-    val delombokMode = getDelombokMode(config)
-    val runDelombok = delombokMode match {
-      case DelombokMode.NoDelombok => false
-      case DelombokMode.Default =>
-        if (hasLombokDependency) {
-          logger.info(s"Analysing delomboked code as lombok dependency was found.")
-        }
-        hasLombokDependency
-      case DelombokMode.RunDelombok => true
-      case DelombokMode.TypesOnly   => true
+  private def recursiveJarsFromPath(path: String): List[String] = {
+    Try(File(path)) match {
+      case Success(file) if file.isDirectory =>
+        file.listRecursively
+          .map(_.canonicalPath)
+          .filter(_.endsWith(".jar"))
+          .toList
+
+      case Success(file) if file.canonicalPath.endsWith(".jar") =>
+        List(file.canonicalPath)
+
+      case _ =>
+        Nil
     }
+  }
 
-    val sourceInfoTuples = SourceRootFinder.getSourceRoots(config.inputPath).map { inputPath =>
-      val inputPathAsFile = File(inputPath)
-      val originalSourcesDir = if (inputPathAsFile.isDirectory) {
-        inputPath
-      } else {
-        val dir = File.newTemporaryDirectory("javasrc").deleteOnExit()
-        inputPathAsFile.copyToDirectory(dir).deleteOnExit()
-        dir.pathAsString
+  private def createSymbolSolver(typesAsts: List[JpAstWithMeta], config: Config): JavaSymbolSolver = {
+    val combinedTypeSolver   = new SimpleCombinedTypeSolver()
+    val reflectionTypeSolver = new CachingReflectionTypeSolver()
+    val sourceTypeSolver     = EagerSourceTypeSolver(typesAsts)
+
+    combinedTypeSolver.appendSolver(sourceTypeSolver)
+    combinedTypeSolver.appendSolver(reflectionTypeSolver)
+
+    // Add solvers for inference jars
+    val jarsList = config.inferenceJarPaths.flatMap(recursiveJarsFromPath).toList
+    (jarsList ++ getDependencyList(config))
+      .flatMap { path =>
+        Try(new JarTypeSolver(path)).toOption
       }
+      .foreach { combinedTypeSolver.appendSolver(_) }
 
-      val delombokSourcesDir = Option.when(runDelombok) {
-        Delombok.run(originalSourcesDir, config.delombokJavaHome)
-      }
-
-      val analysisSourceFilePath =
-        if (runDelombok && (delombokMode != DelombokMode.TypesOnly))
-          delombokSourcesDir.get
-        else
-          originalSourcesDir
-
-      val typeSourcesPath = delombokSourcesDir.getOrElse(originalSourcesDir)
-
-      val sourceFileNames = SourceFiles.determine(analysisSourceFilePath, sourceFileExtensions)
-      val sourceFileInfo = delombokSourcesDir match {
-        case Some(delombokSourcesDir) =>
-          sourceFileNames.map { fileName =>
-            // Directory structure remains unchanged.
-            val originalFileName = fileName.replace(delombokSourcesDir, originalSourcesDir)
-            SourceFileInfo(fileName, originalFileName)
-          }
-
-        case None => sourceFileNames.map { filename => SourceFileInfo(filename, filename) }
-      }
-
-      (typeSourcesPath, sourceFileInfo)
-    }
-
-    val typesPaths   = sourceInfoTuples.map(_._1)
-    val sourcesPaths = sourceInfoTuples.flatMap(_._2)
-    SourceDirectoryInfo(typesPaths, sourcesPaths)
+    new JavaSymbolSolver(combinedTypeSolver)
   }
 
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -1,6 +1,9 @@
 package io.joern.javasrc2cpg
 
 import better.files.File
+import com.github.javaparser.JavaParser
+import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ast.Node.Parsedness
 import io.joern.javasrc2cpg.passes.{AstCreationPass, ConfigFileCreationPass, TypeInferencePass}
 import io.joern.javasrc2cpg.util.{Delombok, SourceRootFinder}
 import io.joern.javasrc2cpg.util.Delombok.DelombokMode
@@ -12,23 +15,136 @@ import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.utils.dependency.DependencyResolver
 import org.slf4j.LoggerFactory
 
-import java.nio.file.Paths
-import scala.jdk.CollectionConverters.EnumerationHasAsScala
+import java.nio.file.{Path, Paths}
+import scala.collection.parallel.CollectionConverters._
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptional
 import scala.util.Try
 
 case class SourceDirectoryInfo(typeSolverSourceDirs: List[String], sourceFiles: List[SourceFileInfo])
-case class SourceFileInfo(analysisFileName: String, originalFileName: String)
+case class SourceFileInfo(analysisFileName: String, originalFilename: String)
+case class SplitDirectories(analysisSourceDir: String, typesSourceDir: String)
+case class JpAstWithMeta(fileInfo: SourceFileInfo, compilationUnit: CompilationUnit)
+case class SplitJpAsts(analysisAsts: List[JpAstWithMeta], typesAsts: List[CompilationUnit])
+
 object JavaSrc2Cpg {
   val language: String = Languages.JAVASRC
 
-  def apply(): JavaSrc2Cpg = new JavaSrc2Cpg()
+  val sourceFileExtensions: Set[String] = Set(".java")
+  def apply(): JavaSrc2Cpg = new NewJavaSrc2Cpg()
+}
+
+class NewJavaSrc2Cpg extends JavaSrc2Cpg {
+  import JavaSrc2Cpg._
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+  override def createCpg(config: Config): Try[Cpg] = {
+    withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
+      new MetaDataPass(cpg, language, config.inputPath).createAndApply()
+
+      val sourceDirectories = getSourcePathsWithDelombok(config)
+      val javaparserAsts = getSplitJavaparserAsts(sourceDirectories, config)
+    }
+  }
+
+  private def getSourcesFromDir(sourceDir: String): List[String] = {
+    SourceRootFinder.getSourceRoots(sourceDir).flatMap(SourceFiles.determine(_, sourceFileExtensions))
+  }
+
+  private def parseFile(filename: String): Option[CompilationUnit] = {
+    val parseResult = new JavaParser().parse(new java.io.File(filename))
+
+    parseResult.getProblems.asScala.toList match {
+      case Nil => // Just carry on as usual
+      case problems =>
+        logger.warn(s"Encountered problems while parsing file $filename:")
+        problems.foreach { problem =>
+          logger.warn(s"- ${problem.getMessage}")
+        }
+    }
+
+    parseResult.getResult.toScala match {
+      case Some(result) if result.getParsed == Parsedness.PARSED => Some(result)
+      case _ =>
+        logger.warn(s"Failed to parse file $filename")
+        None
+    }
+  }
+
+  private def getSplitJavaparserAsts(sourceDirectories: SplitDirectories, config: Config): SplitJpAsts = {
+    val analysisSources = getSourcesFromDir(sourceDirectories.analysisSourceDir)
+    val typesSources = getSourcesFromDir(sourceDirectories.typesSourceDir)
+
+    val analysisAstsMap = analysisSources.par.flatMap { sourceFilename =>
+      val originalFilename = sourceFilename.replaceAll(sourceDirectories.analysisSourceDir, config.inputPath)
+      val sourceFileInfo = SourceFileInfo(sourceFilename, originalFilename)
+      val maybeParsedFile = parseFile(sourceFilename)
+
+      maybeParsedFile.map(cu => sourceFilename -> JpAstWithMeta(sourceFileInfo, cu))
+    }.toMap
+
+    val analysisAsts = analysisAstsMap.values.toList
+    val typesAsts = typesSources.par.flatMap { sourceFilename =>
+      analysisAstsMap.get(sourceFilename).map(_.compilationUnit).orElse(parseFile(sourceFilename))
+    }.toList
+
+    SplitJpAsts(analysisAsts, typesAsts)
+  }
+
+  private def getSourcePathsWithDelombok(config: Config): SplitDirectories = {
+    val dependencies        = getDependencyList(config)
+    val delombokMode        = getDelombokMode(config)
+    val hasLombokDependency = dependencies.exists(_.contains("lombok"))
+    val originalSourcesDir  = config.inputPath
+    lazy val delombokDir    = Delombok.run(originalSourcesDir, config.delombokJavaHome)
+
+    delombokMode match {
+      case DelombokMode.Default if hasLombokDependency=>
+        logger.info(s"Analysing delomboked code as lombok dependency was found.")
+        SplitDirectories(delombokDir, delombokDir)
+
+      case DelombokMode.RunDelombok =>
+        SplitDirectories(delombokDir, delombokDir)
+
+      case DelombokMode.TypesOnly   =>
+        SplitDirectories(originalSourcesDir, delombokDir)
+
+      case _ => SplitDirectories(originalSourcesDir, originalSourcesDir)
+    }
+  }
+
+  private def getDependencyList(config: Config): Seq[String] = {
+    val codeDir = config.inputPath
+    if (config.fetchDependencies) {
+      DependencyResolver.getDependencies(Paths.get(codeDir)) match {
+        case Some(deps) => deps.toSeq
+        case None =>
+          logger.warn(s"Could not fetch dependencies for project at path $codeDir")
+          Seq()
+      }
+    } else {
+      logger.info("dependency resolving disabled")
+      Seq()
+    }
+  }
+  private def getDelombokMode(config: Config): DelombokMode = {
+    config.delombokMode.map(_.toLowerCase) match {
+      case None                 => DelombokMode.Default
+      case Some("no-delombok")  => DelombokMode.NoDelombok
+      case Some("default")      => DelombokMode.Default
+      case Some("types-only")   => DelombokMode.TypesOnly
+      case Some("run-delombok") => DelombokMode.RunDelombok
+      case Some(value) =>
+        logger.warn(s"Found unrecognised delombok mode `$value`. Using default instead.")
+        DelombokMode.Default
+    }
+  }
 }
 
 class JavaSrc2Cpg extends X2CpgFrontend[Config] {
   import JavaSrc2Cpg._
   private val logger = LoggerFactory.getLogger(getClass)
 
-  val sourceFileExtensions: Set[String] = Set(".java")
 
   def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -102,6 +102,10 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     }
   }
 
+  private def escapeBackslash(path: String): String = {
+    path.replaceAll(raw"\\", raw"\\\\")
+  }
+
   private def getSplitJavaparserAsts(sourceDirectories: SplitDirectories, config: Config): SplitJpAsts = {
     val analysisSources = getSourcesFromDir(sourceDirectories.analysisSourceDir)
     val typesSources    = getSourcesFromDir(sourceDirectories.typesSourceDir)
@@ -109,8 +113,8 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     val analysisAstsMap = analysisSources.par.flatMap { sourceFilename =>
       val originalFilename = sourceFilename.replaceAll(
         // Pattern.quote used to escape Windows paths
-        Pattern.quote(sourceDirectories.analysisSourceDir),
-        config.inputPath
+        escapeBackslash(sourceDirectories.analysisSourceDir),
+        escapeBackslash(config.inputPath)
       )
       val sourceFileInfo  = SourceFileInfo(sourceFilename, originalFilename)
       val maybeParsedFile = parseFile(sourceFilename)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -19,7 +19,7 @@ import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.utils.dependency.DependencyResolver
 import org.slf4j.LoggerFactory
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Paths
 import scala.collection.parallel.CollectionConverters._
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -1,105 +1,37 @@
 package io.joern.javasrc2cpg.passes
 
-import better.files.File
-import com.github.javaparser.ParserConfiguration.LanguageLevel
-import com.github.javaparser.ast.Node.Parsedness
-import com.github.javaparser.{JavaParser, ParserConfiguration}
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
-import com.github.javaparser.symbolsolver.cache.{GuavaCache, NoCache}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
-import com.github.javaparser.symbolsolver.resolution.typesolvers.{JarTypeSolver, JavaParserTypeSolver}
-import com.google.common.cache.CacheBuilder
-import io.joern.javasrc2cpg.typesolvers.SimpleCombinedTypeSolver
-import io.joern.javasrc2cpg.{Config, SourceDirectoryInfo, SourceFileInfo}
-import io.joern.javasrc2cpg.util.CachingReflectionTypeSolver
+import io.joern.javasrc2cpg.{Config, JpAstWithMeta}
 import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory
 
-import java.nio.file.Paths
-import scala.jdk.OptionConverters.RichOptional
-import scala.jdk.CollectionConverters._
-import scala.util.{Success, Try}
+import java.util.concurrent.atomic.AtomicInteger
 
-class AstCreationPass(sourceInfo: SourceDirectoryInfo, config: Config, cpg: Cpg, dependencies: Seq[String])
-    extends ConcurrentWriterCpgPass[SourceFileInfo](cpg) {
+class AstCreationPass(asts: List[JpAstWithMeta], config: Config, cpg: Cpg, symbolSolver: JavaSymbolSolver)
+    extends ConcurrentWriterCpgPass[JpAstWithMeta](cpg) {
 
-  val global: Global              = new Global()
-  private val logger              = LoggerFactory.getLogger(classOf[AstCreationPass])
-  lazy private val symbolResolver = createSymbolSolver()
-  private val parserConfig        = new ParserConfiguration().setLanguageLevel(LanguageLevel.CURRENT)
+  val global: Global   = new Global()
+  private val logger   = LoggerFactory.getLogger(classOf[AstCreationPass])
+  private val finished = new AtomicInteger(0)
+  private val initTime = System.nanoTime()
 
-  override def generateParts(): Array[SourceFileInfo] = sourceInfo.sourceFiles.toArray
-
-  override def runOnPart(diffGraph: DiffGraphBuilder, fileInfo: SourceFileInfo): Unit = {
-    if (parserConfig.getSymbolResolver.isEmpty) {
-      parserConfig.setSymbolResolver(symbolResolver)
-    }
-    val parser      = new JavaParser(parserConfig)
-    val parseResult = parser.parse(new java.io.File(fileInfo.analysisFileName))
-
-    parseResult.getProblems.asScala.toList match {
-      case Nil => // Just carry on as usual
-      case problems =>
-        logger.warn(s"Encountered problems while parsing file ${fileInfo.analysisFileName}:")
-        problems.foreach { problem =>
-          logger.warn(s"- ${problem.getMessage}")
-        }
-    }
-
-    parseResult.getResult.toScala match {
-      case Some(result) if result.getParsed == Parsedness.PARSED =>
-        diffGraph.absorb(new AstCreator(fileInfo.originalFilename, result, global, symbolResolver).createAst())
-      case _ =>
-        logger.warn("Failed to parse file " + fileInfo.analysisFileName)
-    }
+  override def generateParts(): Array[JpAstWithMeta] = {
+    logger.info(s"Found ${asts.size} files.")
+    asts.toArray
   }
 
-  private def jarsList: List[String] = {
-    config.inferenceJarPaths.flatMap(recursiveJarsFromPath).toList
-  }
+  override def runOnPart(diffGraph: DiffGraphBuilder, astWithMeta: JpAstWithMeta): Unit = {
+    val originalFilename = astWithMeta.fileInfo.originalFilename
+    val result           = astWithMeta.compilationUnit
+    diffGraph.absorb(new AstCreator(originalFilename, result, global, symbolSolver).createAst())
 
-  private def recursiveJarsFromPath(path: String): List[String] = {
-    Try(File(path)) match {
-      case Success(file) if file.isDirectory =>
-        file.listRecursively
-          .map(_.canonicalPath)
-          .filter(_.endsWith(".jar"))
-          .toList
-
-      case Success(file) if file.canonicalPath.endsWith(".jar") =>
-        List(file.canonicalPath)
-
-      case _ =>
-        Nil
+    if (finished.addAndGet(1) % 250 == 0) {
+      val nowTime = System.nanoTime()
+      logger.info(s"Finished files: $finished")
+      logger.info(s"Time elapsed  : ${(nowTime - initTime) / 1000000000.0}")
     }
-  }
-
-  private def createSymbolSolver(): JavaSymbolSolver = {
-    val combinedTypeSolver   = new SimpleCombinedTypeSolver()
-    val reflectionTypeSolver = new CachingReflectionTypeSolver()
-    combinedTypeSolver.add(reflectionTypeSolver)
-
-    // Add solvers for all detected sources roots
-    sourceInfo.typeSolverSourceDirs.foreach { srcDir =>
-      val javaParserTypeSolver = new JavaParserTypeSolver(
-        Paths.get(srcDir),
-        new JavaParser(parserConfig),
-        new GuavaCache(CacheBuilder.newBuilder().build()),
-        new GuavaCache(CacheBuilder.newBuilder().build()),
-        NoCache.create() // Cache found types in combinedTypeSolver
-      )
-      combinedTypeSolver.add(javaParserTypeSolver)
-    }
-
-    // Add solvers for inference jars
-    (jarsList ++ dependencies)
-      .flatMap { path =>
-        Try(new JarTypeSolver(path)).toOption
-      }
-      .foreach { combinedTypeSolver.add(_) }
-
-    new JavaSymbolSolver(combinedTypeSolver)
   }
 
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -49,7 +49,7 @@ class AstCreationPass(sourceInfo: SourceDirectoryInfo, config: Config, cpg: Cpg,
 
     parseResult.getResult.toScala match {
       case Some(result) if result.getParsed == Parsedness.PARSED =>
-        diffGraph.absorb(new AstCreator(fileInfo.originalFileName, result, global, symbolResolver).createAst())
+        diffGraph.absorb(new AstCreator(fileInfo.originalFilename, result, global, symbolResolver).createAst())
       case _ =>
         logger.warn("Failed to parse file " + fileInfo.analysisFileName)
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -7,15 +7,11 @@ import io.joern.javasrc2cpg.{Config, JpAstWithMeta}
 import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory
 
-import java.util.concurrent.atomic.AtomicInteger
-
 class AstCreationPass(asts: List[JpAstWithMeta], config: Config, cpg: Cpg, symbolSolver: JavaSymbolSolver)
     extends ConcurrentWriterCpgPass[JpAstWithMeta](cpg) {
 
-  val global: Global   = new Global()
-  private val logger   = LoggerFactory.getLogger(classOf[AstCreationPass])
-  private val finished = new AtomicInteger(0)
-  private val initTime = System.nanoTime()
+  val global: Global = new Global()
+  private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
   override def generateParts(): Array[JpAstWithMeta] = {
     logger.info(s"Found ${asts.size} files.")
@@ -26,12 +22,6 @@ class AstCreationPass(asts: List[JpAstWithMeta], config: Config, cpg: Cpg, symbo
     val originalFilename = astWithMeta.fileInfo.originalFilename
     val result           = astWithMeta.compilationUnit
     diffGraph.absorb(new AstCreator(originalFilename, result, global, symbolSolver).createAst())
-
-    if (finished.addAndGet(1) % 250 == 0) {
-      val nowTime = System.nanoTime()
-      logger.info(s"Finished files: $finished")
-      logger.info(s"Time elapsed  : ${(nowTime - initTime) / 1000000000.0}")
-    }
   }
 
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -86,6 +86,8 @@ import com.github.javaparser.resolution.declarations.{
 }
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType, ResolvedTypeVariable}
+import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator
 import io.joern.javasrc2cpg.util.BindingTable.createBindingTable
 import io.joern.x2cpg.utils.NodeBuilders.{
   annotationLiteralNode,
@@ -105,10 +107,9 @@ import io.joern.javasrc2cpg.util.{
   LambdaBindingInfo,
   NameConstants,
   NodeTypeInfo,
-  Scope,
-  TypeInfoCalculator
+  Scope
 }
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.{ObjectMethodSignatures, TypeConstants}
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.{ObjectMethodSignatures, TypeConstants}
 import io.joern.javasrc2cpg.util.Util.{
   composeMethodFullName,
   composeMethodLikeSignature,
@@ -198,14 +199,14 @@ object AstWithStaticInit {
 
 /** Translate a Java Parser AST into a CPG AST
   */
-class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Global, symbolResolver: SymbolResolver)
+class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Global, symbolSolver: JavaSymbolSolver)
     extends AstCreatorBase(filename) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
   import AstCreator._
 
   private val scopeStack                       = Scope()
-  private val typeInfoCalc: TypeInfoCalculator = TypeInfoCalculator(global, symbolResolver)
+  private val typeInfoCalc: TypeInfoCalculator = TypeInfoCalculator(global, symbolSolver)
   private val partialConstructorQueue: mutable.ArrayBuffer[PartialConstructor] = mutable.ArrayBuffer.empty
   private val bindingTableCache = mutable.HashMap.empty[String, BindingTable]
 
@@ -373,12 +374,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
     bindingTableCache.getOrElseUpdate(
       fullName,
-      createBindingTable(
+      createBindingTable[ResolvedReferenceTypeDeclaration](
         fullName,
         typeDecl,
         getBindingTable,
         methodSignature,
-        new BindingTableAdapterForJavaparser(methodSignature)
+        new BindingTableAdapterForJavaparser(methodSignature),
+        (parentDecl, thisDecl) => thisDecl.getQualifiedName == parentDecl.getQualifiedName
       )
     )
   }
@@ -388,12 +390,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     bindingTableCache.getOrElseUpdate(
       fullName,
-      createBindingTable(
+      createBindingTable[LambdaBindingInfo](
         fullName,
         lambdaBindingInfo,
         getBindingTable,
         methodSignature,
-        new BindingTableAdapterForLambdas()
+        new BindingTableAdapterForLambdas(),
+        (parentDecl, thisInfo) => parentDecl.getQualifiedName == thisInfo.fullName
       )
     )
   }
@@ -992,10 +995,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def astForMethod(methodDeclaration: MethodDeclaration): Ast = {
 
-    val maybeResolved = tryWithSafeStackOverflow(methodDeclaration.resolve())
-    val expectedReturnType = Try(
-      symbolResolver.toResolvedType(methodDeclaration.getType, classOf[ResolvedType])
-    ).toOption
+    val maybeResolved      = tryWithSafeStackOverflow(methodDeclaration.resolve())
+    val expectedReturnType = Try(symbolSolver.toResolvedType(methodDeclaration.getType, classOf[ResolvedType])).toOption
     val returnTypeFullName = expectedReturnType
       .flatMap(typeInfoCalc.fullName)
       .orElse(scopeStack.lookupVariableType(methodDeclaration.getTypeAsString, wildcardFallback = true))
@@ -2113,7 +2114,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         variableTypeFullName.orElse(initializerTypeFullName)
 
       // Need the actual resolvedType here for when the RHS is a lambda expression.
-      val resolvedExpectedType = Try(symbolResolver.toResolvedType(variable.getType, classOf[ResolvedType])).toOption
+      val resolvedExpectedType = Try(symbolSolver.toResolvedType(variable.getType, classOf[ResolvedType])).toOption
       val initializerAsts      = astsForExpression(initializer, ExpectedType(typeFullName, resolvedExpectedType))
 
       val typeName = typeFullName

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1167,7 +1167,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case x: TryStmt          => astsForTry(x)
       case x: WhileStmt        => Seq(astForWhile(x))
       case x =>
-        logger.warn(s"Attempting to generate AST for unknown statement $x")
+        logger.warn(s"Attempting to generate AST for unknown statement of type ${x.getClass}")
         Seq(unknownAst(x))
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/CachingReflectionTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/CachingReflectionTypeSolver.scala
@@ -1,4 +1,4 @@
-package io.joern.javasrc2cpg.util
+package io.joern.javasrc2cpg.typesolvers
 
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
 import com.github.javaparser.symbolsolver.cache.GuavaCache

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
@@ -11,7 +11,8 @@ import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.Try
 
-class EagerSourceTypeSolver(asts: List[JpAstWithMeta]) extends TypeSolver {
+class EagerSourceTypeSolver(asts: List[JpAstWithMeta], combinedTypeSolver: SimpleCombinedTypeSolver)
+    extends TypeSolver {
 
   private val logger             = LoggerFactory.getLogger(this.getClass)
   private var parent: TypeSolver = _
@@ -31,9 +32,9 @@ class EagerSourceTypeSolver(asts: List[JpAstWithMeta]) extends TypeSolver {
                 name
             }
             val resolvedSymbol = Try(
-              SymbolReference.solved(JavaParserFacade.get(this).getTypeDeclaration(typeDeclaration)): SymbolReference[
-                ResolvedReferenceTypeDeclaration
-              ]
+              SymbolReference.solved(
+                JavaParserFacade.get(combinedTypeSolver).getTypeDeclaration(typeDeclaration)
+              ): SymbolReference[ResolvedReferenceTypeDeclaration]
             ).getOrElse(SymbolReference.unsolved(classOf[ResolvedReferenceTypeDeclaration]))
             name -> resolvedSymbol
           }
@@ -63,7 +64,7 @@ class EagerSourceTypeSolver(asts: List[JpAstWithMeta]) extends TypeSolver {
 }
 
 object EagerSourceTypeSolver {
-  def apply(asts: List[JpAstWithMeta]): EagerSourceTypeSolver = {
-    new EagerSourceTypeSolver(asts)
+  def apply(asts: List[JpAstWithMeta], combinedTypeSolver: SimpleCombinedTypeSolver): EagerSourceTypeSolver = {
+    new EagerSourceTypeSolver(asts, combinedTypeSolver)
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
@@ -1,0 +1,69 @@
+package io.joern.javasrc2cpg.typesolvers
+
+import com.github.javaparser.ast.body.TypeDeclaration
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade
+import com.github.javaparser.symbolsolver.model.resolution.{SymbolReference, TypeSolver}
+import io.joern.javasrc2cpg.JpAstWithMeta
+import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptional
+import scala.util.Try
+
+class EagerSourceTypeSolver(asts: List[JpAstWithMeta]) extends TypeSolver {
+
+  private val logger             = LoggerFactory.getLogger(this.getClass)
+  private var parent: TypeSolver = _
+
+  private val foundTypes: Map[String, SymbolReference[ResolvedReferenceTypeDeclaration]] = {
+    val ret = asts
+      .map(_.compilationUnit)
+      .flatMap { cu =>
+        cu.findAll(classOf[TypeDeclaration[_]])
+          .asScala
+          .map { typeDeclaration =>
+            val name = typeDeclaration.getFullyQualifiedName.toScala match {
+              case Some(fullyQualifiedName) => fullyQualifiedName
+              case None =>
+                val name = typeDeclaration.getNameAsString
+                logger.error(s"Could not find fully qualified name for typeDecl $name")
+                name
+            }
+            val resolvedSymbol = Try(
+              SymbolReference.solved(JavaParserFacade.get(this).getTypeDeclaration(typeDeclaration)): SymbolReference[
+                ResolvedReferenceTypeDeclaration
+              ]
+            ).getOrElse(SymbolReference.unsolved(classOf[ResolvedReferenceTypeDeclaration]))
+            name -> resolvedSymbol
+          }
+          .toList
+      }
+      .toMap
+    ret
+  }
+
+  override def getParent: TypeSolver = parent
+
+  override def setParent(parent: TypeSolver): Unit = {
+    if (parent == null) {
+      logger.warn(s"Cannot set parent of type solver to null. setParent will be ignored.")
+    } else if (this.parent != null) {
+      logger.warn(s"Attempting to re-set type solver parent. setParent will be ignored.")
+    } else if (parent == this) {
+      logger.warn(s"Parent of TypeSolver cannot be itself. setParent will be ignored.")
+    } else {
+      this.parent = parent
+    }
+  }
+
+  override def tryToSolveType(name: String): SymbolReference[ResolvedReferenceTypeDeclaration] = {
+    foundTypes.getOrElse(name, SymbolReference.unsolved(classOf[ResolvedReferenceTypeDeclaration]))
+  }
+}
+
+object EagerSourceTypeSolver {
+  def apply(asts: List[JpAstWithMeta]): EagerSourceTypeSolver = {
+    new EagerSourceTypeSolver(asts)
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
@@ -1,0 +1,83 @@
+package io.joern.javasrc2cpg.typesolvers
+
+import com.github.javaparser.resolution.UnsolvedSymbolException
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
+import com.github.javaparser.symbolsolver.cache.GuavaCache
+import com.github.javaparser.symbolsolver.model.resolution.{SymbolReference, TypeSolver}
+import com.google.common.cache.{CacheBuilder, LoadingCache}
+import org.slf4j.LoggerFactory
+
+import java.util.Objects
+import scala.collection.mutable
+import scala.jdk.OptionConverters.RichOptional
+import scala.util.Try
+import scala.util.control.Breaks.break
+
+class SimpleCombinedTypeSolver extends TypeSolver {
+
+  private val logger                                       = LoggerFactory.getLogger(this.getClass)
+  private var parent: TypeSolver                           = _
+  private val typeSolvers: mutable.ArrayBuffer[TypeSolver] = mutable.ArrayBuffer()
+  private val typeCache = new GuavaCache(
+    CacheBuilder.newBuilder().build[String, SymbolReference[ResolvedReferenceTypeDeclaration]]()
+  )
+
+  def add(typeSolver: TypeSolver): Unit = {
+    typeSolvers.append(typeSolver)
+    typeSolver.setParent(this)
+  }
+
+  private def unsolved: SymbolReference[ResolvedReferenceTypeDeclaration] =
+    SymbolReference.unsolved(classOf[ResolvedReferenceTypeDeclaration])
+
+  override def tryToSolveType(name: String): SymbolReference[ResolvedReferenceTypeDeclaration] = {
+    typeCache.get(name).toScala match {
+      case Some(result) => result
+
+      case None =>
+        // Use an iterator here so that the map is only applied until a solved result is found.
+        val result = typeSolvers.iterator
+          .map { typeSolver =>
+            try {
+              typeSolver.tryToSolveType(name): SymbolReference[ResolvedReferenceTypeDeclaration]
+            } catch {
+              case _: UnsolvedSymbolException  => unsolved
+              case _: StackOverflowError       => unsolved
+              case _: IllegalArgumentException =>
+                // RecordDeclarations aren't handled by JavaParser yet
+                unsolved
+              case unhandled =>
+                logger.warn("Caught unhandled exception", unhandled)
+                unsolved
+            }
+          }
+          .find(_.isSolved)
+          .getOrElse(unsolved)
+        typeCache.put(name, result)
+        result
+    }
+  }
+
+  override def solveType(name: String): ResolvedReferenceTypeDeclaration = {
+    val result = tryToSolveType(name)
+    if (result.isSolved)
+      result.getCorrespondingDeclaration
+    else
+      throw new UnsolvedSymbolException(name)
+  }
+
+  override def getParent: TypeSolver = parent
+
+  override def setParent(parent: TypeSolver): Unit = {
+    if (parent == null) {
+      logger.warn(s"Cannot set parent of type solver to null. setParent will be ignored.")
+    } else if (this.parent != null) {
+      logger.warn(s"Attempting to re-set type solver parent. setParent will be ignored.")
+    } else if (parent == this) {
+      logger.warn(s"Parent of TypeSolver cannot be itself. setParent will be ignored.")
+    } else {
+      this.parent = parent
+    }
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
@@ -7,11 +7,8 @@ import com.github.javaparser.symbolsolver.model.resolution.{SymbolReference, Typ
 import com.google.common.cache.{CacheBuilder, LoadingCache}
 import org.slf4j.LoggerFactory
 
-import java.util.Objects
 import scala.collection.mutable
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.Try
-import scala.util.control.Breaks.break
 
 class SimpleCombinedTypeSolver extends TypeSolver {
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
@@ -24,6 +24,11 @@ class SimpleCombinedTypeSolver extends TypeSolver {
     typeSolver.setParent(this)
   }
 
+  def prepend(typeSolver: TypeSolver): Unit = {
+    typeSolvers.prepend(typeSolver)
+    typeSolver.setParent(this)
+  }
+
   private def unsolved: SymbolReference[ResolvedReferenceTypeDeclaration] =
     SymbolReference.unsolved(classOf[ResolvedReferenceTypeDeclaration])
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -1,4 +1,4 @@
-package io.joern.javasrc2cpg.util
+package io.joern.javasrc2cpg.typesolvers
 
 import com.github.javaparser.ast.`type`.{PrimitiveType, Type}
 import com.github.javaparser.resolution.SymbolResolver
@@ -7,21 +7,11 @@ import com.github.javaparser.resolution.declarations.{
   ResolvedTypeDeclaration,
   ResolvedTypeParameterDeclaration
 }
+import com.github.javaparser.resolution.types._
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
-import com.github.javaparser.resolution.types.{
-  ResolvedArrayType,
-  ResolvedLambdaConstraintType,
-  ResolvedPrimitiveType,
-  ResolvedReferenceType,
-  ResolvedType,
-  ResolvedTypeVariable,
-  ResolvedUnionType,
-  ResolvedVoidType,
-  ResolvedWildcard
-}
 import com.github.javaparser.symbolsolver.logic.InferenceVariableType
 import com.github.javaparser.symbolsolver.model.typesystem.{LazyType, NullType}
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.{TypeConstants, TypeNameConstants}
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.{TypeConstants, TypeNameConstants}
 import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/BindingTable.scala
@@ -124,12 +124,13 @@ object BindingTable {
     typeDecl: T,
     getBindingTable: ResolvedReferenceTypeDeclaration => BindingTable,
     methodSignature: (ResolvedMethodDeclaration, ResolvedTypeParametersMap) => String,
-    adapter: BindingTableAdapter[T]
+    adapter: BindingTableAdapter[T],
+    typeEqualsDecl: (ResolvedReferenceTypeDeclaration, T) => Boolean
   ): BindingTable = {
     val bindingTable = new BindingTable()
 
     // Take over all binding table entries for parent class/interface binding tables.
-    adapter.directParents(typeDecl).foreach { parentTypeDecl =>
+    adapter.directParents(typeDecl).filterNot(typeEqualsDecl(_, typeDecl)).foreach { parentTypeDecl =>
       val parentBindingTable = getBindingTable(parentTypeDecl)
       parentBindingTable.getEntries.foreach { entry =>
         bindingTable.add(entry)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
@@ -2,7 +2,7 @@ package io.joern.javasrc2cpg.util
 
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
 import com.github.javaparser.resolution.types.ResolvedReferenceType
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 import io.joern.x2cpg.{Ast, Defines}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewFieldIdentifier, NewMember}
@@ -33,7 +33,7 @@ object Util {
     val result = mutable.ArrayBuffer.empty[ResolvedReferenceType]
 
     if (!typeDecl.isJavaLangObject) {
-      safeGetAncestors(typeDecl).foreach { ancestor =>
+      safeGetAncestors(typeDecl).filter(_.getQualifiedName != typeDecl.getQualifiedName).foreach { ancestor =>
         result.append(ancestor)
         getAllParents(ancestor, result)
       }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/InferenceJarTests.scala
@@ -1,7 +1,7 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 import io.joern.x2cpg.Defines
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.utils.ProjectRoot

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
@@ -1,7 +1,7 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 import io.joern.x2cpg.Defines
 import io.shiftleft.semanticcpg.language._
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
@@ -1,7 +1,7 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
-import io.joern.javasrc2cpg.util.TypeInfoCalculator.TypeConstants
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes


### PR DESCRIPTION
Changes included here:
* Add a new SimpleCombinedTypeSolver that does the same as the JavaParser CombinedTypeSolver, except that it caches types if solving results in StackOverflowErrors.
* Add a new EagerSourceTypeSolver to replace the JavaParserTypeSolver (which is responsible for source-based type solving). The JPTS parsed files a second time to search for types in them, so this new eager version pre-computes all types in the given compilation units instead. This does mean enough memory to store the types map must be available, but this seems to be a relatively small amount in the overall computation.
* Add caching to the TypeInferencePass to avoid expensive regex matches.

This brings AST creation time for elasticsearch down to under 10 minutes on a workstation with an i9 and enough RAM.