### PR TITLE
JoernSlice: Option to Exclude Operator Calls

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -889,7 +889,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
             builder.addNode(mRef)
             builder.addEdge(mRef, m, EdgeTypes.REF)
             builder.addEdge(inCall, mRef, EdgeTypes.AST)
-            builder.addEdge(inCall, mRef, EdgeTypes.ARGUMENT)
+            if (inCall.isInstanceOf[Call]) builder.addEdge(inCall, mRef, EdgeTypes.ARGUMENT)
             mRef.argumentIndex(inCall.astChildren.size)
           }
         addedNodes.add((funcPtr.id(), s"${mRef.label()}$pathSep${mRef.methodFullName}"))

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
@@ -33,7 +33,8 @@ object JoernSlice {
     sourceFile: Option[String] = None,
     sliceDepth: Int = 20,
     minNumCalls: Int = 1,
-    typeRecoveryDummyTypes: Boolean = false
+    typeRecoveryDummyTypes: Boolean = false,
+    excludeOperatorCalls: Boolean = false
   )
 
   def main(args: Array[String]): Unit = {
@@ -99,6 +100,9 @@ object JoernSlice {
       opt[Boolean]("dummy-types")
         .text(s"for generating CPGs that use type recovery, enables the use of dummy types - defaults to false.")
         .action((x, c) => c.copy(typeRecoveryDummyTypes = x))
+      opt[Boolean]("exclude-operators")
+        .text(s"excludes operator calls in the slices - defaults to false.")
+        .action((x, c) => c.copy(excludeOperatorCalls = x))
 
     }.parse(args, Config())
 

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernSliceTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernSliceTests.scala
@@ -14,7 +14,9 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
     Languages.JSSRC
   ) { case (cpg: Cpg, _) =>
     val programSlice =
-      UsageSlicing.calculateUsageSlice(cpg, JoernSlice.Config()).asInstanceOf[ProgramUsageSlice]
+      UsageSlicing
+        .calculateUsageSlice(cpg, JoernSlice.Config(excludeOperatorCalls = true))
+        .asInstanceOf[ProgramUsageSlice]
 
     "extract 'express.js' slice" in {
       val Some(slice) = programSlice.objectSlices.get("main.js::program").flatMap(_.headOption)

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernSliceTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernSliceTests.scala
@@ -77,7 +77,9 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
     Languages.JSSRC
   ) { case (cpg: Cpg, _) =>
     val programSlice =
-      UsageSlicing.calculateUsageSlice(cpg, JoernSlice.Config()).asInstanceOf[ProgramUsageSlice]
+      UsageSlicing
+        .calculateUsageSlice(cpg, JoernSlice.Config(excludeOperatorCalls = true))
+        .asInstanceOf[ProgramUsageSlice]
 
     "extract 'name' parameter slice from 'startScene'" in {
       val Some(slice) = programSlice.objectSlices.get("main.ts::program:Game:startScene").flatMap(_.headOption)


### PR DESCRIPTION
* Added option to exclude operator calls
* Fixed bug where `ARGUMENT` edge was added to an annotation when it is meant to be for calls

Resolves #2592

cc @pr0me 