### PR TITLE
PythonTypeRecovery: Navigate Python Decorators

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -760,7 +760,9 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |]
         |""".stripMargin
     val views =
-      """
+      """from django.contrib.auth.decorators import login_required
+        |
+        |@login_required
         |def PasswordChange(request):
         |    print("All pages")
         |


### PR DESCRIPTION
* Override identifier -> call if the call looks like a Python decorator
* Traverse decorator arguments to pick up method ref and resolve method symbol