### PR TITLE
Use X2CpgFrontend and X2CpgConfig in Pysrc frontend.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/build.sbt
+++ b/joern-cli/frontends/pysrc2cpg/build.sbt
@@ -6,7 +6,6 @@ dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->t
 
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph"          % Versions.cpg,
-  "org.rogach"              %% "scallop"                    % "4.1.0",
   "org.scala-lang.modules"  %% "scala-parallel-collections" % "1.0.4",
   "org.apache.logging.log4j" % "log4j-slf4j-impl"           % Versions.log4j     % Runtime,
   "org.scalatest"           %% "scalatest"                  % Versions.scalatest % Test

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
@@ -1,44 +1,32 @@
 package io.joern.pysrc2cpg
 
-import org.rogach.scallop._
+import io.joern.pysrc2cpg.Frontend.cmdLineParser
+import io.joern.x2cpg.X2CpgMain
+import scopt.OParser
 
 import java.nio.file.Paths
 
-class ParsedArguments(arguments: Seq[String]) extends ScallopConf(arguments) {
-  val output: ScallopOption[String] =
-    opt[String](default = Some("out.cpg"), short = 'o', descr = "Output file name. Defaults to out.cpg")
-
-  val input: ScallopOption[String] = trailArg[String](descr = "Input directory name")
-
-  val venvDir: ScallopOption[String] =
-    opt[String](default = Some(".venv"), noshort = true, descr = "Virtual environment directory. Defaults to .venv.")
-  val ignoreVenvDir: ScallopOption[Boolean] = opt[Boolean](
-    default = Some(true),
-    noshort = true,
-    descr = "Specifies whether venv-dir is ignored. Default to true."
-  )
-  verify()
+private object Frontend {
+  val cmdLineParser: OParser[Unit, Py2CpgOnFileSystemConfig] = {
+    val builder = OParser.builder[Py2CpgOnFileSystemConfig]
+    import builder._
+    OParser.sequence(
+      programName("pysrc2cpg"),
+      opt[String]("venvDir")
+        // Default is specified in Py2CpgOFileSystemConfig because Scopt is a shit library.
+        .text("Virtual environment directory. Defaults to .venv.")
+        .action((dir, config) => config.copy(venvDir = Paths.get(dir))),
+      opt[Boolean]("ignoreVenvDir")
+        // Default is specified in Py2CpgOFileSystemConfig because Scopt is a shit library.
+        .text("Specifies whether venv-dir is ignored. Default to true.")
+        .action(((value, config) => config.copy(ignoreVenvDir = value)))
+    )
+  }
 }
 
-object Main {
-  def main(args: Array[String]) = {
-    val parsedArguments = new ParsedArguments(args.toSeq)
-
-    val ignoreVenvDir =
-      if (parsedArguments.ignoreVenvDir.toOption.get) {
-        parsedArguments.venvDir.toOption
-      } else {
-        None
-      }
-
-    val py2CpgConfig =
-      Py2CpgOnFileSystemConfig(
-        Paths.get(parsedArguments.output.toOption.get),
-        Paths.get(parsedArguments.input.toOption.get),
-        ignoreVenvDir.map(Paths.get(_))
-      )
-
-    val cpg = Py2CpgOnFileSystem.buildCpg(py2CpgConfig)
-    cpg.close()
+object NewMain extends X2CpgMain(cmdLineParser, new Py2CpgOnFileSystem())(new Py2CpgOnFileSystemConfig()) {
+  def run(config: Py2CpgOnFileSystemConfig, frontend: Py2CpgOnFileSystem): Unit = {
+    frontend.run(config)
   }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
@@ -1,49 +1,57 @@
 package io.joern.pysrc2cpg
 
-import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.{X2Cpg, X2CpgConfig, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
-import overflowdb.Graph
-
-import java.nio.charset.StandardCharsets
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, Paths, SimpleFileVisitor}
 import scala.collection.mutable
+import scala.util.Try
 
-case class Py2CpgOnFileSystemConfig(outputFile: Path, inputDir: Path, ignoreVenvDir: Option[Path])
+case class Py2CpgOnFileSystemConfig(
+  outputFile: Path = Paths.get(X2CpgConfig.defaultOutputPath),
+  inputDir: Path = null,
+  venvDir: Path = Paths.get(".venv"),
+  ignoreVenvDir: Boolean = true
+) extends X2CpgConfig[Py2CpgOnFileSystemConfig] {
+  override def withInputPath(inputPath: String): Py2CpgOnFileSystemConfig = {
+    copy(inputDir = Paths.get(inputPath))
+  }
 
-object Py2CpgOnFileSystem {
+  override def withOutputPath(x: String): Py2CpgOnFileSystemConfig = {
+    copy(outputFile = Paths.get(x))
+  }
+}
+
+class Py2CpgOnFileSystem extends X2CpgFrontend[Py2CpgOnFileSystemConfig] {
   private val logger = LoggerFactory.getLogger(getClass)
 
   /** Entry point for files system based cpg generation from python code.
     * @param config
     *   Configuration for cpg generation.
     */
-  def buildCpg(config: Py2CpgOnFileSystemConfig): Cpg = {
+  override def createCpg(config: Py2CpgOnFileSystemConfig): Try[Cpg] = {
     logConfiguration(config)
 
-    val cpg = initCpg(config.outputFile)
-
-    val inputFiles = collectInputFiles(config.inputDir, config.ignoreVenvDir.to(Iterable))
-    val inputProviders = inputFiles.map { inputFile => () =>
-      {
-        val content = IOUtils.readLinesInFile(inputFile).mkString("\n")
-        Py2Cpg.InputPair(content, inputFile.toString, config.inputDir.relativize(inputFile).toString)
+    X2Cpg.withNewEmptyCpg(config.outputFile.toString, config) { (cpg, _) =>
+      val ignorePrefixes =
+        if (config.ignoreVenvDir) {
+          config.venvDir :: Nil
+        } else {
+          Nil
+        }
+      val inputFiles = collectInputFiles(config.inputDir, ignorePrefixes)
+      val inputProviders = inputFiles.map { inputFile => () =>
+        {
+          val content = IOUtils.readLinesInFile(inputFile).mkString("\n")
+          Py2Cpg.InputPair(content, inputFile.toString, config.inputDir.relativize(inputFile).toString)
+        }
       }
+
+      val py2Cpg = new Py2Cpg(inputProviders, cpg)
+      py2Cpg.buildCpg()
     }
-
-    val py2Cpg = new Py2Cpg(inputProviders, cpg)
-    py2Cpg.buildCpg()
-    cpg
-  }
-
-  private def initCpg(outputFile: Path): Cpg = {
-    if (Files.exists(outputFile)) {
-      Files.delete(outputFile)
-    }
-
-    X2Cpg.newEmptyCpg(Some(outputFile.toString))
   }
 
   private def collectInputFiles(inputDir: Path, ignorePrefixes: Iterable[Path]): Iterable[Path] = {
@@ -77,6 +85,7 @@ object Py2CpgOnFileSystem {
   private def logConfiguration(config: Py2CpgOnFileSystemConfig): Unit = {
     logger.info(s"Output file: ${config.outputFile}")
     logger.info(s"Input directory: ${config.inputDir}")
-    config.ignoreVenvDir.foreach(dir => logger.info(s"Ignored virtual environment directory: $dir"))
+    logger.info(s"Venv directory: ${config.venvDir}")
+    logger.info(s"IgnoreVenvDir: ${config.ignoreVenvDir}")
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -3,7 +3,6 @@ package io.joern.pysrc2cpg
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.pysrc2cpg.Py2CpgOnFileSystem.buildCpg
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.passes.frontend.{PythonNaiveCallLinker, PythonModuleDefinedCallLinker}
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
@@ -15,11 +14,7 @@ trait PythonFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".py"
 
   override def execute(sourceCodePath: java.io.File): Cpg = {
-    val cpgOutFile = File.newTemporaryFile(suffix = "cpg.bin")
-    cpgOutFile.deleteOnExit()
-    val config = Py2CpgOnFileSystemConfig(cpgOutFile.path, sourceCodePath.toPath, None)
-    val cpg    = buildCpg(config)
-    cpg
+    new Py2CpgOnFileSystem().createCpg(sourceCodePath.getAbsolutePath)(new Py2CpgOnFileSystemConfig()).get
   }
 }
 


### PR DESCRIPTION
Reuse already existing components. Most importantly use the same option
parser library and provide common API via X2CpgFrontend trait.