### PR TITLE
Hash optimisation

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -34,7 +34,7 @@ class Engine(context: EngineContext) {
     */
   private val mainResultTable: mutable.Map[TaskFingerprint, List[TableEntry]] = mutable.Map()
   private var numberOfTasksRunning: Int                                       = 0
-  private val started: mutable.HashSet[TaskFingerprint]                        = mutable.HashSet[TaskFingerprint]()
+  private val started: mutable.HashSet[TaskFingerprint]                       = mutable.HashSet[TaskFingerprint]()
   private val held: mutable.Buffer[ReachableByTask]                           = mutable.Buffer()
 
   /** Determine flows from sources to sinks by exploring the graph backwards from sinks to sources. Returns the list of
@@ -132,7 +132,7 @@ class Engine(context: EngineContext) {
 
   private def submitTasks(tasks: Vector[ReachableByTask], sources: Set[CfgNode]): Unit = {
     tasks.foreach { task =>
-      if (started.contains(task.fingerprint) ){
+      if (started.contains(task.fingerprint)) {
         held ++= Vector(task)
       } else {
         started.add(task.fingerprint)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -113,7 +113,7 @@ class Engine(context: EngineContext) {
     val startTimeSec: Long = System.currentTimeMillis / 1000
     runUntilAllTasksAreSolved()
     val taskFinishTimeSec: Long = System.currentTimeMillis / 1000
-    println(
+    logger.debug(
       "Time measurement -----> Task processing done in " +
         (taskFinishTimeSec - startTimeSec) + " seconds"
     )
@@ -121,7 +121,7 @@ class Engine(context: EngineContext) {
     val dedupResult          = deduplicateFinal(extractResultsFromTable(sinks))
     val allDoneTimeSec: Long = System.currentTimeMillis / 1000
 
-    println(
+    logger.debug(
       "Time measurement -----> Task processing: " +
         (taskFinishTimeSec - startTimeSec) + " seconds" +
         ", Deduplication: " + (allDoneTimeSec - taskFinishTimeSec) +

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -34,7 +34,7 @@ class Engine(context: EngineContext) {
     */
   private val mainResultTable: mutable.Map[TaskFingerprint, List[TableEntry]] = mutable.Map()
   private var numberOfTasksRunning: Int                                       = 0
-  private val started: mutable.Buffer[ReachableByTask]                        = mutable.Buffer()
+  private val started: mutable.HashSet[TaskFingerprint]                        = mutable.HashSet[TaskFingerprint]()
   private val held: mutable.Buffer[ReachableByTask]                           = mutable.Buffer()
 
   /** Determine flows from sources to sinks by exploring the graph backwards from sinks to sources. Returns the list of
@@ -117,10 +117,10 @@ class Engine(context: EngineContext) {
 
   private def submitTasks(tasks: Vector[ReachableByTask], sources: Set[CfgNode]): Unit = {
     tasks.foreach { task =>
-      if (started.exists(x => x.fingerprint == task.fingerprint)) {
+      if (started.contains(task.fingerprint) ){
         held ++= Vector(task)
       } else {
-        started ++= Vector(task)
+        started.add(task.fingerprint)
         numberOfTasksRunning += 1
         completionService.submit(new TaskSolver(task, context, sources))
       }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -110,9 +110,24 @@ class Engine(context: EngineContext) {
     }
 
     submitTasks(tasks.toVector, sources)
+    val startTimeSec: Long = System.currentTimeMillis / 1000
     runUntilAllTasksAreSolved()
+    val taskFinishTimeSec: Long = System.currentTimeMillis / 1000
+    println(
+      "Time measurement -----> Task processing done in " +
+        (taskFinishTimeSec - startTimeSec) + " seconds"
+    )
     new HeldTaskCompletion(held.toList, mainResultTable).completeHeldTasks()
-    deduplicateFinal(extractResultsFromTable(sinks))
+    val dedupResult          = deduplicateFinal(extractResultsFromTable(sinks))
+    val allDoneTimeSec: Long = System.currentTimeMillis / 1000
+
+    println(
+      "Time measurement -----> Task processing: " +
+        (taskFinishTimeSec - startTimeSec) + " seconds" +
+        ", Deduplication: " + (allDoneTimeSec - taskFinishTimeSec) +
+        ", Deduped results size: " + dedupResult.length
+    )
+    dedupResult
   }
 
   private def submitTasks(tasks: Vector[ReachableByTask], sources: Set[CfgNode]): Unit = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -1,57 +1,12 @@
 package io.joern.dataflowengineoss.queryengine
 
 import io.joern.dataflowengineoss.queryengine.QueryEngineStatistics.{PATH_CACHE_HITS, PATH_CACHE_MISSES}
-import io.joern.dataflowengineoss.queryengine.TaskSolver.{doneTaskCounter, totalTaskCounter}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.shiftleft.codepropertygraph.cpgloading.ProtoToCpg.logger
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language.{toCfgNodeMethods, toExpressionMethods}
 
 import java.util.concurrent.Callable
 import scala.collection.mutable
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
-
-object TaskSolver {
-  val totalTaskCounter      = new AtomicInteger(0)
-  val doneTaskCounter       = new AtomicInteger(0)
-  val futuresStartedCounter = new AtomicInteger(0)
-  val futuresEndedCounter   = new AtomicInteger(0)
-  val lastDoneTasks         = new AtomicInteger(0)
-  val lastPrintTime         = new AtomicLong()
-  val myTurn                = new AtomicBoolean()
-
-  def printStats(): Unit = {
-
-    val now: Long = System.currentTimeMillis / 1000
-
-    if (now - lastPrintTime.get() < 1) {
-      return
-    }
-    lastPrintTime.set(now)
-
-    val prevVal = myTurn.getAndSet(true)
-    if (prevVal == true) {
-      return
-    }
-
-    val totalTasks     = totalTaskCounter.get()
-    val doneTasks      = doneTaskCounter.get()
-    val futuresStarted = futuresStartedCounter.get()
-    val futuresEnded   = futuresEndedCounter.get()
-    val backlog        = futuresStarted - futuresEnded
-
-    logger.debug(
-      " Total tasks: " + totalTasks +
-        ", Done tasks: " + doneTasks +
-        ", Futures started: " + futuresStarted +
-        ", Futures ended: " + futuresEnded +
-        ", Future backlog: " + backlog +
-        ", Tasks per sec: " + (doneTasks - lastDoneTasks.get())
-    )
-    lastDoneTasks.set(doneTasks)
-    myTurn.getAndSet(false)
-  }
-}
 
 /** Callable for solving a ReachableByTask
   *
@@ -73,7 +28,6 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
     * list is returned. Otherwise, the task is solved and its results are returned.
     */
   override def call(): TaskSummary = {
-    totalTaskCounter.incrementAndGet()
     implicit val sem: Semantics = context.semantics
     val path                    = Vector(PathElement(task.sink, task.callSiteStack))
     val table: mutable.Map[TaskFingerprint, Vector[ReachableByResult]] = mutable.Map()
@@ -87,8 +41,6 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
     }
     val (partial, complete) = finalResults.partition(_.partial)
     val newTasks            = new TaskCreator(context).createFromResults(partial)
-    doneTaskCounter.incrementAndGet()
-    TaskSolver.printStats()
     TaskSummary(complete.flatMap(r => resultToTableEntries(r)), newTasks)
   }
 


### PR DESCRIPTION
### Description
Converted started list to a hash set for better lookup performance.

### Testing done:

Snap task processing for snap cpg ( 385 MB ) comes down from 20-30 mins to 10 seconds on my machine.
No impact on smaller repositories since task processing is anyway in seconds.
Verified flow counts for `opencrx`, `privado-accounts-api` and `sms-backup-plus` CPGs by comparing with master.

Compared paths for `privado-accounts-api` generated by `master` and this branch and verified that there is no difference.


