### PR TITLE
handle old astgen versions that report `unknown` as their version

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -89,8 +89,9 @@ astGenDlUrl := s"https://github.com/joernio/astgen/releases/download/v${astGenVe
 
 def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
   Try("astgen --version".!!).toOption.map(_.strip()) match {
-    case Some(installedVersion) => VersionHelper.compare(installedVersion, astGenVersion) >= 0
-    case None                   => false
+    case Some(installedVersion) if installedVersion != "unknown" =>
+      VersionHelper.compare(installedVersion, astGenVersion) >= 0
+    case _ => false
   }
 }
 


### PR DESCRIPTION
fixes:
```
[error] java.lang.NumberFormatException: For input string: "unknown"
[error]         at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
[error]         at java.base/java.lang.Integer.parseInt(Integer.java:668)
[error]         at java.base/java.lang.Integer.valueOf(Integer.java:999)
[error]         at versionsort.VersionHelper.compare(VersionHelper.java:32)
[error]         at $c486a84e185d715fb73f$.hasCompatibleAstGenVersion(build.sbt:92)
```