### PR TITLE
Do not create new tasks for literal sinks

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -2,14 +2,7 @@ package io.joern.dataflowengineoss.queryengine
 
 import io.joern.dataflowengineoss.queryengine.Engine.argToOutputParams
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  Call,
-  CfgNode,
-  Expression,
-  MethodParameterIn,
-  MethodParameterOut,
-  Return
-}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, Expression, Literal, MethodParameterIn, MethodParameterOut, Return}
 import io.shiftleft.semanticcpg.language.NoResolve
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.{NodeOps, Traversal}
@@ -120,7 +113,9 @@ class TaskCreator(sources: Set[CfgNode]) {
     }
 
     val forArgs = outArgsAndCalls.flatMap { case (result, args, path, callDepth) =>
-      args.toList.flatMap { case arg: Expression =>
+      args
+        .filterNot(a => a.isInstanceOf[Literal])
+        .toList.flatMap { case arg: Expression =>
         val outParams = if (result.callSiteStack.nonEmpty) {
           List[MethodParameterOut]()
         } else {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -2,7 +2,15 @@ package io.joern.dataflowengineoss.queryengine
 
 import io.joern.dataflowengineoss.queryengine.Engine.argToOutputParams
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, Expression, Literal, MethodParameterIn, MethodParameterOut, Return}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Call,
+  CfgNode,
+  Expression,
+  Literal,
+  MethodParameterIn,
+  MethodParameterOut,
+  Return
+}
 import io.shiftleft.semanticcpg.language.NoResolve
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.{NodeOps, Traversal}
@@ -115,19 +123,21 @@ class TaskCreator(sources: Set[CfgNode]) {
     val forArgs = outArgsAndCalls.flatMap { case (result, args, path, callDepth) =>
       args
         .filterNot(a => a.isInstanceOf[Literal])
-        .toList.flatMap { case arg: Expression =>
-        val outParams = if (result.callSiteStack.nonEmpty) {
-          List[MethodParameterOut]()
-        } else {
-          argToOutputParams(arg).l
-        }
-        outParams
-          .filterNot(_.method.isExternal)
-          .map { p =>
-            val newStack = arg.inCall.headOption.map { x => x :: result.callSiteStack }.getOrElse(result.callSiteStack)
-            ReachableByTask(p, sources, new ResultTable, path, callDepth + 1, newStack)
+        .toList
+        .flatMap { case arg: Expression =>
+          val outParams = if (result.callSiteStack.nonEmpty) {
+            List[MethodParameterOut]()
+          } else {
+            argToOutputParams(arg).l
           }
-      }
+          outParams
+            .filterNot(_.method.isExternal)
+            .map { p =>
+              val newStack =
+                arg.inCall.headOption.map { x => x :: result.callSiteStack }.getOrElse(result.callSiteStack)
+              ReachableByTask(p, sources, new ResultTable, path, callDepth + 1, newStack)
+            }
+        }
     }
 
     forCalls ++ forArgs


### PR DESCRIPTION
This is a minor optimization: if we reach an output argument that is a literal, then we don't need to create a task to further explore because literals can't be sinks.