### PR TITLE
MethodStubCreator: Link Method to TypeDecl if Present

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -100,7 +100,6 @@ object MethodStubCreator {
       stub.fullName.substring(0, nameIdx - 1)
     } match {
       case Success(typeFullName) if !typeFullName.isBlank && !typeFullName.startsWith("<operator>") =>
-        println("Success", typeFullName)
         cpg.typeDecl
           .fullNameExact(typeFullName)
           .map { t => dstGraph.addEdge(t, stub, EdgeTypes.AST); t }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -40,8 +40,7 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
       (CallSummary(name, signature, fullName, dispatchType), parameterCount) <- methodToParameterCount
       if !methodFullNameToNode.contains(fullName)
     ) {
-      val stub = createMethodStub(name, fullName, signature, dispatchType, parameterCount, dstGraph)
-//      linkToTypeDecl(cpg, stub, dstGraph)
+      createMethodStub(name, fullName, signature, dispatchType, parameterCount, dstGraph)
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -164,7 +164,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
   private def linkDynamicCall(call: Call, dstGraph: DiffGraphBuilder): Unit = {
     // This call linker requires a method full name entry
     if (call.methodFullName.equals("<empty>") || call.methodFullName.equals(DynamicCallUnknownFallName)) return
-    // Support for overloading
+    // Support for overriding
     resolveCallInSuperClasses(call)
 
     validM.get(call.methodFullName) match {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -154,7 +154,12 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
         .fullName
         .l
     if (candidateInheritedMethods.nonEmpty) {
-      validM.put(call.methodFullName, mutable.LinkedHashSet.from(candidateInheritedMethods))
+      validM.put(
+        call.methodFullName,
+        validM.getOrElse(call.methodFullName, mutable.LinkedHashSet.empty) ++ mutable.LinkedHashSet.from(
+          candidateInheritedMethods
+        )
+      )
       true
     } else {
       false


### PR DESCRIPTION
This will link the stubbed TYPE_DECL to the stubbed METHOD node by an AST edge, if present.

The aim of this change will allow us to traverse the type node from a method stub. e.g.
```scala
cpg.call.callee(NoResolve).definingTypeDecl.fullName.l
```

Contributes to #2224