### PR TITLE
XTypeRecoveryPass: Replace Global Table by Writing to CPG

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -26,7 +26,10 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
     new ImportsPass(cpg).createAndApply()
     new DynamicTypeHintFullNamePass(cpg).createAndApply()
-    new PythonTypeRecovery(cpg, enabledDummyTypes = !pyConfig.forall(_.disableDummyTypes)).createAndApply()
+    val maxInt = 2
+    for (i <- 0 until maxInt)
+      new PythonTypeRecovery(cpg, i == maxInt - 1, enabledDummyTypes = !pyConfig.forall(_.disableDummyTypes))
+        .createAndApply()
     new PythonTypeHintCallLinker(cpg).createAndApply()
     new PythonNaiveCallLinker(cpg).createAndApply()
     cpg

--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -26,10 +26,7 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
     new ImportsPass(cpg).createAndApply()
     new DynamicTypeHintFullNamePass(cpg).createAndApply()
-    val maxInt = 2
-    for (i <- 0 until maxInt)
-      new PythonTypeRecovery(cpg, i == maxInt - 1, enabledDummyTypes = !pyConfig.forall(_.disableDummyTypes))
-        .createAndApply()
+    new PythonTypeRecoveryPass(cpg, enabledDummyTypes = !pyConfig.forall(_.disableDummyTypes)).createAndApply()
     new PythonTypeHintCallLinker(cpg).createAndApply()
     new PythonNaiveCallLinker(cpg).createAndApply()
     cpg

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -57,8 +57,7 @@ object JsSrc2Cpg {
   def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = {
     List(
       new ConstClosurePass(cpg),
-      new JavaScriptTypeRecovery(cpg, finalIteration = false, enabledDummyTypes = !config.exists(_.disableDummyTypes)),
-      new JavaScriptTypeRecovery(cpg, finalIteration = true, enabledDummyTypes = !config.exists(_.disableDummyTypes)),
+      new JavaScriptTypeRecoveryPass(cpg, enabledDummyTypes = !config.exists(_.disableDummyTypes)),
       new JavaScriptTypeHintCallLinker(cpg)
     )
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -54,11 +54,13 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
 
 object JsSrc2Cpg {
 
-  def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] =
+  def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = {
     List(
       new ConstClosurePass(cpg),
-      new JavaScriptTypeRecovery(cpg, enabledDummyTypes = !config.exists(_.disableDummyTypes)),
+      new JavaScriptTypeRecovery(cpg, finalIteration = false, enabledDummyTypes = !config.exists(_.disableDummyTypes)),
+      new JavaScriptTypeRecovery(cpg, finalIteration = true, enabledDummyTypes = !config.exists(_.disableDummyTypes)),
       new JavaScriptTypeHintCallLinker(cpg)
     )
+  }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -104,8 +104,16 @@ private class RecoverForJavaScriptFile(
             symbolTable.append(CallAlias(alias, Option("this")), methodPaths)
             symbolTable.append(LocalVar(alias), methodPaths)
           case List(_, b: Identifier) =>
-            // Exported variable
-            val typs = globalTable.get(b)
+            // Exported variable that we should find
+            val typs = cpg
+              .file(s"${Matcher.quoteReplacement(resolvedPath)}\\.?.*")
+              .method
+              .ast
+              .isIdentifier
+              .name(b.name)
+              .flatMap(i => i.typeFullName +: i.dynamicTypeHintFullName)
+              .filterNot(_ == "ANY")
+              .toSet
             symbolTable.append(LocalVar(alias), typs)
           case List(x: Call, b: MethodRef) =>
             // Exported function with a method ref of the function

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -9,7 +9,6 @@ import overflowdb.traversal.Traversal
 
 import java.io.{File => JFile}
 import java.util.regex.Matcher
-import scala.collection.mutable
 
 class JavaScriptTypeRecoveryPass(cpg: Cpg, iterations: Int = 2, enabledDummyTypes: Boolean = true)
     extends XTypeRecoveryPass[File](cpg, iterations) {
@@ -25,7 +24,7 @@ private class JavaScriptTypeRecovery(cpg: Cpg, finalIteration: Boolean = false, 
     unit: File,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] =
-    new RecoverForJavaScriptFile(cpg, unit, builder, addedNodes, finalIteration, enabledDummyTypes)
+    new RecoverForJavaScriptFile(cpg, unit, builder, finalIteration, enabledDummyTypes)
 
 }
 
@@ -33,10 +32,9 @@ private class RecoverForJavaScriptFile(
   cpg: Cpg,
   cu: File,
   builder: DiffGraphBuilder,
-  addedNodes: mutable.Set[(Long, String)],
   finalIteration: Boolean,
   enabledDummyTypes: Boolean
-) extends RecoverForXCompilationUnit[File](cpg, cu, builder, addedNodes, finalIteration && enabledDummyTypes) {
+) extends RecoverForXCompilationUnit[File](cpg, cu, builder, finalIteration && enabledDummyTypes) {
 
   override protected val pathSep = ':'
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -25,7 +25,7 @@ private class JavaScriptTypeRecovery(cpg: Cpg, finalIteration: Boolean = false, 
     unit: File,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] =
-    new RecoverForJavaScriptFile(cpg, unit, builder, globalTable, addedNodes, finalIteration, enabledDummyTypes)
+    new RecoverForJavaScriptFile(cpg, unit, builder, addedNodes, finalIteration, enabledDummyTypes)
 
 }
 
@@ -33,18 +33,10 @@ private class RecoverForJavaScriptFile(
   cpg: Cpg,
   cu: File,
   builder: DiffGraphBuilder,
-  globalTable: SymbolTable[GlobalKey],
   addedNodes: mutable.Set[(Long, String)],
   finalIteration: Boolean,
   enabledDummyTypes: Boolean
-) extends RecoverForXCompilationUnit[File](
-      cpg,
-      cu,
-      builder,
-      globalTable,
-      addedNodes,
-      finalIteration && enabledDummyTypes
-    ) {
+) extends RecoverForXCompilationUnit[File](cpg, cu, builder, addedNodes, finalIteration && enabledDummyTypes) {
 
   override protected val pathSep = ':'
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -11,14 +11,15 @@ import java.io.{File => JFile}
 import java.util.regex.Matcher
 import scala.collection.mutable
 
-class JavaScriptTypeRecovery(cpg: Cpg, enabledDummyTypes: Boolean = true) extends XTypeRecovery[File](cpg) {
+class JavaScriptTypeRecovery(cpg: Cpg, finalIteration: Boolean = false, enabledDummyTypes: Boolean = true)
+    extends XTypeRecovery[File](cpg) {
   override def compilationUnit: Traversal[File] = cpg.file
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] =
-    new RecoverForJavaScriptFile(cpg, unit, builder, globalTable, addedNodes, enabledDummyTypes)
+    new RecoverForJavaScriptFile(cpg, unit, builder, globalTable, addedNodes, finalIteration, enabledDummyTypes)
 
 }
 
@@ -28,8 +29,16 @@ class RecoverForJavaScriptFile(
   builder: DiffGraphBuilder,
   globalTable: SymbolTable[GlobalKey],
   addedNodes: mutable.Set[(Long, String)],
+  finalIteration: Boolean,
   enabledDummyTypes: Boolean
-) extends RecoverForXCompilationUnit[File](cpg, cu, builder, globalTable, addedNodes, enabledDummyTypes) {
+) extends RecoverForXCompilationUnit[File](
+      cpg,
+      cu,
+      builder,
+      globalTable,
+      addedNodes,
+      finalIteration && enabledDummyTypes
+    ) {
 
   override protected val pathSep = ':'
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -11,7 +11,13 @@ import java.io.{File => JFile}
 import java.util.regex.Matcher
 import scala.collection.mutable
 
-class JavaScriptTypeRecovery(cpg: Cpg, finalIteration: Boolean = false, enabledDummyTypes: Boolean = true)
+class JavaScriptTypeRecoveryPass(cpg: Cpg, iterations: Int = 2, enabledDummyTypes: Boolean = true)
+    extends XTypeRecoveryPass[File](cpg, iterations) {
+  override protected def generateRecoveryPass(finalIterations: Boolean): XTypeRecovery[File] =
+    new JavaScriptTypeRecovery(cpg, finalIterations, enabledDummyTypes)
+}
+
+private class JavaScriptTypeRecovery(cpg: Cpg, finalIteration: Boolean = false, enabledDummyTypes: Boolean = true)
     extends XTypeRecovery[File](cpg) {
   override def compilationUnit: Traversal[File] = cpg.file
 
@@ -23,7 +29,7 @@ class JavaScriptTypeRecovery(cpg: Cpg, finalIteration: Boolean = false, enabledD
 
 }
 
-class RecoverForJavaScriptFile(
+private class RecoverForJavaScriptFile(
   cpg: Cpg,
   cu: File,
   builder: DiffGraphBuilder,

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -65,15 +65,17 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
     addNodeToDiff(typeRefNode)
   }
 
-  def memberNode(name: String, dynamicTypeHintFullName: Option[String] = None): nodes.NewMember = {
+  def memberNode(name: String): nodes.NewMember = {
     val memberNode = nodes
       .NewMember()
       .code(name)
       .name(name)
       .typeFullName(Constants.ANY)
-    dynamicTypeHintFullName.foreach(hint => memberNode.dynamicTypeHintFullName(hint :: Nil))
     addNodeToDiff(memberNode)
   }
+
+  def memberNode(name: String, dynamicTypeHintFullName: String): nodes.NewMember =
+    memberNode(name).dynamicTypeHintFullName(dynamicTypeHintFullName :: Nil)
 
   def bindingNode(): nodes.NewBinding = {
     val bindingNode = nodes

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -65,13 +65,13 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
     addNodeToDiff(typeRefNode)
   }
 
-  def memberNode(name: String, dynamicTypeHintFullName: String): nodes.NewMember = {
+  def memberNode(name: String, dynamicTypeHintFullName: Option[String] = None): nodes.NewMember = {
     val memberNode = nodes
       .NewMember()
       .code(name)
       .name(name)
       .typeFullName(Constants.ANY)
-      .dynamicTypeHintFullName(dynamicTypeHintFullName :: Nil)
+    dynamicTypeHintFullName.foreach(hint => memberNode.dynamicTypeHintFullName(hint :: Nil))
     addNodeToDiff(memberNode)
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -461,7 +461,7 @@ class PythonAstVisitor(
     // and we cant yet handle super().
     val fakeNewMethod = createFakeNewMethod(initParameters)
 
-    val fakeNewMember = nodeBuilder.memberNode("<fakeNew>", fakeNewMethod.fullName)
+    val fakeNewMember = nodeBuilder.memberNode("<fakeNew>", Option(fakeNewMethod.fullName))
     edgeBuilder.astEdge(fakeNewMember, metaTypeDeclNode, contextStack.order.getAndInc)
 
     // Create binding into class instance type for each method.
@@ -516,7 +516,7 @@ class PythonAstVisitor(
     metaTypeDecl: nodes.NewNode
   ): Unit = {
     val memberForInstance =
-      nodeBuilder.memberNode(functionName, functionDefToMethod.apply(function).fullName)
+      nodeBuilder.memberNode(functionName, Option(functionDefToMethod.apply(function).fullName))
     edgeBuilder.astEdge(memberForInstance, instanceTypeDecl, contextStack.order.getAndInc)
 
     val methodForMetaClass =
@@ -531,7 +531,7 @@ class PythonAstVisitor(
         )
       }
 
-    val memberForMeta = nodeBuilder.memberNode(functionName, methodForMetaClass.fullName)
+    val memberForMeta = nodeBuilder.memberNode(functionName, Option(methodForMetaClass.fullName))
     edgeBuilder.astEdge(memberForMeta, metaTypeDecl, contextStack.order.getAndInc)
   }
 
@@ -1782,7 +1782,7 @@ class PythonAstVisitor(
     contextStack.findEnclosingTypeDecl() match {
       case Some(typeDecl: NewTypeDecl) =>
         if (!members.contains(typeDecl) || !members(typeDecl).contains(name)) {
-          val member = nodeBuilder.memberNode(name, "")
+          val member = nodeBuilder.memberNode(name)
           edgeBuilder.astEdge(member, typeDecl, contextStack.order.getAndInc)
           members(typeDecl) = members.getOrElse(typeDecl, List()) ++ List(name)
         }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -461,7 +461,7 @@ class PythonAstVisitor(
     // and we cant yet handle super().
     val fakeNewMethod = createFakeNewMethod(initParameters)
 
-    val fakeNewMember = nodeBuilder.memberNode("<fakeNew>", Option(fakeNewMethod.fullName))
+    val fakeNewMember = nodeBuilder.memberNode("<fakeNew>", fakeNewMethod.fullName)
     edgeBuilder.astEdge(fakeNewMember, metaTypeDeclNode, contextStack.order.getAndInc)
 
     // Create binding into class instance type for each method.
@@ -516,7 +516,7 @@ class PythonAstVisitor(
     metaTypeDecl: nodes.NewNode
   ): Unit = {
     val memberForInstance =
-      nodeBuilder.memberNode(functionName, Option(functionDefToMethod.apply(function).fullName))
+      nodeBuilder.memberNode(functionName, functionDefToMethod.apply(function).fullName)
     edgeBuilder.astEdge(memberForInstance, instanceTypeDecl, contextStack.order.getAndInc)
 
     val methodForMetaClass =
@@ -531,7 +531,7 @@ class PythonAstVisitor(
         )
       }
 
-    val memberForMeta = nodeBuilder.memberNode(functionName, Option(methodForMetaClass.fullName))
+    val memberForMeta = nodeBuilder.memberNode(functionName, methodForMetaClass.fullName)
     edgeBuilder.astEdge(memberForMeta, metaTypeDecl, contextStack.order.getAndInc)
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -14,7 +14,6 @@ import overflowdb.traversal.Traversal
 import java.io.{File => JFile}
 import java.nio.file.Paths
 import java.util.regex.Matcher
-import scala.collection.mutable
 
 class PythonTypeRecoveryPass(cpg: Cpg, iterations: Int = 2, enabledDummyTypes: Boolean = true)
     extends XTypeRecoveryPass[File](cpg, iterations) {
@@ -31,7 +30,7 @@ private class PythonTypeRecovery(cpg: Cpg, finalIteration: Boolean = false, enab
     unit: File,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] =
-    new RecoverForPythonFile(cpg, unit, builder, addedNodes, finalIteration, enabledDummyTypes)
+    new RecoverForPythonFile(cpg, unit, builder, finalIteration, enabledDummyTypes)
 
 }
 
@@ -41,10 +40,9 @@ private class RecoverForPythonFile(
   cpg: Cpg,
   cu: File,
   builder: DiffGraphBuilder,
-  addedNodes: mutable.Set[(Long, String)],
   finalIteration: Boolean,
   enabledDummyTypes: Boolean
-) extends RecoverForXCompilationUnit[File](cpg, cu, builder, addedNodes, finalIteration && enabledDummyTypes) {
+) extends RecoverForXCompilationUnit[File](cpg, cu, builder, finalIteration && enabledDummyTypes) {
 
   /** Replaces the `this` prefix with the Pythonic `self` prefix for instance methods of functions local to this
     * compilation unit.
@@ -119,7 +117,7 @@ private class RecoverForPythonFile(
     val sep = Matcher.quoteReplacement(JFile.separator)
 
     lazy val methodsWithExportEntityAsIdentifier: List[String] = cpg.typeDecl
-      .fullName(s".*$path.*")
+      .fullName(s".*${Matcher.quoteReplacement(path)}.*")
       .where(_.member.nameExact(expEntity))
       .fullName
       .toList

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -28,9 +28,7 @@ class PySrcTestCpg extends TestCpg with PythonFrontend {
     X2Cpg.applyDefaultOverlays(this)
     new ImportsPass(this).createAndApply()
     new DynamicTypeHintFullNamePass(this).createAndApply()
-    val maxInt = 2
-    for (i <- 0 until maxInt)
-      new PythonTypeRecovery(this, i == maxInt - 1).createAndApply()
+    new PythonTypeRecoveryPass(this).createAndApply()
     new PythonTypeHintCallLinker(this).createAndApply()
     new PythonNaiveCallLinker(this).createAndApply()
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -28,7 +28,9 @@ class PySrcTestCpg extends TestCpg with PythonFrontend {
     X2Cpg.applyDefaultOverlays(this)
     new ImportsPass(this).createAndApply()
     new DynamicTypeHintFullNamePass(this).createAndApply()
-    new PythonTypeRecovery(this).createAndApply()
+    val maxInt = 2
+    for (i <- 0 until maxInt)
+      new PythonTypeRecovery(this, i == maxInt - 1).createAndApply()
     new PythonTypeHintCallLinker(this).createAndApply()
     new PythonNaiveCallLinker(this).createAndApply()
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1,7 +1,6 @@
 package io.joern.pysrc2cpg.passes
 
 import io.joern.pysrc2cpg.PySrc2CpgFixture
-import io.joern.x2cpg.Defines
 import io.shiftleft.semanticcpg.language._
 
 import java.io.File

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -38,12 +38,6 @@ object SBKey {
     })
   }
 
-  def fromNodeToGlobalKey(node: AstNode): Option[GlobalKey] = Option(node match {
-    case n: FieldIdentifier => FieldVar(n.method.fullName, n.canonicalName)
-    case n: Identifier      => FieldVar(n.method.fullName, n.name)
-    case _ => logger.debug(s"Global node of type ${node.label} is not supported in the type recovery pass."); null
-  })
-
 }
 
 /** Represents an identifier of some AST node at an intraprocedural scope.
@@ -63,20 +57,6 @@ case class CollectionVar(override val identifier: String, idx: String) extends L
 /** A name that refers to some kind of callee.
   */
 case class CallAlias(override val identifier: String, receiverName: Option[String] = None) extends LocalKey(identifier)
-
-/** Represents an identifier of some AST node at an interprocedural scope.
-  */
-sealed class GlobalKey(identifier: String) extends SBKey(identifier) {
-  override def fromNode(node: AstNode): Option[SBKey] = SBKey.fromNodeToGlobalKey(node)
-}
-
-/** Represents a field identifier at its declared computational unit.
-  * @param compUnitFullName
-  *   the computational unit's full name.
-  * @param identifier
-  *   the canonical name.
-  */
-case class FieldVar(compUnitFullName: String, override val identifier: String) extends GlobalKey(identifier)
 
 /** A thread-safe symbol table that can represent multiple types per symbol. Each node in an AST gets converted to an
   * [[SBKey]] which gives contextual information to identify an AST entity. Each value in this table represents a set of

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -561,7 +561,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     if (types.nonEmpty) {
       getSymbolFromCall(x) match {
         case (lhs, globalKeys) if globalKeys.nonEmpty =>
-          globalKeys.foreach { fieldVar: FieldPath =>
+          globalKeys.foreach { (fieldVar: FieldPath) =>
             persistMemberWithTypeDecl(fieldVar.compUnitFullName, fieldVar.identifier, types)
           }
           symbolTable.append(lhs, types)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -315,6 +315,9 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
       case List(c: Call, l: Literal)          => visitCallAssignedToLiteral(c, l)
       case List(c: Call, m: MethodRef)        => visitCallAssignedToMethodRef(c, m)
       case List(c: Call, b: Block)            => visitCallAssignedToBlock(c, b)
+      case List(_: Identifier, c: Call, _: MethodRef) if c.name.matches("(import|require)") =>
+        // In a previous iteration, this is some call that has imported a method that is now resolved
+        Set.empty
       case xs =>
         logger.warn(s"Unhandled assignment ${xs.map(x => (x.label, x.code)).mkString(",")} @ ${debugLocation(a)}")
         Set.empty


### PR DESCRIPTION
* Write to CPG each iteration of the type recovery pass to get rid of global table. This should save some memory.
* Fix some bugs where `<var>` placeholder keys would get in the final output for type hints
* Created a wrapper pass `XTypeRecoveryPass` that can run multiple propagation passes internally
* Holding member nodes until the end to make sure the updates don't overwrite one another
* Fixed issue in `pysrc2cpg` where `Member` nodes would have `Seq("")` under `dynamicTypeHintFullName`

Next up is to optimize the cost per iteration given some heuristics and early stopping.