### PR TITLE
[pysrc2cpg] allow traversing from constructor calls to type declarations

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 import io.joern.pysrc2cpg._
 import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.shiftleft.codepropertygraph.Cpg
 
@@ -31,6 +32,11 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
       .createAndApply()
     new PythonTypeHintCallLinker(cpg).createAndApply()
     new PythonNaiveCallLinker(cpg).createAndApply()
+
+    // Some of passes above create new methods, so, we
+    // need to run the ASTLinkerPass one more time
+    new AstLinkerPass(cpg).createAndApply()
+
     cpg
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -199,6 +199,17 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     }
   }
 
+  override def persistType(x: StoredNode, types: Set[String]): Unit = {
+    super.persistType(x, types.map(pyBodyTypeToTypeDecl))
+  }
+
+  /** Converts `Foo.Foo<body>` that holds method declarations to `Foo` which is the "main" type declaration.
+    */
+  private def pyBodyTypeToTypeDecl(typeFullName: String): String =
+    if (typeFullName.endsWith("<body>"))
+      typeFullName.split(pathSep).lastOption.map(x => typeFullName.stripSuffix(s"$pathSep$x")).getOrElse(typeFullName)
+    else typeFullName
+
   /** Determines if a function call is a constructor by following the heuristic that Python classes are typically
     * camel-case and start with an upper-case character.
     */

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -1,6 +1,5 @@
 package io.joern.pysrc2cpg
 
-import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -3,6 +3,7 @@ package io.joern.pysrc2cpg
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
@@ -31,6 +32,10 @@ class PySrcTestCpg extends TestCpg with PythonFrontend {
     new PythonTypeRecoveryPass(this).createAndApply()
     new PythonTypeHintCallLinker(this).createAndApply()
     new PythonNaiveCallLinker(this).createAndApply()
+
+    // Some of passes above create new methods, so, we
+    // need to run the ASTLinkerPass one more time
+    new AstLinkerPass(this).createAndApply()
 
     if (_withOssDataflow) {
       val context = new LayerCreatorContext(this)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -3,7 +3,7 @@ package io.joern.pysrc2cpg.dataflow
 import io.joern.dataflowengineoss.language.toExtendedCfgNode
 import io.joern.pysrc2cpg.PySrc2CpgFixture
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Literal, Member}
+import io.shiftleft.codepropertygraph.generated.nodes.{Literal, Member, Method}
 import io.shiftleft.semanticcpg.language._
 
 class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
@@ -298,7 +298,9 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         "models.py"
       )
 
-    val List(typeDeclFullName) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.typeDecl.fullName.l
+    val List(method : Method) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.l
+    method.fullName shouldBe "models.py:<module>.Foo.Foo<body>.__init__"
+    val List(typeDeclFullName) = method.typeDecl.fullName.l
     typeDeclFullName shouldBe "models.py:<module>.Foo<meta>"
   }
 
@@ -315,8 +317,9 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         "models.py"
       )
 
-    val List(typeDeclFullName) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.typeDecl.fullName.l
-
+    val List(method : Method) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.l
+    method.fullName shouldBe "models.py:<module>.Foo.Foo<body>.__init__"
+    val List(typeDeclFullName) = method.typeDecl.fullName.l
     typeDeclFullName shouldBe "models.py:<module>.Foo<meta>"
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -283,4 +283,27 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     sinks.reachableByFlows(sources).size should not be 0
   }
 
+  "foo" in {
+    val cpg = code(
+      """
+        |from models import Foo
+        |foo = Foo(x,y,z)
+        |""".stripMargin)
+      .moreCode(
+        """
+          |class Foo:
+          |   def __init__(self, a, b, c):
+          |      println("foo")
+          |      pass
+          |""".stripMargin, "models.py")
+
+
+    val parameters = cpg.identifier.name("foo")
+      .inAssignment
+      .source.isCall.callee
+      .parameter.name.l
+
+    parameters shouldBe List("self", "a", "b", "c")
+  }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -3,6 +3,7 @@ package io.joern.pysrc2cpg.dataflow
 import io.joern.dataflowengineoss.language.toExtendedCfgNode
 import io.joern.pysrc2cpg.PySrc2CpgFixture
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Literal, Member, Method}
 import io.shiftleft.semanticcpg.language._
 
@@ -298,7 +299,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         "models.py"
       )
 
-    val List(method : Method) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.l
+    val List(method: Method) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.l
     method.fullName shouldBe "models.py:<module>.Foo.Foo<body>.__init__"
     val List(typeDeclFullName) = method.typeDecl.fullName.l
     typeDeclFullName shouldBe "models.py:<module>.Foo<meta>"
@@ -317,10 +318,10 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         "models.py"
       )
 
-    val List(method : Method) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.l
+    val List(method: Method) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.l
     method.fullName shouldBe "models.py:<module>.Foo.Foo<body>.__init__"
     val List(typeDeclFullName) = method.typeDecl.fullName.l
-    typeDeclFullName shouldBe "models.py:<module>.Foo<meta>"
+    typeDeclFullName shouldBe "models.py:<module>.Foo.Foo<body>"
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -296,13 +296,13 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "provide a dummy type to a member if the member type is not known" in {
       val Some(sessionTmpVar) = cpg.identifier("tmp0").headOption
-      sessionTmpVar.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.<member>(session)"
+      sessionTmpVar.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session)"
 
       val Some(addCall) = cpg
         .call("add")
         .headOption
-      addCall.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.<member>(session).add"
-      addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.<member>(session).add"
+      addCall.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
+      addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
       addCall.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
 
@@ -575,7 +575,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "recover a call to `add`" in {
       val Some(addCall) = cpg.call("add").headOption
-      addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.SQLAlchemy<body>.<member>(session).add"
+      addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -282,9 +282,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     ).cpg
 
     "be determined as a variable reference and have its type recovered correctly" in {
-      cpg.identifier("db").map(_.typeFullName).toSet shouldBe Set(
-        "flask_sqlalchemy.py:<module>.SQLAlchemy"
-      )
+      cpg.identifier("db").map(_.typeFullName).toSet shouldBe Set("flask_sqlalchemy.py:<module>.SQLAlchemy")
 
       cpg
         .call("add")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -935,7 +935,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
       }
   }
 
-  private def persistType(x: StoredNode, types: Set[String]): Unit = {
+  protected def persistType(x: StoredNode, types: Set[String]): Unit = {
     val filteredTypes = if (state.config.enabledDummyTypes) types else types.filterNot(XTypeRecovery.isDummyType)
     if (filteredTypes.nonEmpty) {
       storeNodeTypeInfo(x, filteredTypes.toSeq)


### PR DESCRIPTION
There were a few bugs that prohibited us from traversing from constructor invocations to the corresponding classes. This can now be achieved as illustrated in the tests provided in this PR. In short, `.callee.typeDecl` brings you from the constructor invocation to the type declaration.