### PR TITLE
kotlin2cpg: deduplicate types for Java interop

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -138,9 +138,8 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] {
       if (config.includeJavaSourceFiles && filesWithJavaExtension.nonEmpty) {
         val javaAstCreator = JavasrcInterop.astCreationPass(filesWithJavaExtension, cpg)
         javaAstCreator.createAndApply()
-        val javaAstCreatorTypes                           = javaAstCreator.global.usedTypes.keys().asScala.toList
-        val javaAstCreatorTypesMinusKotlinAstCreatorTypes = javaAstCreatorTypes.toSet -- kotlinAstCreatorTypes.toSet
-        new TypeNodePass(javaAstCreatorTypesMinusKotlinAstCreatorTypes.toList, cpg).createAndApply()
+        val javaAstCreatorTypes = javaAstCreator.global.usedTypes.keys().asScala.toList
+        new TypeNodePass((javaAstCreatorTypes.toSet -- kotlinAstCreatorTypes.toSet).toList, cpg).createAndApply()
       }
 
       val configCreator = new ConfigPass(configFiles, cpg)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -132,12 +132,15 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] {
       new MetaDataPass(cpg, Languages.KOTLIN, config.inputPath).createAndApply()
       val astCreator = new AstCreationPass(sources, typeInfoProvider, cpg)
       astCreator.createAndApply()
-      new TypeNodePass(astCreator.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
+      val kotlinAstCreatorTypes = astCreator.global.usedTypes.keys().asScala.toList
+      new TypeNodePass(kotlinAstCreatorTypes, cpg).createAndApply()
 
       if (config.includeJavaSourceFiles && filesWithJavaExtension.nonEmpty) {
         val javaAstCreator = JavasrcInterop.astCreationPass(filesWithJavaExtension, cpg)
         javaAstCreator.createAndApply()
-        new TypeNodePass(javaAstCreator.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
+        val javaAstCreatorTypes                           = javaAstCreator.global.usedTypes.keys().asScala.toList
+        val javaAstCreatorTypesMinusKotlinAstCreatorTypes = javaAstCreatorTypes.toSet -- kotlinAstCreatorTypes.toSet
+        new TypeNodePass(javaAstCreatorTypesMinusKotlinAstCreatorTypes.toList, cpg).createAndApply()
       }
 
       val configCreator = new ConfigPass(configFiles, cpg)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/JavaInteroperabilityTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/JavaInteroperabilityTests.scala
@@ -7,6 +7,7 @@ class JavaInteroperabilityTests extends KotlinCode2CpgFixture(withOssDataflow = 
   "CPG for code with Java interop" should {
     val cpg = code(
       """package no.such.pkg
+        |fun someFun(x: String)
         |fun main() {
         |  val c = SomeJavaClass()
         |  c.someFunction("greetings")
@@ -33,6 +34,10 @@ class JavaInteroperabilityTests extends KotlinCode2CpgFixture(withOssDataflow = 
     "should contain a CALL node for the call found inside the file written in Java" in {
       val List(c) = cpg.call.codeExact("System.out.println(text)").l
       c.methodFullName shouldBe "java.io.PrintStream.println:void(java.lang.String)"
+    }
+
+    "should deduplicate types if found in both Java and Kotlin code" in {
+      cpg.typ.fullNameExact("java.lang.String").size shouldBe 1
     }
   }
 }


### PR DESCRIPTION
without the change, downstream projects complain:
```
[WARN ] Multiple entities with the same name: ShadowType(android.content.Context), must be distinct for linking
[WARN ] Multiple entities with the same name: ShadowType(android.content.Intent), must be distinct for linking
[WARN ] Multiple entities with the same name: ShadowType(android.content.IntentFilter), must be distinct for linking
```