### PR TITLE
javasrc2cpg: Pass-by-value for primitive parameters

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2675,12 +2675,14 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         val name         = param.getNameAsString
         val typeFullName = maybeType.getOrElse(s"${Defines.UnresolvedNamespace}")
         val code         = s"$typeFullName $name"
+        val evalStrat =
+          if (param.getType.isPrimitiveType) EvaluationStrategies.BY_VALUE else EvaluationStrategies.BY_SHARING
         val paramNode = NewMethodParameterIn()
           .name(name)
           .index(idx + 1)
           .order(idx + 1)
           .code(code)
-          .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+          .evaluationStrategy(evalStrat)
           .typeFullName(typeFullName)
           .lineNumber(line(expr))
         typeInfoCalc.registerType(typeFullName)
@@ -3165,7 +3167,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(scopeStack.lookupVariableType(parameter.getTypeAsString, wildcardFallback = true))
         .map(_ ++ maybeArraySuffix)
         .getOrElse(s"${Defines.UnresolvedNamespace}.${parameter.getTypeAsString}")
-
+    val evalStrat =
+      if (parameter.getType.isPrimitiveType) EvaluationStrategies.BY_VALUE else EvaluationStrategies.BY_SHARING
     typeInfoCalc.registerType(typeFullName)
 
     val parameterNode = NewMethodParameterIn()
@@ -3173,7 +3176,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .code(parameter.toString)
       .lineNumber(line(parameter))
       .columnNumber(column(parameter))
-      .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+      .evaluationStrategy(evalStrat)
       .typeFullName(typeFullName)
       .index(childNum)
       .order(childNum)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
@@ -21,6 +22,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
       param.lineNumber shouldBe Some(3)
       param.columnNumber shouldBe None
       param.typeFullName shouldBe "Foo"
+      param.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
     }
 
     "have correct parameter properties for p1" in {
@@ -30,6 +32,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
       param.lineNumber shouldBe Some(3)
       param.columnNumber shouldBe Some(11)
       param.typeFullName shouldBe "int"
+      param.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
     }
 
     "have correct parameter properties for p2" in {
@@ -39,6 +42,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
       param.lineNumber shouldBe Some(3)
       param.columnNumber shouldBe Some(19)
       param.typeFullName shouldBe "int"
+      param.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
     }
 
     "should allow traversing from parameter to method" in {


### PR DESCRIPTION
Added a check for if the parameter type is primitive and, if so, will set the eval strat to BY_VALUE