### PR TITLE
dataflowengineoss: Regex Method Semantics

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -2,7 +2,7 @@ package io.joern.dataflowengineoss.layers.dataflows
 
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.passes.reachingdef.ReachingDefPass
-import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
 object OssDataFlow {
@@ -12,9 +12,14 @@ object OssDataFlow {
   def defaultOpts = new OssDataFlowOptions()
 }
 
-class OssDataFlowOptions(var maxNumberOfDefinitions: Int = 4000) extends LayerCreatorOptions {}
+class OssDataFlowOptions(
+  var maxNumberOfDefinitions: Int = 4000,
+  var extraFlows: List[FlowSemantic] = List.empty[FlowSemantic]
+) extends LayerCreatorOptions {}
 
-class OssDataFlow(opts: OssDataFlowOptions)(implicit s: Semantics = DefaultSemantics()) extends LayerCreator {
+class OssDataFlow(opts: OssDataFlowOptions)(implicit
+  s: Semantics = Semantics.fromList(DefaultSemantics().elements ++ opts.extraFlows)
+) extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -15,6 +15,8 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000)(implicit s: 
     extends ForkJoinParallelCpgPass[Method](cpg) {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  // If there are any regex method full names, load them early
+  s.loadRegexSemantics(cpg)
 
   override def generateParts(): Array[Method] = cpg.method.toArray
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -196,7 +196,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
         symbolTable.put(k, ts.fullName.toSet)
       else if (ms.nonEmpty)
         symbolTable.put(k, ms.fullName.toSet)
-      else if (tsNonConstructor.nonEmpty)
+      else if (!tsNonConstructor.forall(_.name == "<module>"))
         symbolTable.put(k, tsNonConstructor.fullName.toSet)
       else {
         // This is likely external and we will ignore the init variant to be consistent

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -2,6 +2,7 @@ package io.joern.pysrc2cpg
 
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
+import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
@@ -19,9 +20,15 @@ trait PythonFrontend extends LanguageFrontend {
 
 class PySrcTestCpg extends TestCpg with PythonFrontend {
   private var _withOssDataflow = false
+  private var _extraFlows      = List.empty[FlowSemantic]
 
   def withOssDataflow(value: Boolean = true): this.type = {
     _withOssDataflow = value
+    this
+  }
+
+  def withExtraFlows(value: List[FlowSemantic] = List.empty): this.type = {
+    _extraFlows = value
     this
   }
 
@@ -40,14 +47,14 @@ class PySrcTestCpg extends TestCpg with PythonFrontend {
 
     if (_withOssDataflow) {
       val context = new LayerCreatorContext(this)
-      val options = new OssDataFlowOptions()
+      val options = new OssDataFlowOptions(extraFlows = _extraFlows)
       new OssDataFlow(options).run(context)
     }
   }
 }
 
-class PySrc2CpgFixture(withOssDataflow: Boolean = false)
-    extends Code2CpgFixture(() => new PySrcTestCpg().withOssDataflow(withOssDataflow)) {
+class PySrc2CpgFixture(withOssDataflow: Boolean = false, extraFlows: List[FlowSemantic] = List.empty)
+    extends Code2CpgFixture(() => new PySrcTestCpg().withOssDataflow(withOssDataflow).withExtraFlows(extraFlows)) {
 
   implicit val resolver: ICallResolver = NoResolve
   implicit val context: EngineContext  = EngineContext()


### PR DESCRIPTION
* Added an API to enable regex defined semantic full names
* Involves preloading all method full names that match these into a matching map to avoid expensive regex calls during query time
* Added Python tests to illustrate the usefulness during type recovery
* Added API to add extra flows to `OssDataFlow`