### PR TITLE
JavaScriptTypeRecovery: Initial Implementation Class

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JavaScriptTypeHintCallLinker.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JavaScriptTypeHintCallLinker.scala
@@ -1,0 +1,6 @@
+package io.joern.jssrc2cpg
+
+import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
+import io.shiftleft.codepropertygraph.Cpg
+
+class JavaScriptTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -4,13 +4,12 @@ import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.jssrc2cpg.JsSrc2Cpg.postProcessingPasses
 import io.joern.jssrc2cpg.passes._
-import io.joern.jssrc2cpg.utils.AstGenRunner
-import io.joern.jssrc2cpg.utils.Report
-import io.shiftleft.codepropertygraph.Cpg
+import io.joern.jssrc2cpg.utils.{AstGenRunner, Report}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
-import io.joern.x2cpg.utils.HashUtil
 import io.joern.x2cpg.passes.frontend.JavascriptCallLinker
+import io.joern.x2cpg.utils.HashUtil
+import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
@@ -57,6 +56,12 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
 object JsSrc2Cpg {
 
   def postProcessingPasses(cpg: Cpg): List[CpgPassBase] =
-    List(new RequirePass(cpg), new ConstClosurePass(cpg), new JavascriptCallLinker(cpg))
+    List(
+      new RequirePass(cpg),
+      new ConstClosurePass(cpg),
+      new JavaScriptTypeRecovery(cpg),
+      new JavaScriptTypeHintCallLinker(cpg),
+      new JavascriptCallLinker(cpg)
+    )
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeHintCallLinker.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeHintCallLinker.scala
@@ -1,4 +1,4 @@
-package io.joern.jssrc2cpg
+package io.joern.jssrc2cpg.passes
 
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.codepropertygraph.Cpg

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -36,12 +36,8 @@ class RecoverForJavaScriptFile(
   override protected def visitIdentifierAssignedToConstructor(i: Identifier, c: Call): Set[String] = {
     val constructorPaths = if (c.methodFullName.contains(".alloc")) {
       c.inAssignment.astSiblings.isCall.nameExact("<operator>.new").astChildren.isIdentifier.headOption match {
-        case Some(i) =>
-          symbolTable.get(i).map {
-            case t if t.contains("::program") => s"$t:${i.name}"
-            case t                            => s"$t::program:${i.name}"
-          }
-        case None => Set.empty[String]
+        case Some(i) => symbolTable.get(i)
+        case None    => Set.empty[String]
       }
     } else (symbolTable.get(c) + c.methodFullName).map(t => t.stripSuffix(".factory"))
     associateTypes(i, constructorPaths)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -1,0 +1,42 @@
+package io.joern.jssrc2cpg.passes
+
+import io.joern.x2cpg.passes.frontend.{GlobalKey, RecoverForXCompilationUnit, SymbolTable, XTypeRecovery}
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, File, Identifier}
+import io.shiftleft.semanticcpg.language._
+import overflowdb.BatchedUpdate.DiffGraphBuilder
+import overflowdb.traversal.Traversal
+
+import scala.collection.mutable
+
+class JavaScriptTypeRecovery(cpg: Cpg) extends XTypeRecovery[File](cpg) {
+  override def compilationUnit: Traversal[File] = cpg.file
+
+  override def generateRecoveryForCompilationUnitTask(
+    unit: File,
+    builder: DiffGraphBuilder
+  ): RecoverForXCompilationUnit[File] = new RecoverForJavaScriptFile(cpg, unit, builder, globalTable, addedNodes)
+
+}
+
+class RecoverForJavaScriptFile(
+  cpg: Cpg,
+  cu: File,
+  builder: DiffGraphBuilder,
+  globalTable: SymbolTable[GlobalKey],
+  addedNodes: mutable.Set[(Long, String)]
+) extends RecoverForXCompilationUnit[File](cpg, cu, builder, globalTable, addedNodes) {
+
+  /** A heuristic method to determine if a call is a constructor or not.
+    */
+  override protected def isConstructor(c: Call): Boolean = {
+    c.name.endsWith("factory") && c.inCall.astParent.headOption.isInstanceOf[Some[Block]]
+  }
+
+  override protected def visitIdentifierAssignedToConstructor(i: Identifier, c: Call): Set[String] = {
+    val constructorPaths =
+      (symbolTable.get(c) + c.methodFullName).map(t => t.stripSuffix(".factory"))
+    associateTypes(i, constructorPaths)
+  }
+
+}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/RequirePass.scala
@@ -85,15 +85,20 @@ class RequirePass(cpg: Cpg) extends CpgPass(cpg) {
 
     val target: String = call.inAssignment.target.code.head
 
-    val callsToPatch: List[Call] = call.file.method.ast.isCall.nameExact(target).dedup.l
+    val callsToPatch: List[Call] = call.file.nameExact(fileToInclude).method.ast.isCall.nameExact(target).dedup.l
 
-    val variableToPatch: VariableInformation = VariableInformation(
-      call.file.method.ast.isIdentifier
-        .nameExact(target)
-        .flatMap(i => Seq(i) ++ i.refsTo.collectAll[Local].toSeq)
-        .dedup
-        .toList
-    )
+    val variableToPatch: VariableInformation =
+      VariableInformation(
+        call.file
+          .nameExact(fileToInclude)
+          .method
+          .ast
+          .isIdentifier
+          .nameExact(target)
+          .flatMap(i => Seq(i) ++ i.refsTo.collectAll[Local].toSeq)
+          .dedup
+          .toList
+      )
 
     def relativeExport: String = fileToInclude.stripPrefix(s"$dirHoldingModule${File.separator}")
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1,0 +1,39 @@
+package io.joern.jssrc2cpg.passes
+
+import io.joern.jssrc2cpg.testfixtures.DataFlowCodeToCpgSuite
+import io.shiftleft.semanticcpg.language._
+
+class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
+
+  "literals declared from built-in types" should {
+    lazy val cpg = code("""
+        |let x = 123;
+        |
+        |function foo_shadowing() {
+        |   let x = "foo";
+        |}
+        |
+        |z = {'a': 123};
+        |z = [1, 2, 3];
+        |
+        |z.push(4)
+        |""".stripMargin)
+
+    "resolve 'x' identifier types despite shadowing" in {
+      val List(xOuterScope, xInnerScope) = cpg.identifier("x").take(2).l
+      xOuterScope.dynamicTypeHintFullName shouldBe Seq("__ecma.String", "__ecma.Number")
+      xInnerScope.dynamicTypeHintFullName shouldBe Seq("__ecma.String", "__ecma.Number")
+    }
+
+    "resolve 'z' types correctly" in {
+      // The dictionary/object type is just considered "ANY" which is fine for now
+      cpg.identifier("z").typeFullName.toSet.headOption shouldBe Some("__ecma.Array")
+    }
+
+    "resolve 'z' identifier call correctly" in {
+      val List(zAppend) = cpg.call("push").l
+      zAppend.methodFullName shouldBe "__ecma.Array.push"
+    }
+  }
+
+}

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -36,4 +36,50 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
     }
   }
 
