### PR TITLE
upgrade to JDK19

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,11 +11,11 @@ jobs:
         with:
           fetch-depth: 1
       - uses: coursier/cache-action@v6
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '19'
       - name: Compile and run tests
         run: sbt clean +test
   formatting:
@@ -24,11 +24,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '19'
       - name: Check formatting
         run: sbt ++2.13.8 scalafmtCheck test:scalafmtCheck
       - run: echo "Previous step failed because code is not formatted. Run 'sbt scalafmt Test/scalafmt'"
@@ -39,11 +39,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '19'
       - run: ./testDistro.sh
       - run: |
           mkdir /tmp/foo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - name: Set up JDK 17
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '19'
       - run: sudo apt update && sudo apt install -y gnupg
       - run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Specification: https://cpg.joern.io
 
 ## Requirements
 
-- JDK 17 (other versions _might_ work, but have not been properly tested)
+- JDK 19 (other versions _might_ work, but have not been properly tested)
 - _optional_: gcc and g++ (for auto-discovery of C/C++ system header files if included/used in your C/C++ code)
 
 ## Development Requirements

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,6 @@ ThisBuild / compile / javacOptions ++= Seq(
 
 ThisBuild / scalacOptions ++= Seq(
   "-deprecation", // Emit warning and location for usages of deprecated APIs.
-  "-target:11",
   "--release",
   "11"
 )

--- a/joern-cli/src/universal/schema-extender/project/build.properties
+++ b/joern-cli/src/universal/schema-extender/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.8.2


### PR DESCRIPTION
Core here is dropping the scalac flag `--target`. Previously I
thought that JDK19 doesn't support `--release=11`, but turns out they
only [dropped support for JDK7 in JDK20](https://bugs.openjdk.org/browse/JDK-8173605), so we can leave this as is for
now. `--target` is deprecated anyway, so this seems to be the best way
forward.