### PR TITLE
kotlin2cpg: enable Java interop

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -73,9 +73,7 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] {
 
       val filesWithJavaExtension = SourceFiles.determine(sourceDir, Set(".java"))
       if (filesWithJavaExtension.nonEmpty) {
-        logger.info(
-          s"Found ${filesWithJavaExtension.size} files with the `.java` extension which will not be included in the result."
-        )
+        logger.info(s"Found ${filesWithJavaExtension.size} files with the `.java` extension.")
       }
 
       val dependenciesPaths = if (jar4ImportServiceOpt.isDefined) {
@@ -112,7 +110,13 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] {
       }
       val plugins = Seq()
       val environment =
-        CompilerAPI.makeEnvironment(dirsForSourcesToCompile, defaultContentRootJars, plugins, messageCollector)
+        CompilerAPI.makeEnvironment(
+          dirsForSourcesToCompile,
+          filesWithJavaExtension,
+          defaultContentRootJars,
+          plugins,
+          messageCollector
+        )
 
       val sourceEntries = entriesForSources(environment.getSourceFiles.asScala, sourceDir)
       val sources = sourceEntries.filterNot { entry =>

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/compiler/CompilerAPI.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/compiler/CompilerAPI.scala
@@ -6,7 +6,7 @@ import java.io.{File, FileOutputStream}
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.KotlinSourceRoot
 import org.jetbrains.kotlin.cli.jvm.compiler.{EnvironmentConfigFiles, KotlinCoreEnvironment}
-import org.jetbrains.kotlin.cli.jvm.config.JvmClasspathRoot
+import org.jetbrains.kotlin.cli.jvm.config.{JavaSourceRoot, JvmClasspathRoot}
 import org.jetbrains.kotlin.config.{CommonConfigurationKeys, CompilerConfiguration, CompilerConfigurationKey}
 import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.cli.common.messages.{
   MessageCollector
 }
 import org.slf4j.LoggerFactory
+
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 case class CompilerPluginInfo(
@@ -31,6 +32,7 @@ object CompilerAPI {
 
   def makeEnvironment(
     forDirectories: Seq[String],
+    javaSourceRoots: Seq[String],
     defaultContentRootJarPaths: Seq[DefaultContentRootJarPath] = List(),
     compilerPlugins: Seq[CompilerPluginInfo] = Seq(),
     messageCollector: MessageCollector
@@ -72,6 +74,12 @@ object CompilerAPI {
         }
       }
     }
+
+    javaSourceRoots.foreach { source =>
+      val f = new File(source)
+      config.add(CLIConfigurationKeys.CONTENT_ROOTS, new JavaSourceRoot(f, ""))
+    }
+
     config.put(CommonConfigurationKeys.MODULE_NAME, JvmProtoBufUtil.DEFAULT_MODULE_NAME)
 
     val configFiles = EnvironmentConfigFiles.JVM_CONFIG_FILES

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/CompilerAPITests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/CompilerAPITests.scala
@@ -46,7 +46,7 @@ class CompilerAPITests extends AnyFreeSpec with Matchers {
         .map { f => DefaultContentRootJarPath(f.pathAsString, false) }
         .toSeq
       val messageCollector = new ErrorCountMessageCollector()
-      val environment      = CompilerAPI.makeEnvironment(Seq(projectDirPath), contentRoots, Seq(), messageCollector)
+      val environment = CompilerAPI.makeEnvironment(Seq(projectDirPath), Seq(), contentRoots, Seq(), messageCollector)
 
       KotlinToJVMBytecodeCompiler.INSTANCE.analyze(environment)
       messageCollector.hasErrors() shouldBe false
@@ -54,7 +54,7 @@ class CompilerAPITests extends AnyFreeSpec with Matchers {
 
     "should receive a compiler error message when the dependencies of the project have not been provided" in {
       val messageCollector = new ErrorCountMessageCollector()
-      val environment      = CompilerAPI.makeEnvironment(Seq(projectDirPath), Seq(), Seq(), messageCollector)
+      val environment      = CompilerAPI.makeEnvironment(Seq(projectDirPath), Seq(), Seq(), Seq(), messageCollector)
 
       KotlinToJVMBytecodeCompiler.INSTANCE.analyze(environment)
       messageCollector.hasErrors() shouldBe true

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/JavaInteroperabilityTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/JavaInteroperabilityTests.scala
@@ -1,0 +1,33 @@
+package io.joern.kotlin2cpg.compiler
+
+import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+
+class JavaInteroperabilityTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
+  "CPG for code with call to `takeIf`" should {
+    val cpg = code(
+      """package no.such.pkg
+        |fun main() {
+        |  val c = SomeJavaClass()
+        |  c.someFunction("greetings")
+        |}
+        |""".stripMargin,
+      "App.kt"
+    )
+      .moreCode(
+        """package no.such.pkg;
+          |public class SomeJavaClass {
+          |    public void someFunction(String text) {
+          |      System.out.println(text);
+          |    }
+          |}
+          |""".stripMargin,
+        "SomeJavaClass.java"
+      )
+
+    "should contain a CALL node with the correct METHOD_FULL_NAME set" in {
+      val List(c) = cpg.call.code("c.someFunction.*").l
+      c.methodFullName shouldBe "no.such.pkg.SomeJavaClass.someFunction:void(java.lang.String)"
+    }
+  }
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/plugins/KotlinCompilerPluginTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/plugins/KotlinCompilerPluginTests.scala
@@ -52,7 +52,7 @@ class KotlinCompilerPluginTests extends AnyFreeSpec with Matchers {
       val plugins          = Seq()
       val messageCollector = new ErrorCountMessageCollector()
       val environment =
-        CompilerAPI.makeEnvironment(Seq(sourceDir), defaultContentRootJarPaths, plugins, messageCollector)
+        CompilerAPI.makeEnvironment(Seq(sourceDir), Seq(), defaultContentRootJarPaths, plugins, messageCollector)
       val nameGenerator = new DefaultTypeInfoProvider(environment)
       nameGenerator.bindingContext should not be null
       messageCollector.hasErrors() shouldBe true
@@ -68,7 +68,7 @@ class KotlinCompilerPluginTests extends AnyFreeSpec with Matchers {
       val plugins          = Seq(allOpenPluginInfo)
       val messageCollector = new ErrorCountMessageCollector()
       val environment =
-        CompilerAPI.makeEnvironment(Seq(sourceDir), defaultContentRootJarPaths, plugins, messageCollector)
+        CompilerAPI.makeEnvironment(Seq(sourceDir), Seq(), defaultContentRootJarPaths, plugins, messageCollector)
       val nameGenerator = new DefaultTypeInfoProvider(environment)
       nameGenerator.bindingContext should not be null
       messageCollector.hasErrors() shouldBe false

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/types/KotlinScriptFilteringTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/types/KotlinScriptFilteringTests.scala
@@ -10,8 +10,9 @@ import org.scalatest.Ignore
 class KotlinScriptFilteringTests extends AnyFreeSpec with Matchers {
   "Running `CompilerAPI.makeEnvironment` on external project with lots of KotlinScript sources" - {
     "should return an empty binding context" in {
-      val sourceDir   = "src/test/resources/external_projects/kotlin-dsl"
-      val environment = CompilerAPI.makeEnvironment(Seq(sourceDir), Seq(), Seq(), new ErrorLoggingMessageCollector)
+      val sourceDir = "src/test/resources/external_projects/kotlin-dsl"
+      val environment =
+        CompilerAPI.makeEnvironment(Seq(sourceDir), Seq(), Seq(), Seq(), new ErrorLoggingMessageCollector)
       environment.getSourceFiles should not be List()
 
       val nameGenerator = new DefaultTypeInfoProvider(environment)
@@ -23,7 +24,7 @@ class KotlinScriptFilteringTests extends AnyFreeSpec with Matchers {
       val sourceDir               = "src/test/resources/external_projects/kotlin-dsl"
       val dirsForSourcesToCompile = ContentSourcesPicker.dirsForRoot(sourceDir)
       val environment =
-        CompilerAPI.makeEnvironment(dirsForSourcesToCompile, Seq(), Seq(), new ErrorLoggingMessageCollector)
+        CompilerAPI.makeEnvironment(dirsForSourcesToCompile, Seq(), Seq(), Seq(), new ErrorLoggingMessageCollector)
       environment.getSourceFiles should not be List()
 
       val nameGenerator = new DefaultTypeInfoProvider(environment)


### PR DESCRIPTION
the source files will not be included in the CPG, but the types will be available to the Kotlin compiler