### PR TITLE
if cpggenerator.generate fails: keep the exception, so we can report it

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 /** C/C++ language frontend that translates C/C++ source files into code property graphs using Eclipse CDT parsing /
   * preprocessing.
@@ -16,9 +17,9 @@ case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGene
     inputPath: String,
     outputPath: String = "cpg.bin",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 /** C# language frontend. Translates C# project files into code property graphs.
   */
@@ -14,7 +15,7 @@ case class CSharpCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
     inputPath: String,
     outputPath: String = "cpg.bin.zip",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     var arguments = Seq("-i", inputPath, "-o", outputPath) ++ config.cmdLineParams
     var command   = rootPath.resolve("csharp2cpg.sh").toString
 
@@ -22,7 +23,7 @@ case class CSharpCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
       command = "powershell"
       arguments = Seq(rootPath.resolve("csharp2cpg.ps1").toString) ++ arguments
     }
-    runShellCommand(command, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = rootPath.resolve("csharp2cpg.sh").toFile.exists()

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -19,11 +19,11 @@ abstract class CpgGenerator() {
   /** is this a JVM based frontend? if so, we'll invoke it with -Xmx for max heap settings */
   def isJvmBased: Boolean
 
-  /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
+  /** Generate a CPG for the given input path. Returns the output path, or a Failure, if no CPG was generated.
     *
     * This method appends command line options in config.frontend.cmdLineParams to the shell command.
     */
-  def generate(inputPath: String, outputPath: String = "cpg.bin.zip", namespaces: List[String] = List()): Option[String]
+  def generate(inputPath: String, outputPath: String = "cpg.bin.zip", namespaces: List[String] = List()): Try[String]
 
   protected def runShellCommand(program: String, arguments: Seq[String]): Try[Unit] =
     Try {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -59,8 +59,8 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     inputPath: String,
     outputPath: String,
     namespaces: List[String] = List()
-  ): Option[Path] = {
-    val outputFileOpt: Option[File] =
+  ): Try[Path] = {
+    val outputFileOpt: Try[File] =
       generator.generate(inputPath, outputPath, namespaces).map(File(_))
     outputFileOpt.map { outFile =>
       val parentPath = outFile.parent.path.toAbsolutePath

--- a/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 /** Language frontend for Ghidra - translates compiled binaries into Code Property Graphs.
   */
@@ -15,9 +16,9 @@ case class GhidraCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
     inputPath: String,
     outputPath: String = "cpg.bin",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 /** Language frontend for Go code. Translates Go source code into Code Property Graphs.
   */
@@ -14,7 +15,7 @@ case class GoCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
     inputPath: String,
     outputPath: String = "cpg.bin.zip",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     var command   = rootPath.resolve("go2cpg.sh").toString
     var arguments = Seq("--output", outputPath) ++ config.cmdLineParams ++ Seq("generate") ++ List(inputPath)
 
@@ -23,7 +24,7 @@ case class GoCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
       arguments = Seq(rootPath.resolve("go2cpg.ps1").toString) ++ arguments
     }
 
-    runShellCommand(command, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = rootPath.resolve("go2cpg.sh").toFile.exists()

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -146,6 +146,13 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) extends Rep
       }
     }
 
-    cpgMaybe.getOrElse(throw new ConsoleException(s"Error creating project for input path: `$inputPath`"))
+    cpgMaybe
+      .map { cpg =>
+        report("""|Code successfully imported. You can now query it using `cpg`.
+          |For an overview of all imported code, type `workspace`.""".stripMargin)
+        console.applyDefaultOverlays(cpg)
+        generator.applyPostProcessingPasses(cpg)
+      }
+      .getOrElse(throw new ConsoleException(s"Error creating project for input path: `$inputPath`"))
   }
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 /** Source-based front-end for Java
   */
@@ -15,9 +16,9 @@ case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends C
     inputPath: String,
     outputPath: String = "cpg.bin",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("js2cpg.bat") else rootPath.resolve("js2cpg.sh")
