### PR TITLE
Remove builtin prefix from call names and add fileName to method nodes

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/PhpBuiltins.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/PhpBuiltins.scala
@@ -8,6 +8,4 @@ object PhpBuiltins {
   lazy val FuncNames: Set[String] = {
     Source.fromResource("builtin_functions.txt").getLines().toSet
   }
-
-  val Prefix: String = "__builtin"
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MemberTests.scala
@@ -1,6 +1,6 @@
 package io.joern.php2cpg.querying
 
-import io.joern.php2cpg.parser.Domain.PhpOperators
+import io.joern.php2cpg.parser.Domain
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
@@ -77,7 +77,7 @@ class MemberTests extends PhpCode2CpgFixture {
     }
 
     "have assignments added to the default constructor" in {
-      inside(cpg.method.nameExact(Defines.ConstructorMethodName).l) { case List(initMethod) =>
+      inside(cpg.method.nameExact(Domain.ConstructorMethodName).l) { case List(initMethod) =>
         inside(initMethod.body.astChildren.l) { case List(aAssign: Call, bAssign: Call, cAssign: Call) =>
           checkFieldAssign(aAssign, "a")
           checkFieldAssign(bAssign, "b")
@@ -117,7 +117,7 @@ class MemberTests extends PhpCode2CpgFixture {
     }
 
     "have assignments added to the default constructor" in {
-      inside(cpg.method.nameExact(Defines.ConstructorMethodName).l) { case List(initMethod) =>
+      inside(cpg.method.nameExact(Domain.ConstructorMethodName).l) { case List(initMethod) =>
         inside(initMethod.body.astChildren.l) { case List(aAssign: Call, bAssign: Call, cAssign: Call) =>
           checkFieldAssign(aAssign, "a")
           checkFieldAssign(bAssign, "b")

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -73,4 +73,14 @@ class MethodTests extends PhpCode2CpgFixture {
       }
     }
   }
+
+  "methods should be accessible from the file node" in {
+    val cpg = code("""<?php
+        |function foo() {
+        |  static $x = 42, $y;
+        |}
+        |""".stripMargin)
+
+    cpg.file.method.name.l shouldBe List("foo")
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
@@ -265,7 +265,7 @@ class OperatorTests extends PhpCode2CpgFixture {
     val cpg = code("<?php\nprint(\"Hello, world\");")
 
     inside(cpg.call.nameExact("print").l) { case List(printCall) =>
-      printCall.methodFullName shouldBe "__builtin.print"
+      printCall.methodFullName shouldBe "print"
       printCall.typeFullName shouldBe TypeConstants.Int
       printCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       printCall.lineNumber shouldBe Some(2)
@@ -608,7 +608,7 @@ class OperatorTests extends PhpCode2CpgFixture {
     val cpg = code("<?php\n`ls -la`")
 
     inside(cpg.call.name("shell_exec").l) { case List(shellCall) =>
-      shellCall.methodFullName shouldBe "__builtin.shell_exec"
+      shellCall.methodFullName shouldBe "shell_exec"
       shellCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       shellCall.code shouldBe "`ls -la`"
       shellCall.lineNumber shouldBe Some(2)
@@ -624,7 +624,7 @@ class OperatorTests extends PhpCode2CpgFixture {
 
     inside(cpg.call.l) { case List(unsetCall) =>
       unsetCall.name shouldBe "unset"
-      unsetCall.methodFullName shouldBe "__builtin.unset"
+      unsetCall.methodFullName shouldBe "unset"
       unsetCall.code shouldBe "unset($a, $b)"
       unsetCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       unsetCall.lineNumber shouldBe Some(2)
@@ -662,7 +662,7 @@ class OperatorTests extends PhpCode2CpgFixture {
 
     inside(cpg.call.l) { case List(absCall) =>
       absCall.name shouldBe "abs"
-      absCall.methodFullName shouldBe "__builtin.abs"
+      absCall.methodFullName shouldBe "abs"
       absCall.code shouldBe "abs($a)"
       absCall.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
     }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -75,10 +75,10 @@ class TypeDeclTests extends PhpCode2CpgFixture {
             allocCall.code shouldBe "Foo.<alloc>()"
           }
 
-          initCall.name shouldBe "<init>"
-          initCall.methodFullName shouldBe s"Foo.<init>:${Defines.UnresolvedSignature}(1)"
+          initCall.name shouldBe "__construct"
+          initCall.methodFullName shouldBe s"Foo.__construct:${Defines.UnresolvedSignature}(1)"
           initCall.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
-          initCall.code shouldBe "Foo.<init>(42)"
+          initCall.code shouldBe "Foo.__construct(42)"
           inside(initCall.argument.l) { case List(tmpIdentifier: Identifier, literal: Literal) =>
             tmpIdentifier.name shouldBe "tmp0"
             tmpIdentifier.code shouldBe "$tmp0"


### PR DESCRIPTION
- Rename php constructors from `<init>` to `__construct`  to match PHP naming
- Remove `__builtin` prefix from call names since this didn't actually add any relevant information
- Add filename to method nodes (so that `cpg.file.method.l` returns methods defined in the file)