### PR TITLE
XTypeRecovery: Get Method & Parameter Type Hints Directly from CPG

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -538,7 +538,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |
         |async def get_user_by_email(email: str, db: orm.Session):
         |   return db.query(user_models.User).filter(user_models.User.email == email).first()
-        |""".stripMargin, "foo.py")
+        |""".stripMargin)
 
     "be sufficient to resolve method full names at calls" in {
       val List(call) = cpg.call("query").l

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -538,12 +538,13 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |
         |async def get_user_by_email(email: str, db: orm.Session):
         |   return db.query(user_models.User).filter(user_models.User.email == email).first()
-        |""".stripMargin)
+        |""".stripMargin, "foo.py")
 
     "be sufficient to resolve method full names at calls" in {
       val List(call) = cpg.call("query").l
-      call.methodFullName.startsWith("sqlalchemy.orm") shouldBe true
+      call.methodFullName shouldBe "sqlalchemy.orm.Session.query"
     }
+
   }
 
   "recover a member call from a reference to an imported global variable" should {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -235,8 +235,6 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
 
   protected def members: Traversal[Member] = cu.ast.isMember
 
-  protected def parameters: Traversal[MethodParameterIn] = cu.ast.isParameter
-
   /** For each call that contains the returnValue directive, attempt to replace the return value by the dynamic
     */
   protected def visitCall(call: Call): Unit = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -235,8 +235,6 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
 
   protected def members: Traversal[Member] = cu.ast.isMember
 
-  protected def calls: Traversal[Call] = cu.ast.isCall
-
   protected def parameters: Traversal[MethodParameterIn] = cu.ast.isParameter
 
   /** For each call that contains the returnValue directive, attempt to replace the return value by the dynamic
@@ -278,10 +276,6 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     postVisitImports()
     // Populate local symbol table with assignments
     assignments.foreach(visitAssignments)
-    // Propagate return types
-    calls.filter(symbolTable.contains).foreach(visitCall)
-    // Propagate parameter types
-    parameters.foreach(visitParameter)
     // Persist findings
     setTypeInformation()
     // Return number of changes
@@ -546,7 +540,12 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   /** Will attempt to find the return values of a method if in the CPG, otherwise will give a dummy value.
     */
   protected def methodReturnValues(methodFullNames: Seq[String]): Set[String] = {
-    val rs = cpg.method.fullNameExact(methodFullNames: _*).methodReturn.typeFullName.filterNot(_.equals("ANY")).toSet
+    val rs = cpg.method
+      .fullNameExact(methodFullNames: _*)
+      .methodReturn
+      .flatMap(mr => mr.typeFullName +: mr.dynamicTypeHintFullName)
+      .filterNot(_.equals("ANY"))
+      .toSet
     if (rs.isEmpty) methodFullNames.map(_.concat(s"$pathSep${XTypeRecovery.DummyReturnType}")).toSet
     else rs
   }


### PR DESCRIPTION
* Obtain type hints directly from CPG instead of symbol table
* Removed parameter propagation as the type propagation seems to already utilize this