### PR TITLE
PythonTypeRecovery: Dummy Return from External Libraries 

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -1,5 +1,6 @@
 package io.joern.pysrc2cpg
 
+import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Call
@@ -14,7 +15,8 @@ class PythonTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
       .calleeNames(c)
       .map {
         // Python call from  a type
-        case typ if typ.split("\\.").lastOption.exists(_.charAt(0).isUpper) => s"$typ.${c.name}"
+        case typ if typ.split("\\.").lastOption.exists(_.charAt(0).isUpper) =>
+          s"$typ.${Defines.ConstructorMethodName}"
         // Python call from a function pointer
         case typ => typ
       }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -303,10 +303,12 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |""".stripMargin)
 
     "provide a dummy type" in {
+      val Some(log) = cpg.identifier("log").headOption
+      log.typeFullName shouldBe "logging.py:<module>.getLogger.<returnValue>"
       val List(errorCall) = cpg.call("error").l
-      errorCall.methodFullName shouldBe "logging.py:<module>.getLogger.error"
+      errorCall.methodFullName shouldBe "logging.py:<module>.getLogger.<returnValue>.error"
       val List(getLoggerCall) = cpg.call("getLogger").l
-      getLoggerCall.methodFullName shouldBe "logging.py:<module>"
+      getLoggerCall.methodFullName shouldBe "logging.py:<module>.getLogger"
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -295,4 +295,19 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
   }
 
+  "assignment from a call to a method inside an imported module" should {
+    lazy val cpg = code("""
+        |import logging
+        |log = logging.getLogger(__name__)
+        |log.error("foo")
+        |""".stripMargin)
+
+    "provide a dummy type" in {
+      val List(errorCall) = cpg.call("error").l
+      errorCall.methodFullName shouldBe "logging.py:<module>.getLogger.error"
+      val List(getLoggerCall) = cpg.call("getLogger").l
+      getLoggerCall.methodFullName shouldBe "logging.py:<module>"
+    }
+  }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -312,4 +312,20 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
+  "a constructor call from a field access of an externally imported package" should {
+    lazy val cpg = code("""
+        |import urllib.error
+        |import urllib.request
+        |
+        |req = urllib.request.Request(url=apiUrl, data=dataBytes, method='POST')
+        |""".stripMargin)
+
+    "reasonably determine the constructor type" in {
+      val Some(tmp0) = cpg.identifier("tmp0").headOption
+      tmp0.typeFullName shouldBe "urllib.py:<module>.request"
+      val Some(requestCall) = cpg.call("Request").headOption
+      requestCall.methodFullName shouldBe "urllib.py:<module>.request.Request.<init>"
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -65,7 +65,10 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   private def createMethodStub(methodName: String, call: Call, builder: DiffGraphBuilder): NewMethod = {
-    val name = if (methodName.contains(".")) methodName.substring(methodName.lastIndexOf(".")) else methodName
+    val name =
+      if (methodName.contains(".") && methodName.length > methodName.lastIndexOf(".") + 1)
+        methodName.substring(methodName.lastIndexOf(".") + 1)
+      else methodName
     MethodStubCreator
       .createMethodStub(name, methodName, "", DispatchTypes.DYNAMIC_DISPATCH.name(), call.argumentOut.size, builder)
   }


### PR DESCRIPTION
* Method return values from external libraries now have dummy values so that their calls can be matched with regex
* Added a safety check on method name building for method stub 
* Made sure to check imported type references that use a collection of imports