### PR TITLE
XTypeRecovery: Clean Up With Visitor-Pattern & Support New Imports

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -143,15 +143,6 @@ class SetPythonProcedureDefTask(node: CfgNode, symbolTable: SymbolTable[LocalKey
 class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, globalTable: SymbolTable[GlobalKey])
     extends RecoverForXCompilationUnit[File](cu, builder, globalTable) {
 
-  /** Adds built-in functions to expect.
-    */
-  override def prepopulateSymbolTable(): Unit =
-    PythonTypeRecovery.BUILTINS
-      .map(t => (CallAlias(t), s"${PythonTypeRecovery.BUILTIN_PREFIX}.$t"))
-      .foreach { case (alias, typ) =>
-        symbolTable.put(alias, typ)
-      }
-
   override def importNodes(cu: AstNode): Traversal[CfgNode] = cu.ast.isCall.nameExact("import")
 
   override def postVisitImports(): Unit = {

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -141,7 +141,7 @@ class SetPythonProcedureDefTask(node: CfgNode, symbolTable: SymbolTable[LocalKey
   *   the graph builder
   */
 class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, globalTable: SymbolTable[GlobalKey])
-    extends RecoverForXCompilationUnit[File](cu, builder) {
+    extends RecoverForXCompilationUnit[File](cu, builder, globalTable) {
 
   /** Adds built-in functions to expect.
     */
@@ -296,6 +296,7 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
       case "<operator>.listLiteral"  => associateTypes(i, Set("list"))
       case "<operator>.tupleLiteral" => associateTypes(i, Set("tuple"))
       case "<operator>.dictLiteral"  => associateTypes(i, Set("dict"))
+      case Operators.alloc           => visitIdentifierAssignedToConstructor(i, c)
       case x                         => println(s"Unhandled operation $x (${c.code})"); Set.empty
     }
   }
@@ -315,6 +316,8 @@ class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, global
   override def visitIdentifierAssignedToCall(i: Identifier, c: Call): Set[String] = {
     // Ignore legacy import representation
     if (c.name.equals("import")) Set.empty
+    // Stop custom annotation representation from hitting superclass
+    else if (c.name.isBlank) Set.empty
     else super.visitIdentifierAssignedToCall(i, c)
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -61,7 +61,7 @@ class ScopedPythonProcedure(callingName: String, fullName: String, isConstructor
   */
 class SetPythonProcedureDefTask(node: CfgNode, symbolTable: SymbolTable[LocalKey]) extends SetXProcedureDefTask(node) {
 
-  /** Refers to the declared import information.
+  /** Refers to the declared import information. This will store the alias as both a call and a local variable.
     *
     * @param importCall
     *   the call that imports entities into this scope.
@@ -71,10 +71,12 @@ class SetPythonProcedureDefTask(node: CfgNode, symbolTable: SymbolTable[LocalKey
       case List(path: Literal, funcOrModule: Literal) =>
         val calleeNames = extractMethodDetailsFromImport(path.code, funcOrModule.code).possibleCalleeNames
         symbolTable.put(CallAlias(funcOrModule.code), calleeNames)
+        symbolTable.put(LocalVar(funcOrModule.code), calleeNames)
       case List(path: Literal, funcOrModule: Literal, alias: Literal) =>
         val calleeNames =
           extractMethodDetailsFromImport(path.code, funcOrModule.code, Option(alias.code)).possibleCalleeNames
         symbolTable.put(CallAlias(alias.code), calleeNames)
+        symbolTable.put(LocalVar(alias.code), calleeNames)
       case x => logger.warn(s"Unknown import pattern: ${x.map(_.label).mkString(", ")}")
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -21,8 +21,7 @@ class PythonTypeRecovery(cpg: Cpg) extends XTypeRecovery[File](cpg) {
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,
-    builder: DiffGraphBuilder,
-    globalTable: SymbolTable[GlobalKey]
+    builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] = new RecoverForPythonFile(cpg, unit, builder, globalTable)
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
@@ -203,9 +203,9 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "test that the identifiers are not set to the function pointers but rather the 'ANY' return value" in {
       val List(x, y, z) = cpg.identifier.name("x", "y", "z").l
-      x.typeFullName shouldBe "ANY"
-      y.typeFullName shouldBe "ANY"
-      z.typeFullName shouldBe "ANY"
+      x.typeFullName shouldBe "foo.py:<module>.foo_func.<returnValue>"
+      y.typeFullName shouldBe "foo/bar/__init__.py:<module>.bar_func.<returnValue>"
+      z.typeFullName shouldBe "foo.py:<module>.faz.<returnValue>"
     }
 
     "test call node properties for normal import from module on root path" in {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
@@ -204,7 +204,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
     "test that the identifiers are not set to the function pointers but rather the 'ANY' return value" in {
       val List(x, y, z) = cpg.identifier.name("x", "y", "z").l
       x.typeFullName shouldBe "foo.py:<module>.foo_func.<returnValue>"
-      y.typeFullName shouldBe "foo/bar/__init__.py:<module>.bar_func.<returnValue>"
+      y.typeFullName shouldBe Seq("foo", "bar", "__init__.py:<module>.bar_func.<returnValue>").mkString(File.separator)
       z.typeFullName shouldBe "foo.py:<module>.faz.<returnValue>"
     }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -82,6 +82,11 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       postMessage.methodFullName shouldBe "slack_sdk.py:<module>.WebClient.WebClient<body>.chat_postMessage"
     }
 
+    "resolve a dummy 'send' return value from sg.send" in {
+      val List(postMessage) = cpg.identifier("response").l
+      postMessage.typeFullName shouldBe "sendgrid.py:<module>.SendGridAPIClient.SendGridAPIClient<body>.send.<returnValue>"
+    }
+
   }
 
   "type recovery on class members" should {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -130,7 +130,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     "resolve 'User' field types" in {
       val List(id, firstname, age, address) =
         cpg.identifier.nameExact("id", "firstname", "age", "address").takeRight(4).l
-      id.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column"
+      id.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column.Column<body>"
       firstname.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column.Column<body>"
       age.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column.Column<body>"
       address.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.Column.Column<body>"

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -386,12 +386,15 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "recover a potential type for `self.collection` using the assignment at `get_collection` as a type hint" in {
       val Some(selfFindFound) = cpg.typeDecl(".*InstallationsDAO.*").ast.isCall.name("find_one").headOption
-      selfFindFound.methodFullName shouldBe "pymongo.py:<module>.MongoClient.<init>.<indexAccess>.<indexAccess>.find_one"
+      selfFindFound.dynamicTypeHintFullName shouldBe Seq(
+        "__builtin.None.find_one",
+        "pymongo.py:<module>.MongoClient.<init>.<indexAccess>.<indexAccess>.find_one"
+      )
     }
 
     "correctly determine that, despite being unable to resolve the correct method full name, that it is an internal method" in {
       val Some(selfFindFound) = cpg.typeDecl(".*InstallationsDAO.*").ast.isCall.name("find_one").headOption
-      selfFindFound.callee.isExternal.headOption shouldBe Some(false)
+      selfFindFound.callee.isExternal.toSeq shouldBe Seq(true, false)
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -155,14 +155,14 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "resolve 'print' and 'max' calls" in {
       val Some(printCall) = cpg.call("print").headOption
-      printCall.methodFullName shouldBe "builtins.py:<module>.print"
+      printCall.methodFullName shouldBe "__builtin.print"
       val Some(maxCall) = cpg.call("max").headOption
-      maxCall.methodFullName shouldBe "builtins.py:<module>.max"
+      maxCall.methodFullName shouldBe "__builtin.max"
     }
 
-    "select the imported abs over the built-in type when call is shadowed" in {
+    "conservatively present either option when an imported function uses the same name as a builtin" in {
       val Some(absCall) = cpg.call("abs").headOption
-      absCall.dynamicTypeHintFullName shouldBe Seq("foo.py:<module>.abs")
+      absCall.dynamicTypeHintFullName shouldBe Seq("foo.py:<module>.abs", "__builtin.abs")
     }
 
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -56,6 +56,10 @@ sealed class LocalKey(identifier: String) extends SBKey(identifier) {
   */
 case class LocalVar(override val identifier: String) extends LocalKey(identifier)
 
+/** A collection object that can be accessed with potentially dynamic keys and values.
+  */
+case class CollectionVar(override val identifier: String, idx: String) extends LocalKey(identifier)
+
 /** A name that refers to some kind of callee.
   */
 case class CallAlias(override val identifier: String) extends LocalKey(identifier)
@@ -98,25 +102,25 @@ class SymbolTable[K <: SBKey](fromNode: AstNode => K) {
     table.put(newKey, newValues)
   }
 
-  def put(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] =
-    table.put(sbKey, typeFullNames)
+  def put(sbKey: K, typeFullNames: Set[String]): Set[String] =
+    table.put(sbKey, typeFullNames).getOrElse(Set.empty)
 
-  def put(sbKey: K, typeFullName: String): Option[Set[String]] =
+  def put(sbKey: K, typeFullName: String): Set[String] =
     put(sbKey, Set(typeFullName))
 
-  def put(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
+  def put(node: AstNode, typeFullNames: Set[String]): Set[String] =
     put(fromNode(node), typeFullNames)
 
-  def append(node: AstNode, typeFullName: String): Option[Set[String]] =
+  def append(node: AstNode, typeFullName: String): Set[String] =
     append(node, Set(typeFullName))
 
-  def append(node: AstNode, typeFullNames: Set[String]): Option[Set[String]] =
+  def append(node: AstNode, typeFullNames: Set[String]): Set[String] =
     append(fromNode(node), typeFullNames)
 
-  def append(sbKey: K, typeFullNames: Set[String]): Option[Set[String]] = {
+  def append(sbKey: K, typeFullNames: Set[String]): Set[String] = {
     table.get(sbKey) match {
-      case Some(ts) => table.put(sbKey, ts ++ typeFullNames)
-      case None     => table.put(sbKey, typeFullNames)
+      case Some(ts) => put(sbKey, ts ++ typeFullNames)
+      case None     => put(sbKey, typeFullNames)
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -615,8 +615,7 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
       }
   }
 
-  /**
-    * TODO: Cleaning up using visitor patten
+  /** TODO: Cleaning up using visitor patten
     */
   private def setTypeInformationForRecCall(x: AstNode, n: Option[Call], ms: List[AstNode]): Unit =
     (n, ms) match {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -287,7 +287,7 @@ abstract class RecoverForXCompilationUnit[ComputationalUnit <: AstNode](
             persistType(callFromFieldName, symbolTable.get(callFromFieldName))(builder)
           case Some(callFromFieldName) if iTypes.nonEmpty =>
             persistType(callFromFieldName, iTypes.map(it => s"$it.${f.canonicalName}"))(builder)
-          case None =>
+          case _ =>
         }
       case _ => persistType(x, symbolTable.get(x))(builder)
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -14,6 +14,8 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
 
   def isIdentifier: Boolean = node.isInstanceOf[Identifier]
 
+  def isImport: Boolean = node.isInstanceOf[Import]
+
   def isFieldIdentifier: Boolean = node.isInstanceOf[FieldIdentifier]
 
   def isFile: Boolean = node.isInstanceOf[File]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -134,6 +134,11 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
   def isIdentifier: Traversal[Identifier] =
     traversal.collectAll[Identifier]
 
+  /** Traverse only to AST nodes that are IMPORT nodes
+    */
+  def isImport: Traversal[Import] =
+    traversal.collectAll[Import]
+
   /** Traverse only to FILE AST nodes
     */
   def isFile: Traversal[File] =


### PR DESCRIPTION
- Re-implemented `XTypeRecovery` using visitor pattern. This reduces the `PythonTypeRecovery` file by 50% and increases the language agnostic `XTypeRecovery` file by 100%.
- `XTypeRecovery` can now support the new `Import` node while leaving room to override the `Call` version as still used in Python.
- This change improves the soundness of the type recovery and, as such, resulted in some modifications required for some test cases.
- This change also promotes re-use of code and easy diagnostics using a logger with debugging locators. Debug level used is `WARN`. 

Breaking changes:
- Built-in types are now prefixed with `__builtin` which is what the front-end appears to use.
- `__builtin.None` is now supported, which means potentially more types may be suggested if variables were initialized with `var = None`.