### PR TITLE
RubyParser: support for trailing commas and optional parameters

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -208,7 +208,7 @@ indexingArguments
 
 argumentsWithParentheses
     :   LPAREN wsOrNl* RPAREN
-    |   LPAREN wsOrNl* arguments wsOrNl* RPAREN
+    |   LPAREN wsOrNl* arguments (WS* COMMA)? wsOrNl* RPAREN
     |   LPAREN wsOrNl* expressions WS* COMMA wsOrNl* chainedCommandWithDoBlock wsOrNl* RPAREN
     |   LPAREN wsOrNl* chainedCommandWithDoBlock wsOrNl* RPAREN
     ;

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -332,7 +332,7 @@ optionalParameters
     ;
 
 optionalParameter
-    :   LOCAL_VARIABLE_IDENTIFIER EQ wsOrNl* expression
+    :   LOCAL_VARIABLE_IDENTIFIER WS* EQ wsOrNl* expression
     ;
 
 arrayParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -13,10 +13,10 @@ object AstPrinter {
     val contextName = context.getClass.getSimpleName.stripSuffix("Context")
     val nextLevel   = level + indentationIncrement
     sb.append(s"$indentation$contextName\n")
-    context.children.forEach {
+    Option(context.children).foreach(_.forEach {
       case c: ParserRuleContext => print(nextLevel, sb, c)
       case t: TerminalNode      => print(nextLevel, sb, t)
-    }
+    })
     sb
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -88,8 +88,47 @@ ${"       "}
             |  )
             |""".stripMargin
       }
+
+      "it contains a single symbol literal positional argument" in {
+        val code = "foo(:region)"
+
+        printAst(_.primary(), code) shouldEqual
+          """InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgumentsWithParentheses
+            |  (
+            |  Arguments
+            |   Expressions
+            |    PrimaryExpression
+            |     LiteralPrimary
+            |      Literal
+            |       Symbol
+            |        :region
+            |  )
+            |""".stripMargin
+      }
+
+      "it contains a single symbol literal positional argument and trailing comma" in {
+        val code = "foo(:region,)"
+
+        printAst(_.primary(), code) shouldEqual
+          """InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgumentsWithParentheses
+            |  (
+            |  Arguments
+            |   Expressions
+            |    PrimaryExpression
+            |     LiteralPrimary
+            |      Literal
+            |       Symbol
+            |        :region
+            |  ,
+            |  )
+            |""".stripMargin
+      }
     }
-
   }
-
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -1,0 +1,98 @@
+package io.joern.rubysrc2cpg.parser
+
+class MethodDefinitionTests extends RubyParserAbstractTest {
+
+  "A one-line empty method definition" should {
+
+    "be parsed as a primary expression" when {
+
+      "it contains no parameters" in {
+        val code = "def foo; end"
+        printAst(_.primary(), code) shouldEqual
+          s"""MethodDefinitionPrimary
+            | MethodDefinition
+            |  def
+            |  WsOrNl
+${"    "}
+            |  SimpleMethodNamePart
+            |   DefinedMethodName
+            |    MethodName
+            |     MethodIdentifier
+            |      foo
+            |  MethodParameterPart
+            |   Separator
+            |    ;
+            |  WsOrNl
+${"    "}
+            |  BodyStatement
+            |   CompoundStatement
+            |  end
+            |""".stripMargin
+      }
+
+      "it contains a mandatory parameter" in {
+        val code = "def foo(x);end"
+        printAst(_.primary(), code) shouldEqual
+          s"""MethodDefinitionPrimary
+            | MethodDefinition
+            |  def
+            |  WsOrNl
+${"    "}
+            |  SimpleMethodNamePart
+            |   DefinedMethodName
+            |    MethodName
+            |     MethodIdentifier
+            |      foo
+            |  MethodParameterPart
+            |   (
+            |   Parameters
+            |    MandatoryParameters
+            |     x
+            |   )
+            |  BodyStatement
+            |   CompoundStatement
+            |    Separators
+            |     Separator
+            |      ;
+            |  end
+            |""".stripMargin
+      }
+
+      "it contains an optional numeric parameter" in {
+        val code = "def foo(x=1);end"
+        printAst(_.primary(), code) shouldEqual
+          s"""MethodDefinitionPrimary
+             | MethodDefinition
+             |  def
+             |  WsOrNl
+${"    "}
+             |  SimpleMethodNamePart
+             |   DefinedMethodName
+             |    MethodName
+             |     MethodIdentifier
+             |      foo
+             |  MethodParameterPart
+             |   (
+             |   Parameters
+             |    OptionalParameters
+             |     OptionalParameter
+             |      x
+             |      =
+             |      PrimaryExpression
+             |       LiteralPrimary
+             |        Literal
+             |         NumericLiteral
+             |          UnsignedNumericLiteral
+             |           1
+             |   )
+             |  BodyStatement
+             |   CompoundStatement
+             |    Separators
+             |     Separator
+             |      ;
+             |  end
+             |""".stripMargin
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Fixes a NPE in AstPrinter when `context.children` is null (meaning it's empty)
* Adds a missing WS token when parsing default parameter values
* Adds a missing trailing COMMA when parsing invocation parameters (allowing for invocations such as `foo(1,)`.)