### PR TITLE
PythonTypeRecovery: Filter Type Hints by Existing Types

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate
 
 import java.io.File
-import java.util.regex.Pattern
+import java.util.regex.{Matcher, Pattern}
 
 /** The type hints we pick up via the parser are not full names. This pass fixes that by retrieving the import for each
   * dynamic type hint and adjusting the dynamic type hint full name field accordingly.
@@ -70,7 +70,7 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
         typeFilePath.stripSuffix(s"${File.separator}$typeName").concat(s".py:<module>.$typeName")
       case None => typeFullName
     }
-    cpg.typeDecl.fullName(s".*${Pattern.quote(pythonicTypeFullName)}").l match {
+    cpg.typeDecl.fullName(s".*${Matcher.quoteReplacement(pythonicTypeFullName)}").l match {
       case xs if xs.nonEmpty =>
         diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, xs.fullName.toSeq)
       case _ => diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq(pythonicTypeFullName))

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
@@ -70,7 +70,7 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
         typeFilePath.stripSuffix(s"${File.separator}$typeName").concat(s".py:<module>.$typeName")
       case None => typeFullName
     }
-    cpg.typeDecl.fullName(s".*$pythonicTypeFullName").l match {
+    cpg.typeDecl.fullName(s".*${Pattern.quote(pythonicTypeFullName)}").l match {
       case xs if xs.nonEmpty =>
         diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, xs.fullName.toSeq)
       case _ => diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq(pythonicTypeFullName))

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
@@ -64,13 +64,13 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
     importedEntity: String
   ) = {
     val typeFullName = typeHint.replaceFirst(Pattern.quote(alias), importedEntity)
-    val typeFilePath = typeFullName.replaceAll("\\.", File.separator)
+    val typeFilePath = typeFullName.replaceAll("\\.", Matcher.quoteReplacement(File.separator))
     val pythonicTypeFullName = typeFullName.split("\\.").lastOption match {
       case Some(typeName) =>
         typeFilePath.stripSuffix(s"${File.separator}$typeName").concat(s".py:<module>.$typeName")
       case None => typeFullName
     }
-    cpg.typeDecl.fullName(s".*${Matcher.quoteReplacement(pythonicTypeFullName)}").l match {
+    cpg.typeDecl.fullName(s".*${Pattern.quote(pythonicTypeFullName)}").l match {
       case xs if xs.nonEmpty =>
         diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, xs.fullName.toSeq)
       case _ => diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq(pythonicTypeFullName))

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -13,22 +13,15 @@ import overflowdb.traversal.Traversal
 import java.io.{File => JFile}
 import java.nio.file.Paths
 import java.util.regex.{Matcher, Pattern}
-import scala.collection.concurrent.TrieMap
 
 class PythonTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())
     extends XTypeRecoveryPass[File](cpg, config) {
 
-  /** Mapping between import notation to the type names in the CPG is fairly expensive as it requires graph reads, this
-    * will negate that slowdown slightly.
-    */
-  private val importCache = TrieMap.empty[String, Set[String]]
-
   override protected def generateRecoveryPass(state: XTypeRecoveryState): XTypeRecovery[File] =
-    new PythonTypeRecovery(cpg, state, importCache)
+    new PythonTypeRecovery(cpg, state)
 }
 
-private class PythonTypeRecovery(cpg: Cpg, state: XTypeRecoveryState, importCache: TrieMap[String, Set[String]])
-    extends XTypeRecovery[File](cpg, state) {
+private class PythonTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
 
   override def compilationUnit: Traversal[File] = cpg.file
 
@@ -42,21 +35,15 @@ private class PythonTypeRecovery(cpg: Cpg, state: XTypeRecoveryState, importCach
       builder,
       state.copy(config =
         state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-      ),
-      importCache
+      )
     )
 
 }
 
 /** Performs type recovery from the root of a compilation unit level
   */
