### PR TITLE
simplify pretty printing: Product.productElementName ftw

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.592"
+val cpgVersion = "1.3.592+1-b3c2ad9d"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.592+1-b3c2ad9d"
+val cpgVersion = "1.3.593"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -201,9 +201,7 @@ trait ScriptExecution {
   protected def startInteractiveShell(config: Config, slProduct: SLProduct): (Res[Any], Seq[(Watchable, Long)]) = {
     val configurePPrinterMaybe =
       if (config.nocolors) ""
-      else """val originalPPrinter = repl.pprinter()
-             |repl.pprinter.update(io.joern.console.pprinter.create(originalPPrinter))
-             |""".stripMargin
+      else "repl.pprinter.update(io.joern.console.pprinter.create())"
 
     val replConfig = List(
       "repl.prompt() = \"" + promptStr() + "\"",

--- a/console/src/main/scala/io/joern/console/PPrinter.scala
+++ b/console/src/main/scala/io/joern/console/PPrinter.scala
@@ -1,8 +1,6 @@
 package io.joern.console
 
-import io.shiftleft.codepropertygraph.generated.nodes
 import pprint.{PPrinter, Renderer, Result, Tree, Truncated}
-
 import scala.util.matching.Regex
 
 object pprinter {
@@ -25,8 +23,8 @@ object pprinter {
         "\u001b[$1;$2;$3m"
       ) // `[00;38;05;70m` is encoded as `[38;5;70m` in fansi - 8bit color encoding
 
-  def create(original: PPrinter): PPrinter =
-    new PPrinter(defaultHeight = 99999, additionalHandlers = myAdditionalHandlers(original)) {
+  def create(): PPrinter =
+    new PPrinter(defaultHeight = 99999) {
       override def tokenize(
         x: Any,
         width: Int = defaultWidth,
@@ -50,20 +48,4 @@ object pprinter {
       }
     }
 
-  private def myAdditionalHandlers(original: PPrinter): PartialFunction[Any, Tree] = { case node: nodes.StoredNode =>
-    Tree.Apply(
-      node.productPrefix,
-      Iterator.range(0, node.productArity).map { n =>
-        Tree.Infix(
-          Tree.Literal(node.productElementLabel(n)),
-          "->",
-          original.treeify(
-            node.productElement(n),
-            escapeUnicode = original.defaultEscapeUnicode,
-            showFieldNames = original.defaultShowFieldNames
-          )
-        )
-      }
-    )
-  }
 }

--- a/console/src/test/scala/io/joern/console/PPrinterTest.scala
+++ b/console/src/test/scala/io/joern/console/PPrinterTest.scala
@@ -1,5 +1,6 @@
 package io.joern.console
 
+import fansi.Color
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -8,6 +9,69 @@ import org.scalatest.wordspec.AnyWordSpec
   * these standard encodings out of the box
   */
 class PPrinterTest extends AnyWordSpec with Matchers {
+
+  "a regular List" in {
+    val pp = pprinter.create()
+    pp(List(1, 2, 3)).plainText shouldBe "List(1, 2, 3)"
+    pp(List(1, 2, 3)) shouldBe fansi.Str.join(
+      Seq(
+        Color.Yellow("List"),
+        Color.Reset("("),
+        Color.Green("1"),
+        Color.Reset(", "),
+        Color.Green("2"),
+        Color.Reset(", "),
+        Color.Green("3"),
+        Color.Reset(")"),
+      ))
+  }
+
+  "a case class" in {
+    val pp = pprinter.create()
+    case class Foo(i: Int, s: String)
+    pp(Foo(42, "bar")).plainText shouldBe """Foo(i = 42, s = "bar")"""
+    pp(Foo(42, "bar")) shouldBe fansi.Str.join(
+      Seq(
+        Color.Yellow("Foo"),
+        Color.Reset("(i = "),
+        Color.Green("42"),
+        Color.Reset(", s = "),
+        Color.Green("\"bar\""),
+        Color.Reset(")"),
+      ))
+  }
+
+  "a Product with productElementNames" in {
+    val pp = pprinter.create()
+
+    val product = new Product {
+      def canEqual(that: Any): Boolean = false
+      def productArity: Int = 2
+      def productElement(n: Int): Any = {
+        n match {
+          case 0 => 42
+          case 1 => "println(foo)"
+        }
+      }
+      override def productElementName(n: Int): String = {
+        n match {
+          case 0 => "id"
+          case 1 => "code"
+        }
+      }
+    }
+
+    pp(product).plainText shouldBe """(id = 42, code = "println(foo)")"""
+    pp(product) shouldBe fansi.Str.join(
+      Seq(
+        Color.Reset("(id = "),
+        Color.Green("42"),
+        Color.Reset(", code = "),
+        Color.Green("\"println(foo)\""),
+        Color.Reset(")"),
+      ))
+  }
+
   // ansi colour-encoded strings as source-highlight produces them
   val IntGreenForeground = "\u001b[32mint\u001b[m"
   val IfBlueBold         = "\u001b[01;34mif\u001b[m"

--- a/console/src/test/scala/io/joern/console/PPrinterTest.scala
+++ b/console/src/test/scala/io/joern/console/PPrinterTest.scala
@@ -22,8 +22,9 @@ class PPrinterTest extends AnyWordSpec with Matchers {
         Color.Green("2"),
         Color.Reset(", "),
         Color.Green("3"),
-        Color.Reset(")"),
-      ))
+        Color.Reset(")")
+      )
+    )
   }
 
   "a case class" in {
@@ -37,8 +38,9 @@ class PPrinterTest extends AnyWordSpec with Matchers {
         Color.Green("42"),
         Color.Reset(", s = "),
         Color.Green("\"bar\""),
-        Color.Reset(")"),
-      ))
+        Color.Reset(")")
+      )
+    )
   }
 
   "a Product with productElementNames" in {
@@ -46,7 +48,7 @@ class PPrinterTest extends AnyWordSpec with Matchers {
 
     val product = new Product {
       def canEqual(that: Any): Boolean = false
-      def productArity: Int = 2
+      def productArity: Int            = 2
       def productElement(n: Int): Any = {
         n match {
           case 0 => 42
@@ -68,8 +70,9 @@ class PPrinterTest extends AnyWordSpec with Matchers {
         Color.Green("42"),
         Color.Reset(", code = "),
         Color.Green("\"println(foo)\""),
-        Color.Reset(")"),
-      ))
+        Color.Reset(")")
+      )
+    )
   }
 
   // ansi colour-encoded strings as source-highlight produces them

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -77,7 +77,7 @@ object Steps {
       { case _ => ??? },
       { case node: StoredNode =>
         val elementMap = (0 until node.productArity).map { i =>
-          val label   = node.productElementLabel(i)
+          val label   = node.productElementName(i)
           val element = node.productElement(i)
           label -> element
         }.toMap + ("_label" -> node.label)


### PR DESCRIPTION
Depends on overflowdb-codegen changes... Not sure about the exact history,
but I guess back in the days we simply didn't notice that
`Product.productElementName` exists, and therefor added
`StoredNode.productElementLabel` and tweaked the pretty printer in joern.
This can be done much simpler...

Also: some more tests