@@ -13,9 +14,9 @@ case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
     inputPath: String,
     outputPath: String = "cpg.bin.zip",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
-    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -5,6 +5,7 @@ import io.joern.jssrc2cpg.JsSrc2Cpg
 import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.Path
+import scala.util.Try
 
 case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("jssrc2cpg.bat") else rootPath.resolve("jssrc2cpg.sh")
@@ -15,9 +16,9 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
     inputPath: String,
     outputPath: String = "cpg.bin.zip",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
-    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 /** Source-based front-end for Kotlin
   */
@@ -15,9 +16,9 @@ case class KotlinCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
     inputPath: String,
     outputPath: String = "cpg.bin",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 /** Language frontend for LLVM. Translates LLVM bitcode into Code Property Graphs.
   */
@@ -14,10 +15,10 @@ case class LlvmCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
     inputPath: String,
     outputPath: String = "cpg.bin.zip",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     val command   = rootPath.resolve("llvm2cpg.sh").toString
     val arguments = Seq("--output", outputPath) ++ config.cmdLineParams ++ List(inputPath)
-    runShellCommand(command, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = rootPath.resolve("llvm2cpg.sh").toFile.exists()

--- a/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
@@ -3,13 +3,14 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 
 import java.nio.file.Path
+import scala.util.Try
 
 case class PhpCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("php2cpg.bat") else rootPath.resolve("php2cpg")
 
-  override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
+  override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Try[String] = {
     val arguments = List(inputPath) ++ Seq("-o", outputPath) ++ config.cmdLineParams
-    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -11,6 +11,7 @@ import io.joern.pysrc2cpg.{
 }
 
 import java.nio.file.Path
+import scala.util.Try
 
 case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("pysrc2cpg.bat") else rootPath.resolve("pysrc2cpg")
@@ -21,9 +22,9 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
     inputPath: String,
     outputPath: String = "cpg.bin.zip",
     namespaces: List[String] = List()
-  ): Option[String] = {
+  ): Try[String] = {
     val arguments = Seq(inputPath, "-o", outputPath) ++ config.cmdLineParams
-    runShellCommand(command.toString, arguments).toOption.map(_ => outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean =

--- a/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
@@ -70,7 +70,7 @@ class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory
 
   private class CTestingFrontend extends CpgGenerator {
 
-    override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
+    override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Try[String] = {
       val c2cpg = new C2Cpg()
       val defines = config.frontend.cmdLineParams.toList
         .sliding(2)
@@ -78,8 +78,10 @@ class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory
         .collect {
           case List(h, t) if h == "--define" => t
         }
-      c2cpg.run(Config(inputPath, outputPath, defines = defines.toSet))
-      Some(outputPath)
+      Try {
+        c2cpg.run(Config(inputPath, outputPath, defines = defines.toSet))
+        outputPath
+      }
     }
 
     def isAvailable: Boolean = true

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
@@ -8,6 +8,7 @@ import io.shiftleft.codepropertygraph.generated.Languages
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
 
 object JoernParse {
   // Special string used to separate joern-parse opts from frontend-specific opts
@@ -139,8 +140,11 @@ object JoernParse {
       generator =
         cpgGeneratorForLanguage(language.toUpperCase, FrontendConfig(), installConfig.rootPath.path, frontendArgs).get
       generator.generate(config.inputPath, outputPath = config.outputCpgFile, namespaces = config.namespaces) match {
-        case Some(cmd) => Right(cmd)
-        case None      => Left(s"Could not generate CPG with language = $language and input = ${config.inputPath}")
+        case Success(cmd) => Right(cmd)
+        case Failure(exception) =>
+          Left(
+            s"Could not generate CPG with language = $language and input = ${config.inputPath}: ${exception.getMessage}"
+          )
       }
     }
   }


### PR DESCRIPTION
without this it's very hard to debug a problem in the test or build
setup, because we simply threw away the failure case `Try:toOption`