### PR TITLE
JoernSlice: Extract Usage Slice Across Closure Bounds

### DIFF
--- a/joern-cli/src/test/resources/testcode/jssrc-slice/main.js
+++ b/joern-cli/src/test/resources/testcode/jssrc-slice/main.js
@@ -12,7 +12,9 @@ app.listen(port, () => {
 
 console.log(app)
 
-console.debug(app)
+function notHiddenByClosure() {
+    console.debug(app)
+}
 
 class Car {
     constructor(name, year) {


### PR DESCRIPTION
* Using `capturedByMethodRef` to find related local vars in other scopes
* Ordering calls in the slice by line/col number