### PR TITLE
[pysrc2cpg] Fixed Crashes on Import Code

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -348,9 +348,11 @@ class ContextStack {
 
   def isClassContext: Boolean = {
     val stackTail = stack.tail
-    stackTail.nonEmpty &&
-    (stackTail.head.isInstanceOf[ClassContext] ||
-      stackTail.head.asInstanceOf[MethodContext].name.endsWith("<body>"))
+    stackTail.nonEmpty && (stackTail.headOption match {
+      case Some(_: ClassContext)  => true
+      case Some(x: MethodContext) => x.name.endsWith("<body>")
+      case _                      => false
+    })
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -265,7 +265,7 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
       setIdentifier(i, importedTypes.map(_.stripSuffix(s".${Defines.ConstructorMethodName}")))
     } else {
       // TODO: This identifier should contain the type of the return value of 'c'.
-      //  e.g. x = foo(a, b) but not x = y.foo(a, b) as foo in the latter case is interpeted as a field access
+      //  e.g. x = foo(a, b) but not x = y.foo(a, b) as foo in the latter case is interpreted as a field access
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -260,12 +260,12 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
     if (!callCode.endsWith(")")) {
       // Case 1: The identifier is at the assignment to a function pointer. Lack of parenthesis should indicate this.
       setIdentifier(i, importedTypes)
-    } else if (callName.charAt(0).isUpper && callCode.endsWith(")")) {
+    } else if (!callName.isBlank && callName.charAt(0).isUpper && callCode.endsWith(")")) {
       // Case 2: The identifier is receiving a constructor invocation, thus is now an instance of the type
       setIdentifier(i, importedTypes.map(_.stripSuffix(s".${Defines.ConstructorMethodName}")))
     } else {
       // TODO: This identifier should contain the type of the return value of 'c'.
-      //  e.g. x = foo(a, b) but not x = y.foo(a, b) as foo in the latter case is interpetted as a field access
+      //  e.g. x = foo(a, b) but not x = y.foo(a, b) as foo in the latter case is interpeted as a field access
     }
   }
 


### PR DESCRIPTION
- Used a much more defensive check for `ContextStack.isClassContext`
- Fixed `.charAt(0)` call for empty call names