### PR TITLE
jimple2cpg: Update JimpleDataFlowCodeToCpgSuite to accept extra FlowSemantics

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/SemanticTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/SemanticTests.scala
@@ -1,0 +1,97 @@
+package io.joern.jimple2cpg.querying.dataflow
+
+import io.joern.dataflowengineoss.language._
+import io.joern.jimple2cpg.testfixtures.{JimpleDataFlowCodeToCpgSuite, JimpleDataflowTestCpg}
+import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.x2cpg.Defines
+
+class SemanticTests
+    extends JimpleDataFlowCodeToCpgSuite(extraFlows =
+      List(
+        FlowSemantic("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
+        FlowSemantic("java.nio.file.Paths.get:.*\\(java.lang.String,.*\\)", List.empty, regex = true)
+      )
+    ) {
+
+  "Dataflow through custom semantics" should {
+    lazy implicit val cpg: JimpleDataflowTestCpg = code(
+      """
+      |import java.nio.file.Paths;
+      |import java.net.URI;
+      |
+      |public class Test {
+      | public void test1() {
+      |   String s = "MALICIOUS";
+      |   String b = taint(s);
+      |   System.out.println(b);
+      | }
+      |
+      | public void test2() {
+      |   String s = "MALICIOUS";
+      |   String b = taint(s);
+      |   String c = sanitize(b);
+      |   System.out.println(c);
+      | }
+      |
+      | public void test3() {
+      |   String s = "MALICIOUS";
+      |   String b = Paths.get(URI.create(s)).toString();
+      |   System.out.println(b);
+      | }
+      |
+      | public void test4() {
+      |   String s = "MALICIOUS";
+      |   String b = Paths.get("/tmp", s).toString();
+      |   System.out.println(b);
+      | }
+      |
+      | public void test5() {
+      |   String s = "MALICIOUS";
+      |   byte[] dst = new byte[10];
+      |   System.arraycopy(s.getBytes(), 0, dst, 0, 9);
+      |   String b = new String(dst);
+      |   System.out.println(b);
+      | }
+      |
+      | public String taint(String s) {
+      |     return s + ".taint";
+      | }
+      |
+      | public String sanitize(String s) {
+      |     if (s.contains("..")) {
+      |         return s.replace("..", "");
+      |     }
+      |     return s;
+      | }
+      |}""".stripMargin,
+      "Test.java"
+    )
+
+    "find a path" in {
+      val (source, sink) = getConstSourceSink("test1")
+      sink.reachableBy(source).size shouldBe 1
+    }
+
+    "be kill in sanitizer" in {
+      val (source, sink) = getConstSourceSink("test2")
+      sink.reachableBy(source).size shouldBe 0
+    }
+
+    "taints return" in {
+      val (source, sink) = getConstSourceSink("test3")
+      sink.reachableBy(source).size shouldBe 1
+    }
+
+    "be killed" in {
+      val (source, sink) = getConstSourceSink("test4")
+      sink.reachableBy(source).size shouldBe 0
+    }
+
+    "follow taint rules" in {
+      val (source, sink) = getConstSourceSink("test5")
+      sink.reachableBy(source).size shouldBe 1
+    }
+
+  }
+
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleDataflowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleDataflowCodeToCpgSuite.scala
@@ -3,6 +3,7 @@ package io.joern.jimple2cpg.testfixtures
 import io.joern.dataflowengineoss.language.Path
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
+import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
@@ -10,7 +11,7 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import overflowdb.traversal.Traversal
 
-class JimpleDataflowTestCpg extends JimpleTestCpg {
+class JimpleDataflowTestCpg(val extraFlows: List[FlowSemantic] = List.empty) extends JimpleTestCpg {
 
   implicit val resolver: ICallResolver           = NoResolve
   implicit lazy val engineContext: EngineContext = EngineContext()
@@ -18,13 +19,14 @@ class JimpleDataflowTestCpg extends JimpleTestCpg {
   override def applyPasses(): Unit = {
     super.applyPasses()
     val context = new LayerCreatorContext(this)
-    val options = new OssDataFlowOptions()
+    val options = new OssDataFlowOptions(extraFlows = extraFlows)
     new OssDataFlow(options).run(context)
   }
 
 }
 
-class JimpleDataFlowCodeToCpgSuite extends Code2CpgFixture(() => new JimpleDataflowTestCpg()) {
+class JimpleDataFlowCodeToCpgSuite(val extraFlows: List[FlowSemantic] = List.empty)
+    extends Code2CpgFixture(() => new JimpleDataflowTestCpg(extraFlows)) {
 
   implicit var context: EngineContext = EngineContext()
 


### PR DESCRIPTION
Also fix dataflow test with custom semantics to correctly kill the flow in javasrc2cpg.