### PR TITLE
Write results into table

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -264,7 +264,7 @@ object Engine {
       .groupBy { result =>
         val head = result.path.headOption.map(x => (x.node, x.callSiteStack)).get
         val last = result.path.lastOption.map(x => (x.node, x.callSiteStack)).get
-        (head, last, result.partial, result.fingerprint)
+        (head, last, result.partial)
       }
       .map { case (_, list) =>
         val lenIdPathPairs = list.map(x => (x.path.length, x)).toList


### PR DESCRIPTION
Instead of keeping results in a queue, keep them in a `ResultTable`. This is a step towards reusing of results via table lookups. I also fixed a minor bug in the deduplication, which lead to more flows for current master, and fewer with this change. With the deduplication routine in this PR, we get the same number of flows for both cases.