### PR TITLE
JsSrc2Cpg: Argument index and order property related changes.

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -114,7 +114,7 @@ class AstCreator(
       createParameterInNode("this", "this", 0, isVariadic = false, line = lineNumber, column = columnNumber)
 
     val methodChildren = astsForFile(astNodeInfo)
-    setIndices(methodChildren)
+    setArgIndices(methodChildren)
 
     val methodReturn = NewMethodReturn()
       .code("RET")

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -176,7 +176,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     }
 
     val asts = fromAst +: (specifierAsts ++ declAsts.flatten)
-    setIndices(asts)
+    setArgIndices(asts)
     blockAst(createBlockNode(declaration), asts)
   }
 
@@ -190,7 +190,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     }
 
     val asts = declAsts.toList.flatten
-    setIndices(asts)
+    setArgIndices(asts)
     blockAst(createBlockNode(assignment), asts)
   }
 
@@ -206,7 +206,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     }
 
     val asts = declAsts.toList.flatten
-    setIndices(asts)
+    setArgIndices(asts)
     blockAst(createBlockNode(declaration), asts)
   }
 
@@ -223,7 +223,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     val assignmentCallAst = createExportAssignmentCallAst(s"_$name", exportCallAst, declaration)
 
     val asts = List(fromCallAst, assignmentCallAst)
-    setIndices(asts)
+    setArgIndices(asts)
     blockAst(createBlockNode(declaration), asts)
   }
 
@@ -237,7 +237,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     val declAsts = declaration.json("declarations").arr.toList.map(astForVariableDeclarator(_, scopeType, kind))
     declAsts match {
       case head :: tail =>
-        setIndices(declAsts)
+        setArgIndices(declAsts)
         tail.foreach { declAst =>
           declAst.root.foreach(diffGraph.addEdge(localAstParentStack.head, _, EdgeTypes.AST))
           Ast.storeInDiffGraph(declAst, diffGraph)
@@ -633,7 +633,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     localAstParentStack.pop()
 
     val blockChildren = assignmentTmpCallAst +: subTreeAsts :+ Ast(returnTmpNode)
-    setIndices(blockChildren)
+    setArgIndices(blockChildren)
     Ast(blockNode).withChildren(blockChildren)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -133,7 +133,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     scope.popScope()
     localAstParentStack.pop()
 
-    setIndices(List(assignmentTmpAllocCallNode, callNode, tmpAllocReturnNode))
+    setArgIndices(List(assignmentTmpAllocCallNode, callNode, tmpAllocReturnNode))
     Ast(blockNode).withChild(assignmentTmpAllocCallNode).withChild(callNode).withChild(tmpAllocReturnNode)
   }
 
@@ -309,7 +309,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     scope.pushNewBlockScope(blockNode)
     localAstParentStack.push(blockNode)
     val sequenceExpressionAsts = createBlockStatementAsts(seq.json("expressions"))
-    setIndices(sequenceExpressionAsts)
+    setArgIndices(sequenceExpressionAsts)
     localAstParentStack.pop()
     scope.popScope()
     Ast(blockNode).withChildren(sequenceExpressionAsts)
@@ -396,7 +396,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
       localAstParentStack.pop()
 
       val blockChildrenAsts = List(assignmentTmpArrayCallNode) ++ elementAsts :+ Ast(tmpArrayReturnNode)
-      setIndices(blockChildrenAsts)
+      setArgIndices(blockChildrenAsts)
       Ast(blockNode).withChildren(blockChildrenAsts)
     }
   }
@@ -469,7 +469,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     scope.popScope()
     localAstParentStack.pop()
 
-    setIndices(propertiesAsts)
+    setArgIndices(propertiesAsts)
     Ast(blockNode).withChildren(propertiesAsts).withChild(Ast(tmpNode))
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -469,7 +469,8 @@ trait AstForExpressionsCreator { this: AstCreator =>
     scope.popScope()
     localAstParentStack.pop()
 
+    val allBlockChildren = propertiesAsts :+ Ast(tmpNode)
     setArgIndices(propertiesAsts)
-    Ast(blockNode).withChildren(propertiesAsts).withChild(Ast(tmpNode))
+    Ast(blockNode).withChildren(allBlockChildren)
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -284,7 +284,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
     val mAst = if (methodBlockContent.isEmpty) {
       methodStubAst(methodNode, thisNode +: paramNodes, methodReturnNode, List(virtualModifierNode))
     } else {
-      setIndices(methodBlockContent)
+      setArgIndices(methodBlockContent)
       val bodyAst = blockAst(NewBlock(), methodBlockContent)
       methodAst(methodNode, thisNode +: paramNodes, bodyAst, methodReturnNode)
     }
@@ -357,7 +357,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
         }
       case _ => createBlockStatementAsts(bodyJson("body"))
     }
