### PR TITLE
php2cpg/bin/installdeps.sh doesn't exist any longer - don't call it

### DIFF
--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Install php deps for php2cpg
-        run: joern-cli/frontends/php2cpg/bin/installdeps.sh
       - name: Upgrade all (internal) dependencies
         run: ./updateDependencies.sh --non-interactive
       - run: sbt clean +test

--- a/joern-cli/frontends/php2cpg/README.md
+++ b/joern-cli/frontends/php2cpg/README.md
@@ -10,7 +10,6 @@ A PHP to CPG converter based on `php-parse`.
 
 ```
 sudo apt install php
-sh ./installdeps.sh
 ```
 
 # How it works


### PR DESCRIPTION
cleanup after https://github.com/joernio/joern/pull/2506 as explained in https://github.com/joernio/joern/pull/2506#issuecomment-1517319585