### PR TITLE
Take into account `sink` in deduplication

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -271,7 +271,7 @@ object Engine {
         val head        = result.path.headOption.map(_.node)
         val last        = result.path.lastOption.map(_.node)
         val startAndEnd = (head ++ last).l
-        (startAndEnd, result.partial, result.callDepth)
+        (result.sink, startAndEnd, result.partial, result.callDepth)
       }
       .map { case (_, list) =>
         val lenIdPathPairs = list.map(x => (x.path.length, x)).toList

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -58,7 +58,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val source = cpg.identifier.name("a")
     val sink   = cpg.call.code("foo.*").argument
     val flows  = sink.reachableByFlows(source)
-    flows.size shouldBe 6
+    flows.size shouldBe 9
   }
 
   "Flow chains from x to a" in {


### PR DESCRIPTION
This fixes a bug in `deduplicate`: we were not taking `result.sink` into account when deduplicating flows, leading to inconsistent number of flows when the input to `deduplicate` is calculated in parallel. One would assume that `result.sink` and the last element on the `path` are always the same, but that seems to not be the case. We should look into that as well.