### PR TITLE
Add php.ini file to avoid unexpected system-dependent behaviour when running php-parser

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/resources/php.ini
+++ b/joern-cli/frontends/php2cpg/src/main/resources/php.ini
@@ -1,0 +1,2 @@
+; Uncap memory to avoid OOM errors when parsing large files
+memory_limit = -1

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
@@ -6,8 +6,11 @@ import scopt.OParser
 
 /** Command line configuration parameters
   */
-final case class Config(inputPath: String = "", outputPath: String = X2CpgConfig.defaultOutputPath)
-    extends X2CpgConfig[Config] {
+final case class Config(
+  inputPath: String = "",
+  outputPath: String = X2CpgConfig.defaultOutputPath,
+  phpIni: Option[String] = None
+) extends X2CpgConfig[Config] {
 
   override def withInputPath(inputPath: String): Config =
     copy(inputPath = inputPath)
@@ -20,8 +23,13 @@ private object Frontend {
 
   val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
-    import builder.programName
-    OParser.sequence(programName("php2cpg"))
+    import builder._
+    OParser.sequence(
+      programName("php2cpg"),
+      opt[String]("php-ini")
+        .action((x, c) => c.copy(phpIni = Some(x)))
+        .text("php.ini path used by php-parser. Defaults to php.ini shipped with Joern.")
+    )
   }
 }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -22,7 +22,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
     if (isPhpInstalled) {
       withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
         new MetaDataPass(cpg, Languages.PHP, config.inputPath).createAndApply()
-        val astCreationPass = new AstCreationPass(config.inputPath, cpg)
+        val astCreationPass = new AstCreationPass(config, cpg)
         astCreationPass.createAndApply()
         new TypeNodePass(astCreationPass.allUsedTypes, cpg).createAndApply()
       }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -1,6 +1,7 @@
 package io.joern.php2cpg.passes
 
 import better.files.File
+import io.joern.php2cpg.Config
 import io.joern.php2cpg.astcreation.AstCreator
 import io.joern.php2cpg.parser.PhpParser
 import io.joern.x2cpg.SourceFiles
@@ -11,18 +12,18 @@ import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._
 
-class AstCreationPass(inputPath: String, cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg) {
+class AstCreationPass(config: Config, cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
   val global         = new Global()
 
   val PhpSourceFileExtensions: Set[String] = Set(".php")
 
-  override def generateParts(): Array[String] = SourceFiles.determine(inputPath, PhpSourceFileExtensions).toArray
+  override def generateParts(): Array[String] = SourceFiles.determine(config.inputPath, PhpSourceFileExtensions).toArray
 
   override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
-    val relativeFilename = File(inputPath).relativize(File(filename)).toString
-    PhpParser.parseFile(filename) match {
+    val relativeFilename = File(config.inputPath).relativize(File(filename)).toString
+    PhpParser.parseFile(filename, config.phpIni) match {
       case Some(parseResult) =>
         diffGraph.absorb(new AstCreator(relativeFilename, parseResult, global).createAst())
 


### PR DESCRIPTION
This PR adds a custom `php.ini` file to use when running php-parser. This is to avoid potentially difficult-to-debug errors due to system default or configuration differences, but can be overridden if necessary.

The approach of including it as a resource and then creating a temp php.ini file isn't elegant, but it seems to be a decent approach for ease of distribution.