### PR TITLE
Xmx max heap memory handling for importing large codebases

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
@@ -24,4 +24,5 @@ case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGene
   override def isAvailable: Boolean =
     command.toFile.exists
 
+  override def isJvmBased = true
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
@@ -27,4 +27,5 @@ case class CSharpCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   override def isAvailable: Boolean = rootPath.resolve("csharp2cpg.sh").toFile.exists()
 
+  override def isJvmBased = false
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -15,6 +15,9 @@ abstract class CpgGenerator() {
 
   def isAvailable: Boolean
 
+  /** is this a JVM based frontend? if so, we'll invoke it with -Xmx for max heap settings */
+  def isJvmBased: Boolean
+
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     *
     * This method appends command line options in config.frontend.cmdLineParams to the shell command.

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -31,6 +31,13 @@ abstract class CpgGenerator() {
     }
     val cmd       = Seq[String](program) ++ arguments
     val exitValue = cmd.run().exitValue()
+    println(
+      s"""Invoking CPG generator in a separate process. Note that the new process will consume additional memory.
+         |If you are importing a large codebase (and/or running into memory issues), please try the following:
+         |1) exit joern
+         |2) invoke the frontend: `${cmd.mkString(" ")}`
+         |3) start joern, import the cpg: `importCpg("path/to/cpg")`
+         |""".stripMargin)
     if (exitValue == 0) {
       Some(cmd.toString)
     } else {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -29,25 +29,35 @@ abstract class CpgGenerator() {
       System.err.println(s"CPG generator does not exist at: $program")
       return None
     }
-    val cmd       = Seq[String](program) ++ arguments
-    val exitValue = cmd.run().exitValue()
-    println(
-      s"""Invoking CPG generator in a separate process. Note that the new process will consume additional memory.
+    val cmd       = Seq(program) ++ maxMemoryParameter ++ arguments
+    val cmdString = cmd.mkString(" ")
+
+    println(s"""=======================================================================================================
+         |Invoking CPG generator in a separate process. Note that the new process will consume additional memory.
          |If you are importing a large codebase (and/or running into memory issues), please try the following:
          |1) exit joern
-         |2) invoke the frontend: `${cmd.mkString(" ")}`
+         |2) invoke the frontend: $cmdString
          |3) start joern, import the cpg: `importCpg("path/to/cpg")`
+         |=======================================================================================================
          |""".stripMargin)
+    val exitValue = cmd.run().exitValue()
     if (exitValue == 0) {
-      Some(cmd.toString)
+      Some(cmdString)
     } else {
       System.err.println(s"Error running shell command: $cmd")
       None
     }
   }
 
-  def applyPostProcessingPasses(cpg: Cpg): Cpg = {
-    cpg
+  protected lazy val maxMemoryParameter = {
+    if (isJvmBased) {
+      val maxValueInMegabytes = Runtime.getRuntime.maxMemory / 1024 / 1024
+      Seq(s"-J-Xmx${maxValueInMegabytes}m")
+    } else Nil
   }
+
+  /** override in specific cpg generators to make them apply post processing passes */
+  def applyPostProcessingPasses(cpg: Cpg): Cpg =
+    cpg
 
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
@@ -22,4 +22,6 @@ case class GhidraCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   override def isAvailable: Boolean =
     command.toFile.exists
+
+  override def isJvmBased = true
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
@@ -27,4 +27,6 @@ case class GoCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
   }
 
   override def isAvailable: Boolean = rootPath.resolve("go2cpg.sh").toFile.exists()
+
+  override def isJvmBased = false
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
@@ -75,6 +75,7 @@ case class JavaCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
   private def commercialAvailable: Boolean = rootPath.resolve("java2cpg.sh").toFile.exists()
   private def ossAvailable: Boolean        = rootPath.resolve("jimple2cpg").toFile.exists()
 
+  override def isJvmBased = true
 }
 
 object JavaCpgGenerator {

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -22,4 +22,6 @@ case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends C
 
   override def isAvailable: Boolean =
     command.toFile.exists
+
+  override def isJvmBased = true
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
@@ -20,4 +20,6 @@ case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
 
   override def isAvailable: Boolean =
     command.toFile.exists
+
+  override def isJvmBased = true
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -28,4 +28,5 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
     cpg
   }
 
+  override def isJvmBased = true
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
@@ -22,4 +22,6 @@ case class KotlinCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   override def isAvailable: Boolean =
     command.toFile.exists
+
+  override def isJvmBased = true
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
@@ -21,4 +21,6 @@ case class LlvmCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
   }
 
   override def isAvailable: Boolean = rootPath.resolve("llvm2cpg.sh").toFile.exists()
+
+  override def isJvmBased = false
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
@@ -14,4 +14,6 @@ case class PhpCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGe
 
   override def isAvailable: Boolean =
     command.toFile.exists
+
+  override def isJvmBased = true
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -28,4 +28,6 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
     new PythonNaiveCallLinker(cpg).createAndApply()
     cpg
   }
+
+  override def isJvmBased = true
 }

--- a/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
@@ -85,6 +85,8 @@ class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory
 
     def isAvailable: Boolean = true
 
+    override def isJvmBased = true
+
   }
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/CGlobal.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/CGlobal.scala
@@ -2,7 +2,6 @@ package io.joern.c2cpg.datastructures
 
 import io.joern.c2cpg.astcreation.Defines
 import io.joern.c2cpg.parser.FileDefaults
-import overflowdb.BatchedUpdate.DiffGraphBuilder
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.Global
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
@@ -28,7 +28,6 @@ object JoernSlice {
         storeSliceInNewCpg(config.outFile, slice)
       }
     }
-
   }
 
   private def parseConfig(args: Array[String]): Option[Config] =
@@ -54,7 +53,7 @@ object JoernSlice {
     val sinks = cpg.file.nameExact(sourceFile).ast.lineNumber(sourceLine).isCall.argument.l
 
     implicit val context: EngineContext = EngineContext()
-    val sliceNodes                      = sinks.repeat(_.ddgIn)(_.times(20).emit).dedup.l
+    val sliceNodes                      = sinks.repeat(_.ddgIn)(_.maxDepth(20).emit).dedup.l
     val sliceEdges = sliceNodes
       .flatMap(_.outE)
       .filter(x => sliceNodes.contains(x.inNode()))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -96,7 +96,7 @@ class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
   /** Traverse to canonical type which means unravel aliases until we find a non alias type declaration.
     */
   def canonicalType: Traversal[TypeDecl] =
-    traversal.repeat(_.unravelAlias)(_.until(_.isCanonical).times(maxAliasExpansions))
+    traversal.repeat(_.unravelAlias)(_.until(_.isCanonical).maxDepth(maxAliasExpansions))
 
   /** Direct alias type declarations.
     */


### PR DESCRIPTION
Prior to this, we would not pass the Xmx (max heap) setting from joern to frontends.
Only a globally configured `JAVA_OPTS` would work, but most users would either configure
that specifically for joern (e.g. `JAVA_OPTS=-Xmx30g ./joern`) or use the `-J` flag,
e.g. `./joern -J-Xmx30g` - especially if they want to import large codebases. 

Now, we determine the maxMemory that the user configured joern with, and pass that to 
all JVM based frontends. Since the sum of joern and the frontend may exceed the physical
memory of the machine, we tell the user that they may want to exit joern and invoke the 
frontend themselves.  Determining the available max memory for a machine is tricky, so 
we'll keep it simple for now.