### PR TITLE
jssrc2cpg: handles the `satisfies` operator

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -204,7 +204,7 @@ class AstCreator(
       case TemplateLiteral           => astForTemplateLiteral(nodeInfo)
       case TemplateElement           => astForTemplateElement(nodeInfo)
       case SpreadElement             => astForSpreadOrRestElement(nodeInfo)
-      case TSSatisfiesExpression     => astForSatisfiesExpression(nodeInfo)
+      case TSSatisfiesExpression     => astForTSSatisfiesExpression(nodeInfo)
       case JSXElement                => astForJsxElement(nodeInfo)
       case JSXOpeningElement         => astForJsxOpeningElement(nodeInfo)
       case JSXClosingElement         => astForJsxClosingElement(nodeInfo)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -204,6 +204,7 @@ class AstCreator(
       case TemplateLiteral           => astForTemplateLiteral(nodeInfo)
       case TemplateElement           => astForTemplateElement(nodeInfo)
       case SpreadElement             => astForSpreadOrRestElement(nodeInfo)
+      case TSSatisfiesExpression     => astForSatisfiesExpression(nodeInfo)
       case JSXElement                => astForJsxElement(nodeInfo)
       case JSXOpeningElement         => astForJsxOpeningElement(nodeInfo)
       case JSXClosingElement         => astForJsxClosingElement(nodeInfo)
@@ -215,7 +216,6 @@ class AstCreator(
       case JSXAttribute              => astForJsxAttribute(nodeInfo)
       case EmptyStatement            => Ast()
       case DebuggerStatement         => Ast()
-      case TSSatisfiesExpression     => Ast()
       case _                         => notHandledYet(nodeInfo)
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -215,6 +215,7 @@ class AstCreator(
       case JSXAttribute              => astForJsxAttribute(nodeInfo)
       case EmptyStatement            => Ast()
       case DebuggerStatement         => Ast()
+      case TSSatisfiesExpression     => Ast()
       case _                         => notHandledYet(nodeInfo)
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -519,4 +519,9 @@ trait AstForExpressionsCreator { this: AstCreator =>
     setArgumentIndices(childrenAsts)
     blockAst(blockNode, childrenAsts)
   }
+
+  protected def astForSatisfiesExpression(satisfiesExpr: BabelNodeInfo): Ast = {
+    // Ignores the type, i.e. `x satisfies T` is understood as `x`.
+    astForNode(satisfiesExpr.json("expression"))
+  }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -520,7 +520,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     blockAst(blockNode, childrenAsts)
   }
 
-  protected def astForSatisfiesExpression(satisfiesExpr: BabelNodeInfo): Ast = {
+  protected def astForTSSatisfiesExpression(satisfiesExpr: BabelNodeInfo): Ast = {
     // Ignores the type, i.e. `x satisfies T` is understood as `x`.
     astForNode(satisfiesExpr.json("expression"))
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelAst.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelAst.scala
@@ -226,6 +226,7 @@ object BabelAst {
   object TSPropertySignature             extends BabelNode
   object TSQualifiedName                 extends BabelNode
   object TSRestType                      extends TSType
+  object TSSatisfiesExpression           extends BabelNode
   object TSStringKeyword                 extends TSType
   object TSSymbolKeyword                 extends TSType
   object TSThisType                      extends TSType

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTest.scala
@@ -63,6 +63,13 @@ class TsAstCreationPassTest extends AbstractPassTest {
       cpg.call.code.l shouldBe List("let emptyArray = <VNode[]>[]")
     }
 
+    "have correct structure for satisfies expressions" in TsAstFixture("let x = y satisfies T;") { cpg =>
+      val List(assignment) = cpg.assignment.l
+      val List(x, y)       = assignment.argument.l
+      assignment.code shouldBe "let x = y satisfies T"
+      x.code shouldBe "x"
+      y.code shouldBe "y"
+    }
   }
 
 }


### PR DESCRIPTION
* Ignores the [`satisfies` operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html). Would there be a suitable representation for it?
* Fixes #2588 
