### PR TITLE
c2cpg: fixed macro expansion and CFG generation with nested blocks

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -56,15 +56,10 @@ trait AstForExpressionsCreator { this: AstCreator =>
   }
 
   private def astForExpressionList(exprList: IASTExpressionList): Ast = {
-    val cpgBlock  = newBlockNode(exprList, registerType(Defines.voidTypeName))
-    var currOrder = 1
-    val childAsts = exprList.getExpressions.map { expr =>
-      val r = nullSafeAst(expr, currOrder)
-      currOrder = currOrder + 1
-      r
-    }
-    val blockAst = Ast(cpgBlock).withChildren(childAsts.toIndexedSeq)
-    blockAst
+    val callNode =
+      newCallNode(exprList, "<operator>.expressionList", "<operator>.expressionList", DispatchTypes.STATIC_DISPATCH)
+    val childAsts = exprList.getExpressions.map(nullSafeAst)
+    callAst(callNode, childAsts.toIndexedSeq)
   }
 
   private def astForCallExpression(call: IASTFunctionCallExpression): Ast = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -33,9 +33,15 @@ trait MacroHandler { this: AstCreator =>
       case Some(callAst) =>
         val newAst = ast.subTreeCopy(ast.root.get.asInstanceOf[AstNodeNew], argIndex = 1)
         // We need to wrap the copied AST as it may contain CPG nodes not being allowed
-        // to be connected via AST edges under a CALL. E.g., LOCALs.
-        val b = NewBlock().argumentIndex(1).typeFullName(registerType(Defines.voidTypeName))
-        callAst.withChild(blockAst(b, List(newAst)))
+        // to be connected via AST edges under a CALL. E.g., LOCALs but only if its not already a BLOCK.
+        val childAst = newAst.root match {
+          case Some(_: NewBlock) =>
+            newAst
+          case _ =>
+            val b = NewBlock().argumentIndex(1).typeFullName(registerType(Defines.voidTypeName))
+            blockAst(b, List(newAst))
+        }
+        callAst.withChild(childAst)
       case None => ast
     }
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -2005,8 +2005,11 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
       val source = cpg.identifier("v2").l
       val sink   = cpg.method("foo").methodReturn.l
       sink.reachableByFlows(source).l.map(flowToResultPairs).toSet shouldBe Set(
+        List(("return v2;", Some(4)), ("int", Some(2))),
         List(
           ("v2 == 2", Some(4)),
+          ("v1 = 1", Some(4)),
+          ("v1 = 1, v2 == 2", Some(4)),
           ("(v1 = 1, v2 == 2)", Some(4)),
           ("(v1 = 1, v2 == 2) || v2 <= 3", Some(4)),
           ("int", Some(2))
@@ -2014,6 +2017,8 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
         List(
           ("v2 = 0", Some(3)),
           ("v2 == 2", Some(4)),
+          ("v1 = 1", Some(4)),
+          ("v1 = 1, v2 == 2", Some(4)),
           ("(v1 = 1, v2 == 2)", Some(4)),
           ("(v1 = 1, v2 == 2) || v2 <= 3", Some(4)),
           ("int", Some(2))
@@ -2023,8 +2028,7 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
           ("(v1 = 1, v2 == 2)", Some(4)),
           ("(v1 = 1, v2 == 2) || v2 <= 3", Some(4)),
           ("int", Some(2))
-        ),
-        List(("return v2;", Some(4)), ("int", Some(2)))
+        )
       )
     }
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -750,6 +750,21 @@ class AstCreationPassTests extends AbstractPassTest {
         .l shouldBe List("x")
     }
 
