### PR TITLE
configure jdk11 as target platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,12 @@ ThisBuild / compile / javacOptions ++= Seq(
   "-g", // debug symbols
   "-Xlint",
   "--release=11",
-)
+) ++ {
+  // fail early if users with JDK8 try to run this
+  val javaVersion = sys.props("java.specification.version").toFloat
+  assert(javaVersion.toInt >= 11, s"this build requires JDK11+ - you're using $javaVersion")
+  Nil
+}
 
 ThisBuild / scalacOptions ++= Seq(
   "-deprecation", // Emit warning and location for usages of deprecated APIs.

--- a/build.sbt
+++ b/build.sbt
@@ -48,11 +48,14 @@ ThisBuild / libraryDependencies ++= Seq(
 
 ThisBuild / compile / javacOptions ++= Seq(
   "-g", // debug symbols
-  "-Xlint"
+  "-Xlint",
+  "--release=11",
 )
 
 ThisBuild / scalacOptions ++= Seq(
-  "-deprecation" // Emit warning and location for usages of deprecated APIs.
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-target:11", 
+  "--release", "11",
 )
 
 lazy val createDistribution = taskKey[File]("Create a complete Joern distribution")


### PR DESCRIPTION
We have an implicit lower boundary of jdk11 due to e.g. c2cpg, and usage
of more modern JDK API, so we shouldn't go lower than that IMO.