### PR TITLE
[PythonTypeRecovery] Removed type name duplication to compensate for old type names

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -207,7 +207,7 @@ class RecoverForPythonFile(
       Set(fa.method.fullName)
     } else if (fa.method.typeDecl.nonEmpty) {
       val parentTypes =
-        fa.method.typeDecl.fullName.map(_.stripSuffix("<meta>")).map { t => s"$t.${t.split("\\.").last}" }.toSeq
+        fa.method.typeDecl.fullName.map(_.stripSuffix("<meta>")).toSeq
       val baseTypes = cpg.typeDecl.fullNameExact(parentTypes: _*).inheritsFromTypeFullName.toSeq
       // TODO: inheritsFromTypeFullName does not give full name in pysrc2cpg
       val baseTypeFullNames = cpg.typ.nameExact(baseTypes: _*).fullName.toSeq


### PR DESCRIPTION
Adjusts a compensation used during the type recovery that allowed finding parent/base classes in the CPG. The new adjustment follows the new convention introduced in the target branch.