### PR TITLE
[pysrc2cpg] Handle `self` Property Type Recovery

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -141,7 +141,7 @@ class SetPythonProcedureDefTask(node: CfgNode, symbolTable: SymbolTable[LocalKey
   *   the graph builder
   */
 class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, globalTable: SymbolTable[GlobalKey])
-    extends RecoverForXCompilationUnit[File](cpg, cu, builder, globalTable) {
+    extends RecoverForXCompilationUnit[File](cu, builder) {
 
   /** Adds built-in functions to expect.
     */

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -109,7 +109,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |            'age': self.age,
         |            'address': self.address
         |        }
-        |""".stripMargin)
+        |""".stripMargin).cpg
 
     "resolve 'db' identifier types from import information" in {
       val List(clientAssignment, clientElseWhere) = cpg.identifier("db").take(2).l
@@ -146,7 +146,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |from foo import abs
         |
         |x = abs(-1)
-        |""".stripMargin)
+        |""".stripMargin).cpg
 
     "resolve 'print' and 'max' calls" in {
       val Some(printCall) = cpg.call("print").headOption
@@ -186,7 +186,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |foo.db.deleteTable()
         |""".stripMargin,
       "bar.py"
-    )
+    ).cpg
 
     "resolve 'x' and 'y' locally under foo.py" in {
       val Some(x) = cpg.file.name(".*foo.*").ast.isIdentifier.name("x").headOption
@@ -268,7 +268,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |db = SQLAlchemy()
         |""".stripMargin,
       "app.py"
-    )
+    ).cpg
 
     "be determined as a variable reference and have its type recovered correctly" in {
       cpg.identifier("db").map(_.typeFullName).toSet shouldBe Set("flask_sqlalchemy.py:<module>.SQLAlchemy")
@@ -300,7 +300,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |import logging
         |log = logging.getLogger(__name__)
         |log.error("foo")
-        |""".stripMargin)
+        |""".stripMargin).cpg
 
     "provide a dummy type" in {
       val Some(log) = cpg.identifier("log").headOption
@@ -318,7 +318,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |import urllib.request
         |
         |req = urllib.request.Request(url=apiUrl, data=dataBytes, method='POST')
-        |""".stripMargin)
+        |""".stripMargin).cpg
 
     "reasonably determine the constructor type" in {
       val Some(tmp0) = cpg.identifier("tmp0").headOption
@@ -366,7 +366,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |        return dict(res).get("customerId", None)
         |""".stripMargin,
       "InstallationDao.py"
-    )
+    ).cpg
 
     "recover a potential type for `self.collection` using the assignment at `get_collection` as a type hint" in {
       val Some(selfFindFound) = cpg.typeDecl(".*InstallationsDAO.*").ast.isCall.name("find_one").headOption

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -26,11 +26,12 @@ object SBKey {
   protected val logger: Logger = LoggerFactory.getLogger(getClass)
   def fromNodeToLocalKey(node: AstNode): LocalKey = {
     node match {
-      case n: Identifier => LocalVar(n.name)
-      case n: Local      => LocalVar(n.name)
-      case n: Call       => CallAlias(n.name)
-      case n: Method     => CallAlias(n.name)
-      case n: MethodRef  => CallAlias(n.code)
+      case n: Identifier      => LocalVar(n.name)
+      case n: Local           => LocalVar(n.name)
+      case n: Call            => CallAlias(n.name)
+      case n: Method          => CallAlias(n.name)
+      case n: MethodRef       => CallAlias(n.code)
+      case n: FieldIdentifier => LocalVar(n.canonicalName)
       case _ =>
         throw new RuntimeException(s"Local node of type ${node.label} is not supported in the type recovery pass.")
     }
@@ -112,7 +113,7 @@ class SymbolTable[K <: SBKey](fromNode: AstNode => K) {
   def append(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
     append(fromNode(node), typeFullNames)
 
-  private def append(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] = {
+  def append(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] = {
     table.get(sbKey) match {
       case Some(ts) => table.put(sbKey, ts ++ typeFullNames)
       case None     => table.put(sbKey, typeFullNames)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -49,11 +49,14 @@ abstract class XTypeRecovery[ComputationalUnit <: AstNode](cpg: Cpg, iterations:
     */
   protected val globalTable = new SymbolTable[GlobalKey](SBKey.fromNodeToGlobalKey)
 
-  override def run(builder: DiffGraphBuilder): Unit =
+  override def run(builder: DiffGraphBuilder): Unit = try {
     for (_ <- 0 to iterations)
       computationalUnit
         .map(unit => generateRecoveryForCompilationUnitTask(unit, builder, globalTable).fork())
         .foreach(_.get())
+  } finally {
+    globalTable.clear()
+  }
 
   /** @return
     *   the computational units as per how the language is compiled. e.g. file.
@@ -150,10 +153,8 @@ abstract class SetXProcedureDefTask(node: CfgNode) extends RecursiveTask[Unit] {
   *   the [[AstNode]] type used to represent a computational unit of the language.
   */
 abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
-  cpg: Cpg,
   cu: ComputationalUnit,
   builder: DiffGraphBuilder,
-  globalTable: SymbolTable[GlobalKey]
 ) extends RecursiveTask[Unit] {
 
   /** Stores type information for local structures that live within this compilation unit, e.g. local variables.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -154,7 +154,7 @@ abstract class SetXProcedureDefTask(node: CfgNode) extends RecursiveTask[Unit] {
   */
 abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
   cu: ComputationalUnit,
-  builder: DiffGraphBuilder,
+  builder: DiffGraphBuilder
 ) extends RecursiveTask[Unit] {
 
   /** Stores type information for local structures that live within this compilation unit, e.g. local variables.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -1,7 +1,7 @@
 package io.joern.x2cpg.passes.frontend
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Method, _}
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._


### PR DESCRIPTION
- Load `self` field assignments into the global table
- Approximate field references by name (TODO: match objects with their type decl)
- Using dummy <indexAccess> for dict access types (TODO: model dict memory during analysis)