### PR TITLE
Expression as Child of TypeDecl under Method Bug

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal.{InitialTraversal, PathAwareTraversal, Traversal}
 
 /** An expression (base type)
   */
@@ -59,7 +59,13 @@ class ExpressionTraversal[NodeType <: Expression](val traversal: Traversal[NodeT
   /** Traverse to enclosing method
     */
   def method: Traversal[Method] =
-    traversal.in(EdgeTypes.CONTAINS).cast[Method]
+    traversal
+      .in(EdgeTypes.CONTAINS)
+      .flatMap {
+        case x: Method   => Traversal.from(x)
+        case x: TypeDecl => x.astParent
+      }
+      .collectAll[Method]
 
   /** Traverse to expression evaluation type
     */


### PR DESCRIPTION
Similar to [#2413](https://github.com/joernio/joern/pull/2413), if an expression is a child to a type declaration where the contains edge is the TypeDecl and not the Method then a class cast exception is thrown. This circumstance is common in `jssrc2cpg`.

Resolves #2420