### PR TITLE
CfgNodeMethods: Handle TypeDecl Before Method during `.method` step

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -146,13 +146,16 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
   private def walkUpContains(node: StoredNode): Method =
     node._containsIn.onlyChecked match {
-      case method: Method                                                => method
-      case typeDecl: TypeDecl if typeDecl.astParent.isInstanceOf[Method] =>
-        // For a language such as jssrc2cpg, types may be dynamically declared under procedures
-        typeDecl.astParent.asInstanceOf[Method]
-      case _: TypeDecl =>
-        // TODO - there are csharp CPGs that have typedecls here, which is invalid.
-        null
+      case method: Method => method
+      case typeDecl: TypeDecl =>
+        typeDecl.astParent match {
+          case method: Method =>
+            // For a language such as javascript, types may be dynamically declared under procedures
+            method
+          case _ =>
+            // there are csharp CPGs that have typedecls here, which is invalid.
+            null
+        }
     }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -146,8 +146,11 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
   private def walkUpContains(node: StoredNode): Method =
     node._containsIn.onlyChecked match {
-      case method: Method => method
-      case _: TypeDecl    =>
+      case method: Method                                                => method
+      case typeDecl: TypeDecl if typeDecl.astParent.isInstanceOf[Method] =>
+        // For a language such as jssrc2cpg, types may be dynamically declared under procedures
+        typeDecl.astParent.asInstanceOf[Method]
+      case _: TypeDecl =>
         // TODO - there are csharp CPGs that have typedecls here, which is invalid.
         null
     }


### PR DESCRIPTION
Since `jssrc2cpg` files are `:program` methods, if a type is dynamically declared under this, we have a TYPE_DECL<-AST-METHOD relationship.

If there is a decorator on top of the TYPE_DECL, children of the type decl's annotation have a CHILD<-CONTAINS-TYPE_DECL relationship. CHILD<-CONTAINS-TYPE_DECL is marked initially as invalid by CfgNodeMethods.walkUpContains but in this context it is valid.

Resolves #2407