### PR TITLE
[pysrc2cpg] Interprocedural Field Type Recovery

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -144,12 +144,12 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
 
   /** Adds built-in functions to expect.
     */
-//  override def prepopulateSymbolTable(): Unit =
-//    PythonTypeRecovery.BUILTINS
-//      .map(t => (CallAlias(t), s"${PythonTypeRecovery.BUILTIN_PREFIX}.$t"))
-//      .foreach { case (alias, typ) =>
-//        symbolTable.put(alias, typ)
-//      }
+  override def prepopulateSymbolTable(): Unit =
+    PythonTypeRecovery.BUILTINS
+      .map(t => (CallAlias(t), s"${PythonTypeRecovery.BUILTIN_PREFIX}.$t"))
+      .foreach { case (alias, typ) =>
+        symbolTable.put(alias, typ)
+      }
 
   override def importNodes(cu: AstNode): Traversal[CfgNode] = cu.ast.isCall.nameExact("import")
 
@@ -208,7 +208,7 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
           case List(assigned: Identifier, i: Identifier, f: FieldIdentifier) =>
             val fieldTypes = symbolTable
               .get(CallAlias(i.name))
-              .flatMap(recModule => globalTable.get(Field(recModule, f.canonicalName)))
+              .flatMap(recModule => globalTable.get(FieldVar(recModule, f.canonicalName)))
             if (fieldTypes.nonEmpty) symbolTable.append(assigned, fieldTypes)
           case _ =>
         }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -20,8 +20,10 @@ class PythonTypeRecovery(cpg: Cpg) extends XTypeRecovery[File](cpg) {
   override def computationalUnit: Traversal[File] = cpg.file
   override def generateRecoveryForCompilationUnitTask(
     unit: File,
-    builder: DiffGraphBuilder
-  ): RecoverForXCompilationUnit[File] = new RecoverForPythonFile(cpg, unit, builder)
+    builder: DiffGraphBuilder,
+    globalTable: SymbolTable[GlobalKey]
+  ): RecoverForXCompilationUnit[File] = new RecoverForPythonFile(cpg, unit, builder, globalTable)
+
 }
 
 /** Defines how a procedure is available to be called in the current scope either by it being defined in this module or
@@ -137,17 +139,17 @@ class SetPythonProcedureDefTask(node: CfgNode, symbolTable: SymbolTable[LocalKey
   * @param builder
   *   the graph builder
   */
-class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder)
-    extends RecoverForXCompilationUnit[File](cu, builder) {
+class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, globalTable: SymbolTable[GlobalKey])
+    extends RecoverForXCompilationUnit[File](cu, builder, globalTable) {
 
   /** Adds built-in functions to expect.
     */
-  override def prepopulateSymbolTable(): Unit =
-    PythonTypeRecovery.BUILTINS
-      .map(t => (CallAlias(t), s"${PythonTypeRecovery.BUILTIN_PREFIX}.$t"))
-      .foreach { case (alias, typ) =>
-        symbolTable.put(alias, typ)
-      }
+//  override def prepopulateSymbolTable(): Unit =
+//    PythonTypeRecovery.BUILTINS
+//      .map(t => (CallAlias(t), s"${PythonTypeRecovery.BUILTIN_PREFIX}.$t"))
+//      .foreach { case (alias, typ) =>
+//        symbolTable.put(alias, typ)
+//      }
 
   override def importNodes(cu: AstNode): Traversal[CfgNode] = cu.ast.isCall.nameExact("import")
 
@@ -182,10 +184,10 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder)
         val importedTypes = symbolTable.get(c)
         if (!c.code.endsWith(")")) {
           // Case 1: The identifier is at the assignment to a function pointer. Lack of parenthesis should indicate this.
-          symbolTable.append(i, importedTypes)
+          setIdentifier(i, importedTypes)
         } else if (c.name.charAt(0).isUpper && c.code.endsWith(")")) {
           // Case 2: The identifier is receiving a constructor invocation, thus is now an instance of the type
-          symbolTable.append(i, importedTypes.map(_.stripSuffix(s".${Defines.ConstructorMethodName}")))
+          setIdentifier(i, importedTypes.map(_.stripSuffix(s".${Defines.ConstructorMethodName}")))
         } else {
           // TODO: This identifier should contain the type of the return value of 'c'
         }
