### PR TITLE
pysrc2cpg: Determine if a Field Access is a Method Ref

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -90,7 +90,7 @@ class RecoverForPythonFile(
         val pyFile        = absPath.map(a => Paths.get(a.toString + ".py"))
         fileOrDir match {
           case Some(f) if f.isDirectory && !pyFile.exists { p => better.files.File(p).exists } =>
-            s"${path.replaceAll("\\.", sep)}/$funcOrModule.py:<module>"
+            s"${path.replaceAll("\\.", sep)}${java.io.File.separator}$funcOrModule.py:<module>"
           case Some(f) if f.isDirectory && (f / s"$funcOrModule.py").exists =>
             s"${(f / s"$funcOrModule.py").pathAsString}:<module>"
           case _ =>

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -502,7 +502,9 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "recover its full name successfully" in {
       val List(methodFullName) = cpg.call("query").methodFullName.l
-      methodFullName shouldBe "data/db_session.py:<module>.create_session.<returnValue>.query"
+      methodFullName shouldBe Seq("data", "db_session.py:<module>.create_session.<returnValue>.query").mkString(
+        File.separator
+      )
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -506,4 +506,31 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
+  "recover a method ref from a field identifier" should {
+    lazy val cpg = code(
+      """
+        |from django.conf.urls import url
+        |
+        |from student import views
+        |
+        |urlpatterns = [
+        |    url(r'^addStudent/$', views.add_student)
+        |]
+        |""".stripMargin,
+      "urls.py"
+    ).moreCode(
+      """
+        |def add_student():
+        | pass
+        |""".stripMargin,
+      s"student${File.separator}views.py"
+    )
+
+    "recover the method full name related" in {
+      val Some(methodRef) = cpg.methodRef.code("views.add_student").headOption
+      methodRef.methodFullName shouldBe Seq("student", "views.py:<module>.add_student").mkString(File.separator)
+      methodRef.typeFullName shouldBe "<empty>"
+    }
+  }
+
 }


### PR DESCRIPTION
* Added another import condition that was missing a kind of import
* Added crude "addedNode" tracker to type recovery
* Using the type recovery, will determine if the field access corresponds to an internal method and will add a method ref to the parent node

Example of AST with new method ref for the test case in this PR:
![Screenshot 2023-03-01 at 10 51 43](https://user-images.githubusercontent.com/28294550/222092391-fd7f868f-73b4-4111-8d49-b66db6ba7b51.png)
