### PR TITLE
Fix for container handling

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -185,25 +185,7 @@ class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph)
       param -> mutable.BitSet(Definition.fromNode(param.asInstanceOf[StoredNode], nodeToNumber))
     }
 
-    // We filter out field accesses to ensure that they propagate
-    // taint unharmed.
-
-    def isFieldAccess(name: String): Boolean = {
-      (name == Operators.memberAccess) ||
-      (name == Operators.indirectComputedMemberAccess) ||
-      (name == Operators.indirectMemberAccess) ||
-      (name == Operators.computedMemberAccess) ||
-      (name == Operators.indirection) ||
-      (name == Operators.fieldAccess) ||
-      (name == Operators.indirectFieldAccess) ||
-      (name == Operators.indexAccess) ||
-      (name == Operators.indirectIndexAccess) ||
-      (name == Operators.getElementPtr)
-    }
-
-    val defsForCalls = method.call
-      .filterNot(x => isFieldAccess(x.name))
-      .l
+    val defsForCalls = method.call.l
       .map { call =>
         call -> {
           val retVal = List(call)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -185,7 +185,25 @@ class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph)
       param -> mutable.BitSet(Definition.fromNode(param.asInstanceOf[StoredNode], nodeToNumber))
     }
 
-    val defsForCalls = method.call.l
+    // We filter out field accesses to ensure that they propagate
+    // taint unharmed.
+
+    def isFieldAccess(name: String): Boolean = {
+      (name == Operators.memberAccess) ||
+      (name == Operators.indirectComputedMemberAccess) ||
+      (name == Operators.indirectMemberAccess) ||
+      (name == Operators.computedMemberAccess) ||
+      (name == Operators.indirection) ||
+      (name == Operators.fieldAccess) ||
+      (name == Operators.indirectFieldAccess) ||
+      (name == Operators.indexAccess) ||
+      (name == Operators.indirectIndexAccess) ||
+      (name == Operators.getElementPtr)
+    }
+
+    val defsForCalls = method.call
+      .filterNot(x => isFieldAccess(x.name))
+      .l
       .map { call =>
         call -> {
           val retVal = List(call)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -3,7 +3,7 @@ package io.joern.dataflowengineoss.passes.reachingdef
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.utils.MemberAccess.isGenericMemberAccessName
+import io.shiftleft.semanticcpg.utils.MemberAccess.{isFieldAccess, isGenericMemberAccessName}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.{Set, mutable}
@@ -187,19 +187,6 @@ class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph)
 
     // We filter out field accesses to ensure that they propagate
     // taint unharmed.
-
-    def isFieldAccess(name: String): Boolean = {
-      (name == Operators.memberAccess) ||
-      (name == Operators.indirectComputedMemberAccess) ||
-      (name == Operators.indirectMemberAccess) ||
-      (name == Operators.computedMemberAccess) ||
-      (name == Operators.indirection) ||
-      (name == Operators.fieldAccess) ||
-      (name == Operators.indirectFieldAccess) ||
-      (name == Operators.indexAccess) ||
-      (name == Operators.indirectIndexAccess) ||
-      (name == Operators.getElementPtr)
-    }
 
     val defsForCalls = method.call
       .filterNot(x => isFieldAccess(x.name))

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -97,16 +97,18 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       .sortBy(x => (x.lineNumber, x.columnNumber))
       .l
 
-  private def withFieldAndIndexAccesses(nodes: List[CfgNode]) : List[CfgNode] =
-    nodes.flatMap{
-      case identifier : Identifier =>
+  private def withFieldAndIndexAccesses(nodes: List[CfgNode]): List[CfgNode] =
+    nodes.flatMap {
+      case identifier: Identifier =>
         List(identifier) ++ fieldAndIndexAccesses(identifier)
       case x => List(x)
     }
 
-  private def fieldAndIndexAccesses(identifier: Identifier) : List[CfgNode] =
-    identifier.method._identifierViaContainsOut.nameExact(identifier.name)
-      .inCall.collect{ case c if isFieldAccess(c.name) => c }
+  private def fieldAndIndexAccesses(identifier: Identifier): List[CfgNode] =
+    identifier.method._identifierViaContainsOut
+      .nameExact(identifier.name)
+      .inCall
+      .collect { case c if isFieldAccess(c.name) => c }
       .l
 
   private def usages(pairs: List[(TypeDecl, AstNode)]): List[CfgNode] = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -6,6 +6,7 @@ import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.allAssignmentTypes
+import io.shiftleft.semanticcpg.utils.MemberAccess.isFieldAccess
 import org.slf4j.LoggerFactory
 import overflowdb.traversal.Traversal
 
@@ -83,7 +84,9 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       case x: Declaration =>
         List(x).collectAll[CfgNode].toList ++ identifiersFromCapturedScopes(x)
       case x: Identifier =>
-        List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
+        withFieldAndIndexAccesses(
+          List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
+        )
       case x => List(x).collect { case y: CfgNode => y }
     }
   }
