### PR TITLE
refactor: move querydb.language.android to semanticcpg

### DIFF
--- a/querydb/src/main/scala/io/joern/querydb/language/android/ConfigFileTraversal.scala
+++ b/querydb/src/main/scala/io/joern/querydb/language/android/ConfigFileTraversal.scala
@@ -1,6 +1,6 @@
 package io.joern.querydb.language.android
 
-import io.joern.x2cpg.utils.xml.SecureXmlParsing
+import io.joern.semanticcpg.utils.SecureXmlParsing
 import io.shiftleft.codepropertygraph.generated.nodes
 import overflowdb.traversal._
 

--- a/querydb/src/main/scala/io/joern/scanners/android/ExternalStorage.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/ExternalStorage.scala
@@ -23,7 +23,7 @@ object ExternalStorage extends QueryBundle {
       score = 9,
       withStrRep({ cpg =>
         import overflowdb.traversal.Traversal
-        import io.joern.querydb.language.android._
+        import io.shiftleft.semanticcpg.language.android._
         import io.joern.x2cpg.Defines.ConstructorMethodName
 
         def externalStorageReads =

--- a/querydb/src/main/scala/io/joern/scanners/android/Intents.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/Intents.scala
@@ -21,7 +21,7 @@ object Intents extends QueryBundle {
       description = "-",
       score = 9,
       withStrRep({ cpg =>
-        import io.joern.querydb.language.android._
+        import io.shiftleft.semanticcpg.language.android._
         val exportedActivityNames = cpg.configFile.exportedAndroidActivityNames.l
         def exportedActivities =
           cpg.typeDecl.filter { node => exportedActivityNames.contains(node.name) }

--- a/querydb/src/main/scala/io/joern/scanners/android/JavaScriptInterface.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/JavaScriptInterface.scala
@@ -24,7 +24,7 @@ object JavaScriptInterface extends QueryBundle {
       score = 9,
       withStrRep({ cpg =>
         import overflowdb.traversal.Traversal
-        import io.joern.querydb.language.android._
+        import io.shiftleft.semanticcpg.language.android._
         import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 
         def webViewsWithInsecureLoadUrlCalls =

--- a/querydb/src/main/scala/io/joern/scanners/android/Misconfigurations.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/Misconfigurations.scala
@@ -21,7 +21,7 @@ object Misconfigurations extends QueryBundle {
           |""".stripMargin,
       score = 3,
       withStrRep({ cpg =>
-        import io.joern.x2cpg.utils.xml.SecureXmlParsing
+        import io.joern.semanticcpg.utils.SecureXmlParsing
 
         val androidUri = "http://schemas.android.com/apk/res/android"
         cpg.configFile

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/ConfigFileTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/ConfigFileTraversal.scala
@@ -1,4 +1,4 @@
-package io.joern.querydb.language.android
+package io.shiftleft.semanticcpg.language.android
 
 import io.joern.semanticcpg.utils.SecureXmlParsing
 import io.shiftleft.codepropertygraph.generated.nodes

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/Constants.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/Constants.scala
@@ -1,4 +1,4 @@
-package io.joern.querydb.language.android
+package io.shiftleft.semanticcpg.language.android
 
 object Constants {
   val androidUri         = "http://schemas.android.com/apk/res/android"

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/LocalTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/LocalTraversal.scala
@@ -1,4 +1,4 @@
-package io.joern.querydb.language.android
+package io.shiftleft.semanticcpg.language.android
 
 import io.shiftleft.codepropertygraph.generated.nodes.Local
 import io.shiftleft.semanticcpg.language._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/MethodTraversal.scala
@@ -1,4 +1,4 @@
-package io.joern.querydb.language.android
+package io.shiftleft.semanticcpg.language.android
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import overflowdb.traversal._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/NodeTypeStarters.scala
@@ -1,6 +1,5 @@
-package io.joern.querydb.language.android.starters
+package io.shiftleft.semanticcpg.language.android
 
-import io.joern.querydb.language.android.Constants
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/package.scala
@@ -1,12 +1,14 @@
-package io.joern.querydb.language
+package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{ConfigFile, Literal, Local, Method}
-import overflowdb.traversal.{Traversal, iterableToTraversal}
+import overflowdb.traversal.Traversal
 
+/** Language extensions for android. */
 package object android {
-  implicit def toNodeTypeStartersFlows(cpg: Cpg): starters.NodeTypeStarters =
-    new starters.NodeTypeStarters(cpg)
+
+  implicit def toNodeTypeStartersFlows(cpg: Cpg): NodeTypeStarters =
+    new NodeTypeStarters(cpg)
 
   implicit def singleToLocalExt[A <: Local](a: A): LocalTraversal =
     new LocalTraversal(Traversal.fromSingle(a))
@@ -25,4 +27,5 @@ package object android {
 
   implicit def iterOnceToMethodExt[A <: Method](a: IterableOnce[A]): MethodTraversal =
     new MethodTraversal(iterableToTraversal(a))
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/SecureXmlParsing.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/SecureXmlParsing.scala
@@ -1,4 +1,4 @@
-package io.joern.x2cpg.utils.xml
+package io.joern.semanticcpg.utils
 
 import javax.xml.parsers.SAXParserFactory
 import scala.util.Try


### PR DESCRIPTION
background: we'd like to use it downstream without inheriting a large 
dependency tree incl. console and various frontends