### PR TITLE
JoernSlice: TypeScript Slicing and Remove Receiver Info

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -1,25 +1,22 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
+import io.joern.pysrc2cpg._
+import io.joern.x2cpg.X2Cpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.joern.pysrc2cpg.{
-  DynamicTypeHintFullNamePass,
-  ImportsPass,
-  PythonNaiveCallLinker,
-  PythonTypeHintCallLinker,
-  PythonTypeRecovery
-}
 
 import java.nio.file.Path
 import scala.util.Try
 
 case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("pysrc2cpg.bat") else rootPath.resolve("pysrc2cpg")
+  private var pyConfig: Option[Py2CpgOnFileSystemConfig] = None
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
   override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
     val arguments = Seq(inputPath, "-o", outputPath) ++ config.cmdLineParams
+    pyConfig = X2Cpg.parseCommandLine(arguments.toArray, NewMain.getCmdLineParser, Py2CpgOnFileSystemConfig())
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
@@ -29,7 +26,7 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
     new ImportsPass(cpg).createAndApply()
     new DynamicTypeHintFullNamePass(cpg).createAndApply()
-    new PythonTypeRecovery(cpg).createAndApply()
+    new PythonTypeRecovery(cpg, enabledDummyTypes = !pyConfig.forall(_.disableDummyTypes)).createAndApply()
     new PythonTypeHintCallLinker(cpg).createAndApply()
     new PythonNaiveCallLinker(cpg).createAndApply()
     cpg

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -46,7 +46,7 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
     val maybeCpg = createCpgWithOverlays(config)
     maybeCpg.map { cpg =>
       new OssDataFlow(new OssDataFlowOptions()).run(new LayerCreatorContext(cpg))
-      postProcessingPasses(cpg).foreach(_.createAndApply())
+      postProcessingPasses(cpg, Option(config)).foreach(_.createAndApply())
       cpg
     }
   }
@@ -55,12 +55,12 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
 
 object JsSrc2Cpg {
 
-  def postProcessingPasses(cpg: Cpg): List[CpgPassBase] =
+  def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] =
     List(
       new RequirePass(cpg),
       new ConstClosurePass(cpg),
       new JavascriptCallLinker(cpg),
-      new JavaScriptTypeRecovery(cpg),
+      new JavaScriptTypeRecovery(cpg, enabledDummyTypes = !config.forall(_.disableDummyTypes)),
       new JavaScriptTypeHintCallLinker(cpg)
     )
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
@@ -2,8 +2,7 @@ package io.joern.jssrc2cpg
 
 import io.joern.jssrc2cpg.Frontend._
 import io.joern.jssrc2cpg.utils.Environment
-import io.joern.x2cpg.X2CpgConfig
-import io.joern.x2cpg.X2CpgMain
+import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
 import java.nio.file.Paths
