### PR TITLE
Remove Java 8 compat

### DIFF
--- a/benchmarks/build.sbt
+++ b/benchmarks/build.sbt
@@ -14,14 +14,5 @@ libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % Versions.scalatest 
 
 Compile / doc / sources ~= (_ filter (_ => false))
 
-// we want to consume this from a java8 build
-compile / javacOptions ++= Seq("--release", "8")
-scalacOptions ++= Seq() ++ (
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((3, _)) => Seq("-Xtarget:8")
-    case _            => Seq("-target:jvm-1.8")
-  }
-)
-
 trapExit    := false
 Test / fork := true

--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -16,12 +16,3 @@ Antlr4 / antlr4PackageName := Some("io.joern.dataflowengineoss")
 Antlr4 / antlr4Version     := Versions.antlr
 Antlr4 / javaSource        := (Compile / sourceManaged).value
 Compile / doc / sources ~= (_ filter (_ => false))
-
-// we want to consume this from a java8 build
-compile / javacOptions ++= Seq("--release", "8")
-scalacOptions ++= Seq() ++ (
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((3, _)) => Seq("-Xtarget:8")
-    case _            => Seq("-target:jvm-1.8")
-  }
-)


### PR DESCRIPTION
These 2 builds are not consumed anywhere anymore with Java 8. Last occurrence is in js2cpg where I will remove it too.

This should also fix: https://github.com/joernio/joern/issues/2117