+  "call from a function from an external type" should {
+
+    lazy val cpg = code(
+      """
+        |import { WebClient } from "slack_sdk";
+        |import { SendGridAPIClient } from "sendgrid";
+        |
+        |const client = new WebClient("WOLOLO");
+        |const sg = new SendGridAPIClient("SENGRID_KEY_WOLOLO");
+        |
+        |function sendSlackMessage(chan, msg) {
+        |    client.chatPostMessage(channel=chan, text=msg);
+        |}
+        |
+        |let response = sg.send(message);
+        |""".stripMargin, "test1.ts").cpg
+
+    "resolve 'sg' identifier types from import information" in {
+      val List(sgAssignment, sgElseWhere) = cpg.identifier("sg").take(2).l
+      sgAssignment.typeFullName shouldBe "<export>::sendgrid.js::program:SendGridAPIClient"
+      sgElseWhere.typeFullName shouldBe "<export>::sendgrid.js::program:SendGridAPIClient"
+    }
+
+    "resolve 'sg' call path from import information" in {
+      val List(sendCall) = cpg.call("send").l
+      sendCall.methodFullName shouldBe "<export>::sendgrid.js::program:SendGridAPIClient.send"
+    }
+
+    "resolve 'client' identifier types from import information" in {
+      val List(clientAssignment, clientElseWhere) = cpg.identifier("client").take(2).l
+      clientAssignment.typeFullName shouldBe "<export>::slack_sdk.js::program:WebClient"
+      clientElseWhere.typeFullName shouldBe "<export>::slack_sdk.js::program:WebClient"
+    }
+
+    "resolve 'client' call path from identifier in child scope" in {
+      val List(postMessage) = cpg.call("chatPostMessage").l
+      postMessage.methodFullName shouldBe "<export>::slack_sdk.js::program:WebClient.chatPostMessage"
+    }
+
+    "resolve a dummy 'send' return value from sg.send" in {
+      val List(postMessage) = cpg.identifier("response").l
+      postMessage.typeFullName shouldBe "<export>::sendgrid.js::program:SendGridAPIClient.send.<returnValue>"
+    }
+
+  }
+
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -144,9 +144,9 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
         .name("z")
         .l
       z1.typeFullName shouldBe "ANY"