-private class RecoverForPythonFile(
-  cpg: Cpg,
-  cu: File,
-  builder: DiffGraphBuilder,
-  state: XTypeRecoveryState,
-  importCache: TrieMap[String, Set[String]]
-) extends RecoverForXCompilationUnit[File](cpg, cu, builder, state) {
+private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, state: XTypeRecoveryState)
+    extends RecoverForXCompilationUnit[File](cpg, cu, builder, state) {
 
   /** Replaces the `this` prefix with the Pythonic `self` prefix for instance methods of functions local to this
     * compilation unit.
@@ -91,9 +78,7 @@ private class RecoverForPythonFile(
           else relativeNamespace
         } else path.code
 
-        val importKey = s"$path?$funcOrModule"
-        val calleeNames =
-          importCache.getOrElseUpdate(importKey, extractPossibleCalleeNames(namespace, funcOrModule.code))
+        val calleeNames = extractPossibleCalleeNames(namespace, funcOrModule.code)
         alias match {
           case (alias: Literal) :: Nil =>
             symbolTable.put(CallAlias(alias.code), calleeNames)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -154,7 +154,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
 
     /** The two ways that this procedure could be resolved to in Python. */
     def possibleCalleeNames(procedureName: String, isMaybeConstructor: Boolean, isFieldOrVar: Boolean): Set[String] = {
-      val pythonicFormGuesses = cpg.typeDecl.fullName(s".*$procedureName").fullName.toSet match {
+      val pythonicFormGuesses = cpg.typeDecl.fullName(s".*${Pattern.quote(procedureName)}").fullName.toSet match {
         case xs if xs.nonEmpty => xs
         case _                 => Seq(procedureName)
       }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -154,10 +154,11 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
 
     /** The two ways that this procedure could be resolved to in Python. */
     def possibleCalleeNames(procedureName: String, isMaybeConstructor: Boolean, isFieldOrVar: Boolean): Set[String] = {
-      val pythonicFormGuesses = cpg.typeDecl.fullName(s".*${Matcher.quoteReplacement(procedureName)}").fullName.toSet match {
-        case xs if xs.nonEmpty => xs
-        case _                 => Seq(procedureName)
-      }
+      val pythonicFormGuesses =
+        cpg.typeDecl.fullName(s".*${Pattern.quote(procedureName)}").fullName.toSet match {
+          case xs if xs.nonEmpty => xs
+          case _                 => Seq(procedureName)
+        }
       if (isMaybeConstructor)
         pythonicFormGuesses.map(p => Seq(p, s"$expEntity<body>", "__init__").mkString(pathSep.toString)).toSet
       else if (isFieldOrVar) {

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -154,7 +154,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
 
     /** The two ways that this procedure could be resolved to in Python. */
     def possibleCalleeNames(procedureName: String, isMaybeConstructor: Boolean, isFieldOrVar: Boolean): Set[String] = {
-      val pythonicFormGuesses = cpg.typeDecl.fullName(s".*${Pattern.quote(procedureName)}").fullName.toSet match {
+      val pythonicFormGuesses = cpg.typeDecl.fullName(s".*${Matcher.quoteReplacement(procedureName)}").fullName.toSet match {
         case xs if xs.nonEmpty => xs
         case _                 => Seq(procedureName)
       }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/DynamicTypeHintFullNamePassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/DynamicTypeHintFullNamePassTests.scala
@@ -3,6 +3,8 @@ package io.joern.pysrc2cpg.passes
 import io.joern.pysrc2cpg.PySrc2CpgFixture
 import io.shiftleft.semanticcpg.language._
 
+import java.io.File
+
 class DynamicTypeHintFullNamePassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
   "dynamic type hints" should {
@@ -15,7 +17,9 @@ class DynamicTypeHintFullNamePassTests extends PySrc2CpgFixture(withOssDataflow 
         |""".stripMargin)
 
     "take into accounts imports" in {
-      cpg.method("m").methodReturn.dynamicTypeHintFullName.l shouldBe List("foo/bar.py:<module>.Woo")
+      cpg.method("m").methodReturn.dynamicTypeHintFullName.l shouldBe List(
+        Seq("foo", "bar.py:<module>.Woo").mkString(File.separator)
+      )
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/DynamicTypeHintFullNamePassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/DynamicTypeHintFullNamePassTests.scala
@@ -15,7 +15,7 @@ class DynamicTypeHintFullNamePassTests extends PySrc2CpgFixture(withOssDataflow 
         |""".stripMargin)
 
     "take into accounts imports" in {
-      cpg.method("m").methodReturn.dynamicTypeHintFullName.l shouldBe List("foo.bar.Woo")
+      cpg.method("m").methodReturn.dynamicTypeHintFullName.l shouldBe List("foo/bar.py:<module>.Woo")
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -500,7 +500,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "recover its full name successfully" in {
       val List(methodFullName) = cpg.call("query").methodFullName.l
-      methodFullName shouldBe "sqlalchemy.orm.Session.query"
+      methodFullName shouldBe "sqlalchemy/orm.py:<module>.Session.query"
     }
   }
 
@@ -541,7 +541,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "be sufficient to resolve method full names at calls" in {
       val List(call) = cpg.call("query").l
-      call.methodFullName shouldBe "sqlalchemy.orm.Session.query"
+      call.methodFullName shouldBe "sqlalchemy/orm.py:<module>.Session.query"
     }
 
   }
@@ -616,9 +616,9 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "with the correct identifier and call types" in {
       val Some(postCallReceiver) = cpg.identifier("db").headOption
-      postCallReceiver.typeFullName shouldBe "sqlalchemy.orm.Session"
+      postCallReceiver.typeFullName shouldBe "sqlalchemy/orm.py:<module>.Session"
       val Some(postCall) = cpg.call("query").headOption
-      postCall.methodFullName shouldBe "sqlalchemy.orm.Session.query"
+      postCall.methodFullName shouldBe "sqlalchemy/orm.py:<module>.Session.query"
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -500,7 +500,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "recover its full name successfully" in {
       val List(methodFullName) = cpg.call("query").methodFullName.l
-      methodFullName shouldBe "sqlalchemy/orm.py:<module>.Session.query"
+      methodFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session.query").mkString(File.separator)
     }
   }
 
@@ -541,7 +541,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "be sufficient to resolve method full names at calls" in {
       val List(call) = cpg.call("query").l
-      call.methodFullName shouldBe "sqlalchemy/orm.py:<module>.Session.query"
+      call.methodFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session.query").mkString(File.separator)
     }
 
   }
@@ -616,9 +616,9 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "with the correct identifier and call types" in {
       val Some(postCallReceiver) = cpg.identifier("db").headOption
-      postCallReceiver.typeFullName shouldBe "sqlalchemy/orm.py:<module>.Session"
+      postCallReceiver.typeFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session").mkString(File.separator)
       val Some(postCall) = cpg.call("query").headOption
-      postCall.methodFullName shouldBe "sqlalchemy/orm.py:<module>.Session.query"
+      postCall.methodFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session.query").mkString(File.separator)
     }
   }
 


### PR DESCRIPTION
* Attempt to find instances of `TypeDecl` nodes that match the type hint path
* This fixes instances of partial paths that do not reflect the fully qualified name

This degrades performance slightly