### PR TITLE
c2cpg: fix relative/absolute path handling

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -48,6 +48,7 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   private def fileOffsetTable(node: IASTNode): Array[Int] = {
+    // file path is relative for project files but absolute for system header files
     val path = fileName(node) match {
       case f if Paths.get(f).isAbsolute => Paths.get(f)
       case f                            => Paths.get(config.inputPath, f)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -48,8 +48,11 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   private def fileOffsetTable(node: IASTNode): Array[Int] = {
-    val f = fileName(node)
-    file2OffsetTable.computeIfAbsent(f, _ => genFileOffsetTable(Paths.get(config.inputPath, f)))
+    val path = fileName(node) match {
+      case f if Paths.get(f).isAbsolute => Paths.get(f)
+      case f                            => Paths.get(config.inputPath, f)
+    }
+    file2OffsetTable.computeIfAbsent(path.toString, _ => genFileOffsetTable(path))
   }
 
   private def genFileOffsetTable(fileName: Path): Array[Int] = {


### PR DESCRIPTION
It is relative for project files but absolute for system header files.