### PR TITLE
dataflowengineoss: Track flow from parent identifiers & parameters 

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -618,4 +618,35 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     sink.reachableBy(src2).size shouldBe 1
   }
 
+  "Flow correctly from parent scope to child function scope" in {
+    val cpg: Cpg = code("""
+        |function foo(u) {
+        |
+        |  const x = 1;
+        |
+        |  function bar() {
+        |     y = x;
+        |     console.log(y);
+        |     v = u;
+        |     console.debug(v);
+        |  }
+        |
+        |}""".stripMargin)
+
+    val sink1 = cpg.call("log").l
+    val sink2 = cpg.call("debug").l
+    sink1.size shouldBe 1
+    sink2.size shouldBe 1
+
+    val iSrc = cpg.method("foo").ast.isIdentifier.name("x").lineNumber(4).l
+
+    iSrc.size shouldBe 1
+    sink1.reachableBy(iSrc).size shouldBe 1
+
+    val pSrc = cpg.method("foo").parameter.nameExact("u").l
+
+    pSrc.size shouldBe 1
+    sink2.reachableBy(pSrc).size shouldBe 1
+  }
+
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -639,12 +639,14 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     sink2.size shouldBe 1
 
     val iSrc = cpg.method("foo").ast.isIdentifier.name("x").lineNumber(4).l
-
     iSrc.size shouldBe 1
     sink1.reachableBy(iSrc).size shouldBe 1
 
-    val pSrc = cpg.method("foo").parameter.nameExact("u").l
+    val lSrc = cpg.method("foo").ast.isLiteral.code("1").lineNumber(4).l
+    lSrc.size shouldBe 1
+    sink1.reachableBy(lSrc).size shouldBe 1
 
+    val pSrc = cpg.method("foo").parameter.nameExact("u").l
     pSrc.size shouldBe 1
     sink2.reachableBy(pSrc).size shouldBe 1
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -178,23 +178,19 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |accountId="sometext"
         |response = client.post_data(data, accountId)
         |""".stripMargin)
-    val source = cpg.identifier(".*url.*").l
-    val sink   = cpg.call("post").l
-    source.size shouldBe 2
+    val sourceUrlIdentifier = cpg.identifier(".*url.*").l
+    val sink                = cpg.call("post").l
+    sourceUrlIdentifier.size shouldBe 2
     sink.size shouldBe 1
-    val flows = sink.reachableByFlows(source).l
-    flows.size shouldBe 1
+    sink.reachableByFlows(sourceUrlIdentifier).size shouldBe 1
 
-    val sourcel = cpg.literal(".*app.commissionly.io.*").l
-    sourcel.size shouldBe 1
-
-    val flowsl = sink.reachableByFlows(source).l
-    flowsl.size shouldBe 1
+    val sourceUrlLiteral = cpg.literal(".*app.commissionly.io.*").l
+    sourceUrlLiteral.size shouldBe 1
+    sink.reachableByFlows(sourceUrlLiteral).size shouldBe 1
   }
 
   "Flow correctly from parent scope to child function scope" in {
-    val cpg: Cpg = code(
-      """
+    val cpg: Cpg = code("""
         |def foo(u):
         |
         |  x = 1
@@ -213,12 +209,14 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     sink2.size shouldBe 1
 
     val iSrc = cpg.method("foo").ast.isIdentifier.name("x").lineNumber(4).l
-
     iSrc.size shouldBe 1
     sink1.reachableBy(iSrc).size shouldBe 1
 
-    val pSrc = cpg.method("foo").parameter.nameExact("u").l
+    val lSrc = cpg.method("foo").ast.isLiteral.code("1").lineNumber(4).l
+    lSrc.size shouldBe 1
+    sink1.reachableBy(lSrc).size shouldBe 1
 
+    val pSrc = cpg.method("foo").parameter.nameExact("u").l
     pSrc.size shouldBe 1
     sink2.reachableBy(pSrc).size shouldBe 1
   }


### PR DESCRIPTION
* When determining starting points, check children methods for references to the identifier or parameter
* Added these if they match the name of the tracked node
* Added special case for literals to check if they are assigned to an LHS identifier