+    "be correct for expression list" in AstFixture("""
+        |void method(int x) {
+        |  return (__sync_synchronize(), foo(x));
+        |}
+      """.stripMargin) { cpg =>
+      val List(bracketedPrimaryCall) = cpg.call("<operator>.bracketedPrimary").l
+      val List(expressionListCall)   = bracketedPrimaryCall.argument.isCall.l
+      expressionListCall.name shouldBe "<operator>.expressionList"
+
+      val List(arg1) = expressionListCall.argument(1).collectAll[Call].l
+      arg1.code shouldBe "__sync_synchronize()"
+      val List(arg2) = expressionListCall.argument(2).collectAll[Call].l
+      arg2.code shouldBe "foo(x)"
+    }
+
     "be correct for call expression" in AstFixture("""
         |void method(int x) {
         |  foo(x);

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/MixedCfgCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/MixedCfgCreationPassTest.scala
@@ -180,8 +180,7 @@ class MixedCfgCreationPassTest extends CfgTestFixture(() => new JsCfgTestCpg()) 
         ("param1_0", 1, FalseEdge)
       )
       succOf("param1_0", 1) shouldBe expected(("param1_0 === void 0 ? {} : param1_0", AlwaysEdge))
-      succOf("_tmp_0") shouldBe expected(("{}", AlwaysEdge))
-      succOf("{}") shouldBe expected(("param1_0 === void 0 ? {} : param1_0", AlwaysEdge))
+      succOf("_tmp_0") shouldBe expected(("param1_0 === void 0 ? {} : param1_0", AlwaysEdge))
       succOf("param1_0 === void 0 ? {} : param1_0") shouldBe expected(
         ("_tmp_1 = param1_0 === void 0 ? {} : param1_0", AlwaysEdge)
       )
@@ -195,8 +194,7 @@ class MixedCfgCreationPassTest extends CfgTestFixture(() => new JsCfgTestCpg()) 
         ("_tmp_2", TrueEdge), // holds {}
         ("_tmp_1", 2, FalseEdge)
       )
-      succOf("_tmp_2") shouldBe expected(("{}", AlwaysEdge))
-      succOf("{}", 1) shouldBe expected(("_tmp_1.id === void 0 ? {} : _tmp_1.id", AlwaysEdge))
+      succOf("_tmp_2") shouldBe expected(("_tmp_1.id === void 0 ? {} : _tmp_1.id", AlwaysEdge))
       succOf("_tmp_1", 2) shouldBe expected(("id", 2, AlwaysEdge))
 
       succOf("_tmp_1.id === void 0 ? {} : _tmp_1.id") shouldBe expected(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -133,8 +133,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
   private def blockMatches(block: Block): Boolean = {
     if (block._astIn.hasNext) {
       val parentNode = block.astParent
-      parentNode.isMethod || parentNode.isControlStructure ||
-      isLogicalOperator(parentNode) || isInlinedCall(parentNode)
+      parentNode.isMethod || parentNode.isControlStructure || isLogicalOperator(parentNode) || isInlinedCall(parentNode)
     } else false
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -116,13 +116,27 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
         cfgForChildren(node)
     }
 
+  private def isLogicalOperator(node: AstNode): Boolean = node match {
+    case call: Call =>
+      call.name == Operators.conditional || call.name == Operators.logicalOr || call.name == Operators.logicalAnd
+    case _ => false
+  }
+
+  private def isInlinedCall(node: AstNode): Boolean = node match {
+    case call: Call => call.dispatchType == DispatchTypes.INLINED
+    case _          => false
+  }
+
   /** Only include block nodes that do not describe the entire method body or the bodies of control structures or
-    * inlined calls.
+    * inlined calls or logical operators.
     */
-  private def blockMatches(block: Block): Boolean =
-    block._astIn.hasNext &&
-      (block.astParent.isMethod || block.astParent.isControlStructure ||
-        block.astParent.collectAll[Call].exists(_.dispatchType == DispatchTypes.INLINED))
+  private def blockMatches(block: Block): Boolean = {
+    if (block._astIn.hasNext) {
+      val parentNode = block.astParent
+      parentNode.isMethod || parentNode.isControlStructure ||
+      isLogicalOperator(parentNode) || isInlinedCall(parentNode)
+    } else false
+  }
 
   /** A second layer of dispatching for control structures. This could as well be part of `cfgFor` and has only been
     * placed into a separate function to increase readability.


### PR DESCRIPTION
Nested macro expansions with blocks contained multiple nested blocks which led to broken CFGs. We fixed that by checking for blocks in asChildOfMacroCall.

Also: blocks are not allowed as CFG nodes within logical operators.