### PR TITLE
speed up build: run jssrc tests in parallel (i.e. do not fork)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ null
 **/astgen-linux
 **/php2cpg/bin/vendor/
 **/php2cpg/bin/composer*
+/foo.c
+/woo.c
+/cpg_*.bin.zip

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -61,7 +61,7 @@ scalacOptions ++= Seq() ++ (
 )
 
 compile / javacOptions ++= Seq("-Xlint:all", "-Xlint:-cast", "-g")
-Test / fork := true
+Test / fork := false
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 


### PR DESCRIPTION
* this is a new attempt at https://github.com/joernio/joern/pull/1460
* that one worked locally, but failed on gh actions
* jssrc2cpg is by far the longest subproject to run tests: 110s before this change, 20s now