### PR TITLE
Remove unique javasrc alloc signatures

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2398,14 +2398,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val argumentTypes = argumentTypesForMethodLike(maybeResolvedExpr)
 
-    val allocSignature = typeFullName.map(composeMethodLikeSignature(_, Nil)).getOrElse(composeUnresolvedSignature(0))
     val allocNode = operatorCallNode(
       Operators.alloc,
       expr.toString,
       typeFullName.orElse(Some(TypeConstants.Any)),
       line(expr),
       column(expr)
-    ).signature(allocSignature)
+    )
 
     val initCall = initNode(
       typeFullName.orElse(Some(TypeConstants.Any)),

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
@@ -169,15 +169,6 @@ class NewTypeInferenceTests extends JavaSrcCode2CpgFixture {
         |""".stripMargin)
 
     "create a constructor based on import info" in {
-      cpg.method.name("test2").call.nameExact("<operator>.alloc").l match {
-        case alloc :: Nil =>
-          alloc.typeFullName shouldBe "a.b.c.Bar"
-          alloc.signature shouldBe "a.b.c.Bar()"
-          alloc.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-
-        case res => fail(s"Expected single alloc call but got $res")
-      }
-
       val init = cpg.method.name("test2").call.nameExact(io.joern.x2cpg.Defines.ConstructorMethodName).l match {
         case init :: Nil => init
         case res         => fail(s"Expected single init call but got $res")


### PR DESCRIPTION
Fixes https://github.com/joernio/joern/issues/2017

The unit test removed is wrong, so safe to remove.