### PR TITLE
[pysrc2cpg] Populate Member Types with CPG Info or Dummy Values

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -267,7 +267,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       "app.py"
     )
 
-    "be determined as a variable reference and have it's type recovered correctly" in {
+    "be determined as a variable reference and have its type recovered correctly" in {
       cpg.identifier("db").map(_.typeFullName).toSet shouldBe Set("flask_sqlalchemy.py:<module>.SQLAlchemy")
 
       cpg
@@ -276,6 +276,17 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         .where(_.parentBlock.ast.isFieldIdentifier.canonicalName("session"))
         .headOption
         .map(_.code) shouldBe Some("tmp0.add(user)")
+    }
+
+    "provide a dummy type to a member if the member type is not known" in {
+     val Some(sessionTmpVar) =  cpg.identifier("tmp0")
+        .headOption
+      sessionTmpVar.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session)"
+
+      val Some(addCall) = cpg
+        .call("add").headOption
+      addCall.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session)"
+      addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
     }
 
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -37,7 +37,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       // TODO: These should have callee entries but the method stubs are not present here
       val List(zAppend) = cpg.call("append").l
       zAppend.methodFullName shouldBe Defines.DynamicCallUnknownFallName
-      zAppend.dynamicTypeHintFullName shouldBe Seq("dict", "list", "tuple")
+      zAppend.dynamicTypeHintFullName shouldBe Seq("dict.append", "list.append", "tuple.append")
     }
   }
 
@@ -279,13 +279,13 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
 
     "provide a dummy type to a member if the member type is not known" in {
-     val Some(sessionTmpVar) =  cpg.identifier("tmp0")
-        .headOption
+      val Some(sessionTmpVar) = cpg.identifier("tmp0").headOption
       sessionTmpVar.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session)"
 
       val Some(addCall) = cpg
-        .call("add").headOption
-      addCall.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session)"
+        .call("add")
+        .headOption
+      addCall.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
       addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
     }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -1,9 +1,8 @@
 package io.joern.x2cpg.passes.frontend
 
-import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
@@ -28,11 +27,6 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
     (c.dynamicTypeHintFullName ++ Seq(c.typeFullName))
       .filterNot(_.equals("ANY"))
       .distinct
-      .collect {
-        // Make sure the full name is valid and not simply the type
-        case x if x.endsWith(s".${c.name}") || x.endsWith(Defines.ConstructorMethodName) => x
-        case x                                                                           => s"$x.${c.name}"
-      }
 
   private def callees(names: Seq[String]): Traversal[Method] = cpg.method.fullNameExact(names: _*)
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -1,5 +1,6 @@
 package io.joern.x2cpg.passes.frontend
 
+import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
@@ -27,6 +28,11 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
     (c.dynamicTypeHintFullName ++ Seq(c.typeFullName))
       .filterNot(_.equals("ANY"))
       .distinct
+      .collect {
+        // Make sure the full name is valid and not simply the type
+        case x if x.endsWith(s".${c.name}") || x.endsWith(Defines.ConstructorMethodName) => x
+        case x                                                                           => s"$x.${c.name}"
+      }
 
   private def callees(names: Seq[String]): Traversal[Method] = cpg.method.fullNameExact(names: _*)
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -1,7 +1,7 @@
 package io.joern.x2cpg.passes.frontend
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.{Method, _}
 import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
@@ -150,6 +150,7 @@ abstract class SetXProcedureDefTask(node: CfgNode) extends RecursiveTask[Unit] {
   *   the [[AstNode]] type used to represent a computational unit of the language.
   */
 abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
+  cpg: Cpg,
   cu: ComputationalUnit,
   builder: DiffGraphBuilder,
   globalTable: SymbolTable[GlobalKey]
@@ -269,7 +270,6 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
               persistType(i, symbolTable.get(x))(builder)
             case _ => persistType(x, symbolTable.get(x))(builder)
           }
-        // Case 5: Field access
         case x: Call if symbolTable.contains(x) =>
           builder.setNodeProperty(x, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, symbolTable.get(x).toSeq)
         case _ =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -260,7 +260,8 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
               val callTypes = symbolTable.get(call)
               persistType(i, idHints)(builder)
               if (callTypes.isEmpty) {
-                persistType(call, idHints)(builder)
+                // For now, calls are treated as function pointers and thus the type should point to the method
+                persistType(call, idHints.map(t => s"$t.${call.name}"))(builder)
               } else {
                 persistType(call, callTypes)(builder)
               }


### PR DESCRIPTION
When assigning a type to a member that has an invisible field load:
- Either refer to the CPG, in hopes that there is a type stub with that member's information
- Or make use of a dummy value, so that at least the member's parent type is noted in the type path