@@ -194,8 +196,29 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder)
       case List(i: Identifier, c: Call) if c.receiver.isCall.name.exists(_.equals(Operators.fieldAccess)) =>
         val field = c.receiver.isCall.name(Operators.fieldAccess).map(new OpNodes.FieldAccess(_)).head
         visitCallFromFieldMember(i, c, field, symbolTable)
+      // In second round, use global table knowledge to extract field types
+      case List(_: Identifier, c: Call) if c.name.equals(Operators.fieldAccess) =>
+        c.inCall.argument
+          .flatMap {
+            case n: Call if n.name.equals(Operators.fieldAccess) => new OpNodes.FieldAccess(n).argumentOut
+            case n                                               => n
+          }
+          .take(3)
+          .l match {
+          case List(assigned: Identifier, i: Identifier, f: FieldIdentifier) =>
+            val fieldTypes = symbolTable
+              .get(CallAlias(i.name))
+              .flatMap(recModule => globalTable.get(Field(recModule, f.canonicalName)))
+            if (fieldTypes.nonEmpty) symbolTable.append(assigned, fieldTypes)
+          case _ =>
+        }
       case _ =>
     }
+  }
+
+  private def setIdentifier(i: Identifier, types: Set[String]): Option[Set[String]] = {
+    if (i.method.name.equals("<module>")) globalTable.put(i, types)
+    symbolTable.append(i, types)
   }
 
   private def visitCallFromFieldMember(
@@ -231,22 +254,22 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder)
   private def visitLiteralAssignment(lhs: Identifier, rhs: CfgNode, symbolTable: SymbolTable[LocalKey]): Boolean = {
     ((lhs, rhs) match {
       case (i: Identifier, l: Literal) if Try(java.lang.Integer.parseInt(l.code)).isSuccess =>
-        symbolTable.append(i, Set("int"))
+        setIdentifier(i, Set("int"))
       case (i: Identifier, l: Literal) if Try(java.lang.Double.parseDouble(l.code)).isSuccess =>
-        symbolTable.append(i, Set("float"))
+        setIdentifier(i, Set("float"))
       case (i: Identifier, l: Literal) if "True".equals(l.code) || "False".equals(l.code) =>
-        symbolTable.append(i, Set("bool"))
+        setIdentifier(i, Set("bool"))
       case (i: Identifier, l: Literal) if l.code.matches("^(\"|').*(\"|')$") =>
-        symbolTable.append(i, Set("str"))
+        setIdentifier(i, Set("str"))
       case (i: Identifier, c: Call) if c.name.equals("<operator>.listLiteral") =>
-        symbolTable.append(i, Set("list"))
+        setIdentifier(i, Set("list"))
       case (i: Identifier, c: Call) if c.name.equals("<operator>.tupleLiteral") =>
-        symbolTable.append(i, Set("tuple"))
+        setIdentifier(i, Set("tuple"))
       case (i: Identifier, b: Block)
           if b.astChildren.isCall.headOption.exists(
             _.argument.isCall.exists(_.name.equals("<operator>.dictLiteral"))
           ) =>
-        symbolTable.append(i, Set("dict"))
+        setIdentifier(i, Set("dict"))
       case _ => None
     }).hasNext
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -1,0 +1,110 @@
+package io.joern.x2cpg.passes.frontend
+
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call, FieldIdentifier, Identifier, Local, Method, MethodRef}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.MapView
+import scala.collection.concurrent.TrieMap
+
+
+/** Represents an identifier of some AST node at a specific scope.
+  */
+abstract class SBKey {
+
+  /** Convenience methods to convert a node to a [[SBKey]].
+    *
+    * @param node
+    *   the node to convert.
+    * @return
+    *   the corresponding [[SBKey]].
+    */
+  def fromNode(node: AstNode): SBKey = SBKey.fromNodeToLocalKey(node)
+
+}
+
+object SBKey {
+  protected val logger: Logger = LoggerFactory.getLogger(getClass)
+  def fromNodeToLocalKey(node: AstNode): LocalKey = {
+    node match {
+      case n: FieldIdentifier => FieldVar(n.canonicalName)
+      case n: Identifier      => LocalVar(n.name)
+      case n: Local           => LocalVar(n.name)
+      case n: Call            => CallAlias(n.name)
+      case n: Method          => CallAlias(n.name)
+      case n: MethodRef       => CallAlias(n.code)
+      case _ => throw new RuntimeException(s"Node of type ${node.label} is not supported in the type recovery pass.")
+    }
+  }
+
+}
+
+/** Represents an identifier of some AST node at an intraprocedural scope.
+  */
+sealed trait LocalKey extends SBKey
+
+/** A variable that can hold data within an interprocedural scope.
+  */
+case class FieldVar(identifier: String) extends LocalKey
+
+/** A variable that holds data within an intraprocedural scope.
+  */
+case class LocalVar(identifier: String) extends LocalKey
+
+/** A name that refers to some kind of callee.
+  */
+case class CallAlias(identifier: String) extends LocalKey
+
+/** A thread-safe symbol table that can represent multiple types per symbol. Each node in an AST gets converted to an
+  * [[SBKey]] which gives contextual information to identify an AST entity. Each value in this table represents a set of
+  * types that the key could be in a flow-insensitive manner.
+  *
+  * The [[SymbolTable]] operates like a map with a few convenient methods that are designed for this structure's
+  * purpose.
+  */
+class SymbolTable[K <: SBKey](fromNode: AstNode => K) {
+
+  private val table = TrieMap.empty[K, Set[String]]
+
+  def apply(sbKey: K): Set[String] = table(sbKey)
+
+  def apply(node: AstNode): Set[String] = table(fromNode(node))
+
+  def from(sb: IterableOnce[(K, Set[String])]): SymbolTable[K] = {
+    table.addAll(sb); this
+  }
+
+  def put(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] =
+    table.put(sbKey, typeFullNames)
+
+  def put(sbKey: K, typeFullName: String): Option[Set[String]] =
+    put(sbKey, Set(typeFullName))
+
+  def put(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
+    put(fromNode(node), typeFullNames)
+
+  def append(node: AstNode, typeFullName: String): Option[Set[String]] =
+    append(node, Set(typeFullName))
+
+  def append(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
+    append(fromNode(node), typeFullNames)
+
+  private def append(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] = {
+    table.get(sbKey) match {
+      case Some(ts) => table.put(sbKey, ts ++ typeFullNames)
+      case None     => table.put(sbKey, typeFullNames)
+    }
+  }
+
+  def contains(sbKey: K): Boolean = table.contains(sbKey)
+
+  def contains(node: AstNode): Boolean = contains(fromNode(node))
+
+  def get(sbKey: K): Set[String] = table.getOrElse(sbKey, Set.empty)
+
+  def get(node: AstNode): Set[String] = get(fromNode(node))
+
+  def view: MapView[K, Set[String]] = table.view
+
+  def clear(): Unit = table.clear()
+
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -30,7 +30,7 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   private def callees(names: Seq[String]): Traversal[Method] = cpg.method.fullNameExact(names: _*)
 
-  override def run(builder: DiffGraphBuilder) = linkCalls(builder)
+  override def run(builder: DiffGraphBuilder): Unit = linkCalls(builder)
 
   private def linkCalls(builder: DiffGraphBuilder): Unit =
     calls.map(call => (call, calleeNames(call))).foreach { case (call, ms) =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -249,12 +249,12 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
                   persistType(i, idTypes)(builder)
               }
             // Case 1: 'call' is an assignment from some other data structure
-            case (Some(call: Call), List(i: Identifier, _)) if call.name.equals(Operators.assignment) =>
+            case (Some(call: Call), ::(i: Identifier, _)) if call.name.equals(Operators.assignment) =>
               val idHints = symbolTable.get(i)
               persistType(i, idHints)(builder)
               persistType(call, idHints)(builder)
             // Case 2: 'i' is the receiver of 'call'
-            case (Some(call: Call), List(i: Identifier, _)) if !call.name.equals(Operators.fieldAccess) =>
+            case (Some(call: Call), ::(i: Identifier, _)) if !call.name.equals(Operators.fieldAccess) =>
               val idHints   = symbolTable.get(i)
               val callTypes = symbolTable.get(call)
               persistType(i, idHints)(builder)
@@ -267,7 +267,6 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
             case (Some(call: Call), List(i: Identifier, _: FieldIdentifier))
                 if call.name.equals(Operators.fieldAccess) =>
               persistType(i, symbolTable.get(x))(builder)
-            // Case 4: We are elsewhere
             case _ => persistType(x, symbolTable.get(x))(builder)
           }
         // Case 5: Field access

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -13,8 +13,6 @@ import overflowdb.traversal.Traversal
 
 import java.util.Objects
 import java.util.concurrent.RecursiveTask
-import scala.collection.MapView
-import scala.collection.concurrent.TrieMap
 
 /** Based on a flow-insensitive symbol-table-style approach. This pass aims to be fast and deterministic and does not
   * try to converge to some fixed point. This will help recover: <ol><li>Imported call signatures from external
@@ -263,107 +261,5 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
         builder.setNodeProperty(x, PropertyNames.TYPE_FULL_NAME, types.head)
       else
         builder.setNodeProperty(x, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, types.toSeq)
-
-}
-
-/** Represents an identifier of some AST node at a specific scope.
-  */
-abstract class SBKey {
-
-  /** Convenience methods to convert a node to a [[SBKey]].
-    *
-    * @param node
-    *   the node to convert.
-    * @return
-    *   the corresponding [[SBKey]].
-    */
-  def fromNode(node: AstNode): SBKey = SBKey.fromNodeToLocalKey(node)
-
-}
-
-object SBKey {
-  protected val logger: Logger = LoggerFactory.getLogger(getClass)
-  def fromNodeToLocalKey(node: AstNode): LocalKey = {
-    node match {
-      case n: FieldIdentifier => FieldVar(n.canonicalName)
-      case n: Identifier      => LocalVar(n.name)
-      case n: Local           => LocalVar(n.name)
-      case n: Call            => CallAlias(n.name)
-      case n: Method          => CallAlias(n.name)
-      case n: MethodRef       => CallAlias(n.code)
-      case _ => throw new RuntimeException(s"Node of type ${node.label} is not supported in the type recovery pass.")
-    }
-  }
-
-}
-
-/** Represents an identifier of some AST node at an intraprocedural scope.
-  */
-sealed trait LocalKey extends SBKey
-
-/** A variable that can hold data within an interprocedural scope.
-  */
-case class FieldVar(identifier: String) extends LocalKey
-
-/** A variable that holds data within an intraprocedural scope.
-  */
-case class LocalVar(identifier: String) extends LocalKey
-
-/** A name that refers to some kind of callee.
-  */
-case class CallAlias(identifier: String) extends LocalKey
-
-/** A thread-safe symbol table that can represent multiple types per symbol. Each node in an AST gets converted to an
-  * [[SBKey]] which gives contextual information to identify an AST entity. Each value in this table represents a set of
-  * types that the key could be in a flow-insensitive manner.
-  *
-  * The [[SymbolTable]] operates like a map with a few convenient methods that are designed for this structure's
-  * purpose.
-  */
-class SymbolTable[K <: SBKey](fromNode: AstNode => K) {
-
-  private val table = TrieMap.empty[K, Set[String]]
-
-  def apply(sbKey: K): Set[String] = table(sbKey)
-
-  def apply(node: AstNode): Set[String] = table(fromNode(node))
-
-  def from(sb: IterableOnce[(K, Set[String])]): SymbolTable[K] = {
-    table.addAll(sb); this
-  }
-
-  def put(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] =
-    table.put(sbKey, typeFullNames)
-
-  def put(sbKey: K, typeFullName: String): Option[Set[String]] =
-    put(sbKey, Set(typeFullName))
-
-  def put(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
-    put(fromNode(node), typeFullNames)
-
-  def append(node: AstNode, typeFullName: String): Option[Set[String]] =
-    append(node, Set(typeFullName))
-
-  def append(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
-    append(fromNode(node), typeFullNames)
-
-  private def append(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] = {
-    table.get(sbKey) match {
-      case Some(ts) => table.put(sbKey, ts ++ typeFullNames)
-      case None     => table.put(sbKey, typeFullNames)
-    }
-  }
-
-  def contains(sbKey: K): Boolean = table.contains(sbKey)
-
-  def contains(node: AstNode): Boolean = contains(fromNode(node))
-
-  def get(sbKey: K): Set[String] = table.getOrElse(sbKey, Set.empty)
-
-  def get(node: AstNode): Set[String] = get(fromNode(node))
-
-  def view: MapView[K, Set[String]] = table.view
-
-  def clear(): Unit = table.clear()
 
 }


### PR DESCRIPTION
- Moved symbol table and key variants to their own class `SymbolTable.scala`
- Created a notion of iterating multiple times over the type recovery to continue to avoid a fixed-point algorithm while achieving inter-procedural type propagation
- Tested that primitive and object instance types are successfully propagated using 2 iterations with no aliasing