### PR TITLE
Change python instance class type full names.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -399,18 +399,6 @@ class PythonAstVisitor(
       )
     edgeBuilder.astEdge(metaTypeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
 
-    // Create <body> function which contains the code defining the class
-    contextStack.pushClass(classDef.name, metaTypeDeclNode)
-    val classBodyFunctionName = classDef.name + "<body>"
-    val (_, methodRefNode) = createMethodAndMethodRef(
-      classBodyFunctionName,
-      parameterProvider = () => MethodParameters.empty(),
-      bodyProvider = () => classDef.body.map(convert),
-      None,
-      isAsync = false,
-      lineAndColOf(classDef)
-    )
-
     // Create type for class instances
     val instanceTypeDeclName     = classDef.name
     val instanceTypeDeclFullName = calculateFullNameFromContext(instanceTypeDeclName)
@@ -428,6 +416,18 @@ class PythonAstVisitor(
         lineAndColOf(classDef)
       )
     edgeBuilder.astEdge(instanceTypeDecl, contextStack.astParent, contextStack.order.getAndInc)
+
+    // Create <body> function which contains the code defining the class
+    contextStack.pushClass(classDef.name, metaTypeDeclNode)
+    val classBodyFunctionName = classDef.name + "<body>"
+    val (_, methodRefNode) = createMethodAndMethodRef(
+      classBodyFunctionName,
+      parameterProvider = () => MethodParameters.empty(),
+      bodyProvider = () => classDef.body.map(convert),
+      None,
+      isAsync = false,
+      lineAndColOf(classDef)
+    )
 
     // Create meta class call handling method and bind it to meta class type.
     val functions = classDef.body.collect { case func: ast.FunctionDef => func }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -365,13 +365,15 @@ class PythonAstVisitor(
     // a binding for the method into TYPE_DECL.
     val typeNode     = nodeBuilder.typeNode(name, fullName)
     val typeDeclNode = nodeBuilder.typeDeclNode(name, fullName, absFileName, Seq(Constants.ANY), lineAndColumn)
-    edgeBuilder.astEdge(typeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
-    createBinding(methodNode, typeDeclNode)
+
     // For every method that is a module, the local variables can be imported by other modules. This behaviour is
     // much like fields so they are to be linked as fields to this method type
     if (name == "<module>") contextStack.createMemberLinks(typeDeclNode, edgeBuilder.astEdge)
 
     contextStack.pop()
+
+    edgeBuilder.astEdge(typeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
+    createBinding(methodNode, typeDeclNode)
 
     methodNode
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -247,7 +247,7 @@ class RecoverForPythonFile(
       Set(fa.method.fullName)
     } else if (fa.method.typeDecl.nonEmpty) {
       val parentTypes =
-        fa.method.typeDecl.fullName.map(_.stripSuffix("<meta>")).map { t => s"$t.${t.split("\\.").last}" }.toSeq
+        fa.method.typeDecl.fullName.map(_.stripSuffix("<meta>")).toSeq
       val baseTypes = cpg.typeDecl.fullNameExact(parentTypes: _*).inheritsFromTypeFullName.toSeq
       // TODO: inheritsFromTypeFullName does not give full name in pysrc2cpg
       val baseTypeFullNames = cpg.typ.nameExact(baseTypes: _*).fullName.toSeq

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -4,6 +4,48 @@ import io.joern.pysrc2cpg.PySrc2CpgFixture
 import io.shiftleft.semanticcpg.language._
 
 class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
+  "class" should {
+    val cpg = code("""class Foo:
+        |  pass
+        |""".stripMargin)
+    "have correct instance class type and typeDecl" in {
+      cpg.typ.name("Foo").fullName.head shouldBe "Test0.py:<module>.Foo"
+      val typeDecl = cpg.typeDecl.name("Foo").head
+      typeDecl.fullName shouldBe "Test0.py:<module>.Foo"
+      typeDecl.astParent.head shouldBe cpg.method.name("<module>").head
+    }
+
+    "have correct meta class type and typeDecl" in {
+      cpg.typ.name("Foo<meta>").fullName.head shouldBe "Test0.py:<module>.Foo<meta>"
+      val typeDecl = cpg.typeDecl.name("Foo<meta>").head
+      typeDecl.fullName shouldBe "Test0.py:<module>.Foo<meta>"
+      typeDecl.astParent.head shouldBe cpg.method.name("<module>").head
+    }
+
+    "have correct class body type and typeDecl" in {
+      cpg.typ.name("Foo<body>").fullName.head shouldBe "Test0.py:<module>.Foo.Foo<body>"
+      val typeDecl = cpg.typeDecl.name("Foo<body>").head
+      typeDecl.fullName shouldBe "Test0.py:<module>.Foo.Foo<body>"
+      typeDecl.astParent.head shouldBe cpg.typeDecl.name("Foo<meta>").head
+    }
+
+    "have correct meta class call handler type and typeDecl" in {
+      cpg.typ.name("<metaClassCallHandler>").fullName.head shouldBe
+        "Test0.py:<module>.Foo.<metaClassCallHandler>"
+      val typeDecl = cpg.typeDecl.name("<metaClassCallHandler>").head
+      typeDecl.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
+      typeDecl.astParent.head shouldBe cpg.typeDecl.name("Foo<meta>").head
+    }
+
+    "have correct fake new type and typeDecl" in {
+      cpg.typ.name("<fakeNew>").fullName.head shouldBe
+        "Test0.py:<module>.Foo.<fakeNew>"
+      val typeDecl = cpg.typeDecl.name("<fakeNew>").head
+      typeDecl.fullName shouldBe "Test0.py:<module>.Foo.<fakeNew>"
+      typeDecl.astParent.head shouldBe cpg.typeDecl.name("Foo<meta>").head
+    }
+  }
+
   "class meta call handler" should {
     "have no self parameter if self is explicit" in {
       val cpg = code("""class Foo:


### PR DESCRIPTION
So far the full name for the instance class type of:
```
class Foo:
  pass
```

was `fileName.py:<module>.Foo.Foo`. This is now changed to:
`fileName.py:<module>.Foo`.

C.f.: https://github.com/joernio/joern/issues/2225