### PR TITLE
pysrc2cpg: Recover Call from Imported Module

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -412,4 +412,26 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
+  "a call from an import where the import acts as a module" should {
+    lazy val cpg = code(
+      """import os
+        |import datadog
+        |
+        |# Initialize the Datadog client
+        |options = {
+        |    'api_key': os.environ.get('DD_API_KEY'),
+        |    'app_key': os.environ.get('DD_APP_KEY')
+        |}
+        |
+        |datadog.initialize(**options)
+        |""".stripMargin,
+      "app.py"
+    )
+
+    "recover the import as an identifier and not directly as a call" in {
+      val Some(binkFind) = cpg.call.name("initialize").headOption
+      binkFind.methodFullName shouldBe "datadog.py:<module>.initialize"
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -279,8 +279,12 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
       // Case 3: 'i' is the receiver for a field access on member 'f'
       case (Some(call: Call), List(i: Identifier, f: FieldIdentifier)) if call.name.equals(Operators.fieldAccess) =>
         val iTypes = if (symbolTable.contains(i)) symbolTable.get(i) else symbolTable.get(CallAlias(i.name))
+        val cTypes = symbolTable.get(call)
         persistType(i, iTypes)(builder)
+        persistType(call, cTypes)(builder)
         Traversal.from(call.astParent).isCall.headOption match {
+          case Some(callFromFieldName) if symbolTable.contains(callFromFieldName) =>
+            persistType(callFromFieldName, symbolTable.get(callFromFieldName))(builder)
           case Some(callFromFieldName) =>
             persistType(callFromFieldName, iTypes.map(it => s"$it.${f.canonicalName}"))(builder)
           case None =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -285,7 +285,7 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
         Traversal.from(call.astParent).isCall.headOption match {
           case Some(callFromFieldName) if symbolTable.contains(callFromFieldName) =>
             persistType(callFromFieldName, symbolTable.get(callFromFieldName))(builder)
-          case Some(callFromFieldName) =>
+          case Some(callFromFieldName) if iTypes.nonEmpty =>
             persistType(callFromFieldName, iTypes.map(it => s"$it.${f.canonicalName}"))(builder)
           case None =>
         }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -236,47 +236,57 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
         case x: Local if symbolTable.contains(x) =>
           builder.setNodeProperty(x, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, symbolTable.get(x).toSeq)
         case x: Identifier if symbolTable.contains(x) =>
-          (x.inCall.headOption, x.inCall.argument.take(2).l) match {
-            // Case 1: 'call' is an assignment from some dynamic dispatch call
-            case (Some(call: Call), List(i: Identifier, c: Call)) if call.name.equals(Operators.assignment) =>
-              val idTypes   = symbolTable.get(i)
-              val callTypes = symbolTable.get(c)
-              persistType(call, callTypes)(builder)
-              if (idTypes.nonEmpty || callTypes.nonEmpty) {
-                if (idTypes.equals(callTypes))
-                  // Case 1.1: This is a function pointer or constructor
-                  persistType(i, callTypes)(builder)
-                else
-                  // Case 1.2: This is the return value of the function
-                  persistType(i, idTypes)(builder)
-              }
-            // Case 1: 'call' is an assignment from some other data structure
-            case (Some(call: Call), ::(i: Identifier, _)) if call.name.equals(Operators.assignment) =>
-              val idHints = symbolTable.get(i)
-              persistType(i, idHints)(builder)
-              persistType(call, idHints)(builder)
-            // Case 2: 'i' is the receiver of 'call'
-            case (Some(call: Call), ::(i: Identifier, _)) if !call.name.equals(Operators.fieldAccess) =>
-              val idHints   = symbolTable.get(i)
-              val callTypes = symbolTable.get(call)
-              persistType(i, idHints)(builder)
-              if (callTypes.isEmpty) {
-                // For now, calls are treated as function pointers and thus the type should point to the method
-                persistType(call, idHints.map(t => s"$t.${call.name}"))(builder)
-              } else {
-                persistType(call, callTypes)(builder)
-              }
-            // Case 3: 'i' is the receiver for a field access on member 'f'
-            case (Some(call: Call), List(i: Identifier, _: FieldIdentifier))
-                if call.name.equals(Operators.fieldAccess) =>
-              persistType(i, symbolTable.get(x))(builder)
-            case _ => persistType(x, symbolTable.get(x))(builder)
-          }
+          setTypeInformationForRecCall(x, x.inCall.headOption, x.inCall.argument.take(2).l)
         case x: Call if symbolTable.contains(x) =>
           builder.setNodeProperty(x, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, symbolTable.get(x).toSeq)
+        case x: Identifier if symbolTable.contains(CallAlias(x.name)) && x.inCall.nonEmpty =>
+          setTypeInformationForRecCall(x, x.inCall.headOption, x.inCall.argument.take(2).l)
         case _ =>
       }
   }
+
+  private def setTypeInformationForRecCall(x: AstNode, n: Option[Call], ms: List[AstNode]): Unit =
+    (n, ms) match {
+      // Case 1: 'call' is an assignment from some dynamic dispatch call
+      case (Some(call: Call), List(i: Identifier, c: Call)) if call.name.equals(Operators.assignment) =>
+        val idTypes   = if (symbolTable.contains(i)) symbolTable.get(i) else symbolTable.get(CallAlias(i.name))
+        val callTypes = symbolTable.get(c)
+        persistType(call, callTypes)(builder)
+        if (idTypes.nonEmpty || callTypes.nonEmpty) {
+          if (idTypes.equals(callTypes))
+            // Case 1.1: This is a function pointer or constructor
+            persistType(i, callTypes)(builder)
+          else
+            // Case 1.2: This is the return value of the function
+            persistType(i, idTypes)(builder)
+        }
+      // Case 1: 'call' is an assignment from some other data structure
+      case (Some(call: Call), ::(i: Identifier, _)) if call.name.equals(Operators.assignment) =>
+        val idHints = symbolTable.get(i)
+        persistType(i, idHints)(builder)
+        persistType(call, idHints)(builder)
+      // Case 2: 'i' is the receiver of 'call'
+      case (Some(call: Call), ::(i: Identifier, _)) if !call.name.equals(Operators.fieldAccess) =>
+        val idHints   = symbolTable.get(i)
+        val callTypes = symbolTable.get(call)
+        persistType(i, idHints)(builder)
+        if (callTypes.isEmpty) {
+          // For now, calls are treated as function pointers and thus the type should point to the method
+          persistType(call, idHints.map(t => s"$t.${call.name}"))(builder)
+        } else {
+          persistType(call, callTypes)(builder)
+        }
+      // Case 3: 'i' is the receiver for a field access on member 'f'
+      case (Some(call: Call), List(i: Identifier, f: FieldIdentifier)) if call.name.equals(Operators.fieldAccess) =>
+        val iTypes = if (symbolTable.contains(i)) symbolTable.get(i) else symbolTable.get(CallAlias(i.name))
+        persistType(i, iTypes)(builder)
+        Traversal.from(call.astParent).isCall.headOption match {
+          case Some(callFromFieldName) =>
+            persistType(callFromFieldName, iTypes.map(it => s"$it.${f.canonicalName}"))(builder)
+          case None =>
+        }
+      case _ => persistType(x, symbolTable.get(x))(builder)
+    }
 
   private def persistType(x: StoredNode, types: Set[String])(implicit builder: DiffGraphBuilder): Unit =
     if (types.nonEmpty)


### PR DESCRIPTION
- Direct imports on modules were interpreted as function pointers, this change allows them to be interpreted as modules or fields