### PR TITLE
Complete held tasks

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -63,6 +63,7 @@ class ResultTable(
   *   backwards into method output parameters.
   */
 case class ReachableByResult(
+  sink : CfgNode,
   path: Vector[PathElement],
   table: ResultTable,
   callSiteStack: List[Call],

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -63,7 +63,7 @@ class ResultTable(
   *   backwards into method output parameters.
   */
 case class ReachableByResult(
-  sink : CfgNode,
+  sink: CfgNode,
   path: Vector[PathElement],
   table: ResultTable,
   callSiteStack: List[Call],

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -23,8 +23,8 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1  = Vector(ReachableByResult(Vector(PathElement(node1)), new ResultTable, List()))
-      val res2  = Vector(ReachableByResult(Vector(PathElement(node2)), new ResultTable, List()))
+      val res1  = Vector(ReachableByResult(node1, Vector(PathElement(node1)), new ResultTable, List()))
+      val res2  = Vector(ReachableByResult(node1, Vector(PathElement(node2)), new ResultTable, List()))
       table.add(node1, res1)
       table.add(node1, res2)
       table.get(node1) match {
@@ -54,9 +54,9 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node4               = cpg.literal.code("moo").head
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table               = new ResultTable
-      table.add(pivotNode, Vector(ReachableByResult(pathContainingPivot, new ResultTable, List())))
+      table.add(pivotNode, Vector(ReachableByResult(node1, pathContainingPivot, new ResultTable, List())))
       table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
-        case Some(Vector(ReachableByResult(path, _, _, _, _))) =>
+        case Some(Vector(ReachableByResult(_, path, _, _, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case _ => fail()
       }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -176,6 +176,9 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val source = cpg.identifier.name("a")
     val sink   = cpg.call.code("foo.*").argument
     val flows  = sink.reachableByFlows(source)
+
+    println(flows.p)
+
     flows.size shouldBe 2
   }
 
@@ -543,7 +546,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
 
     val sink = cpg.call("sink1").argument(1).l
     val src  = cpg.identifier.name("foo").l
-    sink.reachableBy(src).size shouldBe 1
+    sink.reachableBy(src).size shouldBe 2
   }
 
   "Flow through constructor" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -58,9 +58,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val source = cpg.identifier.name("a")
     val sink   = cpg.call.code("foo.*").argument
     val flows  = sink.reachableByFlows(source)
-
-    flows.map(flowToResultPairs).toSetMutable shouldBe
-      Set(List(("foo(a)", 7)), List(("var a = 10", 5), ("a < y", 6), ("foo(a)", 7)), List(("a < y", 6), ("foo(a)", 7)))
+    flows.size shouldBe 6
   }
 
   "Flow chains from x to a" in {
@@ -176,10 +174,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val source = cpg.identifier.name("a")
     val sink   = cpg.call.code("foo.*").argument
     val flows  = sink.reachableByFlows(source)
-
-    println(flows.p)
-
-    flows.size shouldBe 2
+    flows.size shouldBe 4
   }
 
   "Flow from function foo to a" in {
@@ -546,7 +541,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
 
     val sink = cpg.call("sink1").argument(1).l
     val src  = cpg.identifier.name("foo").l
-    sink.reachableBy(src).size shouldBe 2
+    sink.reachableBy(src).size shouldBe 1
   }
 
   "Flow through constructor" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/RequirePassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/RequirePassTests.scala
@@ -71,7 +71,7 @@ class RequirePassTests extends DataFlowCodeToCpgSuite {
 
     val sink   = cpg.call("log").argument(1)
     val source = cpg.literal.codeExact("\"literal\"")
-    sink.reachableByFlows(source).size shouldBe 1
+    sink.reachableByFlows(source).size shouldBe 2
   }
 
 }


### PR DESCRIPTION
In https://github.com/joernio/joern/pull/1947, we ensured that tasks would never be computed twice. Unfortunately, we forgot to complete tasks that were held due to this optimization and just discarded them. This lead to missing flows in situations where two sinks lead to the same sources, while traversal for one of them was held and discarded. This PR fixes that issue by keeping a table of completed tasks and storing held tasks. Once all tasks have been solved, held tasks are completed and added to the result list.