### PR TITLE
pysrc2cpg: Adjust Recovered Method and Type Names

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2Cpg.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2Cpg.scala
@@ -22,7 +22,13 @@ class Py2Cpg(inputProviders: Iterable[Py2Cpg.InputProvider], outputCpg: Cpg) {
   private val edgeBuilder = new EdgeBuilder(diffGraph)
 
   def buildCpg(): Unit = {
-    nodeBuilder.metaNode(Languages.PYTHONSRC, version = "")
+    val metaData = nodeBuilder.metaNode(Languages.PYTHONSRC, version = "")
+    inputProviders.headOption match {
+      case Some(headInput: Py2Cpg.InputProvider) =>
+        val inputFile = headInput()
+        metaData.root(inputFile.absFileName.stripSuffix(inputFile.relFileName))
+      case _ =>
+    }
     val globalNamespaceBlock =
       nodeBuilder.namespaceBlockNode(Constants.GLOBAL_NAMESPACE, Constants.GLOBAL_NAMESPACE, "N/A")
     nodeBuilder.typeNode(Constants.ANY, Constants.ANY)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -303,7 +303,7 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
           .map(_.stripSuffix(s".${Defines.ConstructorMethodName}"))
           .map(x => (x.split("\\.").last, x))
           .map {
-            case (x, y)  => s"$y.$x<body>"
+            case (x, y) => s"$y.$x<body>"
             case (_, z) => z
           }
       )
@@ -333,8 +333,8 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
             identifierFullName.map(_.concat(s".${Defines.ConstructorMethodName}"))
           else
             identifierFullName.map(x => (x.split("\\.").takeRight(2), x)).map {
-              case (Array(x, y), z) if x.charAt(0).isUpper && !z.contains("<body>" )=> s"${z.stripSuffix(y)}$x<body>.$y"
-              case (_, y)                                  => y
+              case (Array(x, y), z) if x.charAt(0).isUpper && !z.contains("<body>") => s"${z.stripSuffix(y)}$x<body>.$y"
+              case (_, y)                                                           => y
             }
         symbolTable.put(i, identifierFullName)
         symbolTable.put(c, callMethodFullName)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -297,7 +297,16 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
       setIdentifier(i, importedTypes)
     } else if (!callName.isBlank && callName.charAt(0).isUpper && callCode.endsWith(")")) {
       // Case 2: The identifier is receiving a constructor invocation, thus is now an instance of the type
-      setIdentifier(i, importedTypes.map(_.stripSuffix(s".${Defines.ConstructorMethodName}")))
+      setIdentifier(
+        i,
+        importedTypes
+          .map(_.stripSuffix(s".${Defines.ConstructorMethodName}"))
+          .map(x => (x.split("\\.").last, x))
+          .map {
+            case (x, y)  => s"$y.$x<body>"
+            case (_, z) => z
+          }
+      )
     } else {
       // TODO: This identifier should contain the type of the return value of 'c'.
       //  e.g. x = foo(a, b) but not x = y.foo(a, b) as foo in the latter case is interpreted as a field access
@@ -323,11 +332,14 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
           if (f.canonicalName.charAt(0).isUpper)
             identifierFullName.map(_.concat(s".${Defines.ConstructorMethodName}"))
           else
-            identifierFullName
+            identifierFullName.map(x => (x.split("\\.").takeRight(2), x)).map {
+              case (Array(x, y), z) if x.charAt(0).isUpper && !z.contains("<body>" )=> s"${z.stripSuffix(y)}$x<body>.$y"
+              case (_, y)                                  => y
+            }
         symbolTable.put(i, identifierFullName)
         symbolTable.put(c, callMethodFullName)
       case List(rec: Identifier, f: FieldIdentifier) if symbolTable.contains(CallAlias(rec.name)) =>
-        // Second we ask if the call receiver is known as a function pointer (imports are interpretted as functions first)
+        // Second we ask if the call receiver is known as a function pointer (imports are interpreted as functions first)
         val funcTypes = symbolTable.get(CallAlias(rec.name)).map(t => s"$t.${f.canonicalName}")
         // TODO: Look in the CPG if we can resolve the method return value
         symbolTable.put(i, funcTypes.map(t => s"$t.<returnValue>"))

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -58,28 +58,28 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "resolve 'sg' identifier types from import information" in {
       val List(sgAssignment, sgElseWhere) = cpg.identifier("sg").take(2).l
-      sgAssignment.typeFullName shouldBe "sendgrid.py:<module>.SendGridAPIClient"
-      sgElseWhere.typeFullName shouldBe "sendgrid.py:<module>.SendGridAPIClient"
+      sgAssignment.typeFullName shouldBe "sendgrid.py:<module>.SendGridAPIClient.SendGridAPIClient<body>"
+      sgElseWhere.typeFullName shouldBe "sendgrid.py:<module>.SendGridAPIClient.SendGridAPIClient<body>"
     }
 
     "resolve 'sg' call path from import information" in {
       val List(apiClient) = cpg.call("SendGridAPIClient").l
       apiClient.methodFullName shouldBe "sendgrid.py:<module>.SendGridAPIClient.<init>"
       val List(sendCall) = cpg.call("send").l
-      sendCall.methodFullName shouldBe "sendgrid.py:<module>.SendGridAPIClient.send"
+      sendCall.methodFullName shouldBe "sendgrid.py:<module>.SendGridAPIClient.SendGridAPIClient<body>.send"
     }
 
     "resolve 'client' identifier types from import information" in {
       val List(clientAssignment, clientElseWhere) = cpg.identifier("client").take(2).l
-      clientAssignment.typeFullName shouldBe "slack_sdk.py:<module>.WebClient"
-      clientElseWhere.typeFullName shouldBe "slack_sdk.py:<module>.WebClient"
+      clientAssignment.typeFullName shouldBe "slack_sdk.py:<module>.WebClient.WebClient<body>"
+      clientElseWhere.typeFullName shouldBe "slack_sdk.py:<module>.WebClient.WebClient<body>"
     }
 
     "resolve 'client' call path from identifier in child scope" in {
       val List(client) = cpg.call("WebClient").l
       client.methodFullName shouldBe "slack_sdk.py:<module>.WebClient.<init>"
       val List(postMessage) = cpg.call("chat_postMessage").l
-      postMessage.methodFullName shouldBe "slack_sdk.py:<module>.WebClient.chat_postMessage"
+      postMessage.methodFullName shouldBe "slack_sdk.py:<module>.WebClient.WebClient<body>.chat_postMessage"
     }
 
   }
