### PR TITLE
jimple2cpg: improvement for large Android apk loading

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -53,13 +53,16 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
 
   private val logger = LoggerFactory.getLogger(classOf[Jimple2Cpg])
 
-  def sootLoadApk(input: String, framework: String = null): Unit = {
+  def sootLoadApk(input: String, framework: Option[String] = None): Unit = {
     Options.v().set_process_dir(List(input).asJava)
-    if (framework != null && framework.nonEmpty) {
-      Options.v().set_src_prec(Options.src_prec_apk)
-      Options.v().set_force_android_jar(framework)
-    } else {
-      Options.v().set_src_prec(Options.src_prec_apk_c_j)
+    framework match {
+      case Some(value) => {
+        Options.v().set_src_prec(Options.src_prec_apk)
+        Options.v().set_force_android_jar(value)
+      }
+      case None => {
+        Options.v().set_src_prec(Options.src_prec_apk_c_j)
+      }
     }
     Options.v().set_process_multiple_dex(true)
     // workaround for Soot's bug while parsing large apk.

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -56,11 +56,11 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
   def sootLoadApk(input: String, framework: Option[String] = None): Unit = {
     Options.v().set_process_dir(List(input).asJava)
     framework match {
-      case Some(value) => {
+      case Some(value) if value.nonEmpty => {
         Options.v().set_src_prec(Options.src_prec_apk)
         Options.v().set_force_android_jar(value)
       }
-      case None => {
+      case _ => {
         Options.v().set_src_prec(Options.src_prec_apk_c_j)
       }
     }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -9,7 +9,7 @@ import scopt.OParser
 final case class Config(
   inputPath: String = "",
   outputPath: String = X2CpgConfig.defaultOutputPath,
-  android: String = null
+  android: Option[String] = None
 ) extends X2CpgConfig[Config] {
 
   override def withInputPath(inputPath: String): Config =
@@ -28,7 +28,7 @@ private object Frontend {
       programName("jimple2cpg"),
       opt[String]("android")
         .text("Optional path to android.jar while processing apk file.")
-        .action((android, config) => config.copy(android = android))
+        .action((android, config) => config.copy(android = Some(android)))
     )
   }
 }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -28,7 +28,7 @@ private object Frontend {
       programName("jimple2cpg"),
       opt[String]("android")
         .text("Optional path to android.jar while processing apk file.")
-        .action((android, config) => config.copy(android = Some(android)))
+        .action((android, config) => config.copy(android = Option(android)))
     )
   }
 }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -6,8 +6,11 @@ import scopt.OParser
 
 /** Command line configuration parameters
   */
-final case class Config(inputPath: String = "", outputPath: String = X2CpgConfig.defaultOutputPath)
-    extends X2CpgConfig[Config] {
+final case class Config(
+  inputPath: String = "",
+  outputPath: String = X2CpgConfig.defaultOutputPath,
+  android: String = null
+) extends X2CpgConfig[Config] {
 
   override def withInputPath(inputPath: String): Config =
     copy(inputPath = inputPath)
@@ -20,8 +23,13 @@ private object Frontend {
 
   val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
-    import builder.programName
-    OParser.sequence(programName("jimple2cpg"))
+    import builder._
+    OParser.sequence(
+      programName("jimple2cpg"),
+      opt[String]("android")
+        .text("Optional path to android.jar while processing apk file.")
+        .action((android, config) => config.copy(android = android))
+    )
   }
 }
 


### PR DESCRIPTION
This commit address two issues:

1. While loading Android apk with soot's `src_prec_apk_c_j`, it takes more time than `src_prec_apk`. In my experiment, It takes about 70s to process a modern (large, ~ 120MB, with ~ 100,000 classes) apk in `Scene.v().loadNecessaryClasses()`, however it only takes abount 7s, which is 10x faster, to process the same file with `src_prec_apk`. So I add an option to accept the path to `android.jar` to make it work.

2. When Soot creates JimpleBody for some methods, it may throws exception `StmtSwitch: type of throw argument is not a RefType`. This problem is discussed in https://github.com/soot-oss/soot/issues/1256, but AFAIK it's not yet fixed, so the workaround is to disable `jb.use-original-names` when processing apk, since in most cases there're no original names when dealing with bytecode anyway.