### PR TITLE
use `.map` instead of `.fold` to improve readability

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -73,7 +73,7 @@ trait AstCreatorHelper { this: AstCreator =>
     Option(cdtAst.flattenLocationsToFile(node.getNodeLocations.lastOption.toArray)).map(_.asFileLocation())
 
   protected def fileName(node: IASTNode): String = {
-    val path = nullSafeFileLocation(node).fold(filename)(_.getFileName)
+    val path = nullSafeFileLocation(node).map(_.getFileName).getOrElse(filename)
     IOUtils.toRelativePath(path, config)
   }
 
@@ -212,7 +212,7 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   protected def nullSafeCode(node: IASTNode): String = {
-    Option(node).fold("")(nodeSignature)
+    Option(node).map(nodeSignature).getOrElse("")
   }
 
   protected def nullSafeAst(node: IASTExpression, argIndex: Int): Ast = {
@@ -226,7 +226,7 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   protected def nullSafeAst(node: IASTExpression): Ast =
-    Option(node).fold(Ast())(astForNode(_))
+    Option(node).map(astForNode).getOrElse(Ast())
 
   protected def nullSafeAst(node: IASTStatement, argIndex: Int = -1): Seq[Ast] = {
     Option(node).map(astsForStatement(_, argIndex)).getOrElse(Seq.empty)
@@ -255,7 +255,7 @@ trait AstCreatorHelper { this: AstCreator =>
           case f: CPPFunction if f.getDeclarations != null =>
             usingDeclarationMappings.getOrElse(
               fixQualifiedName(ASTStringUtil.getSimpleName(d.getName)),
-              f.getDeclarations.headOption.fold(f.getName)(n => ASTStringUtil.getSimpleName(n.getName))
+              f.getDeclarations.headOption.map(n => ASTStringUtil.getSimpleName(n.getName)).getOrElse(f.getName)
             )
           case f: CPPFunction if f.getDefinition != null =>
             usingDeclarationMappings.getOrElse(
@@ -274,9 +274,9 @@ trait AstCreatorHelper { this: AstCreator =>
       case cppClass: ICPPASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(cppClass.getName).isEmpty =>
         val name = cppClass.getParent match {
           case decl: IASTSimpleDeclaration =>
-            decl.getDeclarators.headOption.fold(uniqueName("composite_type", "", "")._1)(n =>
-              ASTStringUtil.getSimpleName(n.getName)
-            )
+            decl.getDeclarators.headOption
+              .map(n => ASTStringUtil.getSimpleName(n.getName))
+              .getOrElse(uniqueName("composite_type", "", "")._1)
           case _ => uniqueName("composite_type", "", "")._1
         }
         s"${fullName(cppClass.getParent)}.$name"
@@ -322,7 +322,7 @@ trait AstCreatorHelper { this: AstCreator =>
         val evaluation = d.getEvaluation.asInstanceOf[EvalBinding]
         evaluation.getBinding match {
           case f: CPPFunction if f.getDeclarations != null =>
-            f.getDeclarations.headOption.fold(f.getName)(n => ASTStringUtil.getSimpleName(n.getName))
+            f.getDeclarations.headOption.map(n => ASTStringUtil.getSimpleName(n.getName)).getOrElse(f.getName)
           case f: CPPFunction if f.getDefinition != null =>
             ASTStringUtil.getSimpleName(f.getDefinition.getName)
           case other =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -211,9 +211,9 @@ trait AstForFunctionsCreator { this: AstCreator =>
         )
       case s: IASTSimpleDeclaration =>
         (
-          s.getDeclarators.headOption.fold(uniqueName("parameter", "", "")._1)(n =>
-            ASTStringUtil.getSimpleName(n.getName)
-          ),
+          s.getDeclarators.headOption
+            .map(n => ASTStringUtil.getSimpleName(n.getName))
+            .getOrElse(uniqueName("parameter", "", "")._1),
           nodeSignature(s),
           cleanType(typeForDeclSpecifier(s)),
           false

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -95,7 +95,7 @@ class CdtParser(config: Config) extends ParseProblemsLogger with PreprocessorSta
         logger.info(s"Parsed '${t.getFilePath}' ($c preprocessor error(s), $p problems)")
         Option(t)
       case ParseResult(_, _, _, maybeThrowable) =>
-        logger.warn(s"Failed to parse '$file': ${maybeThrowable.fold("Unknown parse error!")(extractParseException)}")
+        logger.warn(s"Failed to parse '$file': ${maybeThrowable.map(extractParseException).getOrElse("Unknown parse error!")}")
         None
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -79,7 +79,7 @@ trait AstCreatorHelper { this: AstCreator =>
     usedVariableNames: mutable.HashMap[String, Int],
     variableName: String
   ): String = {
-    val counter             = usedVariableNames.get(variableName).fold(0)(_ + 1)
+    val counter             = usedVariableNames.get(variableName).map(_ + 1).getOrElse(0)
     val currentVariableName = s"${variableName}_$counter"
     usedVariableNames.put(variableName, counter)
     currentVariableName

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -117,7 +117,9 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       }
 
   private def extractExportFromNameFromExportDecl(declaration: BabelNodeInfo): String =
-    safeObj(declaration.json, "source").fold(ExportKeyword) { d => s"_${stripQuotes(code(d))}" }
+    safeObj(declaration.json, "source")
+      .map(d => s"_${stripQuotes(code(d))}")
+      .getOrElse(ExportKeyword)
 
   private def cleanImportName(name: String): String = if (name.contains("/")) {
     val stripped = name.stripSuffix("/")
@@ -662,7 +664,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     scope.addVariable(localTmpName, localNode, BlockScope)
     scope.addVariableReference(localTmpName, tmpNode)
 
-    val rhsAssignmentAst = paramName.fold(sourceAst)(createParamAst(pattern, _, sourceAst))
+    val rhsAssignmentAst = paramName.map(createParamAst(pattern, _, sourceAst)).getOrElse(sourceAst)
     val assignmentTmpCallAst =
       createAssignmentCallAst(
         Ast(tmpNode),

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
@@ -13,7 +13,9 @@ trait AstForTemplateDomCreator { this: AstCreator =>
     val openingAst   = astForNodeWithFunctionReference(jsxElem.json("openingElement"))
     val childrenAsts = astForNodes(jsxElem.json("children").arr.toList)
     val closingAst =
-      safeObj(jsxElem.json, "closingElement").fold(Ast())(e => astForNodeWithFunctionReference(Obj(e)))
+      safeObj(jsxElem.json, "closingElement")
+        .map(e => astForNodeWithFunctionReference(Obj(e)))
+        .getOrElse(Ast())
 
     val allChildrenAsts = openingAst +: childrenAsts :+ closingAst
     setArgumentIndices(allChildrenAsts)
@@ -35,7 +37,9 @@ trait AstForTemplateDomCreator { this: AstCreator =>
 
   protected def astForJsxAttribute(jsxAttr: BabelNodeInfo): Ast = {
     val domNode  = createTemplateDomNode(jsxAttr.node.toString, jsxAttr.code, jsxAttr.lineNumber, jsxAttr.columnNumber)
-    val valueAst = safeObj(jsxAttr.json, "value").fold(Ast())(e => astForNodeWithFunctionReference(Obj(e)))
+    val valueAst = safeObj(jsxAttr.json, "value")
+      .map(e => astForNodeWithFunctionReference(Obj(e)))
+      .getOrElse(Ast())
     setArgumentIndices(List(valueAst))
     Ast(domNode).withChild(valueAst)
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
@@ -54,7 +54,9 @@ class RequirePass(cpg: Cpg) extends CpgPass(cpg) {
     private val symbol: String = call.astParent.fieldAccess.fieldIdentifier.canonicalName.headOption.getOrElse("")
 
     private val dirHoldingModule: String =
-      call.file.name.headOption.fold("")(x => Paths.get(codeRoot, x).getParent.toAbsolutePath.normalize.toString)
+      call.file.name.headOption
+        .map(x => Paths.get(codeRoot, x).getParent.toAbsolutePath.normalize.toString)
+        .getOrElse("")
 
     private val fileToInclude: String = call
       .argument(1)
@@ -110,9 +112,9 @@ class RequirePass(cpg: Cpg) extends CpgPass(cpg) {
     /** The dynamic type hints attached to this variable. This assumes all nodes have the same property value at this
       * time.
       */
-    lazy val dynamicTypeHintFullName: Seq[String] = nodes.headOption.fold(IndexedSeq.empty[String])(
+    lazy val dynamicTypeHintFullName: Seq[String] = nodes.headOption.map(
       _.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, IndexedSeq.empty[String])
-    )
+    ).getOrElse(IndexedSeq.empty[String])
   }
 
   override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {


### PR DESCRIPTION
map is more specific and more widely used than the generalist `fold`,
which makes it easier to read, especially for readers who aren't so familiar with scala