### PR TITLE
jssrc2cpg: Name Closure After Export Assigned Name

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
@@ -2,15 +2,16 @@ package io.joern.jssrc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.{Method, MethodRef}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
-import overflowdb.BatchedUpdate
 import overflowdb.traversal._
 
 /** A pass that identifies assignments of closures to constants and updates `METHOD` nodes accordingly.
   */
 class ConstClosurePass(cpg: Cpg) extends CpgPass(cpg) {
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
+    // Handle const closures
     for {
       assignment      <- cpg.assignment
       name            <- assignment.filter(_.code.startsWith("const ")).target.isIdentifier.name
@@ -18,10 +19,30 @@ class ConstClosurePass(cpg: Cpg) extends CpgPass(cpg) {
       method          <- methodRef.referencedMethod
       enclosingMethod <- assignment.start.method.fullName
     } {
-      diffGraph.setNodeProperty(methodRef, PropertyNames.METHOD_FULL_NAME, s"$enclosingMethod:$name")
-      diffGraph.setNodeProperty(method, PropertyNames.NAME, name)
-      diffGraph.setNodeProperty(method, PropertyNames.FULL_NAME, s"$enclosingMethod:$name")
+      updateClosures(diffGraph, method, methodRef, enclosingMethod, name)
     }
+    // Handle closures defined at exports
+    for {
+      assignment <- cpg.assignment
+      name <- assignment.filter(_.code.startsWith("export")).target.isCall.argument.isFieldIdentifier.canonicalName.l
+      methodRef       <- assignment.start.source.ast.isMethodRef
+      method          <- methodRef.referencedMethod
+      enclosingMethod <- assignment.start.method.fullName
+    } {
+      updateClosures(diffGraph, method, methodRef, enclosingMethod, name)
+    }
+  }
 
+  private def updateClosures(
+    diffGraph: DiffGraphBuilder,
+    method: Method,
+    methodRef: MethodRef,
+    enclosingMethod: String,
+    name: String
+  ): Unit = {
+    val fullName = s"$enclosingMethod:$name"
+    diffGraph.setNodeProperty(methodRef, PropertyNames.METHOD_FULL_NAME, fullName)
+    diffGraph.setNodeProperty(method, PropertyNames.NAME, name)
+    diffGraph.setNodeProperty(method, PropertyNames.FULL_NAME, fullName)
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
@@ -13,4 +13,22 @@ class ConstClosurePassTests extends DataFlowCodeToCpgSuite {
     m.fullName.endsWith("program:foo") shouldBe true
   }
 
+  "should return method `export.foo` via `cpg.method`" in {
+    val cpg = code("""
+        |exports.foo = (function() {
+        |	var count = 0;
+        |	return function() {
+        |		count++;
+        |		return count;
+        |	};
+        |})();
+        |
+        |this.foo();
+        |""".stripMargin)
+
+    val List(m) = cpg.method.name("foo").l
+    m.name shouldBe "foo"
+    m.fullName.endsWith("program:foo") shouldBe true
+  }
+
 }


### PR DESCRIPTION
Extended ConstClosurePass to support `export.foo = <closure>` style naming to use `foo`.