### PR TITLE
PythonTypeRecovery: Populate Class Method `cls` Types

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -450,6 +450,7 @@ class PythonAstVisitor(
     edgeBuilder.astEdge(instanceTypeDecl, contextStack.astParent, contextStack.order.getAndInc)
 
     // Create <body> function which contains the code defining the class
+    // TODO: The below should not be metaTypeDeclNode but rather instanceTypeDecl
     contextStack.pushClass(classDef.name, metaTypeDeclNode)
     val (_, methodRefNode) = createMethodAndMethodRef(
       instanceTypeDeclName,

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -784,4 +784,21 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     allPageRef.code shouldBe "PasswordChange"
   }
 
+  "Class methods with the `@classmethod` decorator" should {
+    lazy val cpg = code("""
+        |class MyClass:
+        |
+        |    @classmethod
+        |    def class_method(cls):
+        |        print("Class Method ", cls)
+        |
+        |""".stripMargin)
+
+    "resolve the cls variable" in {
+      cpg.method("class_method").parameter.name("cls").typeFullName.headOption shouldBe Some(
+        "Test0.py:<module>.MyClass"
+      )
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -201,7 +201,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
 
   /** Provides an entrypoint to add known symbols and their possible types.
     */
-  private def prepopulateSymbolTable(): Unit = {
+  protected def prepopulateSymbolTable(): Unit = {
     (cu.ast.isIdentifier ++ cu.ast.isCall ++ cu.ast.isLocal ++ cu.ast.isParameter)
       .filter(hasTypes)
       .foreach(prepopulateSymbolTableEntry)


### PR DESCRIPTION
* During symbol table prepopulation, search for `classmethod` decorated methods and set their `cls` parameter to the parent type declaration name