### PR TITLE
fix logging dependencies setup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,8 +39,12 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq(
   kotlin2cpg
 )
 
-ThisBuild / libraryDependencies +=
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % Versions.log4j % Test
+ThisBuild / libraryDependencies ++= Seq(
+  "org.slf4j"                % "slf4j-api"         % "2.0.6",
+  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.19.0" % Optional,
+  "org.apache.logging.log4j" % "log4j-core"        % "2.19.0" % Optional,
+  // `Optional` means "not transitive", but still included in "stage/lib"
+)
 
 ThisBuild / compile / javacOptions ++= Seq(
   "-g", // debug symbols

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.586"
+val cpgVersion = "1.3.591"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -9,7 +9,6 @@ libraryDependencies ++= Seq(
   "com.github.pathikrit"    %% "better-files"      % "3.9.1",
   "io.circe"                %% "circe-generic"     % "0.14.3",
   "org.reflections"          % "reflections"       % "0.10.2",
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % Versions.log4j     % Runtime,
   "org.scalatest"           %% "scalatest"         % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -8,8 +8,6 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules"  %% "scala-parallel-collections" % "1.0.4",
   "com.diffplug.spotless"    % "spotless-eclipse-cdt"       % "10.5.0",
   "org.jline"                % "jline"                      % "3.21.0",
-  "org.slf4j"                % "slf4j-api"                  % "1.7.36",
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl"          % Versions.log4j     % Runtime,
   "org.scalatest"           %% "scalatest"                  % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/ghidra2cpg/build.sbt
+++ b/joern-cli/frontends/ghidra2cpg/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "org.scalatest"    %% "scalatest"                % Versions.scalatest % Test,
 
   // for whatever reason ghidra2cpg tests still depend on slf4j v1...
-  "org.apache.logging.log4j" % "log4j-slf4j-impl"  % Versions.log4j % Test
+  // "org.apache.logging.log4j" % "log4j-slf4j-impl"  % "2.19.0" % Test
 )
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)

--- a/joern-cli/frontends/ghidra2cpg/build.sbt
+++ b/joern-cli/frontends/ghidra2cpg/build.sbt
@@ -9,10 +9,16 @@ libraryDependencies ++= Seq(
   "io.shiftleft"     %% "codepropertygraph"        % Versions.cpg,
   "io.shiftleft"     %% "codepropertygraph-protos" % Versions.cpg,
   "org.scalatest"    %% "scalatest"                % Versions.scalatest % Test,
-
-  // for whatever reason ghidra2cpg tests still depend on slf4j v1...
-  // "org.apache.logging.log4j" % "log4j-slf4j-impl"  % "2.19.0" % Test
 )
+
+// ghidra2cpg is a fat jar that already ships an old version of log4j, so we need
+// to exclude the ones that we normally bring in... otherwise, tests are failing:
+// java.lang.NoSuchMethodError: 'java.lang.ClassLoader[] org.apache.logging.log4j.util.LoaderUtil.getClassLoaders()'
+excludeDependencies ++= Seq(
+  ExclusionRule("org.apache.logging.log4j", "log4j-slf4j2-impl"),
+  ExclusionRule("org.apache.logging.log4j", "log4j-core")
+)
+
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 

--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -7,7 +7,6 @@ dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->t
 
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % Versions.log4j % Runtime,
   "io.joern" % "javaparser-symbol-solver-core" % "3.24.3-SL3", // custom build of our fork, sources at https://github.com/mpollmeier/javaparser
   "org.gradle"              % "gradle-tooling-api"         % Versions.gradleTooling,
   "org.scalatest"          %% "scalatest"                  % Versions.scalatest % Test,

--- a/joern-cli/frontends/jimple2cpg/build.sbt
+++ b/joern-cli/frontends/jimple2cpg/build.sbt
@@ -7,7 +7,6 @@ dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->t
 
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % Versions.log4j     % Runtime,
   "org.soot-oss"             % "soot"              % "4.4.1",
   "org.scalatest"           %% "scalatest"         % Versions.scalatest % Test
 )

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -10,7 +10,6 @@ libraryDependencies ++= Seq(
   "io.shiftleft"              %% "codepropertygraph" % Versions.cpg,
   "com.lihaoyi"               %% "upickle"           % "2.0.0",
   "com.fasterxml.jackson.core" % "jackson-databind"  % "2.14.2",
-  "org.apache.logging.log4j"   % "log4j-slf4j2-impl" % Versions.log4j     % Runtime,
   "org.scalatest"             %% "scalatest"         % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -14,8 +14,6 @@ libraryDependencies ++= Seq(
   "com.lihaoyi"             %% "ujson"                      % "2.0.0",
   "com.squareup.tools.build" % "maven-archeologist"         % "0.0.10",
   "io.shiftleft"            %% "codepropertygraph"          % Versions.cpg,
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl"          % Versions.log4j % Runtime,
-  "org.slf4j"                % "slf4j-api"                  % "2.0.6",
   "org.gradle"               % "gradle-tooling-api"         % Versions.gradleTooling,
   "org.jetbrains.kotlin"     % "kotlin-stdlib-jdk8"         % kotlinVersion,
   "org.jetbrains.kotlin"     % "kotlin-stdlib"              % kotlinVersion,

--- a/joern-cli/frontends/php2cpg/build.sbt
+++ b/joern-cli/frontends/php2cpg/build.sbt
@@ -13,7 +13,6 @@ libraryDependencies ++= Seq(
   "com.lihaoyi"             %% "upickle"           % "2.0.0",
   "io.shiftleft"            %% "codepropertygraph" % Versions.cpg,
   "org.scalatest"           %% "scalatest"         % Versions.scalatest % Test,
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % Versions.log4j     % Runtime,
   "io.circe"                %% "circe-core"        % "0.15.0-M1"
 )
 

--- a/joern-cli/frontends/pysrc2cpg/build.sbt
+++ b/joern-cli/frontends/pysrc2cpg/build.sbt
@@ -7,7 +7,6 @@ dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->t
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph"          % Versions.cpg,
   "org.scala-lang.modules"  %% "scala-parallel-collections" % "1.0.4",
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl"          % Versions.log4j     % Runtime,
   "org.scalatest"           %% "scalatest"                  % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/x2cpg/build.sbt
+++ b/joern-cli/frontends/x2cpg/build.sbt
@@ -5,8 +5,6 @@ crossScalaVersions := Seq("2.13.8", "3.2.1")
 dependsOn(Projects.semanticcpg)
 
 libraryDependencies ++= Seq(
-  "org.slf4j"                % "slf4j-api"          % "2.0.6",
-  "org.apache.logging.log4j" % "log4j-slf4j2-impl"  % Versions.log4j         % Optional,
   "org.gradle"               % "gradle-tooling-api" % Versions.gradleTooling % Optional,
   "org.scalatest"           %% "scalatest"          % Versions.scalatest     % Test
 )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -6,7 +6,6 @@ object Versions {
   val antlr         = "4.7"
   val scalatest     = "3.2.15"
   val cats          = "3.3.14"
-  val log4j         = "2.19.0"
   val json4s        = "4.0.6"
   val gradleTooling = "7.5.1"
 


### PR DESCRIPTION
We declare slf4j-api as a regular dependency, since most logging
libraries have an implementation for it, and it is considered
a lowest common denominator for logging.

We choose log4j as the logging provider for this build, i.e. for tests
and `sbt stage`. `Optional` means "not transitive", but still included
in "stage/lib". I.e. downstream builds do not inherit it and can/must
make their own choices.