### PR TITLE
JoernSlice: Usage Slicing

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -6,6 +6,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft"     %% "codepropertygraph" % Versions.cpg,
   "com.lihaoyi"      %% "requests"          % "0.7.1",
   "com.github.scopt" %% "scopt"             % "4.1.0",
+  "io.circe"         %% "circe-core"        % "0.14.4",
   "io.circe"         %% "circe-generic"     % "0.14.4",
   "org.reflections"   % "reflections"       % "0.10.2",
   "org.scalatest"    %% "scalatest"         % Versions.scalatest % Test

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
@@ -29,7 +29,7 @@ object JoernSlice {
     cpgFileName: File = File("cpg.bin"),
     outFile: File = File("slices"),
     sliceMode: SliceModes = DataFlow,
-    sourceFile: String = ".*",
+    sourceFile: Option[String] = None,
     sliceDepth: Int = 20,
     minNumCalls: Int = 1
   )
@@ -65,9 +65,9 @@ object JoernSlice {
         .text(s"the kind of slicing to perform - defaults to `DataFlow`. Options: [${SliceMode.values.mkString(", ")}]")
         .action((x, c) => c.copy(sliceMode = x))
       opt[String]("source-file")
-        .text("the name of the source file to generate slices from. This is interpretted as regex.")
+        .text("the name of the source file to generate slices from.")
         .optional()
-        .action((x, c) => c.copy(sourceFile = x))
+        .action((x, c) => c.copy(sourceFile = Some(x)))
       opt[Int]("slice-depth")
         .text(s"the max depth to traverse the DDG for the data-flow slice (for `DataFlow` mode) - defaults to 20.")
         .action((x, c) => c.copy(minNumCalls = x))

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
@@ -1,30 +1,46 @@
 package io.joern.joerncli
 
-import scala.util.Using
+import better.files.File
+import io.circe.generic.auto._
+import io.circe.syntax.EncoderOps
+import io.joern.joerncli.slicing._
+import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
 
-import scala.jdk.CollectionConverters._
-import io.joern.dataflowengineoss.language._
-import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.joerncli.console.Joern.semantics
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
-import overflowdb.Edge
+import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.language.postfixOps
+import scala.util.Using
+
+/** The kind of mode to use for slicing.
+  */
+object SliceMode extends Enumeration {
+  type SliceModes = Value
+  val DataFlow, Usages = Value
+}
 
 object JoernSlice {
-  case class Config(
-    cpgFileName: String = "cpg.bin",
-    outFile: String = "slice.bin",
-    sourceFile: String = "",
-    sourceLine: Int = -1
-  )
 
-  case class Slice(nodes: List[CfgNode], edges: Map[CfgNode, List[Edge]])
+  import io.joern.joerncli.SliceMode._
+
+  implicit val sliceModeRead: scopt.Read[SliceModes] =
+    scopt.Read.reads(SliceMode withName)
+
+  case class Config(
+    cpgFileName: File = File("cpg.bin"),
+    outFile: File = File("slices"),
+    sliceMode: SliceModes = DataFlow,
+    sourceFile: String = ".*",
+    sliceDepth: Int = 20,
+    minNumCalls: Int = 1
+  )
 
   def main(args: Array[String]) = {
     parseConfig(args).foreach { config =>
-      Using.resource(CpgBasedTool.loadFromOdb(config.cpgFileName)) { cpg =>
-        val slice = calculateSlice(cpg, config.sourceFile, config.sourceLine)
+      Using.resource(CpgBasedTool.loadFromOdb(config.cpgFileName.pathAsString)) { cpg =>
+        val slice: ProgramSlice = config.sliceMode match {
+          case DataFlow => DataFlowSlicing.calculateDataFlowSlice(cpg, config)
+          case Usages   => UsageSlicing.calculateUsageSlice(cpg, config)
+        }
         storeSliceInNewCpg(config.outFile, slice)
       }
     }
@@ -32,52 +48,67 @@ object JoernSlice {
 
   private def parseConfig(args: Array[String]): Option[Config] =
     new scopt.OptionParser[Config]("joern-slice") {
-      head("Extract intra-procedural backward slice for a line of code")
+      head("Extract intra-procedural slices from the CPG.")
       help("help")
-      arg[String]("sourcefile")
-        .text("The file holding the sink statement")
-        .action((x, c) => c.copy(sourceFile = x))
-      arg[String]("line")
-        .text("Line number of sink statement")
-        .action((x, c) => c.copy(sourceLine = x.toInt))
       arg[String]("cpg")
         .text("input CPG file name - defaults to `cpg.bin`")
         .optional()
-        .action((x, c) => c.copy(cpgFileName = x))
+        .action { (x, c) =>
+          val path = File(x)
+          if (!path.isRegularFile) failure(s"File at '$x' not found or not regular, e.g. a directory.")
+          c.copy(cpgFileName = path)
+        }
       opt[String]('o', "out")
-        .text("output CPG file")
-        .action((x, c) => c.copy(outFile = x))
+        .text("the output file to write slices to - defaults to `slices`. The file is suffixed based on the mode.")
+        .action((x, c) => c.copy(outFile = File(x)))
+      opt[SliceModes]('m', "mode")
+        .text(s"the kind of slicing to perform - defaults to `DataFlow`. Options: [${SliceMode.values.mkString(", ")}]")
+        .action((x, c) => c.copy(sliceMode = x))
+      opt[String]("source-file")
+        .text("the name of the source file to generate slices from. This is interpretted as regex.")
+        .optional()
+        .action((x, c) => c.copy(sourceFile = x))
+      opt[Int]("slice-depth")
+        .text(s"the max depth to traverse the DDG for the data-flow slice (for `DataFlow` mode) - defaults to 20.")
+        .action((x, c) => c.copy(minNumCalls = x))
+      opt[Int]("min-num-calls")
+        .text(s"the minimum number of calls required for a usage slice (for `Usage` mode) - defaults to 1.")
+        .action((x, c) => c.copy(minNumCalls = x))
+
     }.parse(args, Config())
 
-  private def calculateSlice(cpg: Cpg, sourceFile: String, sourceLine: Int): Slice = {
-    val sinks = cpg.file.nameExact(sourceFile).ast.lineNumber(sourceLine).isCall.argument.l
+  private def storeSliceInNewCpg(outFile: File, programSlice: ProgramSlice): Unit = {
 
-    implicit val context: EngineContext = EngineContext()
-    val sliceNodes                      = sinks.repeat(_.ddgIn)(_.maxDepth(20).emit).dedup.l
-    val sliceEdges = sliceNodes
-      .flatMap(_.outE)
-      .filter(x => sliceNodes.contains(x.inNode()))
-      .groupBy(_.outNode().asInstanceOf[CfgNode])
-    Slice(sliceNodes, sliceEdges)
-  }
-
-  private def storeSliceInNewCpg(outFile: String, slice: Slice): Unit = {
-    val newCpg = Cpg.withStorage(outFile)
-    val graph  = newCpg.graph
-    slice.nodes.foreach { node =>
-      val keyValueSequence = node.propertiesMap().asScala.toList.flatMap { case (k, v) => List[Any](k, v) }
-      graph.addNode(node.id(), node.label, keyValueSequence: _*)
-    }
-    slice.nodes.foreach { node =>
-      val outNode = graph.node(node.id())
-      slice.edges.get(node).toList.foreach { edges =>
-        edges.foreach { edge =>
-          val inNode = graph.node(edge.inNode().id())
-          outNode.addEdge(edge.label, inNode)
+    def storeDataFlowSlices(cpg: Cpg, slices: Set[DataFlowSlice]): Unit = {
+      val graph = cpg.graph
+      slices.foreach { slice =>
+        slice.nodes.foreach { node =>
+          val keyValueSequence = node.propertiesMap().asScala.toList.flatMap { case (k, v) => List[Any](k, v) }
+          if (Option(graph.node(node.id())).isEmpty) graph.addNode(node.id(), node.label, keyValueSequence: _*)
+        }
+        slice.nodes.foreach { node =>
+          val outNode = graph.node(node.id())
+          slice.edges.get(node).toList.foreach { edges =>
+            edges.foreach { edge =>
+              val inNode = graph.node(edge.inNode().id())
+              if (!outNode.out(edge.label()).exists(_.id().equals(inNode.id())))
+                outNode.addEdge(edge.label, inNode)
+            }
+          }
         }
       }
     }
-    newCpg.close()
+
+    programSlice match {
+      case ProgramDataFlowSlice(dataFlowSlices) =>
+        val sliceCpg = File(outFile.pathAsString + ".cpg").createFileIfNotExists()
+        Using.resource(Cpg.withStorage(sliceCpg.pathAsString)) { newCpg =>
+          storeDataFlowSlices(newCpg, dataFlowSlices.flatMap(_._2).toSet)
+        }
+      case programUsageSlice: ProgramUsageSlice =>
+        val sliceCpg = File(outFile.pathAsString + ".json").createFileIfNotExists()
+        sliceCpg.write(programUsageSlice.asJson.spaces2)
+    }
   }
 
 }

--- a/joern-cli/src/main/scala/io/joern/joerncli/slicing/DataFlowSlicing.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/slicing/DataFlowSlicing.scala
@@ -1,0 +1,29 @@
+package io.joern.joerncli.slicing
+
+import io.joern.dataflowengineoss.language._
+import io.joern.joerncli.JoernSlice.Config
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.Traversal
+
+object DataFlowSlicing {
+
+  def calculateDataFlowSlice(cpg: Cpg, config: Config): ProgramDataFlowSlice = {
+    val sliceMapping =
+      cpg.file(config.sourceFile).ast.isCall.groupBy(_.method).map { case (m: Method, calls: Traversal[Call]) =>
+        m.fullName -> calls.map { c =>
+          val sinks = c.argument.l
+
+          val sliceNodes = sinks.repeat(_.ddgIn)(_.maxDepth(config.sliceDepth).emit).dedup.l
+          val sliceEdges = sliceNodes
+            .flatMap(_.outE)
+            .filter(x => sliceNodes.contains(x.inNode()))
+            .groupBy(_.outNode().asInstanceOf[CfgNode])
+          DataFlowSlice(sliceNodes, sliceEdges)
+        }.toSet
+      }
+    ProgramDataFlowSlice(sliceMapping)
+  }
+
+}

--- a/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
@@ -6,6 +6,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.PropertyKey
+import overflowdb.traversal.Traversal
 
 import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
 import scala.jdk.CollectionConverters.IteratorHasAsScala
@@ -22,11 +23,12 @@ object UsageSlicing {
     *   a set of object slices.
     */
   def calculateUsageSlice(cpg: Cpg, config: Config): ProgramSlice = {
-    def getAssignmentDecl = cpg.file(config.sourceFile).assignment.argument(1).isIdentifier.refsTo
+    def getAssignmentDecl: Traversal[Declaration] =
+      cpg.file(config.sourceFile).assignment.argument(1).isIdentifier.refsTo
 
-    def getParameterDecl = cpg.file(config.sourceFile).ast.isParameter
+    def getParameterDecl: Traversal[MethodParameterIn] = cpg.file(config.sourceFile).ast.isParameter
 
-    def getDeclIdentifiers = getAssignmentDecl ++ getParameterDecl
+    def getDeclIdentifiers: Traversal[Declaration] = getAssignmentDecl ++ getParameterDecl
 
     ProgramUsageSlice(
       getDeclIdentifiers

--- a/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
@@ -93,8 +93,10 @@ object UsageSlicing {
           .l
       )
     }
-
-    cpg.typeDecl.filterNot(_.isExternal).map(generateUDT).l
+    cpg.typeDecl
+      .filterNot(t => t.isExternal || t.name.matches("(:program|<module>|<init>|<meta>|<body>)"))
+      .map(generateUDT)
+      .l
   }
 
   /** Given a node, if it is a call, will traverse the AST parent's children for a node with argument index 0.

--- a/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
@@ -1,0 +1,216 @@
+package io.joern.joerncli.slicing
+
+import io.joern.joerncli.JoernSlice.Config
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
+import io.shiftleft.semanticcpg.language._
+import overflowdb.PropertyKey
+
+import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+
+object UsageSlicing {
+
+  private val resolver = NoResolve
+
+  /** Generates object slices from the given CPG.
+    *
+    * @param cpg
+    *   the CPG to slice.
+    * @return
+    *   a set of object slices.
+    */
+  def calculateUsageSlice(cpg: Cpg, config: Config): ProgramSlice = {
+    def getAssignmentDecl = cpg.file(config.sourceFile).assignment.argument(1).isIdentifier.refsTo
+
+    def getParameterDecl = cpg.file(config.sourceFile).ast.isParameter
+
+    def getDeclIdentifiers = getAssignmentDecl ++ getParameterDecl
+
+    ProgramUsageSlice(
+      getDeclIdentifiers
+        .to(LazyList)
+        .par
+        .filter(a => atLeastNCalls(a, config.minNumCalls))
+        .flatMap(trackUsage)
+        .groupBy { case (scope, _) => scope }
+        .mapValues(_.l.map { case (_, slice) => slice }.toSet)
+        .toMap
+        .l
+        .toMap,
+      userDefinedTypes(cpg)
+    )
+  }
+
+  private def getInCallsForReferencedIdentifiers(decl: Declaration): List[Call] = decl
+    .flatMap {
+      case local: Local             => local.referencingIdentifiers
+      case param: MethodParameterIn => param.referencingIdentifiers
+      case _                        => Seq()
+    }
+    .inCall
+    .dedup
+    .toList
+
+  /** Returns true if the given declaration is found to have at least n non-operator calls within its referenced
+    * identifiers' scope.
+    *
+    * @param decl
+    *   the declaration to check.
+    * @param n
+    *   number of calls.
+    * @return
+    *   true if the call count condition is satisfied.
+    */
+  private def atLeastNCalls(decl: Declaration, n: Int): Boolean =
+    getInCallsForReferencedIdentifiers(decl)
+      .filterNot(s => s.name.startsWith("<operator>"))
+      .size >= n
+
+  /** Discovers internally defined types.
+    *
+    * @param cpg
+    *   the CPG to query for types.
+    * @return
+    *   a list of user defined types.
+    */
+  def userDefinedTypes(cpg: Cpg): List[UserDefinedType] = {
+
+    def generateUDT(typeDecl: TypeDecl): UserDefinedType = {
+      UserDefinedType(
+        typeDecl.fullName,
+        typeDecl.member.map(DefComponent.fromNode).l,
+        typeDecl.method
+          .map(m => ObservedCall(None, m.name, m.parameter.map(_.typeFullName).toList, m.methodReturn.typeFullName))
+          .l
+      )
+    }
+
+    cpg.typeDecl.filterNot(_.isExternal).map(generateUDT).l
+  }
+
+  /** Given a node, if it is a call, will traverse the AST parent's children for a node with argument index 0.
+    *
+    * @param node
+    *   the node, which should be a call
+    * @return
+    *   the call receiver, if found.
+    */
+  private def getCallReceiver(node: StoredNode): Option[StoredNode] = {
+    val argKey = new PropertyKey[Int](PropertyNames.ARGUMENT_INDEX)
+    node match {
+      case x: Call if Operators.fieldAccess.equals(x.name) =>
+        x.astParent._argumentOut.asScala.find(n => n.property(argKey, -1) == 0)
+      case x: Call => x.argumentOut.find(n => n.property(argKey, -1) == 0)
+      case _       => None
+    }
+  }
+
+  private def trackUsage(tgt: Declaration): Option[(String, ObjectUsageSlice)] = {
+
+    /** Will attempt to get the API call from the expression if this is a procedure call.
+      *
+      * @param expr
+      *   the expression to extract the API call from.
+      * @return
+      *   an API call if present.
+      */
+    def exprToObservedCall(expr: Expression): Option[ObservedCall] = {
+      val nameKey            = new PropertyKey[String](PropertyNames.NAME)
+      val isMemberInvocation = expr.property(nameKey, Operators.fieldAccess).equals(Operators.fieldAccess)
+      // Handle the case where a call is an invocation of a field member (lambda) or function/method call
+      val callName: Option[String] =
+        if (isMemberInvocation)
+          expr.argumentOut.flatMap {
+            case x: FieldIdentifier => Option(x.code)
+            case x: Call            => Option(x.name)
+            case _                  => None
+          }.headOption
+        else
+          Option(expr.property(nameKey))
+
+      if (callName.isEmpty) return None
+
+      val receiverName = getCallReceiver(expr).flatMap(rec => Option(rec.property(nameKey)))
+
+      val params = (if (isMemberInvocation) expr.astParent.astChildren else expr.argumentOut)
+        .collect { case n: AstNode if n.property(PropertyNames.ARGUMENT_INDEX, -1) > 0 => n }
+        .flatMap {
+          case _: MethodRef => Option("LAMBDA")
+          case x: StoredNode =>
+            Option(
+              x.property(
+                PropertyNames.TYPE_FULL_NAME,
+                x.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq("UNKNOWN")).headOption
+              )
+            )
+        }
+        .collect { case x: String => x }
+        .toList
+      // Not sure how we can get the return type unless it's typescript or we can resolve the callee?
+      val returnType = expr.argumentOut
+        .flatMap {
+          case x: Call => x.callee(resolver).methodReturn.typeFullName.headOption
+          case _       => None
+        }
+        .headOption
+        .getOrElse("ANY")
+
+      Option(ObservedCall(receiverName, callName.get, params, returnType))
+    }
+
+    def partitionInvolvementInCalls: (List[ObservedCall], List[(ObservedCall, Int)]) = {
+      val (invokedCalls, argToCalls) = getInCallsForReferencedIdentifiers(tgt)
+        .filterNot(_.name.startsWith("<operator>"))
+        .map(c => (c, c.argument.find(p => p.code.equals(tgt.name)).map(_.argumentIndex).getOrElse(-1)))
+        .partition { case (_, argIdx) => argIdx == 0 }
+      (
+        invokedCalls.map(_._1).flatMap((expr: Expression) => exprToObservedCall(expr)).reverse,
+        argToCalls.flatMap { case (c: Call, argAt: Int) =>
+          exprToObservedCall(c).map(oc => (oc, argAt))
+        }.reverse
+      )
+    }
+
+    val defNode = tgt match {
+      case local: Local =>
+        local.referencingIdentifiers.inCall.astParent.assignment
+          .where(_.argument(1).code(tgt.name))
+          .argument(2)
+          .headOption
+      case x => Some(x)
+    }
+
+    (tgt, defNode, partitionInvolvementInCalls) match {
+      // Case 1: Generated by variable assignment
+      case (local: Local, Some(genCall: Call), (invokedCalls, argToCalls)) if !genCall.name.equals("require") =>
+        Option(
+          (
+            local.method.fullName.head,
+            ObjectUsageSlice(
+              targetObj = DefComponent.fromNode(local),
+              definedBy = Option(DefComponent.fromNode(genCall)),
+              invokedCalls = invokedCalls,
+              argToCalls = argToCalls
+            )
+          )
+        )
+      // Case 2: Generated by incoming parameter
+      case (param: MethodParameterIn, _, (invokedCalls, argToCalls)) if !param.name.matches("(this|self)") =>
+        Option(
+          (
+            param.method.fullName,
+            ObjectUsageSlice(
+              targetObj = DefComponent.fromNode(param),
+              definedBy = Option(DefComponent.fromNode(param)),
+              invokedCalls = invokedCalls,
+              argToCalls = argToCalls
+            )
+          )
+        )
+      case _ => None
+    }
+  }
+
+}

--- a/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
@@ -23,10 +23,15 @@ object UsageSlicing {
     *   a set of object slices.
     */
   def calculateUsageSlice(cpg: Cpg, config: Config): ProgramSlice = {
-    def getAssignmentDecl: Traversal[Declaration] =
-      cpg.file(config.sourceFile).assignment.argument(1).isIdentifier.refsTo
+    def getAssignmentDecl: Traversal[Declaration] = (config.sourceFile match {
+      case Some(fileName) => cpg.file.nameExact(fileName).assignment
+      case None           => cpg.assignment
+    }).argument(1).isIdentifier.refsTo
 
-    def getParameterDecl: Traversal[MethodParameterIn] = cpg.file(config.sourceFile).ast.isParameter
+    def getParameterDecl: Traversal[MethodParameterIn] = config.sourceFile match {
+      case Some(fileName) => cpg.file.nameExact(fileName).ast.isParameter
+      case None           => cpg.parameter
+    }
 
     def getDeclIdentifiers: Traversal[Declaration] = getAssignmentDecl ++ getParameterDecl
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/slicing/package.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/slicing/package.scala
@@ -1,0 +1,142 @@
+package io.joern.joerncli
+
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Literal, StoredNode}
+import overflowdb.Edge
+
+package object slicing {
+
+  /** A trait for all objects that represent a 1:1 relationship between the CPG and all the slices extracted.
+    */
+  sealed trait ProgramSlice
+
+  /** A data-flow slice vector for a given backwards intraprocedural path.
+    *
+    * @param nodes
+    *   the nodes in the slice.
+    * @param edges
+    *   a map linking nodes with their edges.
+    */
+  case class DataFlowSlice(nodes: List[CfgNode], edges: Map[CfgNode, List[Edge]])
+
+  /** The data-flow slices for the program grouped by procedure.
+    *
+    * @param dataFlowSlices
+    *   the mapped slices.
+    */
+  case class ProgramDataFlowSlice(dataFlowSlices: Map[String, Set[DataFlowSlice]]) extends ProgramSlice
+
+  /** A usage slice of an object at the start of its definition until its final usage.
+    *
+    * @param targetObj
+    *   the name and type of the focus object.
+    * @param definedBy
+    *   the name of the call, identifier, or literal that defined the target object, if available.
+    * @param invokedCalls
+    *   calls this object is observed to call.
+    * @param argToCalls
+    *   the calls this object is observed to be an argument of.
+    */
+  case class ObjectUsageSlice(
+    targetObj: DefComponent,
+    definedBy: Option[DefComponent],
+    invokedCalls: List[ObservedCall],
+    argToCalls: List[(ObservedCall, Int)]
+  ) {
+    override def toString: String =
+      s"""# definition
+         |$targetObj${definedBy.map(p => s" = $p").getOrElse("")}
+         |# invoked calls
+         |${invokedCalls.mkString("\n")}
+         |# argument in the following calls
+         |${argToCalls.map { case (callArg: ObservedCall, idx: Int) => s"$callArg at param $idx" }.mkString("\n")}
+         |""".stripMargin
+  }
+
+  /** Represents a component that carries data. This could be an identifier of a variable or method and supplementary
+    * type information, if available.
+    *
+    * @param name
+    *   the name of the object or method call.
+    * @param typeFullName
+    *   the type full name.
+    * @param literal
+    *   if this object represents a literal or not.
+    */
+  case class DefComponent(name: String, typeFullName: String, literal: Boolean = false) {
+    override def toString: String = s"$name" +
+      (if (typeFullName.nonEmpty) s": $typeFullName" else "") +
+      (if (literal) " [LITERAL]" else "")
+  }
+
+  object DefComponent {
+
+    /** Attempts to generate an [[DefComponent]] from the given CPG node.
+      *
+      * @param node
+      *   the CPG node.
+      * @return
+      *   an ID type pair with default values "UNKNOWN" if the respective properties for [[DefComponent]] could not be
+      *   extracted.
+      */
+    def fromNode(node: StoredNode): DefComponent = {
+      DefComponent(
+        node.property(PropertyNames.NAME, node.property(PropertyNames.CODE, "UNKNOWN")),
+        node.property(PropertyNames.TYPE_FULL_NAME) match {
+          case "ANY" =>
+            val typeHints = node.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq.empty[String])
+            if (typeHints.size == 1) typeHints.head
+            else "ANY"
+          case other: String => other
+          case _             => "ANY"
+        },
+        node.label.equals(Literal.Label)
+      )
+    }
+  }
+
+  /** Details related to an observed call.
+    *
+    * @param receiver
+    *   the name of the receiver, if available.
+    * @param callName
+    *   the name of the call.
+    * @param paramTypes
+    *   the observed parameter types.
+    * @param returnType
+    *   the observed return type.
+    */
+  case class ObservedCall(
+    receiver: Option[String] = None,
+    callName: String,
+    paramTypes: List[String],
+    returnType: String
+  ) {
+    override def toString: String =
+      s"${receiver.map(f => f + ".").getOrElse("")}$callName(${paramTypes.mkString(",")}):$returnType"
+  }
+
+  /** Describes types defined within the application.
+    *
+    * @param name
+    *   name of the type.
+    * @param fields
+    *   the static or object fields.
+    * @param procedures
+    *   defined, named procedures within the type.
+    */
+  case class UserDefinedType(name: String, fields: List[DefComponent], procedures: List[ObservedCall])
+
+  /** The program usage slices and UDTs.
+    *
+    * @param objectSlices
+    *   the object slices under each procedure
+    * @param userDefinedTypes
+    *   the UDTs.
+    */
+  case class ProgramUsageSlice(
+    objectSlices: Map[String, Set[ObjectUsageSlice]],
+    userDefinedTypes: List[UserDefinedType]
+  ) extends ProgramSlice
+
+}


### PR DESCRIPTION
- Refactored `joern-slice` to support multiple "modes"
- The old version is DataFlow mode. This now produces slices for all calls in a given file.
- The new mode is Usage mode. This extracts calls that identifiers for a declaration are callers or arguments for.
- Separated two modes under `slicing` package.
- Added circe for JSON serialization of usage slices.

New help screen:

```
Extract intra-procedural slices from the CPG.
Usage: joern-slice [options] [cpg]

  --help
  cpg                      input CPG file name - defaults to `cpg.bin`
  -o, --out <value>        the output file to write slices to - defaults to `slices`. The file is suffixed based on the mode.
  -m, --mode <value>       the kind of slicing to perform - defaults to `DataFlow`. Options: [DataFlow, Usages]
  --source-file <value>    the name of the source file to generate slices from. This is interpretted as regex.
  --slice-depth <value>    the max depth to traverse the DDG for the data-flow slice (for `DataFlow` mode) - defaults to 20.
  --min-num-calls <value>  the minimum number of calls required for a usage slice (for `Usage` mode) - defaults to 1.
```