### PR TITLE
[jssrc2cpg] Built-in Types Now Set as External Types

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPass.scala
@@ -26,12 +26,11 @@ class BuiltinTypesPass(cpg: Cpg) extends CpgPass(cpg) {
       val typeDecl = NewTypeDecl()
         .name(typeName)
         .fullName(typeName)
-        .isExternal(false)
+        .isExternal(true)
         .astParentType(NodeTypes.NAMESPACE_BLOCK)
         .astParentFullName(Defines.GLOBAL_NAMESPACE)
         .order(index + 1)
         .filename("builtintypes")
-        .isExternal(true)
 
       diffGraph.addNode(typeDecl)
       diffGraph.addEdge(namespaceBlock, typeDecl, EdgeTypes.AST)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPass.scala
@@ -31,6 +31,7 @@ class BuiltinTypesPass(cpg: Cpg) extends CpgPass(cpg) {
         .astParentFullName(Defines.GLOBAL_NAMESPACE)
         .order(index + 1)
         .filename("builtintypes")
+        .isExternal(true)
 
       diffGraph.addNode(typeDecl)
       diffGraph.addEdge(namespaceBlock, typeDecl, EdgeTypes.AST)

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/BuiltinTypesPassTest.scala
@@ -17,7 +17,7 @@ class BuiltinTypesPassTest extends AbstractPassTest {
       Defines.JSTYPES.foreach { (typeName: String) =>
         val List(typeDeclNode) = cpg.typeDecl(typeName).l
         typeDeclNode.fullName shouldBe typeName
-        typeDeclNode.isExternal shouldBe false
+        typeDeclNode.isExternal shouldBe true
         typeDeclNode.filename shouldBe "builtintypes"
 
         cpg.namespaceBlock.astChildren.l should contain(typeDeclNode)


### PR DESCRIPTION
When built-in types are created, they are set as external, to be consistent with other frontends.

Resolves #2079 