### PR TITLE
Python: more fixes for member variable tracking

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -90,10 +90,10 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     }.toMap
     val res = result.par.map { r =>
       val startingPoint = r.path.head.node
-      if (sources.contains(startingPoint) || !startingPointToSource(startingPoint).isInstanceOf[CfgNode]) {
+      if (sources.contains(startingPoint) || !startingPointToSource(startingPoint).isInstanceOf[AstNode]) {
         r
       } else {
-        r.copy(path = PathElement(startingPointToSource(startingPoint).asInstanceOf[CfgNode]) +: r.path)
+        r.copy(path = PathElement(startingPointToSource(startingPoint).asInstanceOf[AstNode]) +: r.path)
       }
     }
     res.toVector

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -84,8 +84,10 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     val result = engine.backwards(sinks, startingPointsWithSources.map(_.startingPoint))
 
     engine.shutdown()
-    val sources               = startingPointsWithSources.map(_.source)
-    val startingPointToSource = startingPointsWithSources.map { x => x.startingPoint -> x.source }.toMap
+    val sources = startingPointsWithSources.map(_.source)
+    val startingPointToSource = startingPointsWithSources.map { x =>
+      x.startingPoint.asInstanceOf[AstNode] -> x.source
+    }.toMap
     val res = result.par.map { r =>
       val startingPoint = r.path.head.node
       if (sources.contains(startingPoint) || !startingPointToSource(startingPoint).isInstanceOf[CfgNode]) {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -23,6 +23,7 @@ import overflowdb.traversal.Traversal
 import java.util.concurrent.{ForkJoinPool, ForkJoinTask, RecursiveTask, RejectedExecutionException}
 import scala.util.{Failure, Success, Try}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.operatorextension.allAssignmentTypes
 
 case class StartingPointWithSource(startingPoint: CfgNode, source: StoredNode)
 
@@ -88,9 +89,6 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
     }
   }
 
-  /** For a list of (type declaration, expression) pairs, determine usages of expression from corresponding type
-    * declaration.
-    */
   private def usages(pairs: List[(TypeDecl, Expression)]): List[CfgNode] = {
     pairs.flatMap { case (typeDecl, expression) =>
       val nonConstructorMethods = methodsRecursively(typeDecl)
@@ -102,7 +100,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
         .l
 
       val usagesInSameClass =
-        nonConstructorMethods.flatMap { m => usagesOfExpression(expression, m) }
+        nonConstructorMethods.flatMap { m => firstUsagesOfExpression(expression, m, typeDecl) }
 
       val usagesInOtherClasses = cpg.method.flatMap { m =>
         m.fieldAccess
@@ -123,29 +121,28 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
     }
   }
 
-  private def usagesOfExpression(expression: Expression, m: Method): List[Expression] = {
+  /** For given method, determine the first usage of the given expression.
+    */
+  private def firstUsagesOfExpression(expression: Expression, m: Method, typeDecl: TypeDecl): List[Expression] = {
     expression match {
       case identifier: Identifier =>
-        // handle this.$identifier as well here
-        val identifiersAndFieldIdentifies = m.ast
-          .or(
-            _.isIdentifier.nameExact(identifier.name).takeWhile(notLeftHandOfAssignment),
-            _.isFieldIdentifier
-              .canonicalNameExact(identifier.name)
-              .inFieldAccess
-              .where(_.argument(1).codeExact("this", "self"))
-          )
-          .cast[Expression]
+        val identifiers      = m.ast.isIdentifier.sortBy(x => (x.lineNumber, x.columnNumber)).l
+        val identifierUsages = identifiers.nameExact(identifier.name).takeWhile(notLeftHandOfAssignment)
+        val fieldIdentifiers = m.ast.isFieldIdentifier.sortBy(x => (x.lineNumber, x.columnNumber)).l
+        val fieldAccessUsages = fieldIdentifiers.isFieldIdentifier
+          .canonicalNameExact(identifier.name)
+          .inFieldAccess
+          .where(_.argument(1).codeExact("this", "self"))
+          .takeWhile(notLeftHandOfAssignment)
           .l
-
-        identifiersAndFieldIdentifies.flatMap {
-          case x: Identifier      => Some(x)
-          case x: FieldIdentifier => x.inFieldAccess.isCall.headOption
-        }
-
+        (identifierUsages ++ fieldAccessUsages).headOption.toList
       case fieldIdentifier: FieldIdentifier =>
-        m.ast.isFieldIdentifier
+        val fieldIdentifiers = m.ast.isFieldIdentifier.sortBy(x => (x.lineNumber, x.columnNumber)).l
+        fieldIdentifiers
           .canonicalNameExact(fieldIdentifier.canonicalName)
+          .inFieldAccess
+          // TODO `isIdentifier` seems to limit us here
+          .where(_.argument(1).isIdentifier.or(_.nameExact("this", "self"), _.typeFullNameExact(typeDecl.fullName)))
           .takeWhile(notLeftHandOfAssignment)
           .l
       case _ => List()
@@ -212,7 +209,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
   }
 
   private def notLeftHandOfAssignment(x: Expression): Boolean = {
-    !(x.argumentIndex == 1 && x.inAssignment.nonEmpty)
+    !(x.argumentIndex == 1 && x.inCall.exists(y => allAssignmentTypes.contains(y.name)))
   }
 
   private def targetsToClassIdentifierPair(targets: List[Expression]): List[(TypeDecl, Expression)] = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -88,6 +88,9 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
     }
   }
 
+  /** For a list of (type declaration, expression) pairs, determine usages of expression from corresponding type
+    * declaration.
+    */
   private def usages(pairs: List[(TypeDecl, Expression)]): List[CfgNode] = {
     pairs.flatMap { case (typeDecl, expression) =>
       val nonConstructorMethods = methodsRecursively(typeDecl)
@@ -115,7 +118,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
           }
           .takeWhile(notLeftHandOfAssignment)
           .headOption
-      }
+      }.l
       usagesInSameClass ++ usagesInOtherClasses
     }
   }
