### PR TITLE
[x|pysrc]2cpg: Methods Stubs for Recovered Method Calls

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
@@ -215,6 +215,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       callNode.lineNumber shouldBe Some(6)
       callNode.methodFullName shouldBe "foo.py:<module>.foo_func"
+      callNode.callee(NoResolve).isExternal.headOption shouldBe Some(false)
     }
 
     "test call node properties for normal import from module deeper on a module path" in {
@@ -224,6 +225,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       callNode.lineNumber shouldBe Some(7)
       callNode.methodFullName shouldBe Seq("foo", "bar", "__init__.py:<module>.bar_func").mkString(File.separator)
+      callNode.callee(NoResolve).isExternal.headOption shouldBe Some(false)
     }
 
     "test call node properties for aliased import from module on root path" in {
@@ -233,6 +235,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       callNode.lineNumber shouldBe Some(8)
       callNode.methodFullName shouldBe "foo.py:<module>.faz"
+      callNode.callee(NoResolve).isExternal.headOption shouldBe Some(false)
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -228,6 +228,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         .l
       d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.createTable"
       d.dynamicTypeHintFullName shouldBe Seq()
+      d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
 
     "resolve a 'deleteTable' call directly from 'foo.db' field access correctly" in {
@@ -237,8 +238,10 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         .isCall
         .name("deleteTable")
         .l
+
       d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.deleteTable"
       d.dynamicTypeHintFullName shouldBe Seq()
+      d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
 
   }
@@ -287,6 +290,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         .headOption
       addCall.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
       addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
+      addCall.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
 
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -1,12 +1,14 @@
 package io.joern.x2cpg.passes.base
 
 import io.joern.x2cpg.Defines
+import io.joern.x2cpg.passes.base.MethodStubCreator.createMethodStub
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, EvaluationStrategies, NodeTypes}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import scala.collection.mutable
 import scala.util.Try
@@ -48,9 +50,19 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
     super.finish()
   }
 
+}
+
+object MethodStubCreator {
+
   private def addLineNumberInfo(methodNode: NewMethod, fullName: String): NewMethod = {
     val s = fullName.split(":")
-    if (s.size == 5 && Try { s(1).toInt }.isSuccess && Try { s(2).toInt }.isSuccess) {
+    if (
+      s.size == 5 && Try {
+        s(1).toInt
+      }.isSuccess && Try {
+        s(2).toInt
+      }.isSuccess
+    ) {
       val filename      = s(0)
       val lineNumber    = s(1).toInt
       val lineNumberEnd = s(2).toInt
@@ -63,7 +75,7 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
     }
   }
 
-  private def createMethodStub(
+  def createMethodStub(
     name: String,
     fullName: String,
     signature: String,
@@ -124,5 +136,4 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
     methodNode
   }
-
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -1,11 +1,15 @@
 package io.joern.x2cpg.passes.frontend
 
+import io.joern.x2cpg.passes.base.MethodStubCreator
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, MethodBase, NewMethod}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.passes.CpgPass
+import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
+
+import scala.collection.mutable
 
 /** Attempts to set the <code>methodFullName</code> and link to callees using the recovered type information from
   * [[XTypeRecovery]]. Note that some methods may not be present as they could be external and have been dynamically
@@ -32,10 +36,38 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(builder: DiffGraphBuilder): Unit = linkCalls(builder)
 
-  private def linkCalls(builder: DiffGraphBuilder): Unit =
-    calls.map(call => (call, calleeNames(call))).foreach { case (call, ms) =>
-      callees(ms).foreach { m => builder.addEdge(call, m, EdgeTypes.CALL) }
-      if (ms.size == 1) builder.setNodeProperty(call, PropertyNames.METHOD_FULL_NAME, ms.head)
+  private def linkCalls(builder: DiffGraphBuilder): Unit = {
+    val methodMap = mutable.HashMap.empty[String, MethodBase]
+    val callerAndCallees = calls
+      .map(call => (call, calleeNames(call)))
+      .toList
+    // Gather all method nodes and/or stubs
+    callerAndCallees
+      .foreach { case (call, methodNames) =>
+        val ms = callees(methodNames).l
+        if (ms.nonEmpty) {
+          ms.foreach { m => methodMap.put(m.fullName, m) }
+        } else {
+          val mNames = ms.map(_.fullName).toSet
+          methodNames
+            .filterNot(mNames.contains)
+            .map(fullName => createMethodStub(fullName, call, builder))
+            .foreach { m => methodMap.put(m.fullName, m) }
+        }
+      }
+    // Link edges to method nodes
+    callerAndCallees.foreach { case (call, methodNames) =>
+      methodNames
+        .flatMap(methodMap.get)
+        .foreach { m => builder.addEdge(call, m, EdgeTypes.CALL) }
+      if (methodNames.size == 1) builder.setNodeProperty(call, PropertyNames.METHOD_FULL_NAME, methodNames.head)
     }
+  }
+
+  private def createMethodStub(methodName: String, call: Call, builder: DiffGraphBuilder): NewMethod = {
+    val name = if (methodName.contains(".")) methodName.substring(methodName.lastIndexOf(".")) else methodName
+    MethodStubCreator
+      .createMethodStub(name, methodName, "", DispatchTypes.DYNAMIC_DISPATCH.name(), call.argumentOut.size, builder)
+  }
 
 }


### PR DESCRIPTION
- Moved `MethodStubPass` node creation to an object class
- Invoked the `MethodStubPass` creation functions in `XTypeHintCallLinker` for methods not currently in the CPG
- Linked recovered method call full names to their stubbed types