### PR TITLE
jssrc2cpg: add AST edge for type ref for classes

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -329,6 +329,8 @@ trait AstForTypesCreator { this: AstCreator =>
     }
 
     if (shouldCreateAssignmentCall) {
+      diffGraph.addEdge(localAstParentStack.head, typeRefNode, EdgeTypes.AST)
+
       // return a synthetic assignment to enable tracing of the implicitly created identifier for
       // the class definition assigned to its constructor
       val classIdNode =


### PR DESCRIPTION
We need the type ref to calculate scopes / capture bindings correctly. Now it is stored under the parent block and `.parentExpression` etc. do work correctly.