### PR TITLE
Extend letter parser token definition.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/pythonGrammar.jj
+++ b/joern-cli/frontends/pysrc2cpg/pythonGrammar.jj
@@ -311,7 +311,7 @@ TOKEN: {
 
 TOKEN: {
   <NAME: <LETTER> (<LETTER> | <DIGIT>)*>
-| <LETTER: ["a" - "z", "A" - "Z", "_"] >
+| <LETTER: ["a" - "z", "A" - "Z", "_", "À" - "Ö", "Ø" - "ö", "ø" - "ÿ"] >
 }
 
 SKIP: {


### PR DESCRIPTION
We now include a bunch more of the common european special characters.

This is fix 1 of 2 for: https://github.com/joernio/joern/issues/2269