### PR TITLE
Cfg step adjustments.

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DdgGenerator.scala
@@ -19,11 +19,9 @@ class DdgGenerator {
   private val edgeCache = mutable.Map[StoredNode, List[Edge]]()
 
   def generate(methodNode: Method)(implicit semantics: Semantics = DefaultSemantics()): Graph = {
-    val entryNode                  = methodNode
     val paramNodes                 = methodNode.parameter.l
     val allOtherNodes              = methodNode.cfgNode.l
-    val exitNode                   = methodNode.methodReturn
-    val allNodes: List[StoredNode] = List(entryNode, exitNode) ++ paramNodes ++ allOtherNodes
+    val allNodes: List[StoredNode] = paramNodes ++ allOtherNodes
     val visibleNodes               = allNodes.filter(shouldBeDisplayed)
 
     val edges = visibleNodes.map { dstNode =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
@@ -13,7 +13,7 @@ class CfgGenerator {
   val edgeType: String = EdgeTypes.CFG
 
   def generate(methodNode: Method): Graph = {
-    val vertices          = methodNode.cfgNode.l ++ List(methodNode, methodNode.methodReturn) ++ methodNode.parameter.l
+    val vertices          = methodNode.cfgNode.l ++ methodNode.parameter.l
     val verticesToDisplay = vertices.filter(cfgNodeShouldBeDisplayed)
 
     def edgesToDisplay(srcNode: StoredNode, visited: List[StoredNode] = List()): List[Edge] = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -23,7 +23,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
   /** Successors in the CFG
     */
   def cfgNext: Traversal[CfgNode] = {
-    node._cfgOut.filterNot(_.isInstanceOf[MethodReturn]).collectAll[CfgNode]
+    node._cfgOut.collectAll[CfgNode]
   }
 
   /** Maps each node in the traversal to a traversal returning its n successors.
@@ -43,7 +43,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
   /** Predecessors in the CFG
     */
   def cfgPrev: Traversal[CfgNode] = {
-    node._cfgIn.filterNot(_.isInstanceOf[Method]).collectAll[CfgNode]
+    node._cfgIn.collectAll[CfgNode]
   }
 
   /** Recursively determine all nodes on which this CFG node is control-dependent.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -23,7 +23,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
   /** Successors in the CFG
     */
   def cfgNext: Traversal[CfgNode] = {
-    Traversal.fromSingle(node).cfgNext
+    node._cfgOut.filterNot(_.isInstanceOf[MethodReturn]).collectAll[CfgNode]
   }
 
   /** Maps each node in the traversal to a traversal returning its n successors.
@@ -43,7 +43,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
   /** Predecessors in the CFG
     */
   def cfgPrev: Traversal[CfgNode] = {
-    Traversal.fromSingle(node).cfgPrev
+    node._cfgIn.filterNot(_.isInstanceOf[Method]).collectAll[CfgNode]
   }
 
   /** Recursively determine all nodes on which this CFG node is control-dependent.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -33,7 +33,7 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
   }
 
   def cfgNode: Traversal[CfgNode] =
-    method._containsOut.collectAll[CfgNode]
+    method ++ method._containsOut.collectAll[CfgNode] ++ method.methodReturn
 
   /** List of CFG nodes in reverse post order
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -37,19 +37,13 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
 
   @Doc(info = "Nodes directly reachable via outgoing CFG edges")
   def cfgNext: Traversal[CfgNode] =
-    traversal
-      .out(EdgeTypes.CFG)
-      .not(_.hasLabel(NodeTypes.METHOD_RETURN))
-      .cast[CfgNode]
+    traversal.flatMap(_.cfgNext)
 
   /** Traverse to previous expression in CFG.
     */
   @Doc(info = "Nodes directly reachable via incoming CFG edges")
   def cfgPrev: Traversal[CfgNode] =
-    traversal
-      .in(EdgeTypes.CFG)
-      .not(_.hasLabel(NodeTypes.METHOD))
-      .cast[CfgNode]
+    traversal.flatMap(_.cfgPrev)
 
   /** All nodes reachable in the CFG by up to n forward expansions
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -136,7 +136,7 @@ class MethodTraversal(val iterableOnce: IterableOnce[Method]) extends AnyVal {
       .not(_.hasLabel(NodeTypes.LOCAL))
       .cast[Expression]
 
-  @Doc(info = "Control flow graph nodes")
+  @Doc(info = "Control flow graph nodes. This include the method itself as entry and the method return node as exit.")
   def cfgNode: Traversal[CfgNode] =
     traversal.flatMap(_.cfgNode)
 


### PR DESCRIPTION
- Step `cfgNode` now also return Methode and MethodReturn nodes.

- Do not filter out Method and MethodReturn nodes anymore.

- Define steps on travesal based on steps on individual node.