### PR TITLE
XTypeRecovery: Major Performance Improvements and Regex Handling 

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -137,8 +137,8 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
   }
 
   override protected def isField(i: Identifier): Boolean =
-    state.isFieldMemoization.getOrElseUpdate(
-      i,
+    state.isFieldCache.getOrElseUpdate(
+      i.id(),
       cu.method
         .nameExact(":program")
         .ast

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -69,7 +69,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
 
     def targetModule = Try(
       cpg
-        .file(s"${Matcher.quoteReplacement(resolvedPath)}\\.?.*")
+        .file(s"${Pattern.quote(resolvedPath)}\\.?.*")
         .method
     ) match {
       case Failure(_) =>
@@ -110,7 +110,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
           case List(_, b: Identifier) =>
             // Exported variable that we should find
             val typs = cpg
-              .file(s"${Matcher.quoteReplacement(resolvedPath)}\\.?.*")
+              .file(s"${Pattern.quote(resolvedPath)}\\.?.*")
               .method
               .ast
               .isIdentifier

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
@@ -7,7 +7,6 @@ import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate
 
 import java.util.regex.Pattern
-import scala.util.Try
 
 /** The type hints we pick up via the parser are not full names. This pass fixes that by retrieving the import for each
   * dynamic type hint and adjusting the dynamic type hint full name field accordingly.
@@ -28,8 +27,8 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
       file         <- methodReturn.file
       imports      <- fileToImports.get(file.name)
       importedEntity <- imports.filter { x =>
-        // TODO: Handle * imports correctly. This causes a regex exception otherwise.
-        x.importedAs.exists { imported => Try(typeHint.matches(imported + "(\\..+)*")).getOrElse(false) }
+        // TODO: Handle * imports correctly
+        x.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") }
       }.importedEntity
     } {
       val typeFullName = typeHint.replaceFirst(Pattern.quote(typeHint), importedEntity)
@@ -42,8 +41,8 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
       file     <- param.file
       imports  <- fileToImports.get(file.name)
       importDetails <- imports
-        // TODO: Handle * imports correctly. This causes a regex exception otherwise.
-        .filter(_.importedAs.exists { imported => Try(typeHint.matches(imported + "(\\..+)*")).getOrElse(false) })
+        // TODO: Handle * imports correctly
+        .filter(_.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") })
         .map(i => (i.importedEntity, i.importedAs))
     } {
       importDetails match {

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -209,7 +209,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
   /** If the parent method is module then it can be used as a field.
     */
   override def isField(i: Identifier): Boolean =
-    state.isFieldMemoization.getOrElseUpdate(i, i.method.name.matches("(<module>|__init__)") || super.isField(i))
+    state.isFieldCache.getOrElseUpdate(i.id(), i.method.name.matches("(<module>|__init__)") || super.isField(i))
 
   override def visitIdentifierAssignedToOperator(i: Identifier, c: Call, operation: String): Set[String] = {
     operation match {

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -13,7 +13,7 @@ import overflowdb.traversal.Traversal
 
 import java.io.{File => JFile}
 import java.nio.file.Paths
-import java.util.regex.Matcher
+import java.util.regex.{Matcher, Pattern}
 
 class PythonTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())
     extends XTypeRecoveryPass[File](cpg, config) {
@@ -118,7 +118,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     val sep = Matcher.quoteReplacement(JFile.separator)
 
     lazy val methodsWithExportEntityAsIdentifier: List[String] = cpg.typeDecl
-      .fullName(s".*${Matcher.quoteReplacement(path)}.*")
+      .fullName(s".*${Pattern.quote(path)}.*")
       .where(_.member.nameExact(expEntity))
       .fullName
       .toList


### PR DESCRIPTION
* Found `DynamicTypeHintFullNamePass` directly injected code into regex, made a note here to handle this better but, for now, simply using a `Try`
* Implemented early stopping if no changes were detected from previous iteration
* Found that whole graph traversals were being done where partial graph traversals were intended when propagating method and parameter types

Resolves #2458 