### PR TITLE
pysrc2cpg: Handle Classes Extending Call Return

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -2,7 +2,7 @@ package io.joern.pysrc2cpg
 
 import io.joern.x2cpg.passes.frontend._
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
@@ -340,5 +340,21 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
          typeFullName.substring(0, typeFullName.lastIndexOf(pathSep))
        else typeFullName).concat("<meta>")
   }
+
+  override protected def postSetTypeInformation(): Unit =
+    cu.typeDecl.map(t => t -> t.inheritsFromTypeFullName.partition(_.startsWith("tmp"))).foreach {
+      case (t, (tmpTypes, nonTmpTypes)) =>
+        val existingTypes = (tmpTypes ++ nonTmpTypes).distinct
+        val resolvedTypes = tmpTypes.flatMap { tmpT =>
+          val tmpKey = LocalVar(tmpT)
+          if (symbolTable.contains(tmpKey))
+            symbolTable.get(tmpKey)
+          else Set(tmpT)
+        }
+        if (existingTypes != resolvedTypes && resolvedTypes.nonEmpty) {
+          state.changesWereMade.compareAndExchange(false, true)
+          builder.setNodeProperty(t, PropertyNames.INHERITS_FROM_TYPE_FULL_NAME, resolvedTypes)
+        }
+    }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -800,8 +800,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
   }
 
   "Class methods with the `@classmethod` decorator" should {
-    lazy val cpg = code(
-      """
+    lazy val cpg = code("""
         |class MyClass:
         |
         |    @classmethod

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -785,4 +785,19 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     allPageRef.code shouldBe "PasswordChange"
   }
 
+  "Classes extended by function calls" should {
+    lazy val cpg = code("""
+        |from sqlalchemy.ext.declarative import declarative_base
+        |
+        |class Foo(declarative_base(metadata=metadata)):
+        |    pass
+        |""".stripMargin)
+
+    "should present an appropriate dummy type" in {
+      cpg.typeDecl("Foo").inheritsFromTypeFullName.l shouldBe List(
+        "sqlalchemy/ext/declarative.py:<module>.declarative_base.<returnValue>"
+      )
+    }
+  }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -794,7 +794,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "should present an appropriate dummy type" in {
       cpg.typeDecl("Foo").inheritsFromTypeFullName.l shouldBe List(
-        "sqlalchemy/ext/declarative.py:<module>.declarative_base.<returnValue>"
+        Seq("sqlalchemy", "ext", "declarative.py:<module>.declarative_base.<returnValue>").mkString(File.separator)
       )
     }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -249,6 +249,8 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     assignments.foreach(visitAssignments)
     // Persist findings
     setTypeInformation()
+    // Entrypoint for any final changes
+    postSetTypeInformation()
     // Return number of changes
     state.changesWereMade.get()
   } finally {
@@ -1006,5 +1008,9 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   protected def storeLocalTypeInfo(l: Local, types: Seq[String]): Unit = {
     storeDefaultTypeInfo(l, if (state.config.enabledDummyTypes) types else types.filterNot(XTypeRecovery.isDummyType))
   }
+
+  /** Allows an implementation to perform an operation once type persistence is complete.
+    */
+  protected def postSetTypeInformation(): Unit = {}
 
 }


### PR DESCRIPTION
* Iterate through class inheritance and convert calls
* Assign calls to temp variable and set inheritance string seq to the name of the temp variable
* Type recovery resolves temp variable if found in symbol table