### PR TITLE
[pysrc2cpg] Built-in Function Call `MethodFullName`

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -13,6 +13,7 @@ dependsOn(
   Projects.semanticcpg,
   Projects.macros,
   Projects.jssrc2cpg,
+  Projects.pysrc2cpg,
   Projects.c2cpg % Test,
   Projects.x2cpg % "compile->compile;test->test"
 )

--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -1,9 +1,8 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
-import io.joern.x2cpg.passes.frontend.impl.{PythonTypeHintCallLinker, PythonTypeRecovery}
-import io.joern.x2cpg.passes.frontend.PythonNaiveCallLinker
 import io.shiftleft.codepropertygraph.Cpg
+import io.joern.pysrc2cpg.{PythonTypeRecovery, PythonTypeHintCallLinker, PythonNaiveCallLinker}
 
 import java.nio.file.Path
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonNaiveCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonNaiveCallLinker.scala
@@ -1,4 +1,4 @@
-package io.joern.x2cpg.passes.frontend
+package io.joern.pysrc2cpg
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -1,4 +1,4 @@
-package io.joern.x2cpg.passes.frontend.impl
+package io.joern.pysrc2cpg
 
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.codepropertygraph.Cpg

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -1,4 +1,4 @@
-package io.joern.x2cpg.passes.frontend.impl
+package io.joern.pysrc2cpg
 
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend._

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -3,8 +3,6 @@ package io.joern.pysrc2cpg
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.x2cpg.X2Cpg
-import io.joern.x2cpg.passes.frontend.impl.{PythonTypeHintCallLinker, PythonTypeRecovery}
-import io.joern.x2cpg.passes.frontend.PythonNaiveCallLinker
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -140,10 +140,15 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
     */
   protected val symbolTable = new SymbolTable[LocalKey](SBKey.fromNodeToLocalKey)
 
+  /** Provides an entrypoint to add known symbols and their possible types.
+    */
+  def prepopulateSymbolTable(): Unit = {}
+
   private def assignments: Traversal[Assignment] =
     cu.ast.isCall.name(Operators.assignment).map(new OpNodes.Assignment(_))
 
   override def compute(): Unit = try {
+    prepopulateSymbolTable()
     // Set known aliases that point to imports for local and external methods/modules
     setImportsFromDeclaredProcedures(importNodes(cu) ++ internalMethodNodes(cu))
     // Prune import names if the methods exist in the CPG

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -7,7 +7,7 @@ import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
-import org.apache.logging.log4j.{LogManager, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 import overflowdb.traversal.Traversal
 
@@ -97,7 +97,7 @@ abstract class ScopedXProcedure(val callingName: String, val fullName: String, v
   */
 abstract class SetXProcedureDefTask(node: CfgNode) extends RecursiveTask[Unit] {
 
-  protected val logger: Logger = LogManager.getLogger(classOf[SetXProcedureDefTask])
+  protected val logger: Logger = LoggerFactory.getLogger(classOf[SetXProcedureDefTask])
 
   override def compute(): Unit =
     node match {
@@ -245,7 +245,7 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
                 persistType(call, callTypes)(builder)
               }
             // Case 3: 'i' is the receiver for a field access on member 'f'
-            case (Some(call: Call), List(i: Identifier, f: FieldIdentifier))
+            case (Some(call: Call), List(i: Identifier, _: FieldIdentifier))
                 if call.name.equals(Operators.fieldAccess) =>
               persistType(i, symbolTable.get(x))(builder)
             // Case 4: We are elsewhere
@@ -282,8 +282,7 @@ abstract class SBKey {
 }
 
 object SBKey {
-  protected val logger: Logger = LogManager.getLogger(getClass)
-
+  protected val logger: Logger = LoggerFactory.getLogger(getClass)
   def fromNodeToLocalKey(node: AstNode): LocalKey = {
     node match {
       case n: FieldIdentifier => FieldVar(n.canonicalName)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/impl/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/impl/PythonTypeRecovery.scala
@@ -140,6 +140,15 @@ class SetPythonProcedureDefTask(node: CfgNode, symbolTable: SymbolTable[LocalKey
 class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder)
     extends RecoverForXCompilationUnit[File](cu, builder) {
 
+  /** Adds built-in functions to expect.
+    */
+  override def prepopulateSymbolTable(): Unit =
+    PythonTypeRecovery.BUILTINS
+      .map(t => (CallAlias(t), s"${PythonTypeRecovery.BUILTIN_PREFIX}.$t"))
+      .foreach { case (alias, typ) =>
+        symbolTable.put(alias, typ)
+      }
+
   override def importNodes(cu: AstNode): Traversal[CfgNode] = cu.ast.isCall.nameExact("import")
 
   override def postVisitImports(): Unit = {
@@ -242,4 +251,84 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder)
     }).hasNext
   }
 
+}
+
+object PythonTypeRecovery {
+
+  /** @see
+    *   <a href="https://docs.python.org/3/library/functions.html#func-dict">Python Built-in Functions</a>
+    */
+  lazy val BUILTINS: Set[String] = Set(
+    "abs",
+    "aiter",
+    "all",
+    "anext",
+    "ascii",
+    "bin",
+    "bool",
+    "breakpoint",
+    "bytearray",
+    "bytes",
+    "callable",
+    "chr",
+    "classmethod",
+    "compile",
+    "complex",
+    "delattr",
+    "dict",
+    "dir",
+    "divmod",
+    "enumerate",
+    "eval",
+    "exec",
+    "filter",
+    "float",
+    "format",
+    "frozenset",
+    "getattr",
+    "globals",
+    "hasattr",
+    "hash",
+    "help",
+    "hex",
+    "id",
+    "input",
+    "int",
+    "isinstance",
+    "issubclass",
+    "iter",
+    "len",
+    "list",
+    "locals",
+    "map",
+    "max",
+    "memoryview",
+    "min",
+    "next",
+    "object",
+    "oct",
+    "open",
+    "ord",
+    "pow",
+    "print",
+    "property",
+    "range",
+    "repr",
+    "reversed",
+    "round",
+    "set",
+    "setattr",
+    "slice",
+    "sorted",
+    "staticmethod",
+    "str",
+    "sum",
+    "super",
+    "tuple",
+    "type",
+    "vars",
+    "zip",
+    "__import__"
+  )
+  def BUILTIN_PREFIX = "builtins.py:<module>"
 }


### PR DESCRIPTION
- Added entrypoint to base class for pre-populating
- Pre-populated symbol table with built-in function names
- Moved Python passes from `x2cpg` to `pysrc2cpg`

Resolves #2207