### PR TITLE
[x2cpg]: DynamicCallLinker Excludes Non-Overriden Inheritted Methods

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
@@ -3,54 +3,54 @@ package io.joern.jimple2cpg.querying
 import io.joern.jimple2cpg.testfixtures.JimpleCode2CpgFixture
 import io.shiftleft.semanticcpg.language.{NoResolve, _}
 
-class DynamicCallGraphTests extends JimpleCode2CpgFixture {
+class DynamicCallGraphTests1 extends JimpleCode2CpgFixture {
 
   implicit val resolver: NoResolve.type = NoResolve
 
-  val cpg = code("""
-class Foo {
-
-	public static void main(String[] args){
-		A b1 = new B();
-		A c1 = new C();
-
-		A b2 = b1;
-		A c2 = c1;
-
-		// what will get printed?
-		b2.print(c2);
-	}
-
-	public static class A extends Object {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to A's print(A object)");
-		}
-	}
-
-	public static class B extends A {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to B's print(A object)");
-		}
-	}
-
-	public static class C extends B {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to C's print(A object)");
-		}
-	}
-
-	public static class D extends A {
-		public void print(A object) {
-			System.out.println("An instance of " + object.getClass().getSimpleName()
-					+ " was passed to D's print(A object)");
-		}
-	}
-
-}
-    """)
+  private val cpg = code("""
+      |class Foo {
+      |
+      |      public static void main(String[] args){
+      |          A b1 = new B();
+      |          A c1 = new C();
+      |
+      |          A b2 = b1;
+      |          A c2 = c1;
+      |
+      |          // what will get printed?
+      |          b2.print(c2);
+      |      }
+      |
+      |      public static class A extends Object {
+      |          public void print(A object) {
+      |              System.out.println("An instance of " + object.getClass().getSimpleName()
+      |                      + " was passed to A's print(A object)");
+      |          }
+      |      }
+      |
+      |      public static class B extends A {
+      |          public void print(A object) {
+      |              System.out.println("An instance of " + object.getClass().getSimpleName()
+      |                      + " was passed to B's print(A object)");
+      |          }
+      |      }
+      |
+      |      public static class C extends B {
+      |          public void print(A object) {
+      |              System.out.println("An instance of " + object.getClass().getSimpleName()
+      |                      + " was passed to C's print(A object)");
+      |          }
+      |      }
+      |
+      |      public static class D extends A {
+      |          public void print(A object) {
+      |              System.out.println("An instance of " + object.getClass().getSimpleName()
+      |                      + " was passed to D's print(A object)");
+      |          }
+      |      }
+      |
+      |}
+      |""".stripMargin)
 
   "should find that add is called by main" in {
     cpg.method.name("print").caller.name.toSetMutable shouldBe Set("main")
@@ -63,6 +63,44 @@ class Foo {
       "Foo$C",
       "Foo$A"
     )
+  }
+
+}
+
+class DynamicCallGraphTests2 extends JimpleCode2CpgFixture {
+
+  implicit val resolver: NoResolve.type = NoResolve
+
+  private val cpg = code("""
+      |class Foo {
+      |
+      |  private int x = 0;
+      |
+      |  public int foo(int a) {
+      |    this.x = a;
+      |    return this.x;
+      |  }
+      |}
+      |
+      |class Bar extends Foo {
+      |
+      |  public int bar(int b) {
+      |    return foo(b);
+      |  }
+      |
+      |}
+      |""".stripMargin)
+
+  "should find that foo is not defined and thus methodFullName should reflect the target callee" in {
+    cpg.call.name("foo").methodFullName.toSetMutable shouldBe Set("Foo.foo:int(int)")
+  }
+
+  "should find that foo is not defined and thus point to the superclass implementation" in {
+    cpg.method.name("foo").caller.name.toSetMutable shouldBe Set("bar")
+  }
+
+  "should account for call to inherited superclass" in {
+    cpg.call.name("foo").callee.definingTypeDecl.fullName.toSetMutable shouldBe Set("Foo")
   }
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/DynamicCallGraphTests.scala
@@ -91,8 +91,8 @@ class DynamicCallGraphTests2 extends JimpleCode2CpgFixture {
       |}
       |""".stripMargin)
 
-  "should find that foo is not defined and thus methodFullName should reflect the target callee" in {
-    cpg.call.name("foo").methodFullName.toSetMutable shouldBe Set("Foo.foo:int(int)")
+  "should find that foo is still called with the derived full name" in {
+    cpg.call.name("foo").methodFullName.toSetMutable shouldBe Set("Bar.foo:int(int)")
   }
 
   "should find that foo is not defined and thus point to the superclass implementation" in {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -184,9 +184,6 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
             fallbackToStaticResolution(call, dstGraph)
           }
         }
-        // If we only find one method to resolve, we can set it to the full name if this is not already the case
-        if (tgts.size == 1 && call.methodFullName != tgts.head)
-          dstGraph.setNodeProperty(call, PropertyNames.METHOD_FULL_NAME, tgts.head)
       case None if resolveCallInSuperClasses(call) =>
         // Resolve "hidden" inherited method and leave an alias for the result in validM, then retry
         linkDynamicCall(call, dstGraph)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -72,6 +72,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
         linkDynamicCall(call, dstGraph)
       } catch {
         case exception: Exception =>
+          exception.printStackTrace()
           throw new RuntimeException(exception)
       }
     }
@@ -143,6 +144,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   private def resolveCallInSuperClasses(call: Call): Boolean = {
+    if (!call.methodFullName.contains(":")) return false
     val Array(fullName, signature) = call.methodFullName.split(":")
     val typeDeclFullName           = fullName.replace(s".${call.name}", "")
     val candidateInheritedMethods =
@@ -164,6 +166,9 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   @tailrec
   private def linkDynamicCall(call: Call, dstGraph: DiffGraphBuilder): Unit = {
+    // This call linker requires a method full name entry
+    if (call.methodFullName.equals("<empty>")) return
+
     validM.get(call.methodFullName) match {
       case Some(tgts) =>
         val callsOut = call.callOut.fullName.toSetImmutable

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -2,7 +2,7 @@ package io.joern.x2cpg.passes.callgraph
 
 import io.joern.x2cpg.Defines.DynamicCallUnknownFallName
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, Type, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, TypeDecl}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -143,7 +143,8 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   private def resolveCallInSuperClasses(call: Call): Boolean = {
     if (!call.methodFullName.contains(":")) return false
-    val Array(fullName, signature) = call.methodFullName.split(":")
+    def split(str: String, n: Int) = (str.take(n), str.drop(n + 1))
+    val (fullName, signature)      = split(call.methodFullName, call.methodFullName.lastIndexOf(":"))
     val typeDeclFullName           = fullName.replace(s".${call.name}", "")
     val candidateInheritedMethods =
       cpg.typeDecl

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -75,6 +75,8 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
           throw new RuntimeException(exception)
       }
     }
+
+    superclassCache.clear()
   }
 
   /** Recursively returns all the sub-types of the given type declaration. Does not account for circular hierarchies.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -72,7 +72,6 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
         linkDynamicCall(call, dstGraph)
       } catch {
         case exception: Exception =>
-          exception.printStackTrace()
           throw new RuntimeException(exception)
       }
     }


### PR DESCRIPTION
- If no methods are in the list of callees, attempts to first resolve the result by inspecting the superclass method names and signatures
- The method full name still makes use of the derived full name

Resolves #2142