### PR TITLE
PySrc2Cpg: Add Line & Column Info to `TypeDecl` Member Functions

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -64,7 +64,7 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .columnNumber(lineAndColumn.column)
     addNodeToDiff(typeRefNode)
   }
-  
+
   def memberNode(name: String): nodes.NewMember = {
     val memberNode = nodes
       .NewMember()

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -75,14 +75,9 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
   }
 
   def memberNode(name: String, lineAndColumn: LineAndColumn): nodes.NewMember = {
-    val memberNode = nodes
-      .NewMember()
-      .code(name)
-      .name(name)
+    memberNode(name)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
-      .typeFullName(Constants.ANY)
-    addNodeToDiff(memberNode)
   }
 
   def memberNode(name: String, dynamicTypeHintFullName: String): nodes.NewMember =

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -64,7 +64,7 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .columnNumber(lineAndColumn.column)
     addNodeToDiff(typeRefNode)
   }
-
+  
   def memberNode(name: String): nodes.NewMember = {
     val memberNode = nodes
       .NewMember()
@@ -74,8 +74,21 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
     addNodeToDiff(memberNode)
   }
 
+  def memberNode(name: String, lineAndColumn: LineAndColumn): nodes.NewMember = {
+    val memberNode = nodes
+      .NewMember()
+      .code(name)
+      .name(name)
+      .lineNumber(lineAndColumn.line)
+      .columnNumber(lineAndColumn.column)
+      .typeFullName(Constants.ANY)
+    addNodeToDiff(memberNode)
+  }
+
   def memberNode(name: String, dynamicTypeHintFullName: String): nodes.NewMember =
     memberNode(name).dynamicTypeHintFullName(dynamicTypeHintFullName :: Nil)
+  def memberNode(name: String, dynamicTypeHintFullName: String, lineAndColumn: LineAndColumn): nodes.NewMember =
+    memberNode(name, lineAndColumn).dynamicTypeHintFullName(dynamicTypeHintFullName :: Nil)
 
   def bindingNode(): nodes.NewBinding = {
     val bindingNode = nodes

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -1784,8 +1784,8 @@ class PythonAstVisitor(
     * __getattribute__ and __get__.
     */
   def convert(attribute: ast.Attribute): nodes.NewNode = {
-    val baseNode  = convert(attribute.value)
-    val fieldName = attribute.attr
+    val baseNode   = convert(attribute.value)
+    val fieldName  = attribute.attr
     val lineAndCol = lineAndColOf(attribute)
 
     val fieldAccess = createFieldAccess(baseNode, fieldName, lineAndCol)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -517,7 +517,7 @@ class PythonAstVisitor(
     metaTypeDecl: nodes.NewNode
   ): Unit = {
     val memberForInstance =
-      nodeBuilder.memberNode(functionName, functionDefToMethod.apply(function).fullName)
+      nodeBuilder.memberNode(functionName, functionDefToMethod.apply(function).fullName, lineAndColOf(function))
     edgeBuilder.astEdge(memberForInstance, instanceTypeDecl, contextStack.order.getAndInc)
 
     val methodForMetaClass =
@@ -532,7 +532,7 @@ class PythonAstVisitor(
         )
       }
 
-    val memberForMeta = nodeBuilder.memberNode(functionName, methodForMetaClass.fullName)
+    val memberForMeta = nodeBuilder.memberNode(functionName, methodForMetaClass.fullName, lineAndColOf(function))
     edgeBuilder.astEdge(memberForMeta, metaTypeDecl, contextStack.order.getAndInc)
   }
 
@@ -1786,23 +1786,24 @@ class PythonAstVisitor(
   def convert(attribute: ast.Attribute): nodes.NewNode = {
     val baseNode  = convert(attribute.value)
     val fieldName = attribute.attr
+    val lineAndCol = lineAndColOf(attribute)
 
-    val fieldAccess = createFieldAccess(baseNode, fieldName, lineAndColOf(attribute))
+    val fieldAccess = createFieldAccess(baseNode, fieldName, lineAndCol)
 
     attribute.value match {
       case name: ast.Name if name.id == "self" =>
-        createAndRegisterMember(fieldName)
+        createAndRegisterMember(fieldName, lineAndCol)
       case _ =>
     }
 
     fieldAccess
   }
 
-  private def createAndRegisterMember(name: String): Unit = {
+  private def createAndRegisterMember(name: String, lineAndCol: LineAndColumn): Unit = {
     contextStack.findEnclosingTypeDecl() match {
       case Some(typeDecl: NewTypeDecl) =>
         if (!members.contains(typeDecl) || !members(typeDecl).contains(name)) {
-          val member = nodeBuilder.memberNode(name)
+          val member = nodeBuilder.memberNode(name, lineAndCol)
           edgeBuilder.astEdge(member, typeDecl, contextStack.order.getAndInc)
           members(typeDecl) = members.getOrElse(typeDecl, List()) ++ List(name)
         }
@@ -1834,7 +1835,7 @@ class PythonAstVisitor(
     val identifier      = createIdentifierNode(name.id, memoryOperation, lineAndColOf(name))
     contextStack.astParent match {
       case method: NewMethod if method.name.endsWith("<body>") =>
-        createAndRegisterMember(identifier.name)
+        createAndRegisterMember(identifier.name, lineAndColOf(name))
       case _ =>
     }
     identifier

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -47,4 +47,35 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
 
   }
 
+  "An instance variable with additional MEMBER fn" - {
+
+    lazy val cpg = Py2CpgTestContext.buildCpg(
+      """
+        |class Foo():
+        |   self.x = 'foo'
+        |   def replace(self, x):
+        |      self.x = x
+        |""".stripMargin)
+
+    "should have a MEMBER" in {
+      val List(member: Member) = cpg.member.name("x").l
+      member.code shouldBe "x"
+    }
+
+    "should have the MEMBER attached to the meta class" in {
+      val List(typeDecl) = cpg.member.name("x").typeDecl.l
+      typeDecl.name shouldBe "Foo<meta>"
+      typeDecl.lineNumber shouldBe Some(2)
+      typeDecl.columnNumber shouldBe Some(1)
+    }
+
+    "should have the MEMBER fn attached to the meta class and have col+line no" in {
+      val List(memberFn) = cpg.typeDecl("Foo").where(node => node.member.name("replace").l).l
+      memberFn.fullName shouldBe "test.py:<module>.Foo"
+      memberFn.lineNumber shouldBe Some(2)
+      memberFn.columnNumber shouldBe Some(1)
+    }
+
+  }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -49,8 +49,7 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
 
   "An instance variable with additional MEMBER fn" - {
 
-    lazy val cpg = Py2CpgTestContext.buildCpg(
-      """
+    lazy val cpg = Py2CpgTestContext.buildCpg("""
         |class Foo():
         |   self.x = 'foo'
         |   def replace(self, x):


### PR DESCRIPTION
    - __init__ fakemethod for typeDecl will work as is
    - Added couple of new memberNode() fn as overloaded fn to use LineAndColumn param
    - Updated all instances & passing LineAndColumn param