### PR TITLE
JavaTypeRecoveryPass: Introducing `XTypeRecoveryPass` for Java

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -60,7 +60,7 @@ object JavaSrc2Cpg {
     }
   }
 
-  def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = {
+  def typeRecoveryPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = {
     List(
       new JavaTypeRecoveryPass(cpg, XTypeRecoveryConfig(enabledDummyTypes = !config.exists(_.disableDummyTypes))),
       new JavaTypeHintCallLinker(cpg)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -2,25 +2,31 @@ package io.joern.javasrc2cpg
 
 import better.files.File
 import com.github.javaparser.ParserConfiguration.LanguageLevel
-import com.github.javaparser.{JavaParser, ParserConfiguration}
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.Node.Parsedness
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver
-import io.joern.javasrc2cpg.passes.{AstCreationPass, ConfigFileCreationPass, TypeInferencePass}
+import com.github.javaparser.{JavaParser, ParserConfiguration}
+import io.joern.javasrc2cpg.passes.{
+  AstCreationPass,
+  ConfigFileCreationPass,
+  JavaTypeHintCallLinker,
+  JavaTypeRecoveryPass,
+  TypeInferencePass
+}
 import io.joern.javasrc2cpg.typesolvers.{CachingReflectionTypeSolver, EagerSourceTypeSolver, SimpleCombinedTypeSolver}
-import io.joern.javasrc2cpg.util.{Delombok, SourceRootFinder}
 import io.joern.javasrc2cpg.util.Delombok.DelombokMode
+import io.joern.javasrc2cpg.util.{Delombok, SourceRootFinder}
+import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
+import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass, XTypeRecoveryConfig}
+import io.joern.x2cpg.utils.dependency.DependencyResolver
+import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
-import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
-import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
-import io.joern.x2cpg.utils.dependency.DependencyResolver
+import io.shiftleft.passes.CpgPassBase
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths
-import java.util.regex.Pattern
 import scala.collection.parallel.CollectionConverters._
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
@@ -52,6 +58,13 @@ object JavaSrc2Cpg {
       logger.info("dependency resolving disabled")
       Seq()
     }
+  }
+
+  def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = {
+    List(
+      new JavaTypeRecoveryPass(cpg, XTypeRecoveryConfig(enabledDummyTypes = !config.exists(_.disableDummyTypes))),
+      new JavaTypeHintCallLinker(cpg)
+    )
   }
 }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -13,7 +13,8 @@ final case class Config(
   fetchDependencies: Boolean = false,
   javaFeatureSetVersion: Option[String] = None,
   delombokJavaHome: Option[String] = None,
-  delombokMode: Option[String] = None
+  delombokMode: Option[String] = None,
+  disableDummyTypes: Boolean = false
 ) extends X2CpgConfig[Config] {
 
   override def withInputPath(inputPath: String): Config =
@@ -45,7 +46,11 @@ private object Frontend {
                  | default => run delombok if a lombok dependency is found and analyse delomboked code.
                  | types-only => to run delombok, but use it for type information only
                  | run-delombok => to force run delombok and analyse delomboked code.""".stripMargin)
-        .action((mode, c) => c.copy(delombokMode = Some(mode)))
+        .action((mode, c) => c.copy(delombokMode = Some(mode))),
+      opt[Unit]("no-dummyTypes")
+        .hidden()
+        .action((_, c) => c.copy(disableDummyTypes = true))
+        .text("disable generation of dummy types during type recovery")
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeHintCallLinker.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeHintCallLinker.scala
@@ -1,0 +1,22 @@
+package io.joern.javasrc2cpg.passes
+
+import io.joern.x2cpg.Defines
+import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.Traversal
+
+import java.util.regex.Pattern
+
+class JavaTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
+
+  override protected def calls: Traversal[Call] = {
+    cpg.call
+      .nameNot("<operator>.*", "<operators>.*")
+      .filter(c =>
+        calleeNames(c).nonEmpty && c.callee.fullNameNot(Pattern.quote(Defines.UnresolvedNamespace) + ".*").isEmpty
+      )
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeRecoveryPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeRecoveryPass.scala
@@ -1,0 +1,62 @@
+package io.joern.javasrc2cpg.passes
+
+import io.joern.x2cpg.Defines
+import io.joern.x2cpg.passes.frontend._
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.semanticcpg.language._
+import overflowdb.BatchedUpdate.DiffGraphBuilder
+import overflowdb.traversal.Traversal
+
+class JavaTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())
+    extends XTypeRecoveryPass[Method](cpg, config) {
+  override protected def generateRecoveryPass(state: XTypeRecoveryState): XTypeRecovery[Method] =
+    new JavaTypeRecovery(cpg, state)
+}
+
+private class JavaTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[Method](cpg, state) {
+
+  override def compilationUnit: Traversal[Method] = cpg.method.whereNot(_.nameExact("ANY"))
+
+  override def generateRecoveryForCompilationUnitTask(
+    unit: Method,
+    builder: DiffGraphBuilder
+  ): RecoverForXCompilationUnit[Method] = new RecoverForJavaFile(
+    cpg,
+    unit,
+    builder,
+    state.copy(config = state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes))
+  )
+}
+
+private class RecoverForJavaFile(cpg: Cpg, cu: Method, builder: DiffGraphBuilder, state: XTypeRecoveryState)
+    extends RecoverForXCompilationUnit[Method](cpg, cu, builder, state) {
+
+  private def javaNodeToLocalKey(n: AstNode): Option[LocalKey] = n match {
+    case i: Identifier if i.name == "this" && i.code == "super" => Option(LocalVar("super"))
+    case _                                                      => SBKey.fromNodeToLocalKey(n)
+  }
+
+  override protected val symbolTable                     = new SymbolTable[LocalKey](javaNodeToLocalKey)
+  override protected def isConstructor(c: Call): Boolean = !c.name.isBlank && c.name.charAt(0).isUpper
+
+  override protected def postVisitImports(): Unit = {
+    symbolTable.view.foreach { case (k, ts) =>
+      val tss = ts.filterNot(_.startsWith(Defines.UnresolvedNamespace))
+      if (tss.isEmpty)
+        symbolTable.remove(k)
+      else
+        symbolTable.put(k, tss)
+    }
+  }
+
+  override protected def nodeExistingTypes(storedNode: StoredNode): Seq[String] =
+    super.nodeExistingTypes(storedNode).filterNot(_.startsWith(Defines.UnresolvedNamespace))
+
+  // There seems to be issues with inferring these, often due to situations where super and this are confused on name
+  // and code properties.
+  override protected def storeIdentifierTypeInfo(i: Identifier, types: Seq[String]): Unit = if (i.name != "this") {
+    super.storeIdentifierTypeInfo(i, types)
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
@@ -200,6 +200,10 @@ class NewTypeInferenceTests extends JavaSrcCode2CpgFixture {
     }
   }
 
+}
+
+class JavaTypeRecoveryPassTests extends JavaSrcCode2CpgFixture(enableTypeRecovery = true) {
+
   "chained calls from external dependencies" should {
     lazy val cpg = code(
       """
@@ -241,7 +245,7 @@ class NewTypeInferenceTests extends JavaSrcCode2CpgFixture {
     "should be resolved using dummy return values" in {
       val Some(getResultList) = cpg.call("getResultList").headOption
       // Changes the below from <unresolvedNamespace>.getResultList:<unresolvedSignature>(0) to:
-      getResultList.methodFullName shouldBe "org.hibernate.Session.createNamedQuery:<unresolvedSignature>(2).<returnValue>.getResultList"
+      getResultList.methodFullName shouldBe "org.hibernate.Session.createNamedQuery:<unresolvedSignature>(2).<returnValue>.getResultList:<unresolvedSignature>(0)"
       getResultList.dynamicTypeHintFullName shouldBe Seq()
     }
 
@@ -251,6 +255,7 @@ class NewTypeInferenceTests extends JavaSrcCode2CpgFixture {
       transaction.dynamicTypeHintFullName.contains("null")
     }
   }
+
 }
 
 class TypeInferenceTests extends JavaSrcCode2CpgFixture {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
@@ -270,7 +270,7 @@ class TypeTests extends JavaSrcCode2CpgFixture {
     }
   }
 
-  "should use correct type for super calls" in {
+  "should use correct type for super calls in the constructor of foo.Foo" in {
     val List(call) = cpg.call.name(io.joern.x2cpg.Defines.ConstructorMethodName).l
     call.methodFullName shouldBe s"java.lang.Object.${io.joern.x2cpg.Defines.ConstructorMethodName}:void()"
     call.typeFullName shouldBe "void"

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -25,7 +25,9 @@ trait JavaSrcFrontend extends LanguageFrontend {
   }
 }
 
-class JavaSrcTestCpg(override protected val delombokMode: String) extends TestCpg with JavaSrcFrontend {
+class JavaSrcTestCpg(override protected val delombokMode: String, enableTypeRecovery: Boolean = false)
+    extends TestCpg
+    with JavaSrcFrontend {
   private var _withOssDataflow = false
 
   def withOssDataflow(value: Boolean = true): this.type = {
@@ -35,7 +37,7 @@ class JavaSrcTestCpg(override protected val delombokMode: String) extends TestCp
 
   override def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
-    JavaSrc2Cpg.postProcessingPasses(this).foreach(_.createAndApply())
+    if (enableTypeRecovery) JavaSrc2Cpg.typeRecoveryPasses(this).foreach(_.createAndApply())
     if (_withOssDataflow) {
       val context = new LayerCreatorContext(this)
       val options = new OssDataFlowOptions()
@@ -45,8 +47,11 @@ class JavaSrcTestCpg(override protected val delombokMode: String) extends TestCp
 
 }
 
-class JavaSrcCode2CpgFixture(withOssDataflow: Boolean = false, delombokMode: String = "default")
-    extends Code2CpgFixture(() => new JavaSrcTestCpg(delombokMode).withOssDataflow(withOssDataflow)) {
+class JavaSrcCode2CpgFixture(
+  withOssDataflow: Boolean = false,
+  delombokMode: String = "default",
+  enableTypeRecovery: Boolean = false
+) extends Code2CpgFixture(() => new JavaSrcTestCpg(delombokMode, enableTypeRecovery).withOssDataflow(withOssDataflow)) {
 
   implicit val resolver: ICallResolver           = NoResolve
   implicit lazy val engineContext: EngineContext = EngineContext()

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -35,7 +35,7 @@ class JavaSrcTestCpg(override protected val delombokMode: String) extends TestCp
 
   override def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
-
+    JavaSrc2Cpg.postProcessingPasses(this).foreach(_.createAndApply())
     if (_withOssDataflow) {
       val context = new LayerCreatorContext(this)
       val options = new OssDataFlowOptions()

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -4,8 +4,8 @@ import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecovery.isDummyType
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodBase}
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
 
@@ -30,13 +30,12 @@ class PythonTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
       methodNames
         .flatMap(methodMap.get)
         .foreach { m => builder.addEdge(call, m, EdgeTypes.CALL) }
-      if (methodNames.size == 1) {
-        builder.setNodeProperty(call, PropertyNames.METHOD_FULL_NAME, methodNames.head)
-      } else if (methodNames.size > 1) {
-        val nonDummyMethodNames = methodNames.filterNot(isDummyType)
-        if (nonDummyMethodNames.nonEmpty) {
-          builder.setNodeProperty(call, PropertyNames.METHOD_FULL_NAME, nonDummyMethodNames.minBy(_.length))
-        }
+      if (methodNames.sizeIs == 1) {
+        setCallees(call, methodNames, builder)
+      } else if (methodNames.sizeIs > 1) {
+        val nonDummyMethodNames =
+          methodNames.filterNot(x => isDummyType(x) || x.startsWith(PythonAstVisitor.builtinPrefix + "None"))
+        setCallees(call, nonDummyMethodNames, builder)
       }
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -37,7 +37,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     "resolve 'z' identifier calls conservatively" in {
       // TODO: These should have callee entries but the method stubs are not present here
       val List(zAppend) = cpg.call("append").l
-      zAppend.methodFullName shouldBe "__builtin.dict.append"
+      zAppend.methodFullName shouldBe "<unknownFullName>"
       zAppend.dynamicTypeHintFullName shouldBe Seq(
         "__builtin.dict.append",
         "__builtin.list.append",
@@ -299,7 +299,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       val Some(addCall) = cpg
         .call("add")
         .headOption
-      addCall.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
+      addCall.typeFullName shouldBe "ANY"
       addCall.methodFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.<member>(session).add"
       addCall.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -127,6 +127,13 @@ class SymbolTable[K <: SBKey](val keyFromNode: AstNode => Option[K]) {
     case None      => Set.empty
   }
 
+  def remove(sbKey: K): Set[String] = table.remove(sbKey).getOrElse(Set.empty)
+
+  def remove(node: AstNode): Set[String] = keyFromNode(node) match {
+    case Some(key) => remove(key)
+    case None      => Set.empty
+  }
+
   def view: MapView[K, Set[String]] = table.view
 
   def clear(): Unit = table.clear()

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -15,7 +15,6 @@ import overflowdb.traversal.Traversal
 
 import java.util.concurrent.RecursiveTask
 import java.util.concurrent.atomic.AtomicBoolean
-import scala.annotation.nowarn
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
@@ -116,7 +115,8 @@ abstract class XTypeRecovery[CompilationUnitType <: AstNode](cpg: Cpg, state: XT
     val changesWereMade = compilationUnit
       .map(unit => generateRecoveryForCompilationUnitTask(unit, builder).fork())
       .map(_.get())
-      .reduce((a, b) => a || b)
+      .reduceOption((a, b) => a || b)
+      .getOrElse(false)
     if (!changesWereMade) state.stopEarly.set(true)
   }
 
@@ -201,22 +201,24 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
 
   /** Provides an entrypoint to add known symbols and their possible types.
     */
-  protected def prepopulateSymbolTable(): Unit = {
-    def getTypes(node: AstNode): Set[String] =
-      (node.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq.empty) :+ node.property(
-        PropertyNames.TYPE_FULL_NAME,
-        "ANY"
-      )).filterNot(_.toUpperCase.matches("(UNKNOWN|ANY)")).toSet
-
+  private def prepopulateSymbolTable(): Unit = {
     (cu.ast.isIdentifier ++ cu.ast.isCall ++ cu.ast.isLocal ++ cu.ast.isParameter)
       .filter(hasTypes)
-      .foreach {
-        case x: Identifier        => symbolTable.put(x, getTypes(x))
-        case x: Call              => symbolTable.put(x, Set(x.methodFullName))
-        case x: Local             => symbolTable.put(x, getTypes(x))
-        case x: MethodParameterIn => symbolTable.put(x, getTypes(x))
-        case _                    =>
-      }
+      .foreach(prepopulateSymbolTableEntry)
+  }
+
+  protected def getTypes(node: AstNode): Set[String] =
+    (node.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq.empty) :+ node.property(
+      PropertyNames.TYPE_FULL_NAME,
+      "ANY"
+    )).filterNot(_.toUpperCase.matches("(UNKNOWN|ANY)")).toSet
+
+  protected def prepopulateSymbolTableEntry(x: AstNode): Unit = x match {
+    case x: Identifier        => symbolTable.put(x, getTypes(x))
+    case x: Call              => symbolTable.put(x, Set(x.methodFullName))
+    case x: Local             => symbolTable.put(x, getTypes(x))
+    case x: MethodParameterIn => symbolTable.put(x, getTypes(x))
+    case _                    =>
   }
 
   private def hasTypes(node: AstNode): Boolean = node match {
@@ -360,7 +362,17 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   /** Will build a call full path using the call base node. This method assumes the base node is in the symbol table.
     */
   protected def setCallMethodFullNameFromBase(c: Call): Set[String] = {
-    val recTypes  = c.argument.headOption.map(symbolTable.get).getOrElse(Set.empty[String])
+    val recTypes = c.argument.headOption
+      .map {
+        case x: Call if x.typeFullName != "ANY" => Set(x.typeFullName)
+        case x: Call =>
+          cpg.method.fullNameExact(c.methodFullName).methodReturn.typeFullNameNot("ANY").typeFullName.toSet match {
+            case xs if xs.nonEmpty => xs
+            case _ => symbolTable.get(x).map(t => Seq(t, XTypeRecovery.DummyReturnType).mkString(pathSep.toString))
+          }
+        case x => symbolTable.get(x)
+      }
+      .getOrElse(Set.empty[String])
     val callTypes = recTypes.map(_.concat(s"$pathSep${c.name}"))
     symbolTable.append(c, callTypes)
   }
@@ -746,6 +758,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     cu.ast
       .collect {
         case n: Local                                       => n
+        case n: Call                                        => n
         case n: Expression                                  => n
         case n: MethodParameterIn if state.isFinalIteration => n
         case n: MethodReturn if state.isFinalIteration      => n
@@ -810,10 +823,10 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
         val idHints   = symbolTable.get(i)
         val callTypes = symbolTable.get(call)
         persistType(i, idHints)
-        if (callTypes.isEmpty) {
+        if (callTypes.isEmpty && !call.name.startsWith("<operator>"))
           // For now, calls are treated as function pointers and thus the type should point to the method
           persistType(call, idHints.map(t => createCallFromIdentifierTypeFullName(t, call.name)))
-        } else {
+        else {
           persistType(call, callTypes)
         }
       // Case 3: 'i' is the receiver for a field access on member 'f'
@@ -955,8 +968,10 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
             case Some(ts) => Some(ts ++ types)
             case None     => Some(types.toSet)
           }
-        case i: Identifier => storeIdentifierTypeInfo(i, types)
-        case l: Local      => storeLocalTypeInfo(l, types)
+        case i: Identifier                               => storeIdentifierTypeInfo(i, types)
+        case l: Local                                    => storeLocalTypeInfo(l, types)
+        case c: Call if !c.name.startsWith("<operator>") => storeCallTypeInfo(c, types)
+        case _: Call                                     =>
         case n =>
           state.changesWereMade.compareAndSet(false, true)
           setTypes(n, types)
@@ -964,20 +979,17 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     }
   }
 
-  private def nodeExistingTypes(storedNode: StoredNode): Seq[String] = (storedNode.property(
+  protected def storeCallTypeInfo(c: Call, types: Seq[String]) = {
+    if (types.nonEmpty) {
+      state.changesWereMade.compareAndSet(false, true)
+      builder.setNodeProperty(c, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, types)
+    }
+  }
+
+  protected def nodeExistingTypes(storedNode: StoredNode): Seq[String] = (storedNode.property(
     PropertyNames.TYPE_FULL_NAME,
     "ANY"
   ) +: storedNode.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq.empty)).filterNot(_ == "ANY")
-
-  /** Allows one to modify the types assigned to fields.
-    */
-  protected def storeMemberTypeInfo(m: Member, types: Seq[String]): Unit = {
-    // To avoid overwriting member updates, we store them elsewhere until the end
-    newTypesForMembers.updateWith(m) {
-      case Some(ts) => Some(ts ++ types)
-      case None     => Some(types.toSet)
-    }
-  }
 
   /** Allows one to modify the types assigned to identifiers.
     */
@@ -996,11 +1008,8 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     * cleared. If not then `dynamicTypeHintFullName` is set to the types.
     */
   protected def setTypes(n: StoredNode, types: Seq[String]): Unit =
-    if (types.size == 1) {
-      builder.setNodeProperty(n, PropertyNames.TYPE_FULL_NAME, types.head)
-      if (n.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq.empty).nonEmpty)
-        builder.setNodeProperty(n, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq.empty)
-    } else builder.setNodeProperty(n, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, types)
+    if (types.size == 1) builder.setNodeProperty(n, PropertyNames.TYPE_FULL_NAME, types.head)
+    else builder.setNodeProperty(n, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, types.distinct)
 
   /** Allows one to modify the types assigned to locals.
     */


### PR DESCRIPTION
* This aids the current type recovery by helping propagate types across boundaries and having optional dummy types
* Fixed issue where `Call(typeFullName)` was being used to hold the type of the call base/receiver instead of return value.
* Fixed assumption on `PythonTypeHintCallLinker` where if there were non-dummy types it would pick the first one instead of checking if there is exactly one before setting it to `methodFullName`