### PR TITLE
rubysrc2cpg: fixes missing WS the rule for arguments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val jssrc2cpg         = Projects.jssrc2cpg
 lazy val javasrc2cpg       = Projects.javasrc2cpg
 lazy val jimple2cpg        = Projects.jimple2cpg
 lazy val kotlin2cpg        = Projects.kotlin2cpg
+lazy val rubysrc2cpg       = Projects.rubysrc2cpg
 
 lazy val aggregatedProjects: Seq[ProjectReference] = Seq(
   joerncli,
@@ -36,7 +37,8 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq(
   jssrc2cpg,
   javasrc2cpg,
   jimple2cpg,
-  kotlin2cpg
+  kotlin2cpg,
+  rubysrc2cpg
 )
 
 ThisBuild / libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ lazy val jssrc2cpg         = Projects.jssrc2cpg
 lazy val javasrc2cpg       = Projects.javasrc2cpg
 lazy val jimple2cpg        = Projects.jimple2cpg
 lazy val kotlin2cpg        = Projects.kotlin2cpg
-lazy val rubysrc2cpg       = Projects.rubysrc2cpg
 
 lazy val aggregatedProjects: Seq[ProjectReference] = Seq(
   joerncli,
@@ -37,8 +36,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq(
   jssrc2cpg,
   javasrc2cpg,
   jimple2cpg,
-  kotlin2cpg,
-  rubysrc2cpg
+  kotlin2cpg
 )
 
 ThisBuild / libraryDependencies ++= Seq(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -208,9 +208,9 @@ indexingArguments
 
 argumentsWithParentheses
     :   LPAREN wsOrNl* RPAREN
-    |   LPAREN arguments RPAREN
-    |   LPAREN expressions WS* COMMA wsOrNl* chainedCommandWithDoBlock wsOrNl* RPAREN
-    |   LPAREN chainedCommandWithDoBlock RPAREN
+    |   LPAREN wsOrNl* arguments wsOrNl* RPAREN
+    |   LPAREN wsOrNl* expressions WS* COMMA wsOrNl* chainedCommandWithDoBlock wsOrNl* RPAREN
+    |   LPAREN wsOrNl* chainedCommandWithDoBlock wsOrNl* RPAREN
     ;
 
 expressions

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -1,0 +1,98 @@
+package io.joern.rubysrc2cpg.parser
+
+class InvocationWithParenthesesTests extends RubyParserAbstractTest {
+
+  "A method invocation with parentheses" should {
+
+    "be parsed as a primary expression" when {
+
+      "it contains no arguments" in {
+        val code = "foo()"
+
+        printAst(_.primary(), code) shouldEqual
+          """InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgumentsWithParentheses
+            |  (
+            |  )
+            |""".stripMargin
+      }
+
+      "it contains no arguments but has newline in between" in {
+        val code =
+          """foo(
+            |)
+            |""".stripMargin
+
+        printAst(_.primary(), code) shouldEqual
+          s"""InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgumentsWithParentheses
+            |  (
+            |  WsOrNl
+${"   " /* accounting for the Nl */}
+${""    /* accounting for the Ws, which is none */}
+            |  )
+            |""".stripMargin
+      }
+
+      "it contains a single numeric literal positional argument" in {
+        val code = "foo(1)"
+
+        printAst(_.primary(), code) shouldEqual
+          """InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgumentsWithParentheses
+            |  (
+            |  Arguments
+            |   Expressions
+            |    PrimaryExpression
+            |     LiteralPrimary
+            |      Literal
+            |       NumericLiteral
+            |        UnsignedNumericLiteral
+            |         1
+            |  )
+            |""".stripMargin
+      }
+
+      "it contains a single numeric literal keyword argument" in {
+        val code = "foo(region: 1)"
+
+        printAst(_.primary(), code) shouldEqual
+          s"""InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgumentsWithParentheses
+            |  (
+            |  Arguments
+            |   Associations
+            |    Association
+            |     PrimaryExpression
+            |      VariableReferencePrimary
+            |       VariableReference
+            |        VariableIdentifier
+            |         region
+            |     :
+            |     WsOrNl
+${"       "}
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       Literal
+            |        NumericLiteral
+            |         UnsignedNumericLiteral
+            |          1
+            |  )
+            |""".stripMargin
+      }
+    }
+
+  }
+
+
+
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -33,7 +33,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  (
             |  WsOrNl
 ${"   " /* accounting for the Nl */}
-${""    /* accounting for the Ws, which is none */}
+${"" /* accounting for the Ws, which is none */}
             |  )
             |""".stripMargin
       }
@@ -91,8 +91,5 @@ ${"       "}
     }
 
   }
-
-
-
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -8,20 +8,22 @@ import org.scalatest.matchers.should.Matchers
 
 class RubyLexerTests extends AnyFlatSpec with Matchers {
 
+  class RubySyntaxErrorListener extends BaseErrorListener {
+    var errors = 0
+    override def syntaxError(
+      recognizer: Recognizer[_, _],
+      offendingSymbol: Any,
+      line: Int,
+      charPositionInLine: Int,
+      msg: String,
+      e: RecognitionException
+    ): Unit =
+      errors += 1
+  }
+
   def tokenize(code: String): Iterable[Int] = {
-    val lexer = new RubyLexer(CharStreams.fromString(code))
-    val syntaxErrorListener = new BaseErrorListener {
-      var errors = 0
-      override def syntaxError(
-        recognizer: Recognizer[_, _],
-        offendingSymbol: Any,
-        line: Int,
-        charPositionInLine: Int,
-        msg: String,
-        e: RecognitionException
-      ): Unit =
-        errors += 1
-    }
+    val lexer               = new RubyLexer(CharStreams.fromString(code))
+    val syntaxErrorListener = new RubySyntaxErrorListener
     lexer.addErrorListener(syntaxErrorListener)
     val stream = new CommonTokenStream(lexer)
     stream.fill() // Run the lexer

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyParserAbstractTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyParserAbstractTest.scala
@@ -12,7 +12,7 @@ abstract class RubyParserAbstractTest extends AnyWordSpec with Matchers {
   def rubyParser(code: String): RubyParser =
     new RubyParser(rubyStream(code))
 
-  def prettyPrint(withContext: RubyParser => ParserRuleContext, input: String): String =
+  def printAst(withContext: RubyParser => ParserRuleContext, input: String): String =
     AstPrinter.print(withContext(rubyParser(input)))
 
   def accepts(withContext: RubyParser => ParserRuleContext, input: String): Boolean = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -2,89 +2,100 @@ package io.joern.rubysrc2cpg.parser
 
 class StringTests extends RubyParserAbstractTest {
 
-  "Empty string literals" should {
-    val singleQuotedExample = "''"
-    val doubleQuotedExample = "\"\""
+  "A single-quoted string literal" when {
 
-    "be parsed as primary expressions" in {
-      prettyPrint(_.primary(), singleQuotedExample) shouldEqual
-        """LiteralPrimary
-          | Literal
-          |  ''
-          |""".stripMargin
+    "empty" should {
+      val code = "''"
 
-      prettyPrint(_.primary(), doubleQuotedExample) shouldEqual
-        """LiteralPrimary
-          | Literal
-          |  "
-          |  "
-          |""".stripMargin
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """LiteralPrimary
+            | Literal
+            |  ''
+            |""".stripMargin
+      }
     }
   }
 
-  "One-hole string interpolation containing text and a numeric literal" should {
-    val code = """"text=#{1}""""
+  "A double-quoted string literal" when {
 
-    "be parsed as a primary expression" in {
-      prettyPrint(_.primary(), code) shouldEqual
-        """StringInterpolationPrimary
-          | StringInterpolation
-          |  "
-          |  text=
-          |  Interpolation
-          |   #{
-          |   CompoundStatement
-          |    Statements
-          |     ExpressionOrCommandStatement
-          |      ExpressionExpressionOrCommand
-          |       PrimaryExpression
-          |        LiteralPrimary
-          |         Literal
-          |          NumericLiteral
-          |           UnsignedNumericLiteral
-          |            1
-          |   }
-          |  "
-          |""".stripMargin
+    "empty" should {
+      val code = "\"\""
+
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """LiteralPrimary
+            | Literal
+            |  "
+            |  "
+            |""".stripMargin
+      }
     }
-  }
 
-  "Two-hole string interpolation containing numeric literals" should {
-    val code = """"#{1}#{2}""""
+    "containing text and a numeric literal interpolation" should {
+      val code = """"text=#{1}""""
 
-    "be parsed as a primary expression" in {
-      prettyPrint(_.primary(), code) shouldBe
-        """StringInterpolationPrimary
-          | StringInterpolation
-          |  "
-          |  Interpolation
-          |   #{
-          |   CompoundStatement
-          |    Statements
-          |     ExpressionOrCommandStatement
-          |      ExpressionExpressionOrCommand
-          |       PrimaryExpression
-          |        LiteralPrimary
-          |         Literal
-          |          NumericLiteral
-          |           UnsignedNumericLiteral
-          |            1
-          |   }
-          |  Interpolation
-          |   #{
-          |   CompoundStatement
-          |    Statements
-          |     ExpressionOrCommandStatement
-          |      ExpressionExpressionOrCommand
-          |       PrimaryExpression
-          |        LiteralPrimary
-          |         Literal
-          |          NumericLiteral
-          |           UnsignedNumericLiteral
-          |            2
-          |   }
-          |  "
-          |""".stripMargin
+      "be parsed as primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """StringInterpolationPrimary
+            | StringInterpolation
+            |  "
+            |  text=
+            |  Interpolation
+            |   #{
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         Literal
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            1
+            |   }
+            |  "
+            |""".stripMargin
+      }
+    }
+
+    "containing two numeric literal interpolations" should {
+      val code = """"#{1}#{2}""""
+
+      "be parsed as primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """StringInterpolationPrimary
+            | StringInterpolation
+            |  "
+            |  Interpolation
+            |   #{
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         Literal
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            1
+            |   }
+            |  Interpolation
+            |   #{
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         Literal
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            2
+            |   }
+            |  "
+            |""".stripMargin
+      }
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/SymbolTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/SymbolTests.scala
@@ -2,54 +2,93 @@ package io.joern.rubysrc2cpg.parser
 
 class SymbolTests extends RubyParserAbstractTest {
 
-  "Keyword-named symbols" should {
-    val symWhile = ":while"
-    val symDef   = ":def"
+  "Symbol literals" should {
 
-    "be parsed as symbols" in {
-      prettyPrint(_.symbol(), symWhile) shouldBe
-        """Symbol
-          | :while
-          |""".stripMargin
+    "be parsed as primary expressions" when {
 
-      prettyPrint(_.symbol(), symDef) shouldBe
-        """Symbol
-          | :def
-          |""".stripMargin
-    }
+      def symbolLiteralParseTreeText(symbolName: String): String =
+        s"""LiteralPrimary
+           | Literal
+           |  Symbol
+           |   $symbolName
+           |""".stripMargin
 
-    "be accepted as literals" in {
-      accepts(_.literal(), symWhile) shouldBe true
-      accepts(_.literal(), symDef) shouldBe true
+      "they are named after keywords" in {
+        val eg = Seq(
+          ":__LINE__",
+          ":__ENCODING__",
+          ":__FILE__",
+          ":BEGIN",
+          ":END",
+          ":alias",
+          ":begin",
+          ":break",
+          ":case",
+          ":class",
+          ":def",
+          ":defined?",
+          ":do",
+          ":else",
+          ":elsif",
+          ":end",
+          ":ensure",
+          ":for",
+          ":false",
+          ":if",
+          ":in",
+          ":module",
+          ":next",
+          ":nil",
+          ":not",
+          ":or",
+          ":redo",
+          ":rescue",
+          ":retry",
+          ":self",
+          ":super",
+          ":then",
+          ":true",
+          ":undef",
+          ":unless",
+          ":until",
+          ":when",
+          ":while",
+          ":yield"
+        )
+        eg.map(code => printAst(_.primary(), code)) shouldEqual eg.map(symbolLiteralParseTreeText)
+      }
+
+      "they are named after operators" in {
+        val eg = Seq(
+          ":^",
+          ":&",
+          ":|",
+          ":<=>",
+          ":==",
+          ":===",
+          ":=~",
+          ":>",
+          ":>=",
+          ":<",
+          ":<=",
+          ":<<",
+          ":>>",
+          ":+",
+          ":-",
+          ":*",
+          ":/",
+          ":%",
+          ":**",
+          ":~",
+          ":+@",
+          ":-@",
+          ":[]",
+          ":[]="
+        )
+        eg.map(code => printAst(_.primary(), code)) shouldEqual eg.map(symbolLiteralParseTreeText)
+      }
+
     }
   }
 
-  "Operator-named symbols" should {
-    val symCaret   = ":^"
-    val symEq2     = ":=="
-    val symLRBrack = ":[]"
-
-    "be parsed as primary expressions" in {
-      prettyPrint(_.primary(), symCaret) shouldEqual
-        """LiteralPrimary
-          | Literal
-          |  Symbol
-          |   :^
-          |""".stripMargin
-
-      prettyPrint(_.primary(), symEq2) shouldEqual
-        """LiteralPrimary
-          | Literal
-          |  Symbol
-          |   :==
-          |""".stripMargin
-
-      prettyPrint(_.primary(), symLRBrack) shouldEqual
-        """LiteralPrimary
-          | Literal
-          |  Symbol
-          |   :[]
-          |""".stripMargin
-    }
-  }
 }


### PR DESCRIPTION
* Refactors and expands the previous unit-tests
* Adds `rubysrc2cpg` to `build.sbt` so that it (among other things) benefits from scalafmt
* Fixes missing whitespaces (WS) in the rule for arguments. Aside: this rule ought to be refactored in a future PR.