### PR TITLE
[CfgNodeTraversal] Match Error on MethodParameter_

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
-import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
@@ -19,17 +18,7 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
   /** Traverse to enclosing method
     */
   def method: Traversal[Method] =
-    traversal.map {
-      case method: Method =>
-        method
-      case expression: Expression =>
-        expression.method
-      case callRepr: CallRepr =>
-        callRepr._astIn.onlyChecked.asInstanceOf[Method]
-      case jumpTarget: JumpTarget =>
-        jumpTarget.method
-      case cfgNode => cfgNode.method // refers to `semanticcpg.language.nodemethods.CfgNodeMethods.method`
-    }
+    traversal.map(_.method) // refers to `semanticcpg.language.nodemethods.CfgNodeMethods.method`
 
   /** Traverse to next expression in CFG.
     */


### PR DESCRIPTION
When traversing to the method from a `MethodParameterIn` node as a `CfgNode` I get a match error. I have added this default case, which will then refer the traversal to `io.shiftleft.semanticcpg.language.nodemethods.CfgNodeMethods.method` that handles the `Method[Return | Parameter[In | Out]]` case