### PR TITLE
refactor: simplify

### DIFF
--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -101,10 +101,9 @@ object JoernExport extends App {
     val context = new LayerCreatorContext(cpg)
 
     format match {
+      case Format.Dot if representation == Representation.All || representation == Representation.Cpg =>
+        exportWithOdbFormat(cpg, representation, outDir, DotExporter)
       case Format.Dot =>
-        if (representation == Representation.All || representation == Representation.Cpg)
-          exportWithOdbFormat(cpg, representation, outDir, DotExporter)
-        else
           exportDot(representation, outDir, context)
       case Format.Neo4jCsv =>
         exportWithOdbFormat(cpg, representation, outDir, Neo4jCsvExporter)

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -104,7 +104,7 @@ object JoernExport extends App {
       case Format.Dot if representation == Representation.All || representation == Representation.Cpg =>
         exportWithOdbFormat(cpg, representation, outDir, DotExporter)
       case Format.Dot =>
-          exportDot(representation, outDir, context)
+        exportDot(representation, outDir, context)
       case Format.Neo4jCsv =>
         exportWithOdbFormat(cpg, representation, outDir, Neo4jCsvExporter)
       case Format.Graphml =>

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -101,8 +101,6 @@ object JoernExport extends App {
     val context = new LayerCreatorContext(cpg)
 
     format match {
-      case Format.Dot if representation == Representation.All || representation == Representation.Cpg =>
-        exportWithOdbFormat(cpg, representation, outDir, DotExporter)
       case Format.Dot =>
         if (representation == Representation.All || representation == Representation.Cpg)
           exportWithOdbFormat(cpg, representation, outDir, DotExporter)


### PR DESCRIPTION
The removed code performs the same comparison as the code directly below it.

Found this code while investigating:
```
Exception in thread "main" scala.MatchError: All (of class scala.Enumeration$Val)
	at io.joern.joerncli.JoernExport$.exportDot(JoernExport.scala:120)
	at io.joern.joerncli.JoernExport$.exportCpg(JoernExport.scala:105)
	at io.joern.joerncli.JoernExport$.$anonfun$new$8(JoernExport.scala:90)
	at io.joern.joerncli.JoernExport$.$anonfun$new$8$adapted(JoernExport.scala:89)
	at scala.util.Using$.resource(Using.scala:261)
	at io.joern.joerncli.JoernExport$.$anonfun$new$7(JoernExport.scala:89)
	at io.joern.joerncli.JoernExport$.$anonfun$new$7$adapted(JoernExport.scala:83)
	at scala.Option.foreach(Option.scala:437)
	at io.joern.joerncli.JoernExport$.delayedEndpoint$io$joern$joerncli$JoernExport$1(JoernExport.scala:83)
	at io.joern.joerncli.JoernExport$delayedInit$body.apply(JoernExport.scala:25)
	at scala.Function0.apply$mcV$sp(Function0.scala:39)
	at scala.Function0.apply$mcV$sp$(Function0.scala:39)
	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
	at scala.App.$anonfun$main$1(App.scala:76)
	at scala.App.$anonfun$main$1$adapted(App.scala:76)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at scala.App.main(App.scala:76)
	at scala.App.main$(App.scala:74)
	at io.joern.joerncli.JoernExport$.main(JoernExport.scala:25)
	at io.joern.joerncli.JoernExport.main(JoernExport.scala)
```

Edit: The issue above seems to stem from old dependencies on the classpath. Deleted all joern files and re-ran quick installation instructions to fix.