### PR TITLE
runShellCommand: return `Try[Unit]`

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
@@ -18,7 +18,7 @@ case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGene
     namespaces: List[String] = List()
   ): Option[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
@@ -22,7 +22,7 @@ case class CSharpCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
       command = "powershell"
       arguments = Seq(rootPath.resolve("csharp2cpg.ps1").toString) ++ arguments
     }
-    runShellCommand(command, arguments).map(_ => outputPath)
+    runShellCommand(command, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = rootPath.resolve("csharp2cpg.sh").toFile.exists()

--- a/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
@@ -17,7 +17,7 @@ case class GhidraCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
     namespaces: List[String] = List()
   ): Option[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
@@ -23,7 +23,7 @@ case class GoCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
       arguments = Seq(rootPath.resolve("go2cpg.ps1").toString) ++ arguments
     }
 
-    runShellCommand(command, arguments).map(_ => outputPath)
+    runShellCommand(command, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = rootPath.resolve("go2cpg.sh").toFile.exists()

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
@@ -30,7 +30,7 @@ case class JavaCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
     if (inputPath.endsWith(".apk")) {
       println("found .apk ending - will first transform it to a jar using dex2jar.sh")
       val dex2jar = rootPath.resolve("dex2jar.sh").toString
-      runShellCommand(dex2jar, Seq(inputPath)).flatMap { _ =>
+      runShellCommand(dex2jar, Seq(inputPath)).toOption.flatMap { _ =>
         val jarPath = s"$inputPath.jar"
         generateCommercial(jarPath, outputPath, namespaces)
       }
@@ -42,14 +42,14 @@ case class JavaCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
         command = "powershell"
         arguments = Seq(rootPath.resolve("java2cpg.ps1").toString) ++ arguments
       }
-      runShellCommand(command, arguments).map(_ => outputPath)
+      runShellCommand(command, arguments).toOption.map(_ => outputPath)
     }
   }
 
   private def generateOss(inputPath: String, outputPath: String): Option[String] = {
     val command   = if (isWin) rootPath.resolve("jimple2cpg.bat") else rootPath.resolve("jimple2cpg")
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   private def jvmLanguages: List[String] = {

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -17,7 +17,7 @@ case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends C
     namespaces: List[String] = List()
   ): Option[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
@@ -15,7 +15,7 @@ case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
     namespaces: List[String] = List()
   ): Option[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -17,7 +17,7 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
     namespaces: List[String] = List()
   ): Option[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
@@ -17,7 +17,7 @@ case class KotlinCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
     namespaces: List[String] = List()
   ): Option[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
@@ -17,7 +17,7 @@ case class LlvmCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
   ): Option[String] = {
     val command   = rootPath.resolve("llvm2cpg.sh").toString
     val arguments = Seq("--output", outputPath) ++ config.cmdLineParams ++ List(inputPath)
-    runShellCommand(command, arguments).map(_ => outputPath)
+    runShellCommand(command, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = rootPath.resolve("llvm2cpg.sh").toFile.exists()

--- a/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
@@ -9,7 +9,7 @@ case class PhpCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGe
 
   override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
     val arguments = List(inputPath) ++ Seq("-o", outputPath) ++ config.cmdLineParams
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -17,7 +17,7 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
     namespaces: List[String] = List()
   ): Option[String] = {
     val arguments = Seq(inputPath, "-o", outputPath) ++ config.cmdLineParams
-    runShellCommand(command.toString, arguments).map(_ => outputPath)
+    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.1


### PR DESCRIPTION
previously it would return `Option[String]` which contained the executed 
command - that didn't make much sense