### PR TITLE
fix dockerfile: use jdk17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:latest
+FROM alpine:3.17.3
 
 # dependencies
-RUN apk update && apk upgrade && apk add --no-cache openjdk19-jre python3 git curl gnupg bash nss ncurses php
+RUN apk update && apk upgrade && apk add --no-cache openjdk17-jdk python3 git curl gnupg bash nss ncurses php
 RUN ln -sf python3 /usr/bin/python
 
 # sbt


### PR DESCRIPTION
* alpine's latest jdk is 17 - that's ok
* stick to a fixed alpine tag to avoid surprises in the future
* fixes https://github.com/joernio/joern/issues/2479