### PR TITLE
jssrc2cpg: fixed handling of rest parameters

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -27,14 +27,11 @@ trait AstForFunctionsCreator { this: AstCreator =>
     ast.root match {
       case Some(_: NewIdentifier) =>
         val keyNode = createFieldIdentifierNode(restName, elementNodeInfo.lineNumber, elementNodeInfo.columnNumber)
-        val tpe     = typeFor(elementNodeInfo)
-        val localParamNode = createIdentifierNode(restName, elementNodeInfo)
-        localParamNode.typeFullName = tpe
         val paramNode = createIdentifierNode(paramName, elementNodeInfo)
         val accessAst =
           createFieldAccessCallAst(paramNode, keyNode, elementNodeInfo.lineNumber, elementNodeInfo.columnNumber)
         createAssignmentCallAst(
-          Ast(localParamNode),
+          ast,
           accessAst,
           s"$restName = ${codeOf(accessAst.nodes.head)}",
           elementNodeInfo.lineNumber,


### PR DESCRIPTION
The actual AST for the parameter node went missing and was created artificially instead. That's wrong and resulted in dangling identifiers without any incoming edges.