-      z1.dynamicTypeHintFullName shouldBe Seq("__builtin.int", "__builtin.str")
+      z1.dynamicTypeHintFullName shouldBe Seq("__ecma.Number", "__ecma.String")
       z2.typeFullName shouldBe "ANY"
-      z2.dynamicTypeHintFullName shouldBe Seq("__builtin.int", "__builtin.str")
+      z2.dynamicTypeHintFullName shouldBe Seq("__ecma.Number", "__ecma.String")
     }
 
     "resolve 'foo.d' field access object types correctly" in {
@@ -156,7 +156,7 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
         .isIdentifier
         .name("d")
         .headOption
-      d.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>"
+      d.typeFullName shouldBe "flask_sqlalchemy:SQLAlchemy"
       d.dynamicTypeHintFullName shouldBe Seq()
     }
 
@@ -167,7 +167,7 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
         .isCall
         .name("createTable")
         .l
-      d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.createTable"
+      d.methodFullName shouldBe "flask_sqlalchemy:SQLAlchemy.createTable"
       d.dynamicTypeHintFullName shouldBe Seq()
       d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
@@ -180,7 +180,7 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
         .name("deleteTable")
         .l
 
-      d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.deleteTable"
+      d.methodFullName shouldBe "flask_sqlalchemy:SQLAlchemy.deleteTable"
       d.dynamicTypeHintFullName shouldBe Seq()
       d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -51,33 +51,138 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
         |}
         |
         |let response = sg.send(message);
