### PR TITLE
PythonTypeRecovery: Importing Variable from File 

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -361,14 +361,17 @@ class PythonAstVisitor(
       edgeBuilder.astEdge(bodyStmt, blockNode, bodyOrder.getAndInc)
     }
 
-    contextStack.pop()
-
     // For every method we create a corresponding TYPE and TYPE_DECL and
     // a binding for the method into TYPE_DECL.
     val typeNode     = nodeBuilder.typeNode(name, fullName)
     val typeDeclNode = nodeBuilder.typeDeclNode(name, fullName, absFileName, Seq(Constants.ANY), lineAndColumn)
     edgeBuilder.astEdge(typeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
     createBinding(methodNode, typeDeclNode)
+    // For every method that is a module, the local variables can be imported by other modules. This behaviour is
+    // much like fields so they are to be linked as fields to this method type
+    if (name == "<module>") contextStack.createMemberLinks(typeDeclNode, edgeBuilder.astEdge)
+
+    contextStack.pop()
 
     methodNode
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -437,6 +437,7 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
     val callNode = nodeBuilder.callNode(code, Operators.assignment, DispatchTypes.STATIC_DISPATCH, lineAndColumn)
 
     addAstChildrenAsArguments(callNode, 1, lhsNode, rhsNode)
+    if (!codeOf(rhsNode).startsWith("import(")) contextStack.considerAsGlobalVariable(lhsNode)
 
     callNode
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -437,7 +437,9 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
     val callNode = nodeBuilder.callNode(code, Operators.assignment, DispatchTypes.STATIC_DISPATCH, lineAndColumn)
 
     addAstChildrenAsArguments(callNode, 1, lhsNode, rhsNode)
-    if (!codeOf(rhsNode).startsWith("import(")) contextStack.considerAsGlobalVariable(lhsNode)
+    // Do not include imports or function pointers
+    if (!codeOf(rhsNode).startsWith("import(") && codeOf(rhsNode) != s"def ${codeOf(lhsNode)}(...)")
+      contextStack.considerAsGlobalVariable(lhsNode)
 
     callNode
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -115,7 +115,7 @@ class RecoverForPythonFile(
         Set(procedureName.concat(s".${Defines.ConstructorMethodName}"))
       else if (isFieldOrVar) {
         val Array(m, v) = procedureName.split("<var>")
-        cpg.method.fullNameExact(m).ast.isIdentifier.nameExact(v).headOption match {
+        cpg.typeDecl.fullNameExact(m).member.nameExact(v).headOption match {
           case Some(i) => (Seq(i.typeFullName) ++ i.dynamicTypeHintFullName).filterNot(_ == "ANY").toSet
           case None    => Set.empty
         }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -532,7 +532,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       methodRef.typeFullName shouldBe "<empty>"
     }
   }
-  
+
   "a type hint on a parameter" should {
     lazy val cpg = code("""
         |import sqlalchemy.orm as orm
@@ -540,7 +540,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |async def get_user_by_email(email: str, db: orm.Session):
         |   return db.query(user_models.User).filter(user_models.User.email == email).first()
         |""".stripMargin)
-        
+
     "be sufficient to resolve method full names at calls" in {
       val List(call) = cpg.call("query").l
       call.methodFullName.startsWith("sqlalchemy.orm") shouldBe true

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -533,4 +533,35 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
+  "recover a member call from a reference to an imported global variable" should {
+    lazy val cpg = code(
+      """from api import db
+        |
+        |class UserModel(db.Model):
+        |
+        |   def save(self):
+        |        try:
+        |            db.session.add(self)
+        |            db.session.commit()
+        |        except IntegrityError:
+        |            print(f"User with username={self.username} already exist")
+        |            db.session.rollback()
+        |""".stripMargin,
+      Seq("api", "models", "user.py").mkString(File.separator)
+    ).moreCode(
+      """from flask_sqlalchemy import SQLAlchemy
+        |
+        |app = Flask(__name__, static_folder=Config.UPLOAD_FOLDER)
+        |
+        |db = SQLAlchemy(app)
+        |""".stripMargin,
+      Seq("api", "__init__.py").mkString(File.separator)
+    )
+
+    "recover a call to `add`" in {
+      val Some(addCall) = cpg.call("add").headOption
+      addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.<member>(session).add"
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -83,13 +83,13 @@ case class FieldVar(compUnitFullName: String, override val identifier: String) e
   * The [[SymbolTable]] operates like a map with a few convenient methods that are designed for this structure's
   * purpose.
   */
-class SymbolTable[K <: SBKey](fromNode: AstNode => Option[K]) {
+class SymbolTable[K <: SBKey](val keyFromNode: AstNode => Option[K]) {
 
   private val table = TrieMap.empty[K, Set[String]]
 
   def apply(sbKey: K): Set[String] = table(sbKey)
 
-  def apply(node: AstNode): Set[String] = fromNode(node) match {
+  def apply(node: AstNode): Set[String] = keyFromNode(node) match {
     case Some(key) => table(key)
     case None      => Set.empty
   }
@@ -113,7 +113,7 @@ class SymbolTable[K <: SBKey](fromNode: AstNode => Option[K]) {
   def put(sbKey: K, typeFullName: String): Set[String] =
     put(sbKey, Set(typeFullName))
 
-  def put(node: AstNode, typeFullNames: Set[String]): Set[String] = fromNode(node) match {
+  def put(node: AstNode, typeFullNames: Set[String]): Set[String] = keyFromNode(node) match {
     case Some(key) => put(key, typeFullNames)
     case None      => Set.empty
   }
@@ -121,7 +121,7 @@ class SymbolTable[K <: SBKey](fromNode: AstNode => Option[K]) {
   def append(node: AstNode, typeFullName: String): Set[String] =
     append(node, Set(typeFullName))
 
-  def append(node: AstNode, typeFullNames: Set[String]): Set[String] = fromNode(node) match {
+  def append(node: AstNode, typeFullNames: Set[String]): Set[String] = keyFromNode(node) match {
     case Some(key) => append(key, typeFullNames)
     case None      => Set.empty
   }
@@ -136,14 +136,14 @@ class SymbolTable[K <: SBKey](fromNode: AstNode => Option[K]) {
 
   def contains(sbKey: K): Boolean = table.contains(sbKey)
 
-  def contains(node: AstNode): Boolean = fromNode(node) match {
+  def contains(node: AstNode): Boolean = keyFromNode(node) match {
     case Some(key) => contains(key)
     case None      => false
   }
 
   def get(sbKey: K): Set[String] = table.getOrElse(sbKey, Set.empty)
 
-  def get(node: AstNode): Set[String] = fromNode(node) match {
+  def get(node: AstNode): Set[String] = keyFromNode(node) match {
     case Some(key) => get(key)
     case None      => Set.empty
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -103,8 +103,12 @@ class SymbolTable[K <: SBKey](fromNode: AstNode => Option[K]) {
     table.put(newKey, newValues)
   }
 
-  def put(sbKey: K, typeFullNames: Set[String]): Set[String] =
-    table.put(sbKey, typeFullNames).getOrElse(Set.empty)
+  def put(sbKey: K, typeFullNames: Set[String]): Set[String] = {
+    if (typeFullNames.nonEmpty)
+      table.put(sbKey, typeFullNames).getOrElse(Set.empty)
+    else
+      Set.empty
+  }
 
   def put(sbKey: K, typeFullName: String): Set[String] =
     put(sbKey, Set(typeFullName))
@@ -124,8 +128,9 @@ class SymbolTable[K <: SBKey](fromNode: AstNode => Option[K]) {
 
   def append(sbKey: K, typeFullNames: Set[String]): Set[String] = {
     table.get(sbKey) match {
-      case Some(ts) => put(sbKey, ts ++ typeFullNames)
-      case None     => put(sbKey, typeFullNames)
+      case Some(ts) if typeFullNames.nonEmpty => put(sbKey, ts ++ typeFullNames)
+      case None if typeFullNames.nonEmpty     => put(sbKey, typeFullNames)
+      case _                                  => Set.empty
     }
   }
 


### PR DESCRIPTION
* Identify when the entity imported is a variable
* Find associated types with the identifier being imported and add this to the symbol table
* Detect module-level variables that could be exported and set them as members under the module-type
* Making use of member during import
* Fixed type recovery from imported variable without full refactoring
* Removed useless visitMember method