### PR TITLE
jssrc2cpg: astgen update

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "2.21.0"
+    astgen_version: "2.22.0"
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -9,6 +9,13 @@ trait TypeHelper { this: AstCreator =>
   private val TypeAnnotationKey = "typeAnnotation"
   private val ReturnTypeKey     = "returnType"
 
+  private val ArrayReplacements = Map(
+    "any[]"     -> s"${Defines.Any}[]",
+    "number[]"  -> s"${Defines.Number}[]",
+    "string[]"  -> s"${Defines.String}[]",
+    "boolean[]" -> s"${Defines.Boolean}[]"
+  )
+
   private val TypeReplacements = Map(
     " any"     -> s" ${Defines.Any}",
     " number"  -> s" ${Defines.Number}",
@@ -85,7 +92,7 @@ trait TypeHelper { this: AstCreator =>
       case Some(value) if value == "boolean"  => Defines.Boolean
       case Some(value) if value == "any"      => Defines.Any
       case Some(other) =>
-        TypeReplacements.foldLeft(other) { case (typeStr, (m, r)) =>
+        (TypeReplacements ++ ArrayReplacements).foldLeft(other) { case (typeStr, (m, r)) =>
           typeStr.replace(m, r)
         }
       case None => Defines.Any

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
@@ -47,7 +47,7 @@ class TSTypesTest extends AbstractPassTest {
     args.name shouldBe "args"
     args.code shouldBe "...args"
     args.isVariadic shouldBe true
-    args.typeFullName shouldBe Defines.Any
+    args.typeFullName shouldBe s"${Defines.Any}[]"
   }
 
   "have return types for arrow functions" in AstFixture("const foo = () => 42;", tsTypes = true) { cpg =>


### PR DESCRIPTION
Brings in some more optimizations:
* Array types are more exact.
* Filtered "any" types from generated *.typemap files (we infer "any" in case of no type info anyway). Makes the *.typemap files much smaller.
* *.typemap files are human-readable now (added json formatting, easier to debug).