### PR TITLE
[x2cpg] Refactor some duplicated `root{Code,Type}` methods

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
@@ -69,14 +69,6 @@ object Util {
     s"${Defines.UnresolvedSignature}($paramCount)"
   }
 
-  def rootCode(ast: Seq[Ast]): String = {
-    ast.headOption.flatMap(_.root).flatMap(_.properties.get(PropertyNames.CODE).map(_.toString)).getOrElse("")
-  }
-
-  def rootType(ast: Ast): Option[String] = {
-    ast.root.flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
-  }
-
   private def getAllParents(typ: ResolvedReferenceType, result: mutable.ArrayBuffer[ResolvedReferenceType]): Unit = {
     if (typ.isJavaLangObject) {
       Iterable.empty

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
@@ -237,7 +237,7 @@ class OperatorTests extends PhpCode2CpgFixture {
         call
       }
 
-      // Code is not exactly like the original because we loose the spacing information during parsing
+      // Code is not exactly like the original because we lose the spacing information during parsing
       call.code shouldBe "isset($a,$b,$c)"
       call.methodFullName shouldBe PhpOperators.issetFunc
       call.typeFullName shouldBe TypeConstants.Bool

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
@@ -218,6 +218,7 @@ class OperatorTests extends PhpCode2CpgFixture {
         call
       }
 
+      call.code shouldBe "isset($a)"
       call.methodFullName shouldBe PhpOperators.issetFunc
       call.typeFullName shouldBe TypeConstants.Bool
       call.lineNumber shouldBe Some(2)
@@ -236,6 +237,8 @@ class OperatorTests extends PhpCode2CpgFixture {
         call
       }
 
+      // Code is not exactly like the original because we loose the spacing information during parsing
+      call.code shouldBe "isset($a,$b,$c)"
       call.methodFullName shouldBe PhpOperators.issetFunc
       call.typeFullName shouldBe TypeConstants.Bool
       call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/AstPropertiesUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/AstPropertiesUtil.scala
@@ -1,0 +1,21 @@
+package io.joern.x2cpg.utils
+
+import io.joern.x2cpg.Ast
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+
+object AstPropertiesUtil {
+
+  implicit class RootProperties(ast: Ast) {
+
+    private def rootProperty(propertyName: String): Option[String] = {
+      ast.root.flatMap(_.properties.get(propertyName).map(_.toString))
+    }
+
+    def rootType: Option[String] = rootProperty(PropertyNames.TYPE_FULL_NAME)
+
+    def rootCode: Option[String] = rootProperty(PropertyNames.CODE)
+
+    def rootCodeOrEmpty: String = rootCode.getOrElse("")
+
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/AstPropertiesUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/AstPropertiesUtil.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.PropertyNames
 
 object AstPropertiesUtil {
 
-  implicit class RootProperties(ast: Ast) {
+  implicit class RootProperties(val ast: Ast) extends AnyVal {
 
     private def rootProperty(propertyName: String): Option[String] = {
       ast.root.flatMap(_.properties.get(propertyName).map(_.toString))
@@ -19,7 +19,7 @@ object AstPropertiesUtil {
 
   }
 
-  implicit class RootPropertiesOnSeq(asts: Seq[Ast]) {
+  implicit class RootPropertiesOnSeq(val asts: Seq[Ast]) extends AnyVal {
 
     def rootType: Option[String] = asts.headOption.flatMap(_.rootType)
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/AstPropertiesUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/AstPropertiesUtil.scala
@@ -18,4 +18,13 @@ object AstPropertiesUtil {
     def rootCodeOrEmpty: String = rootCode.getOrElse("")
 
   }
+
+  implicit class RootPropertiesOnSeq(asts: Seq[Ast]) {
+
+    def rootType: Option[String] = asts.headOption.flatMap(_.rootType)
+
+    def rootCode: Option[String] = asts.headOption.flatMap(_.rootCode)
+
+    def rootCodeOrEmpty: String = asts.rootCode.getOrElse("")
+  }
 }


### PR DESCRIPTION
This moves 2 duplicated methods out of PHP/Javasrc's frontends, viz. `rootCode` and `rootType`. 

It also fixes a very minor bug in PHP's `isset` `code` property due to an unbalanced parenthesis.

Aside: I'm not sure I've written fully idiomatic Scala (it's been a few years since the last time) here. I look forward for any kind of improvement suggestions you see fit.

