### PR TITLE
Update astgen

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "2.19.0"
+    astgen_version: "2.20.0"
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "2.20.0"
+    astgen_version: "2.21.0"
 }


### PR DESCRIPTION
Brings in astgen performance improvements.

With this, astgen takes ~120 sec incl. TS types for https://github.com/microsoft/TypeScript on my machine with standard node heap size settings.