### PR TITLE
JavaScriptTypeRecovery: Fix Regex Entering isField Check

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -142,8 +142,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
         .ast
         .assignment
         .code("exports.*")
-        .where(_.argument.code(s".*${i.name}.*"))
-        .nonEmpty || super.isField(i)
+        .exists(_.argument.code.exists(_.contains(i.name))) || super.isField(i)
     )
 
   override protected def visitIdentifierAssignedToConstructor(i: Identifier, c: Call): Set[String] = {


### PR DESCRIPTION
Since the regex is basically checking if the code contains the name of an identifier, we use the "contains" method instead of regex.

Resolves #2439