### PR TITLE
pysrc2cpg: Fix Wrong Type Hint Path when Aliased

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -606,4 +606,23 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
+
+  "handle a call from parameter with a type hint" should {
+    lazy val cpg = code(
+      """
+        |import models.user as user_models
+        |import sqlalchemy.orm as orm
+        |
+        |async def get_user_by_email(email: str, db: orm.Session):
+        |    return db.query(user_models.User).filter(user_models.User.email == email).first()
+        |""".stripMargin)
+
+    "with the correct identifier and call types" in {
+      val Some(postCallReceiver) = cpg.identifier("db").headOption
+      postCallReceiver.typeFullName shouldBe "sqlalchemy.orm.Session"
+      val Some(postCall) = cpg.call("query").headOption
+      postCall.methodFullName shouldBe "sqlalchemy.orm.Session.query"
+    }
+  }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -606,10 +606,8 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
-
   "handle a call from parameter with a type hint" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |import models.user as user_models
         |import sqlalchemy.orm as orm
         |

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -30,9 +30,10 @@ object SBKey {
       case n: Local      => LocalVar(n.name)
       case n: Call =>
         CallAlias(n.name, n.argument.where(_.argumentIndex(0)).isIdentifier.map(_.name).headOption)
-      case n: Method          => CallAlias(n.name, Option("this"))
-      case n: MethodRef       => CallAlias(n.code)
-      case n: FieldIdentifier => LocalVar(n.canonicalName)
+      case n: Method            => CallAlias(n.name, Option("this"))
+      case n: MethodRef         => CallAlias(n.code)
+      case n: FieldIdentifier   => LocalVar(n.canonicalName)
+      case n: MethodParameterIn => LocalVar(n.name)
       case _ => logger.debug(s"Local node of type ${node.label} is not supported in the type recovery pass."); null
     })
   }


### PR DESCRIPTION
* Implemented `prepopulateSymbolTable` for nodes that already contain type hints
* Fixed issue where type hint full name being replaced with full import path and not alias