### PR TITLE
Fix handling of global variables

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -1,0 +1,17 @@
+package io.joern
+
+import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Identifier}
+import io.shiftleft.semanticcpg.language._
+
+package object dataflowengineoss {
+
+  def identifierToFirstUsages(identifier : Identifier): List[Identifier] = identifier
+    .refsTo.flatMap(identifiersFromCapturedScopes).l
+
+  def identifiersFromCapturedScopes(i: Declaration): List[Identifier] =
+    i.capturedByMethodRef.referencedMethod.ast.isIdentifier
+      .nameExact(i.name)
+      .sortBy(x => (x.lineNumber, x.columnNumber))
+      .l
+
+}

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -7,7 +7,7 @@ import overflowdb.traversal.Traversal
 package object dataflowengineoss {
 
   def globalFromLiteral(lit: Literal): Traversal[Expression] = lit
-    .where(_.inAssignment.method.name("<module>"))
+    .where(_.inAssignment.method.nameExact("<module>", ":package"))
     .inAssignment
     .argument(1)
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 
 package object dataflowengineoss {
 
-  def identifierToFirstUsages(identifier : Identifier): List[Identifier] = identifier
+  def identifierToFirstUsages(node : Identifier): List[Identifier] = node
     .refsTo.flatMap(identifiersFromCapturedScopes).l
 
   def identifiersFromCapturedScopes(i: Declaration): List[Identifier] =

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -1,12 +1,17 @@
 package io.joern
 
-import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Identifier}
+import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Expression, Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.Traversal
 
 package object dataflowengineoss {
 
-  def identifierToFirstUsages(node : Identifier): List[Identifier] = node
-    .refsTo.flatMap(identifiersFromCapturedScopes).l
+  def globalFromLiteral(lit: Literal): Traversal[Expression] = lit
+    .where(_.inAssignment.method.name("<module>"))
+    .inAssignment
+    .argument(1)
+
+  def identifierToFirstUsages(node: Identifier): List[Identifier] = node.refsTo.flatMap(identifiersFromCapturedScopes).l
 
   def identifiersFromCapturedScopes(i: Declaration): List[Identifier] =
     i.capturedByMethodRef.referencedMethod.ast.isIdentifier

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -168,7 +168,7 @@ class DdgGenerator(semantics: Semantics) {
       }
     }
 
-    def addEdgesToCapturedIdentifiers(): Unit = {
+    def addEdgesToCapturedIdentifiersAndParameters(): Unit = {
       val identifiersInMethod = method._identifierViaContainsOut.l
       val identifierDestPairs =
         identifiersInMethod.flatMap{ identifier =>
@@ -176,6 +176,11 @@ class DdgGenerator(semantics: Semantics) {
         }.l.distinctBy(_._2.method)
       identifierDestPairs.foreach{ case (src, dst) =>
         addEdge(src, dst, nodeToEdgeLabel(src))
+      }
+      method.parameter.foreach{ param =>
+        param.capturedByMethodRef.referencedMethod.ast.isIdentifier.foreach{ identifier =>
+          addEdge(param, identifier, nodeToEdgeLabel(param))
+        }
       }
     }
 
@@ -187,7 +192,7 @@ class DdgGenerator(semantics: Semantics) {
       case _                            =>
     }
 
-    addEdgesToCapturedIdentifiers()
+    addEdgesToCapturedIdentifiersAndParameters()
 
     addEdgesToExitNode(method.methodReturn)
     addEdgesFromLoneIdentifiersToExit(method)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -1,5 +1,6 @@
 package io.joern.dataflowengineoss.passes.reachingdef
 
+import io.joern.dataflowengineoss.identifierToFirstUsages
 import io.joern.dataflowengineoss.queryengine.AccessPathUsage.toTrackedBaseAndAccessPathSimple
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.generated.nodes._
@@ -7,6 +8,7 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators, PropertyN
 import io.shiftleft.semanticcpg.accesspath.MatchResult
 import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate.DiffGraphBuilder
+import overflowdb.traversal.Traversal
 
 import scala.collection.{Set, mutable}
 
@@ -166,6 +168,17 @@ class DdgGenerator(semantics: Semantics) {
       }
     }
 
+    def addEdgesToCapturedIdentifiers(): Unit = {
+      val identifiersInMethod = method._identifierViaContainsOut.l
+      val identifierDestPairs =
+        identifiersInMethod.flatMap{ identifier =>
+          identifierToFirstUsages(identifier).map(usage => (identifier, usage))
+        }.l.distinctBy(_._2.method)
+      identifierDestPairs.foreach{ case (src, dst) =>
+        addEdge(src, dst, nodeToEdgeLabel(src))
+      }
+    }
+
     addEdgesFromEntryNode()
     allNodes.foreach {
       case call: Call                   => addEdgesToCallSite(call)
@@ -173,6 +186,9 @@ class DdgGenerator(semantics: Semantics) {
       case paramOut: MethodParameterOut => addEdgesToMethodParameterOut(paramOut)
       case _                            =>
     }
+
+    addEdgesToCapturedIdentifiers()
+
     addEdgesToExitNode(method.methodReturn)
     addEdgesFromLoneIdentifiersToExit(method)
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -169,9 +169,8 @@ class DdgGenerator(semantics: Semantics) {
     }
 
     def addEdgesToCapturedIdentifiersAndParameters(): Unit = {
-      val identifiersInMethod = method._identifierViaContainsOut.l
       val identifierDestPairs =
-        identifiersInMethod
+        method._identifierViaContainsOut
           .flatMap { identifier =>
             identifierToFirstUsages(identifier).map(usage => (identifier, usage))
           }
@@ -189,7 +188,7 @@ class DdgGenerator(semantics: Semantics) {
       }
 
       val globalIdentifiers =
-        method.ast.isLiteral.flatMap(lit => globalFromLiteral(lit)).collect { case x: Identifier => x }.l
+        method.ast.isLiteral.flatMap(globalFromLiteral).collectAll[Identifier].l
       globalIdentifiers
         .foreach { global =>
           identifierToFirstUsages(global).map { identifier =>
@@ -207,7 +206,6 @@ class DdgGenerator(semantics: Semantics) {
     }
 
     addEdgesToCapturedIdentifiersAndParameters()
-
     addEdgesToExitNode(method.methodReturn)
     addEdgesFromLoneIdentifiersToExit(method)
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -1,6 +1,6 @@
 package io.joern.dataflowengineoss.queryengine
 
-import io.joern.dataflowengineoss.{identifierToFirstUsages, identifiersFromCapturedScopes}
+import io.joern.dataflowengineoss.{globalFromLiteral, identifierToFirstUsages, identifiersFromCapturedScopes}
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -72,13 +72,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       case methodReturn: MethodReturn =>
         methodReturn.method.callIn.l
       case lit: Literal =>
-        // `firstUsagesOfLHSIdentifiers` is required to handle children methods referencing the identifier this literal
-        // is being passed to. Perhaps not the most sound as this doesn't handle re-assignment super well but it's
-        // difficult to check the control flow of when the method ref might use the value
-        val firstUsagesOfLHSIdentifiers = lit.inAssignment.argument(1).isIdentifier.l
-        List(lit) ++ usages(
-          targetsToClassIdentifierPair(literalToInitializedMembers(lit))
-        ) ++ firstUsagesOfLHSIdentifiers.flatMap(identifierToFirstUsages)
+        List(lit) ++ usages(targetsToClassIdentifierPair(literalToInitializedMembers(lit))) ++ globalFromLiteral(lit)
       case member: Member =>
         usages(targetsToClassIdentifierPair(List(member)))
       case x: Declaration =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -1,5 +1,6 @@
 package io.joern.dataflowengineoss.queryengine
 
+import io.joern.dataflowengineoss.identifiersFromCapturedScopes
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -74,15 +75,14 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
         // `firstUsagesOfLHSIdentifiers` is required to handle children methods referencing the identifier this literal
         // is being passed to. Perhaps not the most sound as this doesn't handle re-assignment super well but it's
         // difficult to check the control flow of when the method ref might use the value
-        val firstUsagesOfLHSIdentifiers =
-          lit.inAssignment.argument(1).isIdentifier.refsTo.flatMap(identifiersFromCapturedScopes).l.distinctBy(_.method)
+        val firstUsagesOfLHSIdentifiers = lit.inAssignment.argument(1).isIdentifier.refsTo.flatMap(identifiersFromCapturedScopes).l.distinctBy(_.method)
         List(lit) ++ usages(
           targetsToClassIdentifierPair(literalToInitializedMembers(lit))
         ) ++ firstUsagesOfLHSIdentifiers
       case member: Member =>
         usages(targetsToClassIdentifierPair(List(member)))
       case x: Declaration =>
-        List(x).collectAll[CfgNode].toList ++ identifiersFromCapturedScopes(x)
+        List(x).collectAll[CfgNode].toList
       case x: Identifier =>
         withFieldAndIndexAccesses(
           List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
@@ -90,12 +90,6 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       case x => List(x).collect { case y: CfgNode => y }
     }
   }
-
-  private def identifiersFromCapturedScopes(i: Declaration): List[Identifier] =
-    i.capturedByMethodRef.referencedMethod.ast.isIdentifier
-      .nameExact(i.name)
-      .sortBy(x => (x.lineNumber, x.columnNumber))
-      .l
 
   private def withFieldAndIndexAccesses(nodes: List[CfgNode]): List[CfgNode] =
     nodes.flatMap {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -1,6 +1,6 @@
 package io.joern.dataflowengineoss.queryengine
 
-import io.joern.dataflowengineoss.identifiersFromCapturedScopes
+import io.joern.dataflowengineoss.{identifierToFirstUsages, identifiersFromCapturedScopes}
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -75,10 +75,10 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
         // `firstUsagesOfLHSIdentifiers` is required to handle children methods referencing the identifier this literal
         // is being passed to. Perhaps not the most sound as this doesn't handle re-assignment super well but it's
         // difficult to check the control flow of when the method ref might use the value
-        val firstUsagesOfLHSIdentifiers = lit.inAssignment.argument(1).isIdentifier.refsTo.flatMap(identifiersFromCapturedScopes).l.distinctBy(_.method)
+        val firstUsagesOfLHSIdentifiers = lit.inAssignment.argument(1).isIdentifier.l
         List(lit) ++ usages(
           targetsToClassIdentifierPair(literalToInitializedMembers(lit))
-        ) ++ firstUsagesOfLHSIdentifiers
+        ) ++ firstUsagesOfLHSIdentifiers.flatMap(identifierToFirstUsages)
       case member: Member =>
         usages(targetsToClassIdentifierPair(List(member)))
       case x: Declaration =>

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -5,11 +5,6 @@ import io.joern.pysrc2cpg.PySrc2CpgFixture
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Literal, Member}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
-
-import java.io.File
-import scala.sys.process.Process
-import scala.util.Try
 
 class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -182,7 +182,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     val sink                = cpg.call("post").l
     sourceUrlIdentifier.size shouldBe 2
     sink.size shouldBe 1
-    sink.reachableByFlows(sourceUrlIdentifier).size shouldBe 1
+    sink.reachableByFlows(sourceUrlIdentifier).size shouldBe 2
 
     val sourceUrlLiteral = cpg.literal(".*app.commissionly.io.*").l
     sourceUrlLiteral.size shouldBe 1
@@ -266,8 +266,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
   }
 
   "flow from expression that taints global variable to sink" in {
-    val cpg : Cpg = code(
-      """
+    val cpg: Cpg = code("""
         |d = {
         |   'x': F.sum('x'),
         |   'y': F.sum('y'),
@@ -280,7 +279,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |""".stripMargin)
 
     val sources = cpg.call("<operator>.indexAccess").argument.isIdentifier.l
-    val sinks = cpg.call("sink").l
+    val sinks   = cpg.call("sink").l
     sinks.reachableByFlows(sources).size should not be 0
   }
 


### PR DESCRIPTION
Improved the handling of global variables by moving some of the logic from `SourceToStartingPoints` into DDG creation. In particular, we now create `REACHING_DEF` edges from identifiers/parameters to first usages in methods that capture them.