### PR TITLE
javasrc2cpg: Use `ImportNode` to represent imports

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ImportTests.scala
@@ -3,7 +3,7 @@ package io.joern.javasrc2cpg.querying
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
 
-class ImportTests  extends JavaSrcCode2CpgFixture {
+class ImportTests extends JavaSrcCode2CpgFixture {
 
   "fully defined imports" should {
     lazy val cpg = code(

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ImportTests.scala
@@ -1,0 +1,36 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+
+class ImportTests  extends JavaSrcCode2CpgFixture {
+
+  "fully defined imports" should {
+    lazy val cpg = code(
+      """
+        |package org.codeminers.controller;
+        |
+        |import org.codeminers.thirdparty.ThirdParty;
+        |import org.codeminers.thirdparty.util.*;
+        |
+        |public class Controller {
+        |
+        |    public void foo() {
+        |        Request request = new Request();
+        |        ThirdParty.getSgClient().api(request);
+        |    }
+        |}""".stripMargin,
+      fileName = "Controller.java"
+    )
+
+    "have specific namespaces represented correctly via an import node" in {
+      val List(thirdParty, asterix) = cpg.imports.l
+      thirdParty.importedAs shouldBe Some("ThirdParty")
+      thirdParty.importedEntity shouldBe Some("org.codeminers.thirdparty.ThirdParty")
+
+      asterix.importedAs shouldBe Some("*")
+      asterix.importedEntity shouldBe Some("org.codeminers.thirdparty.util")
+    }
+  }
+
+}


### PR DESCRIPTION
To conform to the recent standard of using `Import` nodes, replaced the import identifier with the import node.