### PR TITLE
Improved caching

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -397,8 +397,8 @@ object Engine {
   def deduplicateTableEntries(list: List[TableEntry]): List[TableEntry] = {
     list
       .groupBy { result =>
-        val head = result.path.headOption.map(x => (x.node, x.callSiteStack))
-        val last = result.path.lastOption.map(x => (x.node, x.callSiteStack))
+        val head = result.path.headOption.map(x => (x.node, x.callSiteStack)).get
+        val last = result.path.lastOption.map(x => (x.node, x.callSiteStack)).get
         (head, last)
       }
       .map { case (_, list) =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -397,8 +397,8 @@ object Engine {
   def deduplicateTableEntries(list: List[TableEntry]): List[TableEntry] = {
     list
       .groupBy { result =>
-        val head = result.path.head.node
-        val last = result.path.last.node
+        val head = result.path.headOption.map(x => (x.node, x.callSiteStack))
+        val last = result.path.lastOption.map(x => (x.node, x.callSiteStack))
         (head, last)
       }
       .map { case (_, list) =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -7,7 +7,7 @@ import scala.jdk.CollectionConverters._
 
 /** The TaskFingerprint uniquely identifies a task.
   */
-case class TaskFingerprint(sink: CfgNode, callSiteStack: List[Call])
+case class TaskFingerprint(sink: CfgNode, callSiteStack: List[Call], callDepth: Int)
 
 /** The Result Table is a cache that allows retrieving known paths for nodes, that is, paths that end in the node.
   */
@@ -34,9 +34,10 @@ class ResultTable(
   def createFromTable(
     first: PathElement,
     callSiteStack: List[Call],
-    remainder: Vector[PathElement]
+    remainder: Vector[PathElement],
+    callDepth: Int
   ): Option[Vector[ReachableByResult]] = {
-    table.get(TaskFingerprint(first.node, callSiteStack)).map { res =>
+    table.get(TaskFingerprint(first.node, callSiteStack, callDepth)).map { res =>
       res.map { r =>
         val pathToFirstNode =
           r.path.slice(0, r.path.map(x => (x.node, x.callSiteStack)).indexOf((first.node, first.callSiteStack)))
@@ -70,16 +71,13 @@ class ResultTable(
   *   indicate whether this result stands on its own or requires further analysis, e.g., by expanding output arguments
   *   backwards into method output parameters.
   */
-case class ReachableByResult(
-  taskStack: List[TaskFingerprint],
-  path: Vector[PathElement],
-  callDepth: Int,
-  partial: Boolean = false
-) {
+case class ReachableByResult(taskStack: List[TaskFingerprint], path: Vector[PathElement], partial: Boolean = false) {
 
   def fingerprint: TaskFingerprint = taskStack.last
   def sink: CfgNode                = fingerprint.sink
   def callSiteStack: List[Call]    = fingerprint.callSiteStack
+
+  def callDepth: Int = fingerprint.callDepth
 
   def startingPoint: CfgNode = path.head.node
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/ResultTable.scala
@@ -7,7 +7,7 @@ import scala.jdk.CollectionConverters._
 
 /** The TaskFingerprint uniquely identifies a task.
   */
-case class TaskFingerprint(sink: CfgNode, callSiteStack: List[Call], callDepth: Int)
+case class TaskFingerprint(sink: CfgNode, callSiteStack: List[Call])
 
 /** The Result Table is a cache that allows retrieving known paths for nodes, that is, paths that end in the node.
   */
@@ -34,10 +34,9 @@ class ResultTable(
   def createFromTable(
     first: PathElement,
     callSiteStack: List[Call],
-    callDepth: Int,
     remainder: Vector[PathElement]
   ): Option[Vector[ReachableByResult]] = {
-    table.get(TaskFingerprint(first.node, callSiteStack, callDepth)).map { res =>
+    table.get(TaskFingerprint(first.node, callSiteStack)).map { res =>
       res.map { r =>
         val pathToFirstNode =
           r.path.slice(0, r.path.map(x => (x.node, x.callSiteStack)).indexOf((first.node, first.callSiteStack)))
@@ -71,12 +70,16 @@ class ResultTable(
   *   indicate whether this result stands on its own or requires further analysis, e.g., by expanding output arguments
   *   backwards into method output parameters.
   */
-case class ReachableByResult(taskStack: List[TaskFingerprint], path: Vector[PathElement], partial: Boolean = false) {
+case class ReachableByResult(
+  taskStack: List[TaskFingerprint],
+  path: Vector[PathElement],
+  callDepth: Int,
+  partial: Boolean = false
+) {
 
   def fingerprint: TaskFingerprint = taskStack.last
   def sink: CfgNode                = fingerprint.sink
   def callSiteStack: List[Call]    = fingerprint.callSiteStack
-  def callDepth: Int               = fingerprint.callDepth
 
   def startingPoint: CfgNode = path.head.node
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -24,10 +24,7 @@ class TaskCreator(context: EngineContext) {
     } else {
       tasks.filter(_.callDepth <= context.config.maxCallDepth)
     }
-
-    tasksWithValidCallDepth.filter { t =>
-      t.taskStack.dedup.size == t.taskStack.size
-    }
+    tasksWithValidCallDepth
   }
 
   /** Create new tasks from all results that start in a parameter. In essence, we want to traverse to corresponding

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -24,7 +24,10 @@ class TaskCreator(context: EngineContext) {
     } else {
       tasks.filter(_.callDepth <= context.config.maxCallDepth)
     }
-    tasksWithValidCallDepth
+
+    tasksWithValidCallDepth.filter { t =>
+      t.taskStack.dedup.size == t.taskStack.size
+    }
   }
 
   /** Create new tasks from all results that start in a parameter. In essence, we want to traverse to corresponding

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -13,8 +13,16 @@ class TaskCreator() {
 
   /** For a given list of results and sources, generate new tasks.
     */
-  def createFromResults(results: Vector[ReachableByResult]): Vector[ReachableByTask] =
-    tasksForParams(results) ++ tasksForUnresolvedOutArgs(results)
+  def createFromResults(results: Vector[ReachableByResult]): Vector[ReachableByTask] = {
+    val newTasks = tasksForParams(results) ++ tasksForUnresolvedOutArgs(results)
+    removeTasksWithLoops(newTasks)
+  }
+
+  private def removeTasksWithLoops(tasks: Vector[ReachableByTask]): Vector[ReachableByTask] = {
+    tasks.filter { t =>
+      t.taskStack.dedup.size == t.taskStack.size
+    }
+  }
 
   /** Create new tasks from all results that start in a parameter. In essence, we want to traverse to corresponding
     * arguments of call sites, but we need to be careful here not to create unrealizable paths. We achieve this by

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -48,12 +48,12 @@ class TaskCreator(context: EngineContext) {
         case callSite :: tail =>
           // Case 1
           paramToArgs(param).filter(x => x.inCall.exists(c => c == callSite)).map { arg =>
-            ReachableByTask(result.taskStack :+ TaskFingerprint(arg, tail), result.path, result.callDepth - 1)
+            ReachableByTask(result.taskStack :+ TaskFingerprint(arg, tail, result.callDepth - 1), result.path)
           }
         case _ =>
           // Case 2
           paramToArgs(param).map { arg =>
-            ReachableByTask(result.taskStack :+ TaskFingerprint(arg, List()), result.path, result.callDepth + 1)
+            ReachableByTask(result.taskStack :+ TaskFingerprint(arg, List(), result.callDepth + 1), result.path)
           }
       }
     }
@@ -108,15 +108,15 @@ class TaskCreator(context: EngineContext) {
         if (method.isExternal || method.start.isStub.nonEmpty) {
           val newPath = path
           (call.receiver.l ++ call.argument.l).map { arg =>
-            val taskStack = result.taskStack :+ TaskFingerprint(arg, result.callSiteStack)
-            ReachableByTask(taskStack, newPath, callDepth)
+            val taskStack = result.taskStack :+ TaskFingerprint(arg, result.callSiteStack, callDepth)
+            ReachableByTask(taskStack, newPath)
           }
         } else {
           returnStatements.map { returnStatement =>
             val newPath = Vector(PathElement(methodReturn, result.callSiteStack)) ++ path
             val taskStack =
-              result.taskStack :+ TaskFingerprint(returnStatement, call :: result.callSiteStack)
-            ReachableByTask(taskStack, newPath, callDepth + 1)
+              result.taskStack :+ TaskFingerprint(returnStatement, call :: result.callSiteStack, callDepth + 1)
+            ReachableByTask(taskStack, newPath)
           }
         }
       }
@@ -133,7 +133,7 @@ class TaskCreator(context: EngineContext) {
           .filterNot(_.method.isExternal)
           .map { p =>
             val newStack = arg.inCall.headOption.map { x => x :: result.callSiteStack }.getOrElse(result.callSiteStack)
-            ReachableByTask(result.taskStack :+ TaskFingerprint(p, newStack), path, callDepth + 1)
+            ReachableByTask(result.taskStack :+ TaskFingerprint(p, newStack, callDepth + 1), path)
           }
       }
     }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -30,12 +30,15 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       TaskSummary(task, Vector(), Vector())
     } else {
       implicit val sem: Semantics = context.semantics
-      val path                    = PathElement(task.sink, task.callSiteStack) +: task.initialPath
+      val path                    = Vector(PathElement(task.sink, task.callSiteStack))
       val table                   = new ResultTable
       results(task.sink, path, table, task.callSiteStack)
       // TODO why do we update the call depth here?
       val finalResults = table.get(task.fingerprint).get.map { r =>
-        r.copy(taskStack = r.taskStack.dropRight(1) :+ r.fingerprint.copy(callDepth = task.callDepth))
+        r.copy(
+          taskStack = r.taskStack.dropRight(1) :+ r.fingerprint.copy(callDepth = task.callDepth),
+          path = r.path ++ task.initialPath
+        )
       }
       val (partial, complete) = finalResults.partition(_.partial)
       val newTasks            = new TaskCreator().createFromResults(partial).distinctBy(t => (t.sink, t.callSiteStack))

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -112,7 +112,14 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
     val res = curNode match {
       // Case 1: we have reached a source => return result and continue traversing (expand into parents)
       case x if sources.contains(x.asInstanceOf[NodeType]) =>
-        Vector(ReachableByResult(task.taskStack, path)) ++ computeResultsForParents()
+        if (x.isInstanceOf[MethodParameterIn]) {
+          Vector(
+            ReachableByResult(task.taskStack, path),
+            ReachableByResult(task.taskStack, path, partial = true)
+          ) ++ computeResultsForParents()
+        } else {
+          Vector(ReachableByResult(task.taskStack, path)) ++ computeResultsForParents()
+        }
       // Case 2: we have reached a method parameter (that isn't a source) => return partial result and stop traversing
       case _: MethodParameterIn =>
         Vector(ReachableByResult(task.taskStack, path, partial = true))

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -6,7 +6,6 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language.{toCfgNodeMethods, toExpressionMethods}
 
 import java.util.concurrent.Callable
-import scala.collection.mutable
 
 /** Callable for solving a ReachableByTask
   *
@@ -35,9 +34,8 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       r.copy(callDepth = task.callDepth, path = r.path ++ task.initialPath)
     }
     val (partial, complete) = finalResults.partition(_.partial)
-    val newTasks            = new TaskCreator(context).createFromResults(partial) // .distinctBy(t => t.fingerprint)
-    TaskSummary(task, complete, newTasks)
-
+    val newTasks            = new TaskCreator(context).createFromResults(partial)
+    TaskSummary(complete, newTasks)
   }
 
   /** Recursively expand the DDG backwards and return a list of all results, given by at least a source node in

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -16,6 +16,8 @@ import java.util.concurrent.Callable
   *   the data flow problem to solve
   * @param context
   *   state of the data flow engine
+  * @param sources
+  *   the set of sources that we are looking to reach.
   */
 class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[CfgNode]) extends Callable[TaskSummary] {
 

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -23,11 +23,11 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1  = Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), Vector(PathElement(node1))))
-      val res2  = Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), Vector(PathElement(node2))))
-      table.add(TaskFingerprint(node1, List(), 0), res1)
-      table.add(TaskFingerprint(node1, List(), 0), res2)
-      table.get(TaskFingerprint(node1, List(), 0)) match {
+      val res1  = Vector(ReachableByResult(List(TaskFingerprint(node1, List())), Vector(PathElement(node1)), 0))
+      val res2  = Vector(ReachableByResult(List(TaskFingerprint(node1, List())), Vector(PathElement(node2)), 0))
+      table.add(TaskFingerprint(node1, List()), res1)
+      table.add(TaskFingerprint(node1, List()), res2)
+      table.get(TaskFingerprint(node1, List())) match {
         case Some(results) =>
           results.flatMap(_.path.map(_.node.id)) shouldBe List(node1.id, node2.id)
         case None => fail()
@@ -55,11 +55,11 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table               = new ResultTable
       table.add(
-        TaskFingerprint(pivotNode, List(), 0),
-        Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), pathContainingPivot))
+        TaskFingerprint(pivotNode, List()),
+        Vector(ReachableByResult(List(TaskFingerprint(node1, List())), pathContainingPivot, 0))
       )
-      table.createFromTable(PathElement(pivotNode), List(), 0, Vector(PathElement(node1))) match {
-        case Some(Vector(ReachableByResult(_, path, _))) =>
+      table.createFromTable(PathElement(pivotNode), List(), Vector(PathElement(node1))) match {
+        case Some(Vector(ReachableByResult(_, path, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case _ => fail()
       }

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -23,11 +23,11 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1  = Vector(ReachableByResult(List(TaskFingerprint(node1, List())), Vector(PathElement(node1)), 0))
-      val res2  = Vector(ReachableByResult(List(TaskFingerprint(node1, List())), Vector(PathElement(node2)), 0))
-      table.add(TaskFingerprint(node1, List()), res1)
-      table.add(TaskFingerprint(node1, List()), res2)
-      table.get(TaskFingerprint(node1, List())) match {
+      val res1  = Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), Vector(PathElement(node1))))
+      val res2  = Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), Vector(PathElement(node2))))
+      table.add(TaskFingerprint(node1, List(), 0), res1)
+      table.add(TaskFingerprint(node1, List(), 0), res2)
+      table.get(TaskFingerprint(node1, List(), 0)) match {
         case Some(results) =>
           results.flatMap(_.path.map(_.node.id)) shouldBe List(node1.id, node2.id)
         case None => fail()
@@ -55,11 +55,11 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table               = new ResultTable
       table.add(
-        TaskFingerprint(pivotNode, List()),
-        Vector(ReachableByResult(List(TaskFingerprint(node1, List())), pathContainingPivot, 0))
+        TaskFingerprint(pivotNode, List(), 0),
+        Vector(ReachableByResult(List(TaskFingerprint(node1, List(), 0)), pathContainingPivot))
       )
-      table.createFromTable(PathElement(pivotNode), List(), Vector(PathElement(node1))) match {
-        case Some(Vector(ReachableByResult(_, path, _, _))) =>
+      table.createFromTable(PathElement(pivotNode), List(), Vector(PathElement(node1)), 0) match {
+        case Some(Vector(ReachableByResult(_, path, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case _ => fail()
       }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -351,10 +351,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val source = cpg.call.code("source.*")
     val sink   = cpg.call.code("sink.*").argument(1)
     val flows  = sink.reachableByFlows(source)
-
-    flows.map(flowToResultPairs).toSetMutable shouldBe Set(
-      List(("source()", 3), ("return source()", 3), ("RET", 2), ("bar()", 9), ("var y = bar()", 9), ("sink(y)", 10))
-    )
+    flows.size shouldBe 1
   }
 
   "Flow for using formal parameters as sink" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -351,7 +351,10 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     val source = cpg.call.code("source.*")
     val sink   = cpg.call.code("sink.*").argument(1)
     val flows  = sink.reachableByFlows(source)
-    flows.size shouldBe 1
+
+    flows.map(flowToResultPairs).toSetMutable shouldBe Set(
+      List(("source()", 3), ("return source()", 3), ("RET", 2), ("bar()", 9), ("var y = bar()", 9), ("sink(y)", 10))
+    )
   }
 
   "Flow for using formal parameters as sink" in {


### PR DESCRIPTION
This brings back the caching that I introduced a month back in and needed to revert because of inconsistent results. With this change, we get much improved performance while generating the same number of flows, and  `(source,sink)` pairs over runs. I do still suspect some areas in the code that could lead to inconsistencies, which I will look into next. In particular, I can imagine problems for overlapping flows.

Notes:
* I reworked the deduplication in the process, and it is a lot more aggressive now, meaning, we are intentionally returning only one result per `(source,sink)` pair
* The result table seems to not always be exactly the same, but it may not need to be.
* The number of held tasks can vary. This may also be perfectly fine, but it is worth inspecting.
* We should now be able to further simplify the TaskSolver as it works exclusively within single functions.
