### PR TITLE
`s/SimpleCpgPass/CpgPass/g`

### DIFF
--- a/console/src/main/scala/io/joern/console/Commit.scala
+++ b/console/src/main/scala/io/joern/console/Commit.scala
@@ -1,6 +1,6 @@
 package io.joern.console
 
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
@@ -19,7 +19,7 @@ class Commit(opts: CommitOptions) extends LayerCreator {
   override val storeOverlayName: Boolean = false
 
   override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
-    val pass: SimpleCpgPass = new SimpleCpgPass(context.cpg) {
+    val pass: CpgPass = new CpgPass(context.cpg) {
       override val name = "commit"
       override def run(builder: DiffGraphBuilder): Unit = {
         builder.absorb(opts.diffGraphBuilder)

--- a/console/src/main/scala/io/joern/console/Run.scala
+++ b/console/src/main/scala/io/joern/console/Run.scala
@@ -1,6 +1,6 @@
 package io.joern.console
 
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.HasStoreMethod
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
 import org.reflections8.Reflections
@@ -16,7 +16,7 @@ object Run {
       override val description: String = "A custom pass"
 
       override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
-        val pass: SimpleCpgPass = new SimpleCpgPass(console.cpg) {
+        val pass: CpgPass = new CpgPass(console.cpg) {
           override val name = "custom"
           override def run(builder: DiffGraphBuilder): Unit = {
             query.store()(builder)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
@@ -7,14 +7,14 @@ import io.joern.c2cpg.utils.IncludeAutoDiscovery
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, NodeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.Ast
 import overflowdb.traversal.toNodeTraversal
 
-class HeaderContentPass(cpg: Cpg, config: Config) extends SimpleCpgPass(cpg) {
+class HeaderContentPass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
 
   private val systemIncludePaths =
     IncludeAutoDiscovery.discoverIncludePathsC(config) ++ IncludeAutoDiscovery.discoverIncludePathsCPP(config)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/MetaDataPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/MetaDataPass.scala
@@ -2,10 +2,10 @@ package io.joern.ghidra2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{Languages, nodes}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import overflowdb.BatchedUpdate
 
-class MetaDataPass(filename: String, cpg: Cpg) extends SimpleCpgPass(cpg) {
+class MetaDataPass(filename: String, cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
     diffGraph.addNode(

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/TypesPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/TypesPass.scala
@@ -3,9 +3,9 @@ package io.joern.ghidra2cpg.passes
 import io.joern.ghidra2cpg._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 
-class TypesPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class TypesPass(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     Types.types

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsReturnEdgesPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsReturnEdgesPass.scala
@@ -2,11 +2,11 @@ package io.joern.ghidra2cpg.passes.mips
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 
-class MipsReturnEdgesPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class MipsReturnEdgesPass(cpg: Cpg) extends CpgPass(cpg) {
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/ReturnEdgesPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/ReturnEdgesPass.scala
@@ -2,11 +2,11 @@ package io.joern.ghidra2cpg.passes.x86
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.LoggerFactory
 
-class ReturnEdgesPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class ReturnEdgesPass(cpg: Cpg) extends CpgPass(cpg) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPass.scala
@@ -3,9 +3,9 @@ package io.joern.jssrc2cpg.passes
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNamespaceBlock, NewType, NewTypeDecl}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 
-class BuiltinTypesPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class BuiltinTypesPass(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val namespaceBlock = NewNamespaceBlock()

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
@@ -1,14 +1,14 @@
 package io.joern.jssrc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import overflowdb.BatchedUpdate
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
 /** A pass that identifies assignments of closures to constants and updates `METHOD` nodes accordingly.
   */
-class ConstClosurePass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class ConstClosurePass(cpg: Cpg) extends CpgPass(cpg) {
   override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
     for {
       assignment      <- cpg.assignment

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
@@ -5,11 +5,11 @@ import io.joern.jssrc2cpg.utils.PackageJsonParser
 import io.joern.x2cpg.SourceFiles
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewDependency
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 
 import java.nio.file.Paths
 
-class DependenciesPass(cpg: Cpg, config: Config) extends SimpleCpgPass(cpg) {
+class DependenciesPass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val packagesJsons = SourceFiles

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JsMetaDataPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JsMetaDataPass.scala
@@ -4,9 +4,9 @@ import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 
-class JsMetaDataPass(cpg: Cpg, hash: String, inputPath: String) extends SimpleCpgPass(cpg) {
+class JsMetaDataPass(cpg: Cpg, hash: String, inputPath: String) extends CpgPass(cpg) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val absolutePathToRoot = File(inputPath).path.toAbsolutePath.toString

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
@@ -4,7 +4,7 @@ import io.joern.jssrc2cpg.passes.RequirePass.JS_EXPORT_PREFIX
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call, Identifier, Local}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate
 import overflowdb.traversal.{NodeOps, Traversal}
@@ -14,7 +14,7 @@ import java.nio.file.Paths
 
 /** This pass enhances the call graph and call nodes by interpreting assignments of the form `foo = require("module")`.
   */
-class RequirePass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class RequirePass(cpg: Cpg) extends CpgPass(cpg) {
 
   private val codeRoot = cpg.metaData.root.headOption.getOrElse("")
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/TypeNodePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/TypeNodePass.scala
@@ -2,9 +2,9 @@ package io.joern.jssrc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewType
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 
-class TypeNodePass(usedTypes: List[(String, String)], cpg: Cpg) extends SimpleCpgPass(cpg, "types") {
+class TypeNodePass(usedTypes: List[(String, String)], cpg: Cpg) extends CpgPass(cpg, "types") {
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val filteredTypes = usedTypes.filterNot { case (name, _) =>
       name == Defines.ANY || Defines.JSTYPES.contains(name)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/AstLinkerPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/AstLinkerPass.scala
@@ -9,10 +9,10 @@ import io.joern.x2cpg.passes.callgraph.MethodRefLinker.{
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 
-class AstLinkerPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class AstLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
 
   import MethodRefLinker.{logFailedSrcLookup, logger}
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/FileCreationPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/FileCreationPass.scala
@@ -3,7 +3,7 @@ package io.joern.x2cpg.passes.base
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewFile, StoredNode}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 import io.joern.x2cpg.passes.callgraph.MethodRefLinker
@@ -13,7 +13,7 @@ import scala.collection.mutable
 /** For all nodes with FILENAME fields, create corresponding FILE nodes and connect node with FILE node via outgoing
   * SOURCE_FILE edges.
   */
-class FileCreationPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class FileCreationPass(cpg: Cpg) extends CpgPass(cpg) {
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     val originalFileNameToNode = mutable.Map.empty[String, StoredNode]
     val newFileNameToNode      = mutable.Map.empty[String, NewFile]

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodDecoratorPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodDecoratorPass.scala
@@ -2,7 +2,7 @@ package io.joern.x2cpg.passes.base
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -11,7 +11,7 @@ import org.slf4j.{Logger, LoggerFactory}
   *
   * This pass has MethodStubCreator as prerequisite for language frontends which do not provide method stubs.
   */
-class MethodDecoratorPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
   import MethodDecoratorPass.logger
 
   private[this] var loggedDeprecatedWarning   = false

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -4,7 +4,7 @@ import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, NodeTypes}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate
 
@@ -15,7 +15,7 @@ case class NameAndSignature(name: String, signature: String, fullName: String)
 
 /** This pass has no other pass as prerequisite.
   */
-class MethodStubCreator(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
   // Since the method fullNames for fuzzyc are not unique, we do not have
   // a 1to1 relation and may overwrite some values. This is ok for now.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/NamespaceCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/NamespaceCreator.scala
@@ -3,14 +3,14 @@ package io.joern.x2cpg.passes.base
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.NewNamespace
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 
 /** Creates NAMESPACE nodes and connects NAMESPACE_BLOCKs to corresponding NAMESPACE nodes.
   *
   * This pass has no other pass as prerequisite.
   */
-class NamespaceCreator(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class NamespaceCreator(cpg: Cpg) extends CpgPass(cpg) {
 
   /** Creates NAMESPACE nodes and connects NAMESPACE_BLOCKs to corresponding NAMESPACE nodes.
     */

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
@@ -3,14 +3,14 @@ package io.joern.x2cpg.passes.base
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.PropertyNames
 import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn.PropertyDefaults
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import overflowdb.BatchedUpdate
 import io.shiftleft.semanticcpg.language._
 
 /** Old CPGs use the `order` field to indicate the parameter index while newer CPGs use the `parameterIndex` field. This
   * pass checks whether `parameterIndex` is not set, in which case the value of `order` is copied over.
   */
-class ParameterIndexCompatPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class ParameterIndexCompatPass(cpg: Cpg) extends CpgPass(cpg) {
   override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
     cpg.parameter.foreach { param =>
       if (param.index == PropertyDefaults.Index) {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/TypeDeclStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/TypeDeclStubCreator.scala
@@ -3,14 +3,14 @@ package io.joern.x2cpg.passes.base
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{NewTypeDecl, TypeDeclBase}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.{FileTraversal, NamespaceTraversal}
 
 /** This pass has no other pass as prerequisite. For each `TYPE` node that does not have a corresponding `TYPE_DECL`
   * node, this pass creates a `TYPE_DECL` node. The `TYPE_DECL` is considered external.
   */
-class TypeDeclStubCreator(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
   private var typeDeclFullNameToNode = Map[String, TypeDeclBase]()
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/TypeUsagePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/TypeUsagePass.scala
@@ -2,10 +2,10 @@ package io.joern.x2cpg.passes.base
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.joern.x2cpg.passes.callgraph.MethodRefLinker.{linkToSingle, typeDeclFullNameToNode, typeFullNameToNode}
 
-class TypeUsagePass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class TypeUsagePass(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     // Create REF edges from TYPE nodes to TYPE_DECL

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -3,7 +3,7 @@ package io.joern.x2cpg.passes.callgraph
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, TypeDecl}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.{NodeDb, NodeRef}
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters._
   * Based on the algorithm by Jang, Dongseok & Tatlock, Zachary & Lerner, Sorin. (2014). SAFEDISPATCH: Securing C++
   * Virtual Calls from Memory Corruption Attacks. 10.14722/ndss.2014.23287.
   */
-class DynamicCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   import DynamicCallLinker._
   // Used to track potential method candidates for a given method fullname. Since our method full names contain the type

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/MethodRefLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/MethodRefLinker.scala
@@ -3,7 +3,7 @@ package io.joern.x2cpg.passes.callgraph
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.joern.x2cpg.passes.callgraph.MethodRefLinker._
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb._
@@ -15,7 +15,7 @@ import scala.jdk.CollectionConverters._
 /** This pass has MethodStubCreator and TypeDeclStubCreator as prerequisite for language frontends which do not provide
   * method stubs and type decl stubs.
   */
-class MethodRefLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class MethodRefLinker(cpg: Cpg) extends CpgPass(cpg) {
   import MethodRefLinker.linkToSingle
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
@@ -3,13 +3,13 @@ package io.joern.x2cpg.passes.callgraph
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.mutable
 
-class StaticCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class StaticCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   import StaticCallLinker._
   private val methodFullNameToNode = mutable.Map.empty[String, List[Method]]

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/JavascriptCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/JavascriptCallLinker.scala
@@ -3,7 +3,7 @@ package io.joern.x2cpg.passes.frontend
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.{NodeOps, jIteratortoTraversal}
 
@@ -12,7 +12,7 @@ import scala.collection.mutable
 /** The Javascript specific call linker links static call sites (by full name) and call sites to methods in the same
   * file (by name).
   */
-class JavascriptCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class JavascriptCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   private type MethodsByNameAndFileType = mutable.HashMap[(String, String), Method]
   private type MethodsByFullNameType    = mutable.HashMap[String, Method]

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/MetaDataPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/MetaDataPass.scala
@@ -3,13 +3,13 @@ package io.joern.x2cpg.passes.frontend
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewMetaData, NewNamespaceBlock}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.types.structure.{FileTraversal, NamespaceTraversal}
 
 /** A pass that creates a MetaData node, specifying that this is a CPG for language, and a NamespaceBlock for anything
   * that cannot be assigned to any other namespace.
   */
-class MetaDataPass(cpg: Cpg, language: String, root: String) extends SimpleCpgPass(cpg) {
+class MetaDataPass(cpg: Cpg, language: String, root: String) extends CpgPass(cpg) {
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     def addMetaDataNode(diffGraph: DiffGraphBuilder): Unit = {
       val absolutePathToRoot = File(root).path.toAbsolutePath.toString

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonModuleDefinedCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonModuleDefinedCallLinker.scala
@@ -3,7 +3,7 @@ package io.joern.x2cpg.passes.frontend
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, TypeDecl}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 
 import java.io.File
@@ -15,7 +15,7 @@ import java.util.regex.Matcher
   * @param cpg
   *   the target code property graph.
   */
-class PythonModuleDefinedCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class PythonModuleDefinedCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(builder: DiffGraphBuilder): Unit =
     cpg.method.where(_.nameExact("<module>")).foreach(module => runOnModule(module, builder))

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonNaiveCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/PythonNaiveCallLinker.scala
@@ -2,7 +2,7 @@ package io.joern.x2cpg.passes.frontend
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.jIteratortoTraversal
 
@@ -10,7 +10,7 @@ import overflowdb.traversal.jIteratortoTraversal
   * @param cpg
   *   the target code property graph.
   */
-class PythonNaiveCallLinker(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class PythonNaiveCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     val methodNameToNode = cpg.method.toList.groupBy(_.name)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
@@ -3,12 +3,12 @@ package io.joern.x2cpg.passes.frontend
 import io.joern.x2cpg.passes.frontend.TypeNodePass.fullToShortName
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewType
-import io.shiftleft.passes.{KeyPool, SimpleCpgPass}
+import io.shiftleft.passes.{KeyPool, CpgPass}
 
 /** Creates a `TYPE` node for each type in `usedTypes`
   */
 class TypeNodePass(usedTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] = None)
-    extends SimpleCpgPass(cpg, "types", keyPool) {
+    extends CpgPass(cpg, "types", keyPool) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/typerelations/AliasLinkerPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/typerelations/AliasLinkerPass.scala
@@ -3,10 +3,10 @@ package io.joern.x2cpg.passes.typerelations
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.joern.x2cpg.passes.callgraph.MethodRefLinker.{linkToMultiple, typeFullNameToNode}
 
-class AliasLinkerPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class AliasLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     // Create ALIAS_OF edges from TYPE_DECL nodes to
     // TYPE

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/typerelations/TypeHierarchyPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/typerelations/TypeHierarchyPass.scala
@@ -3,12 +3,12 @@ package io.joern.x2cpg.passes.typerelations
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, PropertyNames}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.joern.x2cpg.passes.callgraph.MethodRefLinker.{linkToMultiple, typeFullNameToNode}
 
 /** Create INHERITS_FROM edges from `TYPE_DECL` nodes to `TYPE` nodes.
   */
-class TypeHierarchyPass(cpg: Cpg) extends SimpleCpgPass(cpg) {
+class TypeHierarchyPass(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     linkToMultiple(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -2,14 +2,14 @@ package io.shiftleft.semanticcpg
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Properties
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate
 
 object Overlays {
 
   def appendOverlayName(cpg: Cpg, overlayName: String): Unit = {
-    new SimpleCpgPass(cpg) {
+    new CpgPass(cpg) {
       override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
         cpg.metaData.headOption match {
           case Some(metaData) =>
@@ -23,7 +23,7 @@ object Overlays {
   }
 
   def removeLastOverlayName(cpg: Cpg): Unit = {
-    new SimpleCpgPass(cpg) {
+    new CpgPass(cpg) {
       override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
         cpg.metaData.headOption match {
           case Some(metaData) =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Languages, ModifierTypes}
-import io.shiftleft.passes.SimpleCpgPass
+import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate
 import overflowdb.BatchedUpdate.DiffGraphBuilder
@@ -202,7 +202,7 @@ package object testing {
     def withCustom(f: (DiffGraphBuilder, Cpg) => Unit): MockCpg = {
       val diffGraph = new DiffGraphBuilder
       f(diffGraph, cpg)
-      class MyPass extends SimpleCpgPass(cpg) {
+      class MyPass extends CpgPass(cpg) {
         override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit = {
           builder.absorb(diffGraph)
         }


### PR DESCRIPTION
removes a number of deprecation warnings plaguing the logs
```
$ find . -name "*scala" -type f | xargs -I{} sed -i -E 's/SimpleCpgPass/CpgPass/g' {}
```