### PR TITLE
Fix meta class call handler generation.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -1,0 +1,41 @@
+package io.joern.pysrc2cpg.cpg
+
+import io.joern.pysrc2cpg.PySrc2CpgFixture
+import io.shiftleft.semanticcpg.language._
+
+class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
+  "class meta call handler" should {
+    "have no self parameter if self is explicit" in {
+      val cpg = code("""class Foo:
+          |  def __init__(self, x):
+          |    pass
+          |""".stripMargin)
+
+      val handlerMethod = cpg.method.name("<metaClassCallHandler>").head
+      handlerMethod.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
+      handlerMethod.lineNumber shouldBe Some(2)
+
+      handlerMethod.parameter.size shouldBe 1
+      val xParameter = handlerMethod.parameter.head
+      xParameter.name shouldBe "x"
+
+    }
+
+    "have no self parameter if self is in varargs" in {
+      val cpg = code("""class Foo:
+          |  def __init__(*x):
+          |    pass
+          |""".stripMargin)
+
+      val handlerMethod = cpg.method.name("<metaClassCallHandler>").head
+      handlerMethod.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
+      handlerMethod.lineNumber shouldBe Some(2)
+
+      handlerMethod.parameter.size shouldBe 1
+      val xParameter = handlerMethod.parameter.head
+      xParameter.name shouldBe "x"
+
+    }
+  }
+
+}


### PR DESCRIPTION
In cases were the "self" parameter is not explicitly given in a class
__init__ function we did crash because we assumed that at least one
positional parameter is always defined. This is now fixed.

This is fix 2 of 2 for: https://github.com/joernio/joern/issues/2269