### PR TITLE
Remove `namespaces` from `CpgGenerator::generate`

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
@@ -13,11 +13,7 @@ case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGene
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
@@ -11,11 +11,7 @@ case class CSharpCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin.zip",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
     var arguments = Seq("-i", inputPath, "-o", outputPath) ++ config.cmdLineParams
     var command   = rootPath.resolve("csharp2cpg.sh").toString
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -23,7 +23,7 @@ abstract class CpgGenerator() {
     *
     * This method appends command line options in config.frontend.cmdLineParams to the shell command.
     */
-  def generate(inputPath: String, outputPath: String = "cpg.bin.zip", namespaces: List[String] = List()): Try[String]
+  def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String]
 
   protected def runShellCommand(program: String, arguments: Seq[String]): Try[Unit] =
     Try {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -54,14 +54,9 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
 
   def languageIsKnown(language: String): Boolean = CpgGeneratorFactory.KNOWN_LANGUAGES.contains(language)
 
-  def runGenerator(
-    generator: CpgGenerator,
-    inputPath: String,
-    outputPath: String,
-    namespaces: List[String] = List()
-  ): Try[Path] = {
+  def runGenerator(generator: CpgGenerator, inputPath: String, outputPath: String): Try[Path] = {
     val outputFileOpt: Try[File] =
-      generator.generate(inputPath, outputPath, namespaces).map(File(_))
+      generator.generate(inputPath, outputPath).map(File(_))
     outputFileOpt.map { outFile =>
       val parentPath = outFile.parent.path.toAbsolutePath
       if (isZipFile(outFile)) {

--- a/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
@@ -12,11 +12,7 @@ case class GhidraCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
@@ -11,11 +11,7 @@ case class GoCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin.zip",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
     var command   = rootPath.resolve("go2cpg.sh").toString
     var arguments = Seq("--output", outputPath) ++ config.cmdLineParams ++ Seq("generate") ++ List(inputPath)
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
@@ -12,14 +12,10 @@ case class JavaCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin.zip",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
 
     if (commercialAvailable) {
-      generateCommercial(inputPath, outputPath, namespaces)
+      generateCommercial(inputPath, outputPath)
     } else if (ossAvailable) {
       generateOss(inputPath, outputPath)
     } else {
@@ -27,18 +23,18 @@ case class JavaCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
     }
   }
 
-  private def generateCommercial(inputPath: String, outputPath: String, namespaces: List[String]): Try[String] = {
+  private def generateCommercial(inputPath: String, outputPath: String): Try[String] = {
     if (inputPath.endsWith(".apk")) {
       println("found .apk ending - will first transform it to a jar using dex2jar.sh")
 
       val dex2jar = rootPath.resolve("dex2jar.sh").toString
       s"$dex2jar $inputPath".run().exitValue()
       val jarPath = s"$inputPath.jar"
-      generateCommercial(jarPath, outputPath, namespaces)
+      generateCommercial(jarPath, outputPath)
     } else {
       var command = rootPath.resolve("java2cpg.sh").toString
       var arguments =
-        Seq(inputPath, "-o", outputPath) ++ jvmLanguages ++ namespaceArgs(namespaces) ++ config.cmdLineParams
+        Seq(inputPath, "-o", outputPath) ++ jvmLanguages ++ config.cmdLineParams
       if (System.getProperty("os.name").startsWith("Windows")) {
         command = "powershell"
         arguments = Seq(rootPath.resolve("java2cpg.ps1").toString) ++ arguments

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -12,11 +12,7 @@ case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends C
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
@@ -10,11 +10,7 @@ case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin.zip",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -12,11 +12,7 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin.zip",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
@@ -12,11 +12,7 @@ case class KotlinCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
@@ -11,11 +11,7 @@ case class LlvmCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin.zip",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
     val command   = rootPath.resolve("llvm2cpg.sh").toString
     val arguments = Seq("--output", outputPath) ++ config.cmdLineParams ++ List(inputPath)
     runShellCommand(command, arguments).map(_ => outputPath)

--- a/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 case class PhpCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("php2cpg.bat") else rootPath.resolve("php2cpg")
 
-  override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Try[String] = {
+  override def generate(inputPath: String, outputPath: String): Try[String] = {
     val arguments = List(inputPath) ++ Seq("-o", outputPath) ++ config.cmdLineParams
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -18,11 +18,7 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(
-    inputPath: String,
-    outputPath: String = "cpg.bin.zip",
-    namespaces: List[String] = List()
-  ): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
     val arguments = Seq(inputPath, "-o", outputPath) ++ config.cmdLineParams
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
@@ -139,7 +139,7 @@ object JoernParse {
       println("[+] Running language frontend")
       generator =
         cpgGeneratorForLanguage(language.toUpperCase, FrontendConfig(), installConfig.rootPath.path, frontendArgs).get
-      generator.generate(config.inputPath, outputPath = config.outputCpgFile, namespaces = config.namespaces) match {
+      generator.generate(config.inputPath, outputPath = config.outputCpgFile) match {
         case Success(cmd) => Right(cmd)
         case Failure(exception) =>
           Left(


### PR DESCRIPTION
We aren't using the `namespaces` parameter inside overloaded methods of `generate`, it seems. It may be that it is still used somewhere in Ocular when calling `java2cpg`, but then I would propose that we remove that.