### PR TITLE
CodeDumper: safer filename calculation

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -34,12 +34,6 @@ object CodeDumper {
         logger.info(s"dump not supported for language '$lang'")
         ""
       case (Some(node), Some(lang)) =>
-        val filename = location.filename match {
-          case f if Paths.get(f).isAbsolute =>
-            f
-          case f =>
-            rootPath.map(r => Paths.get(r, f).toAbsolutePath.toString).getOrElse(f)
-        }
         val method: Option[Method] = node match {
           case n: Method     => Some(n)
           case n: Expression => Some(n.method)
@@ -52,6 +46,10 @@ object CodeDumper {
               val rawCode = if (lang == Languages.GHIDRA) {
                 m.code
               } else {
+                val filename = location.filename match {
+                  case f if Paths.get(f).isAbsolute => f
+                  case f => rootPath.map(r => Paths.get(r, f).toAbsolutePath.toString).getOrElse(f)
+                }
                 code(filename, m.lineNumber.get, m.lineNumberEnd.get, location.lineNumber)
               }
               if (highlight) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -43,9 +43,8 @@ object CodeDumper {
         method
           .collect {
             case m: Method if m.lineNumber.isDefined && m.lineNumberEnd.isDefined =>
-              val rawCode = if (lang == Languages.GHIDRA) {
-                m.code
-              } else {
+              val rawCode = if (lang == Languages.GHIDRA) { m.code }
+              else {
                 val filename = location.filename match {
                   case f if Paths.get(f).isAbsolute => f
                   case f => rootPath.map(r => Paths.get(r, f).toAbsolutePath.toString).getOrElse(f)


### PR DESCRIPTION
For methods generated by the MethodStubCreator (e.g., for operators) we end up with artificial method nodes in the `<global>` namespace and file but without line numbers. The fake filename (`<global>`) would crash the filename calculation here. So I moved that piece of code where it is guarded by lineNumber existence.