### PR TITLE
Fix Javascript Source frontend constructor binding.

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -294,10 +294,6 @@ trait AstForTypesCreator { this: AstCreator =>
     val constructor     = createClassConstructor(clazz, memberInitCalls)
     val constructorNode = constructor.methodNode
 
-    val constructorBindingNode = createBindingNode()
-    diffGraph.addEdge(typeDeclNode, constructorBindingNode, EdgeTypes.BINDS)
-    diffGraph.addEdge(constructorBindingNode, constructorNode, EdgeTypes.REF)
-
     // adding all class methods / functions and uninitialized, non-static members
     allClassMembers
       .filter(member => isClassMethodOrUninitializedMember(member) && !isStaticMember(member))

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
@@ -61,19 +61,6 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       funcLocalA.closureBindingId shouldBe Some("code.js::program:b:A")
     }
 
-    "have constructor binding in TYPE_DECL for ClassA" in AstFixture("""
-        |var x = class ClassA {
-        |  constructor() {}
-        |}""".stripMargin) { cpg =>
-      val List(classATypeDecl)     = cpg.typeDecl.nameExact("ClassA").fullNameExact("code.js::program:ClassA").l
-      val List(constructorBinding) = classATypeDecl.bindsOut.l
-      constructorBinding.name shouldBe ""
-      constructorBinding.signature shouldBe ""
-      val List(boundMethod) = constructorBinding.refOut.l
-      boundMethod.fullName shouldBe s"code.js::program:ClassA:${io.joern.x2cpg.Defines.ConstructorMethodName}"
-      boundMethod.code shouldBe "constructor() {}"
-    }
-
     "have member for static method in TYPE_DECL for ClassA" in AstFixture("""
        |var x = class ClassA {
        |  static staticFoo() {}


### PR DESCRIPTION
The frontend did bind constructor methods to the type which the
constructors are supposed to create. This was wrong.

This caused the closed source data flow tracker to be unable to
resolve the `start` call in this example:

```
class BrowserRunner {
  constructor() {
    this._foo = null; // if this is missing, resolution also fails with js2cpg
  }
​
  start() {
  }
}
​
new BrowserRunner().start();
```