@@ -14,7 +13,8 @@ final case class Config(
   outputPath: String = X2CpgConfig.defaultOutputPath,
   ignoredFilesRegex: Regex = "".r,
   ignoredFiles: Seq[String] = Seq.empty,
-  tsTypes: Boolean = true
+  tsTypes: Boolean = true,
+  disableDummyTypes: Boolean = false
 ) extends X2CpgConfig[Config] {
 
   def createPathForIgnore(ignore: String): String = {
@@ -49,7 +49,11 @@ private object Frontend {
       opt[Unit]("no-tsTypes")
         .hidden()
         .action((_, c) => c.copy(tsTypes = false))
-        .text("disable generation of types via Typescript")
+        .text("disable generation of types via Typescript"),
+      opt[Unit]("no-dummyTypes")
+        .hidden()
+        .action((_, c) => c.copy(disableDummyTypes = true))
+        .text("disable generation of dummy types during type recovery")
     )
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -9,13 +9,14 @@ import overflowdb.traversal.Traversal
 
 import scala.collection.mutable
 
-class JavaScriptTypeRecovery(cpg: Cpg) extends XTypeRecovery[File](cpg) {
+class JavaScriptTypeRecovery(cpg: Cpg, enabledDummyTypes: Boolean = true) extends XTypeRecovery[File](cpg) {
   override def compilationUnit: Traversal[File] = cpg.file
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,
     builder: DiffGraphBuilder
-  ): RecoverForXCompilationUnit[File] = new RecoverForJavaScriptFile(cpg, unit, builder, globalTable, addedNodes)
+  ): RecoverForXCompilationUnit[File] =
+    new RecoverForJavaScriptFile(cpg, unit, builder, globalTable, addedNodes, enabledDummyTypes)
 
 }
 
@@ -24,8 +25,9 @@ class RecoverForJavaScriptFile(
   cu: File,
   builder: DiffGraphBuilder,
   globalTable: SymbolTable[GlobalKey],
-  addedNodes: mutable.Set[(Long, String)]
-) extends RecoverForXCompilationUnit[File](cpg, cu, builder, globalTable, addedNodes) {
+  addedNodes: mutable.Set[(Long, String)],
+  enabledDummyTypes: Boolean
+) extends RecoverForXCompilationUnit[File](cpg, cu, builder, globalTable, addedNodes, enabledDummyTypes) {
 
   /** A heuristic method to determine if a call is a constructor or not.
     */

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
@@ -19,7 +19,11 @@ private object Frontend {
       opt[Boolean]("ignoreVenvDir")
         // Default is specified in Py2CpgOFileSystemConfig because Scopt is a shit library.
         .text("Specifies whether venv-dir is ignored. Default to true.")
-        .action(((value, config) => config.copy(ignoreVenvDir = value)))
+        .action(((value, config) => config.copy(ignoreVenvDir = value))),
+      opt[Unit]("no-dummyTypes")
+        .hidden()
+        .action((_, c) => c.copy(disableDummyTypes = true))
+        .text("disable generation of dummy types during type recovery")
     )
   }
 }
