### PR TITLE
[XTypeRecovery] Simplify the base class

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -147,7 +147,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
     val typeDeclFullName           = fullName.replace(s".${call.name}", "")
     val candidateInheritedMethods =
       cpg.typeDecl
-        .fullNameExact(allSuperClasses(typeDeclFullName).toArray: _*)
+        .fullNameExact(allSuperClasses(typeDeclFullName).toIndexedSeq: _*)
         .astChildren
         .isMethod
         .name(call.name)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -16,86 +16,47 @@ import java.util.concurrent.RecursiveTask
 import scala.collection.MapView
 import scala.collection.concurrent.TrieMap
 
-/** Based on a flow-insensitive symbol-table-style approach. This does not accurately determine the difference between
-  * shadowed variables in the same file but this is due to REF edges not connecting children methods to parent scope
-  * (yet).
+/** Based on a flow-insensitive symbol-table-style approach. This pass aims to be fast and deterministic and does not
+  * try to converge to some fixed point. This will help recover: <ol><li>Imported call signatures from external
+  * dependencies</li><li>Dynamic type hints for mutable variables in a computational unit.</ol>
   *
-  * The algorithm flows roughly as follows: <ol> <li> Scan the CPG for method signatures of methods which are in scope
-  * of each compilation unit, either by internally defined methods or by reading import signatures. This includes
-  * looking for aliases, e.g. import foo as bar. Store these details in the global table</li><li>TODO: While performing
-  * the above, note field/member assignments in the global table.</li><li>(Optionally) Prune these method signatures by
-  * checking their validity against the CPG.</li><li>Visit each compilation unit and:</li><ol><li>Visit assignments to
-  * populate where variables are assigned a value to extrapolate its type. Store these values in a local symbol
-  * table.</li><li>Find instances of where these variables are used and update their type information.</li><li>If this
-  * variable is the receiver of a call, make sure to set the type of the call accordingly.</li></ol></ol>
+  * The algorithm flows roughly as follows: <ol> <li> Scan for method signatures of methods for each compilation unit,
+  * either by internally defined methods or by reading import signatures. This includes looking for aliases, e.g. import
+  * foo as bar.</li><li>TODO: While performing the above, note field/member assignments in a symbol
+  * table.</li><li>(Optionally) Prune these method signatures by checking their validity against the CPG.</li><li>Visit
+  * assignments to populate where variables are assigned a value to extrapolate its type. Store these values in a local
+  * symbol table.</li><li>Find instances of where these variables are used and update their type information.</li><li>If
+  * this variable is the receiver of a call, make sure to set the type of the call accordingly.</li></ol>
   *
-  * The global and local symbol tables use the [[SymbolTable]] class to track possible type information.
+  * The symbol tables use the [[SymbolTable]] class to track possible type information.
+  *
+  * @param cpg
+  *   the CPG to recovery types for.
+  * @tparam ComputationalUnit
+  *   the [[AstNode]] type used to represent a computational unit of the language.
   */
-abstract class XTypeRecovery(cpg: Cpg) extends CpgPass(cpg) {
-
-  /** Stores all interprocedural information, e.g., method signatures, field types, etc.
-    */
-  protected val globalTable = new SymbolTable()
+abstract class XTypeRecovery[ComputationalUnit <: AstNode](cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(builder: DiffGraphBuilder): Unit =
-    try {
-      // Set known aliases that point to imports for local and external methods/modules
-      setImportsFromDeclaredProcedures(importNodes ++ internalMethodNodes)
-      // Prune import names if the methods exist in the CPG
-      postVisitImports()
-      // Find identifiers that have been declared with some literal or function known in the symbol table
-      cpg.file.map(unit => generateRecoveryForCompilationUnitTask(unit, builder, globalTable).fork()).foreach(_.get())
-    } finally {
-      globalTable.clear()
-    }
+    computationalUnit.map(unit => generateRecoveryForCompilationUnitTask(unit, builder).fork()).foreach(_.get())
+
+  /** @return
+    *   the computational units as per how the language is compiled. e.g. file.
+    */
+  def computationalUnit: Traversal[ComputationalUnit]
 
   /** A factory method to generate a [[RecoverForXCompilationUnit]] task with the given parameters.
     * @param unit
     *   the compilation unit.
     * @param builder
     *   the graph builder.
-    * @param globalTable
-    *   the global table.
     * @return
     *   a forkable [[RecoverForXCompilationUnit]] task.
     */
   def generateRecoveryForCompilationUnitTask(
-    unit: AstNode,
-    builder: DiffGraphBuilder,
-    globalTable: SymbolTable
-  ): RecoverForXCompilationUnit
-
-  /** Using import information and internally defined procedures, will generate a mapping between how functions and
-    * types are aliased and called and themselves.
-    *
-    * @param procedureDeclarations
-    *   imports to types or functions and internally defined methods themselves.
-    */
-  private def setImportsFromDeclaredProcedures(procedureDeclarations: Traversal[CfgNode]): Unit =
-    procedureDeclarations.map(f => generateSetProcedureDefTask(f, globalTable).fork()).foreach(_.get())
-
-  /** Generates a task to create an import task.
-    * @param node
-    *   the import node or method definition node.
-    * @param globalTable
-    *   the global table.
-    * @return
-    *   a forkable [[SetXProcedureDefTask]] task.
-    */
-  def generateSetProcedureDefTask(node: CfgNode, globalTable: SymbolTable): SetXProcedureDefTask
-
-  /** @return
-    *   the import nodes of this CPG.
-    */
-  def importNodes: Traversal[CfgNode]
-
-  private def internalMethodNodes: Traversal[Method] = cpg.method.isExternal(false)
-
-  /** The initial import setting is over-approximated, so this step checks the CPG for any matches and prunes against
-    * these findings. If there are no findings, it will leave the table as is. The latter is significant for external
-    * types or methods.
-    */
-  def postVisitImports(): Unit = {}
+    unit: ComputationalUnit,
+    builder: DiffGraphBuilder
+  ): RecoverForXCompilationUnit[ComputationalUnit]
 
 }
 
