### PR TITLE
jssrc2cpg: fix EJS file names

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -228,9 +228,10 @@ class AstGenRunner(config: Config) {
       val jsonFile    = File(jsonPath)
       val jsonContent = IOUtils.readLinesInFile(jsonFile.path).mkString
       val json        = ujson.read(jsonContent)
-      val fileName    = json("relativeName").str
+      val fileName    = json("fullName").str
       val newFileName = fileName.replace(".js", ".ejs")
       json("relativeName") = newFileName
+      json("fullName") = newFileName
       jsonFile.writeText(json.toString())
     }
 


### PR DESCRIPTION
`relativeName` and `fullName` in the `*.json` files returned by `astgen` are different between Linux and Windows systems. While `astgen` on Windows generates them correctly, on Linux the relative path is lost.

This is for: https://github.com/joernio/joern/issues/2579