### PR TITLE
kotlin2cpg: inner class naming

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeRenderer.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeRenderer.scala
@@ -87,9 +87,7 @@ object TypeRenderer {
             }
           } else {
             val descriptor = TypeUtils.getClassDescriptor(t)
-            if (descriptor.isInner) {
-              JvmClassName.byClassId(descriptor.getSource.asInstanceOf[KotlinSourceElement].getPsi.asInstanceOf[KtClass].getClassId).toString
-            } else if (DescriptorUtils.isCompanionObject(descriptor)) {
+            if (DescriptorUtils.isCompanionObject(descriptor)) {
               val rendered            = stripped(renderer.renderFqName(fqName))
               val companionObjectName = descriptor.getName
               // replaces `apkg.ContainingClass.CompanionObjectName` with `apkg.ContainingClass$CompanionObjectName`

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InnerClassesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/InnerClassesTests.scala
@@ -2,9 +2,7 @@ package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
-import org.scalatest.Ignore
 
-@Ignore
 class InnerClassesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   implicit val resolver: ICallResolver = NoResolve
@@ -25,5 +23,9 @@ class InnerClassesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
         |""".stripMargin)
 
     // TODO: add the test cases
+
+    "should contain inner class name `Outer$Inner`" in {
+      cpg.typ.fullNameExact("Outer$Inner").l.size shouldBe 1
+    }
   }
 }


### PR DESCRIPTION
I wanted to try contributing a fix but got stuck. The following code isn't correct but does solve the errornous inner class naming issue present in kotlin2cpg. Inner classes should follow `Outer$Inner` naming but currently Joern names as `Outer.Inner`.