### PR TITLE
javasrc2cpg: Fixed issue when reading single file 

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -77,8 +77,22 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     }
   }
 
-  private def getSourcesFromDir(sourceDir: String): List[String] = {
-    SourceRootFinder.getSourceRoots(sourceDir).flatMap(SourceFiles.determine(_, sourceFileExtensions))
+  /** Will extract source files from the given path if it is a directory, or in the case of a single file, will check
+    * the file's extension and return a singleton list of the file if the file extension is supported.
+    * @param sourcePath
+    *   the input directory or source file.
+    * @return
+    *   a list of all source files.
+    */
+  private def getSourcesFromDir(sourcePath: String): List[String] = {
+    val f = File(sourcePath)
+    if (f.isDirectory)
+      SourceRootFinder.getSourceRoots(sourcePath).flatMap(SourceFiles.determine(_, sourceFileExtensions))
+    else if (f.hasExtension && f.extension.exists(f => sourceFileExtensions.contains(f))) {
+      List(sourcePath)
+    } else {
+      List.empty
+    }
   }
 
   private def parseFile(filename: String): Option[CompilationUnit] = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -88,11 +88,10 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
     val f = File(sourcePath)
     if (f.isDirectory)
       SourceRootFinder.getSourceRoots(sourcePath).flatMap(SourceFiles.determine(_, sourceFileExtensions))
-    else if (f.hasExtension && f.extension.exists(f => sourceFileExtensions.contains(f))) {
+    else if (f.hasExtension && f.extension.exists(f => sourceFileExtensions.contains(f)))
       List(sourcePath)
-    } else {
+    else
       List.empty
-    }
   }
 
   private def parseFile(filename: String): Option[CompilationUnit] = {


### PR DESCRIPTION
Reading in a single file with `javasrc` gives the following stacktrace
```
java.nio.file.NotDirectoryException: /Users/david/Documents/joernio/joern/tests/swap/swap.java
        at java.base/sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:419)
        at java.base/java.nio.file.Files.newDirectoryStream(Files.java:482)
        at java.base/java.nio.file.Files.list(Files.java:3793)
        at better.files.File.list(File.scala:747)
        at better.files.File.children(File.scala:749)
        at io.joern.javasrc2cpg.util.SourceRootFinder$.statePreSrc(SourceRootFinder.scala:19)
```

The following PR addresses this by:

- Check if the input path is a supported file or directory
- Return a singleton list if it is a supported file (or empty list if not)
- Assume usual behaviour if it is a directory