### PR TITLE
Refactoring of data flow engine and minor fixes

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -251,7 +251,9 @@ object Engine {
           withMaxLength.head
         } else {
           withMaxLength.minBy { x =>
-            x.taskStack.map(x => x.sink.id + ":" + x.callSiteStack.map(_.id).mkString("|") + x.callDepth) + " " + x.path
+            x.taskStack
+              .map(x => x.sink.id + ":" + x.callSiteStack.map(_.id).mkString("|") + x.callDepth)
+              .toString + " " + x.path
               .map(x => (x.node.id, x.callSiteStack.map(_.id), x.visible, x.isOutputArg, x.outEdgeLabel).toString)
               .mkString("-")
           }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -26,7 +26,11 @@ case class ReachableByTask(
   callSiteStack: List[Call] = List()
 )
 
-case class TaskSummary(results: Vector[ReachableByResult], followupTasks: Vector[ReachableByTask])
+case class TaskSummary(
+  task: ReachableByTask,
+  results: Vector[ReachableByResult],
+  followupTasks: Vector[ReachableByTask]
+)
 
 /** The data flow engine allows determining paths to a set of sinks from a set of sources. To this end, it solves tasks
   * in parallel, creating and submitting new tasks upon completion of tasks. This class deals only with task scheduling,

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -31,14 +31,14 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
     } else {
       implicit val sem: Semantics = context.semantics
       val path                    = PathElement(task.sink, task.callSiteStack) +: task.initialPath
-      results(task.sink, path, task.sources, task.table, task.callSiteStack)
+      val table                   = new ResultTable
+      results(task.sink, path, table, task.callSiteStack)
       // TODO why do we update the call depth here?
-      val finalResults = task.table.get(task.sink).get.map { r =>
-        r.copy(callDepth = task.callDepth)
+      val finalResults = table.get(task.sink).get.map { r =>
+        r.copy(taskStack = r.taskStack.dropRight(1) :+ r.fingerprint.copy(callDepth = task.callDepth))
       }
-
       val (partial, complete) = finalResults.partition(_.partial)
-      val newTasks = new TaskCreator(sources).createFromResults(partial).distinctBy(t => (t.sink, t.callSiteStack))
+      val newTasks            = new TaskCreator().createFromResults(partial).distinctBy(t => (t.sink, t.callSiteStack))
       TaskSummary(task, complete, newTasks)
     }
   }
@@ -52,9 +52,6 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
     * @param path
     *   This is a path from a node to the sink. The first node of the path is expanded by this method
     *
-    * @param sources
-    *   This is the set of sources, i.e., nodes where traversal should end.
-    *
     * @param table
     *   The result table is a cache of known results that we can re-use
     *
@@ -64,7 +61,6 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
   private def results[NodeType <: CfgNode](
     sink: CfgNode,
     path: Vector[PathElement],
-    sources: Set[NodeType],
     table: ResultTable,
     callSiteStack: List[Call]
   )(implicit semantics: Semantics): Vector[ReachableByResult] = {
@@ -88,17 +84,15 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       } else {
         QueryEngineStatistics.incrementBy(PATH_CACHE_MISSES, 1L)
         val newPath = elemToPrepend +: path
-        results(sink, newPath, sources, table, callSiteStack)
+        results(sink, newPath, table, callSiteStack)
       }
     }
 
     def createPartialResultForOutputArgOrRet() = {
       Vector(
         ReachableByResult(
-          sink,
+          task.taskStack,
           PathElement(path.head.node, callSiteStack, isOutputArg = true) +: path.tail,
-          table,
-          callSiteStack,
           partial = true
         )
       )
@@ -109,10 +103,10 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
     val res = curNode match {
       // Case 1: we have reached a source => return result and continue traversing (expand into parents)
       case x if sources.contains(x.asInstanceOf[NodeType]) =>
-        Vector(ReachableByResult(sink, path, table, callSiteStack)) ++ deduplicate(computeResultsForParents())
+        Vector(ReachableByResult(task.taskStack, path)) ++ deduplicate(computeResultsForParents())
       // Case 2: we have reached a method parameter (that isn't a source) => return partial result and stop traversing
       case _: MethodParameterIn =>
-        Vector(ReachableByResult(sink, path, table, callSiteStack, partial = true))
+        Vector(ReachableByResult(task.taskStack, path, partial = true))
       // Case 3: we have reached a call to an internal method without semantic (return value) and
       // this isn't the start node => return partial result and stop traversing
       case call: Call

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -25,9 +25,9 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val table = new ResultTable
       val res1  = Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), Vector(PathElement(node1))))
       val res2  = Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), Vector(PathElement(node2))))
-      table.add(node1, res1)
-      table.add(node1, res2)
-      table.get(node1) match {
+      table.add(TaskFingerprint(node1, List(), 0), res1)
+      table.add(TaskFingerprint(node1, List(), 0), res2)
+      table.get(TaskFingerprint(node1, List(), 0)) match {
         case Some(results) =>
           results.flatMap(_.path.map(_.node.id)) shouldBe List(node1.id, node2.id)
         case None => fail()
@@ -54,8 +54,11 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node4               = cpg.literal.code("moo").head
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table               = new ResultTable
-      table.add(pivotNode, Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), pathContainingPivot)))
-      table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
+      table.add(
+        TaskFingerprint(pivotNode, List(), 0),
+        Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), pathContainingPivot))
+      )
+      table.createFromTable(PathElement(pivotNode), List(), 0, Vector(PathElement(node1))) match {
         case Some(Vector(ReachableByResult(_, path, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case _ => fail()

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -23,8 +23,8 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1  = Vector(ReachableByResult(node1, Vector(PathElement(node1)), new ResultTable, List()))
-      val res2  = Vector(ReachableByResult(node1, Vector(PathElement(node2)), new ResultTable, List()))
+      val res1  = Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), Vector(PathElement(node1))))
+      val res2  = Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), Vector(PathElement(node2))))
       table.add(node1, res1)
       table.add(node1, res2)
       table.get(node1) match {
@@ -54,9 +54,9 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node4               = cpg.literal.code("moo").head
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table               = new ResultTable
-      table.add(pivotNode, Vector(ReachableByResult(node1, pathContainingPivot, new ResultTable, List())))
+      table.add(pivotNode, Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), pathContainingPivot)))
       table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
-        case Some(Vector(ReachableByResult(_, path, _, _, _, _))) =>
+        case Some(Vector(ReachableByResult(_, path, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case _ => fail()
       }


### PR DESCRIPTION
I cleaned up the data flow engine code in preparation for bringing in of a stable version of the fingerprinting change I previously had to revert. This PR brings the following changes:

- ReachableByTask and ReachableByResult have been simplified significantly
- `TaskFingerprint` is introduced. The idea is that when two tasks have the same `TaskFingerprint`, then their results should also be the same, making it possible to cache results.
- ResultTable now uses `TaskFingerprint` as a key. This will serve as our cache.
- The deduplication mechanism was not deterministic when facing multiple flows of the same length with the same node ids. Fixed that as well.
- `createFromTable` did not take into account `callSiteStack` on lookup, fixed that as well.