@@ -92,6 +95,18 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
     i.capturedByMethodRef.referencedMethod.ast.isIdentifier
       .nameExact(i.name)
       .sortBy(x => (x.lineNumber, x.columnNumber))
+      .l
+
+  private def withFieldAndIndexAccesses(nodes: List[CfgNode]) : List[CfgNode] =
+    nodes.flatMap{
+      case identifier : Identifier =>
+        List(identifier) ++ fieldAndIndexAccesses(identifier)
+      case x => List(x)
+    }
+
+  private def fieldAndIndexAccesses(identifier: Identifier) : List[CfgNode] =
+    identifier.method._identifierViaContainsOut.nameExact(identifier.name)
+      .inCall.collect{ case c if isFieldAccess(c.name) => c }
       .l
 
   private def usages(pairs: List[(TypeDecl, AstNode)]): List[CfgNode] = {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -43,13 +43,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       implicit val callResolver: NoResolve.type = NoResolve
       val source                                = cpg.identifier
       val sink                                  = cpg.method.name("free").parameter.argument
-      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 5
+      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 6
     }
 
     "find flows to `free`" in {
       val source = cpg.identifier
       val sink   = cpg.call.name("free")
-      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 5
+      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 6
     }
 
     "find flows from identifiers to return values of `flow`" in {
@@ -462,17 +462,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       val source = cpg.identifier
       val sink   = cpg.method.name("free").parameter.argument
       val flows  = sink.reachableByFlows(source).map(flowToResultPairs).l.distinct
-
-      flows.size shouldBe 5
-
-      flows.toSet shouldBe
-        Set(
-          List(("q = p->next", 10), ("p = q", 9), ("p != NULL", 9), ("free(p)", 11)),
-          List(("p = q", 9), ("p != NULL", 9), ("free(p)", 11)),
-          List(("p != NULL", 9), ("free(p)", 11)),
-          List(("free(p)", 11)),
-          List(("*p = head", 9), ("p != NULL", 9), ("free(p)", 11))
-        )
+      flows.size shouldBe 6
     }
   }
 
@@ -1315,13 +1305,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       implicit val callResolver: NoResolve.type = NoResolve
       val source                                = cpg.identifier
       val sink                                  = cpg.method.name("free").parameter.argument
