### PR TITLE
Update astgen to 2.10.0

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/README.md
+++ b/joern-cli/frontends/jssrc2cpg/README.md
@@ -30,7 +30,7 @@ yarn install
 ```
 (requires `yarn`).
 
-Copy the resulting `astgen-linux`, `astgen-macos`, and `astgen-win.exe` to `joern/joern-cli/frontends/jssrc2cpg/bin/astgen`.
+Copy the resulting `astgen-linux`, `astgen-macos`, `astgen-macos-arm`, and `astgen-win.exe` to `joern/joern-cli/frontends/jssrc2cpg/bin/astgen`.
 
 ## Running
 

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -4,7 +4,7 @@ crossScalaVersions := Seq("2.13.8", "3.2.1")
 
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 
-val astGenVersion = "2.9.0"
+val astGenVersion = "2.10.0"
 
 libraryDependencies ++= Seq(
   "io.shiftleft"              %% "codepropertygraph" % Versions.cpg,

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -66,7 +66,7 @@ Test / fork := false
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 
 lazy val astGenDlUrl       = s"https://github.com/joernio/astgen/releases/download/v$astGenVersion/"
-lazy val astGenBinaryNames = Seq("astgen-linux", "astgen-macos", "astgen-win.exe")
+lazy val astGenBinaryNames = Seq("astgen-linux", "astgen-macos", "astgen-macos-arm", "astgen-win.exe")
 
 lazy val astGenDlTask = taskKey[Unit](s"Download astgen binaries")
 astGenDlTask := {


### PR DESCRIPTION
This branch patches Joern to utilize the newest release of astgen (2.10.0) which includes binaries for macOS ARM.

Integration of this patch will resolve the outstanding dependency issues raised by `Homebrew/homebrew-core` maintainers for https://github.com/Homebrew/homebrew-core/pull/120622.