### PR TITLE
PythonTypeRecovery: Distinguish Call Alias by Receiver

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -38,6 +38,17 @@ class RecoverForPythonFile(
   addedNodes: mutable.Set[(Long, String)]
 ) extends RecoverForXCompilationUnit[File](cpg, cu, builder, globalTable, addedNodes) {
 
+  /** Replaces the `this` prefix with the Pythonic `self` prefix for instance methods of functions local to this
+    * compilation unit.
+    */
+  private def fromNodeToLocalPythonKey(node: AstNode): Option[LocalKey] =
+    node match {
+      case n: Method => Option(CallAlias(n.name, Option("self")))
+      case _         => SBKey.fromNodeToLocalKey(node)
+    }
+
+  override val symbolTable: SymbolTable[LocalKey] = new SymbolTable[LocalKey](fromNodeToLocalPythonKey)
+
   /** Overridden to include legacy import calls until imports are supported.
     */
   override def importNodes(cu: AstNode): Traversal[AstNode] =

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -579,8 +579,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
   }
 
   "handle a wrapper function with the same name as an imported function" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import requests
         |
         |class Client:

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -26,10 +26,11 @@ object SBKey {
   protected val logger: Logger = LoggerFactory.getLogger(getClass)
   def fromNodeToLocalKey(node: AstNode): Option[LocalKey] = {
     Option(node match {
-      case n: Identifier      => LocalVar(n.name)
-      case n: Local           => LocalVar(n.name)
-      case n: Call            => CallAlias(n.name)
-      case n: Method          => CallAlias(n.name)
+      case n: Identifier => LocalVar(n.name)
+      case n: Local      => LocalVar(n.name)
+      case n: Call =>
+        CallAlias(n.name, n.argument.where(_.argumentIndex(0)).isIdentifier.map(_.name).headOption)
+      case n: Method          => CallAlias(n.name, Option("this"))
       case n: MethodRef       => CallAlias(n.code)
       case n: FieldIdentifier => LocalVar(n.canonicalName)
       case _ => logger.debug(s"Local node of type ${node.label} is not supported in the type recovery pass."); null
@@ -60,7 +61,7 @@ case class CollectionVar(override val identifier: String, idx: String) extends L
 
 /** A name that refers to some kind of callee.
   */
-case class CallAlias(override val identifier: String) extends LocalKey(identifier)
+case class CallAlias(override val identifier: String, receiverName: Option[String] = None) extends LocalKey(identifier)
 
 /** Represents an identifier of some AST node at an interprocedural scope.
   */


### PR DESCRIPTION
* Modified symbol table key to acknowledge a receiver is one is present