### PR TITLE
jssrc2cpg / c2cpg: fixed warnings from Scala 3 compiler

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/ReachingDefTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/ReachingDefTests.scala
@@ -3,7 +3,6 @@ package io.joern.c2cpg.dataflow
 import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.passes.reachingdef.ReachingDefFlowGraph
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
-import io.shiftleft.codepropertygraph.generated.nodes.Return
 import io.shiftleft.semanticcpg.language._
 
 class ReachingDefTests extends DataFlowCodeToCpgSuite {
@@ -25,16 +24,18 @@ class ReachingDefTests extends DataFlowCodeToCpgSuite {
     }
 
     "create ReachingDefFlowGraph with correct successors" in {
-      val List(id: Identifier) = flowGraph.succ(fooMethod)
+      val List(id) = flowGraph.succ(fooMethod).collectAll[Identifier].l
       id.name shouldBe "y"
+
       flowGraph.succ(fooMethod.methodReturn) shouldBe List()
-      val List(ret: Return) = cpg.method("foo").ast.isReturn.l
+
+      val List(ret) = cpg.method("foo").ast.isReturn.l
       flowGraph.succ(ret) shouldBe List(fooMethod.methodReturn)
     }
 
     "create ReachingDefFlowGraph with correct predecessors" in {
-      val List(ret: Return)    = cpg.method("foo").ast.isReturn.l
-      val List(id: Identifier) = flowGraph.succ(fooMethod)
+      val List(ret) = cpg.method("foo").ast.isReturn.l
+      val List(id)  = flowGraph.succ(fooMethod).collectAll[Identifier].l
       flowGraph.pred(id) shouldBe List(fooMethod)
       flowGraph.pred(fooMethod.methodReturn) shouldBe List(ret)
     }
@@ -59,21 +60,21 @@ class ReachingDefTests extends DataFlowCodeToCpgSuite {
 
       flowGraph.succ(fooMethod) shouldBe List(param1)
       flowGraph.succ(param1) shouldBe List(param2)
-      val List(id: Identifier) = flowGraph.succ(param2)
+      val List(id) = flowGraph.succ(param2).collectAll[Identifier].l
       id.name shouldBe "y"
-      val List(ret: Return) = cpg.method("foo").ast.isReturn.l
 
+      val List(ret) = cpg.method("foo").ast.isReturn.l
       flowGraph.succ(ret).toSet shouldBe Set(paramOut1)
       flowGraph.succ(paramOut1) shouldBe List(paramOut2)
       flowGraph.succ(paramOut2) shouldBe List(fooMethod.methodReturn)
     }
 
     "create ReachingDefFlowGraph with correct predecessors" in {
-      val param1            = fooMethod.parameter.index(1).head
-      val param2            = fooMethod.parameter.index(2).head
-      val paramOut1         = param1.asOutput.head
-      val paramOut2         = param2.asOutput.head
-      val List(ret: Return) = cpg.method("foo").ast.isReturn.l
+      val param1    = fooMethod.parameter.index(1).head
+      val param2    = fooMethod.parameter.index(2).head
+      val paramOut1 = param1.asOutput.head
+      val paramOut2 = param2.asOutput.head
+      val List(ret) = cpg.method("foo").ast.isReturn.l
 
       flowGraph.pred(param2) shouldBe List(param1)
       flowGraph.pred(param1) shouldBe List(fooMethod)
@@ -99,10 +100,11 @@ class ReachingDefTests extends DataFlowCodeToCpgSuite {
       val param2    = fooMethod.parameter.index(2).head
       val paramOut1 = param1.asOutput.head
       val paramOut2 = param2.asOutput.head
-
       flowGraph.succ(param1) shouldBe List(param2)
-      val List(id: Identifier) = flowGraph.succ(param2)
+
+      val List(id) = flowGraph.succ(param2).collectAll[Identifier].l
       id.name shouldBe "y"
+
       flowGraph.succ(cpg.call.codeExact("y = x + 1").head) shouldBe List(paramOut1)
       flowGraph.succ(paramOut1) shouldBe List(paramOut2)
       flowGraph.succ(paramOut2) shouldBe List(fooMethod.methodReturn)

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/macros/MacroHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/macros/MacroHandlingTests.scala
@@ -5,10 +5,6 @@ import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.language._
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.codepropertygraph.generated.nodes.Identifier
-import io.shiftleft.codepropertygraph.generated.nodes.Literal
-import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.shiftleft.semanticcpg.language._
 
 class MacroHandlingTests extends CCodeToCpgSuite {
@@ -24,26 +20,32 @@ class MacroHandlingTests extends CCodeToCpgSuite {
     """.stripMargin)
 
     "should correctly expand macro" in {
-      val List(x: Call) = cpg.method("foo").call.nameExact(Operators.assignment).l
+      val List(x) = cpg.method("foo").call.nameExact(Operators.assignment).l
       x.code shouldBe "*y = 10 + 2"
       x.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      val List(macroCall: Call) = cpg.method("foo").call.nameExact("A_MACRO").l
+
+      val List(macroCall) = cpg.method("foo").call.nameExact("A_MACRO").l
       macroCall.code shouldBe "A_MACRO(*y, 2)"
-      val List(arg1: Call, arg2: Literal) = macroCall.argument.l.sortBy(_.order)
+
+      val List(arg1) = macroCall.argument.isCall.l
       arg1.name shouldBe Operators.indirection
       arg1.code shouldBe "*y"
       arg1.order shouldBe 1
       arg1.argumentIndex shouldBe 1
-      val List(identifier: Identifier) = arg1.argument.l
+
+      val List(identifier) = arg1.argument.isIdentifier.l
       identifier.name shouldBe "y"
       identifier.order shouldBe 1
+      identifier.argumentIndex shouldBe 1
+
+      val List(arg2) = macroCall.argument.isLiteral.l
       arg2.code shouldBe "2"
       arg2.order shouldBe 2
       arg2.argumentIndex shouldBe 2
     }
 
     "should create a METHOD for the expanded macro" in {
-      val List(m: Method) = cpg.method.name("A_MACRO").l
+      val List(m) = cpg.method.name("A_MACRO").l
       m.fullName.endsWith("A_MACRO:2") shouldBe true
       m.filename.endsWith(".c") shouldBe true
       m.lineNumber shouldBe Some(2)
@@ -67,15 +69,22 @@ class MacroHandlingTests extends CCodeToCpgSuite {
     """.stripMargin)
 
     "should correctly expand macro inside macro" in {
-      val List(x: Call) = cpg.method("foo").call.nameExact(Operators.assignment).l
+      val List(x) = cpg.method("foo").call.nameExact(Operators.assignment).l
       x.code shouldBe "y = (y + 1)"
-      val List(identifier: Identifier, call2: Call) = x.astChildren.l.sortBy(_.order)
+
+      val List(identifier) = x.argument.isIdentifier.l
       identifier.code shouldBe "y"
+      identifier.argumentIndex shouldBe 1
+      val List(call2) = x.argument.isCall.l
       call2.code shouldBe "y + 1"
-      val List(arg1: Identifier, arg2: Literal) = call2.argument.l.sortBy(_.argumentIndex)
+      call2.argumentIndex shouldBe 2
+
+      val List(arg1) = call2.argument.isIdentifier.l
       arg1.name shouldBe "y"
       arg1.order shouldBe 1
       arg1.argumentIndex shouldBe 1
+
+      val List(arg2) = call2.argument.isLiteral.l
       arg2.code shouldBe "1"
       arg2.order shouldBe 2
       arg2.argumentIndex shouldBe 2
@@ -93,10 +102,12 @@ class MacroHandlingTests extends CCodeToCpgSuite {
     """.stripMargin)
 
     "should correctly expand macro inside macro" in {
-      val List(x: Call) = cpg.method("foo").call.nameExact("printf").l
+      val List(x) = cpg.method("foo").call.nameExact("printf").l
       x.code shouldBe "printf(y)"
-      val List(arg: Identifier) = x.argument.l
+
+      val List(arg) = x.argument.isIdentifier.l
       arg.name shouldBe "y"
+      arg.argumentIndex shouldBe 1
     }
   }
 
@@ -130,7 +141,7 @@ class MacroHandlingTests extends CCodeToCpgSuite {
     """.stripMargin)
 
     "should correctly include calls to macros" in {
-      val List(call1: Call) = cpg.method("foo").call.nameExact("A_MACRO").l
+      val List(call1) = cpg.method("foo").call.nameExact("A_MACRO").l
       call1.code shouldBe "A_MACRO(dst, ptr, 1)"
       call1.name shouldBe "A_MACRO"
       call1.methodFullName.endsWith("A_MACRO:3") shouldBe true
@@ -138,12 +149,13 @@ class MacroHandlingTests extends CCodeToCpgSuite {
       call1.columnNumber shouldBe Some(1)
       call1.typeFullName shouldBe "ANY"
       call1.dispatchType shouldBe DispatchTypes.INLINED
+
       val List(arg1, arg2, arg3) = call1.argument.l.sortBy(_.order)
       arg1.code shouldBe "dst"
       arg2.code shouldBe "ptr"
       arg3.code shouldBe "1"
 
-      val List(call2: Call) = cpg.method("foo").call.nameExact("A_MACRO_2").l
+      val List(call2) = cpg.method("foo").call.nameExact("A_MACRO_2").l
       call2.code shouldBe "A_MACRO_2()"
       call2.name shouldBe "A_MACRO_2"
       call2.methodFullName.endsWith("A_MACRO_2:0") shouldBe true
@@ -164,7 +176,7 @@ class MacroHandlingTests extends CCodeToCpgSuite {
     """.stripMargin)
 
     "should correctly include call to macro that is only a constant in a return" in {
-      val List(call: Call) = cpg.method("foo").call.l
+      val List(call) = cpg.method("foo").call.l
       call.name shouldBe "A_MACRO"
       call.code shouldBe "A_MACRO"
       call.argument.size shouldBe 0
@@ -180,7 +192,7 @@ class MacroHandlingTests extends CCodeToCpgSuite {
     """.stripMargin)
 
     "should correctly include call to macro that is only a constant (no brackets) in a return" in {
-      val List(call: Call) = cpg.method("foo").call.l
+      val List(call) = cpg.method("foo").call.l
       call.name shouldBe "A_MACRO"
       call.code shouldBe "A_MACRO"
       call.argument.size shouldBe 0
@@ -215,9 +227,10 @@ class CfgMacroTests extends DataFlowCodeToCpgSuite {
     |}""".stripMargin)
 
   "should create correct CFG for macro expansion and find data flow" in {
-    val List(callToMacro: Call) = cpg.method("foo").call.dispatchType(DispatchTypes.INLINED).l
+    val List(callToMacro) = cpg.method("foo").call.dispatchType(DispatchTypes.INLINED).l
     callToMacro.argument.code.l shouldBe List("x")
     callToMacro.cfgNext.code.toSetMutable shouldBe Set("x", "i_read")
+
     val source = cpg.method("foo").call.name("MP4_GET4BYTES").argument(1).l
     val sink   = cpg.method("foo").call.name("sink").argument(1).l
     val flows  = sink.reachableByFlows(source)

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
@@ -194,7 +194,7 @@ class MethodTests extends CCodeToCpgSuite {
       val List(indentifierX) = method.block.ast.isIdentifier.l
       indentifierX.name shouldBe "x"
 
-      val Some(localX) = indentifierX._localViaRefOut
+      val localX = indentifierX._localViaRefOut.get
       localX.name shouldBe "x"
     }
 
@@ -203,7 +203,7 @@ class MethodTests extends CCodeToCpgSuite {
       val List(indentifierX) = method.block.ast.isIdentifier.l
       indentifierX.name shouldBe "x"
 
-      val Some(parameterX) = indentifierX._methodParameterInViaRefOut
+      val parameterX = indentifierX._methodParameterInViaRefOut.get
       parameterX.name shouldBe "x"
     }
 
@@ -211,7 +211,7 @@ class MethodTests extends CCodeToCpgSuite {
       val List(method)           = cpg.method.nameExact("method3").l
       val List(outerIdentifierX) = method.block.astChildren.astChildren.isIdentifier.nameExact("x").l
 
-      val Some(parameterX) = outerIdentifierX._methodParameterInViaRefOut
+      val parameterX = outerIdentifierX._methodParameterInViaRefOut.get
       parameterX.name shouldBe "x"
 
       val List(expectedParameterX) = method.parameter.l
@@ -220,7 +220,7 @@ class MethodTests extends CCodeToCpgSuite {
 
       val List(outerIdentifierY) = method.block.astChildren.astChildren.isIdentifier.nameExact("y").l
 
-      val Some(outerLocalY) = outerIdentifierY._localViaRefOut
+      val outerLocalY = outerIdentifierY._localViaRefOut.get
       outerLocalY.name shouldBe "y"
 
       val List(expectedOuterLocalY) = method.block.astChildren.isLocal.l
@@ -232,7 +232,7 @@ class MethodTests extends CCodeToCpgSuite {
       val List(nestedIdentifierX) = nestedBlock.ast.isIdentifier.nameExact("x").l
       nestedIdentifierX.name shouldBe "x"
 
-      val Some(nestedLocalX) = nestedIdentifierX._localViaRefOut
+      val nestedLocalX = nestedIdentifierX._localViaRefOut.get
       nestedLocalX.name shouldBe "x"
 
       val List(expectedNestedLocalX) = nestedBlock.ast.isLocal.nameExact("x").l
@@ -241,7 +241,7 @@ class MethodTests extends CCodeToCpgSuite {
       val List(nestedIdentifierY) = nestedBlock.ast.isIdentifier.nameExact("y").l
       nestedIdentifierY.name shouldBe "y"
 
-      val Some(nestedLocalY) = nestedIdentifierY._localViaRefOut
+      val nestedLocalY = nestedIdentifierY._localViaRefOut.get
       nestedLocalY.name shouldBe "y"
 
       val List(expectedNestedLocalY) = nestedBlock.ast.isLocal.nameExact("y").l

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CallLinkerPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/CallLinkerPassTest.scala
@@ -14,7 +14,6 @@ class CallLinkerPassTest extends DataFlowCodeToCpgSuite {
         |function sayhi() {
         |  console.log("Hello World!");
         |}
-        |
         |sayhi();
         |""".stripMargin)
 
@@ -42,10 +41,10 @@ class CallLinkerPassTest extends DataFlowCodeToCpgSuite {
       ).moreCode(
         """
           |module.exports = {
-          |  sayhi: function() {            // this will be called anonymous
+          |  sayhi: function() { // this will be called anonymous
           |    console.log("Hello World!");
           |  },
-          |  saybye: function() {           // this will be called anonymous1
+          |  saybye: function() { // this will be called anonymous1
           |    console.log("Good-bye!");
           |  }
           |}
@@ -54,7 +53,7 @@ class CallLinkerPassTest extends DataFlowCodeToCpgSuite {
       ).moreCode(
         """
           |module.exports = {
-          |  sayhowdy: function() {       // this will be called anonymous
+          |  sayhowdy: function() { // this will be called anonymous
           |    console.log("Howdy World!");
           |  }
           |}
@@ -103,7 +102,7 @@ class CallLinkerPassTest extends DataFlowCodeToCpgSuite {
       ).moreCode(
         """
           |module.exports = {
-          |  sayhi: function() {            // this will be called anonymous
+          |  sayhi: function() { // this will be called anonymous
           |    console.log("Hello World, love BAR");
           |  }
           |}
@@ -112,7 +111,7 @@ class CallLinkerPassTest extends DataFlowCodeToCpgSuite {
       ).moreCode(
         """
           |module.exports = {
-          |  sayhi: function() {            // this will be called anonymous
+          |  sayhi: function() { // this will be called anonymous
           |    console.log("Howdy World, love BAZ");
           |  }
           |}

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
@@ -6,11 +6,7 @@ import io.shiftleft.semanticcpg.language._
 class ConstClosurePassTests extends DataFlowCodeToCpgSuite {
 
   "should return method `foo` via `cpg.method`" in {
-    val cpg = code("""
-         const foo = (x,y) => {
-           return x + y;
-         }
-      """.stripMargin)
+    val cpg = code("const foo = (x,y) => { return x + y; }")
 
     val List(m) = cpg.method.name("foo").l
     m.name shouldBe "foo"

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/RequirePassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/RequirePassTests.scala
@@ -9,22 +9,23 @@ class RequirePassTests extends DataFlowCodeToCpgSuite {
   "methods imported via `require` should be resolved correctly" in {
     val cpg = code(
       """
-         | const externalfunc = require('./sampleone')
-         | function testone() {
-         | var name = "foo";
-         | console.log(name);
-         | externalfunc(name);
-         | }
-         | testone();
+         |const externalfunc = require('./sampleone');
+         |function testone() {
+         |  var name = "foo";
+         |  console.log(name);
+         |  externalfunc(name);
+         |}
+         |
+         |testone();
       """.stripMargin,
       "sample.js"
     )
 
     cpg.moreCode(
       """
-        | module.exports = function (nameparam){
-        | console.log( "external func" + nameparam);
-        | }
+        |module.exports = function (nameparam) {
+        |  console.log( "external func" + nameparam);
+        |}
         |""".stripMargin,
       "sampleone.js"
     )
@@ -41,11 +42,10 @@ class RequirePassTests extends DataFlowCodeToCpgSuite {
   "methods imported via `import` should be resolved correctly" in {
     val cpg = code(
       """
-         | import {foo, bar} from './sampleone.mjs';
-         | var x = "literal";
-         | foo(x);
-         | bar(x);
-         |
+         |import {foo, bar} from './sampleone.mjs';
+         |var x = "literal";
+         |foo(x);
+         |bar(x);
       """.stripMargin,
       "sample.js"
     )
@@ -53,11 +53,11 @@ class RequirePassTests extends DataFlowCodeToCpgSuite {
     cpg.moreCode(
       """
         |export function foo(x) {
-        |console.log(x);
+        |  console.log(x);
         |}
         |
         |export function bar(x) {
-        |console.log(x);
+        |  console.log(x);
         |}
         |""".stripMargin,
       "sampleone.mjs"

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTest.scala
@@ -156,7 +156,7 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
   }
 
   "AST generation for constructor" should {
-    "have correct structure for simple new" in AstFixture("new MyClass()") { cpg =>
+    "have correct structure for simple new" in AstFixture("new MyClass();") { cpg =>
       val List(program)      = cpg.method.nameExact(":program").l
       val List(programBlock) = program.astChildren.isBlock.l
       val List(newCallBlock) = programBlock.astChildren.isBlock.codeExact("new MyClass()").l
@@ -192,7 +192,7 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       returnTmp.name shouldBe tmpName
     }
 
-    "have correct structure for simple new with arguments" in AstFixture("new MyClass(arg1, arg2)") { cpg =>
+    "have correct structure for simple new with arguments" in AstFixture("new MyClass(arg1, arg2);") { cpg =>
       val List(program)      = cpg.method.nameExact(":program").l
       val List(programBlock) = program.astChildren.isBlock.l
       val List(newCallBlock) = programBlock.astChildren.isBlock.codeExact("new MyClass(arg1, arg2)").l
@@ -240,7 +240,7 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       returnTmp.name shouldBe tmpName
     }
 
-    "have correct structure for new with access path" in AstFixture("new foo.bar.MyClass()") { cpg =>
+    "have correct structure for new with access path" in AstFixture("new foo.bar.MyClass();") { cpg =>
       val List(program)      = cpg.method.nameExact(":program").l
       val List(programBlock) = program.astChildren.isBlock.l
       val List(newCallBlock) = programBlock.astChildren.isBlock.codeExact("new foo.bar.MyClass()").l
@@ -280,9 +280,9 @@ class JsClassesAstCreationPassTest extends AbstractPassTest {
       returnTmp.name shouldBe tmpName
     }
 
-    "have correct structure for throw new exceptions" in AstFixture("function foo() { throw new Foo() }") { cpg =>
+    "have correct structure for throw new exceptions" in AstFixture("function foo() { throw new Foo(); }") { cpg =>
       val List(fooBlock)  = cpg.method.nameExact("foo").astChildren.isBlock.l
-      val List(throwCall) = fooBlock.astChildren.isCall.codeExact("throw new Foo()").l
+      val List(throwCall) = fooBlock.astChildren.isCall.codeExact("throw new Foo();").l
       throwCall.name shouldBe "<operator>.throw"
 
       val List(newCallBlock) = throwCall.astChildren.isBlock.codeExact("new Foo()").l

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
@@ -71,9 +71,9 @@ class TsAstCreationPassTest extends AbstractPassTest {
 
     "have correct structure for casts" in AstFixture(
       """
-        | const x = "foo" as string;
-        | var y = 1 as int;
-        | let z = true as boolean;
+        |const x = "foo" as string;
+        |var y = 1 as int;
+        |let z = true as boolean;
         |""".stripMargin,
       "code.ts"
     ) { cpg =>
@@ -96,8 +96,8 @@ class TsAstCreationPassTest extends AbstractPassTest {
 
     "have correct structure for import assignments" in AstFixture(
       """
-        |import fs = require('fs')
-        |import models = require('../models/index')
+        |import fs = require('fs');
+        |import models = require('../models/index');
         |""".stripMargin,
       "code.ts"
     ) { cpg =>
@@ -119,9 +119,7 @@ class TsAstCreationPassTest extends AbstractPassTest {
     }
 
     "have correct structure for declared functions" in AstFixture(
-      """
-        |declare function foo(arg: string): string
-        |""".stripMargin,
+      "declare function foo(arg: string): string",
       "code.ts"
     ) { cpg =>
       val List(func) = cpg.method("foo").l

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
@@ -6,8 +6,8 @@ import io.shiftleft.semanticcpg.language._
 
 class TSTypesTest extends AbstractPassTest {
   "have correct types for variables" in TsAstFixture("""
-     |var x: string = ""
-     |var y: Foo = null
+     |var x: string = "";
+     |var y: Foo = null;
      |""".stripMargin) { cpg =>
     inside(cpg.identifier.l) { case List(x, y) =>
       x.name shouldBe "x"
@@ -22,7 +22,7 @@ class TSTypesTest extends AbstractPassTest {
   "have correct types for TS intrinsics" in TsAstFixture("""
      |type NickName = "user2069"
      |type ModifiedNickName = Uppercase<NickName>
-     |var x: ModifiedNickName = ""
+     |var x: ModifiedNickName = "";
      |""".stripMargin) { cpg =>
     inside(cpg.identifier.l) { case List(x) =>
       x.name shouldBe "x"


### PR DESCRIPTION
From the Scala 3 compiler:
* fixed explicit types for List deconstruction in tests
* fixed local return (c2cpg)

Also:
* fixed JS test strings to be consistent