### PR TITLE
kotlin2cpg: use StringOps in single spot

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
@@ -588,7 +588,7 @@ class DefaultTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeIn
     val paramsString =
       if (expr.getValueParameters.isEmpty) TypeConstants.javaLangObject
       else
-        s"${TypeConstants.javaLangObject}${("," + TypeConstants.javaLangObject).repeat(expr.getValueParameters.size())}"
+        s"${TypeConstants.javaLangObject}${("," + TypeConstants.javaLangObject) * expr.getValueParameters.size()}"
     s"${TypeConstants.javaLangObject}($paramsString)"
   }
 


### PR DESCRIPTION
instead of _repeat_ which might cause issues on older JDKs