### PR TITLE
jssrc2cpg: improved support for ObjectProperty

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -435,7 +435,14 @@ trait AstForExpressionsCreator { this: AstCreator =>
           val keyNode = createFieldIdentifierNode(keyName, nodeInfo.lineNumber, nodeInfo.columnNumber)
           (keyNode, astForFunctionDeclaration(nodeInfo, shouldCreateFunctionReference = true))
         case ObjectProperty =>
-          val keyName = code(nodeInfo.json("key"))
+          val key = createBabelNodeInfo(nodeInfo.json("key"))
+          val keyName = key.node match {
+            case Identifier if nodeInfo.json("computed").bool =>
+              key.code
+            case _ if nodeInfo.json("computed").bool =>
+              generateUnusedVariableName(usedVariableNames, "_computed_object_property")
+            case _ => key.code
+          }
           val keyNode = createFieldIdentifierNode(keyName, nodeInfo.lineNumber, nodeInfo.columnNumber)
           val ast     = astForNodeWithFunctionReference(nodeInfo.json("value"))
           (keyNode, ast)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -330,11 +330,14 @@ trait AstNodeBuilder { this: AstCreator =>
     name: String,
     line: Option[Integer],
     column: Option[Integer]
-  ): NewFieldIdentifier = NewFieldIdentifier()
-    .code(name)
-    .canonicalName(name)
-    .lineNumber(line)
-    .columnNumber(column)
+  ): NewFieldIdentifier = {
+    val cleanedName = stripQuotes(name)
+    NewFieldIdentifier()
+      .code(cleanedName)
+      .canonicalName(cleanedName)
+      .lineNumber(line)
+      .columnNumber(column)
+  }
 
   protected def createLiteralNode(
     code: String,

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/SimpleCfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/SimpleCfgCreationPassTest.scala
@@ -9,8 +9,6 @@ import io.joern.x2cpg.testfixtures.CfgTestFixture
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.Cpg
 
-import scala.annotation.unused
-
 class SimpleCfgCreationPassTest extends CfgTestFixture(() => new JsCfgTestCpg()) {
 
   "CFG generation for simple fragments" should {
@@ -241,10 +239,22 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new JsCfgTestCpg())
       succOf("foo(a + 1, b)") shouldBe expected(("RET", AlwaysEdge))
     }
 
-    "be correct for chained calls" ignore {
-      @unused
+    "be correct for chained calls" in {
       implicit val cpg: Cpg = code("x.foo(y).bar(z)")
-      // TODO the current style of writing this tests in unmaintainable.
+      succOf(":program") shouldBe expected(("_tmp_0", AlwaysEdge))
+      succOf("_tmp_0") shouldBe expected(("x", AlwaysEdge))
+      succOf("x") shouldBe expected(("foo", AlwaysEdge))
+      succOf("foo") shouldBe expected(("x.foo", AlwaysEdge))
+      succOf("x.foo") shouldBe expected(("x", 1, AlwaysEdge))
+      succOf("x", 1) shouldBe expected(("y", AlwaysEdge))
+      succOf("y") shouldBe expected(("x.foo(y)", AlwaysEdge))
+      succOf("x.foo(y)") shouldBe expected(("(_tmp_0 = x.foo(y))", AlwaysEdge))
+      succOf("(_tmp_0 = x.foo(y))") shouldBe expected(("bar", AlwaysEdge))
+      succOf("bar") shouldBe expected(("(_tmp_0 = x.foo(y)).bar", AlwaysEdge))
+      succOf("(_tmp_0 = x.foo(y)).bar") shouldBe expected(("_tmp_0", 1, AlwaysEdge))
+      succOf("_tmp_0", 1) shouldBe expected(("z", AlwaysEdge))
+      succOf("z") shouldBe expected(("x.foo(y).bar(z)", AlwaysEdge))
+      succOf("x.foo(y).bar(z)") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "be correct for unary expression '++'" in {


### PR DESCRIPTION
Now with limited support for computed properties.
Also fixed field identifier names for string-based literals there.