### PR TITLE
A fix for handling of METHOD_RETURN

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -11,7 +11,13 @@ import io.shiftleft.semanticcpg.language._
 import org.slf4j.LoggerFactory
 import overflowdb.traversal.Traversal
 
-import java.util.concurrent.{ForkJoinPool, ForkJoinTask, RecursiveTask, RejectedExecutionException, RejectedExecutionHandler}
+import java.util.concurrent.{
+  ForkJoinPool,
+  ForkJoinTask,
+  RecursiveTask,
+  RejectedExecutionException,
+  RejectedExecutionHandler
+}
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 import scala.collection.parallel.CollectionConverters._
@@ -125,7 +131,6 @@ object ExtendedCfgNode {
   * problematic, but it works quite well in practice.
   *
   * The code also translates METHOD_RETURN to the corresponding call sites for backward compatability.
-  *
   */
 class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode]] {
 
@@ -207,7 +212,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
   }
   override def compute(): List[CfgNode] =
     src match {
-      case methodReturn : MethodReturn =>
+      case methodReturn: MethodReturn =>
         methodReturn.method.callIn.l
       case lit: Literal =>
         List(lit) ++ usages(targetsToClassIdentifierPair(literalToInitializedMembers(lit)))

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -13,7 +13,6 @@ import overflowdb.traversal.{NodeOps, Traversal}
 
 import scala.collection.parallel.CollectionConverters._
 import java.util.concurrent._
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -85,7 +84,6 @@ class Engine(context: EngineContext) {
     def handleSummary(taskSummary: TaskSummary): Unit = {
       val newTasks = taskSummary.followupTasks
       submitTasks(newTasks, sources)
-      val task       = taskSummary.task
       val newResults = taskSummary.results
       completedResults ++= newResults
     }
@@ -119,6 +117,8 @@ class Engine(context: EngineContext) {
 }
 
 object Engine {
+
+  private val logger: Logger                   = LoggerFactory.getLogger(Engine.getClass)
 
   /** Traverse from a node to incoming DDG nodes, taking into account semantics. This method is exposed via the `ddgIn`
     * step, but is also called by the engine internally by the `TaskSolver`.

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -10,12 +10,32 @@ import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.Edge
 import overflowdb.traversal.{NodeOps, Traversal}
-
-import scala.collection.parallel.CollectionConverters._
 import java.util.concurrent._
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
+/**
+ * @param sink
+ * The sink for which to find flows
+ *
+ * @param sources
+ * The set of sources from which to find flows
+ *
+ * @param table
+ * An initial result table to use for this task
+ *
+ * @param initialPath
+ * A path from the sink downwards towards another sink (excluding the sink)
+ *
+ * @param callDepth
+ *
+ * The number of calls we expanded in order to create this result
+ *
+ * @param callSiteStack
+ *
+ * The call sites that were expanded in order to create this result
+ *
+ * */
 case class ReachableByTask(
   sink: CfgNode,
   sources: Set[CfgNode],

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -14,28 +14,26 @@ import java.util.concurrent._
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-/**
- * @param sink
- * The sink for which to find flows
- *
- * @param sources
- * The set of sources from which to find flows
- *
- * @param table
- * An initial result table to use for this task
- *
- * @param initialPath
- * A path from the sink downwards towards another sink (excluding the sink)
- *
- * @param callDepth
- *
- * The number of calls we expanded in order to create this result
- *
- * @param callSiteStack
- *
- * The call sites that were expanded in order to create this result
- *
- * */
+/** @param sink
+  *   The sink for which to find flows
+  *
+  * @param sources
+  *   The set of sources from which to find flows
+  *
+  * @param table
+  *   An initial result table to use for this task
+  *
+  * @param initialPath
+  *   A path from the sink downwards towards another sink (excluding the sink)
+  *
+  * @param callDepth
+  *
+  * The number of calls we expanded in order to create this result
+  *
+  * @param callSiteStack
+  *
+  * The call sites that were expanded in order to create this result
+  */
 case class ReachableByTask(
   sink: CfgNode,
   sources: Set[CfgNode],
@@ -138,7 +136,7 @@ class Engine(context: EngineContext) {
 
 object Engine {
 
-  private val logger: Logger                   = LoggerFactory.getLogger(Engine.getClass)
+  private val logger: Logger = LoggerFactory.getLogger(Engine.getClass)
 
   /** Traverse from a node to incoming DDG nodes, taking into account semantics. This method is exposed via the `ddgIn`
     * step, but is also called by the engine internally by the `TaskSolver`.

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -51,10 +51,11 @@ class ResultTable(
 
 /** A (partial) result, informing about a path that exists from a source to another node in the graph.
   *
+  * @param sink
+  * the sink node of the task that yields this result
+  *
   * @param path
   *   this is the main result - a known path
-  * @param table
-  *   the result table - kept to allow for detailed inspection of intermediate paths
   * @param callSiteStack
   *   the call site stack containing the call sites that were expanded to kick off the task. We require this to match
   *   call sites to exclude non-realizable paths through other callers
@@ -65,7 +66,6 @@ class ResultTable(
 case class ReachableByResult(
   sink: CfgNode,
   path: Vector[PathElement],
-  table: ResultTable,
   callSiteStack: List[Call],
   callDepth: Int = 0,
   partial: Boolean = false

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -52,7 +52,7 @@ class ResultTable(
 /** A (partial) result, informing about a path that exists from a source to another node in the graph.
   *
   * @param sink
-  * the sink node of the task that yields this result
+  *   the sink node of the task that yields this result
   *
   * @param path
   *   this is the main result - a known path

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -110,7 +110,7 @@ class TaskCreator(sources: Set[CfgNode])(implicit semantics: Semantics) {
             methodReturn.method.parameter.index(indices: _*).l
           }
           taintedParameters.map { param =>
-            val newPath = Vector(PathElement(param, result.callSiteStack)) ++ path
+            val newPath = Vector(PathElement(methodReturn, result.callSiteStack)) ++ path
             ReachableByTask(param, sources, new ResultTable, newPath, callDepth + 1, call :: result.callSiteStack)
           }
         } else {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -101,13 +101,14 @@ class TaskCreator(sources: Set[CfgNode])(implicit semantics: Semantics) {
       methodReturns.flatMap { case (call, methodReturn) =>
         if (methodReturn.method.isExternal) {
           val semantics = semanticsForCall(call)
+          val method = methodReturn.method
           val taintedParameters = if (semantics.isEmpty) {
-            methodReturn.method.parameter.l
+            method.parameter.l
           } else {
             val indices = semantics.flatMap { semantic =>
               semantic.mappings.collect { case (src, dst) if dst == -1 => src }
             }
-            methodReturn.method.parameter.index(indices: _*).l
+            method.parameter.index(indices: _*).l
           }
           taintedParameters.map { param =>
             val newPath = Vector(PathElement(methodReturn, result.callSiteStack)) ++ path

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -97,30 +97,16 @@ class TaskCreator(sources: Set[CfgNode]) {
 
       methodReturns.flatMap { case (call, methodReturn) =>
         val returnStatements = methodReturn._reachingDefIn.toList.collect { case r: Return => r }
-        if (returnStatements.isEmpty) {
-          val newPath = path
-          List(
-            ReachableByTask(
-              methodReturn,
-              sources,
-              new ResultTable,
-              newPath,
-              callDepth + 1,
-              call :: result.callSiteStack
-            )
+        returnStatements.map { returnStatement =>
+          val newPath = Vector(PathElement(methodReturn, result.callSiteStack)) ++ path
+          ReachableByTask(
+            returnStatement,
+            sources,
+            new ResultTable,
+            newPath,
+            callDepth + 1,
+            call :: result.callSiteStack
           )
-        } else {
-          returnStatements.map { returnStatement =>
-            val newPath = Vector(PathElement(methodReturn, result.callSiteStack)) ++ path
-            ReachableByTask(
-              returnStatement,
-              sources,
-              new ResultTable,
-              newPath,
-              callDepth + 1,
-              call :: result.callSiteStack
-            )
-          }
         }
       }
     }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -109,16 +109,6 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       // Case 1: we have reached a source => return result and continue traversing (expand into parents)
       case x if sources.contains(x.asInstanceOf[NodeType]) =>
         Vector(ReachableByResult(sink, path, callSiteStack)) ++ deduplicate(computeResultsForParents())
-      // Case 1.5: the second node on the path is a METHOD_RETURN and its a source. This clumsy check is necessary because
-      // for method returns, the derived tasks we create in TaskCreator jump immediately to the RETURN statements in
-      // order to only pick up values that actually propagate via a RETURN and don't just flow to METHOD_RETURN because
-      // it is the exit node.
-      case _
-          if path.size > 1
-            && path(1).node.isInstanceOf[MethodReturn]
-            && sources.contains(path(1).node.asInstanceOf[NodeType]) =>
-        Vector(ReachableByResult(sink, path.drop(1), callSiteStack)) ++ deduplicate(computeResultsForParents())
-
       // Case 2: we have reached a method parameter (that isn't a source) => return partial result and stop traversing
       case _: MethodParameterIn =>
         Vector(ReachableByResult(sink, path, callSiteStack, partial = true))

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -109,6 +109,16 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       // Case 1: we have reached a source => return result and continue traversing (expand into parents)
       case x if sources.contains(x.asInstanceOf[NodeType]) =>
         Vector(ReachableByResult(sink, path, callSiteStack)) ++ deduplicate(computeResultsForParents())
+      // Case 1.5: the second node on the path is a METHOD_RETURN and its a source. This clumsy check is necessary because
+      // for method returns, the derived tasks we create in TaskCreator jump immediately to the RETURN statements in
+      // order to only pick up values that actually propagate via a RETURN and don't just flow to METHOD_RETURN because
+      // it is the exit node.
+      case _
+          if path.size > 1
+            && path(1).node.isInstanceOf[MethodReturn]
+            && sources.contains(path(1).node.asInstanceOf[NodeType]) =>
+        Vector(ReachableByResult(sink, path.drop(1), callSiteStack)) ++ deduplicate(computeResultsForParents())
+
       // Case 2: we have reached a method parameter (that isn't a source) => return partial result and stop traversing
       case _: MethodParameterIn =>
         Vector(ReachableByResult(sink, path, callSiteStack, partial = true))

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -97,7 +97,6 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
         ReachableByResult(
           sink,
           PathElement(path.head.node, callSiteStack, isOutputArg = true) +: path.tail,
-          table,
           callSiteStack,
           partial = true
         )
@@ -109,7 +108,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
     val res = curNode match {
       // Case 1: we have reached a source => return result and continue traversing (expand into parents)
       case x if sources.contains(x.asInstanceOf[NodeType]) =>
-        Vector(ReachableByResult(sink, path, table, callSiteStack)) ++ deduplicate(computeResultsForParents())
+        Vector(ReachableByResult(sink, path, callSiteStack)) ++ deduplicate(computeResultsForParents())
       // Case 1.5: the second node on the path is a METHOD_RETURN and its a source. This clumsy check is necessary because
       // for method returns, the derived tasks we create in TaskCreator jump immediately to the RETURN statements in
       // order to only pick up values that actually propagate via a RETURN and don't just flow to METHOD_RETURN because
@@ -118,11 +117,11 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
           if path.size > 1
             && path(1).node.isInstanceOf[MethodReturn]
             && sources.contains(path(1).node.asInstanceOf[NodeType]) =>
-        Vector(ReachableByResult(sink, path.drop(1), table, callSiteStack)) ++ deduplicate(computeResultsForParents())
+        Vector(ReachableByResult(sink, path.drop(1), callSiteStack)) ++ deduplicate(computeResultsForParents())
 
       // Case 2: we have reached a method parameter (that isn't a source) => return partial result and stop traversing
       case _: MethodParameterIn =>
-        Vector(ReachableByResult(sink, path, table, callSiteStack, partial = true))
+        Vector(ReachableByResult(sink, path, callSiteStack, partial = true))
       // Case 3: we have reached a call to an internal method without semantic (return value) and
       // this isn't the start node => return partial result and stop traversing
       case call: Call

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -23,8 +23,8 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1  = Vector(ReachableByResult(node1, Vector(PathElement(node1)), new ResultTable, List()))
-      val res2  = Vector(ReachableByResult(node1, Vector(PathElement(node2)), new ResultTable, List()))
+      val res1  = Vector(ReachableByResult(node1, Vector(PathElement(node1)), List()))
+      val res2  = Vector(ReachableByResult(node1, Vector(PathElement(node2)), List()))
       table.add(node1, res1)
       table.add(node1, res2)
       table.get(node1) match {
@@ -54,9 +54,9 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node4               = cpg.literal.code("moo").head
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table               = new ResultTable
-      table.add(pivotNode, Vector(ReachableByResult(node1, pathContainingPivot, new ResultTable, List())))
+      table.add(pivotNode, Vector(ReachableByResult(node1, pathContainingPivot, List())))
       table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
-        case Some(Vector(ReachableByResult(_, path, _, _, _, _))) =>
+        case Some(Vector(ReachableByResult(_, path, _, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case _ => fail()
       }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -1110,7 +1110,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "handle deref vs array access correctly" in {
-      val source = cpg.call("source")
+      val source = cpg.method.name("source").methodReturn
       val sink   = cpg.call.codeExact("*arg")
       val flows  = sink.reachableByFlows(source)
       flows.size shouldBe 1

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -295,13 +295,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
     "Exclusions behind over-taint" should {
       "not kill flows" in {
-        val source = cpg.method.name("source").methodReturn
+        val source = cpg.call("source")
         val sink   = cpg.method.name("sink").parameter
         val flows  = sink.reachableByFlows(source)
 
         flows.map(flowToResultPairs).toSetMutable shouldBe Set(
           List(
-            ("int", Some(2)),
             ("source()", Some(6)),
             ("c[1][2] = source()", Some(6)),
             ("sink(c[1])", Some(8)),
@@ -327,13 +326,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
     "Pointer-to-struct, arrow vs star-dot" should {
       "actually find flows" in {
-        val source = cpg.method.name("source").methodReturn
+        val source = cpg.call("source")
         val sink   = cpg.method.name("sink").parameter
         val flows  = sink.reachableByFlows(source)
 
         flows.map(flowToResultPairs).toSetMutable shouldBe Set(
           List(
-            ("int", Some(3)),
             ("source()", Some(7)),
             ("arg->field = source()", Some(7)),
             ("sink((*arg).field)", Some(8)),
@@ -358,18 +356,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
     "Pointer deref vs array access" should {
       "actually find flows" in {
-        val source = cpg.method.name("source").methodReturn
+        val source = cpg.call("source")
         val sink   = cpg.method.name("sink").parameter
         val flows  = sink.reachableByFlows(source)
 
         flows.map(flowToResultPairs).toSetMutable shouldBe Set(
-          List(
-            ("int", Some(2)),
-            ("source()", Some(6)),
-            ("arg[0] = source()", Some(6)),
-            ("sink(*arg)", Some(7)),
-            ("sink(int i)", Some(3))
-          )
+          List(("source()", Some(6)), ("arg[0] = source()", Some(6)), ("sink(*arg)", Some(7)), ("sink(int i)", Some(3)))
         )
       }
     }
@@ -438,7 +430,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
     "NOP on overtaint" should {
       "not widen the search" in {
-        val source = cpg.method.name("source").methodReturn
+        val source = cpg.call("source")
         val sink   = cpg.method.name("sink").parameter
         val flows  = sink.reachableByFlows(source)
 
@@ -448,7 +440,6 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
           flows.map(flowToResultPairs).toSetMutable shouldBe Set(
             // bad flow. delete once fixed, here for documentation only
             List(
-              ("$ret", Some(2)),
               ("source()", Some(8)),
               ("p2", None),
               ("p1", None),
@@ -984,13 +975,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "struct data flow" in {
-      val source = cpg.method.name("source").methodReturn
+      val source = cpg.call("source")
       val sink   = cpg.method.name("sink").parameter.name("x")
       val flows  = sink.reachableByFlows(source)
 
       flows.map(flowToResultPairs).toSetMutable shouldBe Set(
         List(
-          ("double", Some(7)),
           ("source(2)", Some(16)),
           ("k = source(2)", Some(16)),
           ("point.x = k", Some(18)),
@@ -1025,13 +1015,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "tainted struct" in {
-      val source = cpg.method.name("source").methodReturn
+      val source = cpg.call("source")
       val sink   = cpg.method.name("sink").parameter.name("x")
       val flows  = sink.reachableByFlows(source)
 
       flows.map(flowToResultPairs).toSetMutable shouldBe Set(
         List(
-          ("struct Point", Some(7)),
           ("source(2)", Some(17)),
           ("point = source(2)", Some(17)),
           ("sink(point.x)", Some(18)),
@@ -1059,7 +1048,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "not find any flows" in {
-      val source = cpg.method.name("source").methodReturn
+      val source = cpg.call("source")
       val sink   = cpg.method.name("sink").parameter
       val flows  = sink.reachableByFlows(source)
       flows.size shouldBe 0
@@ -1080,7 +1069,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "find flow" in {
-      val source = cpg.method.name("source").methodReturn
+      val source = cpg.call("source")
       val sink   = cpg.method.name("sink").parameter
       val flows  = sink.reachableByFlows(source)
 
@@ -1101,7 +1090,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "find flows (pointer-to-struct/arrows vs star-dot)" in {
-      val source = cpg.method.name("source").methodReturn
+      val source = cpg.call("source")
       val sink   = cpg.method.name("sink").parameter
       val flows  = sink.reachableByFlows(source)
       flows.size shouldBe 1
@@ -1121,7 +1110,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "handle deref vs array access correctly" in {
-      val source = cpg.method.name("source").methodReturn
+      val source = cpg.call("source")
       val sink   = cpg.call.codeExact("*arg")
       val flows  = sink.reachableByFlows(source)
       flows.size shouldBe 1

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -94,6 +94,7 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
       val param = NewMethodParameterIn()
         .code(nameAndCode)
         .order(parameterOrder)
+        .index(parameterOrder)
         .name(nameAndCode)
         .evaluationStrategy(EvaluationStrategies.BY_VALUE)
         .typeFullName("ANY")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -83,7 +83,7 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
     dstGraph.addNode(methodNode)
 
-    val startIndex = if (dispatchType == DispatchTypes.DYNAMIC_DISPATCH) {
+    val startIndex = if (dispatchType == DispatchTypes.DYNAMIC_DISPATCH.toString) {
       0
     } else {
       1


### PR DESCRIPTION
The `METHOD_RETURN` node currently represents two things: the formal return parameter and the exit node. This is problematic because the semantics of using `METHOD_RETURN` nodes as sources/sinks in data flow queries are not clear.  I'm proposing the following semantics and adapting the tests accordingly:

`METHOD_RETURN` represents the exit node, not the formal return parameter. In consequence:

- METHOD_RETURN as a sink means: flows to the exit node
- METHOD_RETURN as a source is not allowed, because in a DDG, all nodes eventually flow to the exit node, and this is unlikely what a user is looking for. For backward compatibility, we allow it anyway and translate METHOD_RETURN sources into corresponding CALL nodes.
- To use all return values of `foo` as a source, we use `cpg.call("foo")` as the CALL node represents the actual output parameter.
- To identify all flows to returns, one uses `RETURN` nodes as sinks

With these rules in place, when the interprocedural data flow engine reaches a CALL node in backward tracking, it is clear that it should traverse to the corresponding RETURN nodes, and not to the METHOD_RETURN node.

*Change in behavior* If there are no RETURN nodes inside the method with a given METHOD_RETURN, then we should not just expand to the METHOD_RETURN node as this would mean expanding to the exit node of the method. I believe this is a bug fix, but it may now result in fewer (invalid) flows.

This PR makes these adaptions.