### PR TITLE
Use archived php-parser instead of source dir

### DIFF
--- a/joern-cli/frontends/php2cpg/build.sbt
+++ b/joern-cli/frontends/php2cpg/build.sbt
@@ -6,7 +6,7 @@ name := "php2cpg"
 scalaVersion       := "2.13.8"
 crossScalaVersions := Seq("2.13.8", "3.2.2")
 
-val phpParserVersion = "4.15.5"
+val phpParserVersion = "4.15.6"
 val phpParserBinName = "php-parser.phar"
 val phpParserDlUrl   = s"https://github.com/joernio/PHP-Parser/releases/download/v$phpParserVersion/$phpParserBinName"
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")

--- a/joern-cli/frontends/php2cpg/src/main/resources/log4j2.xml
+++ b/joern-cli/frontends/php2cpg/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5p] %m%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="${env:SL_LOGGING_LEVEL:-info}">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Before this PR, we were using the source archives attached to https://github.com/joernio/PHP-Parser releases and extracting those to set up PHP-parser. This makes setting up php-parser quite cumbersome, so I've added a release step to our PHP-Parser fork to pack the code into a phar which is fetched by the code in this PR. Also adds log4j config for php2cpg.