@@ -167,22 +128,26 @@ abstract class SetXProcedureDefTask(node: CfgNode) extends RecursiveTask[Unit] {
   *   a compilation unit, e.g. file, procedure, type, etc.
   * @param builder
   *   the graph builder
+  * @tparam ComputationalUnit
+  *   the [[AstNode]] type used to represent a computational unit of the language.
   */
-abstract class RecoverForXCompilationUnit(cu: AstNode, builder: DiffGraphBuilder, globalTable: SymbolTable)
-    extends RecursiveTask[Unit] {
+abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
+  cu: ComputationalUnit,
+  builder: DiffGraphBuilder
+) extends RecursiveTask[Unit] {
 
   /** Stores type information for local structures that live within this compilation unit, e.g. local variables.
     */
-  protected val symbolTable = new SymbolTable()
+  protected val symbolTable = new SymbolTable[LocalKey](SBKey.fromNodeToLocalKey)
 
   private def assignments: Traversal[Assignment] =
     cu.ast.isCall.name(Operators.assignment).map(new OpNodes.Assignment(_))
 
   override def compute(): Unit = try {
-    // Conservatively populate local table with interprocedural knowledge, i.e. if every method and dependency was
-    // imported into this scope
-    // TODO: Only populate global knowledge that is in scope, what is imported and defined
-    symbolTable.from(globalTable.view)
+    // Set known aliases that point to imports for local and external methods/modules
+    setImportsFromDeclaredProcedures(importNodes(cu) ++ internalMethodNodes(cu))
+    // Prune import names if the methods exist in the CPG
+    postVisitImports()
     // Populate local symbol table with assignments
     assignments.foreach(visitAssignments)
     // Persist findings
@@ -190,6 +155,44 @@ abstract class RecoverForXCompilationUnit(cu: AstNode, builder: DiffGraphBuilder
   } finally {
     symbolTable.clear()
   }
+
+  /** Using import information and internally defined procedures, will generate a mapping between how functions and
+    * types are aliased and called and themselves.
+    *
+    * @param procedureDeclarations
+    *   imports to types or functions and internally defined methods themselves.
+    */
+  private def setImportsFromDeclaredProcedures(procedureDeclarations: Traversal[CfgNode]): Unit =
+    procedureDeclarations.map(f => generateSetProcedureDefTask(f, symbolTable).fork()).foreach(_.get())
+
+  /** Generates a task to create an import task.
+    *
+    * @param node
+    *   the import node or method definition node.
+    * @param symbolTable
+    *   the local table.
+    * @return
+    *   a forkable [[SetXProcedureDefTask]] task.
+    */
+  def generateSetProcedureDefTask(node: CfgNode, symbolTable: SymbolTable[LocalKey]): SetXProcedureDefTask
+
+  /** @return
+    *   the import nodes of this computational unit.
+    */
+  def importNodes(cu: AstNode): Traversal[CfgNode]
+
+  /** @param cu
+    *   the current computational unit.
+    * @return
+    *   the methods defined within this computational unit.
+    */
+  private def internalMethodNodes(cu: AstNode): Traversal[Method] = cu.ast.isMethod.isExternal(false)
+
+  /** The initial import setting is over-approximated, so this step checks the CPG for any matches and prunes against
+    * these findings. If there are no findings, it will leave the table as is. The latter is significant for external
+    * types or methods.
+    */
+  def postVisitImports(): Unit = {}
 
   /** Using assignment and import information (in the global symbol table), will propagate these types in the symbol
     * table.
@@ -250,54 +253,52 @@ abstract class RecoverForXCompilationUnit(cu: AstNode, builder: DiffGraphBuilder
 }
 
 /** Represents an identifier of some AST node at a specific scope.
-  *
-  * @param filename
-  *   the file name in which this identifier belongs.
-  * @param idName
-  *   the name of the identifier.
   */
-case class SBKey(filename: String, idName: String) {
-
-  override def equals(obj: Any): Boolean = {
-    obj match {
-      case node: CfgNode => this.equals(SBKey.fromNode(node))
-      case o: SBKey      => filename.equals(o.filename) && idName.equals(o.idName)
-      case _             => false
-    }
-  }
-
-}
-
-object SBKey {
-
-  private val logger = LogManager.getLogger(classOf[SBKey])
+abstract class SBKey {
 
   /** Convenience methods to convert a node to a [[SBKey]].
+    *
     * @param node
     *   the node to convert.
     * @return
     *   the corresponding [[SBKey]].
     */
-  def fromNode(node: AstNode): SBKey = {
-    val name = node match {
-      case x: Identifier => x.name
-      case x: Method     => x.name
-      case x: Call       => x.name
-      case x: Local      => x.name
-      case x             => x.code
+  def fromNode(node: AstNode): SBKey = SBKey.fromNodeToLocalKey(node)
+
+}
+
+object SBKey {
+  protected val logger: Logger = LogManager.getLogger(getClass)
+
+  def fromNodeToLocalKey(node: AstNode): LocalKey = {
+    node match {
+      case n: FieldIdentifier => FieldVar(n.canonicalName)
+      case n: Identifier      => LocalVar(n.name)
+      case n: Local           => LocalVar(n.name)
+//      case n: Literal         => CallAlias(n.code) // Some imports define calls via arguments
+      case n: Call   => CallAlias(n.name)
+      case n: Method => CallAlias(n.name)
+      case _ => throw new RuntimeException(s"Node of type ${node.label} is not supported in the type recovery pass.")
     }
-    val filename = node.file.name.headOption match {
-      case Some(fileName) => fileName
-      case None =>
-        logger.warn(
-          s"Unable to successfully use file name for symbol table, type recovery may become more imprecise. Node: ${node.propertiesMap()}"
-        );
-        ""
-    }
-    SBKey(filename, name)
   }
 
 }
+
+/** Represents an identifier of some AST node at an intraprocedural scope.
+  */
+sealed trait LocalKey extends SBKey
+
+/** A variable that can hold data within an interprocedural scope.
+  */
+case class FieldVar(identifier: String) extends LocalKey
+
+/** A variable that holds data within an intraprocedural scope.
+  */
+case class LocalVar(identifier: String) extends LocalKey
+
+/** A name that refers to some kind of callee.
+  */
+case class CallAlias(identifier: String) extends LocalKey
 
 /** A thread-safe symbol table that can represent multiple types per symbol. Each node in an AST gets converted to an
   * [[SBKey]] which gives contextual information to identify an AST entity. Each value in this table represents a set of
@@ -305,26 +306,20 @@ object SBKey {
   *
   * The [[SymbolTable]] operates like a map with a few convenient methods that are designed for this structure's
   * purpose.
-  *
-  * TODO: Local symbol tables likely need a different [[SBKey]] with different context info. This can be a generic type.
-  * TODO: Global symbol table should likely need to tag when it refers to a method, import, or field and in which
-  * computational units it's definition is valid
   */
-class SymbolTable {
+class SymbolTable[K <: SBKey](fromNode: AstNode => K) {
 
-  import SBKey.fromNode
+  private val table = TrieMap.empty[K, Set[String]]
 
-  private val table = TrieMap.empty[SBKey, Set[String]]
-
-  def apply(sbKey: SBKey): Set[String] = table(sbKey)
+  def apply(sbKey: K): Set[String] = table(sbKey)
 
   def apply(node: AstNode): Set[String] = table(fromNode(node))
 
-  def from(sb: IterableOnce[(SBKey, Set[String])]): SymbolTable = {
+  def from(sb: IterableOnce[(K, Set[String])]): SymbolTable[K] = {
     table.addAll(sb); this
   }
 
-  def put(sbKey: SBKey, typeFullNames: Set[String]): Option[Set[String]] =
+  def put(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] =
     table.put(sbKey, typeFullNames)
 
   def put(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
@@ -336,22 +331,22 @@ class SymbolTable {
   def append(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
     append(fromNode(node), typeFullNames)
 
-  private def append(sbKey: SBKey, typeFullNames: Set[String]): Option[Set[String]] = {
+  private def append(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] = {
     table.get(sbKey) match {
       case Some(ts) => table.put(sbKey, ts ++ typeFullNames)
       case None     => table.put(sbKey, typeFullNames)
     }
   }
 
-  private def contains(sbKey: SBKey): Boolean = table.contains(sbKey)
+  private def contains(sbKey: K): Boolean = table.contains(sbKey)
 
   def contains(node: AstNode): Boolean = contains(fromNode(node))
 
-  private def get(sbKey: SBKey): Set[String] = table.getOrElse(sbKey, Set.empty)
+  private def get(sbKey: K): Set[String] = table.getOrElse(sbKey, Set.empty)
 
   def get(node: AstNode): Set[String] = get(fromNode(node))
 
-  def view: MapView[SBKey, Set[String]] = table.view
+  def view: MapView[K, Set[String]] = table.view
 
   def clear(): Unit = table.clear()
 


### PR DESCRIPTION
- Abstracted the computational unit type
- Removed the need for a global table (for now)
- All recovery is within a computational unit scope, as per current capabilities
- Added `.toIndexedSeq` under `DynamicCallLinker` as per compiler suggestions