@@ -113,8 +113,8 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "resolve 'db' identifier types from import information" in {
       val List(clientAssignment, clientElseWhere) = cpg.identifier("db").take(2).l
-      clientAssignment.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy"
-      clientElseWhere.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy"
+      clientAssignment.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>"
+      clientElseWhere.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>"
     }
 
     "resolve the 'SQLAlchemy' constructor in the module" in {
@@ -125,15 +125,15 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     "resolve 'User' field types" in {
       val List(id, firstname, age, address) =
         cpg.identifier.nameExact("id", "firstname", "age", "address").takeRight(4).l
-      id.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.Column"
-      firstname.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.Column"
-      age.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.Column"
-      address.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.Column"
+      id.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column"
+      firstname.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column"
+      age.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column"
+      address.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column"
     }
 
     "resolve the 'Column' constructor for a class member" in {
       val Some(columnConstructor) = cpg.call("Column").headOption
-      columnConstructor.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.Column.<init>"
+      columnConstructor.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column.<init>"
     }
 
   }
@@ -226,7 +226,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         .isCall
         .name("createTable")
         .l
-      d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.createTable"
+      d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.createTable"
       d.dynamicTypeHintFullName shouldBe Seq()
       d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
@@ -239,7 +239,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         .name("deleteTable")
         .l
 
