### PR TITLE
Fix php namespace and method full names

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -1013,9 +1013,12 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case _ => PropertyDefaults.MethodFullName
     }
 
+    // Use method signature for methods that can be linked to avoid varargs issue.
+    val signature = s"${Defines.UnresolvedSignature}(${call.args.size})"
     val callNode = NewCall()
       .name(name)
       .methodFullName(fullName)
+      .signature(signature)
       .code(code)
       .dispatchType(dispatchType)
       .lineNumber(line(call))

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
@@ -77,8 +77,8 @@ class Scope extends X2CpgScope[String, NewNode, NewNode] {
   def getEnclosingNamespaceNames: List[String] =
     stack.map(_.scopeNode).collect { case ns: NewNamespaceBlock => ns.name }.reverse
 
-  def getEnclosingTypeDeclType: Option[String] =
-    stack.map(_.scopeNode).collectFirst { case td: NewTypeDecl => td }.map(_.fullName)
+  def getEnclosingTypeDeclTypeName: Option[String] =
+    stack.map(_.scopeNode).collectFirst { case td: NewTypeDecl => td }.map(_.name)
 
   def getLocalsInScope: List[NewLocal] = localStack.headOption.map(_.toList).toList.flatten
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
@@ -74,8 +74,8 @@ class Scope extends X2CpgScope[String, NewNode, NewNode] {
     methods
   }
 
-  def getEnclosingNamespaceName: Option[String] =
-    stack.map(_.scopeNode).collectFirst { case ns: NewNamespaceBlock => ns }.map(_.name)
+  def getEnclosingNamespaceNames: List[String] =
+    stack.map(_.scopeNode).collect { case ns: NewNamespaceBlock => ns.name }.reverse
 
   def getEnclosingTypeDeclType: Option[String] =
     stack.map(_.scopeNode).collectFirst { case td: NewTypeDecl => td }.map(_.fullName)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -63,8 +63,10 @@ object Domain {
   }
 
   private val logger                      = LoggerFactory.getLogger(Domain.getClass)
-  private val NamespaceDelimiter          = "\\"
   private val FullyQualifiedNameDelimiter = "\\"
+  val NamespaceDelimiter                  = "\\"
+  val StaticMethodDelimiter               = "::"
+  val InstanceMethodDelimiter             = "->"
 
   final case class PhpAttributes(lineNumber: Option[Integer], kind: Option[Int])
   object PhpAttributes {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -62,11 +62,10 @@ object Domain {
     val unset  = "unset"
   }
 
-  private val logger                      = LoggerFactory.getLogger(Domain.getClass)
-  private val FullyQualifiedNameDelimiter = "\\"
-  val NamespaceDelimiter                  = "\\"
-  val StaticMethodDelimiter               = "::"
-  val InstanceMethodDelimiter             = "->"
+  private val logger          = LoggerFactory.getLogger(Domain.getClass)
+  val NamespaceDelimiter      = "\\"
+  val StaticMethodDelimiter   = "::"
+  val InstanceMethodDelimiter = "->"
 
   final case class PhpAttributes(lineNumber: Option[Integer], kind: Option[Int])
   object PhpAttributes {
@@ -1344,12 +1343,12 @@ object Domain {
       case Str(name) => PhpNameExpr(correctConstructor(name), PhpAttributes.Empty)
 
       case Obj(value) if value.get("nodeType").map(_.str).contains("Name_FullyQualified") =>
-        val name = value("parts").arr.map(_.str).mkString(FullyQualifiedNameDelimiter)
+        val name = value("parts").arr.map(_.str).mkString(NamespaceDelimiter)
         PhpNameExpr(correctConstructor(name), PhpAttributes(json))
 
       case Obj(value) if value.get("nodeType").map(_.str).contains("Name") =>
         // TODO Can this case just be merged with Name_FullyQualified?
-        val name = value("parts").arr.map(_.str).mkString(FullyQualifiedNameDelimiter)
+        val name = value("parts").arr.map(_.str).mkString(NamespaceDelimiter)
         PhpNameExpr(correctConstructor(name), PhpAttributes(json))
 
       case Obj(value) if value.get("nodeType").map(_.str).contains("Identifier") =>

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -35,7 +35,8 @@ class CallTests extends PhpCode2CpgFixture {
 
     inside(cpg.call.l) { case List(fooCall) =>
       fooCall.name shouldBe "foo"
-      fooCall.methodFullName shouldBe s"foo:${Defines.UnresolvedSignature}(1)"
+      fooCall.methodFullName shouldBe s"foo"
+      fooCall.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
       fooCall.receiver.isEmpty shouldBe true
       fooCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       fooCall.lineNumber shouldBe Some(2)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
@@ -56,7 +56,8 @@ class ClosureTests extends PhpCode2CpgFixture {
       }
 
       closureMethod.name shouldBe "__closure0"
-      closureMethod.fullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+      closureMethod.fullName shouldBe s"__closure0"
+      closureMethod.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
       closureMethod.code shouldBe "function __closure0($value) use($use1, &$use2)"
       closureMethod.parameter.size shouldBe 1
 
@@ -82,8 +83,8 @@ class ClosureTests extends PhpCode2CpgFixture {
 
     "have a correct MethodRef added to the AST where the closure is defined" in {
       inside(cpg.assignment.code(".*closure.*").argument.l) { case List(_: Identifier, methodRef: MethodRef) =>
-        methodRef.methodFullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
-        methodRef.code shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+        methodRef.methodFullName shouldBe s"__closure0"
+        methodRef.code shouldBe s"__closure0"
         methodRef.lineNumber shouldBe Some(3)
       }
     }
@@ -100,7 +101,8 @@ class ClosureTests extends PhpCode2CpgFixture {
       }
 
       closureMethod.name shouldBe "__closure0"
-      closureMethod.fullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+      closureMethod.fullName shouldBe s"__closure0"
+      closureMethod.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
       closureMethod.code shouldBe "function __closure0($value)"
       closureMethod.parameter.size shouldBe 1
 
@@ -115,8 +117,8 @@ class ClosureTests extends PhpCode2CpgFixture {
 
     "have a correct MethodRef added to the AST where the closure is defined" in {
       inside(cpg.assignment.argument.l) { case List(_: Identifier, methodRef: MethodRef) =>
-        methodRef.methodFullName shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
-        methodRef.code shouldBe s"__closure0:${Defines.UnresolvedSignature}(1)"
+        methodRef.methodFullName shouldBe s"__closure0"
+        methodRef.code shouldBe s"__closure0"
         methodRef.lineNumber shouldBe Some(2)
       }
     }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -14,7 +14,8 @@ class MethodTests extends PhpCode2CpgFixture {
      |""".stripMargin)
 
     inside(cpg.method.name("foo").l) { case List(fooMethod) =>
-      fooMethod.fullName shouldBe s"foo:${Defines.UnresolvedSignature}(0)"
+      fooMethod.fullName shouldBe s"foo"
+      fooMethod.signature shouldBe s"${Defines.UnresolvedSignature}(0)"
       fooMethod.lineNumber shouldBe Some(2)
       fooMethod.code shouldBe "function foo()"
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -34,8 +34,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
   }
 
   "methods defined in a namespace with brace syntax without sub-namespace should have the correct name" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |namespace ns {
         |  function foo() {}
         |}
@@ -45,8 +44,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
   }
 
   "methods defined in sub-namespace should have the correct name" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |namespace ns {
         |  function foo() {}
         |}
@@ -61,8 +59,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
   }
 
   "methods in different namespaces in the same file should have the correct names" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |namespace first;
         |function foo() {}
         |
@@ -75,8 +72,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
   }
 
   "methods in different namespaces using brace syntax in the same file should have the correct names" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |namespace first {
         |  function foo() {}
         |}
@@ -91,8 +87,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
   }
 
   "methods in different namespaces mixing global and named namespaces should have the correct names" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |namespace first {
         |  function foo() {}
         |}
@@ -112,8 +107,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
   }
 
   "static and instance methods in non-namespaced code should be correct" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |class A {
         |  function foo() {}
         |
@@ -123,5 +117,19 @@ class NamespaceTests extends PhpCode2CpgFixture {
 
     cpg.method.name("foo").fullName.l shouldBe List("A->foo")
     cpg.method.name("bar").fullName.l shouldBe List("A::bar")
+  }
+
+  "static and instance methods in namespaced code should be correct" in {
+    val cpg = code("""<?php
+        |namespace ns;
+        |class A {
+        |  function foo() {}
+        |
+        |  static function bar() {}
+        |}
+        |""".stripMargin)
+
+    cpg.method.name("foo").fullName.l shouldBe List("ns\\A->foo")
+    cpg.method.name("bar").fullName.l shouldBe List("ns\\A::bar")
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -30,7 +30,98 @@ class NamespaceTests extends PhpCode2CpgFixture {
         |function foo() {}
         |""".stripMargin)
 
-    cpg.namespace.isEmpty shouldBe false
     cpg.method.name("foo").fullName.l shouldBe List("ns\\foo")
+  }
+
+  "methods defined in a namespace with brace syntax without sub-namespace should have the correct name" in {
+    val cpg = code(
+      """<?php
+        |namespace ns {
+        |  function foo() {}
+        |}
+        |""".stripMargin)
+
+    cpg.method.name("foo").fullName.l shouldBe List("ns\\foo")
+  }
+
+  "methods defined in sub-namespace should have the correct name" in {
+    val cpg = code(
+      """<?php
+        |namespace ns {
+        |  function foo() {}
+        |}
+        |
+        |namespace ns\sub {
+        |  function bar() {}
+        |}
+        |""".stripMargin)
+
+    cpg.method.name("foo").fullName.l shouldBe List("ns\\foo")
+    cpg.method.name("bar").fullName.l shouldBe List("ns\\sub\\bar")
+  }
+
+  "methods in different namespaces in the same file should have the correct names" in {
+    val cpg = code(
+      """<?php
+        |namespace first;
+        |function foo() {}
+        |
+        |namespace second;
+        |function bar() {}
+        |""".stripMargin)
+
+    cpg.method.name("foo").fullName.l shouldBe List("first\\foo")
+    cpg.method.name("bar").fullName.l shouldBe List("second\\bar")
+  }
+
+  "methods in different namespaces using brace syntax in the same file should have the correct names" in {
+    val cpg = code(
+      """<?php
+        |namespace first {
+        |  function foo() {}
+        |}
+        |
+        |namespace second {
+        |  function bar() {}
+        |}
+        |""".stripMargin)
+
+    cpg.method.name("foo").fullName.l shouldBe List("first\\foo")
+    cpg.method.name("bar").fullName.l shouldBe List("second\\bar")
+  }
+
+  "methods in different namespaces mixing global and named namespaces should have the correct names" in {
+    val cpg = code(
+      """<?php
+        |namespace first {
+        |  function foo() {}
+        |}
+        |
+        |namespace ns\second {
+        |  function bar() {}
+        |}
+        |
+        |namespace {
+        |  function baz() {}
+        |}
+        |""".stripMargin)
+
+    cpg.method.name("foo").fullName.l shouldBe List("first\\foo")
+    cpg.method.name("bar").fullName.l shouldBe List("ns\\second\\bar")
+    cpg.method.name("baz").fullName.l shouldBe List("baz")
+  }
+
+  "static and instance methods in non-namespaced code should be correct" in {
+    val cpg = code(
+      """<?php
+        |class A {
+        |  function foo() {}
+        |
+        |  static function bar() {}
+        |}
+        |""".stripMargin)
+
+    cpg.method.name("foo").fullName.l shouldBe List("A->foo")
+    cpg.method.name("bar").fullName.l shouldBe List("A::bar")
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -15,4 +15,22 @@ class NamespaceTests extends PhpCode2CpgFixture {
       ns.astChildren.code.l shouldBe List("echo 0")
     }
   }
+
+  "methods defined in non-namespaced code should not include a namespace prefix" in {
+    val cpg = code("""<?php
+        |function foo() {}
+        |""".stripMargin)
+
+    cpg.method.name("foo").fullName.l shouldBe List("foo")
+  }
+
+  "methods defined in a namespace without sub-namespace should have the correct name" in {
+    val cpg = code("""<?php
+        |namespace ns;
+        |function foo() {}
+        |""".stripMargin)
+
+    cpg.namespace.isEmpty shouldBe false
+    cpg.method.name("foo").fullName.l shouldBe List("ns\\foo")
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
@@ -1,8 +1,9 @@
 package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.astcreation.AstCreator.{NameConstants, TypeConstants}
-import io.joern.php2cpg.parser.Domain.{PhpOperators, PhpDomainTypeConstants}
+import io.joern.php2cpg.parser.Domain.{PhpDomainTypeConstants, PhpOperators}
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, TypeRef}
 import io.shiftleft.passes.IntervalKeyPool
@@ -663,7 +664,7 @@ class OperatorTests extends PhpCode2CpgFixture {
       absCall.name shouldBe "abs"
       absCall.methodFullName shouldBe "__builtin.abs"
       absCall.code shouldBe "abs($a)"
-      absCall.signature.isEmpty shouldBe true
+      absCall.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
     }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -30,7 +30,7 @@ class TypeDeclTests extends PhpCode2CpgFixture {
 		 |""".stripMargin)
 
     inside(cpg.method.name("foo").l) { case List(fooMethod) =>
-      fooMethod.fullName shouldBe s"Foo.foo:${Defines.UnresolvedSignature}(1)"
+      fooMethod.fullName shouldBe s"Foo->foo"
       fooMethod.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
       fooMethod.modifier.map(_.modifierType).toSet shouldBe Set(ModifierTypes.FINAL, ModifierTypes.PUBLIC)
       fooMethod.methodReturn.typeFullName shouldBe "int"
@@ -123,7 +123,8 @@ class TypeDeclTests extends PhpCode2CpgFixture {
 
       inside(fooDecl.astChildren.l) { case List(fooMethod: Method) =>
         fooMethod.name shouldBe "foo"
-        fooMethod.fullName shouldBe s"Foo.foo:${Defines.UnresolvedSignature}(0)"
+        fooMethod.fullName shouldBe s"Foo->foo"
+        fooMethod.signature shouldBe s"${Defines.UnresolvedSignature}(0)"
       }
     }
   }
@@ -157,7 +158,8 @@ class TypeDeclTests extends PhpCode2CpgFixture {
 
       inside(fooDecl.astChildren.l) { case List(fooMethod: Method) =>
         fooMethod.name shouldBe "foo"
-        fooMethod.fullName shouldBe s"Foo.foo:${Defines.UnresolvedSignature}(0)"
+        fooMethod.fullName shouldBe s"Foo->foo"
+        fooMethod.signature shouldBe s"${Defines.UnresolvedSignature}(0)"
       }
     }
   }
@@ -210,7 +212,7 @@ class TypeDeclTests extends PhpCode2CpgFixture {
 
       inside(fooDecl.method.l) { case List(clinitMethod: Method) =>
         clinitMethod.name shouldBe Defines.StaticInitMethodName
-        clinitMethod.fullName shouldBe s"Foo.${Defines.StaticInitMethodName}:void()"
+        clinitMethod.fullName shouldBe s"Foo::${Defines.StaticInitMethodName}"
         clinitMethod.signature shouldBe "void()"
 
         inside(clinitMethod.body.astChildren.l) { case List(aAssign: Call, bAssign: Call) =>


### PR DESCRIPTION
The main purpose of this PR is to establish fixed methodFullNames for method nodes. These deviate from the typical format seen in Joern front-ends for 2 main reasons:
- PHP uses `\` as a delimiter for namespaces 
- PHP does not support overloading via signatures, so signatures are omitted from the MFN.

The naming scheme also adopts different notation for functions, class methods and instance methods:
```php
// function `foo` in global namespace
foo

// function `foo` in namespace A\B
A\B\foo

// static method foo in class Foo in namespace A\B
A\B\Foo::foo

// instance method foo in class Foo in namespace A\B
A\B\Foo->foo
```

The `::` and `->` notation was chosen to mimic how these methods would be called (at least from external classes/code). More examples illustrating the naming scheme are shown in the unit tests. 

2 notable cases regarding method names:
- Constructors use the `Defines.ConstructorMethodName` (i.e. `<init>`), instead of the PHP default ` __construct`. The reasoning behind this is basically not knowing whether the closed source dataflow tracker treats the `<init>` name in any special way. If constructor names are only special at the policy level, then using `__construct` makes more sense.
- A `<clinit>` method (with the name again matching JVM since there's already precedent for that) is added for classes with constant or static variable intializers. This was part of a much earlier php2cpg PR and was added since I remember running into issues attempting to add arbitrary statements as direct children to TypeDecl nodes. Whether or not having this method is the correct choice is certainly up for debate, but while it is present, `<clinit>` is probably a fine name for it since there isn't a PHP equivalent, as far as I'm aware.