### PR TITLE
add a PyCpgGenerator that does not run pythonsrc passes

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -51,7 +51,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) extends Rep
   def kotlin: SourceBasedFrontend =
     new SourceBasedFrontend("kotlin", Languages.KOTLIN, "Kotlin Source Frontend", "kotlin")
 
-  def python: SourceBasedFrontend = new SourceBasedFrontend("python", Languages.PYTHON, "Python Source Frontend", "py")
+  def python: SourceBasedFrontend = new SourceBasedFrontend("python", Languages.PYTHONSRC, "Python Source Frontend", "py")
   def golang: SourceBasedFrontend = new SourceBasedFrontend("golang", Languages.GOLANG, "Golang Source Frontend", "go")
   def javascript: SourceBasedFrontend =
     new SourceBasedFrontend("javascript", Languages.JAVASCRIPT, "Javascript Source Frontend", "js")

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -51,7 +51,8 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) extends Rep
   def kotlin: SourceBasedFrontend =
     new SourceBasedFrontend("kotlin", Languages.KOTLIN, "Kotlin Source Frontend", "kotlin")
 
-  def python: SourceBasedFrontend = new SourceBasedFrontend("python", Languages.PYTHONSRC, "Python Source Frontend", "py")
+  def python: SourceBasedFrontend =
+    new SourceBasedFrontend("python", Languages.PYTHONSRC, "Python Source Frontend", "py")
   def golang: SourceBasedFrontend = new SourceBasedFrontend("golang", Languages.GOLANG, "Golang Source Frontend", "go")
   def javascript: SourceBasedFrontend =
     new SourceBasedFrontend("javascript", Languages.JAVASCRIPT, "Javascript Source Frontend", "js")

--- a/console/src/main/scala/io/joern/console/cpgcreation/PyCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PyCpgGenerator.scala
@@ -1,0 +1,25 @@
+package io.joern.console.cpgcreation
+
+import io.joern.console.FrontendConfig
+
+import java.nio.file.Path
+import scala.util.Try
+
+/** Proprietary language frontend for Python code.
+  */
+case class PyCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+
+  lazy val command = rootPath.resolve("py2cpg.sh")
+
+  /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
+    */
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+    val arguments = Seq("i", inputPath, "-o", outputPath) ++ config.cmdLineParams ++ Seq("-i", inputPath)
+
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean = command.toFile.exists()
+
+  override def isJvmBased = false
+}

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -28,12 +28,12 @@ package object cpgcreation {
         val jssrc = JsSrcCpgGenerator(conf, rootPath)
         if (jssrc.isAvailable) Some(jssrc)
         else Some(JsCpgGenerator(conf, rootPath))
-      case Languages.PYTHONSRC          => Some(PythonSrcCpgGenerator(conf, rootPath))
-      case Languages.PYTHON             => Some(PyCpgGenerator(conf, rootPath))
-      case Languages.PHP                => Some(PhpCpgGenerator(conf, rootPath))
-      case Languages.GHIDRA             => Some(GhidraCpgGenerator(conf, rootPath))
-      case Languages.KOTLIN             => Some(KotlinCpgGenerator(conf, rootPath))
-      case _                            => None
+      case Languages.PYTHONSRC => Some(PythonSrcCpgGenerator(conf, rootPath))
+      case Languages.PYTHON    => Some(PyCpgGenerator(conf, rootPath))
+      case Languages.PHP       => Some(PhpCpgGenerator(conf, rootPath))
+      case Languages.GHIDRA    => Some(GhidraCpgGenerator(conf, rootPath))
+      case Languages.KOTLIN    => Some(KotlinCpgGenerator(conf, rootPath))
+      case _                   => None
     }
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -28,11 +28,12 @@ package object cpgcreation {
         val jssrc = JsSrcCpgGenerator(conf, rootPath)
         if (jssrc.isAvailable) Some(jssrc)
         else Some(JsCpgGenerator(conf, rootPath))
-      case Languages.PYTHONSRC | Languages.PYTHON => Some(PythonSrcCpgGenerator(conf, rootPath))
-      case Languages.PHP                          => Some(PhpCpgGenerator(conf, rootPath))
-      case Languages.GHIDRA                       => Some(GhidraCpgGenerator(conf, rootPath))
-      case Languages.KOTLIN                       => Some(KotlinCpgGenerator(conf, rootPath))
-      case _                                      => None
+      case Languages.PYTHONSRC          => Some(PythonSrcCpgGenerator(conf, rootPath))
+      case Languages.PYTHON             => Some(PyCpgGenerator(conf, rootPath))
+      case Languages.PHP                => Some(PhpCpgGenerator(conf, rootPath))
+      case Languages.GHIDRA             => Some(GhidraCpgGenerator(conf, rootPath))
+      case Languages.KOTLIN             => Some(KotlinCpgGenerator(conf, rootPath))
+      case _                            => None
     }
   }
 


### PR DESCRIPTION
CPGs from py2cpg already has types resolved, so we don't want to run any of the type inference stuff meant for pythonsrc when importing it's cpgs in joern (or more likely ocular)