### PR TITLE
jssrc2cpg: fix for `IMPORT` nodes

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/DependencyAstCreationPassTest.scala
@@ -85,16 +85,16 @@ class DependencyAstCreationPassTest extends AbstractPassTest {
         |""".stripMargin) { cpg =>
       val List(a, b, c, d) = cpg.imports.l
       a.code shouldBe "import {a} from \"depA\""
-      a.importedEntity shouldBe Some("depA")
+      a.importedEntity shouldBe Some("depA:a")
       a.importedAs shouldBe Some("a")
       b.code shouldBe "import {b} from \"depB\""
-      b.importedEntity shouldBe Some("depB")
+      b.importedEntity shouldBe Some("depB:b")
       b.importedAs shouldBe Some("b")
       c.code shouldBe "import {c} from \"\""
-      c.importedEntity should not be defined
+      c.importedEntity shouldBe Some(":c")
       c.importedAs shouldBe Some("c")
       d.code shouldBe "import * as d from \"depD\""
-      d.importedEntity shouldBe Some("depD")
+      d.importedEntity shouldBe Some("depD:d")
       d.importedAs shouldBe Some("d")
       val List(n) = a.namespaceBlock.l
       n.fullName shouldBe "code.js:<global>"

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1290,7 +1290,7 @@ class MixedAstCreationPassTest extends AbstractPassTest {
     "make available `import` statements via cpg.imports" in AstFixture("import {x} from \"foo\";") { cpg =>
       val List(imp) = cpg.imports.l
       imp.code shouldBe "import {x} from \"foo\""
-      imp.importedEntity shouldBe Some("foo")
+      imp.importedEntity shouldBe Some("foo:x")
       imp.importedAs shouldBe Some("x")
 
     }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/VueJsDomAstCreationPassTest.scala
@@ -182,13 +182,13 @@ class VueJsDomAstCreationPassTest extends AbstractDomPassTest {
 
       inside(cpg.imports.l) { case List(component, prop, vue) =>
         component.importedAs shouldBe Some("Component")
-        component.importedEntity shouldBe Some("vue-property-decorator")
+        component.importedEntity shouldBe Some("vue-property-decorator:Component")
         component.code shouldBe "import { Component, Prop, Vue } from 'vue-property-decorator'"
         prop.importedAs shouldBe Some("Prop")
-        prop.importedEntity shouldBe Some("vue-property-decorator")
+        prop.importedEntity shouldBe Some("vue-property-decorator:Prop")
         prop.code shouldBe "import { Component, Prop, Vue } from 'vue-property-decorator'"
         vue.importedAs shouldBe Some("Vue")
-        vue.importedEntity shouldBe Some("vue-property-decorator")
+        vue.importedEntity shouldBe Some("vue-property-decorator:Vue")
         vue.code shouldBe "import { Component, Prop, Vue } from 'vue-property-decorator'"
       }
       inside(cpg.typeDecl("HelloWorld").l) { case List(helloWorld) =>


### PR DESCRIPTION
Imports of the form `import {foo, bar} from 'abc.js'` currently result in the creation of one import node for `foo`, and one import node for `bar`, and for both of them, `importedEntity` is `'abc.js'`, while really, it should be `'abc.js:foo'` and `abc.js:bar` respectively, where I've chosen `:` as a separator for now.
