### PR TITLE
pysrc2cpg: Handling for .import use case 

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -61,7 +61,7 @@ class RecoverForPythonFile(
           // TODO: pysrc2cpg does not link files to the correct namespace nodes
           val root     = cpg.metaData.root.headOption.getOrElse("")
           val fileName = path.file.name.headOption.getOrElse("").stripPrefix(root)
-          val sep      = java.io.File.separator
+          val sep      = Matcher.quoteReplacement(JFile.separator)
           // The below gives us the full path of the relative "."
           (if (fileName.contains(sep)) fileName.substring(0, fileName.lastIndexOf(sep))
            else "").replaceAll(sep, ".")

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -63,8 +63,9 @@ class RecoverForPythonFile(
           val fileName = path.file.name.headOption.getOrElse("").stripPrefix(root)
           val sep      = Matcher.quoteReplacement(JFile.separator)
           // The below gives us the full path of the relative "."
-          (if (fileName.contains(sep)) fileName.substring(0, fileName.lastIndexOf(sep))
-           else "").replaceAll(sep, ".")
+          if (fileName.contains(sep))
+            fileName.substring(0, fileName.lastIndexOf(sep)).replaceAll(sep, ".")
+          else ""
         } else path.code
         val calleeNames = extractPossibleCalleeNames(namespace, funcOrModule.code)
         alias match {

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -57,16 +57,16 @@ class RecoverForPythonFile(
   override def visitImport(importCall: Call): Unit = {
     importCall.argument.l match {
       case (path: Literal) :: (funcOrModule: Literal) :: alias =>
-        val tpath = if (path.code == ".") {
+        val namespace = if (path.code == ".") {
           // TODO: pysrc2cpg does not link files to the correct namespace nodes
           val root     = cpg.metaData.root.headOption.getOrElse("")
-          val fileName = path.file.name.head.stripPrefix(root)
+          val fileName = path.file.name.headOption.getOrElse("").stripPrefix(root)
           val sep      = java.io.File.separator
           // The below gives us the full path of the relative "."
           (if (fileName.contains(sep)) fileName.substring(0, fileName.lastIndexOf(sep))
            else "").replaceAll(sep, ".")
         } else path.code
-        val calleeNames = extractPossibleCalleeNames(tpath, funcOrModule.code)
+        val calleeNames = extractPossibleCalleeNames(namespace, funcOrModule.code)
         alias match {
           case (alias: Literal) :: Nil =>
             symbolTable.put(CallAlias(alias.code), calleeNames)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -57,7 +57,16 @@ class RecoverForPythonFile(
   override def visitImport(importCall: Call): Unit = {
     importCall.argument.l match {
       case (path: Literal) :: (funcOrModule: Literal) :: alias =>
-        val calleeNames = extractPossibleCalleeNames(path.code, funcOrModule.code)
+        val tpath = if (path.code == ".") {
+          // TODO: pysrc2cpg does not link files to the correct namespace nodes
+          val root     = cpg.metaData.root.headOption.getOrElse("")
+          val fileName = path.file.name.head.stripPrefix(root)
+          val sep      = java.io.File.separator
+          // The below gives us the full path of the relative "."
+          (if (fileName.contains(sep)) fileName.substring(0, fileName.lastIndexOf(sep))
+           else "").replaceAll(sep, ".")
+        } else path.code
+        val calleeNames = extractPossibleCalleeNames(tpath, funcOrModule.code)
         alias match {
           case (alias: Literal) :: Nil =>
             symbolTable.put(CallAlias(alias.code), calleeNames)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -6,6 +6,8 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Literal, Member}
 import io.shiftleft.semanticcpg.language._
 
+import java.io.File
+
 class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
 
   "intra-procedural" in {
@@ -239,8 +241,8 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |	print("All pages")
         |""".stripMargin
     val cpg = code("print('Hello, world!')")
-      .moreCode(controller, "controller/urls.py")
-      .moreCode(views, "student/views.py")
+      .moreCode(controller, Seq("controller", "urls.py").mkString(File.separator))
+      .moreCode(views, Seq("student", "views.py").mkString(File.separator))
 
     val args = cpg.call.methodFullName("django.*[.](path|url)").l.head.argument.l
     args.size shouldBe 3
@@ -289,8 +291,8 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |	print("All pages")
         |""".stripMargin
     val cpg = code("print('Hello, world!')")
-      .moreCode(controller, "controller/urls.py")
-      .moreCode(views, "controller/views.py")
+      .moreCode(controller, Seq("controller", "urls.py").mkString(File.separator))
+      .moreCode(views, Seq("controller", "views.py").mkString(File.separator))
 
     val args = cpg.call.methodFullName("django.*[.](path|url)").l.head.argument.l
     args.size shouldBe 3

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -221,6 +221,81 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     sink2.reachableBy(pSrc).size shouldBe 1
   }
 
+  "Import statement with method ref sample one" in {
+    val controller =
+      """
+        |from django.contrib import admin
+        |from django.urls import path
+        |from django.conf.urls import url
+        |from student import views
+        |
+        |urlpatterns = [
+        |    url(r'^allPage/$', views.all_page)
+        |]
+        |""".stripMargin
+    val views =
+      """
+        |def all_page(request):
+        |	print("All pages")
+        |""".stripMargin
+    val cpg = code("print('Hello, world!')")
+      .moreCode(controller, "controller/urls.py")
+      .moreCode(views, "student/views.py")
+
+    val args = cpg.call.methodFullName("django.*[.](path|url)").l.head.argument.l
+    args.size shouldBe 3
+  }
+
+  "Import statement with method ref sample two" in {
+    val controller =
+      """
+        |from django.contrib import admin
+        |from django.urls import path
+        |from django.conf.urls import url
+        |from .import views
+        |
+        |urlpatterns = [
+        |    url(r'^allPage/$', views.all_page)
+        |]
+        |""".stripMargin
+    val views =
+      """
+        |def all_page(request):
+        |	print("All pages")
+        |""".stripMargin
+    val cpg = code("print('Hello, world!')")
+      .moreCode(controller, "urls.py")
+      .moreCode(views, "views.py")
+
+    val args = cpg.call.methodFullName("django.*[.](path|url)").l.head.argument.l
+    args.size shouldBe 3
+  }
+
+  "Import statement with method ref sample three" in {
+    val controller =
+      """
+        |from django.contrib import admin
+        |from django.urls import path
+        |from django.conf.urls import url
+        |from .import views
+        |
+        |urlpatterns = [
+        |    url(r'^allPage/$', views.all_page)
+        |]
+        |""".stripMargin
+    val views =
+      """
+        |def all_page(request):
+        |	print("All pages")
+        |""".stripMargin
+    val cpg = code("print('Hello, world!')")
+      .moreCode(controller, "controller/urls.py")
+      .moreCode(views, "controller/views.py")
+
+    val args = cpg.call.methodFullName("django.*[.](path|url)").l.head.argument.l
+    args.size shouldBe 3
+  }
+
   "flow from function param to sink" in {
     val cpg: Cpg = code("""
       |import requests
@@ -249,5 +324,4 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     val flowsGet = sinkGet.reachableByFlows(sourceParam).l
     flowsGet.size shouldBe 2
   }
-
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -232,7 +232,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |from student import views
         |
         |urlpatterns = [
-        |    url(r'^allPage/$', views.all_page)
+        |    url(r'allPage', views.all_page)
         |]
         |""".stripMargin
     val views =
@@ -257,7 +257,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |from .import views
         |
         |urlpatterns = [
-        |    url(r'^allPage/$', views.all_page)
+        |    url(r'allPage', views.all_page)
         |]
         |""".stripMargin
     val views =
@@ -282,7 +282,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |from .import views
         |
         |urlpatterns = [
-        |    url(r'^allPage/$', views.all_page)
+        |    url(r'allPage', views.all_page)
         |]
         |""".stripMargin
     val views =

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -273,31 +273,6 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     args.size shouldBe 3
   }
 
-  "Import statement with method ref sample three" in {
-    val controller =
-      """
-        |from django.contrib import admin
-        |from django.urls import path
-        |from django.conf.urls import url
-        |from .import views
-        |
-        |urlpatterns = [
-        |    url(r'allPage', views.all_page)
-        |]
-        |""".stripMargin
-    val views =
-      """
-        |def all_page(request):
-        |	print("All pages")
-        |""".stripMargin
-    val cpg = code("print('Hello, world!')")
-      .moreCode(controller, Seq("controller", "urls.py").mkString(File.separator))
-      .moreCode(views, Seq("controller", "views.py").mkString(File.separator))
-
-    val args = cpg.call.methodFullName("django.*[.](path|url)").l.head.argument.l
-    args.size shouldBe 3
-  }
-
   "flow from function param to sink" in {
     val cpg: Cpg = code("""
       |import requests

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -796,7 +796,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
       }
       .foreach { case (m, mRef) =>
         fieldAccess.astParent
-          .filterNot(_.astChildren.isMethodRef.methodFullName(mRef.methodFullName).nonEmpty)
+          .filterNot(_.astChildren.isMethodRef.methodFullNameExact(mRef.methodFullName).nonEmpty)
           .foreach { inCall =>
             builder.addNode(mRef)
             builder.addEdge(mRef, m, EdgeTypes.REF)


### PR DESCRIPTION
* Handling of .import use case 
* Unit tests for the given use case

--------
student/urls.py 
--------
```

from django.contrib import admin
from django.urls import path
from django.conf.urls import url

from .import views

urlpatterns = [
    url(r'^allPage/$', views.all_page)
]


```
--------
student/views.py
--------

```
def all_page(request):
	print("All pages")
```

The handling of `.import` wasn't there. This code change will handle the given use case. Added respective unit tests as well.