### PR TITLE
Handle AnnotationParameterAssign in .parentExpression

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsDecoratorAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsDecoratorAstCreationPassTest.scala
@@ -228,8 +228,7 @@ class TsDecoratorAstCreationPassTest extends AbstractPassTest {
       }
     }
 
-    "create annotations with literals correctly for class members" in TsAstFixture(
-      """
+    "create annotations with literals correctly for class members" in TsAstFixture("""
         |class Foo {
         |  @a('lit')
         |  public x: number;

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsDecoratorAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsDecoratorAstCreationPassTest.scala
@@ -228,6 +228,31 @@ class TsDecoratorAstCreationPassTest extends AbstractPassTest {
       }
     }
 
+    "create annotations with literals correctly for class members" in TsAstFixture(
+      """
+        |class Foo {
+        |  @a('lit')
+        |  public x: number;
+        |}
+        |""".stripMargin) { cpg =>
+      inside(cpg.typeDecl.name("Foo").member.name("x").annotation.l) { case List(a) =>
+        a.code shouldBe "@a('lit')"
+        a.name shouldBe "a"
+        a.fullName shouldBe "a"
+        val List(assign) = a.parameterAssign.l
+        assign.code shouldBe "'lit'"
+        assign.order shouldBe 1
+        val List(paramA) = assign.parameter.l
+        paramA.code shouldBe "value"
+        paramA.order shouldBe 1
+        val List(lit) = assign.value.isLiteral.l
+        lit.code shouldBe "\"lit\""
+        lit.order shouldBe 2
+        lit.argumentIndex shouldBe 2
+        lit.parentExpression.code.head shouldBe "@a('lit')"
+      }
+    }
+
     "create annotations correctly for class accessors" in TsAstFixture("""
         |class Foo {
         |  private _x: number;

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -29,6 +29,8 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
         _parentExpression(call)
       case expression: Expression =>
         Some(expression)
+      case annotationParameterAssign: AnnotationParameterAssign =>
+        _parentExpression(annotationParameterAssign)
       case _ =>
         None
     }


### PR DESCRIPTION
Fixes crashes in CS passes with jssrc2cpg.
See: https://github.com/ShiftLeftSecurity/codescience/pull/6921