-    setIndices(methodBlockContent ++ additionalBlockStatements.toList ++ bodyStmtAsts)
+    setArgIndices(methodBlockContent ++ additionalBlockStatements.toList ++ bodyStmtAsts)
 
     val methodReturnNode = createMethodReturnNode(func)
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -253,7 +253,7 @@ trait AstForStatementsCreator { this: AstCreator =>
     val switchExpressionAst = astForNode(switchStmt.json("discriminant"))
 
     val blockNode = createBlockNode(switchStmt)
-    val blockAst = Ast(blockNode)
+    val blockAst  = Ast(blockNode)
     scope.pushNewBlockScope(blockNode)
     localAstParentStack.push(blockNode)
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -42,7 +42,7 @@ trait AstForStatementsCreator { this: AstCreator =>
   protected def createBlockStatementAsts(json: Value): List[Ast] = {
     val blockStmts = sortBlockStatements(json.arr.map(createBabelNodeInfo).toList)
     val blockAsts  = blockStmts.map(stmt => astForNodeWithFunctionReferenceAndCall(stmt.json))
-    setIndices(blockAsts)
+    setArgIndices(blockAsts)
     blockAsts
   }
 
@@ -51,7 +51,7 @@ trait AstForStatementsCreator { this: AstCreator =>
     scope.pushNewBlockScope(blockNode)
     localAstParentStack.push(blockNode)
     val blockStatementAsts = createBlockStatementAsts(block.json("body"))
-    setIndices(blockStatementAsts)
+    setArgIndices(blockStatementAsts)
     localAstParentStack.pop()
     scope.popScope()
     Ast(blockNode).withChildren(blockStatementAsts)
@@ -184,7 +184,7 @@ trait AstForStatementsCreator { this: AstCreator =>
     localAstParentStack.pop()
 
     val labelAsts = List(Ast(labeledNode), bodyAst)
-    setIndices(labelAsts)
+    setArgIndices(labelAsts)
     Ast(blockNode).withChildren(labelAsts)
   }
 
@@ -258,7 +258,7 @@ trait AstForStatementsCreator { this: AstCreator =>
     localAstParentStack.push(blockNode)
 
     val casesAsts = switchStmt.json("cases").arr.flatMap(c => astsForSwitchCase(createBabelNodeInfo(c)))
-    setIndices(casesAsts.toList)
+    setArgIndices(casesAsts.toList)
 
     scope.popScope()
     localAstParentStack.pop()

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
@@ -15,7 +15,7 @@ trait AstForTemplateDomCreator { this: AstCreator =>
     val closingAst   = safeObj(jsxElem.json, "closingElement").map(e => astForNode(Obj(e))).getOrElse(Ast())
 
     val allChildrenAsts = openingAst +: childrenAsts :+ closingAst
-    setIndices(allChildrenAsts)
+    setArgIndices(allChildrenAsts)
 
     Ast(domNode).withChildren(allChildrenAsts)
   }
@@ -28,14 +28,14 @@ trait AstForTemplateDomCreator { this: AstCreator =>
       jsxFragment.columnNumber
     )
     val childrenAsts = astForNodes(jsxFragment.json("children").arr.toList)
-    setIndices(childrenAsts)
+    setArgIndices(childrenAsts)
     Ast(domNode).withChildren(childrenAsts)
   }
 
   protected def astForJsxAttribute(jsxAttr: BabelNodeInfo): Ast = {
     val domNode  = createTemplateDomNode(jsxAttr.node.toString, jsxAttr.code, jsxAttr.lineNumber, jsxAttr.columnNumber)
     val valueAst = safeObj(jsxAttr.json, "value").map(e => astForNode(Obj(e))).getOrElse(Ast())
-    setIndices(List(valueAst))
+    setArgIndices(List(valueAst))
     Ast(domNode).withChild(valueAst)
   }
 
@@ -47,7 +47,7 @@ trait AstForTemplateDomCreator { this: AstCreator =>
       jsxOpeningElem.columnNumber
     )
     val childrenAsts = astForNodes(jsxOpeningElem.json("attributes").arr.toList)
-    setIndices(childrenAsts)
+    setArgIndices(childrenAsts)
     Ast(domNode).withChildren(childrenAsts)
   }
 
@@ -76,7 +76,7 @@ trait AstForTemplateDomCreator { this: AstCreator =>
       case JSXEmptyExpression => Ast()
       case _                  => astForNode(nodeInfo.json)
     }
-    setIndices(List(exprAst))
+    setArgIndices(List(exprAst))
     Ast(domNode).withChild(exprAst)
   }
 
@@ -88,7 +88,7 @@ trait AstForTemplateDomCreator { this: AstCreator =>
       jsxSpreadAttr.columnNumber
     )
     val argAst = astForNode(jsxSpreadAttr.json("argument"))
-    setIndices(List(argAst))
+    setArgIndices(List(argAst))
     Ast(domNode).withChild(argAst)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -108,7 +108,6 @@ trait AstNodeBuilder { this: AstCreator =>
     val receiverRoot = receiver.flatMap(_.root).toList
     receiverRoot match {
       case List(x: ExpressionNew) =>
-        x.argumentIndex = 0
         x.order = 0
       case _ =>
     }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -76,6 +76,10 @@ trait AstNodeBuilder { this: AstCreator =>
       .columnNumber(column)
   }
 
+  protected def setOrderExplicitly(ast: Ast, order: Int): Unit = {
+    ast.root.foreach { case expr: ExpressionNew => expr.order = order }
+  }
+
   protected def setIndices(
     asts: List[Ast],
     receiver: Option[Ast] = None,
@@ -89,7 +93,7 @@ trait AstNodeBuilder { this: AstCreator =>
       a.root match {
         case Some(x: ExpressionNew) =>
           x.argumentIndex = currIndex
-          x.order = currOrder
+          //x.order = currOrder
           currIndex = currIndex + 1
           currOrder = currOrder + 1
         case None if !countEmpty => // do nothing
@@ -102,13 +106,13 @@ trait AstNodeBuilder { this: AstCreator =>
     baseRoot match {
       case List(x: ExpressionNew) =>
         x.argumentIndex = 0
-        x.order = 1
+        //x.order = 1
       case _ =>
     }
     val receiverRoot = receiver.flatMap(_.root).toList
     receiverRoot match {
       case List(x: ExpressionNew) =>
-        x.order = 0
+        //x.order = 0
       case _ =>
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -80,41 +80,23 @@ trait AstNodeBuilder { this: AstCreator =>
     ast.root.foreach { case expr: ExpressionNew => expr.order = order }
   }
 
-  protected def setIndices(
+  protected def setArgIndices(
     asts: List[Ast],
-    receiver: Option[Ast] = None,
-    countEmpty: Boolean = false,
     base: Option[Ast] = None
   ): Unit = {
     var currIndex = 1
-    var currOrder = if (base.isDefined) 2 else 1
 
     asts.foreach { a =>
       a.root match {
         case Some(x: ExpressionNew) =>
           x.argumentIndex = currIndex
-          //x.order = currOrder
           currIndex = currIndex + 1
-          currOrder = currOrder + 1
-        case None if !countEmpty => // do nothing
+        case None => // do nothing
         case _ =>
           currIndex = currIndex + 1
-          currOrder = currOrder + 1
       }
     }
-    val baseRoot = base.flatMap(_.root).toList
-    baseRoot match {
-      case List(x: ExpressionNew) =>
-        x.argumentIndex = 0
-        //x.order = 1
-      case _ =>
-    }
-    val receiverRoot = receiver.flatMap(_.root).toList
-    receiverRoot match {
-      case List(x: ExpressionNew) =>
-        //x.order = 0
-      case _ =>
-    }
+    base.flatMap(_.root).foreach{ case expr: ExpressionNew => expr.argumentIndex = 0}
   }
 
   protected def createCallAst(
@@ -123,7 +105,7 @@ trait AstNodeBuilder { this: AstCreator =>
     receiver: Option[Ast] = None,
     base: Option[Ast] = None
   ): Ast = {
-    setIndices(arguments, receiver, base = base)
+    setArgIndices(arguments, base = base)
 
     val receiverRoot = receiver.flatMap(_.root).toList
     val rcvAst       = receiver.getOrElse(Ast())
@@ -139,7 +121,7 @@ trait AstNodeBuilder { this: AstCreator =>
   }
 
   protected def createReturnAst(returnNode: NewReturn, arguments: List[Ast] = List()): Ast = {
-    setIndices(arguments)
+    setArgIndices(arguments)
     Ast(returnNode)
       .withChildren(arguments)
       .withArgEdges(returnNode, arguments.flatMap(_.root))

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -80,10 +80,7 @@ trait AstNodeBuilder { this: AstCreator =>
     ast.root.foreach { case expr: ExpressionNew => expr.order = order }
   }
 
-  protected def setArgIndices(
-    asts: List[Ast],
-    base: Option[Ast] = None
-  ): Unit = {
+  protected def setArgIndices(asts: List[Ast], base: Option[Ast] = None): Unit = {
     var currIndex = 1
 
     asts.foreach { a =>
@@ -96,7 +93,7 @@ trait AstNodeBuilder { this: AstCreator =>
           currIndex = currIndex + 1
       }
     }
-    base.flatMap(_.root).foreach{ case expr: ExpressionNew => expr.argumentIndex = 0}
+    base.flatMap(_.root).foreach { case expr: ExpressionNew => expr.argumentIndex = 0 }
   }
 
   protected def createCallAst(

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
@@ -166,14 +166,12 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       constructorCall.astChildren.isIdentifier.nameExact("MyClass").size shouldBe 1
 
       val List(receiver) = constructorCall.receiver.isIdentifier.nameExact("MyClass").l
-      receiver.order shouldBe 0
+      receiver.argumentIndex shouldBe -1
 
       val List(tmpArg0) = constructorCall.astChildren.isIdentifier.nameExact(tmpName).l
-      tmpArg0.order shouldBe 1
       tmpArg0.argumentIndex shouldBe 0
 
       val List(tmpArg0Argument) = constructorCall.argument.isIdentifier.nameExact(tmpName).l
-      tmpArg0Argument.order shouldBe 1
       tmpArg0Argument.argumentIndex shouldBe 0
 
       val List(returnTmp) = newCallBlock.astChildren.isIdentifier.l
@@ -204,14 +202,12 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       constructorCall.astChildren.isIdentifier.nameExact("MyClass").size shouldBe 1
 
       val List(receiver) = constructorCall.receiver.isIdentifier.nameExact("MyClass").l
-      receiver.order shouldBe 0
+      receiver.argumentIndex shouldBe -1
 
       val List(tmpArg0) = constructorCall.astChildren.isIdentifier.nameExact(tmpName).l
-      tmpArg0.order shouldBe 1
       tmpArg0.argumentIndex shouldBe 0
 
       val List(tmpArg0Argument) = constructorCall.argument.isIdentifier.nameExact(tmpName).l
-      tmpArg0Argument.order shouldBe 1
       tmpArg0Argument.argumentIndex shouldBe 0
 
       val List(arg1) = constructorCall.astChildren.isIdentifier.nameExact("arg1").l
@@ -258,14 +254,12 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
 
       val List(receiver) = constructorCall.receiver.isCall.codeExact("foo.bar.MyClass").l
       receiver.name shouldBe Operators.fieldAccess
-      receiver.order shouldBe 0
+      receiver.argumentIndex shouldBe -1
 
       val List(tmpArg0) = constructorCall.astChildren.isIdentifier.nameExact(tmpName).l
-      tmpArg0.order shouldBe 1
       tmpArg0.argumentIndex shouldBe 0
 
       val List(tmpArg0Argument) = constructorCall.argument.isIdentifier.nameExact(tmpName).l
-      tmpArg0Argument.order shouldBe 1
       tmpArg0Argument.argumentIndex shouldBe 0
 
       val List(returnTmp) = newCallBlock.astChildren.isIdentifier.l
@@ -299,14 +293,12 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       constructorCall.astChildren.isIdentifier.nameExact("Foo").size shouldBe 1
 
       val List(receiver) = constructorCall.receiver.isIdentifier.nameExact("Foo").l
-      receiver.order shouldBe 0
+      receiver.argumentIndex shouldBe -1
 
       val List(tmpArg0) = constructorCall.astChildren.isIdentifier.nameExact(tmpName).l
-      tmpArg0.order shouldBe 1
       tmpArg0.argumentIndex shouldBe 0
 
       val List(tmpArg0Argument) = constructorCall.argument.isIdentifier.nameExact(tmpName).l
-      tmpArg0Argument.order shouldBe 1
       tmpArg0Argument.argumentIndex shouldBe 0
 
       val List(returnTmp) = newCallBlock.astChildren.isIdentifier.l

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1086,14 +1086,12 @@ class MixedAstCreationPassTest extends AbstractPassTest {
 
       val List(receiver) = fooCall.receiver.isIdentifier.l
       receiver.name shouldBe "foo"
-      receiver.order shouldBe 0
+      receiver.argumentIndex shouldBe -1
 
       val List(argumentThis) = fooCall.astChildren.isIdentifier.nameExact("this").l
-      argumentThis.order shouldBe 1
       argumentThis.argumentIndex shouldBe 0
 
       val List(argument1) = fooCall.astChildren.isIdentifier.nameExact("args").l
-      argument1.order shouldBe 2
       argument1.argumentIndex shouldBe 1
     }
 
@@ -1104,14 +1102,12 @@ class MixedAstCreationPassTest extends AbstractPassTest {
 
       val List(receiver) = fooCall.receiver.isIdentifier.l
       receiver.name shouldBe "foo"
-      receiver.order shouldBe 0
+      receiver.argumentIndex shouldBe -1
 
       val List(argumentThis) = fooCall.astChildren.isIdentifier.nameExact("this").l
-      argumentThis.order shouldBe 1
       argumentThis.argumentIndex shouldBe 0
 
       val List(argument1) = fooCall.astChildren.isCall.codeExact("x.bar()").l
-      argument1.order shouldBe 2
       argument1.argumentIndex shouldBe 1
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1489,7 +1489,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
     val List(pushCallReceiver) = pushCall.receiver.isCall.l
     pushCallReceiver.name shouldBe Operators.fieldAccess
-    pushCallReceiver.argumentIndex shouldBe 0
+    pushCallReceiver.argumentIndex shouldBe -1
 
     val pushCallReceiverBase = pushCallReceiver.argument(1).asInstanceOf[Identifier]
     pushCallReceiverBase.name shouldBe "_tmp_0"

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -503,14 +503,12 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(receiver) = fooCall.receiver.isIdentifier.l
       receiver.name shouldBe "foo"
-      receiver.order shouldBe 0
+      receiver.argumentIndex shouldBe -1
 
       val List(argumentThis) = fooCall.astChildren.isIdentifier.nameExact("this").l
-      argumentThis.order shouldBe 1
       argumentThis.argumentIndex shouldBe 0
 
       val List(argument1) = fooCall.astChildren.isIdentifier.nameExact("x").l
-      argument1.order shouldBe 2
       argument1.argumentIndex shouldBe 1
     }
 
@@ -528,7 +526,7 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       receiver shouldBe receiverViaAst
       receiver.code shouldBe "(_tmp_0 = x.foo(y)).bar"
       receiver.name shouldBe Operators.fieldAccess
-      receiver.order shouldBe 0
+      receiver.argumentIndex shouldBe -1
 
       val List(barIdentifier) = receiver.astChildren.isFieldIdentifier.l
       barIdentifier.canonicalName shouldBe "bar"
@@ -537,7 +535,6 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(tmpAssignment) = receiver.astChildren.isCall.l
       tmpAssignment.code shouldBe "(_tmp_0 = x.foo(y))"
       tmpAssignment.name shouldBe "<operator>.assignment"
-      tmpAssignment.order shouldBe 1
 
       val List(tmpIdentifier) = tmpAssignment.astChildren.isIdentifier.l
       tmpIdentifier.name shouldBe "_tmp_0"
@@ -552,11 +549,9 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
       val List(thisArg) = barCall.astChildren.isIdentifier.argumentIndex(0).l
       thisArg.name shouldBe "_tmp_0"
-      thisArg.order shouldBe 1
 
       val List(zArg) = barCall.astChildren.isIdentifier.argumentIndex(1).l
       zArg.name shouldBe "z"
-      zArg.order shouldBe 2
     }
 
     "be correct for call on object" in AstFixture("""
@@ -609,10 +604,8 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(baseArg, arg) = call.argument.l.sortBy(_.order)
       baseArg.code shouldBe "a"
       baseArg.argumentIndex shouldBe 0
-      baseArg.order shouldBe 1
       arg.code shouldBe "x"
       arg.argumentIndex shouldBe 1
-      arg.order shouldBe 2
     }
 
     "have block for while body for while statement with brackets" in AstFixture("while (x < 0) {}") { cpg =>
@@ -1493,19 +1486,19 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
 
     val pushCallReceiverBase = pushCallReceiver.argument(1).asInstanceOf[Identifier]
     pushCallReceiverBase.name shouldBe "_tmp_0"
-    pushCallReceiverBase.order shouldBe 1
+    pushCallReceiverBase.argumentIndex shouldBe 1
 
     val pushCallReceiverMember = pushCallReceiver.argument(2).asInstanceOf[FieldIdentifier]
     pushCallReceiverMember.canonicalName shouldBe "push"
-    pushCallReceiverMember.order shouldBe 2
+    pushCallReceiverMember.argumentIndex shouldBe 2
 
     val pushCallThis = pushCall.argument(1).asInstanceOf[Identifier]
     pushCallThis.name shouldBe "_tmp_0"
-    pushCallThis.order shouldBe 1
+    pushCallThis.argumentIndex shouldBe 1
 
     val pushCallArg = pushCall.argument(2).asInstanceOf[Literal]
     pushCallArg.code shouldBe element.toString
-    pushCallArg.order shouldBe 2
+    pushCallArg.argumentIndex shouldBe 2
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -1,8 +1,8 @@
 package io.joern.x2cpg
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode.PropertyDefaults
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, ExpressionNew, NewNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, ExpressionNew, NewBlock, NewCall, NewControlStructure, NewFieldIdentifier, NewIdentifier, NewLiteral, NewMethodRef, NewNode, NewReturn, NewTypeRef, NewUnknown}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 case class AstEdge(src: NewNode, dst: NewNode)
@@ -146,6 +146,28 @@ case class Ast(
 
   def withArgEdges(src: NewNode, dsts: Seq[NewNode]): Ast = {
     this.copy(argEdges = argEdges ++ dsts.map(AstEdge(src, _)))
+  }
+
+  def withArgEdges(src: NewNode, dsts: Seq[NewNode], argIndexStart: Int): Ast = {
+    var index = argIndexStart
+    this.copy(argEdges = argEdges ++ dsts.map { dst =>
+      addArgumentIndex(dst, index)
+      index += 1
+      AstEdge(src, dst)
+    })
+  }
+
+  private def addArgumentIndex(node: NewNode, argIndex: Int): Unit = node match {
+    case n: NewBlock            => n.argumentIndex = argIndex
+    case n: NewCall             => n.argumentIndex = argIndex
+    case n: NewFieldIdentifier  => n.argumentIndex = argIndex
+    case n: NewIdentifier       => n.argumentIndex = argIndex
+    case n: NewMethodRef        => n.argumentIndex = argIndex
+    case n: NewTypeRef          => n.argumentIndex = argIndex
+    case n: NewUnknown          => n.argumentIndex = argIndex
+    case n: NewControlStructure => n.argumentIndex = argIndex
+    case n: NewLiteral          => n.argumentIndex = argIndex
+    case n: NewReturn           => n.argumentIndex = argIndex
   }
 
   def withConditionEdges(src: NewNode, dsts: List[NewNode]): Ast = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -2,7 +2,21 @@ package io.joern.x2cpg
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode.PropertyDefaults
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, ExpressionNew, NewBlock, NewCall, NewControlStructure, NewFieldIdentifier, NewIdentifier, NewLiteral, NewMethodRef, NewNode, NewReturn, NewTypeRef, NewUnknown}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  AstNodeNew,
+  ExpressionNew,
+  NewBlock,
+  NewCall,
+  NewControlStructure,
+  NewFieldIdentifier,
+  NewIdentifier,
+  NewLiteral,
+  NewMethodRef,
+  NewNode,
+  NewReturn,
+  NewTypeRef,
+  NewUnknown
+}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 case class AstEdge(src: NewNode, dst: NewNode)


### PR DESCRIPTION
- missing argumentIndex on last block element identifier.

- Rename setIndices to setArgIndices and cleanup in that function as
  it does not set order anymore.

- Set order mostly implicitly via Ast relation.

- Dont set argument index to 0 for receiver.
  The call receiver in Javascript is not passed into calls as instance object
  and thus an argument index of 0 was not correct.