-        |""".stripMargin, "test1.ts").cpg
+        |""".stripMargin, "Test1.ts").cpg
 
     "resolve 'sg' identifier types from import information" in {
       val List(sgAssignment, sgElseWhere) = cpg.identifier("sg").take(2).l
-      sgAssignment.typeFullName shouldBe "<export>::sendgrid.js::program:SendGridAPIClient"
-      sgElseWhere.typeFullName shouldBe "<export>::sendgrid.js::program:SendGridAPIClient"
+      sgAssignment.typeFullName shouldBe "sendgrid:SendGridAPIClient"
+      sgElseWhere.typeFullName shouldBe "sendgrid:SendGridAPIClient"
     }
 
     "resolve 'sg' call path from import information" in {
       val List(sendCall) = cpg.call("send").l
-      sendCall.methodFullName shouldBe "<export>::sendgrid.js::program:SendGridAPIClient.send"
+      sendCall.methodFullName shouldBe "sendgrid:SendGridAPIClient.send"
     }
 
     "resolve 'client' identifier types from import information" in {
       val List(clientAssignment, clientElseWhere) = cpg.identifier("client").take(2).l
-      clientAssignment.typeFullName shouldBe "<export>::slack_sdk.js::program:WebClient"
-      clientElseWhere.typeFullName shouldBe "<export>::slack_sdk.js::program:WebClient"
+      clientAssignment.typeFullName shouldBe "slack_sdk:WebClient"
+      clientElseWhere.typeFullName shouldBe "slack_sdk:WebClient"
     }
 
     "resolve 'client' call path from identifier in child scope" in {
       val List(postMessage) = cpg.call("chatPostMessage").l
-      postMessage.methodFullName shouldBe "<export>::slack_sdk.js::program:WebClient.chatPostMessage"
+      postMessage.methodFullName shouldBe "slack_sdk:WebClient.chatPostMessage"
     }
 
     "resolve a dummy 'send' return value from sg.send" in {
       val List(postMessage) = cpg.identifier("response").l
-      postMessage.typeFullName shouldBe "<export>::sendgrid.js::program:SendGridAPIClient.send.<returnValue>"
+      postMessage.typeFullName shouldBe "sendgrid:SendGridAPIClient.send.<returnValue>"
+    }
+
+  }
+
+  "recovering paths for built-in calls" should {
+    lazy val cpg = code(
+      """
+        |console.log("Hello world");
+        |let x = Math.abs(-1);
+        |""".stripMargin).cpg
+
+    "resolve 'print' and 'max' calls" in {
+      val Some(printCall) = cpg.call("log").headOption
+      printCall.methodFullName shouldBe "__whatwg.console.log"
+      val Some(maxCall) = cpg.call("abs").headOption
+      maxCall.methodFullName shouldBe "__ecma.Math.abs"
+      val Some(x) = cpg.identifier("x").headOption
+      // TODO: Ideally we would know the result of `abs` but this can be a future task
+      x.typeFullName shouldBe "__ecma.Math.abs.<returnValue>"
+    }
+
+  }
+
+  "recovering module members across modules" should {
+    lazy val cpg = code(
+      """
+        |import { SQLAlchemy } from "flask_sqlalchemy";
+        |
+        |export const x = 1;
+        |export const y = "test";
+        |export const db = new SQLAlchemy();
+        |""".stripMargin,
+      "Foo.ts"
+    ).moreCode(
+      """
+        |import { x, y, db } from './Foo';
+        |
+        |let z = x;
+        |z = y;
+        |
+        |let d = db;
+        |
+        |d.createTable()
+        |
+        |db.deleteTable();
+        |""".stripMargin,
+      "Bar.ts"
+    ).cpg
+
+    "resolve 'x' and 'y' locally under foo.py" in {
+      val Some(x) = cpg.file.name(".*Foo.*").ast.isIdentifier.name("x").headOption
+      x.typeFullName shouldBe "__ecma.Number"
+      val Some(y) = cpg.file.name(".*Foo.*").ast.isIdentifier.name("y").headOption
+      y.typeFullName shouldBe "__ecma.String"
+      val Some(db) = cpg.file.name(".*Foo.*").ast.isIdentifier.name("db").headOption
+      db.typeFullName shouldBe "flask_sqlalchemy:SQLAlchemy"
+    }
+
+    "resolve 'foo.x' and 'foo.y' field access primitive types correctly" in {
+      val List(z1, z2) = cpg.file
+        .name(".*Bar.*")
+        .ast
+        .isIdentifier
+        .name("z")
+        .l
+      z1.typeFullName shouldBe "ANY"
+      z1.dynamicTypeHintFullName shouldBe Seq("__builtin.int", "__builtin.str")
+      z2.typeFullName shouldBe "ANY"
+      z2.dynamicTypeHintFullName shouldBe Seq("__builtin.int", "__builtin.str")
+    }
+
+    "resolve 'foo.d' field access object types correctly" in {
+      val Some(d) = cpg.file
+        .name(".*Bar.*")
+        .ast
+        .isIdentifier
+        .name("d")
+        .headOption
+      d.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>"
+      d.dynamicTypeHintFullName shouldBe Seq()
+    }
+
+    "resolve a 'createTable' call indirectly from 'foo.d' field access correctly" in {
+      val List(d) = cpg.file
+        .name(".*Bar.*")
+        .ast
+        .isCall
+        .name("createTable")
+        .l
+      d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.createTable"
+      d.dynamicTypeHintFullName shouldBe Seq()
+      d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
+    }
+
+    "resolve a 'deleteTable' call directly from 'foo.db' field access correctly" in {
+      val List(d) = cpg.file
+        .name(".*Bar.*")
+        .ast
+        .isCall
+        .name("deleteTable")
+        .l
+
+      d.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.deleteTable"
+      d.dynamicTypeHintFullName shouldBe Seq()
+      d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
 
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -15,7 +15,6 @@ import java.io.{File => JFile}
 import java.nio.file.Paths
 import java.util.regex.Matcher
 import scala.collection.mutable
-import scala.util.Try
 
 class PythonTypeRecovery(cpg: Cpg) extends XTypeRecovery[File](cpg) {
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -51,7 +51,7 @@ class RecoverForPythonFile(
   /** Overridden to include legacy import calls until imports are supported.
     */
   override def importNodes(cu: AstNode): Traversal[AstNode] =
-    cu.ast.isCall.nameExact("import") ++ super.importNodes(cu)
+    cu.ast.isCall.nameExact("import") // TODO: Remove and use IMPORT nodes
 
   override def visitImport(importCall: Call): Unit = {
     importCall.argument.l match {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -149,8 +149,9 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
             x,
             (x.dynamicTypeHintFullName :+ x.typeFullName).filterNot(_.toUpperCase.matches("(UNKNOWN|ANY)")).toSet
           )
-        case x: Call => symbolTable.put(x, Set(x.methodFullName))
-        case _       =>
+        case x: Call =>
+          symbolTable.put(x, Set(x.methodFullName))
+        case _ =>
       }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -129,12 +129,6 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   /** Provides an entrypoint to add known symbols and their possible types.
     */
   protected def prepopulateSymbolTable(): Unit = {
-    def getTypes(x: CfgNode) =
-      (x.property(PropertyNames.TYPE_FULL_NAME, "ANY") +: x.property(
-        PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME,
-        Seq.empty
-      )).filterNot(x => x.matches("(ANY|UNKNOWN)")).toSet
-
     (cpg.identifier ++ cpg.call)
       .filter {
         case x: Identifier =>
@@ -250,7 +244,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   /** @return
     *   the import nodes of this compilation unit.
     */
-  protected def importNodes(cu: AstNode): Traversal[AstNode] = cu.ast.isImport
+  protected def importNodes(cu: AstNode): Traversal[AstNode] = cu.ast.isCall.referencedImports
 
   /** The initial import setting is over-approximated, so this step checks the CPG for any matches and prunes against
     * these findings. If there are no findings, it will leave the table as is. The latter is significant for external

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -129,24 +129,32 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   /** Provides an entrypoint to add known symbols and their possible types.
     */
   protected def prepopulateSymbolTable(): Unit = {
-    (cpg.identifier ++ cpg.call)
-      .filter {
-        case x: Identifier =>
-          x.dynamicTypeHintFullName.nonEmpty || !x.typeFullName.toUpperCase.matches("(UNKNOWN|ANY)")
-        case x: Call if !x.methodFullName.startsWith("<operator>") =>
-          !x.methodFullName.toLowerCase().matches("(<unknownfullname>|any)")
-        case _ => false
-      }
+    def getTypes(node: AstNode): Set[String] =
+      (node.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq.empty) :+ node.property(
+        PropertyNames.TYPE_FULL_NAME,
+        "ANY"
+      )).filterNot(_.toUpperCase.matches("(UNKNOWN|ANY)")).toSet
+
+    (cu.ast.isIdentifier ++ cu.ast.isCall ++ cu.ast.isLocal ++ cu.ast.isParameter)
+      .filter(hasTypes)
       .foreach {
-        case x: Identifier =>
-          symbolTable.put(
-            x,
-            (x.dynamicTypeHintFullName :+ x.typeFullName).filterNot(_.toUpperCase.matches("(UNKNOWN|ANY)")).toSet
-          )
-        case x: Call =>
-          symbolTable.put(x, Set(x.methodFullName))
+        case x: Identifier => symbolTable.put(x, getTypes(x))
+        case x: Call => symbolTable.put(x, Set(x.methodFullName))
+        case x: Local => symbolTable.put(x, getTypes(x))
+        case x: MethodParameterIn => symbolTable.put(x, getTypes(x))
         case _ =>
       }
+  }
+
+  private def hasTypes(node: AstNode): Boolean = node match {
+    case x: Identifier =>
+      x.dynamicTypeHintFullName.nonEmpty || !x.typeFullName.toUpperCase.matches("(UNKNOWN|ANY)")
+    case x: Call if !x.methodFullName.startsWith("<operator>") =>
+      !x.methodFullName.toLowerCase().matches("(<unknownfullname>|any)")
+    case x: Local => x.dynamicTypeHintFullName.nonEmpty || !x.typeFullName.toUpperCase.matches("(UNKNOWN|ANY)")
+    case x: MethodParameterIn =>
+      x.dynamicTypeHintFullName.nonEmpty || !x.typeFullName.toUpperCase.matches("(UNKNOWN|ANY)")
+    case _ => false
   }
 
   protected def assignments: Traversal[Assignment] =

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -138,11 +138,11 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     (cu.ast.isIdentifier ++ cu.ast.isCall ++ cu.ast.isLocal ++ cu.ast.isParameter)
       .filter(hasTypes)
       .foreach {
-        case x: Identifier => symbolTable.put(x, getTypes(x))
-        case x: Call => symbolTable.put(x, Set(x.methodFullName))
-        case x: Local => symbolTable.put(x, getTypes(x))
+        case x: Identifier        => symbolTable.put(x, getTypes(x))
+        case x: Call              => symbolTable.put(x, Set(x.methodFullName))
+        case x: Local             => symbolTable.put(x, getTypes(x))
         case x: MethodParameterIn => symbolTable.put(x, getTypes(x))
-        case _ =>
+        case _                    =>
       }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/CallTraversal.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.callgraphextension
 
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Import, Method}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
@@ -12,5 +12,8 @@ class CallTraversal(val traversal: Traversal[Call]) extends AnyVal {
   /** The callee method */
   def callee(implicit callResolver: ICallResolver): Traversal[Method] =
     traversal.flatMap(callResolver.getCalledMethodsAsTraversal)
+
+  def referencedImports: Traversal[Import] =
+    traversal.flatMap(_._importViaIsCallForImportOut)
 
 }


### PR DESCRIPTION
* Implemented `XTypeRecovery` classes for JavaScript
* Fixed bug in how import nodes were fetched from `XTypeRecovery` - added convenient traversal for this
* Carried tests over from `pysrc2cpg` and re-implemented a couple into JS/TS to test basic interprocedural type recovery