### PR TITLE
Fix interprocedural tracking via METHOD_RETURN nodes

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -211,6 +211,8 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
   }
   override def compute(): List[CfgNode] =
     src match {
+      case methodReturn: MethodReturn =>
+        methodReturn.method.callIn.l
       case lit: Literal =>
         List(lit) ++ usages(targetsToClassIdentifierPair(literalToInitializedMembers(lit)))
       case member: Member =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -85,7 +85,6 @@ class Engine(context: EngineContext) {
     def handleSummary(taskSummary: TaskSummary): Unit = {
       val newTasks = taskSummary.followupTasks
       submitTasks(newTasks, sources)
-      val task       = taskSummary.task
       val newResults = taskSummary.results
       completedResults ++= newResults
     }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -242,7 +242,7 @@ object Engine {
         val head        = result.path.headOption.map(_.node)
         val last        = result.path.lastOption.map(_.node)
         val startAndEnd = (head ++ last).l
-        (result.sink, startAndEnd, result.partial, result.callDepth)
+        (startAndEnd, result.partial, result.callDepth)
       }
       .map { case (_, list) =>
         val lenIdPathPairs = list.map(x => (x.path.length, x)).toList

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -242,7 +242,7 @@ object Engine {
         val head        = result.path.headOption.map(_.node)
         val last        = result.path.lastOption.map(_.node)
         val startAndEnd = (head ++ last).l
-        (startAndEnd, result.partial, result.callDepth)
+        (result.sink, startAndEnd, result.partial, result.callDepth)
       }
       .map { case (_, list) =>
         val lenIdPathPairs = list.map(x => (x.path.length, x)).toList

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -99,10 +99,7 @@ class TaskCreator(sources: Set[CfgNode]) {
         val method           = methodReturn.method.head
         val returnStatements = methodReturn._reachingDefIn.toList.collect { case r: Return => r }
         if (method.isExternal) {
-          val newPath = path
-          (call.receiver.l ++ call.argument.l).map { arg =>
-            ReachableByTask(arg, sources, new ResultTable, newPath, callDepth, result.callSiteStack)
-          }
+          List()
         } else {
           returnStatements.map { returnStatement =>
             val newPath = Vector(PathElement(methodReturn, result.callSiteStack)) ++ path

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -1,7 +1,6 @@
 package io.joern.dataflowengineoss.queryengine
 
-import io.joern.dataflowengineoss.queryengine.Engine.{argToOutputParams, semanticsForCall}
-import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.joern.dataflowengineoss.queryengine.Engine.argToOutputParams
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{
   Call,
@@ -17,9 +16,7 @@ import io.shiftleft.semanticcpg.language._
 
 /** Creation of new tasks from results of completed tasks.
   */
-class TaskCreator(sources: Set[CfgNode])(implicit val semantics: Semantics) {
-
-  implicit val s: Semantics = semantics
+class TaskCreator(sources: Set[CfgNode]) {
 
   /** For a given list of results and sources, generate new tasks.
     */
@@ -100,9 +97,7 @@ class TaskCreator(sources: Set[CfgNode])(implicit val semantics: Semantics) {
 
       methodReturns.flatMap { case (call, methodReturn) =>
         val method           = methodReturn.method.head
-        val semantics        = semanticsForCall(call)
         val returnStatements = methodReturn._reachingDefIn.toList.collect { case r: Return => r }
-        // TODO handle semantics
         if (method.isExternal) {
           val newPath = path
           List(

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -100,16 +100,9 @@ class TaskCreator(sources: Set[CfgNode]) {
         val returnStatements = methodReturn._reachingDefIn.toList.collect { case r: Return => r }
         if (method.isExternal) {
           val newPath = path
-          List(
-            ReachableByTask(
-              methodReturn,
-              sources,
-              new ResultTable,
-              newPath,
-              callDepth + 1,
-              call :: result.callSiteStack
-            )
-          )
+          (call.receiver.l ++ call.argument.l).map { arg =>
+            ReachableByTask(arg, sources, new ResultTable, newPath, callDepth, result.callSiteStack)
+          }
         } else {
           returnStatements.map { returnStatement =>
             val newPath = Vector(PathElement(methodReturn, result.callSiteStack)) ++ path

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -3,16 +3,23 @@ package io.joern.dataflowengineoss.queryengine
 import io.joern.dataflowengineoss.queryengine.Engine.{argToOutputParams, semanticsForCall}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, Expression, MethodParameterIn, MethodParameterOut, Return}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Call,
+  CfgNode,
+  Expression,
+  MethodParameterIn,
+  MethodParameterOut,
+  Return
+}
 import io.shiftleft.semanticcpg.language.NoResolve
 import overflowdb.traversal.{Traversal, jIteratortoTraversal}
 import io.shiftleft.semanticcpg.language._
 
 /** Creation of new tasks from results of completed tasks.
   */
-class TaskCreator(sources: Set[CfgNode])(implicit val semantics : Semantics) {
+class TaskCreator(sources: Set[CfgNode])(implicit val semantics: Semantics) {
 
-  implicit val s : Semantics = semantics
+  implicit val s: Semantics = semantics
 
   /** For a given list of results and sources, generate new tasks.
     */
@@ -92,9 +99,10 @@ class TaskCreator(sources: Set[CfgNode])(implicit val semantics : Semantics) {
         .to(Traversal)
 
       methodReturns.flatMap { case (call, methodReturn) =>
-        val method = methodReturn.method.head
-        val semantics = semanticsForCall(call)
+        val method           = methodReturn.method.head
+        val semantics        = semanticsForCall(call)
         val returnStatements = methodReturn._reachingDefIn.toList.collect { case r: Return => r }
+        // TODO handle semantics
         if (method.isExternal) {
           val newPath = path
           List(

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -11,8 +11,8 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   Return
 }
 import io.shiftleft.semanticcpg.language.NoResolve
-import overflowdb.traversal._
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.{NodeOps, Traversal}
 
 /** Creation of new tasks from results of completed tasks.
   */
@@ -99,7 +99,10 @@ class TaskCreator(sources: Set[CfgNode]) {
         val method           = methodReturn.method.head
         val returnStatements = methodReturn._reachingDefIn.toList.collect { case r: Return => r }
         if (method.isExternal || method.start.isStub.nonEmpty) {
-          List()
+          val newPath = path
+          (call.receiver.l ++ call.argument.l).map { arg =>
+            ReachableByTask(arg, sources, new ResultTable, newPath, callDepth, result.callSiteStack)
+          }
         } else {
           returnStatements.map { returnStatement =>
             val newPath = Vector(PathElement(methodReturn, result.callSiteStack)) ++ path

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -11,7 +11,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   Return
 }
 import io.shiftleft.semanticcpg.language.NoResolve
-import overflowdb.traversal.{Traversal, jIteratortoTraversal}
+import overflowdb.traversal._
 import io.shiftleft.semanticcpg.language._
 
 /** Creation of new tasks from results of completed tasks.
@@ -98,7 +98,7 @@ class TaskCreator(sources: Set[CfgNode]) {
       methodReturns.flatMap { case (call, methodReturn) =>
         val method           = methodReturn.method.head
         val returnStatements = methodReturn._reachingDefIn.toList.collect { case r: Return => r }
-        if (method.isExternal) {
+        if (method.isExternal || method.start.isStub.nonEmpty) {
           List()
         } else {
           returnStatements.map { returnStatement =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -110,16 +110,6 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       // Case 1: we have reached a source => return result and continue traversing (expand into parents)
       case x if sources.contains(x.asInstanceOf[NodeType]) =>
         Vector(ReachableByResult(sink, path, table, callSiteStack)) ++ deduplicate(computeResultsForParents())
-      // Case 1.5: the second node on the path is a METHOD_RETURN and its a source. This clumsy check is necessary because
-      // for method returns, the derived tasks we create in TaskCreator jump immediately to the RETURN statements in
-      // order to only pick up values that actually propagate via a RETURN and don't just flow to METHOD_RETURN because
-      // it is the exit node.
-      case _
-          if path.size > 1
-            && path(1).node.isInstanceOf[MethodReturn]
-            && sources.contains(path(1).node.asInstanceOf[NodeType]) =>
-        Vector(ReachableByResult(sink, path.drop(1), table, callSiteStack)) ++ deduplicate(computeResultsForParents())
-
       // Case 2: we have reached a method parameter (that isn't a source) => return partial result and stop traversing
       case _: MethodParameterIn =>
         Vector(ReachableByResult(sink, path, table, callSiteStack, partial = true))

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/MethodReturnTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/MethodReturnTests.scala
@@ -1,0 +1,42 @@
+package io.joern.javasrc2cpg.querying.dataflow
+
+import io.joern.javasrc2cpg.testfixtures.JavaDataflowFixture
+import io.shiftleft.semanticcpg.language._
+import io.joern.dataflowengineoss.language._
+
+class MethodReturnTests extends JavaDataflowFixture {
+
+  behavior of "Dataflow to method return"
+
+  override val code: String = """
+      |public class Foo {
+      | public void foo(int y) {
+      |   int x = 10;
+      | }
+      |
+      | public void bar() {
+      |   bar(foo(1));
+      | }
+      |
+      |}
+      |""".stripMargin
+
+  it should "find flow from x to METHOD_RETURN (exit node)" in {
+    val src = cpg.identifier.name("x")
+    val snk = cpg.method("foo").methodReturn
+    snk.reachableBy(src).size shouldBe 1
+  }
+
+  it should "not find a flow from x to bar's argument" in {
+    val src = cpg.identifier("x")
+    val snk = cpg.method("bar").parameter.index(1)
+    snk.reachableBy(src).size shouldBe 0
+  }
+
+  it should "not find a flow from y to bar's argument" in {
+    val src = cpg.parameter("y")
+    val snk = cpg.method("bar").parameter.index(1)
+    snk.reachableBy(src).size shouldBe 0
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/MethodReturnTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/MethodReturnTests.scala
@@ -18,6 +18,12 @@ class MethodReturnTests extends JavaDataflowFixture {
       |   bar(foo(1));
       | }
       |
+      | public void woo() {
+      |   int x = 20;
+      |   System.out.println(1, x);
+      |   sink(x);
+      | }
+      |
       |}
       |""".stripMargin
 
@@ -37,6 +43,12 @@ class MethodReturnTests extends JavaDataflowFixture {
     val src = cpg.parameter("y")
     val snk = cpg.method("bar").parameter.index(1)
     snk.reachableBy(src).size shouldBe 0
+  }
+
+  it should "find a flow passed an external method with semantic" in {
+    val src = cpg.literal.code("20")
+    val snk = cpg.method("sink").parameter.index(1)
+    snk.reachableBy(src).size shouldBe 1
   }
 
 }


### PR DESCRIPTION
The tests illustrate the problem quite nicely: because `METHOD_RETURN` is also the exit node, we ended up overtainting in the past. We revert to this behavior for external methods and method stubs. For internal methods, we traverse to RETURN nodes instead.
