### PR TITLE
kotlin2cpg: add basic Java interop support

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -2,7 +2,7 @@ name := "kotlin2cpg"
 
 val kotlinVersion = "1.6.21"
 
-dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
+dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test", Projects.javasrc2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
   "com.github.pathikrit"    %% "better-files"               % "3.9.1",

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -19,8 +19,8 @@ import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import io.shiftleft.semanticcpg.language._
-
 import com.squareup.tools.maven.resolution.ArtifactResolver
+import io.joern.kotlin2cpg.interop.JavasrcInterop
 import java.net.{MalformedURLException, URL}
 import java.nio.file.{Files, Paths}
 import scala.util.Try
@@ -133,6 +133,12 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] {
       val astCreator = new AstCreationPass(sources, typeInfoProvider, cpg)
       astCreator.createAndApply()
       new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
+
+      if (config.includeJavaSourceFiles && filesWithJavaExtension.nonEmpty) {
+        val javaAstCreator = JavasrcInterop.astCreationPass(filesWithJavaExtension, cpg)
+        javaAstCreator.createAndApply()
+        new TypeNodePass(javaAstCreator.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
+      }
 
       val configCreator = new ConfigPass(configFiles, cpg)
       configCreator.createAndApply()

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
@@ -15,7 +15,8 @@ final case class Config(
   downloadDependencies: Boolean = false,
   gradleProjectName: Option[String] = None,
   gradleConfigurationName: Option[String] = None,
-  jar4importServiceUrl: Option[String] = None
+  jar4importServiceUrl: Option[String] = None,
+  includeJavaSourceFiles: Boolean = false
 ) extends X2CpgConfig[Config] {
 
   override def withInputPath(inputPath: String): Config =

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/interop/JavasrcInterop.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/interop/JavasrcInterop.scala
@@ -1,0 +1,124 @@
+package io.joern.kotlin2cpg.interop
+
+import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import io.joern.javasrc2cpg.{JpAstWithMeta, SplitJpAsts, SourceFileInfo, SplitDirectories, Config => JavaSrcConfig}
+import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ast.Node.Parsedness
+import io.joern.javasrc2cpg.typesolvers.{CachingReflectionTypeSolver, EagerSourceTypeSolver, SimpleCombinedTypeSolver}
+import io.joern.javasrc2cpg.JavaSrc2Cpg.sourceFileExtensions
+import io.joern.javasrc2cpg.util.SourceRootFinder
+
+import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
+import scala.jdk.OptionConverters.RichOptional
+import com.github.javaparser.ParserConfiguration.LanguageLevel
+import com.github.javaparser.{JavaParser, ParserConfiguration}
+import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import better.files.File
+import io.joern.x2cpg.SourceFiles
+import io.shiftleft.codepropertygraph.Cpg
+import io.joern.javasrc2cpg.passes.{AstCreationPass => JavaSrcAstCreationPass}
+
+object JavasrcInterop {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  val frontendConfig = JavaSrcConfig()
+
+  def astCreationPass(paths: List[String], cpg: Cpg): JavaSrcAstCreationPass = {
+    val javaSrcConfig  = JavaSrcConfig()
+    val javaParserAsts = JavasrcInterop.javaParserAsts(paths, javaSrcConfig.inputPath)
+    val symbolSolver   = JavasrcInterop.symbolSolver(javaParserAsts)
+    new JavaSrcAstCreationPass(javaParserAsts.analysisAsts, javaSrcConfig, cpg, symbolSolver)
+  }
+
+  private def symbolSolver(javaParserAsts: SplitJpAsts): JavaSymbolSolver = {
+    val symbolSolver = createSymbolSolver(javaParserAsts.typesAsts)
+    javaParserAsts.analysisAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
+    javaParserAsts.typesAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
+    symbolSolver
+  }
+
+  private def javaParserAsts(paths: Seq[String], inputPath: String): SplitJpAsts = {
+    paths.foldLeft(SplitJpAsts(List(), List())) { (acc, p) =>
+      val splitDirectories = SplitDirectories(p, p)
+      val splitParserAsts  = getSplitJavaparserAsts(splitDirectories, inputPath)
+      SplitJpAsts(acc.analysisAsts ++ splitParserAsts.analysisAsts, acc.typesAsts ++ splitParserAsts.typesAsts)
+    }
+  }
+
+  private def parseFile(filename: String): Option[CompilationUnit] = {
+    val config      = new ParserConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE)
+    val parseResult = new JavaParser(config).parse(new java.io.File(filename))
+
+    parseResult.getProblems.asScala.toList match {
+      case Nil => // Just carry on as usual
+      case problems =>
+        logger.warn(s"Encountered problems while parsing file $filename:")
+        problems.foreach { problem =>
+          logger.warn(s"- ${problem.getMessage}")
+        }
+    }
+
+    parseResult.getResult.toScala match {
+      case Some(result) if result.getParsed == Parsedness.PARSED => Some(result)
+      case _ =>
+        logger.warn(s"Failed to parse file $filename")
+        None
+    }
+  }
+
+  private def getSourcesFromDir(sourcePath: String): List[String] = {
+    val f = File(sourcePath)
+    if (f.isDirectory)
+      SourceRootFinder.getSourceRoots(sourcePath).flatMap(SourceFiles.determine(_, sourceFileExtensions))
+    else if (f.hasExtension && f.extension.exists(f => sourceFileExtensions.contains(f)))
+      List(sourcePath)
+    else
+      List.empty
+  }
+
+  private def escapeBackslash(path: String): String = {
+    path.replaceAll(raw"\\", raw"\\\\")
+  }
+
+  private def getSplitJavaparserAsts(sourceDirectories: SplitDirectories, inputPath: String): SplitJpAsts = {
+    val analysisSources = getSourcesFromDir(sourceDirectories.analysisSourceDir)
+    val typesSources    = getSourcesFromDir(sourceDirectories.typesSourceDir)
+
+    val analysisAstsMap = analysisSources.par.flatMap { sourceFilename =>
+      val originalFilename = sourceFilename.replaceAll(
+        // Pattern.quote used to escape Windows paths
+        escapeBackslash(sourceDirectories.analysisSourceDir),
+        escapeBackslash(inputPath)
+      )
+      val sourceFileInfo  = SourceFileInfo(sourceFilename, originalFilename)
+      val maybeParsedFile = parseFile(sourceFilename)
+
+      maybeParsedFile.map(cu => sourceFilename -> JpAstWithMeta(sourceFileInfo, cu))
+    }.toMap
+
+    val analysisAsts = analysisAstsMap.values.toList
+    val typesAsts = typesSources.par.flatMap { sourceFilename =>
+      val sourceFileInfo = SourceFileInfo(sourceFilename, sourceFilename)
+      analysisAstsMap
+        .get(sourceFilename)
+        .map(_.compilationUnit)
+        .orElse(parseFile(sourceFilename))
+        .map(cu => JpAstWithMeta(sourceFileInfo, cu))
+    }.toList
+
+    SplitJpAsts(analysisAsts, typesAsts)
+  }
+
+  private def createSymbolSolver(typesAsts: List[JpAstWithMeta]): JavaSymbolSolver = {
+    val combinedTypeSolver   = new SimpleCombinedTypeSolver()
+    val reflectionTypeSolver = new CachingReflectionTypeSolver()
+    combinedTypeSolver.add(reflectionTypeSolver)
+
+    val sourceTypeSolver = EagerSourceTypeSolver(typesAsts, combinedTypeSolver)
+    combinedTypeSolver.prepend(sourceTypeSolver)
+
+    new JavaSymbolSolver(combinedTypeSolver)
+  }
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/JavaInteroperabilityTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/JavaInteroperabilityTests.scala
@@ -4,7 +4,7 @@ import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
 
 class JavaInteroperabilityTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
-  "CPG for code with call to `takeIf`" should {
+  "CPG for code with Java interop" should {
     val cpg = code(
       """package no.such.pkg
         |fun main() {
@@ -28,6 +28,11 @@ class JavaInteroperabilityTests extends KotlinCode2CpgFixture(withOssDataflow = 
     "should contain a CALL node with the correct METHOD_FULL_NAME set" in {
       val List(c) = cpg.call.code("c.someFunction.*").l
       c.methodFullName shouldBe "no.such.pkg.SomeJavaClass.someFunction:void(java.lang.String)"
+    }
+
+    "should contain a CALL node for the call found inside the file written in Java" in {
+      val List(c) = cpg.call.codeExact("System.out.println(text)").l
+      c.methodFullName shouldBe "java.io.PrintStream.println:void(java.lang.String)"
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/dataflow/JavaInteroperabilityTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/dataflow/JavaInteroperabilityTests.scala
@@ -1,0 +1,52 @@
+package io.joern.kotlin2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.toExtendedCfgNode
+import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+
+class JavaInteroperabilityTests extends KotlinCode2CpgFixture(withOssDataflow = true) {
+  implicit val resolver: ICallResolver = NoResolve
+
+  "CPG for code with Java interop" should {
+    val cpg = code(
+      """package no.such.pkg
+        |fun main() {
+        |  val c = SomeJavaClass()
+        |  val someGreeting = "hithere"
+        |  c.someFunction(someGreeting)
+        |}
+        |""".stripMargin,
+      "App.kt"
+    )
+      .moreCode(
+        """package no.such.pkg;
+          |public class SomeJavaClass {
+          |    public void someFunction(String text) {
+          |      System.out.println(text);
+          |    }
+          |}
+          |""".stripMargin,
+        "SomeJavaClass.java"
+      )
+
+    "should find a flow from an IDENTIFIER defined in Kotlin code to the argument of a CALL inside Java code" in {
+      val source = cpg.local.nameExact("someGreeting").referencingIdentifiers
+      val sink   = cpg.call.code("System.out.*").argument
+      val flows  = sink.reachableByFlows(source)
+      flows.map(flowToResultPairs).toSet shouldBe
+        Set(
+          List(
+            ("val someGreeting = \"hithere\"", Some(4)),
+            ("c.someFunction(someGreeting)", Some(5)),
+            ("someFunction(this, String text)", Some(3)),
+            ("System.out.println(text)", Some(4))
+          ),
+          List(
+            ("c.someFunction(someGreeting)", Some(5)),
+            ("someFunction(this, String text)", Some(3)),
+            ("System.out.println(text)", Some(4))
+          )
+        )
+    }
+  }
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -22,7 +22,10 @@ trait KotlinFrontend extends LanguageFrontend {
     val defaultContentRoot =
       BFile(ProjectRoot.relativise("joern-cli/frontends/kotlin2cpg/src/test/resources/jars/"))
     implicit val defaultConfig: Config =
-      Config(classpath = if (withTestResourcePaths) Set(defaultContentRoot.path.toAbsolutePath.toString) else Set())
+      Config(
+        classpath = if (withTestResourcePaths) Set(defaultContentRoot.path.toAbsolutePath.toString) else Set(),
+        includeJavaSourceFiles = true
+      )
     new Kotlin2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
   }
 }


### PR DESCRIPTION
A number of Android Apps out in the wild use both Kotlin _and_ Java in the same project, having the ASTs for both should be very helpful. The functionality is currently hidden behind a flag until it's been tested a bit more that it doesn't lead to issues.