### PR TITLE
c2cpg: fix dangling sub ASTs

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -68,7 +68,7 @@ class AstCreator(
   /** Creates an AST of all declarations found in the translation unit - wrapped in a fake method.
     */
   private def astInFakeMethod(fullName: String, path: String, iASTTranslationUnit: IASTTranslationUnit): Ast = {
-    val allDecls      = iASTTranslationUnit.getDeclarations
+    val allDecls      = iASTTranslationUnit.getDeclarations.toSeq
     val lineNumber    = allDecls.headOption.flatMap(line)
     val lineNumberEnd = allDecls.lastOption.flatMap(lineEnd)
 
@@ -104,17 +104,8 @@ class AstCreator(
       .typeFullName("ANY")
 
     val declsAsts = allDecls.flatMap { stmt =>
-      val r =
-        CGlobal.getAstsFromAstCache(
-          diffGraph,
-          fileName(stmt),
-          filename,
-          line(stmt),
-          column(stmt),
-          astsForDeclaration(stmt)
-        )
-      r
-    }.toIndexedSeq
+      CGlobal.getAstsFromAstCache(fileName(stmt), filename, line(stmt), column(stmt), astsForDeclaration(stmt))
+    }
 
     val methodReturn = NewMethodReturn()
       .code("RET")

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/CGlobal.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/CGlobal.scala
@@ -33,43 +33,38 @@ object CGlobal extends Global {
   }
 
   def getAstsFromAstCache(
-    diffGraph: DiffGraphBuilder,
     filename: String,
     fromFilename: String,
     linenumber: Option[Integer],
     columnnumber: Option[Integer],
     astCreatorFunction: => Seq[Ast]
   ): Seq[Ast] = {
-    val (callCreatorFunc, addDirectlyToDiff) =
+    val callCreatorFunc =
       CGlobal.synchronized {
         if (
-          FileDefaults
-            .isHeaderFile(filename) && filename != fromFilename && linenumber.isDefined && columnnumber.isDefined
+          FileDefaults.isHeaderFile(filename) &&
+          filename != fromFilename &&
+          linenumber.isDefined &&
+          columnnumber.isDefined
         ) {
           if (!headerAstCache.contains(filename)) {
             headerAstCache.put(filename, mutable.HashSet((linenumber.get, columnnumber.get)))
-            (true, true)
+            true
           } else {
             if (!headerAstCache(filename).contains((linenumber.get, columnnumber.get))) {
               headerAstCache(filename).add((linenumber.get, columnnumber.get))
-              (true, true)
+              true
             } else {
-              (false, false)
+              false
             }
           }
         } else {
-          (true, false)
+          true
         }
       }
 
     if (callCreatorFunc) {
-      val asts = astCreatorFunction
-      if (addDirectlyToDiff) {
-        asts.foreach(Ast.storeInDiffGraph(_, diffGraph))
-        Seq.empty
-      } else {
-        asts
-      }
+      astCreatorFunction
     } else {
       Seq.empty
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/HeaderAstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/HeaderAstCreationPassTests.scala
@@ -1,6 +1,5 @@
 package io.joern.c2cpg.passes.ast
 
-import better.files.File
 import io.joern.c2cpg.testfixtures.CCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
@@ -32,7 +31,7 @@ class HeaderAstCreationPassTests extends CCodeToCpgSuite {
     )
 
     "create all source and header files correctly" in {
-      val fileNames = cpg.file.nameNot(".*<includes>|<unknown>").name.sorted.map(File(_).name)
+      val fileNames = cpg.file.nameNot(".*<includes>|<unknown>").name.sorted
       fileNames shouldBe Seq("main.c", "main.h", "other.h")
     }
 
@@ -42,16 +41,16 @@ class HeaderAstCreationPassTests extends CCodeToCpgSuite {
           // note that we don't see bar twice even so it is contained
           // in main.h and included in main.c and we do scan both
           bar.fullName shouldBe "bar"
-          bar.filename should endWith("main.h")
+          bar.filename shouldBe "main.h"
           foo.fullName shouldBe "foo"
-          foo.filename should endWith("other.h")
+          foo.filename shouldBe "other.h"
           // main is include twice. First time for the header file,
           // second time for the actual implementation in the source file
           // We do not de-duplicate this as line/column numbers differ
           m1.fullName shouldBe "main"
-          m1.filename should endWith("main.h")
+          m1.filename shouldBe "main.h"
           m2.fullName shouldBe "main"
-          m2.filename should endWith("main.c")
+          m2.filename shouldBe "main.c"
           printf.fullName shouldBe "printf"
       }
     }


### PR DESCRIPTION
We stored sub ASTs from header files directly into the diffgraph when de-duplicating using the global cache. Now they are correctly stored where included.

This is for: https://github.com/ShiftLeftSecurity/product/issues/11354