### PR TITLE
c2cpg: fixed handling of relative paths as input CLI argument

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -32,8 +32,11 @@ final case class Config(
     }
   }
 
-  override def withInputPath(inputPath: String): Config = copy(inputPath = inputPath)
-  override def withOutputPath(x: String): Config        = copy(outputPath = x)
+  override def withInputPath(inputPath: String): Config = {
+    val absoluteInputPath = Paths.get(inputPath).toAbsolutePath.normalize().toString
+    copy(inputPath = absoluteInputPath)
+  }
+  override def withOutputPath(x: String): Config = copy(outputPath = x)
 }
 
 private object Frontend {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -88,16 +88,16 @@ class AstCreationPass(cpg: Cpg, forFiles: InputFiles, config: Config, report: Re
       val parseResult = parser.parse(path)
       parseResult match {
         case Some(translationUnit) =>
-          report.addReportInfo(filename, fileLOC, parsed = true)
+          report.addReportInfo(relPath, fileLOC, parsed = true)
           val localDiff = new AstCreator(relPath, config, translationUnit, file2OffsetTable).createAst()
           diffGraph.absorb(localDiff)
           true
         case None =>
-          report.addReportInfo(filename, fileLOC)
+          report.addReportInfo(relPath, fileLOC)
           false
       }
     }
-    report.updateReport(filename, gotCpg, duration)
+    report.updateReport(relPath, gotCpg, duration)
   }
 
 }


### PR DESCRIPTION
If c2cpg was invoked with a relative path to the input folder we kept it that way. That broke absolute to relative (and vice versa) path conversion later on ultimately resulting in absolute paths for CPG filenames.