### PR TITLE
XTypeHintCallLinker: Clean-Up and Duplicate MethodStub Fix

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -4,12 +4,10 @@ import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecovery.isDummyType
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodBase}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
-
-import scala.collection.mutable
 
 class PythonTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
 
@@ -22,25 +20,11 @@ class PythonTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
     case typ => typ
   }
 
-  override def linkCalls(builder: DiffGraphBuilder): Unit = {
-    val methodMap = mutable.HashMap.empty[String, MethodBase]
-    val callerAndCallees = calls
-      .map(call => (call, calleeNames(call)))
-      .toList
-    // Gather all method nodes and/or stubs
-    callerAndCallees
-      .foreach { case (call, methodNames) =>
-        val ms = callees(methodNames).l
-        if (ms.nonEmpty) {
-          ms.foreach { m => methodMap.put(m.fullName, m) }
-        } else {
-          val mNames = ms.map(_.fullName).toSet
-          methodNames
-            .filterNot(mNames.contains)
-            .map(fullName => createMethodStub(fullName, call, builder))
-            .foreach { m => methodMap.put(m.fullName, m) }
-        }
-      }
+  override protected def linkCallsToCallees(
+    callerAndCallees: List[(Call, Seq[String])],
+    methodMap: Map[String, MethodBase],
+    builder: DiffGraphBuilder
+  ): Unit = {
     // Link edges to method nodes
     callerAndCallees.foreach { case (call, methodNames) =>
       methodNames


### PR DESCRIPTION
* Fix an issue where duplicate method stubs would be generated
* Separate linkCall logic for fine-grained overrides