### PR TITLE
Fix: Create Sources from ClosureBindings over MethodRefs

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -83,7 +83,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       case x: Declaration =>
         List(x).collectAll[CfgNode].toList ++ identifiersFromCapturedScopes(x)
       case x: Identifier =>
-        List(x).collectAll[CfgNode].toList ++ x.refsTo.flatMap(sourceToStartingPoints)
+        List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
       case x => List(x).collect { case y: CfgNode => y }
     }
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -86,7 +86,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
 
   private def identifiersFromChildScopes(i: CfgNode): List[Identifier] = {
     val name = i.property(PropertyNames.NAME, i.code)
-    i.method.ast.isMethodRef.referencedMethod.ast.isIdentifier
+    i.method.ast.isIdentifier
       .nameExact(name)
       .sortBy(x => (x.lineNumber, x.columnNumber))
       .l

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -13,6 +13,7 @@ import io.shiftleft.semanticcpg.language.nodemethods._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{
   AstNodeTraversal,
   CfgNodeTraversal,
+  DeclarationTraversal,
   ExpressionTraversal
 }
 import io.shiftleft.semanticcpg.language.types.expressions.{CallTraversal => OriginalCall, _}
@@ -271,4 +272,9 @@ trait LowPrioImplicits extends overflowdb.traversal.Implicits {
     new AstNodeTraversal[A](Traversal.fromSingle(a))
   implicit def iterOnceToAstNodeTraversal[A <: AstNode](a: IterableOnce[A]): AstNodeTraversal[A] =
     new AstNodeTraversal[A](iterableToTraversal(a))
+
+  implicit def singleToDeclarationNodeTraversal[A <: Declaration](a: A): DeclarationTraversal[A] =
+    new DeclarationTraversal[A](Traversal.fromSingle(a))
+  implicit def iterOnceToDeclarationNodeTraversal[A <: Declaration](a: IterableOnce[A]): DeclarationTraversal[A] =
+    new DeclarationTraversal[A](iterableToTraversal(a))
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/DeclarationTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/DeclarationTraversal.scala
@@ -1,0 +1,23 @@
+package io.shiftleft.semanticcpg.language.types.expressions.generalizations
+
+import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Declaration, MethodRef}
+import overflowdb.traversal.{Traversal, help, jIteratortoTraversal}
+
+/** A declaration, such as a local or parameter.
+  */
+@help.Traversal(elementType = classOf[Declaration])
+class DeclarationTraversal[NodeType <: Declaration](val traversal: Traversal[NodeType]) extends AnyVal {
+
+  /** The closure binding node referenced by this declaration
+    */
+  def closureBinding: Traversal[ClosureBinding] = traversal.flatMap(_._refIn).collectAll[ClosureBinding]
+
+  /** Methods that capture this declaration
+    */
+  def capturedByMethodRef: Traversal[MethodRef] = closureBinding.flatMap(_._captureIn).collectAll[MethodRef]
+
+  /** Types that capture this declaration
+    */
+  def capturedByTypeRef: Traversal[MethodRef] = closureBinding.flatMap(_._captureIn).collectAll[MethodRef]
+
+}


### PR DESCRIPTION
The nodes and edges of `ClosureBinding` and `CAPTURE` hold the information containing which parent identifiers are associated with which child identifiers in children scopes.

* Added `DeclarationTraversal` to centralize the ability to use `CAPTURE` and `CLOSURE_BINDING` properties
* Leverage these properties instead of naively traversing child methods