### PR TITLE
PythonTypeRecovery: Inheritance via Identifiers

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -790,10 +790,21 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |
         |class Foo(declarative_base(metadata=metadata)):
         |    pass
+        |
+        |x = declarative_base(metadata=metadata)
+        |class Bar(x):
+        |    pass
+        |
         |""".stripMargin)
 
-    "should present an appropriate dummy type" in {
+    "present an appropriate dummy type for direct call returns" in {
       cpg.typeDecl("Foo").inheritsFromTypeFullName.l shouldBe List(
+        Seq("sqlalchemy", "ext", "declarative.py:<module>.declarative_base.<returnValue>").mkString(File.separator)
+      )
+    }
+
+    "present an appropriate dummy type for call results held by identifiers" in {
+      cpg.typeDecl("Bar").inheritsFromTypeFullName.l shouldBe List(
         Seq("sqlalchemy", "ext", "declarative.py:<module>.declarative_base.<returnValue>").mkString(File.separator)
       )
     }


### PR DESCRIPTION
If an identifier holds some kind of type-ref or type dummy value then an attempt to propagate this is made.