-      d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.deleteTable"
+      d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.deleteTable"
       d.dynamicTypeHintFullName shouldBe Seq()
       d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
@@ -369,6 +369,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     ).cpg
 
     "recover a potential type for `self.collection` using the assignment at `get_collection` as a type hint" in {
+      cpg.method.isExternal(false).fullName.foreach(println)
       val Some(selfFindFound) = cpg.typeDecl(".*InstallationsDAO.*").ast.isCall.name("find_one").headOption
       selfFindFound.methodFullName shouldBe "pymongo.py:<module>.MongoClient.<init>.<indexAccess>.<indexAccess>.find_one"
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -81,13 +81,14 @@ object MethodStubCreator {
     signature: String,
     dispatchType: String,
     parameterCount: Int,
-    dstGraph: DiffGraphBuilder
+    dstGraph: DiffGraphBuilder,
+    isExternal: Boolean = true
   ): NewMethod = {
     val methodNode = addLineNumberInfo(
       NewMethod()
         .name(name)
         .fullName(fullName)
-        .isExternal(true)
+        .isExternal(isExternal)
         .signature(signature)
         .astParentType(NodeTypes.NAMESPACE_BLOCK)
         .astParentFullName("<global>")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -74,7 +74,7 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
     val basePath = cpg.metaData.root.head
     val isExternal = if (matcher.matches()) {
       val fileName = matcher.group(1)
-      cpg.file(basePath + fileName).isEmpty
+      cpg.file.nameExact(basePath + fileName).isEmpty
     } else {
       true
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -9,6 +9,8 @@ import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
 
+import java.io.File
+import java.util.regex.Pattern
 import scala.collection.mutable
 
 /** Attempts to set the <code>methodFullName</code> and link to callees using the recovered type information from
@@ -21,6 +23,7 @@ import scala.collection.mutable
 abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   implicit private val resolver: NoResolve.type = NoResolve
+  private val fileNamePattern                   = Pattern.compile("^(.*(.py|.js)).*$")
 
   def calls: Traversal[Call] = cpg.call
     .filterNot(c => c.name.startsWith("<operator>"))
@@ -65,12 +68,30 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   private def createMethodStub(methodName: String, call: Call, builder: DiffGraphBuilder): NewMethod = {
+    // In the case of Python/JS we can use name info to check if, despite the method name might be incorrect, that we
+    // label the method correctly as internal by finding that the method should belong to an internal file
+    val matcher  = fileNamePattern.matcher(methodName)
+    val basePath = cpg.metaData.root.head
+    val isExternal = if (matcher.matches()) {
+      val fileName = matcher.group(1)
+      cpg.file(basePath + fileName).isEmpty
+    } else {
+      true
+    }
     val name =
       if (methodName.contains(".") && methodName.length > methodName.lastIndexOf(".") + 1)
         methodName.substring(methodName.lastIndexOf(".") + 1)
       else methodName
     MethodStubCreator
-      .createMethodStub(name, methodName, "", DispatchTypes.DYNAMIC_DISPATCH.name(), call.argumentOut.size, builder)
+      .createMethodStub(
+        name,
+        methodName,
+        "",
+        DispatchTypes.DYNAMIC_DISPATCH.name(),
+        call.argumentOut.size,
+        builder,
+        isExternal
+      )
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -175,6 +175,7 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
     // Prune import names if the methods exist in the CPG
     postVisitImports()
     // Populate local symbol table with assignments
+//    symbolTable.view.filterNot(_._2.exists(_.startsWith("built"))).foreach(println)
     assignments.foreach(visitAssignments)
     // Persist findings
     setTypeInformation()


### PR DESCRIPTION
- Made changes to recover the types based on the "type<body>" style syntax to improve linkage
- Added value for MetaData("root") in pysrc2cpg
- Check if the method belongs to an internal file to make the `isExternal=false` if a stub ultimately needs to be created due to incorrect method full name