### PR TITLE
Use `List` instead of `mutable.Stack` for callsite stack

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -96,7 +96,7 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
         r
       } else {
         r.copy(path =
-          PathElement(startingPointToSource(r.startingPoint).asInstanceOf[CfgNode], r.callSiteStack.clone()) +: r.path
+          PathElement(startingPointToSource(r.startingPoint).asInstanceOf[CfgNode], r.callSiteStack) +: r.path
         )
       }
     }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -65,7 +65,7 @@ class ResultTable(
 case class ReachableByResult(
   path: Vector[PathElement],
   table: ResultTable,
-  callSiteStack: mutable.Stack[Call],
+  callSiteStack: List[Call],
   callDepth: Int = 0,
   partial: Boolean = false
 ) {
@@ -103,7 +103,7 @@ case class ReachableByResult(
   */
 case class PathElement(
   node: CfgNode,
-  callSiteStack: mutable.Stack[Call] = mutable.Stack(),
+  callSiteStack: List[Call] = List(),
   visible: Boolean = true,
   isOutputArg: Boolean = false,
   outEdgeLabel: String = ""

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -30,7 +30,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
       Vector()
     } else {
       implicit val sem: Semantics = context.semantics
-      val path                    = PathElement(task.sink, task.callSiteStack.clone()) +: task.initialPath
+      val path                    = PathElement(task.sink, task.callSiteStack) +: task.initialPath
       results(path, task.sources, task.table, task.callSiteStack)
       // TODO why do we update the call depth here?
       task.table.get(task.sink).get.map { r =>
@@ -61,7 +61,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
     path: Vector[PathElement],
     sources: Set[NodeType],
     table: ResultTable,
-    callSiteStack: mutable.Stack[Call]
+    callSiteStack: List[Call]
   )(implicit semantics: Semantics): Vector[ReachableByResult] = {
 
     val curNode = path.head.node
@@ -90,7 +90,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext) extends Callable
     def createPartialResultForOutputArgOrRet() = {
       Vector(
         ReachableByResult(
-          PathElement(path.head.node, callSiteStack.clone(), isOutputArg = true) +: path.tail,
+          PathElement(path.head.node, callSiteStack, isOutputArg = true) +: path.tail,
           table,
           callSiteStack,
           partial = true

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -23,8 +23,8 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1  = Vector(ReachableByResult(Vector(PathElement(node1)), new ResultTable, mutable.Stack()))
-      val res2  = Vector(ReachableByResult(Vector(PathElement(node2)), new ResultTable, mutable.Stack()))
+      val res1  = Vector(ReachableByResult(Vector(PathElement(node1)), new ResultTable, List()))
+      val res2  = Vector(ReachableByResult(Vector(PathElement(node2)), new ResultTable, List()))
       table.add(node1, res1)
       table.add(node1, res2)
       table.get(node1) match {
@@ -54,7 +54,7 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node4               = cpg.literal.code("moo").head
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table               = new ResultTable
-      table.add(pivotNode, Vector(ReachableByResult(pathContainingPivot, new ResultTable, mutable.Stack())))
+      table.add(pivotNode, Vector(ReachableByResult(pathContainingPivot, new ResultTable, List())))
       table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
         case Some(Vector(ReachableByResult(path, _, _, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)


### PR DESCRIPTION
Re: https://github.com/joernio/joern/pull/1967

Cleaning up and redesigning the caching at the same time may have been a bit optimistic. I am now bringing in the cleanups first and testing whether any of the cleanups negatively impact performance. In this PR, I'm getting rid of the `mutable.Stack` for call site stacks first.