### PR TITLE
gh actions: disable cache from setup-java plugin that doesn't to work

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'sbt'
       - name: Compile and run tests
         run: sbt clean +test
   formatting:
@@ -30,7 +29,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'sbt'
       - name: Check formatting
         run: sbt ++2.13.8 scalafmtCheck test:scalafmtCheck
       - run: echo "Previous step failed because code is not formatted. Run 'sbt scalafmt Test/scalafmt'"
@@ -46,7 +44,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'sbt'
       - run: ./testDistro.sh
       - run: |
           mkdir /tmp/foo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'sbt'
       - run: sudo apt update && sudo apt install -y gnupg
       - run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'sbt'
       - name: Install php deps for php2cpg
         run: joern-cli/frontends/php2cpg/bin/installdeps.sh
       - name: Upgrade all (internal) dependencies


### PR DESCRIPTION
the newly added cache-action seems to work:

https://github.com/joernio/joern/actions/runs/4244917158/jobs/7379717333

```
coursier cache keys:
  coursier-release-4cbd9c71ea3856573ad5d756bdf282076d91db81
  coursier-release-
  coursier-
Received 75497472 of 682483443 (11.1%), 72.0 MBs/sec
Received 285212672 of 682483443 (41.8%), 136.0 MBs/sec
Received 494927872 of 682483443 (72.5%), 157.3 MBs/sec
Received 674094835 of 682483443 (98.8%), 160.6 MBs/sec
Received 682483443 of 682483443 (100.0%), 143.5 MBs/sec
Cache Size: ~651 MB (682483443 B)
/usr/bin/tar -xf /home/runner/work/_temp/f87eb0a6-de24-4145-a8a4-8e3dd48e919b/cache.tgz -P -C /home/runner/work/joern/joern -z
Cache restored successfully
coursier cache miss, fell back on coursier-release-41b508109eb9fd2c21f2db507f6c286db11483fc.
coursier cache will be saved in post run job.
  
sbt-ivy2-cache cache keys:
  sbt-ivy2-cache-release-c8a865ed922f8ac359c8b2ad26e2a79ddbd8f5e9
  sbt-ivy2-cache-release-
  sbt-ivy2-cache-
Received 159383552 of 208012399 (76.6%), 152.0 MBs/sec
Received 208012399 of 208012399 (100.0%), 132.6 MBs/sec
Cache Size: ~198 MB (208012399 B)
/usr/bin/tar -xf /home/runner/work/_temp/24da9c49-774f-4614-9e95-08ee70f662ee/cache.tgz -P -C /home/runner/work/joern/joern -z
Cache restored successfully
sbt-ivy2-cache cache miss, fell back on sbt-ivy2-cache-release-eb79ac0a4ebe651a47539e5c608ad40ed8346d45.
sbt-ivy2-cache cache will be saved in post run job.
  
ammonite cache keys:
  ammonite-release-5e417304af0254403378013ed10d766e65e6a243
  ammonite-release-
  ammonite-
Received 56029044 of 56029044 (100.0%), 86.9 MBs/sec
Cache Size: ~53 MB (56029044 B)
/usr/bin/tar -xf /home/runner/work/_temp/8f3f00c5-bd87-4edd-9226-82261c814e02/cache.tgz -P -C /home/runner/work/joern/joern -z
Cache restored successfully
ammonite cache hit.
ammonite cache will not be saved in post run job.
```