### PR TITLE
fix log4j/osgi error and massively trim classpath

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -1,6 +1,6 @@
 name := "joern-cli"
 
-dependsOn(Projects.console, Projects.console % "test->test", Projects.c2cpg, Projects.dataflowengineoss, Projects.x2cpg)
+dependsOn(Projects.console, Projects.console % "test->test", Projects.dataflowengineoss, Projects.x2cpg)
 
 libraryDependencies ++= Seq(
   "io.shiftleft"     %% "codepropertygraph" % Versions.cpg,

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -11,6 +11,27 @@ libraryDependencies ++= Seq(
   "org.scalatest"          %% "scalatest"                  % Versions.scalatest % Test
 )
 
+dependencyOverrides ++= Seq(
+  /* tl;dr; we'll stay on 2.19.0
+   * Full story: if we upgrade to 2.20.0 we run into the following osgi error:
+   *   Unknown error checking OSGI environment.
+   *   java.lang.reflect.InvocationTargetException
+   *     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+   *     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
+   *     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+   *     at java.base/java.lang.reflect.Method.invoke(Method.java:568)
+   *     at org.apache.logging.log4j.util.OsgiServiceLocator.checkOsgiAvailable(OsgiServiceLocator.java:39)
+   *   ...
+   *   Caused by: java.lang.NullPointerException: Cannot invoke "org.osgi.framework.BundleContext.getBundles()" because "context" is null
+   *     at com.diffplug.spotless.extra.eclipse.base.osgi.SimpleBundle.<init>(SimpleBundle.java:57)
+   *     at com.diffplug.spotless.extra.eclipse.base.osgi.SimpleBundle.<init>(SimpleBundle.java:49)
+   *     at com.diffplug.spotless.extra.eclipse.base.osgi.FrameworkBundleRegistry.getBundle(FrameworkBundleRegistry.java:47)
+   *     at org.osgi.framework.FrameworkUtil.lambda$5(FrameworkUtil.java:234)
+   */
+  "org.apache.logging.log4j" % "log4j-core" % "2.19.0" % Optional,
+  "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.19.0" % Optional,
+)
+
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)
 
 scalacOptions ++= Seq() ++ (


### PR DESCRIPTION
After upgrading log4j to 2.20.0 we got an OSGI error when
invoking *any* frontend, also logging didn't work.

This fixes this by removing c2cpg from the joern-cli classpath -
we invoke it via subprocess anyway, so there's really no reason to have it in the
classpath. c2cpg brings a lot of baggage from the OSGI world which
we'd rather avoid.

To fix the error for c2cpg we downgrade it's log4j version to 2.19.0.

Stacktrace:
```
Unknown error checking OSGI environment.
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.apache.logging.log4j.util.OsgiServiceLocator.checkOsgiAvailable(OsgiServiceLocator.java:39)
        at org.apache.logging.log4j.util.OsgiServiceLocator.<clinit>(OsgiServiceLocator.java:29)
        at org.apache.logging.log4j.util.ServiceLoaderUtil.loadServices(ServiceLoaderUtil.java:91)
        at org.apache.logging.log4j.util.PropertiesUtil$Environment.<init>(PropertiesUtil.java:466)
        at org.apache.logging.log4j.util.PropertiesUtil$Environment.<init>(PropertiesUtil.java:444)
        at org.apache.logging.log4j.util.PropertiesUtil.<init>(PropertiesUtil.java:88)
        at org.apache.logging.log4j.util.PropertiesUtil.<init>(PropertiesUtil.java:80)
        at org.apache.logging.log4j.util.PropertiesUtil.<clinit>(PropertiesUtil.java:56)
        at org.apache.logging.log4j.util.Constants.<clinit>(Constants.java:30)
        at org.apache.logging.log4j.spi.AbstractLogger.createClassForProperty(AbstractLogger.java:203)
        at org.apache.logging.log4j.spi.AbstractLogger.<clinit>(AbstractLogger.java:92)
        at org.apache.logging.slf4j.Log4jMarkerFactory.<clinit>(Log4jMarkerFactory.java:36)
        at org.apache.logging.slf4j.SLF4JServiceProvider.initialize(SLF4JServiceProvider.java:53)
        at org.slf4j.LoggerFactory.bind(LoggerFactory.java:183)
        at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:170)
        at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:455)
        at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:441)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:390)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:416)
        at io.joern.x2cpg.X2Cpg$.<clinit>(X2Cpg.scala:129)
        at io.joern.x2cpg.X2CpgMain.delayedEndpoint$io$joern$x2cpg$X2CpgMain$1(X2Cpg.scala:44)
        at io.joern.x2cpg.X2CpgMain$delayedInit$body.apply(X2Cpg.scala:36)
        at scala.Function0.apply$mcV$sp(Function0.scala:39)
        at scala.Function0.apply$mcV$sp$(Function0.scala:39)
        at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
        at scala.App.$anonfun$main$1(App.scala:76)
        at scala.App.$anonfun$main$1$adapted(App.scala:76)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
        at scala.App.main(App.scala:76)
        at scala.App.main$(App.scala:74)
        at io.joern.x2cpg.X2CpgMain.main(X2Cpg.scala:36)
        at io.joern.c2cpg.Main.main(Main.scala)
Caused by: java.lang.NullPointerException: Cannot invoke "org.osgi.framework.BundleContext.getBundles()" because "context" is null
        at com.diffplug.spotless.extra.eclipse.base.osgi.SimpleBundle.<init>(SimpleBundle.java:57)
        at com.diffplug.spotless.extra.eclipse.base.osgi.SimpleBundle.<init>(SimpleBundle.java:49)
        at com.diffplug.spotless.extra.eclipse.base.osgi.FrameworkBundleRegistry.getBundle(FrameworkBundleRegistry.java:47)
        at org.osgi.framework.FrameworkUtil.lambda$5(FrameworkUtil.java:234)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1602)
        at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
        at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
        at org.osgi.framework.FrameworkUtil.lambda$4(FrameworkUtil.java:237)
        at java.base/java.util.Optional.orElseGet(Optional.java:364)
        at org.osgi.framework.FrameworkUtil.getBundle(FrameworkUtil.java:233)
        ... 38 more
```