### PR TITLE
pysrc2cpg: Recover Type for 3-Depth Call Access

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -175,7 +175,6 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
     // Prune import names if the methods exist in the CPG
     postVisitImports()
     // Populate local symbol table with assignments
-//    symbolTable.view.filterNot(_._2.exists(_.startsWith("built"))).foreach(println)
     assignments.foreach(visitAssignments)
     // Persist findings
     setTypeInformation()


### PR DESCRIPTION
- Added a temporary solution for deep field access. TODO: Highlights the need for a recursive solution
- Added a dummy path for the method full name