### PR TITLE
don't upgrade antlr

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,5 +4,6 @@ updates.ignore = [
   { groupId = "org.jetbrains.kotlin", artifactId = "kotlin-stdlib" },
   { groupId = "org.jetbrains.kotlin", artifactId = "kotlin-compiler-embeddable" },
   { groupId = "org.jetbrains.kotlin", artifactId = "kotlin-allopen" },
-  { groupId = "org.antlr", artifactId = "antlr4-runtime" }
+  { groupId = "org.antlr", artifactId = "antlr4-runtime" },
+  { groupId = "org.antlr", artifactId = "antlr4" }
 ]


### PR DESCRIPTION
As per comment in project/Versions.scala:
Dont upgrade antlr to 4.10 or above since those versions require java 11 or higher which
causes problems upstreams.