### PR TITLE
Remove warning about handled unhandled php statements in namespace bodies

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -768,19 +768,9 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
       case method: PhpMethodDecl if method.name.name == Defines.ConstructorMethodName => None // Handled above
 
-      case method: PhpMethodDecl =>
-        Option(astForMethodDecl(method))
-
-      case classLikeStmt: PhpClassLikeStmt =>
-        Option(astForClassLikeStmt(classLikeStmt))
-
-      case enumCase: PhpEnumCaseStmt => Option(astForEnumCase(enumCase))
-
-      case expr: PhpExpr => Option(astForExpr(expr))
-
-      case other =>
-        logger.warn(s"Found unhandled class body stmt $other")
-        Option(astForStmt(other))
+      // Not all statements are supported in class bodies, but since this is re-used for namespaces
+      // we allow that here.
+      case stmt => Some(astForStmt(stmt))
     }
 
     val clinitAst           = astForStaticAndConstInits

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -115,6 +115,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case groupUseStmt: PhpGroupUseStmt   => astForGroupUseStmt(groupUseStmt)
       case foreachStmt: PhpForeachStmt     => astForForeachStmt(foreachStmt)
       case traitUseStmt: PhpTraitUseStmt   => astforTraitUseStmt(traitUseStmt)
+      case enumCase: PhpEnumCaseStmt       => astForEnumCase(enumCase)
       // TODO Figure out if this is breaking any assumptions that will cause issues later.
       case staticStmt: PhpStaticStmt => Ast().withChildren(astsForStaticStmt(staticStmt))
       case unhandled =>

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -1,8 +1,18 @@
 package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
 
 class NamespaceTests extends PhpCode2CpgFixture {
+  "namespaces should be able to contain statements as top-level AST children" in {
+    val cpg = code("""<?php
+        |namespace foo {
+        |  echo 0;
+        |}
+        |""".stripMargin)
 
-  // TODO
+    inside(cpg.namespaceBlock.name("foo").l) { case List(ns) =>
+      ns.astChildren.l.map(_.code) shouldBe List("echo 0")
+    }
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -12,7 +12,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
         |""".stripMargin)
 
     inside(cpg.namespaceBlock.name("foo").l) { case List(ns) =>
-      ns.astChildren.l.map(_.code) shouldBe List("echo 0")
+      ns.astChildren.code.l shouldBe List("echo 0")
     }
   }
 }


### PR DESCRIPTION
Only specific types of statements were expected for class bodies, but when that code was shared with namespace bodies which can contain any statement, the fallback case wasn't cleaned up. The ASTs for these statements were created anyways, so this changes nothing about the functionality of the frontend while removing the warning for perfectly valid code.