### PR TITLE
jssrc: normalize input path to fix --exclude

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
@@ -25,8 +25,9 @@ final case class Config(
     }
   }
 
-  override def withInputPath(inputPath: String): Config = copy(inputPath = inputPath)
-  override def withOutputPath(x: String): Config        = copy(outputPath = x)
+  override def withInputPath(inputPath: String): Config =
+    copy(inputPath = Paths.get(inputPath).toAbsolutePath.normalize().toString)
+  override def withOutputPath(x: String): Config = copy(outputPath = x)
 }
 
 private object Frontend {


### PR DESCRIPTION
`--exclude` wasn't working for relative input paths because it would compare paths like `/foo/./bar` against a normalized excluded path `/foo/bar`