@@ -28,5 +32,7 @@ object NewMain extends X2CpgMain(cmdLineParser, new Py2CpgOnFileSystem())(new Py
   def run(config: Py2CpgOnFileSystemConfig, frontend: Py2CpgOnFileSystem): Unit = {
     frontend.run(config)
   }
+
+  def getCmdLineParser = cmdLineParser
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
@@ -13,7 +13,8 @@ case class Py2CpgOnFileSystemConfig(
   outputFile: Path = Paths.get(X2CpgConfig.defaultOutputPath),
   inputDir: Path = null,
   venvDir: Path = Paths.get(".venv"),
-  ignoreVenvDir: Boolean = true
+  ignoreVenvDir: Boolean = true,
+  disableDummyTypes: Boolean = false
 ) extends X2CpgConfig[Py2CpgOnFileSystemConfig] {
   override def withInputPath(inputPath: String): Py2CpgOnFileSystemConfig = {
     copy(inputDir = Paths.get(inputPath))
@@ -87,5 +88,6 @@ class Py2CpgOnFileSystem extends X2CpgFrontend[Py2CpgOnFileSystemConfig] {
     logger.info(s"Input directory: ${config.inputDir}")
     logger.info(s"Venv directory: ${config.venvDir}")
     logger.info(s"IgnoreVenvDir: ${config.ignoreVenvDir}")
+    logger.info(s"No dummy types: ${config.disableDummyTypes}")
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -16,14 +16,15 @@ import java.nio.file.Paths
 import java.util.regex.Matcher
 import scala.collection.mutable
 
-class PythonTypeRecovery(cpg: Cpg) extends XTypeRecovery[File](cpg) {
+class PythonTypeRecovery(cpg: Cpg, enabledDummyTypes: Boolean = true) extends XTypeRecovery[File](cpg) {
 
   override def compilationUnit: Traversal[File] = cpg.file
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,
     builder: DiffGraphBuilder
-  ): RecoverForXCompilationUnit[File] = new RecoverForPythonFile(cpg, unit, builder, globalTable, addedNodes)
+  ): RecoverForXCompilationUnit[File] =
+    new RecoverForPythonFile(cpg, unit, builder, globalTable, addedNodes, enabledDummyTypes)
 
 }
 
@@ -34,8 +35,9 @@ class RecoverForPythonFile(
   cu: File,
   builder: DiffGraphBuilder,
   globalTable: SymbolTable[GlobalKey],
-  addedNodes: mutable.Set[(Long, String)]
-) extends RecoverForXCompilationUnit[File](cpg, cu, builder, globalTable, addedNodes) {
+  addedNodes: mutable.Set[(Long, String)],
+  enabledDummyTypes: Boolean
+) extends RecoverForXCompilationUnit[File](cpg, cu, builder, globalTable, addedNodes, enabledDummyTypes) {
 
   /** Replaces the `this` prefix with the Pythonic `self` prefix for instance methods of functions local to this
     * compilation unit.

--- a/joern-cli/src/test/resources/testcode/tssrc-slice/main.ts
+++ b/joern-cli/src/test/resources/testcode/tssrc-slice/main.ts
@@ -1,0 +1,89 @@
+import Loader from './loader'; // Used to load files from the web server
+import Input from './input'; // Used to manage the user input
+
+//This is the abstract base of all scenes
+export abstract class Scene {
+    game: Game;
+    gl: WebGL2RenderingContext;
+    public constructor(game: Game){
+        this.game = game;
+        this.gl = game.gl;
+    }
+
+    public abstract load(): void; // Here we will tell the loader which files to load from the webserver
+    public abstract timer(): void;
+    public abstract start(): void; // Here we will initialize the scene objects before entering the draw loop
+    public abstract draw(deltaTime: number): number; // Here will draw the scene (deltaTime is the difference in time between this frame and the past frame in milliseconds)
+    public abstract end(): void; // Here we free the memory from objects we allocated
+}
+
+//This class create the WebGL2 context, manages the scenes and handles the game loop
+export default class Game {
+    canvas: HTMLCanvasElement; // The canvas on which we will draw
+    gl: WebGL2RenderingContext; // The WebGL2 context of the canvas (we will use it to draw)
+    loader: Loader = new Loader(); // A loader to read files from the webserver
+    input: Input; // A manager for user input (keyboard and mouse)
+    scenes: {[name: string]: Scene} = {}; // A dictionary of all available scenes
+    currentScene: Scene = null; // The scene that is currently being drawn
+    nextScene: Scene = null; // The scene that will replace the current scene after its files have been loaded
+    nextSceneReady: boolean = false; // Whether the files requested by the next scene has been loaded or not
+    lastTick: number; // The time of the last frame in milliseconds (used to calculate delta time)
+
+    constructor(canvas: HTMLCanvasElement){
+        this.canvas = canvas;
+        this.gl = this.canvas.getContext("webgl2", {
+            preserveDrawingBuffer: true, // This will prevent the Browser from automatically clearing the frame buffer every frame
+            alpha: true, // this will tell the browser that we want an alpha component in our frame buffer
+            antialias: true, // this will tell the browser that we want antialiasing
+            depth: true, // this will tell the browser that we want a depth buffer
+            powerPreference: "high-performance",
+            premultipliedAlpha: false, // This can be used if the canvas are going to be blended with the rest of the webpage (transparency)
+            stencil: true // this will tell the browser that we want a stencil buffer
+        }); // This command loads the WebGL2 context which we will use to draw
+        this.input = new Input(this.canvas);
+        this.lastTick = performance.now();
+        this.loop(performance.now()); // Start the game loop
+    }
+
+    public addScene(name: string, type: new (game: Game) => Scene){
+        this.scenes[name] = new type(this);
+    }
+
+    public addScenes(scenes: {[name: string]: new (game: Game) => Scene}){
+        for(let name in scenes) this.addScene(name, scenes[name]);
+    }
+
+    public startScene(name: string){
+        if(name in this.scenes){
+            this.nextScene = this.scenes[name];
+            this.nextSceneReady = false;
+            this.nextScene.load();
+            this.loader.wait().then(()=>{this.nextSceneReady = true;}) // This will make the loader notify us when the files are ready
+        } else {
+            console.warn(`Scene "${name}" not found`);
+        }
+    }
+
+    private loop(time: DOMHighResTimeStamp){
+        requestAnimationFrame((time) => this.loop(time)); // Tell the browser to call this function again when the next frame needs to be drawn
+        if(this.nextScene != null && this.nextSceneReady){ // If there is a next scene and it is ready, replace the current scene with it.
+            if(this.currentScene != null) this.currentScene.end(); // If there was an old scene, tell it to free its memory
+            this.currentScene = this.nextScene;
+            this.nextScene = null;
+            this.currentScene.start(); // Tell the scene to initialize its objects
+        }
+        // this.currentScene = this.nextScene;
+        // this.currentScene.start();
+        if(this.currentScene != null){
+            let state = this.currentScene.draw(time-this.lastTick); // Tell the scene to draw itself
+            if (state == -1)
+            {
+                console.log("Game");
+                return;
+            }
+        }
+        this.input.update(); // Update some information about the user input
+        this.lastTick = time;
+    }
+
+}

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernSliceTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernSliceTests.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTest {
 
-  "extracting a usage slice from code" should withTestCpg(
+  "extracting a usage slice from JavaScript code" should withTestCpg(
     File(getClass.getClassLoader.getResource("testcode/jssrc-slice")),
     Languages.JSSRC
   ) { case (cpg: Cpg, _) =>
@@ -18,7 +18,7 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
 
     "extract 'express.js' slice" in {
       val Some(slice) = programSlice.objectSlices.get("main.js::program").flatMap(_.headOption)
-      slice.definedBy shouldBe Some(DefComponent("express()", "ANY"))
+      slice.definedBy shouldBe Some(DefComponent("express", "ANY"))
       slice.targetObj shouldBe DefComponent("app", "ANY")
 
       val List(inv1, inv2) = slice.invokedCalls
@@ -53,7 +53,7 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
 
     "extract 'Car' object instantiation" in {
       val Some(slice) = programSlice.objectSlices.get("main.js::program:carTest").flatMap(_.headOption)
-      slice.definedBy shouldBe Some(DefComponent("new Car(\"Noodle\", 2012)", "ANY"))
+      slice.definedBy shouldBe Some(DefComponent("new Car", "ANY"))
       slice.targetObj shouldBe DefComponent("c", "main.js::program:Car")
 
       val List(inv1) = slice.invokedCalls
@@ -66,6 +66,52 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
       pos1 shouldBe 1
       arg1.callName shouldBe "Car"
       arg1.paramTypes shouldBe List("__ecma.String", "__ecma.Number")
+      arg1.returnType shouldBe "ANY"
+    }
+  }
+
+  "extracting a usage slice from TypeScript code" should withTestCpg(
+    File(getClass.getClassLoader.getResource("testcode/tssrc-slice")),
+    Languages.JSSRC
+  ) { case (cpg: Cpg, _) =>
+    val programSlice =
+      UsageSlicing.calculateUsageSlice(cpg, JoernSlice.Config()).asInstanceOf[ProgramUsageSlice]
+
+    "extract 'name' parameter slice from 'startScene'" in {
+      val Some(slice) = programSlice.objectSlices.get("main.ts::program:Game:startScene").flatMap(_.headOption)
+      slice.definedBy shouldBe Some(DefComponent("name", "__ecma.String"))
+      slice.targetObj shouldBe DefComponent("name", "__ecma.String")
+
+      val List((arg1, pos1)) = slice.argToCalls
+
+      pos1 shouldBe 2
+      arg1.callName shouldBe "__Runtime.TO_STRING"
+      arg1.paramTypes shouldBe List("__ecma.String", "__ecma.String", "__ecma.String")
+      arg1.returnType shouldBe "ANY"
+    }
+
+    "extract 'loader' object slice from the main program" in {
+      val Some(slice) = programSlice.objectSlices.get("main.ts::program").flatMap(_.headOption)
+      slice.definedBy shouldBe Some(DefComponent("new Loader", "ANY"))
+      slice.targetObj shouldBe DefComponent("loader", "ANY")
+
+      val List((arg1, pos1)) = slice.argToCalls
+
+      pos1 shouldBe 1
+      arg1.callName shouldBe "Loader"
+      arg1.returnType shouldBe "ANY"
+    }
+
+    "extract 'time' parameter slice from the lambda in 'loop'" in {
+      val Some(slice) = programSlice.objectSlices.get("main.ts::program:Game:loop:anonymous").flatMap(_.headOption)
+      slice.definedBy shouldBe Some(DefComponent("time", "__ecma.Number"))
+      slice.targetObj shouldBe DefComponent("time", "__ecma.Number")
+
+      val List((arg1, pos1)) = slice.argToCalls
+
+      pos1 shouldBe 1
+      arg1.callName shouldBe "loop"
+      arg1.paramTypes shouldBe List("__ecma.Number")
       arg1.returnType shouldBe "ANY"
     }
   }


### PR DESCRIPTION
* Testing TS slicing
* Fixed how "name" properties were extracted by matching node types
* Removed `receiver` property as it was mostly duplicate info or not meaningful
* Enabled the ability to disable dummy types on frontends that use type recovery