### PR TITLE
pysrc2cpg: Fix RHS of Class Variable becoming Members

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -1834,7 +1834,7 @@ class PythonAstVisitor(
     val memoryOperation = memOpMap.get(name).get
     val identifier      = createIdentifierNode(name.id, memoryOperation, lineAndColOf(name))
     contextStack.astParent match {
-      case method: NewMethod if method.name.endsWith("<body>") =>
+      case method: NewMethod if method.name.endsWith("<body>") && memoryOperation == Store =>
         createAndRegisterMember(identifier.name, lineAndColOf(name))
       case _ =>
     }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/AstNodeToMemoryOperationMap.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/AstNodeToMemoryOperationMap.scala
@@ -18,6 +18,8 @@ class AstNodeToMemoryOperationMap {
     override def hashCode(): Int = {
       System.identityHashCode(astNode)
     }
+
+    override def toString: String = astNode.toString
   }
 
   private val astNodeToMemOp = mutable.HashMap.empty[IdentityHashWrapper, MemoryOperation]

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/MemoryOperation.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/MemoryOperation.scala
@@ -1,6 +1,8 @@
 package io.joern.pysrc2cpg.memop
 
-sealed trait MemoryOperation
+sealed trait MemoryOperation {
+  override def toString: String = getClass.getSimpleName
+}
 object Store extends MemoryOperation
 object Load  extends MemoryOperation
 object Del   extends MemoryOperation

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -2,9 +2,9 @@ package io.joern.pysrc2cpg.cpg
 
 import io.joern.pysrc2cpg.Py2CpgTestContext
 import io.shiftleft.codepropertygraph.generated.nodes.Member
+import io.shiftleft.semanticcpg.language._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import io.shiftleft.semanticcpg.language._
 
 class MemberCpgTests extends AnyFreeSpec with Matchers {
 
@@ -75,6 +75,26 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
       memberFn.columnNumber shouldBe Some(1)
     }
 
+  }
+
+  "A class variable instantiated by some expression" - {
+
+    lazy val cpg = Py2CpgTestContext.buildCpg("""import models
+        |
+        |class SocialApp():
+        |    member1 = "1"
+        |
+        |class SocialAccount():
+        |    member2 = "2"
+        |
+        |class SocialToken(models.Model):
+        |    app = models.ForeignKey(SocialApp, on_delete=models.CASCADE)
+        |    account = models.ForeignKey(SocialAccount, on_delete=models.CASCADE)
+        |""".stripMargin)
+
+    "should only render the LHS of the expression as the member and not the RHS" in {
+      cpg.typeDecl("SocialToken<meta>").member.name.l shouldBe List("app", "account", "<fakeNew>")
+    }
   }
 
 }


### PR DESCRIPTION
* Added `toString` overrides to make memory operations easier to debug
* Added the condition that only identifiers under classes with `STORE` operations become members

Resolves #2498