### PR TITLE
c2cpg: refactorings and clean-ups

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -261,11 +261,11 @@ trait AstCreatorHelper { this: AstCreator =>
         }
       case alias: ICPPASTNamespaceAlias => alias.getMappingName.toString
       case namespace: ICPPASTNamespaceDefinition if ASTStringUtil.getSimpleName(namespace.getName).nonEmpty =>
-        fullName(namespace.getParent) + "." + ASTStringUtil.getSimpleName(namespace.getName)
+        s"${fullName(namespace.getParent)}.${ASTStringUtil.getSimpleName(namespace.getName)}"
       case namespace: ICPPASTNamespaceDefinition if ASTStringUtil.getSimpleName(namespace.getName).isEmpty =>
-        fullName(namespace.getParent) + "." + uniqueName("namespace", "", "")._1
+        s"${fullName(namespace.getParent)}.${uniqueName("namespace", "", "")._1}"
       case cppClass: ICPPASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(cppClass.getName).nonEmpty =>
-        fullName(cppClass.getParent) + "." + ASTStringUtil.getSimpleName(cppClass.getName)
+        s"${fullName(cppClass.getParent)}.${ASTStringUtil.getSimpleName(cppClass.getName)}"
       case cppClass: ICPPASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(cppClass.getName).isEmpty =>
         val name = cppClass.getParent match {
           case decl: IASTSimpleDeclaration =>
@@ -276,24 +276,25 @@ trait AstCreatorHelper { this: AstCreator =>
         }
         s"${fullName(cppClass.getParent)}.$name"
       case enumSpecifier: IASTEnumerationSpecifier =>
-        fullName(enumSpecifier.getParent) + "." + ASTStringUtil.getSimpleName(enumSpecifier.getName)
+        s"${fullName(enumSpecifier.getParent)}.${ASTStringUtil.getSimpleName(enumSpecifier.getName)}"
       case c: IASTCompositeTypeSpecifier =>
-        fullName(c.getParent) + "." + ASTStringUtil.getSimpleName(c.getName)
+        s"${fullName(c.getParent)}.${ASTStringUtil.getSimpleName(c.getName)}"
       case f: IASTFunctionDeclarator
           if ASTStringUtil.getSimpleName(f.getName).isEmpty && f.getNestedDeclarator != null =>
-        fullName(f.getParent) + "." + ASTStringUtil.getSimpleName(f.getNestedDeclarator.getName)
+        s"${fullName(f.getParent)}.${ASTStringUtil.getSimpleName(f.getNestedDeclarator.getName)}"
       case f: IASTFunctionDeclarator =>
-        fullName(f.getParent) + "." + ASTStringUtil.getSimpleName(f.getName)
+        s"${fullName(f.getParent)}.${ASTStringUtil.getSimpleName(f.getName)}"
       case f: ICPPASTLambdaExpression =>
-        fullName(f.getParent) + "."
+        s"${fullName(f.getParent)}."
       case f: IASTFunctionDefinition if f.getDeclarator != null =>
-        fullName(f.getParent) + "." + ASTStringUtil.getQualifiedName(f.getDeclarator.getName)
+        s"${fullName(f.getParent)}.${ASTStringUtil.getQualifiedName(f.getDeclarator.getName)}"
       case f: IASTFunctionDefinition =>
-        fullName(f.getParent) + "." + ASTStringUtil.getSimpleName(f.getDeclarator.getName)
+        s"${fullName(f.getParent)}.${ASTStringUtil.getSimpleName(f.getDeclarator.getName)}"
+      case e: IASTElaboratedTypeSpecifier =>
+        s"${fullName(e.getParent)}.${ASTStringUtil.getSimpleName(e.getName)}"
       case d: IASTIdExpression              => ASTStringUtil.getSimpleName(d.getName)
       case _: IASTTranslationUnit           => ""
       case u: IASTUnaryExpression           => nodeSignature(u.getOperand)
-      case e: IASTElaboratedTypeSpecifier   => fullName(e.getParent) + "." + ASTStringUtil.getSimpleName(e.getName)
       case other if other.getParent != null => fullName(other.getParent)
       case other if other != null           => notHandledYet(other); ""
       case null                             => ""

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -2,7 +2,7 @@ package io.joern.c2cpg.astcreation
 
 import io.joern.c2cpg.datastructures.CGlobal
 import io.joern.c2cpg.utils.IOUtils
-import io.shiftleft.codepropertygraph.generated.nodes.{ExpressionNew, NewBlock, NewNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{ExpressionNew, NewNode}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.joern.x2cpg.Ast
 import org.apache.commons.lang.StringUtils
@@ -75,11 +75,11 @@ trait AstCreatorHelper { this: AstCreator =>
     IOUtils.toRelativePath(path, config)
   }
 
-  protected def line(node: IASTNode): Option[Integer] = {
+  protected def line(node: IASTNode): Option[Int] = {
     nullSafeFileLocation(node).map(_.getStartingLineNumber)
   }
 
-  protected def lineEnd(node: IASTNode): Option[Integer] = {
+  protected def lineEnd(node: IASTNode): Option[Int] = {
     nullSafeFileLocationLast(node).map(_.getEndingLineNumber)
   }
 
@@ -96,14 +96,14 @@ trait AstCreatorHelper { this: AstCreator =>
     column
   }
 
-  protected def column(node: IASTNode): Option[Integer] = {
+  protected def column(node: IASTNode): Option[Int] = {
     val loc = nullSafeFileLocation(node)
     loc.map { x =>
       offsetToColumn(node, x.getNodeOffset)
     }
   }
 
-  protected def columnEnd(node: IASTNode): Option[Integer] = {
+  protected def columnEnd(node: IASTNode): Option[Int] = {
     val loc = nullSafeFileLocation(node)
 
     loc.map { x =>
@@ -203,7 +203,7 @@ trait AstCreatorHelper { this: AstCreator =>
       val text = notHandledText(node)
       logger.info(text)
     }
-    Ast(newUnknown(node))
+    Ast(newUnknownNode(node))
   }
 
   protected def nullSafeCode(node: IASTNode): String = {
@@ -352,10 +352,7 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   private def astForCASTDesignatedInitializer(d: ICASTDesignatedInitializer): Ast = {
-    val b = NewBlock()
-      .typeFullName(registerType(Defines.voidTypeName))
-      .lineNumber(line(d))
-      .columnNumber(column(d))
+    val b = newBlockNode(d, Defines.voidTypeName)
     scope.pushNewScope(b)
     val op = Operators.assignment
 
@@ -371,10 +368,7 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   private def astForCPPASTDesignatedInitializer(d: ICPPASTDesignatedInitializer): Ast = {
-    val b = NewBlock()
-      .typeFullName(registerType(Defines.voidTypeName))
-      .lineNumber(line(d))
-      .columnNumber(column(d))
+    val b = newBlockNode(d, Defines.voidTypeName)
     scope.pushNewScope(b)
     val op = Operators.assignment
     val calls = withIndex(d.getDesignators) { (des, o) =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.astcreation
 
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewCall, NewIdentifier, NewMethodRef}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewIdentifier, NewMethodRef}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.joern.x2cpg.Ast
 import org.eclipse.cdt.core.dom.ast._
@@ -56,10 +56,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
   }
 
   private def astForExpressionList(exprList: IASTExpressionList): Ast = {
-    val b = NewBlock()
-      .typeFullName(registerType(Defines.voidTypeName))
-      .lineNumber(line(exprList))
-      .columnNumber(column(exprList))
+    val b = newBlockNode(exprList, Defines.voidTypeName)
     Ast(b).withChildren(exprList.getExpressions.toIndexedSeq.map(astForExpression))
   }
 
@@ -188,7 +185,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
 
     val expr    = astForExpression(castExpression.getOperand)
     val argNode = castExpression.getTypeId
-    val arg     = newUnknown(argNode)
+    val arg     = newUnknownNode(argNode)
 
     callAst(cpgCastExpression, List(Ast(arg), expr))
   }
@@ -229,7 +226,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     val cpgCastExpression =
       newCallNode(typeIdInit, Operators.cast, Operators.cast, DispatchTypes.STATIC_DISPATCH)
 
-    val typeAst = newUnknown(typeIdInit.getTypeId)
+    val typeAst = newUnknownNode(typeIdInit.getTypeId)
     val expr    = astForNode(typeIdInit.getInitializer)
     callAst(cpgCastExpression, List(Ast(typeAst), expr))
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -86,7 +86,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
     parameterNodes.lastOption.foreach {
       case p: NewMethodParameterIn if isVariadic(func) =>
         p.isVariadic = true
-        p.code = p.code + "..."
+        p.code = s"${p.code}..."
       case _ =>
     }
   }
@@ -103,9 +103,8 @@ trait AstForFunctionsCreator { this: AstCreator =>
       case null => Defines.anyTypeName
     }
     val (name, fullname) = uniqueName("lambda", "", fullName(lambdaExpression))
-    val signature =
-      returnType + " " + fullname + " " + parameterListSignature(lambdaExpression, includeParamNames = false)
-    val code = returnType + " " + name + " " + parameterListSignature(lambdaExpression, includeParamNames = true)
+    val signature = s"$returnType $fullname ${parameterListSignature(lambdaExpression, includeParamNames = false)}"
+    val code      = s"$returnType $name ${parameterListSignature(lambdaExpression, includeParamNames = true)}"
     val methodNode = newMethodNode(
       lambdaExpression,
       StringUtils.normalizeSpace(name),
@@ -137,8 +136,8 @@ trait AstForFunctionsCreator { this: AstCreator =>
     val fullname       = fullName(funcDecl)
     val templateParams = templateParameters(funcDecl).getOrElse("")
     val signature =
-      returnType + " " + fullname + templateParams + " " + parameterListSignature(funcDecl, includeParamNames = false)
-    val code = returnType + " " + name + " " + parameterListSignature(funcDecl, includeParamNames = true)
+      s"$returnType $fullname$templateParams ${parameterListSignature(funcDecl, includeParamNames = false)}"
+    val code = s"$returnType $name ${parameterListSignature(funcDecl, includeParamNames = true)}"
     val methodNode =
       newMethodNode(funcDecl, StringUtils.normalizeSpace(name), code, StringUtils.normalizeSpace(fullname), filename)
         .isExternal(false)
@@ -165,8 +164,8 @@ trait AstForFunctionsCreator { this: AstCreator =>
     val fullname       = fullName(funcDef)
     val templateParams = templateParameters(funcDef).getOrElse("")
     val signature =
-      returnType + " " + fullname + templateParams + " " + parameterListSignature(funcDef, includeParamNames = false)
-    val code = returnType + " " + name + " " + parameterListSignature(funcDef, includeParamNames = true)
+      s"$returnType $fullname$templateParams ${parameterListSignature(funcDef, includeParamNames = false)}"
+    val code = s"$returnType $name ${parameterListSignature(funcDef, includeParamNames = true)}"
     val methodNode =
       newMethodNode(funcDef, StringUtils.normalizeSpace(name), code, StringUtils.normalizeSpace(fullname), filename)
         .isExternal(false)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewReturn}
 import io.joern.x2cpg.Ast
 import org.eclipse.cdt.core.dom.ast._
 import org.eclipse.cdt.core.dom.ast.cpp._
@@ -16,12 +15,10 @@ trait AstForStatementsCreator { this: AstCreator =>
   import AstCreatorHelper.OptionSafeAst
 
   protected def astForBlockStatement(blockStmt: IASTCompoundStatement, order: Int = -1): Ast = {
-    val cpgBlock = NewBlock()
-      .order(order)
-      .argumentIndex(order)
-      .typeFullName(registerType(Defines.voidTypeName))
-      .lineNumber(line(blockStmt))
-      .columnNumber(column(blockStmt))
+    val cpgBlock =
+      newBlockNode(blockStmt, registerType(Defines.voidTypeName))
+        .order(order)
+        .argumentIndex(order)
 
     scope.pushNewScope(cpgBlock)
     var currOrder = 1
@@ -60,11 +57,8 @@ trait AstForStatementsCreator { this: AstCreator =>
     }
 
   private def astForReturnStatement(ret: IASTReturnStatement): Ast = {
-    val cpgReturn = NewReturn()
-      .code(nodeSignature(ret))
-      .lineNumber(line(ret))
-      .columnNumber(column(ret))
-    val expr = nullSafeAst(ret.getReturnValue)
+    val cpgReturn = newReturnNode(ret, nodeSignature(ret))
+    val expr      = nullSafeAst(ret.getReturnValue)
     Ast(cpgReturn).withChild(expr).withArgEdge(cpgReturn, expr.root)
   }
 
@@ -93,7 +87,7 @@ trait AstForStatementsCreator { this: AstCreator =>
   }
 
   private def astsForLabelStatement(label: IASTLabelStatement): Seq[Ast] = {
-    val cpgLabel    = newJumpTarget(label)
+    val cpgLabel    = newJumpTargetNode(label)
     val nestedStmts = nullSafeAst(label.getNestedStatement)
     Ast(cpgLabel) +: nestedStmts
   }
@@ -127,13 +121,13 @@ trait AstForStatementsCreator { this: AstCreator =>
   }
 
   private def astsForCaseStatement(caseStmt: IASTCaseStatement): Seq[Ast] = {
-    val labelNode = newJumpTarget(caseStmt)
+    val labelNode = newJumpTargetNode(caseStmt)
     val stmt      = nullSafeAst(caseStmt.getExpression)
     Seq(Ast(labelNode), stmt)
   }
 
   private def astForDefaultStatement(caseStmt: IASTDefaultStatement): Ast = {
-    Ast(newJumpTarget(caseStmt))
+    Ast(newJumpTargetNode(caseStmt))
   }
 
   private def astForTryStatement(tryStmt: ICPPASTTryBlockStatement): Ast = {
@@ -181,10 +175,7 @@ trait AstForStatementsCreator { this: AstCreator =>
     val code    = s"for ($codeInit$codeCond;$codeIter)"
     val forNode = newControlStructureNode(forStmt, ControlStructureTypes.FOR, code)
 
-    val initAstBlock = NewBlock()
-      .typeFullName(registerType(Defines.voidTypeName))
-      .lineNumber(line(forStmt))
-      .columnNumber(column(forStmt))
+    val initAstBlock = newBlockNode(forStmt, registerType(Defines.voidTypeName))
     scope.pushNewScope(initAstBlock)
     val initAst = Ast(initAstBlock).withChildren(nullSafeAst(forStmt.getInitializerStatement, 1))
     scope.popScope()
@@ -243,11 +234,8 @@ trait AstForStatementsCreator { this: AstCreator =>
         val a = nullSafeAst(ifStmt.getConditionExpression)
         (c, a)
       case s: CPPASTIfStatement if s.getConditionExpression == null =>
-        val c = s"if (${nullSafeCode(s.getConditionDeclaration)})"
-        val exprBlock = NewBlock()
-          .typeFullName(registerType(Defines.voidTypeName))
-          .lineNumber(line(s.getConditionDeclaration))
-          .columnNumber(column(s.getConditionDeclaration))
+        val c         = s"if (${nullSafeCode(s.getConditionDeclaration)})"
+        val exprBlock = newBlockNode(s.getConditionDeclaration, Defines.voidTypeName)
         scope.pushNewScope(exprBlock)
         val a        = astsForDeclaration(s.getConditionDeclaration)
         val blockAst = Ast(exprBlock).withChildren(a)
@@ -260,10 +248,7 @@ trait AstForStatementsCreator { this: AstCreator =>
     val thenAst = ifStmt.getThenClause match {
       case block: IASTCompoundStatement => astForBlockStatement(block)
       case other if other != null =>
-        val thenBlock = NewBlock()
-          .typeFullName(registerType(Defines.voidTypeName))
-          .lineNumber(line(other))
-          .columnNumber(column(other))
+        val thenBlock = newBlockNode(other, Defines.voidTypeName)
         scope.pushNewScope(thenBlock)
         val a        = astsForStatement(other)
         val blockAst = Ast(thenBlock).withChildren(a)
@@ -278,11 +263,8 @@ trait AstForStatementsCreator { this: AstCreator =>
         val elseAst  = astForBlockStatement(block)
         Ast(elseNode).withChild(elseAst)
       case other if other != null =>
-        val elseNode = newControlStructureNode(ifStmt.getElseClause, ControlStructureTypes.ELSE, "else")
-        val elseBlock = NewBlock()
-          .typeFullName(registerType(Defines.voidTypeName))
-          .lineNumber(line(other))
-          .columnNumber(column(other))
+        val elseNode  = newControlStructureNode(ifStmt.getElseClause, ControlStructureTypes.ELSE, "else")
+        val elseBlock = newBlockNode(other, Defines.voidTypeName)
         scope.pushNewScope(elseBlock)
         val a        = astsForStatement(other)
         val blockAst = Ast(elseBlock).withChildren(a)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -35,22 +35,12 @@ trait AstForTypesCreator { this: AstCreator =>
   }
 
   private def astForNamespaceDefinition(namespaceDefinition: ICPPASTNamespaceDefinition): Ast = {
-    val linenumber   = line(namespaceDefinition)
-    val columnnumber = column(namespaceDefinition)
-    val filename     = fileName(namespaceDefinition)
-
     val (name, fullname) =
       uniqueName("namespace", namespaceDefinition.getName.getLastName.toString, fullName(namespaceDefinition))
-    val code = "namespace " + fullname
-    val cpgNamespace = NewNamespaceBlock()
-      .code(code)
-      .lineNumber(linenumber)
-      .columnNumber(columnnumber)
-      .filename(filename)
-      .name(name)
-      .fullName(fullname)
-
+    val code         = "namespace " + fullname
+    val cpgNamespace = newNamespaceBlockNode(namespaceDefinition, name, fullname, code, fileName(namespaceDefinition))
     scope.pushNewScope(cpgNamespace)
+
     val childrenAsts = namespaceDefinition.getDeclarations.flatMap { decl =>
       val declAsts = astsForDeclaration(decl)
       declAsts
@@ -62,10 +52,6 @@ trait AstForTypesCreator { this: AstCreator =>
   }
 
   protected def astForNamespaceAlias(namespaceAlias: ICPPASTNamespaceAlias): Ast = {
-    val linenumber   = line(namespaceAlias)
-    val columnnumber = column(namespaceAlias)
-    val filename     = fileName(namespaceAlias)
-
     val name     = ASTStringUtil.getSimpleName(namespaceAlias.getAlias)
     val fullname = fullName(namespaceAlias)
 
@@ -73,71 +59,35 @@ trait AstForTypesCreator { this: AstCreator =>
       usingDeclarationMappings.put(name, fullname)
     }
 
-    val code = "namespace " + name + " = " + fullname
-    val cpgNamespace = NewNamespaceBlock()
-      .code(code)
-      .lineNumber(linenumber)
-      .columnNumber(columnnumber)
-      .filename(filename)
-      .name(name)
-      .fullName(fullname)
-
+    val code         = "namespace " + name + " = " + fullname
+    val cpgNamespace = newNamespaceBlockNode(namespaceAlias, name, fullname, code, fileName(namespaceAlias))
     Ast(cpgNamespace)
   }
 
   protected def astForDeclarator(declaration: IASTSimpleDeclaration, declarator: IASTDeclarator, index: Int): Ast = {
-    val name         = ASTStringUtil.getSimpleName(declarator.getName)
-    val lineNumber   = line(declarator)
-    val columnNumber = column(declarator)
+    val name = ASTStringUtil.getSimpleName(declarator.getName)
     declaration match {
       case d if isTypeDef(d) =>
         val filename = fileName(declaration)
         val tpe      = registerType(typeFor(declarator))
-        Ast(
-          newTypeDecl(
-            name,
-            registerType(name),
-            filename,
-            nodeSignature(d),
-            alias = Some(tpe),
-            line = lineNumber,
-            column = columnNumber
-          )
-        )
+        Ast(newTypeDeclNode(declarator, name, registerType(name), filename, nodeSignature(d), alias = Some(tpe)))
       case d if parentIsClassDef(d) =>
         val tpe = registerType(typeFor(declaration.getDeclSpecifier))
-        Ast(
-          NewMember()
-            .code(nodeSignature(declarator))
-            .name(name)
-            .typeFullName(tpe)
-            .lineNumber(lineNumber)
-            .columnNumber(columnNumber)
-        )
+        Ast(newMemberNode(declarator, name, nodeSignature(declarator), tpe))
       case _ if declarator.isInstanceOf[IASTArrayDeclarator] =>
-        val tpe     = registerType(typeFor(declarator))
-        val codeTpe = typeFor(declarator, stripKeywords = false)
-        val l = NewLocal()
-          .code(s"$codeTpe $name")
-          .name(name)
-          .typeFullName(tpe)
-          .lineNumber(lineNumber)
-          .columnNumber(columnNumber)
-        scope.addToScope(name, (l, tpe))
-        Ast(l)
+        val tpe       = registerType(typeFor(declarator))
+        val codeTpe   = typeFor(declarator, stripKeywords = false)
+        val localNode = newLocalNode(declarator, name, s"$codeTpe $name", tpe)
+        scope.addToScope(name, (localNode, tpe))
+        Ast(localNode)
       case _ =>
         val tpe = registerType(
           cleanType(typeForDeclSpecifier(declaration.getDeclSpecifier, stripKeywords = true, index))
         )
-        val codeTpe = typeForDeclSpecifier(declaration.getDeclSpecifier, stripKeywords = false, index)
-        val l = NewLocal()
-          .code(s"$codeTpe $name")
-          .name(name)
-          .typeFullName(tpe)
-          .lineNumber(lineNumber)
-          .columnNumber(columnNumber)
-        scope.addToScope(name, (l, tpe))
-        Ast(l)
+        val codeTpe   = typeForDeclSpecifier(declaration.getDeclSpecifier, stripKeywords = false, index)
+        val localNode = newLocalNode(declarator, name, s"$codeTpe $name", tpe)
+        scope.addToScope(name, (localNode, tpe))
+        Ast(localNode)
     }
 
   }
@@ -179,41 +129,28 @@ trait AstForTypesCreator { this: AstCreator =>
   }
 
   protected def astForAliasDeclaration(aliasDeclaration: ICPPASTAliasDeclaration): Ast = {
-    val linenumber   = line(aliasDeclaration)
-    val columnnumber = column(aliasDeclaration)
-    val filename     = fileName(aliasDeclaration)
-
     val name       = aliasDeclaration.getAlias.toString
     val mappedName = registerType(typeFor(aliasDeclaration.getMappingTypeId))
     val typeDeclNode =
-      newTypeDecl(
+      newTypeDeclNode(
+        aliasDeclaration,
         name,
         registerType(name),
-        filename,
+        fileName(aliasDeclaration),
         nodeSignature(aliasDeclaration),
-        alias = Some(mappedName),
-        line = linenumber,
-        column = columnnumber
+        alias = Some(mappedName)
       )
     Ast(typeDeclNode)
   }
 
-  protected def astForASMDeclaration(asm: IASTASMDeclaration): Ast = Ast(newUnknown(asm))
+  protected def astForASMDeclaration(asm: IASTASMDeclaration): Ast = Ast(newUnknownNode(asm))
 
-  private def astForStructuredBindingDeclaration(
-    structuredBindingDeclaration: ICPPASTStructuredBindingDeclaration
-  ): Ast = {
-    val cpgBlock = NewBlock()
-      .typeFullName(registerType(Defines.voidTypeName))
-      .lineNumber(line(structuredBindingDeclaration))
-      .columnNumber(column(structuredBindingDeclaration))
-
+  private def astForStructuredBindingDeclaration(decl: ICPPASTStructuredBindingDeclaration): Ast = {
+    val cpgBlock = newBlockNode(decl, Defines.voidTypeName)
     scope.pushNewScope(cpgBlock)
-
-    val childAsts = structuredBindingDeclaration.getNames.toList.map { name =>
+    val childAsts = decl.getNames.toList.map { name =>
       astForNode(name)
     }
-
     val blockAst = Ast(cpgBlock).withChildren(childAsts)
     scope.popScope()
     blockAst
@@ -233,7 +170,7 @@ trait AstForTypesCreator { this: AstCreator =>
           case spec: IASTNamedTypeSpecifier if declaration.getDeclarators.isEmpty =>
             val filename = fileName(spec)
             val name     = ASTStringUtil.getSimpleName(spec.getName)
-            Seq(Ast(newTypeDecl(name, registerType(name), filename, nodeSignature(spec), alias = Some(name))))
+            Seq(Ast(newTypeDeclNode(spec, name, registerType(name), filename, nodeSignature(spec), alias = Some(name))))
           case _ if declaration.getDeclarators.nonEmpty =>
             declaration.getDeclarators.toIndexedSeq.zipWithIndex.map {
               case (d: IASTFunctionDeclarator, _) =>
@@ -302,9 +239,17 @@ trait AstForTypesCreator { this: AstCreator =>
       case cppClass: ICPPASTCompositeTypeSpecifier =>
         val baseClassList =
           cppClass.getBaseSpecifiers.toSeq.map(s => registerType(s.getNameSpecifier.toString))
-        newTypeDecl(name, fullname, filename, code, inherits = baseClassList, alias = nameWithTemplateParams)
+        newTypeDeclNode(
+          typeSpecifier,
+          name,
+          fullname,
+          filename,
+          code,
+          inherits = baseClassList,
+          alias = nameWithTemplateParams
+        )
       case _ =>
-        newTypeDecl(name, fullname, filename, code, alias = nameWithTemplateParams)
+        newTypeDeclNode(typeSpecifier, name, fullname, filename, code, alias = nameWithTemplateParams)
     }
 
     methodAstParentStack.push(typeDecl)
@@ -343,7 +288,14 @@ trait AstForTypesCreator { this: AstCreator =>
     val nameWithTemplateParams = templateParameters(typeSpecifier).map(t => registerType(fullname + t))
 
     val typeDecl =
-      newTypeDecl(name, fullname, filename, nodeSignature(typeSpecifier), alias = nameWithTemplateParams)
+      newTypeDeclNode(
+        typeSpecifier,
+        name,
+        fullname,
+        filename,
+        nodeSignature(typeSpecifier),
+        alias = nameWithTemplateParams
+      )
 
     Ast(typeDecl) +: declAsts
   }
@@ -354,10 +306,12 @@ trait AstForTypesCreator { this: AstCreator =>
         enumeration.getBaseType.toString
       case _ => typeFor(enumerator)
     }
-    val cpgMember = NewMember()
-      .code(nodeSignature(enumerator))
-      .name(ASTStringUtil.getSimpleName(enumerator.getName))
-      .typeFullName(registerType(cleanType(tpe)))
+    val cpgMember = newMemberNode(
+      enumerator,
+      ASTStringUtil.getSimpleName(enumerator.getName),
+      nodeSignature(enumerator),
+      registerType(cleanType(tpe))
+    )
 
     if (enumerator.getValue != null) {
       val operatorName = Operators.assignment
@@ -380,7 +334,7 @@ trait AstForTypesCreator { this: AstCreator =>
 
     val (name, fullname) =
       uniqueName("enum", ASTStringUtil.getSimpleName(typeSpecifier.getName), fullName(typeSpecifier))
-    val typeDecl = newTypeDecl(name, registerType(fullname), filename, nodeSignature(typeSpecifier))
+    val typeDecl = newTypeDeclNode(typeSpecifier, name, registerType(fullname), filename, nodeSignature(typeSpecifier))
 
     methodAstParentStack.push(typeDecl)
     scope.pushNewScope(typeDecl)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -37,7 +37,7 @@ trait AstForTypesCreator { this: AstCreator =>
   private def astForNamespaceDefinition(namespaceDefinition: ICPPASTNamespaceDefinition): Ast = {
     val (name, fullname) =
       uniqueName("namespace", namespaceDefinition.getName.getLastName.toString, fullName(namespaceDefinition))
-    val code         = "namespace " + fullname
+    val code         = s"namespace $fullname"
     val cpgNamespace = newNamespaceBlockNode(namespaceDefinition, name, fullname, code, fileName(namespaceDefinition))
     scope.pushNewScope(cpgNamespace)
 
@@ -59,7 +59,7 @@ trait AstForTypesCreator { this: AstCreator =>
       usingDeclarationMappings.put(name, fullname)
     }
 
-    val code         = "namespace " + name + " = " + fullname
+    val code         = s"namespace $name = $fullname"
     val cpgNamespace = newNamespaceBlockNode(namespaceAlias, name, fullname, code, fileName(namespaceAlias))
     Ast(cpgNamespace)
   }
@@ -120,7 +120,7 @@ trait AstForTypesCreator { this: AstCreator =>
     if (!isQualifiedName(simpleName)) {
       usingDecl.getParent match {
         case ns: ICPPASTNamespaceDefinition =>
-          usingDeclarationMappings.put(fullName(ns) + "." + mappedName, fixQualifiedName(simpleName))
+          usingDeclarationMappings.put(s"${fullName(ns)}.$mappedName", fixQualifiedName(simpleName))
         case _ =>
           usingDeclarationMappings.put(mappedName, fixQualifiedName(simpleName))
       }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstNodeBuilder.scala
@@ -7,25 +7,177 @@ import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 trait AstNodeBuilder { this: AstCreator =>
 
-  protected def newUnknown(node: IASTNode): NewUnknown =
+  protected def newUnknownNode(node: IASTNode): NewUnknown = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
     NewUnknown()
       .parserTypeName(node.getClass.getSimpleName)
       .code(nodeSignature(node))
-      .lineNumber(line(node))
-      .columnNumber(column(node))
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
+
+  protected def newFieldIdentifierNode(node: IASTNode, name: String, code: String): NewFieldIdentifier = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewFieldIdentifier()
+      .canonicalName(name)
+      .code(code)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
+
+  protected def newIdentifierNode(node: IASTNode, name: String, code: String, typeFullName: String): NewIdentifier = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewIdentifier()
+      .name(name)
+      .typeFullName(typeFullName)
+      .code(code)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
+
+  protected def newLiteralNode(node: IASTNode, code: String, typeFullName: String): NewLiteral = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewLiteral()
+      .typeFullName(typeFullName)
+      .code(code)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
+
+  protected def newCommentNode(node: IASTNode, code: String, filename: String): NewComment = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewComment().code(code).filename(filename).lineNumber(lineNumber).columnNumber(columnNumber)
+  }
+
+  protected def newLocalNode(node: IASTNode, name: String, code: String, typeFullName: String): NewLocal = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewLocal()
+      .code(code)
+      .name(name)
+      .typeFullName(typeFullName)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
+
+  protected def newMemberNode(node: IASTNode, name: String, code: String, typeFullName: String): NewMember = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewMember()
+      .code(code)
+      .name(name)
+      .typeFullName(typeFullName)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
+
+  protected def newNamespaceBlockNode(
+    node: IASTNode,
+    name: String,
+    fullname: String,
+    code: String,
+    filename: String
+  ): NewNamespaceBlock = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewNamespaceBlock()
+      .code(code)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+      .filename(filename)
+      .name(name)
+      .fullName(fullname)
+  }
+
+  protected def newBlockNode(node: IASTNode, typeFullName: String): NewBlock = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewBlock()
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+      .typeFullName(typeFullName)
+  }
+
+  protected def newMethodReturnNode(node: IASTNode, typeFullName: String): NewMethodReturn = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    methodReturnNode(typeFullName, None, lineNumber, columnNumber)
+  }
+
+  protected def newReturnNode(node: IASTNode, code: String): NewReturn = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewReturn().code(code).lineNumber(lineNumber).columnNumber(columnNumber)
+  }
+
+  protected def newParameterInNode(
+    node: IASTNode,
+    name: String,
+    code: String,
+    typeFullName: String,
+    index: Int,
+    evaluationStrategy: String,
+    isVariadic: Boolean
+  ): NewMethodParameterIn = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    NewMethodParameterIn()
+      .name(name)
+      .code(code)
+      .typeFullName(typeFullName)
+      .index(index)
+      .evaluationStrategy(evaluationStrategy)
+      .isVariadic(isVariadic)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
+
+  protected def newMethodNode(
+    node: IASTNode,
+    name: String,
+    code: String,
+    fullName: String,
+    fileName: String,
+    astParentType: Option[String] = None,
+    astParentFullName: Option[String] = None
+  ): NewMethod = {
+    val lineNumber      = line(node).map(Integer.valueOf)
+    val lineNumberEnd   = lineEnd(node).map(Integer.valueOf)
+    val columnNumber    = column(node).map(Integer.valueOf)
+    val columnNumberEnd = columnEnd(node).map(Integer.valueOf)
+    NewMethod()
+      .name(name)
+      .code(code)
+      .fullName(fullName)
+      .filename(fileName)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+      .lineNumberEnd(lineNumberEnd)
+      .columnNumberEnd(columnNumberEnd)
+      .astParentType(astParentType.getOrElse("<empty>"))
+      .astParentFullName(astParentFullName.getOrElse("<empty>"))
+  }
 
   protected def newMethodRefNode(
     code: String,
     methodFullName: String,
     typeFullName: String,
     node: IASTNode
-  ): NewMethodRef =
+  ): NewMethodRef = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
     NewMethodRef()
       .code(code)
       .methodFullName(methodFullName)
       .typeFullName(registerType(typeFullName))
-      .lineNumber(line(node))
-      .columnNumber(column(node))
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
 
   protected def newCallNode(
     node: IASTNode,
@@ -34,30 +186,37 @@ trait AstNodeBuilder { this: AstCreator =>
     dispatchType: String,
     argIndex: Int = -1
   ): NewCall = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
     NewCall()
       .name(StringUtils.normalizeSpace(name))
       .dispatchType(dispatchType)
       .methodFullName(StringUtils.normalizeSpace(fullname))
       .code(nodeSignature(node))
       .argumentIndex(argIndex)
-      .lineNumber(line(node))
-      .columnNumber(column(node))
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
   }
 
   protected def newControlStructureNode(
     node: IASTNode,
     controlStructureType: String,
     code: String
-  ): NewControlStructure =
+  ): NewControlStructure = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
     NewControlStructure()
       .parserTypeName(node.getClass.getSimpleName)
       .controlStructureType(controlStructureType)
       .code(code)
-      .lineNumber(line(node))
-      .columnNumber(column(node))
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
 
-  protected def newJumpTarget(node: IASTNode): NewJumpTarget = {
-    val code = nodeSignature(node)
+  protected def newJumpTargetNode(node: IASTNode): NewJumpTarget = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
+    val code         = nodeSignature(node)
     val name = node match {
       case label: IASTLabelStatement    => ASTStringUtil.getSimpleName(label.getName)
       case _ if code.startsWith("case") => "case"
@@ -67,25 +226,26 @@ trait AstNodeBuilder { this: AstCreator =>
       .parserTypeName(node.getClass.getSimpleName)
       .name(name)
       .code(code)
-      .lineNumber(line(node))
-      .columnNumber(column(node))
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
   }
 
-  protected def newTypeDecl(
+  protected def newTypeDeclNode(
+    node: IASTNode,
     name: String,
-    fullname: String,
+    fullName: String,
     filename: String,
     code: String,
     astParentType: String = "",
     astParentFullName: String = "",
     inherits: Seq[String] = Seq.empty,
-    alias: Option[String] = None,
-    line: Option[Integer] = None,
-    column: Option[Integer] = None
-  ): NewTypeDecl =
+    alias: Option[String] = None
+  ): NewTypeDecl = {
+    val lineNumber   = line(node).map(Integer.valueOf)
+    val columnNumber = column(node).map(Integer.valueOf)
     NewTypeDecl()
       .name(name)
-      .fullName(fullname)
+      .fullName(fullName)
       .code(code)
       .isExternal(false)
       .filename(filename)
@@ -93,7 +253,8 @@ trait AstNodeBuilder { this: AstCreator =>
       .astParentFullName(astParentFullName)
       .inheritsFromTypeFullName(inherits)
       .aliasTypeFullName(alias)
-      .lineNumber(line)
-      .columnNumber(column)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -119,7 +119,7 @@ trait MacroHandler { this: AstCreator =>
     val filename  = fileName(macroDef)
     val lineNo    = line(macroDef).getOrElse(-1)
     val lineNoEnd = lineEnd(macroDef).getOrElse(-1)
-    filename + ":" + lineNo + ":" + lineNoEnd + ":" + name + ":" + argAsts.size
+    s"$filename:$lineNo:$lineNoEnd:$name:${argAsts.size}"
   }
 
   /** The CDT utility method is unfortunately in a class that is marked as deprecated, however, this is because the CDT

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -1,14 +1,7 @@
 package io.joern.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  AstNodeNew,
-  ExpressionNew,
-  NewBlock,
-  NewCall,
-  NewFieldIdentifier,
-  NewNode
-}
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, ExpressionNew, NewBlock, NewFieldIdentifier, NewNode}
 import io.joern.x2cpg.Ast
 import org.apache.commons.lang.StringUtils
 import org.eclipse.cdt.core.dom.ast.{IASTMacroExpansionLocation, IASTNode, IASTPreprocessorMacroDefinition}
@@ -88,11 +81,9 @@ trait MacroHandler { this: AstCreator =>
     if (normalizedCode == "") {
       None
     } else {
-      ast.nodes
-        .collect { case x: AstNodeNew => x }
-        .find { x =>
-          x.isInstanceOf[ExpressionNew] && !x.isInstanceOf[NewFieldIdentifier] && x.code == normalizedCode
-        }
+      ast.nodes.collectFirst {
+        case x: ExpressionNew if !x.isInstanceOf[NewFieldIdentifier] && x.code == normalizedCode => x
+      }
     }
   }
 
@@ -110,14 +101,12 @@ trait MacroHandler { this: AstCreator =>
     val code    = node.getRawSignature.stripSuffix(";")
     val argAsts = argumentTrees(arguments, ast).map(_.getOrElse(Ast()))
 
-    val callNode = NewCall()
-      .name(StringUtils.normalizeSpace(name))
-      .methodFullName(StringUtils.normalizeSpace(fullName(macroDef, argAsts)))
-      .code(code)
-      .lineNumber(line(node))
-      .columnNumber(column(node))
-      .typeFullName(typeFor(node))
-      .dispatchType(DispatchTypes.INLINED)
+    val callNode = newCallNode(
+      node,
+      StringUtils.normalizeSpace(name),
+      StringUtils.normalizeSpace(fullName(macroDef, argAsts)),
+      DispatchTypes.INLINED
+    ).code(code).typeFullName(typeFor(node))
 
     callAst(callNode, argAsts)
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/CGlobal.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/CGlobal.scala
@@ -11,7 +11,7 @@ import scala.jdk.CollectionConverters._
 
 object CGlobal extends Global {
 
-  private val headerAstCache: mutable.HashMap[String, mutable.HashSet[(Integer, Integer)]] =
+  private val headerAstCache: mutable.HashMap[String, mutable.HashSet[(Int, Int)]] =
     mutable.HashMap.empty
 
   def headerFiles: Set[String] = headerAstCache.keySet.toSet
@@ -34,8 +34,8 @@ object CGlobal extends Global {
   def getAstsFromAstCache(
     filename: String,
     fromFilename: String,
-    linenumber: Option[Integer],
-    columnnumber: Option[Integer],
+    linenumber: Option[Int],
+    columnnumber: Option[Int],
     astCreatorFunction: => Seq[Ast]
   ): Seq[Ast] = {
     val callCreatorFunc =

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
@@ -1,6 +1,7 @@
 package io.joern.c2cpg.passes
 
 import io.joern.c2cpg.Config
+import io.joern.c2cpg.astcreation.Defines
 import io.joern.c2cpg.datastructures.CGlobal
 import io.joern.c2cpg.utils.IncludeAutoDiscovery
 import io.shiftleft.codepropertygraph.Cpg
@@ -42,13 +43,13 @@ class HeaderContentPass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
         .astParentType(NodeTypes.NAMESPACE_BLOCK)
         .astParentFullName(fullName)
 
-    val blockNode = NewBlock()
-      .typeFullName("ANY")
+    val blockNode = NewBlock().typeFullName(Defines.anyTypeName)
 
-    val methodReturn = NewMethodReturn()
-      .code("RET")
-      .evaluationStrategy(EvaluationStrategies.BY_VALUE)
-      .typeFullName("ANY")
+    val methodReturn =
+      NewMethodReturn()
+        .code("RET")
+        .evaluationStrategy(EvaluationStrategies.BY_VALUE)
+        .typeFullName(Defines.anyTypeName)
 
     val ast = Ast(includesFile).withChild(
       Ast(namespaceBlock)

--- a/joern-cli/frontends/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
@@ -82,7 +82,7 @@ class C2CpgMacroExpansionTracker(stepToTrack: Int) extends MacroExpansionTracker
     var tok: IToken = tokenList.first()
     var arg         = ""
     while (tok != null) {
-      arg += tok.toString + " "
+      arg += s"${tok.toString} "
       tok = tok.getNext
     }
     arg.trim

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -15,25 +15,25 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |struct node {
         |  int value;
         |  struct node *next;
-        | };
+        |};
         |
-        | void free_list(struct node *head) {
+        |void free_list(struct node *head) {
         |  struct node *q;
         |  for (struct node *p = head; p != NULL; p = q) {
         |    q = p->next;
         |    free(p);
         |  }
-        | }
+        |}
         |
-        | int flow(int p0) {
-        |    int a = p0;
-        |    int b=a;
-        |    int c=0x31;
-        |    int z = b + c;
-        |    z++;
-        |    int x = z;
-        |    return x;
-        | }""".stripMargin)
+        |int flow(int p0) {
+        |  int a = p0;
+        |  int b=a;
+        |  int c=0x31;
+        |  int z = b + c;
+        |  z++;
+        |  int x = z;
+        |  return x;
+        |}""".stripMargin)
 
     "identify all calls to `free`" in {
       cpg.call.name("free").code.toSetMutable shouldBe Set("free(p)")
@@ -66,12 +66,10 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
   }
 
   "DataFlowTest2" should {
-
     val cpg = code("""
-        | int main(int x) {
-        |  return x;
-        |}
-        """.stripMargin)
+      |int main(int x) {
+      |  return x;
+      |}""".stripMargin)
 
     "Test ParameterToReturn1" should {
       "have a flow from input parameter to return" in {
@@ -87,14 +85,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
   }
 
   "DataFlowTest3" should {
-
     val cpg = code("""
-        | int main(int x) {
-        |  int k = x + 1;
-        |  int y = k + 2;
-        |  return y + 3;
-        |}
-          """.stripMargin)
+      |int main(int x) {
+      |  int k = x + 1;
+      |  int y = k + 2;
+      |  return y + 3;
+      |}""".stripMargin)
 
     "Test ParameterToReturn2" should {
       "have a flow from input parameter to return" in {
@@ -120,29 +116,27 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
   }
 
   "DataFlowTest4" should {
-
     val cpg = code("""
-        | struct Point {
-        |   int x;
-        |   int y;
-        | };
-        |
-        | double source () {
-        |   return 2.0;
-        | }
-        |
-        | int sink(int x) {
-        |   return 3;
-        | }
-        |
-        | void main() {
-        |   int k = source(2);
-        |   struct Point point;
-        |   point.x = k;
-        |   point.y = 2;
-        |   sink(point.x);
-        | }
-          """.stripMargin)
+      |struct Point {
+      |  int x;
+      |  int y;
+      |};
+      |
+      |double source () {
+      |  return 2.0;
+      |}
+      |
+      |int sink(int x) {
+      |  return 3;
+      |}
+      |
+      |void main() {
+      |  int k = source(2);
+      |  struct Point point;
+      |  point.x = k;
+      |  point.y = 2;
+      |  sink(point.x);
+      |}""".stripMargin)
 
     "Test StructDataFlow" should {
       "have a flow from input parameter to return" in {
@@ -167,24 +161,23 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
   }
 
   "DataFlowTest5" should {
-
     val cpg = code("""
-        | int source() {
-        |   return 2;
-        | }
-        |
-        | int sink(int x) {
-        |   return 3;
-        | }
-        |
-        | void main() {
-        |   int k = source();
-        |   foo(k);
-        | }
-        |
-        | void foo(int par) {
-        |   sink(par);
-        | }""".stripMargin)
+      |int source() {
+      |  return 2;
+      |}
+      |
+      |int sink(int x) {
+      |  return 3;
+      |}
+      |
+      |void main() {
+      |  int k = source();
+      |  foo(k);
+      |}
+      |
+      |void foo(int par) {
+      |  sink(par);
+      |}""".stripMargin)
 
     "Test Interprocedural" should {
       "have a flow from input parameter to return" in {
@@ -211,25 +204,24 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest6" should {
     val cpg = code("""
-        | struct Point {
-        |   int x;
-        |   int y;
-        | };
-        |
-        | struct Point source () {
-        |   struct Point point;
-        |   return point;
-        | }
-        |
-        | int sink(int x) {
-        |   return 0;
-        | }
-        |
-        | void main() {
-        |   struct Point point = source(2);
-        |   sink(point.x);
-        | }
-          """.stripMargin)
+      |struct Point {
+      |  int x;
+      |  int y;
+      |};
+      |
+      |struct Point source () {
+      |  struct Point point;
+      |  return point;
+      |}
+      |
+      |int sink(int x) {
+      |  return 0;
+      |}
+      |
+      |void main() {
+      |  struct Point point = source(2);
+      |  sink(point.x);
+      |}""".stripMargin)
 
     "Test TaintedStruct" should {
       "have a flow from input parameter to return" in {
@@ -254,20 +246,19 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest7" should {
     val cpg = code("""
-        | typedef struct {
-        |   int len;
-        |   int* buf;
-        | } container;
-        |
-        | int source();
-        | void sink(container* cont);
-        |
-        | void foo(container* c, int idx) {
-        |   c->buf[idx] = source();
-        |   c->buf = 0;
-        |   sink(c);
-        | }
-          """.stripMargin)
+      |typedef struct {
+      |  int len;
+      |  int* buf;
+      |} container;
+      |
+      |int source();
+      |void sink(container* cont);
+      |
+      |void foo(container* c, int idx) {
+      |  c->buf[idx] = source();
+      |  c->buf = 0;
+      |  sink(c);
+      |}""".stripMargin)
 
     "Overtaint behind exclusion" should {
       "not find any flows" in {
@@ -283,15 +274,14 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest8" should {
     val cpg = code("""
-        | int source();
-        | void sink(int* cont);
-        |
-        | void foo(int** c, int idx) {
-        |   c[1][2] = source();
-        |   c[idx][2] = 0;
-        |   sink(c[1]);
-        | }
-          """.stripMargin)
+      |int source();
+      |void sink(int* cont);
+      |
+      |void foo(int** c, int idx) {
+      |  c[1][2] = source();
+      |  c[idx][2] = 0;
+      |  sink(c[1]);
+      |}""".stripMargin)
 
     "Exclusions behind over-taint" should {
       "not kill flows" in {
@@ -315,15 +305,14 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest9" should {
     val cpg = code("""
-        |typedef struct {int field;} S;
-        | int source();
-        | void sink(int i);
-        |
-        | void foo(S* arg) {
-        |   arg->field = source();
-        |   sink((*arg).field);
-        | }
-          """.stripMargin)
+      |typedef struct {int field;} S;
+      |int source();
+      |void sink(int i);
+      |
+      |void foo(S* arg) {
+      |  arg->field = source();
+      |  sink((*arg).field);
+      |}""".stripMargin)
 
     "Pointer-to-struct, arrow vs star-dot" should {
       "actually find flows" in {
@@ -347,14 +336,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest10" should {
     val cpg = code("""
-        | int source();
-        | void sink(int i);
-        |
-        | void foo(int* arg) {
-        |   arg[0] = source();
-        |   sink(*arg);
-        | }
-          """.stripMargin)
+      |int source();
+      |void sink(int i);
+      |
+      |void foo(int* arg) {
+      |  arg[0] = source();
+      |  sink(*arg);
+      |}""".stripMargin)
 
     "Pointer deref vs array access" should {
       "actually find flows" in {
@@ -378,43 +366,39 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest11" should {
     val cpg = code("""
-        |#include <stdio.h>
-        |#include <stdlib.h>
-        |#include <sys/types.h>
-        |#include <unistd.h>
-        |
-        |void main()
-        |{
-        |    int a = getpid();
-        |    int b = 888;    if(a == 666)
-        |    {
-        |        a = a * 666;
-        |        b = 999;
-        |    }
-        |    else
-        |    {
-        |        a = a * 777;
-        |    }    return a;
-        |}""".stripMargin)
+      |#include <stdio.h>
+      |#include <stdlib.h>
+      |#include <sys/types.h>
+      |#include <unistd.h>
+      |
+      |void main() {
+      |  int a = getpid();
+      |  int b = 888;
+      |  if(a == 666) {
+      |    a = a * 666;
+      |    b = 999;
+      |  } else {
+      |    a = a * 777;
+      |  } 
+      |  return a;
+      |}""".stripMargin)
 
     "PathUnfolding with allFlows" should {
       // regression test for  https://github.com/ShiftLeftSecurity/product/issues/7017
       "work as expected" in {
-        def source = cpg.call("getpid")
-
-        def sink = cpg.ret
-
-        val flows = sink.reachableByFlows(source)
+        val source = cpg.call("getpid")
+        val sink   = cpg.ret
+        val flows  = sink.reachableByFlows(source)
 
         flows.map(flowToResultPairs).toSetMutable shouldBe
           Set(
             List(
-              ("getpid()", Some(9)),
-              ("a = getpid()", Some(9)),
+              ("getpid()", Some(8)),
+              ("a = getpid()", Some(8)),
               ("a == 666", Some(10)),
-              ("a * 666", Some(12)),
-              ("a = a * 666", Some(12)),
-              ("return a;", Some(18))
+              ("a * 666", Some(11)),
+              ("a = a * 666", Some(11)),
+              ("return a;", Some(16))
             )
           )
       }
@@ -424,17 +408,15 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest12" should {
     val cpg = code("""
-        | int source();
-        | void sink(int arg);
-        | void nop(int x) {return;};
-        |
-        |
-        | void foo(int* c, int idx) {
-        |   c[2] = source();
-        |   nop(c[idx]);
-        |   sink(c[1]);
-        | }
-          """.stripMargin)
+      |int source();
+      |void sink(int arg);
+      |void nop(int x) {return;};
+      |
+      |void foo(int* c, int idx) {
+      |  c[2] = source();
+      |  nop(c[idx]);
+      |  sink(c[1]);
+      |}""".stripMargin)
 
     "NOP on overtaint" should {
       "not widen the search" in {
@@ -449,60 +431,54 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest13" should {
     val cpg = code("""
-        |
-        | void flows1(FILE *fd, int mode) {
-        |     char buff[40];
-        |
-        |     int sz = 0;
-        |     if (mode == 1) sz = 20;
-        |     if (mode == 2) sz = 200;
-        |     if (mode == 3) sz = 41;
-        |     if (mode == 5) sz = -5;
-        |
-        |     read(fd, buff, sz);
-        | }
-      """.stripMargin)
+      |void flows1(FILE *fd, int mode) {
+      |  char buff[40];
+      |  int sz = 0;
+      |  if (mode == 1) sz = 20;
+      |  if (mode == 2) sz = 200;
+      |  if (mode == 3) sz = 41;
+      |  if (mode == 5) sz = -5;
+      |  read(fd, buff, sz);
+      |}""".stripMargin)
 
     "flow from function call read to multiple versions of the same variable" in {
       def source = cpg.identifier.name("sz")
-
-      def sink = cpg.call.name("read")
-
-      def flows = sink.reachableByFlows(source)
+      def sink   = cpg.call.name("read")
+      def flows  = sink.reachableByFlows(source)
 
       flows.map(flowToResultPairs).toSetMutable shouldBe
         Set(
-          List[(String, Option[Integer])](("sz = 200", 8), ("read(fd, buff, sz)", 12)),
-          List[(String, Option[Integer])](("sz = -5", 10), ("read(fd, buff, sz)", 12)),
-          List[(String, Option[Integer])](("sz = 41", 9), ("read(fd, buff, sz)", 12)),
-          List[(String, Option[Integer])](("sz = 0", 6), ("read(fd, buff, sz)", 12)),
-          List[(String, Option[Integer])](("sz = 20", 7), ("read(fd, buff, sz)", 12)),
-          List[(String, Option[Integer])](("read(fd, buff, sz)", 12))
+          List(("sz = 20", Some(5)), ("read(fd, buff, sz)", Some(9))),
+          List(("sz = 0", Some(4)), ("read(fd, buff, sz)", Some(9))),
+          List(("sz = 200", Some(6)), ("read(fd, buff, sz)", Some(9))),
+          List(("read(fd, buff, sz)", Some(9))),
+          List(("sz = -5", Some(8)), ("read(fd, buff, sz)", Some(9))),
+          List(("sz = 41", Some(7)), ("read(fd, buff, sz)", Some(9)))
         )
 
-      // pretty printing for flows
       val flowsPretty = flows.p.mkString
-      flowsPretty.should(include("sz = 20"))
-      flowsPretty.should(include("read(fd, buff, sz)"))
+      flowsPretty should include("sz = 20")
+      flowsPretty should include("read(fd, buff, sz)")
+
       val tmpSourceFile = flows.head.elements.head.method.filename
-      flowsPretty.should(include(tmpSourceFile))
+      flowsPretty should include(tmpSourceFile)
     }
   }
 
   "DataFlowTest14" should {
     val cpg = code("""
-        |struct node {
-        | int value;
-        | struct node *next;
-        |};
-        |void free_list(struct node *head) {
-        | struct node *q;
-        | for (struct node *p = head; p != NULL; p = q) {
-        | q = p->next;
-        | free(p);
-        | }
-        |}
-      """.stripMargin)
+      |struct node {
+      |  int value;
+      |  struct node *next;
+      |};
+      |
+      |void free_list(struct node *head) {
+      |  struct node *q;
+      |  for (struct node *p = head; p != NULL; p = q) {
+      |    q = p->next;
+      |    free(p);
+      |  }
+      |}""".stripMargin)
 
     "flow with pointers" in {
       implicit val callResolver: NoResolve.type = NoResolve
@@ -515,24 +491,23 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
       flows.toSet shouldBe
         Set(
-          List[(String, Option[Integer])](("*p = head", 8), ("p != NULL", 8), ("free(p)", 10)),
-          List[(String, Option[Integer])](("q = p->next", 9), ("p = q", 8), ("p != NULL", 8), ("free(p)", 10)),
-          List[(String, Option[Integer])](("p = q", 8), ("p != NULL", 8), ("free(p)", 10)),
-          List[(String, Option[Integer])](("p != NULL", 8), ("free(p)", 10)),
-          List[(String, Option[Integer])](("free(p)", 10))
+          List(("q = p->next", Some(10)), ("p = q", Some(9)), ("p != NULL", Some(9)), ("free(p)", Some(11))),
+          List(("p = q", Some(9)), ("p != NULL", Some(9)), ("free(p)", Some(11))),
+          List(("p != NULL", Some(9)), ("free(p)", Some(11))),
+          List(("free(p)", Some(11))),
+          List(("*p = head", Some(9)), ("p != NULL", Some(9)), ("free(p)", Some(11)))
         )
     }
   }
 
   "DataFlowTest15" should {
     val cpg = code("""
-        | int method(int y){
-        |  int a = 10;
-        |  if (a < y){
-        |    foo(a);
-        |  }
-        | }
-      """.stripMargin)
+      |int method(int y){
+      |  int a = 10;
+      |  if (a < y){
+      |    foo(a);
+      |  }
+      |}""".stripMargin)
 
     "flow from function call argument" in {
       implicit val callResolver: NoResolve.type = NoResolve
@@ -552,16 +527,15 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest16" should {
     val cpg = code("""
-        | void flow(void) {
-        |   int a = 0x37;
-        |   int b=a;
-        |   int c=0x31;
-        |   int z = b + c;
-        |   z++;
-        |   int* p = &z;
-        |   int x = z;
-        | }
-      """.stripMargin)
+      |void flow(void) {
+      |  int a = 0x37;
+      |  int b=a;
+      |  int c=0x31;
+      |  int z = b + c;
+      |  z++;
+      |  int* p = &z;
+      |  int x = z;
+      |}""".stripMargin)
 
     "flow chains from x to a" in {
       val source = cpg.identifier.name("a")
@@ -585,13 +559,11 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest17" should {
     val cpg = code("""
-        | int flow(int a){
-        |   int z = a;
-        |   int b = z;
-        |
-        |   return b;
-        | }
-      """.stripMargin)
+      |int flow(int a) {
+      |  int z = a;
+      |  int b = z;
+      |  return b;
+      |}""".stripMargin)
 
     "flow from method return to a" in {
       val source = cpg.identifier.name("a")
@@ -599,27 +571,24 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       val flows  = sink.reachableByFlows(source)
 
       flows.map(flowToResultPairs).toSetMutable shouldBe
-        Set(List[(String, Option[Integer])](("z = a", 3), ("b = z", 4), ("return b;", 6)))
+        Set(List[(String, Option[Integer])](("z = a", 3), ("b = z", 4), ("return b;", 5)))
     }
   }
 
   "DataFlowTest18" should {
     val cpg = code("""
-        | int nested(int a){
-        |   int x;
-        |   int z = 0x37;
-        |   if(a < 10){
-        |     if( a < 5){
-        |       if(a < 2){
-        |          x = a;
-        |       }
-        |     }
-        |   } else
-        |     x = z;
-        |
-        |   return x;
-        | }
-      """.stripMargin)
+      |int nested(int a) {
+      |  int x;
+      |  int z = 0x37;
+      |  if(a < 10) {
+      |    if( a < 5) {
+      |      if(a < 2) {
+      |        x = a;
+      |      }
+      |    }
+      |  } else x = z;
+      |  return x;
+      |}""".stripMargin)
 
     "flow with nested if-statements from method return to a" in {
       val source = cpg.call.code("a < 10").argument.code("a")
@@ -633,7 +602,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
             ("a < 5", Some(6)),
             ("a < 2", Some(7)),
             ("x = a", 8),
-            ("return x;", 14)
+            ("return x;", 12)
           )
         )
     }
@@ -641,21 +610,18 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest19" should {
     val cpg = code("""
-        | int nested(int a){
-        |   int x;
-        |   int z = 0x37;
-        |   if(a < 10){
-        |     if( a < 5){
-        |       if(a < 2){
-        |          x = a;
-        |       }
-        |     }
-        |   } else
-        |     x = z;
-        |
-        |   return x;
-        | }
-      """.stripMargin)
+      |int nested(int a) {
+      |  int x;
+      |  int z = 0x37;
+      |  if(a < 10) {
+      |    if( a < 5) {
+      |      if(a < 2) {
+      |        x = a;
+      |      }
+      |    }
+      |  } else x = z;
+      |  return x;
+      |}""".stripMargin)
 
     "flow with nested if-statements to `return x`" in {
       val source = cpg.identifier.name("x")
@@ -664,21 +630,20 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
       flows.map(flowToResultPairs).toSetMutable shouldBe
         Set(
-          List[(String, Option[Integer])](("x = z", 12), ("return x;", 14)),
-          List[(String, Option[Integer])](("x = a", 8), ("return x;", 14)),
-          List[(String, Option[Integer])](("return x;", 14))
+          List(("x = a", Some(8)), ("return x;", Some(12))),
+          List(("x = z", Some(11)), ("return x;", Some(12))),
+          List(("return x;", Some(12)))
         )
     }
   }
 
   "DataFlowTest20" should {
     val cpg = code("""
-        | void param(int x){
-        |    int a = x;
-        |    int b = a;
-        |    int z = foo(b);
-        |  }
-      """.stripMargin)
+      |void param(int x) {
+      |  int a = x;
+      |  int b = a;
+      |  int z = foo(b);
+      |}""".stripMargin)
 
     "flow chain from function argument of foo to a" in {
       implicit val callResolver: NoResolve.type = NoResolve
@@ -697,11 +662,11 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest21" should {
     val cpg = code("""
-        | void param(int x){
-        |    int a = x;
-        |    int b = a;
-        |    int z = foo(b);
-        |  }
+      |void param(int x) {
+      |  int a = x;
+      |  int b = a;
+      |  int z = foo(b);
+      |}
       """.stripMargin)
 
     "flow from function foo to a" in {
@@ -719,18 +684,17 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest22" should {
     val cpg = code("""
-        | struct node {
-        | int value1;
-        | int value2;
-        |};
-        |
-        |void test(void){
-        |  int x = 10;
-        |  struct node n;
-        |  n.value1 = x;
-        |  n.value2 = n.value1;
-        |}
-      """.stripMargin)
+      |struct node {
+      |  int value1;
+      |  int value2;
+      |};
+      |
+      |void test(void) {
+      |  int x = 10;
+      |  struct node n;
+      |  n.value1 = x;
+      |  n.value2 = n.value1;
+      |}""".stripMargin)
 
     "flow with member access in expression to identifier x" in {
       val source = cpg.identifier.name("x")
@@ -747,16 +711,15 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest23" should {
     val cpg = code("""
-        | void flow(void) {
-        |   int a = 0x37;
-        |   int b=a;
-        |   int c=0x31;
-        |   int z = b + c;
-        |   z++;
-        |   int* p = &z;
-        |   int x = z;
-        | }
-      """.stripMargin)
+      |void flow(void) {
+      |  int a = 0x37;
+      |  int b=a;
+      |  int c=0x31;
+      |  int z = b + c;
+      |  z++;
+      |  int* p = &z;
+      |  int x = z;
+      |}""".stripMargin)
 
     "flow chain from x to literal 0x37" in {
       val source = cpg.literal.code("0x37")
@@ -779,13 +742,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest24" should {
     val cpg = code("""
-        | void flow(void) {
-        |    int a = 0x37;
-        |    int b = a;
-        |    int z = b;
-        |    z+=a;
-        | }
-       """.stripMargin)
+      |void flow(void) {
+      |  int a = 0x37;
+      |  int b = a;
+      |  int z = b;
+      |  z+=a;
+      |}""".stripMargin)
 
     "flow with short hand assignment operator" in {
       val source = cpg.call.code("a = 0x37").argument(2)
@@ -799,14 +761,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest25" should {
     val cpg = code("""
-        | void flow(void) {
-        |    int a = 0x37;
-        |    int b = a;
-        |    int z = b;
-        |    z+=a;
-        |    int w = z;
-        | }
-      """.stripMargin)
+      |void flow(void) {
+      |  int a = 0x37;
+      |  int b = a;
+      |  int z = b;
+      |  z+=a;
+      |  int w = z;
+      |}""".stripMargin)
 
     "flow after short hand assignment" in {
       val source = cpg.call.code("a = 0x37").argument(1)
@@ -820,14 +781,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest26" should {
     val cpg = code("""
-        | int main(int argc, char** argv){
-        |    int x = argv[1];
-        |    int y = x;
-        |    int z = y;
-        |
-        |    return 0;
-        | }
-      """.stripMargin)
+      |int main(int argc, char** argv) {
+      |  int x = argv[1];
+      |  int y = x;
+      |  int z = y;
+      |  return 0;
+      |}""".stripMargin)
 
     "flow from array method parameter to identifier" in {
       val source = cpg.method.parameter
@@ -849,11 +808,10 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest27" should {
     val cpg = code("""
-  void foo(bool x, void* y) {
-    void* z =  x ? f(y) : g(y);
-    return;
-  }
-      """.stripMargin)
+      |void foo(bool x, void* y) {
+      |  void* z =  x ? f(y) : g(y);
+      |  return;
+      |}""".stripMargin)
 
     "conditional expressions (joern issue #91)" in {
       val source = cpg.method.parameter.name("y")
@@ -865,28 +823,25 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest28" should {
     val cpg = code("""
-
-  int bar() {
-    int x = source();
-    foo(x);
-  }
-
-  void foo(int y) {
-    sink(y);
-  }
-
-  """.stripMargin)
+      |int bar() {
+      | int x = source();
+      | foo(x);
+      |}
+      |
+      |void foo(int y) {
+      |  sink(y);
+      |}""".stripMargin)
 
     "find source in caller" in {
       val source = cpg.call("source")
       val sink   = cpg.call("sink").argument(1)
       sink.reachableByFlows(source).map(flowToResultPairs).toSetMutable shouldBe Set(
         List(
-          ("source()", Some(4)),
-          ("x = source()", Some(4)),
-          ("foo(x)", Some(5)),
-          ("foo(int y)", Some(8)),
-          ("sink(y)", Some(9))
+          ("source()", Some(3)),
+          ("x = source()", Some(3)),
+          ("foo(x)", Some(4)),
+          ("foo(int y)", Some(7)),
+          ("sink(y)", Some(8))
         )
       )
     }
@@ -894,29 +849,26 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest29" should {
     val cpg = code("""
-
-  int bar() {
-    return source();
-  }
-
-  void foo(int y) {
-    int y = bar();
-    sink(y);
-  }
-
-  """.stripMargin)
+      |int bar() {
+      |  return source();
+      |}
+      |
+      |void foo(int y) {
+      |  int y = bar();
+      |  sink(y);
+      |}""".stripMargin)
 
     "find source in callee" in {
       val source = cpg.call("source")
       val sink   = cpg.call("sink").argument(1)
       sink.reachableByFlows(source).map(flowToResultPairs).toSetMutable shouldBe Set(
         List(
-          ("source()", Some(4)),
-          ("return source();", Some(4)),
-          ("int", Some(3)),
-          ("bar()", Some(8)),
-          ("y = bar()", Some(8)),
-          ("sink(y)", Some(9))
+          ("source()", Some(3)),
+          ("return source();", Some(3)),
+          ("int", Some(2)),
+          ("bar()", Some(7)),
+          ("y = bar()", Some(7)),
+          ("sink(y)", Some(8))
         )
       )
     }
@@ -926,12 +878,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       val sink   = cpg.method("sink").parameter.index(1)
       sink.reachableByFlows(source).map(flowToResultPairs).toSetMutable shouldBe Set(
         List(
-          ("source()", Some(4)),
-          ("return source();", Some(4)),
-          ("int", Some(3)),
-          ("bar()", Some(8)),
-          ("y = bar()", Some(8)),
-          ("sink(y)", Some(9)),
+          ("source()", Some(3)),
+          ("return source();", Some(3)),
+          ("int", Some(2)),
+          ("bar()", Some(7)),
+          ("y = bar()", Some(7)),
+          ("sink(y)", Some(8)),
           ("sink(p1)", None)
         )
       )
@@ -940,27 +892,26 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest30" should {
     val cpg = code("""
-        | struct Point {
-        |   int x;
-        |   int y;
-        | };
-        |
-        | double source () {
-        |   return 2.0;
-        | }
-        |
-        | int sink(int x) {
-        |   return 3;
-        | }
-        |
-        | void main() {
-        |   int k = source(2);
-        |   struct Point point;
-        |   point.x = k;
-        |   point.y = 2;
-        |   sink(point.x);
-        | }
-        |""".stripMargin)
+      |struct Point {
+      |  int x;
+      |  int y;
+      |};
+      |
+      |double source () {
+      |  return 2.0;
+      |}
+      |
+      |int sink(int x) {
+      |  return 3;
+      |}
+      |
+      |void main() {
+      |  int k = source(2);
+      |  struct Point point;
+      |  point.x = k;
+      |  point.y = 2;
+      |  sink(point.x);
+      |}""".stripMargin)
 
     "struct data flow" in {
       val source = cpg.method.name("source").methodReturn
@@ -983,25 +934,24 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest31" should {
     val cpg = code("""
-        | struct Point {
-        |   int x;
-        |   int y;
-        | };
-        |
-        | struct Point source () {
-        |   struct Point point;
-        |   return point;
-        | }
-        |
-        | int sink(int x) {
-        |   return 0;
-        | }
-        |
-        | void main() {
-        |   struct Point point = source(2);
-        |   sink(point.x);
-        | }
-        |""".stripMargin)
+      |struct Point {
+      |  int x;
+      |  int y;
+      |};
+      |
+      |struct Point source () {
+      |  struct Point point;
+      |  return point;
+      |}
+      |
+      |int sink(int x) {
+      |  return 0;
+      |}
+      |
+      |void main() {
+      |  struct Point point = source(2);
+      |  sink(point.x);
+      |}""".stripMargin)
 
     "tainted struct" in {
       val source = cpg.method.name("source").methodReturn
@@ -1022,20 +972,19 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest32" should {
     val cpg = code("""
-        | typedef struct {
-        |   int len;
-        |   int* buf;
-        | } container;
-        |
-        | int source();
-        | void sink(container* cont);
-        |
-        | void foo(container* c, int idx) {
-        |   c->buf[idx] = source();
-        |   c->buf = 0;
-        |   sink(c);
-        | }
-        |""".stripMargin)
+      |typedef struct {
+      |  int len;
+      |  int* buf;
+      |} container;
+      |
+      |int source();
+      |void sink(container* cont);
+      |
+      |void foo(container* c, int idx) {
+      |  c->buf[idx] = source();
+      |  c->buf = 0;
+      |  sink(c);
+      |}""".stripMargin)
 
     "not find any flows" in {
       val source = cpg.method.name("source").methodReturn
@@ -1047,16 +996,14 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest33" should {
     val cpg = code("""
-        |
-        | int source();
-        | void sink(int* cont);
-        |
-        | void foo(int** c, int idx) {
-        |   c[1][2] = source();
-        |   c[idx][2] = 0;
-        |   sink(c[1]);
-        | }
-        |""".stripMargin)
+      |int source();
+      |void sink(int* cont);
+      |
+      |void foo(int** c, int idx) {
+      |  c[1][2] = source();
+      |  c[idx][2] = 0;
+      |  sink(c[1]);
+      |}""".stripMargin)
 
     "find flow" in {
       val source = cpg.method.name("source").methodReturn
@@ -1069,15 +1016,15 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest34" should {
     val cpg = code("""
-        |typedef struct {int field;} S;
-        | int source();
-        | void sink(int i);
-        |
-        | void foo(S* arg) {
-        |   arg->field = source();
-        |   sink((*arg).field);
-        | }
-        |""".stripMargin)
+      |typedef struct {int field;} S;
+      |int source();
+      |void sink(int i);
+      |
+      |void foo(S* arg) {
+      |  arg->field = source();
+      |  sink((*arg).field);
+      |}
+      |""".stripMargin)
 
     "find flows (pointer-to-struct/arrows vs star-dot)" in {
       val source = cpg.method.name("source").methodReturn
@@ -1090,14 +1037,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest35" should {
     val cpg = code("""
-        | int source();
-        | void sink(int i);
-        |
-        | void foo(int* arg) {
-        |   arg[0] = source();
-        |   sink(*arg);
-        | }
-        |""".stripMargin)
+      |int source();
+      |void sink(int i);
+      |
+      |void foo(int* arg) {
+      |  arg[0] = source();
+      |  sink(*arg);
+      |}""".stripMargin)
 
     "handle deref vs array access correctly" in {
       val source = cpg.method.name("source").methodReturn
@@ -1110,11 +1056,10 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest36" should {
     val cpg = code("""
-        |int foo() {
-        |  source(&a->c);
-        |  sink(a->b);
-        |}
-        |""".stripMargin)
+      |int foo() {
+      |  source(&a->c);
+      |  sink(a->b);
+      |}""".stripMargin)
 
     "not report flow if access path differs" in {
       val source = cpg.call.name("source").argument
@@ -1126,12 +1071,10 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest37" should {
     val cpg = code("""
-        |int bar() {
-        |  source(&a->b);
-        |  sink(a->b);
-        |}
-        |
-        |""".stripMargin)
+      |int bar() {
+      |  source(&a->b);
+      |  sink(a->b);
+      |}""".stripMargin)
 
     "report flow if address passed to source" in {
       val source = cpg.call("source").argument
@@ -1146,13 +1089,11 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest38" should {
     val cpg = code("""
-        |int foo() {
-        |  a->b = source();
-        |  a->b = 10;
-        |  sink(a->b);
-        |}
-        |
-        |""".stripMargin)
+      |int foo() {
+      |  a->b = source();
+      |  a->b = 10;
+      |  sink(a->b);
+      |}""".stripMargin)
 
     "not report flow" in {
       val source = cpg.call.name("source")
@@ -1170,13 +1111,11 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest40" should {
     val cpg = code("""
-        |int foo() {
-        |   int y = 1;
-        |   y = something_else;
-        |   y = 10;
-        |}
-        |
-        |""".stripMargin)
+      |int foo() {
+      |  int y = 1;
+      |  y = something_else;
+      |  y = 10;
+      |}""".stripMargin)
 
     "find that there is a flow from `y = 1` to exit node" in {
       // This one may be a bit surprising, but what's happening here
@@ -1192,13 +1131,11 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest41" should {
     val cpg = code("""
-        |int foo() {
-        |   char * y = malloc(10);
-        |   free(y);
-        |   y = 10;
-        |}
-        |
-        |""".stripMargin)
+      |int foo() {
+      |  char * y = malloc(10);
+      |  free(y);
+      |  y = 10;
+      |}""".stripMargin)
 
     "find that there is no flow from free(y) to exit node" in {
       val source = cpg.call("free").argument(1)
@@ -1211,13 +1148,11 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest42" should {
     val cpg = code("""
-        |int foo(int b) {
-        |  b = source();
-        |  b = 10;
-        |  sink(b);
-        |}
-        |
-        |""".stripMargin)
+      |int foo(int b) {
+      |  b = source();
+      |  b = 10;
+      |  sink(b);
+      |}""".stripMargin)
 
     "block flow even if variable decl cannot be found" in {
       val source = cpg.call.name("source")
@@ -1234,10 +1169,9 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest43" should {
     val cpg = code("""
-        |int foo() {
-        |   return bar();
-        |}
-    """.stripMargin)
+      |int foo() {
+      |  return bar();
+      |}""".stripMargin)
 
     "not create edges from call to ret twice" in {
       cpg
@@ -1249,36 +1183,29 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest44" should {
     val cpg = code("""
-        |void f(int x, int y)
-        |{
-        |  g(x, y);
-        |}
-    """.stripMargin)
+      |void f(int x, int y) {
+      |  g(x, y);
+      |}""".stripMargin)
 
     "find flow from outer params to inner params" in {
-      def source = cpg.method.name("f").parameter
-
-      def sink = cpg.method.name("g").parameter
-
-      sink.size shouldBe 2
-      source.size shouldBe 2
+      val source = cpg.method.name("f").parameter
+      val sink   = cpg.method.name("g").parameter
       sink.reachableBy(source).size shouldBe 4
     }
   }
 
   "DataFlowTest45" should {
     val cpg = code("""
-        |int bar(int z) {
-        |  int x = 10;
-        |  int y = x + source()
-        |  return y;
-        |}
-        |
-        |int foo() {
-        |int y = bar(x);
-        |sink(y);
-        |}
-        |""".stripMargin)
+      |int bar(int z) {
+      |  int x = 10;
+      |  int y = x + source()
+      |  return y;
+      |}
+      |
+      |int foo() {
+      |  int y = bar(x);
+      |  sink(y);
+      |}""".stripMargin)
 
     "provide correct flow for source in sibling callee" in {
       cpg.call("sink").argument(1).reachableByFlows(cpg.call("source")).size shouldBe 1
@@ -1288,11 +1215,10 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest46" should {
     val cpg = code("""
-        | void foo() {
-        |   int x = source();
-        |   sink(x);
-        | }
-        |""".stripMargin)
+      |void foo() {
+      |  int x = source();
+      |  sink(x);
+      |}""".stripMargin)
 
     "find flow via assignment" in {
       val source = cpg.call("source")
@@ -1307,13 +1233,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest47" should {
     val cpg = code("""
-        | int sink(int arg){  return arg; };
-        | int source(){ return 0; };
-        |
-        | void foo() {
-        |   sink(source());
-        | }
-        |""".stripMargin)
+      |int sink(int arg){  return arg; };
+      |int source(){ return 0; };
+      |
+      |void foo() {
+      |  sink(source());
+      |}""".stripMargin)
 
     "find flow of call in call" in {
       val source = cpg.call("source")
@@ -1333,11 +1258,10 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest49" should {
     val cpg = code("""
-        | void foo(int x) {
-        |   x = source();
-        |   sink(x);
-        | }
-        |""".stripMargin)
+      |void foo(int x) {
+      |  x = source();
+      |  sink(x);
+      |}""".stripMargin)
 
     "find flow via assignment for global" in {
       val source = cpg.call("source")
@@ -1352,12 +1276,11 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest50" should {
     val cpg = code("""
-        | void foo() {
-        |   int x = source();
-        |   x = y;
-        |   sink(x);
-        | }
-        |""".stripMargin)
+      |void foo() {
+      |  int x = source();
+      |  x = y;
+      |  sink(x);
+      |}""".stripMargin)
 
     "find that flow is blocked by assignment" in {
       val source     = cpg.call("source")
@@ -1374,11 +1297,10 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest51" should {
     val cpg = code("""
-        | void foo() {
-        |   x.y = source();
-        |   sink(x.y);
-        | }
-        |""".stripMargin)
+      |void foo() {
+      |  x.y = source();
+      |  sink(x.y);
+      |}""".stripMargin)
 
     "find via assignment with field access" in {
       val source = cpg.call("source")
@@ -1393,11 +1315,10 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest52" should {
     val cpg = code("""
-        | void foo() {
-        |   x->y = source();
-        |   sink(x->y);
-        | }
-        |""".stripMargin)
+      |void foo() {
+      |  x->y = source();
+      |  sink(x->y);
+      |}""".stripMargin)
 
     "find flow via assignment with indirect field access" in {
       val source = cpg.call("source")
@@ -1412,21 +1333,18 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest53" should {
     val cpg = code("""
-        | void foo() {
-        |   int x.y = source();
-        |   x.y = z;
-        |   sink(x);
-        | }
-        |""".stripMargin)
+      |void foo() {
+      |  int x.y = source();
+      |  x.y = z;
+      |  sink(x);
+      |}""".stripMargin)
 
     "find that flow is blocked by assignment" in {
-      def source = cpg.call("source")
-
-      def sink = cpg.call("sink")
-
+      val source     = cpg.call("source")
+      def sink       = cpg.call("sink")
       val assignment = cpg.assignment.codeExact("x.y = z")
+      val flows      = sink.reachableByFlows(source)
 
-      val flows = sink.reachableByFlows(source)
       flows.size shouldBe 0
 
       val flows2 = sink.reachableByFlows(assignment.target)
@@ -1436,20 +1354,17 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest54" should {
     val cpg = code("""
-        |void foo() {
-        |  int data;
-        |  fscanf(stdin, "%d", &data);
-        |  int result = data + 1;
-        |  printf("%d\n", result);
-        |}
-        |""".stripMargin)
+      |void foo() {
+      |  int data;
+      |  fscanf(stdin, "%d", &data);
+      |  int result = data + 1;
+      |  printf("%d\n", result);
+      |}""".stripMargin)
 
     "find flow via fscanf" in {
-      def source = cpg.call("fscanf").argument
-
-      def sink = cpg.identifier("result")
-
-      def flows = sink.reachableByFlows(source)
+      val source = cpg.call("fscanf").argument
+      val sink   = cpg.identifier("result")
+      val flows  = sink.reachableByFlows(source)
 
       flows.map(flowToResultPairs).toSetMutable shouldBe Set(
         List(
@@ -1465,28 +1380,28 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest55" should {
     val cpg = code("""
-        | struct node {
-        |  int value;
-        |  struct node *next;
-        | };
-        |
-        | void free_list(struct node *head) {
-        |  struct node *q;
-        |  for (struct node *p = head; p != NULL; p = q) {
-        |    q = p->next;
-        |    free(p);
-        |  }
-        | }
-        |
-        | int flow(int p0) {
-        |  int a = p0;
-        |  int b=a;
-        |  int c=0x31;
-        |  int z = b + c;
-        |  z++;
-        |  int x = z;
-        |  return x;
-        | }""".stripMargin)
+      |struct node {
+      |  int value;
+      |  struct node *next;
+      |};
+      |
+      |void free_list(struct node *head) {
+      |  struct node *q;
+      |  for (struct node *p = head; p != NULL; p = q) {
+      |    q = p->next;
+      |    free(p);
+      |  }
+      |}
+      |
+      |int flow(int p0) {
+      |  int a = p0;
+      |  int b=a;
+      |  int c=0x31;
+      |  int z = b + c;
+      |  z++;
+      |  int x = z;
+      |  return x;
+      |}""".stripMargin)
 
     "identify all calls to `free`" in {
       cpg.call.name("free").code.toSetMutable shouldBe Set("free(p)")
@@ -1521,26 +1436,22 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest56" should {
     val cpg = code("""
-        |int test() {
-        |  char inputBuffer[0x100] = "";
-        |  int buffer[10] = {0};
-        |  int data = 1;
-        |  fgets(inputBuffer, 0x100, stdin);
-        |  data = atoi(inputBuffer);
-        |  buffer[data] = 1;
-        |  strncpy(buffer, "hello", data);
-        |  return 0;
-        |}""".stripMargin)
+      |int test() {
+      |  char inputBuffer[0x100] = "";
+      |  int buffer[10] = {0};
+      |  int data = 1;
+      |  fgets(inputBuffer, 0x100, stdin);
+      |  data = atoi(inputBuffer);
+      |  buffer[data] = 1;
+      |  strncpy(buffer, "hello", data);
+      |  return 0;
+      |}""".stripMargin)
 
     "find flow from <operator>.indirectIndexAccess" in {
-
       def source = cpg.call("fgets").argument(1)
-
-      def sink1 = cpg.call("strncpy").argument(3)
-
-      def sink2 = cpg.call("<operator>.indirectIndexAccess").argument(2)
-
-      def flows1 = sink1.reachableByFlows(source)
+      val sink1  = cpg.call("strncpy").argument(3)
+      val sink2  = cpg.call("<operator>.indirectIndexAccess").argument(2)
+      val flows1 = sink1.reachableByFlows(source)
 
       flows1.map(flowToResultPairs).toSetMutable shouldBe Set(
         List(
@@ -1551,7 +1462,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         )
       )
 
-      def flows2 = sink2.reachableByFlows(source)
+      val flows2 = sink2.reachableByFlows(source)
 
       flows2.map(flowToResultPairs).toSetMutable shouldBe Set(
         List(
@@ -1566,63 +1477,52 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest57" should {
     val cpg = code("""
-        |void abc()
-        |{
-        |    int a;
-        |    a = foo();
-        |    a = bar(0x80);
-        |    sink(a);
-        |}
-        |""".stripMargin)
+      |void abc() {
+      |  int a;
+      |  a = foo();
+      |  a = bar(0x80);
+      |  sink(a);
+      |}""".stripMargin)
 
     "not find a flow from 'a' at 'foo' to 'sink'" in {
-      def src = cpg.call("foo").inAssignment.target.head
-
-      def snk = cpg.method("sink").parameter
-
-      snk.reachableByFlows(src).size shouldBe 0
+      val src  = cpg.call("foo").inAssignment.target.head
+      val sink = cpg.method("sink").parameter
+      sink.reachableByFlows(src).size shouldBe 0
     }
   }
 
   "DataFlowTest58" should {
     val cpg = code("""
-        |void abc(int a)
-        |{
-        |    a = foo();
-        |    a = bar(0x80);
-        |    sink(a);
-        |}
-        |""".stripMargin)
+      |void abc(int a) {
+      |  a = foo();
+      |  a = bar(0x80);
+      |  sink(a);
+      |}""".stripMargin)
 
     "not find a flow from parameter 'a' to 'sink'" in {
-      def src = cpg.method("abc").parameter
-
-      def snk = cpg.method("sink").parameter
-
-      snk.reachableByFlows(src).size shouldBe 0
+      val src  = cpg.method("abc").parameter
+      val sink = cpg.method("sink").parameter
+      sink.reachableByFlows(src).size shouldBe 0
     }
   }
 
   "DataFlowTest59" should {
     val cpg = code("""
-        |typedef struct {
-        | char *buf1;
-        |} FooStruct;
-        |
-        |void doFoo(FooStruct *str) {
-        |}
-        |int main(void) {
-        | FooStruct foo;
-        | doFoo(&foo);
-        | return 0;
-        |}
-        |""".stripMargin)
+      |typedef struct {
+      | char *buf1;
+      |} FooStruct;
+      |
+      |void doFoo(FooStruct *str) {}
+      |
+      |int main(void) {
+      |  FooStruct foo;
+      |  doFoo(&foo);
+      |  return 0;
+      |}""".stripMargin)
 
     "find flow from local to 'doFoo'" in {
-      def source = cpg.local.name("foo").referencingIdentifiers
-
-      def sink = cpg.call.code("doFoo.*").argument
-
+      val source = cpg.local.name("foo").referencingIdentifiers
+      val sink   = cpg.call.code("doFoo.*").argument
       sink.reachableByFlows(source).size shouldBe 1
     }
 
@@ -1630,24 +1530,21 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTests60" should {
     val cpg = code("""
-        |
-        |void outer(char* ptr){
-        | taint1(ptr);
-        | inner(ptr);
-        | return;
-        | }
-        | void inner(char * ptr)
-        | {
-        | // taint2(ptr);
-        | ptr = malloc(0x80);
-        | sink(ptr);
-        | }""".stripMargin)
+      |void outer(char* ptr){
+      |  taint1(ptr);
+      |  inner(ptr);
+      |  return;
+      |}
+      |
+      |void inner(char * ptr) {
+      |  // taint2(ptr);
+      |  ptr = malloc(0x80);
+      |  sink(ptr);
+      |}""".stripMargin)
 
     "not return flow" in {
-      def source = cpg.call("taint1").argument
-
-      def sink = cpg.call("sink").argument
-
+      val source = cpg.call("taint1").argument
+      val sink   = cpg.call("sink").argument
       sink.reachableByFlows(source).size shouldBe 0
     }
 
@@ -1655,109 +1552,90 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTests61" should {
     val cpg = code("""
-        |void reassignThenFree(char * ptr)
-        |{
-        |ptr = malloc(0x80);
-        |free(ptr);
-        |return;
-        |}
-        |
-        |void reassign(char * ptr)
-        |{
-        |ptr = malloc(0x80);
-        |return;
-        |}
-        |
-        |// This flow from `free` to `free` should be returned
-        |int case0()
-        |{
-        |char * data = malloc(0x100);
-        |free(data);
-        |free(data);
-        |return 0;
-        |}
-        |
-        |""".stripMargin)
+      |void reassignThenFree(char * ptr) {
+      |  ptr = malloc(0x80);
+      |  free(ptr);
+      |  return;
+      |}
+      |
+      |void reassign(char * ptr) {
+      |  ptr = malloc(0x80);
+      |  return;
+      |}
+      |
+      |// This flow from `free` to `free` should be returned
+      |int case0() {
+      |  char * data = malloc(0x100);
+      |  free(data);
+      |  free(data);
+      |  return 0;
+      |}""".stripMargin)
 
     "find flow from `free` to `free`" in {
-      def sink = cpg.call("free").argument(1)
-
-      def source = cpg.call("free").argument(1)
-
+      val sink   = cpg.call("free").argument(1)
+      val source = cpg.call("free").argument(1)
       val List(flow: Path) = sink
         .reachableByFlows(source)
         .filter(path => path.elements.size > 1)
         .l
+
       inside(flow.elements) { case List(i1: Identifier, i2: Identifier) =>
         i1.name shouldBe "data"
-        i1.lineNumber shouldBe Some(19)
+        i1.lineNumber shouldBe Some(16)
         i2.name shouldBe "data"
-        i2.lineNumber shouldBe Some(20)
+        i2.lineNumber shouldBe Some(17)
       }
     }
   }
 
   "DataFlowTests62" should {
     val cpg = code("""
-        |void reassignThenFree(char * ptr)
-        |{
-        |ptr = malloc(0x80);
-        |free(ptr);
-        |return;
-        |}
-        |
-        |void reassign(char * ptr)
-        |{
-        |ptr = malloc(0x80);
-        |return;
-        |}
-        |
-        |// This flow should NOT be returned
-        |int case1()
-        |{
-        |char * data = malloc(0x100);
-        |free(data);
-        |data = malloc(0x80);
-        |free(data);
-        |return 0;
-        |}
-        |
-        |""".stripMargin)
+      |void reassignThenFree(char * ptr) {
+      |  ptr = malloc(0x80);
+      |  free(ptr);
+      |  return;
+      |}
+      |
+      |void reassign(char * ptr) {
+      |  ptr = malloc(0x80);
+      |  return;
+      |}
+      |
+      |// This flow should NOT be returned
+      |int case1() {
+      |  char * data = malloc(0x100);
+      |  free(data);
+      |  data = malloc(0x80);
+      |  free(data);
+      |  return 0;
+      |}""".stripMargin)
 
     "not report flow" in {
-      def sink = cpg.call("free").argument(1)
-
-      def source = cpg.call("free").argument(1)
-
+      val sink   = cpg.call("free").argument(1)
+      val source = cpg.call("free").argument(1)
       sink.reachableByFlows(source).count(path => path.elements.size > 1) shouldBe 0
     }
   }
 
   "DataFlowTests63" should {
     val cpg = code("""
-        |void reassignThenFree(char * ptr)
-        |{
-        |ptr = malloc(0x80);
-        |free(ptr);
-        |return;
-        |}
-        |
-        |// This flow should NOT be returned
-        |int case2()
-        |{
-        |char * data = malloc(0x100);
-        |free(data);
-        |reassignThenFree(data);
-        |return 0;
-        |}
-        |
-        |""".stripMargin)
+      |void reassignThenFree(char * ptr) {
+      |  ptr = malloc(0x80);
+      |  free(ptr);
+      |  return;
+      |}
+      |
+      |// This flow should NOT be returned
+      |int case2() {
+      |  char * data = malloc(0x100);
+      |  free(data);
+      |  reassignThenFree(data);
+      |  return 0;
+      |}""".stripMargin)
 
     "not report flow" in {
-      def sink = cpg.call("free").argument(1)
-
-      def source = cpg.call("free").argument(1)
-
+      val sink   = cpg.call("free").argument(1)
+      val source = cpg.call("free").argument(1)
       sink.reachableByFlows(source).count(path => path.elements.size > 1) shouldBe 0
     }
   }
@@ -1766,28 +1644,23 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     // This case is a double-free that we return, the reason being that modifying `ptr`
     // does not modify `data` as arguments  are passed by value.
     val cpg = code("""
-        |void reassign(char * ptr)
-        |{
-        |ptr = malloc(0x80);
-        |return;
-        |}
-        |
-        |// This flow should NOT be returned
-        |int case3()
-        |{
-        |char * data = malloc(0x100);
-        |free(data);
-        |reassign(data);
-        |free(data);
-        |return 0;
-        |}
-        |""".stripMargin)
+      |void reassign(char * ptr) {
+      |  ptr = malloc(0x80);
+      |  return;
+      |}
+      |
+      |// This flow should NOT be returned
+      |int case3() {
+      |  char * data = malloc(0x100);
+      |  free(data);
+      |  reassign(data);
+      |  free(data);
+      |  return 0;
+      |}""".stripMargin)
 
     "report flow" in {
-      def sink = cpg.call("free").argument(1)
-
-      def source = cpg.call("free").argument(1)
-
+      val sink   = cpg.call("free").argument(1)
+      val source = cpg.call("free").argument(1)
       sink.reachableByFlows(source).count(path => path.elements.size > 1) shouldBe 1
     }
 
@@ -1795,27 +1668,22 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTests65" should {
     val cpg = code("""
-        |char * reassign(char * ptr)
-        |{
-        |ptr = malloc(0x80);
-        |return ptr;
-        |}
-        |
-        |int case3()
-        |{
-        |char * data = malloc(0x80);
-        |free(data);
-        |data = reassign(data);
-        |free(data):
-        |return 0;
-        |}
-        |""".stripMargin)
+      |char * reassign(char * ptr) {
+      |  ptr = malloc(0x80);
+      |  return ptr;
+      |}
+      |
+      |int case3() {
+      |  char * data = malloc(0x80);
+      |  free(data);
+      |  data = reassign(data);
+      |  free(data):
+      |  return 0;
+      |}""".stripMargin)
 
     "not report flow from free to free" in {
-      def sink = cpg.call("free").argument(1)
-
-      def source = cpg.call("free").argument(1)
-
+      val sink   = cpg.call("free").argument(1)
+      val source = cpg.call("free").argument(1)
       sink.reachableByFlows(source).count(path => path.elements.size > 1) shouldBe 0
     }
 
@@ -1823,16 +1691,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTests66" should {
     val cpg = code("""
-        |int foo(int x) {
-        |  x = 10;
-        |}
-  """.stripMargin)
+      |int foo(int x) {
+      |  x = 10;
+      |}""".stripMargin)
 
     "report flow from method assignment to method parameter out" in {
-      def sink = cpg.method("foo").parameter.asOutput
-
-      def source = cpg.method("foo").ast.isIdentifier.name("x")
-
+      val sink   = cpg.method("foo").parameter.asOutput
+      val source = cpg.method("foo").ast.isIdentifier.name("x")
       sink.reachableByFlows(source).size shouldBe 1
     }
 
@@ -1840,14 +1705,14 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTests69" should {
     val cpg = code("""
-                     |char *foo() {
-                     |  return "abc" + "firstName";
-                     |}
-                     |
-                     |void bar() {
-                     | log(foo());
-                     |}
-                     |""".stripMargin)
+     |char *foo() {
+     |  return "abc" + "firstName";
+     |}
+     |
+     |void bar() {
+     | log(foo());
+     |}
+     |""".stripMargin)
 
     "find a flow where the first element is a literal" in {
       val source           = cpg.literal.code(".*firstName.*")
@@ -1860,13 +1725,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest70" should {
     val cpg = code("""
-        | int source() {
-        |   return 42;
-        | }
-        | void main() {
-        |   sink(source());
-        | }
-        | """.stripMargin)
+      |int source() {
+      |  return 42;
+      |}
+      |
+      |void main() {
+      |  sink(source());
+      |}""".stripMargin)
 
     "Test Interprocedural" should {
       "have a flow from argument(which itself is a call) to return" in {
@@ -1887,108 +1752,94 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
     val cpg = code("""
       |void CWE415_Double_Free__malloc_free_char_53b_badSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_53_bad()
-      |{
-      |    char * data;
-      |    /* Initialize data */
-      |    data = NULL;
-      |    data = (char *)malloc(100*sizeof(char));
-      |    if (data == NULL) {exit(-1);}
-      |    /* POTENTIAL FLAW: Free data in the source - the bad sink frees data as well */
-      |    free(data);
-      |    CWE415_Double_Free__malloc_free_char_53b_badSink(data);
+      |void CWE415_Double_Free__malloc_free_char_53_bad() {
+      |  char * data;
+      |  /* Initialize data */
+      |  data = NULL;
+      |  data = (char *)malloc(100*sizeof(char));
+      |  if (data == NULL) {exit(-1);}
+      |  /* POTENTIAL FLAW: Free data in the source - the bad sink frees data as well */
+      |  free(data);
+      |  CWE415_Double_Free__malloc_free_char_53b_badSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_53b_goodG2BSink(char * data);
       |
-      |static void goodG2B()
-      |{
-      |    char * data;
-      |    /* Initialize data */
-      |    data = NULL;
-      |    data = (char *)malloc(100*sizeof(char));
-      |    if (data == NULL) {exit(-1);}
-      |    /* FIX: Do NOT free data in the source - the bad sink frees data */
-      |    CWE415_Double_Free__malloc_free_char_53b_goodG2BSink(data);
+      |static void goodG2B() {
+      |  char * data;
+      |  /* Initialize data */
+      |  data = NULL;
+      |  data = (char *)malloc(100*sizeof(char));
+      |  if (data == NULL) {exit(-1);}
+      |  /* FIX: Do NOT free data in the source - the bad sink frees data */
+      |  CWE415_Double_Free__malloc_free_char_53b_goodG2BSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_53b_goodB2GSink(char * data);
       |
-      |static void goodB2G()
-      |{
-      |    char * data;
-      |    /* Initialize data */
-      |    data = NULL;
-      |    data = (char *)malloc(100*sizeof(char));
-      |    if (data == NULL) {exit(-1);}
-      |    /* POTENTIAL FLAW: Free data in the source - the bad sink frees data as well */
-      |    free(data);
-      |    CWE415_Double_Free__malloc_free_char_53b_goodB2GSink(data);
+      |static void goodB2G() {
+      |  char * data;
+      |  /* Initialize data */
+      |  data = NULL;
+      |  data = (char *)malloc(100*sizeof(char));
+      |  if (data == NULL) {exit(-1);}
+      |  /* POTENTIAL FLAW: Free data in the source - the bad sink frees data as well */
+      |  free(data);
+      |  CWE415_Double_Free__malloc_free_char_53b_goodB2GSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_53c_badSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_53b_badSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_53c_badSink(data);
+      |void CWE415_Double_Free__malloc_free_char_53b_badSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_53c_badSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_53c_goodG2BSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_53b_goodG2BSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_53c_goodG2BSink(data);
+      |void CWE415_Double_Free__malloc_free_char_53b_goodG2BSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_53c_goodG2BSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_53c_goodB2GSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_53b_goodB2GSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_53c_goodB2GSink(data);
+      |void CWE415_Double_Free__malloc_free_char_53b_goodB2GSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_53c_goodB2GSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_53d_badSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_53c_badSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_53d_badSink(data);
+      |void CWE415_Double_Free__malloc_free_char_53c_badSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_53d_badSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_53d_goodG2BSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_53c_goodG2BSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_53d_goodG2BSink(data);
+      |void CWE415_Double_Free__malloc_free_char_53c_goodG2BSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_53d_goodG2BSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_53d_goodB2GSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_53c_goodB2GSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_53d_goodB2GSink(data);
+      |void CWE415_Double_Free__malloc_free_char_53c_goodB2GSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_53d_goodB2GSink(data);
       |}
       |
-      |void CWE415_Double_Free__malloc_free_char_53d_badSink(char * data)
-      |{
-      |    /* POTENTIAL FLAW: Possibly freeing memory twice */
-      |    free(data);
+      |void CWE415_Double_Free__malloc_free_char_53d_badSink(char * data) {
+      |  /* POTENTIAL FLAW: Possibly freeing memory twice */
+      |  free(data);
       |}
       |
-      |void CWE415_Double_Free__malloc_free_char_53d_goodG2BSink(char * data)
-      |{
-      |    /* POTENTIAL FLAW: Possibly freeing memory twice */
-      |    free(data);
+      |void CWE415_Double_Free__malloc_free_char_53d_goodG2BSink(char * data) {
+      |  /* POTENTIAL FLAW: Possibly freeing memory twice */
+      |  free(data);
       |}
       |
       |/* goodB2G uses the BadSource with the GoodSink */
-      |void CWE415_Double_Free__malloc_free_char_53d_goodB2GSink(char * data)
-      |{
+      |void CWE415_Double_Free__malloc_free_char_53d_goodB2GSink(char * data) {
       |    /* do nothing */
       |    /* FIX: Don't attempt to free the memory */
       |    ; /* empty statement needed for some flow variants */
-      |}
-      |
-      |""".stripMargin)
+      |}""".stripMargin)
 
     "find flow for maxCallDepth = -1" in {
       def freeArg = cpg.call("free").argument(1)
@@ -2000,135 +1851,117 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
     val cpg = code("""
       |void CWE415_Double_Free__malloc_free_char_54b_badSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54_bad()
-      |{
-      |    char * data;
-      |    /* Initialize data */
-      |    data = NULL;
-      |    data = (char *)malloc(100*sizeof(char));
-      |    if (data == NULL) {exit(-1);}
-      |    /* POTENTIAL FLAW: Free data in the source - the bad sink frees data as well */
-      |    free(data);
-      |    CWE415_Double_Free__malloc_free_char_54b_badSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54_bad() {
+      |  char * data;
+      |  /* Initialize data */
+      |  data = NULL;
+      |  data = (char *)malloc(100*sizeof(char));
+      |  if (data == NULL) {exit(-1);}
+      |  /* POTENTIAL FLAW: Free data in the source - the bad sink frees data as well */
+      |  free(data);
+      |  CWE415_Double_Free__malloc_free_char_54b_badSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54b_goodG2BSink(char * data);
       |
-      |static void goodG2B()
-      |{
-      |    char * data;
-      |    /* Initialize data */
-      |    data = NULL;
-      |    data = (char *)malloc(100*sizeof(char));
-      |    if (data == NULL) {exit(-1);}
-      |    /* FIX: Do NOT free data in the source - the bad sink frees data */
-      |    CWE415_Double_Free__malloc_free_char_54b_goodG2BSink(data);
+      |static void goodG2B() {
+      |  char * data;
+      |  /* Initialize data */
+      |  data = NULL;
+      |  data = (char *)malloc(100*sizeof(char));
+      |  if (data == NULL) {exit(-1);}
+      |  /* FIX: Do NOT free data in the source - the bad sink frees data */
+      |  CWE415_Double_Free__malloc_free_char_54b_goodG2BSink(data);
       |}
       |
       |/* goodB2G uses the BadSource with the GoodSink */
       |void CWE415_Double_Free__malloc_free_char_54b_goodB2GSink(char * data);
       |
-      |static void goodB2G()
-      |{
-      |    char * data;
-      |    /* Initialize data */
-      |    data = NULL;
-      |    data = (char *)malloc(100*sizeof(char));
-      |    if (data == NULL) {exit(-1);}
-      |    /* POTENTIAL FLAW: Free data in the source - the bad sink frees data as well */
-      |    free(data);
-      |    CWE415_Double_Free__malloc_free_char_54b_goodB2GSink(data);
+      |static void goodB2G() {
+      |  char * data;
+      |  /* Initialize data */
+      |  data = NULL;
+      |  data = (char *)malloc(100*sizeof(char));
+      |  if (data == NULL) {exit(-1);}
+      |  /* POTENTIAL FLAW: Free data in the source - the bad sink frees data as well */
+      |  free(data);
+      |  CWE415_Double_Free__malloc_free_char_54b_goodB2GSink(data);
       |}
       |
-      |void CWE415_Double_Free__malloc_free_char_54_good()
-      |{
-      |    goodG2B();
-      |    goodB2G();
+      |void CWE415_Double_Free__malloc_free_char_54_good() {
+      |  goodG2B();
+      |  goodB2G();
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54c_badSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54b_badSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54c_badSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54b_badSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54c_badSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54c_goodG2BSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54b_goodG2BSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54c_goodG2BSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54b_goodG2BSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54c_goodG2BSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54c_goodB2GSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54b_goodB2GSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54c_goodB2GSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54b_goodB2GSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54c_goodB2GSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54d_badSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54c_badSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54d_badSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54c_badSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54d_badSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54d_goodG2BSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54c_goodG2BSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54d_goodG2BSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54c_goodG2BSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54d_goodG2BSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54d_goodB2GSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54c_goodB2GSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54d_goodB2GSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54c_goodB2GSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54d_goodB2GSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54e_badSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54d_badSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54e_badSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54d_badSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54e_badSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54e_goodG2BSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54d_goodG2BSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54e_goodG2BSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54d_goodG2BSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54e_goodG2BSink(data);
       |}
       |
       |void CWE415_Double_Free__malloc_free_char_54e_goodB2GSink(char * data);
       |
-      |void CWE415_Double_Free__malloc_free_char_54d_goodB2GSink(char * data)
-      |{
-      |    CWE415_Double_Free__malloc_free_char_54e_goodB2GSink(data);
+      |void CWE415_Double_Free__malloc_free_char_54d_goodB2GSink(char * data) {
+      |  CWE415_Double_Free__malloc_free_char_54e_goodB2GSink(data);
       |}
       |
-      |void CWE415_Double_Free__malloc_free_char_54e_badSink(char * data)
-      |{
-      |    /* POTENTIAL FLAW: Possibly freeing memory twice */
-      |    free(data);
+      |void CWE415_Double_Free__malloc_free_char_54e_badSink(char * data) {
+      |  /* POTENTIAL FLAW: Possibly freeing memory twice */
+      |  free(data);
       |}
       |
-      |void CWE415_Double_Free__malloc_free_char_54e_goodG2BSink(char * data)
-      |{
-      |    /* POTENTIAL FLAW: Possibly freeing memory twice */
-      |    free(data);
+      |void CWE415_Double_Free__malloc_free_char_54e_goodG2BSink(char * data) {
+      |  /* POTENTIAL FLAW: Possibly freeing memory twice */
+      |  free(data);
       |}
       |
-      |void CWE415_Double_Free__malloc_free_char_54e_goodB2GSink(char * data)
-      |{
-      |    /* do nothing */
-      |    /* FIX: Don't attempt to free the memory */
-      |    ; /* empty statement needed for some flow variants */
-      |}
-      |
-      |""".stripMargin)
+      |void CWE415_Double_Free__malloc_free_char_54e_goodB2GSink(char * data) {
+      |  /* do nothing */
+      |  /* FIX: Don't attempt to free the memory */
+      |  ; /* empty statement needed for some flow variants */
+      |}""".stripMargin)
 
     "find flow for maxCallDepth = -1" in {
       def freeArg = cpg.call("free").argument(1)
@@ -2138,21 +1971,19 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest69" should {
     val cpg = code("""
-        |void sink(int);
-        |
-        |void foo() {
-        |	int val = 42, a, b;
-        |	a = b = val;
-        |	sink(a);
-        |}
-        |
-        |void bar() {
-        |	int val = 42, a;
-        |	a = val++;
-        |	sink(a);
-        |}
-        |
-        |""".stripMargin)
+      |void sink(int);
+      |
+      |void foo() {
+      |	 int val = 42, a, b;
+      |	 a = b = val;
+      |	 sink(a);
+      |}
+      |
+      |void bar() {
+      |	 int val = 42, a;
+      |	 a = val++;
+      |	 sink(a);
+      |}""".stripMargin)
 
     "find flows" in {
       val sink = cpg.method("sink").parameter.index(1).l
@@ -2163,12 +1994,13 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest70" should {
     val cpg = code("""
-        |int foo() {
-        |  int v1, v2 = 0;
-        |  if((v1 = 1, v2 == 2) || v2 <= 3) return v2;
-        |  return 0;
-        |}
-        |""".stripMargin)
+      |int foo() {
+      |  int v1, v2 = 0;
+      |  if((v1 = 1, v2 == 2) || v2 <= 3) return v2;
+      |  return 0;
+      |}
+      |""".stripMargin)
+
     "find flows" in {
       val source = cpg.identifier("v2").l
       val sink   = cpg.method("foo").methodReturn.l
@@ -2199,13 +2031,14 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
 
   "DataFlowTest71" should {
     val cpg = code("""
-        |#define BAR(x) (x)
-        |
-        |void foo() {
-        |  int v1 = 0;
-        |  if (BAR(v1)) v1 = 1;
-        |}
-        |""".stripMargin)
+      |#define BAR(x) (x)
+      |
+      |void foo() {
+      |  int v1 = 0;
+      |  if (BAR(v1)) v1 = 1;
+      |}
+      |""".stripMargin)
+
     "find flows" in {
       val source = cpg.identifier("v1").l
       val sink   = cpg.method("foo").methodReturn.l

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MetaDataTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MetaDataTests.scala
@@ -7,7 +7,6 @@ import io.joern.x2cpg.layers.ControlFlow
 import io.joern.x2cpg.layers.TypeRelations
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class MetaDataTests extends CCodeToCpgSuite {
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
@@ -20,28 +20,24 @@ class ClassTypeTests extends CCodeToCpgSuite(FileDefaults.CPP_EXT) {
 
     "create TYPE node with correct fields for class member" in {
       val List(x) = cpg.typ.name("member_type").l
-      x.name shouldBe "member_type"
       x.fullName shouldBe "member_type"
       x.typeDeclFullName shouldBe "member_type"
     }
 
     "create TYPE node with correct fields for return type" in {
       val List(x) = cpg.typ.name("ret_type").l
-      x.name shouldBe "ret_type"
       x.fullName shouldBe "ret_type"
       x.typeDeclFullName shouldBe "ret_type"
     }
 
     "create TYPE node with correct fields for parameter type" in {
       val List(x) = cpg.typ.name("param_type").l
-      x.name shouldBe "param_type"
       x.fullName shouldBe "param_type"
       x.typeDeclFullName shouldBe "param_type"
     }
 
     "create TYPE node with correct fields for local type" in {
       val List(x) = cpg.typ.name("local_type").l
-      x.name shouldBe "local_type"
       x.fullName shouldBe "local_type"
       x.typeDeclFullName shouldBe "local_type"
     }
@@ -79,7 +75,6 @@ class ClassTypeTests extends CCodeToCpgSuite(FileDefaults.CPP_EXT) {
 
     "should contain a type decl for `foo` with correct fields" in {
       val List(x) = cpg.typeDecl("foo").l
-      x.name shouldBe "foo"
       x.fullName shouldBe "foo"
       x.isExternal shouldBe false
       x.inheritsFromTypeFullName shouldBe List("bar")
@@ -91,7 +86,6 @@ class ClassTypeTests extends CCodeToCpgSuite(FileDefaults.CPP_EXT) {
 
     "should contain type decl for alias `mytype` of `int`" in {
       val List(x) = cpg.typeDecl("mytype").l
-      x.name shouldBe "mytype"
       x.fullName shouldBe "mytype"
       x.isExternal shouldBe false
       x.inheritsFromTypeFullName shouldBe List()
@@ -104,7 +98,6 @@ class ClassTypeTests extends CCodeToCpgSuite(FileDefaults.CPP_EXT) {
 
     "should contain type decl for external type `int`" in {
       val List(x) = cpg.typeDecl("int").l
-      x.name shouldBe "int"
       x.fullName shouldBe "int"
       x.isExternal shouldBe true
       x.inheritsFromTypeFullName shouldBe List()


### PR DESCRIPTION
Put some helper node creation functions into AstNodeBuilder which simplifies AST node creation a lot. The Scala Int -> Java Integer mapping looks strange but is required as the NewNode interface requires Java Integers there. Switching to Scala Int also fixes some compiler warnings for c2cpg (type was inferred to Any).