### PR TITLE
kotlin2cpg: remove duplication from `KtPsiToAst`

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
@@ -322,12 +322,16 @@ class DefaultTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeIn
     descMaybe.collect { case desc: FunctionDescriptor => desc }
   }
 
-  def isConstructorCall(expr: KtCallExpression): Option[Boolean] = {
-    resolvedCallDescriptor(expr).collect {
-      case _: ClassConstructorDescriptorImpl     => Some(true)
-      case _: TypeAliasConstructorDescriptorImpl => Some(true)
-      case _                                     => Some(false)
-    }.flatten
+  def isConstructorCall(expr: KtExpression): Option[Boolean] = {
+    expr match {
+      case call =>
+        resolvedCallDescriptor(call).collect {
+          case _: ClassConstructorDescriptorImpl     => Some(true)
+          case _: TypeAliasConstructorDescriptorImpl => Some(true)
+          case _                                     => Some(false)
+        }.flatten
+      case _ => Some(false)
+    }
   }
 
   def fullNameWithSignature(expr: KtCallExpression, defaultValue: (String, String)): (String, String) = {

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
@@ -85,7 +85,7 @@ trait TypeInfoProvider {
 
   def nameReferenceKind(expr: KtNameReferenceExpression): NameReferenceKinds.NameReferenceKind
 
-  def isConstructorCall(expr: KtCallExpression): Option[Boolean]
+  def isConstructorCall(expr: KtExpression): Option[Boolean]
 
   def typeFullName(expr: KtTypeReference, defaultValue: String): String
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/DestructuringTests.scala
@@ -107,6 +107,18 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
     }
   }
 
+  /*
+   _______ example lowering _________
+  | -> val (one, two) = Person("a", "b")
+  | -> LOCAL one
+  | -> LOCAL two
+  | -> LOCAL tmp
+  | -> tmp = alloc
+  | -> tmp.<init>
+  | -> CALL one = tmp.component1()
+  | -> CALL two = tmp.component2()
+  |__________________________________
+   */
   "CPG for code with destructuring expression with a ctor-invocation RHS" should {
     val cpg = code("""
         |package main
@@ -394,6 +406,17 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = false) 
     }
   }
 
+  /*
+   _______ example lowering _________
+  | -> val (one, two) = makeA("AMESSAGE")
+  | -> LOCAL one
+  | -> LOCAL two
+  | -> LOCAL tmp
+  | -> tmp = makeA("AMESSAGE")
+  | -> CALL one = tmp.component1()
+  | -> CALL two = tmp.component2()
+  |__________________________________
+   */
   "CPG for code with destructuring expression with a DQE call RHS" should {
     val cpg = code("""
         |package mypkg


### PR DESCRIPTION
Merged two fns – `astsForDestructuringDeclarationWithNonCtorCallRHS` and `astsForDestructuringDeclarationWithCtorRHS` – into one — `astsForDestructuringDeclarationWithRHS`.