### PR TITLE
PythonTypeRecovery: Fix leading slash in relative import

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -74,8 +74,8 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
             if (fileName.contains(JFile.separator))
               fileName.substring(0, fileName.lastIndexOf(JFile.separator)).replaceAll(sep, ".")
             else ""
-          if (path.code.length > 1) relativeNamespace + path.code.stripPrefix(".").replaceAll(sep, ".")
-          else relativeNamespace
+          (if (path.code.length > 1) relativeNamespace + path.code.replaceAll(sep, ".")
+           else relativeNamespace).stripPrefix(".")
         } else path.code
 
         val calleeNames = extractPossibleCalleeNames(namespace, funcOrModule.code)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -74,7 +74,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
             if (fileName.contains(JFile.separator))
               fileName.substring(0, fileName.lastIndexOf(JFile.separator)).replaceAll(sep, ".")
             else ""
-          if (path.code.length > 1) relativeNamespace + path.code.replaceAll(sep, ".")
+          if (path.code.length > 1) relativeNamespace + path.code.stripPrefix(".").replaceAll(sep, ".")
           else relativeNamespace
         } else path.code
 


### PR DESCRIPTION
Fixed instances where a dot import e.g. `.foo` would result in a recovered type reading as `/foo`.