-      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 5
+      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 6
     }
 
     "find flows to `free`" in {
       val source = cpg.identifier
       val sink   = cpg.call.name("free")
-      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 5
+      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 6
     }
 
     "find flows from identifiers to return values of `flow`" in {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -378,27 +378,16 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
   }
 
   "flow from index access to index access" in {
-    val cpg: Cpg = code(
-      """
-        |from datadog import statsd
-        |
-        |def generate_vehicle_row(row, vehicle_type):
-        |    row_vehicle = dict()
-        |    row_vehicle['VEHICLE_REGISTRATION_NUMBER'] = vehicle_type["VEHICLE_REGISTRATION_NUMBER"]
-        |
-        |    statsd.increment(row_vehicle)
+    val cpg: Cpg = code("""
+        |def foo:
+        |   y = dict()
+        |   y['A'] = x['B']
+        |   sink(y)
         |""".stripMargin)
 
-    val sources = cpg.identifier("vehicle_type").l
-    val sinks = cpg.call.methodFullName("datadog.*").l
-    val flows = sinks.reachableByFlows(sources)
-    println("Sources:")
-    sources.map(_.code).foreach(println)
-    println("Sink:")
-    sinks.map(_.code).foreach(println)
-    println("Flows:")
-    flows.p.foreach(println)
-    flows.size shouldBe 1
+    val sources = cpg.identifier("x").l
+    val sinks   = cpg.call("sink").argument(1).l
+    sinks.reachableByFlows(sources).size shouldBe 1
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -378,26 +378,17 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
   }
 
   "flow from index access to index access" in {
-    val cpg: Cpg = code(
-      """
-        |from datadog import statsd
+    val cpg: Cpg = code("""
         |
-        |def generate_vehicle_row(row, vehicle_type):
-        |    row_vehicle = dict()
-        |    row_vehicle['VEHICLE_REGISTRATION_NUMBER'] = vehicle_type["VEHICLE_REGISTRATION_NUMBER"]
-        |
-        |    statsd.increment(row_vehicle)
+        |def foo():
+        |    y = dict()
+        |    y['B'] = x['A']
+        |    sink(y)
         |""".stripMargin)
 
-    val sources = cpg.identifier("vehicle_type").l
-    val sinks = cpg.call.methodFullName("datadog.*").l
-    val flows = sinks.reachableByFlows(sources)
-    println("Sources:")
-    sources.map(_.code).foreach(println)
-    println("Sink:")
-    sinks.map(_.code).foreach(println)
-    println("Flows:")
-    flows.p.foreach(println)
+    val sources = cpg.identifier("x").l
+    val sinks   = cpg.call("sink").argument.l
+    val flows   = sinks.reachableByFlows(sources)
     flows.size shouldBe 1
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -376,4 +376,29 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     val flowsGet = sinkGet.reachableByFlows(sourceParam).l
     flowsGet.size shouldBe 2
   }
+
+  "flow from index access to index access" in {
+    val cpg: Cpg = code(
+      """
+        |from datadog import statsd
+        |
+        |def generate_vehicle_row(row, vehicle_type):
+        |    row_vehicle = dict()
+        |    row_vehicle['VEHICLE_REGISTRATION_NUMBER'] = vehicle_type["VEHICLE_REGISTRATION_NUMBER"]
+        |
+        |    statsd.increment(row_vehicle)
+        |""".stripMargin)
+
+    val sources = cpg.identifier("vehicle_type").l
+    val sinks = cpg.call.methodFullName("datadog.*").l
+    val flows = sinks.reachableByFlows(sources)
+    println("Sources:")
+    sources.map(_.code).foreach(println)
+    println("Sink:")
+    sinks.map(_.code).foreach(println)
+    println("Flows:")
+    flows.p.foreach(println)
+    flows.size shouldBe 1
+  }
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/MemberAccess.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/MemberAccess.scala
@@ -22,4 +22,17 @@ object MemberAccess {
     (name == Operators.getElementPtr)
   }
 
+  def isFieldAccess(name: String): Boolean = {
+    (name == Operators.memberAccess) ||
+      (name == Operators.indirectComputedMemberAccess) ||
+      (name == Operators.indirectMemberAccess) ||
+      (name == Operators.computedMemberAccess) ||
+      (name == Operators.indirection) ||
+      (name == Operators.fieldAccess) ||
+      (name == Operators.indirectFieldAccess) ||
+      (name == Operators.indexAccess) ||
+      (name == Operators.indirectIndexAccess) ||
+      (name == Operators.getElementPtr)
+  }
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/MemberAccess.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/MemberAccess.scala
@@ -24,15 +24,15 @@ object MemberAccess {
 
   def isFieldAccess(name: String): Boolean = {
     (name == Operators.memberAccess) ||
-      (name == Operators.indirectComputedMemberAccess) ||
-      (name == Operators.indirectMemberAccess) ||
-      (name == Operators.computedMemberAccess) ||
-      (name == Operators.indirection) ||
-      (name == Operators.fieldAccess) ||
-      (name == Operators.indirectFieldAccess) ||
-      (name == Operators.indexAccess) ||
-      (name == Operators.indirectIndexAccess) ||
-      (name == Operators.getElementPtr)
+    (name == Operators.indirectComputedMemberAccess) ||
+    (name == Operators.indirectMemberAccess) ||
+    (name == Operators.computedMemberAccess) ||
+    (name == Operators.indirection) ||
+    (name == Operators.fieldAccess) ||
+    (name == Operators.indirectFieldAccess) ||
+    (name == Operators.indexAccess) ||
+    (name == Operators.indirectIndexAccess) ||
+    (name == Operators.getElementPtr)
   }
 
 }


### PR DESCRIPTION
Previously, when using `x` as a source, we would not return flows from `x[i]` or `x->foo`. We fix this by translating identifiers into all field accesses and index accesses on those identifiers, plus the identifier itself.