### PR TITLE
c2cpg: fixes for method stubs / expression lists

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -56,8 +56,15 @@ trait AstForExpressionsCreator { this: AstCreator =>
   }
 
   private def astForExpressionList(exprList: IASTExpressionList): Ast = {
-    val b = newBlockNode(exprList, Defines.voidTypeName)
-    Ast(b).withChildren(exprList.getExpressions.toIndexedSeq.map(astForExpression))
+    val cpgBlock  = newBlockNode(exprList, registerType(Defines.voidTypeName))
+    var currOrder = 1
+    val childAsts = exprList.getExpressions.map { expr =>
+      val r = nullSafeAst(expr, currOrder)
+      currOrder = currOrder + 1
+      r
+    }
+    val blockAst = Ast(cpgBlock).withChildren(childAsts.toIndexedSeq)
+    blockAst
   }
 
   private def astForCallExpression(call: IASTFunctionCallExpression): Ast = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -65,6 +65,7 @@ abstract class AstCreatorBase(filename: String) {
   ): Ast =
     Ast(method)
       .withChildren(parameters.map(Ast(_)))
+      .withChild(Ast(NewBlock()))
       .withChildren(modifiers.map(Ast(_)))
       .withChild(Ast(methodReturn))
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -122,7 +122,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
   private def blockMatches(block: Block): Boolean =
     block._astIn.hasNext &&
       (block.astParent.isMethod || block.astParent.isControlStructure ||
-        block.astParent.exists(_.collectAll[Call].exists(_.dispatchType == DispatchTypes.INLINED)))
+        block.astParent.collectAll[Call].exists(_.dispatchType == DispatchTypes.INLINED))
 
   /** A second layer of dispatching for control structures. This could as well be part of `cfgFor` and has only been
     * placed into a separate function to increase readability.


### PR DESCRIPTION
* order of expression list elements was missing
* method stubs need an outgoing AST edge to a block (otherwise we end up with a schema violation reported when calling e.g., `cpg.method.block.l`)