@@ -144,7 +147,6 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
         m.ast.isFieldIdentifier
           .canonicalNameExact(fieldIdentifier.canonicalName)
           .takeWhile(notLeftHandOfAssignment)
-          .inFieldAccess
           .l
       case _ => List()
     }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -81,7 +81,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       * table. If not, determine results recursively.
       */
     def computeResultsForParents() = {
-      deduplicateWithinTask(expandIn(curNode, path, callSiteStack).iterator.flatMap { parent =>
+      deduplicateWithinTask(expandIn(curNode.asInstanceOf[CfgNode], path, callSiteStack).iterator.flatMap { parent =>
         createResultsFromCacheOrCompute(parent, path)
       }.toVector)
     }
@@ -139,7 +139,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       remainder: Vector[PathElement],
       callDepth: Int
     ): Option[Vector[ReachableByResult]] = {
-      table.get(TaskFingerprint(first.node, callSiteStack, callDepth)).map { res =>
+      table.get(TaskFingerprint(first.node.asInstanceOf[CfgNode], callSiteStack, callDepth)).map { res =>
         res.map { r =>
           val stopIndex       = r.path.map(x => (x.node, x.callSiteStack)).indexOf((first.node, first.callSiteStack))
           val pathToFirstNode = r.path.slice(0, stopIndex)
@@ -194,7 +194,7 @@ class TaskSolver(task: ReachableByTask, context: EngineContext, sources: Set[Cfg
       case _ =>
         computeResultsForParents()
     }
-    val key = TaskFingerprint(curNode, task.callSiteStack, task.callDepth)
+    val key = TaskFingerprint(curNode.asInstanceOf[CfgNode], task.callSiteStack, task.callDepth)
     table.updateWith(key) {
       case Some(existingValue) => Some(existingValue ++ res)
       case None                => Some(res)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/package.scala
@@ -44,7 +44,9 @@ package object queryengine {
     * label of its outgoing edge.
     *
     * @param node
-    *   The parent node
+    *   The parent node. This is actually always a CfgNode during data flow computation, however, since the source may
+    *   be an arbitrary AST node, we may add an AST node to the start of the flow right before returning flows to the
+    *   user.
     *
     * @param callSiteStack
     *   The call stack when this path element was created. Since we may enter the same function via two different call

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/package.scala
@@ -1,6 +1,6 @@
 package io.joern.dataflowengineoss
 
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call, CfgNode}
 
 package object queryengine {
 
@@ -28,14 +28,14 @@ package object queryengine {
 
     def callDepth: Int = fingerprint.callDepth
 
-    def startingPoint: CfgNode = path.head.node
+    def startingPoint: CfgNode = path.head.node.asInstanceOf[CfgNode]
 
     /** If the result begins in an output argument, return it.
       */
     def outputArgument: Option[CfgNode] = {
       path.headOption.collect {
         case elem: PathElement if elem.isOutputArg =>
-          elem.node
+          elem.node.asInstanceOf[CfgNode]
       }
     }
   }
@@ -61,7 +61,7 @@ package object queryengine {
     *   label of the outgoing DDG edge
     */
   case class PathElement(
-    node: CfgNode,
+    node: AstNode,
     callSiteStack: List[Call] = List(),
     visible: Boolean = true,
     isOutputArg: Boolean = false,

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -4,7 +4,7 @@ import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.toNodeTraversal
 
@@ -436,7 +436,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       flowsPretty should include("sz = 20")
       flowsPretty should include("read(fd, buff, sz)")
 
-      val tmpSourceFile = flows.head.elements.head.method.filename
+      val tmpSourceFile = flows.head.elements.head.asInstanceOf[CfgNode].method.filename
       flowsPretty should include(tmpSourceFile)
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -4,6 +4,7 @@ import io.joern.dataflowengineoss.language._
 import io.joern.jssrc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
 import io.shiftleft.semanticcpg.language._
 
 class DataflowTest extends DataFlowCodeToCpgSuite {
@@ -37,7 +38,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
         List(("sz = -5", 9), ("read(fd, buff, sz)", 11))
       )
 
-    val tmpSourceFile = flows.head.elements.head.method.filename
+    val tmpSourceFile = flows.head.elements.head.asInstanceOf[CfgNode].method.filename
     val flowsPretty   = flows.p.mkString
     flowsPretty should (include("sz = 20") and include("read(fd, buff, sz)"))
     flowsPretty should include(tmpSourceFile)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -129,8 +129,9 @@ class ContextStack {
 
   def findEnclosingTypeDecl(): Option[NewNode] = {
     stack.find(_.isInstanceOf[ClassContext]) match {
-      case Some(classContext: ClassContext) => Some(classContext.astParent)
-      case _                                => None
+      case Some(classContext: ClassContext) =>
+        Some(classContext.astParent)
+      case _ => None
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -1,25 +1,50 @@
 package io.joern.pysrc2cpg.cpg
 
 import io.joern.pysrc2cpg.Py2CpgTestContext
+import io.shiftleft.codepropertygraph.generated.nodes.Member
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import io.shiftleft.semanticcpg.language._
 
 class MemberCpgTests extends AnyFreeSpec with Matchers {
 
-  lazy val cpg = Py2CpgTestContext.buildCpg("""
-      |class Foo():
-      |   x = 'foo'
-      |
-      |""".stripMargin)
+  "A class variable" - {
 
-  "member should exist for class variable" in {
-    val List(member) = cpg.member.name("x").l
-    member.typeDecl.name shouldBe "Foo<meta>"
+    lazy val cpg = Py2CpgTestContext.buildCpg("""
+                                                |class Foo():
+                                                |   x = 'foo'
+                                                |
+                                                |""".stripMargin)
+
+    "should have a MEMBER" in {
+      val List(member: Member) = cpg.member.name("x").l
+      member.code shouldBe "x"
+    }
+
+    "should have the MEMBER attached to the meta class" in {
+      val List(typeDecl) = cpg.member.name("x").typeDecl.l
+      typeDecl.name shouldBe "Foo<meta>"
+    }
   }
 
-  "member should be attached to meta class" in {
-    val List(typeDecl) = cpg.member.name("x").typeDecl.l
-    typeDecl.name shouldBe "Foo<meta>"
+  "An instance variable" - {
+
+    lazy val cpg = Py2CpgTestContext.buildCpg("""
+                                                |class Foo():
+                                                |   def __init__(self):
+                                                |      self.x = 'foo'
+                                                |""".stripMargin)
+
+    "should have a MEMBER" in {
+      val List(member: Member) = cpg.member.name("x").l
+      member.code shouldBe "x"
+    }
+
+    "should have the MEMBER attached to the meta class" in {
+      val List(typeDecl) = cpg.member.name("x").typeDecl.l
+      typeDecl.name shouldBe "Foo<meta>"
+    }
+
   }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -3,6 +3,7 @@ package io.joern.pysrc2cpg.dataflow
 import io.joern.dataflowengineoss.language.toExtendedCfgNode
 import io.joern.pysrc2cpg.PySrc2CpgFixture
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Member
 import io.shiftleft.semanticcpg.language._
 
 class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
@@ -80,7 +81,13 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     val sink   = cpg.call(".*sink").argument(1).l
     source.size shouldBe 1
     sink.size shouldBe 1
-    sink.reachableByFlows(source).size shouldBe 1
+    val flows = sink.reachableByFlows(source).l
+    flows.size shouldBe 1
+    flows.head.elements.head match {
+      case member: Member =>
+        member.name shouldBe "x"
+      case _ => fail
+    }
   }
 
   "flow from instance variable in constructor (MEMBER) to sink" in {
@@ -99,7 +106,13 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     val sink   = cpg.call(".*sink").argument(1).l
     source.size shouldBe 1
     sink.size shouldBe 1
-    sink.reachableByFlows(source).size shouldBe 1
+    val flows = sink.reachableByFlows(source).l
+    flows.size shouldBe 1
+    flows.head.elements.head match {
+      case member: Member =>
+        member.name shouldBe "x"
+      case _ => fail
+    }
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -82,4 +82,23 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     sink.reachableByFlows(source).size shouldBe 1
   }
 
+  "flow from instance variable in constructor (MEMBER) to sink" in {
+
+    val cpg: Cpg = code("""
+        |class Foo:
+        |    def __init__(self):
+        |        self.x = 'sensitive'
+        |
+        |    def foo(self):
+        |        a = sink(self.x)
+        |
+        |""".stripMargin)
+
+    val source = cpg.member(".*x.*").l
+    val sink   = cpg.call(".*sink").argument(1).l
+    source.size shouldBe 1
+    sink.size shouldBe 1
+    sink.reachableByFlows(source).size shouldBe 1
+  }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -75,6 +75,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |    def foo(self):
         |        a = sink(self.x)
         |""".stripMargin)
+
     val source = cpg.member(".*x.*").l
     val sink   = cpg.call(".*sink").argument(1).l
     source.size shouldBe 1

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -4,6 +4,8 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.nodemethods.AstNodeMethods.lastExpressionInBlock
+import io.shiftleft.semanticcpg.utils.MemberAccess
 import overflowdb.traversal.Traversal
 
 class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
@@ -78,5 +80,63 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
     */
   def ast: Traversal[AstNode] =
     Traversal.fromSingle(node).ast
+
+  /** Textual representation of AST node
+    */
+  def repr: String =
+    node match {
+      case method: Method                             => method.name
+      case member: Member                             => member.name
+      case methodReturn: MethodReturn                 => methodReturn.code
+      case expr: Expression                           => expr.code
+      case call: CallRepr if !call.isInstanceOf[Call] => call.code
+    }
+
+  def statement: AstNode =
+    statementInternal(node, _.parentExpression.get)
+
+  @scala.annotation.tailrec
+  private def statementInternal(node: AstNode, parentExpansion: Expression => Expression): AstNode = {
+
+    node match {
+      case node: Identifier => parentExpansion(node)
+      case node: MethodRef  => parentExpansion(node)
+      case node: TypeRef    => parentExpansion(node)
+      case node: Literal    => parentExpansion(node)
+
+      case member: Member          => member
+      case node: MethodParameterIn => node.method
+
+      case node: MethodParameterOut =>
+        node.method.methodReturn
+
+      case node: Call if MemberAccess.isGenericMemberAccessName(node.name) =>
+        parentExpansion(node)
+
+      case node: CallRepr     => node
+      case node: MethodReturn => node
+      case block: Block       =>
+        // Just taking the lastExpressionInBlock is not quite correct because a BLOCK could have
+        // different return expressions. So we would need to expand via CFG.
+        // But currently the frontends do not even put the BLOCK into the CFG so this is the best
+        // we can do.
+        statementInternal(lastExpressionInBlock(block).get, identity)
+      case node: Expression => node
+    }
+  }
+
+}
+
+object AstNodeMethods {
+
+  import scala.jdk.CollectionConverters._
+  private def lastExpressionInBlock(block: Block): Option[Expression] =
+    block._astOut.asScala
+      .collect {
+        case node: Expression if !node.isInstanceOf[Local] && !node.isInstanceOf[Method] => node
+      }
+      .toVector
+      .sortBy(_.order)
+      .lastOption
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -10,16 +10,6 @@ import scala.jdk.CollectionConverters._
 
 class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
-  /** Textual representation of CFG node
-    */
-  def repr: String =
-    node match {
-      case method: Method                             => method.name
-      case methodReturn: MethodReturn                 => methodReturn.code
-      case expr: Expression                           => expr.code
-      case call: CallRepr if !call.isInstanceOf[Call] => call.code
-    }
-
   /** Successors in the CFG
     */
   def cfgNext: Traversal[CfgNode] = {


### PR DESCRIPTION
Previously, we were able to track flows from class variables (Python's version of static members), but not from instance variables. This PR fixes that. Previously, these flows also did not start in the member variables, which they now do.