### PR TITLE
jssrc2cpg: Handle Exported Closures

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -5,8 +5,8 @@ import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.{Defines, EcmaBuiltins, GlobalBuiltins}
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.Stack._
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.NewNode
+import io.shiftleft.codepropertygraph.generated.nodes.{NewMethod, NewNode}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators, nodes}
 
 import scala.util.Try
 
@@ -92,7 +92,9 @@ trait AstForExpressionsCreator { this: AstCreator =>
       case None =>
         typeFor(thisExpr) match {
           case t if t != Defines.Any => Option(t)
-          case _                     => None
+          case _ if methodAstParentStack.collect { case n: nodes.NewMethod if n.name == ":program" => n }.nonEmpty =>
+            methodAstParentStack.collectFirst { case n: NewMethod if n.name == ":program" => n.fullName }
+          case _ => None
         }
     }
     val thisNode = createIdentifierNode(thisExpr.code, dynamicTypeOption, thisExpr.lineNumber, thisExpr.columnNumber)

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -189,4 +189,40 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
 
   }
 
+  "Importing an anonymous function" should {
+    lazy val cpg = code(
+      """
+        |var refThis = this;
+        |
+        |exports.getIncrementalInteger = (function() {
+        |	var count = 0;
+        |	return function() {
+        |		count++;
+        |		return count;
+        |	};
+        |})();
+        |
+        |refThis.getIncrementalInteger();
+        |""".stripMargin,
+      "util.js"
+    ).moreCode(
+      """
+        |var util = require("./util.js");
+        |
+        |util.getIncrementalInteger()
+        |""".stripMargin,
+      "foo.js"
+    )
+
+    "resolve the method full name off of an aliased 'this'" in {
+      val Some(x) = cpg.file("util.js").ast.isCall.nameExact("getIncrementalInteger").headOption
+      x.methodFullName shouldBe "util.js::program:getIncrementalInteger"
+    }
+
+    "resolve the method full name off of the imported 'util'" in {
+      val Some(x) = cpg.file("foo.js").ast.isCall.nameExact("getIncrementalInteger").headOption
+      x.methodFullName shouldBe "util.js::program:getIncrementalInteger"
+    }
+  }
+
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
@@ -13,7 +13,7 @@ class TSTypesTest extends AbstractPassTest {
   ) { cpg =>
     val List(t) = cpg.identifier("this").l
     t.typeFullName shouldBe Defines.Any
-    t.dynamicTypeHintFullName shouldBe List()
+    t.dynamicTypeHintFullName shouldBe List("code.js::program")
   }
 
   "have correct types for this with proper surrounding type" in AstFixture(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -323,7 +323,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   protected def visitStatementsInBlock(b: Block): Set[String] =
     b.astChildren
       .map {
-        case x: Call if x.name.equals(Operators.assignment)                => visitAssignments(new Assignment(x))
+        case x: Call if x.name.startsWith(Operators.assignment)            => visitAssignments(new Assignment(x))
         case x: Identifier if symbolTable.contains(x)                      => symbolTable.get(x)
         case x: Call if symbolTable.contains(x)                            => symbolTable.get(x)
         case x: Call if x.argument.headOption.exists(symbolTable.contains) => setCallMethodFullNameFromBase(x)


### PR DESCRIPTION
* Let `this` take on the name of the parent `:program` module if it is in the method stack and there are now dynamic types in scope
* Type recovery now handles `exports.*` not only `module.exports.*`
* Type recovery also handles the exporting of closures
* Fix in `XTypeRecovery` where assign statements in blocks were only being handled if they were exactly `<operator>.assignment`