### PR TITLE
Container images based on almalinux for joern

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,76 @@
+name: Upload Container image
+
+on:
+  schedule:
+  - cron: "0 */12 * * *"
+  push:
+    branches:
+     - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/joernio/joern
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ci/Dockerfile.alma
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=joern
+          cache-to: type=gha,mode=max,scope=joern
+          provenance: true
+          sbom: true
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/joernio/joern-alma8
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ci/Dockerfile.alma8
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=joern-alma8
+          cache-to: type=gha,mode=max,scope=joern-alma8
+          provenance: true
+          sbom: true

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ If the installation script fails for any reason, try
 ./joern-install --interactive
 ```
 
+## Docker based execution
+
+```
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern
+```
+
+To run joern in server mode:
+
+```
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern --server
+```
+
+Almalinux 9 requires the CPU to support SSE4.2. For kvm64 VM use the Almalinux 8 version instead.
+```
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8
+```
+
 ## Developers: IDE setup
 
 ### Intellij IDEA
@@ -90,9 +107,9 @@ More details in the [separate querydb readme](querydb/README.md)
 
 ## Benchmarks
 
-Various static analysis benchmarks that measure Joern are contained under the `benchmarks`. The benchmarks are 
-implemented in ScalaTest and can be run using the `joern-benchmarks` script. The benchmark results can be found on 
-the `benchmarks` subproject's `README`. The currently implemented benchmarks along with the language frontends tested 
+Various static analysis benchmarks that measure Joern are contained under the `benchmarks`. The benchmarks are
+implemented in ScalaTest and can be run using the `joern-benchmarks` script. The benchmark results can be found on
+the `benchmarks` subproject's `README`. The currently implemented benchmarks along with the language frontends tested
 are:
 
 * [Securibench Micro](http://too4words.github.io/securibench-micro/) [`javasrc2cpg`, `jimple2cpg`]
@@ -100,5 +117,5 @@ are:
 * [JInfoFlow](https://github.com/plast-lab/JInfoFlow-bench) ([paper](https://yanniss.github.io/ptaint-oopsla17-prelim.pdf)) [`javasrc2cpg`, `jimple2cpg`]
 
 For more instructions on how to run benchmarks individually head over to the `benchmarks` subproject. If you would
-like the benchmark results to be written to a file instead of printed to STDOUT, set the path to the environment 
+like the benchmark results to be written to a file instead of printed to STDOUT, set the path to the environment
 variable `JOERN_BENCHMARK_RESULT_FILE`.

--- a/ci/Dockerfile.alma
+++ b/ci/Dockerfile.alma
@@ -12,6 +12,9 @@ LABEL maintainer="joern" \
       org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern"
 
 ENV JOERN_HOME=/usr/local/bin \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
     JAVA_HOME="/etc/alternatives/jre_17" \
     JAVA_17_HOME="/etc/alternatives/jre_17" \
     JOERN_DATAFLOW_TRACKED_WIDTH=128 \
@@ -21,7 +24,7 @@ ENV JOERN_HOME=/usr/local/bin \
 COPY . /usr/local/src/
 
 RUN microdnf install -y gcc git-core php php-cli python3 python3-devel pcre2 which tar zip unzip sudo \
-        java-17-openjdk-headless ncurses jq zlib graphviz \
+        java-17-openjdk-headless ncurses jq zlib graphviz glibc-common glibc-all-langpacks \
     && curl -LO https://github.com/joernio/joern/releases/latest/download/joern-install.sh \
     && chmod +x ./joern-install.sh \
     && ./joern-install.sh \

--- a/ci/Dockerfile.alma
+++ b/ci/Dockerfile.alma
@@ -1,7 +1,7 @@
 FROM almalinux/9-minimal:latest
 
 LABEL maintainer="joern" \
-      org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
+      org.opencontainers.image.authors="Team Joern" \
       org.opencontainers.image.source="https://github.com/joernio/joern" \
       org.opencontainers.image.url="https://github.com/joernio/joern" \
       org.opencontainers.image.version="1.1.1643" \

--- a/ci/Dockerfile.alma
+++ b/ci/Dockerfile.alma
@@ -1,0 +1,36 @@
+FROM almalinux/9-minimal:latest
+
+LABEL maintainer="joern" \
+      org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
+      org.opencontainers.image.source="https://github.com/joernio/joern" \
+      org.opencontainers.image.url="https://github.com/joernio/joern" \
+      org.opencontainers.image.version="1.1.1643" \
+      org.opencontainers.image.vendor="Joern" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="joern" \
+      org.opencontainers.image.description="Joern is a platform for analyzing source code, bytecode, and binary executables" \
+      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern"
+
+ENV JOERN_HOME=/usr/local/bin \
+    JAVA_HOME="/etc/alternatives/jre_17" \
+    JAVA_17_HOME="/etc/alternatives/jre_17" \
+    JOERN_DATAFLOW_TRACKED_WIDTH=128 \
+    CLASSPATH=$CLASSPATH:/usr/local/bin: \
+    PATH=${PATH}:/opt/joern/joern-cli:/opt/joern/joern-cli/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin:/root/.local/bin:${JAVA_HOME}/bin:
+
+COPY . /usr/local/src/
+
+RUN microdnf install -y gcc git-core php php-cli python3 python3-devel pcre2 which tar zip unzip sudo \
+        java-17-openjdk-headless ncurses jq zlib graphviz \
+    && curl -LO https://github.com/joernio/joern/releases/latest/download/joern-install.sh \
+    && chmod +x ./joern-install.sh \
+    && ./joern-install.sh \
+    && useradd -ms /bin/bash joern \
+    && chown -R joern:joern /opt/joern \
+    && rm /joern-cli.zip /joern-install.sh \
+    && rm -rf /var/cache/yum \
+    && microdnf clean all
+
+WORKDIR /app
+
+ENTRYPOINT [ "joern" ]

--- a/ci/Dockerfile.alma8
+++ b/ci/Dockerfile.alma8
@@ -12,6 +12,9 @@ LABEL maintainer="joern" \
       org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8"
 
 ENV JOERN_HOME=/usr/local/bin \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
     JAVA_HOME="/etc/alternatives/jre_17" \
     JAVA_17_HOME="/etc/alternatives/jre_17" \
     JOERN_DATAFLOW_TRACKED_WIDTH=128 \
@@ -21,7 +24,7 @@ ENV JOERN_HOME=/usr/local/bin \
 COPY . /usr/local/src/
 
 RUN microdnf install -y gcc git-core php php-cli python3 python3-devel pcre2 which tar zip unzip sudo \
-        java-17-openjdk-headless ncurses jq zlib graphviz \
+        java-17-openjdk-headless ncurses jq zlib graphviz glibc-common glibc-all-langpacks \
     && curl -LO https://github.com/joernio/joern/releases/latest/download/joern-install.sh \
     && chmod +x ./joern-install.sh \
     && ./joern-install.sh \

--- a/ci/Dockerfile.alma8
+++ b/ci/Dockerfile.alma8
@@ -1,7 +1,7 @@
 FROM almalinux/8-minimal:latest
 
 LABEL maintainer="joern" \
-      org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
+      org.opencontainers.image.authors="Team Joern" \
       org.opencontainers.image.source="https://github.com/joernio/joern" \
       org.opencontainers.image.url="https://github.com/joernio/joern" \
       org.opencontainers.image.version="1.1.1643" \

--- a/ci/Dockerfile.alma8
+++ b/ci/Dockerfile.alma8
@@ -9,7 +9,7 @@ LABEL maintainer="joern" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="joern" \
       org.opencontainers.image.description="Joern is a platform for analyzing source code, bytecode, and binary executables" \
-      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern"
+      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8"
 
 ENV JOERN_HOME=/usr/local/bin \
     JAVA_HOME="/etc/alternatives/jre_17" \

--- a/ci/Dockerfile.alma8
+++ b/ci/Dockerfile.alma8
@@ -1,0 +1,36 @@
+FROM almalinux/8-minimal:latest
+
+LABEL maintainer="joern" \
+      org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
+      org.opencontainers.image.source="https://github.com/joernio/joern" \
+      org.opencontainers.image.url="https://github.com/joernio/joern" \
+      org.opencontainers.image.version="1.1.1643" \
+      org.opencontainers.image.vendor="Joern" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="joern" \
+      org.opencontainers.image.description="Joern is a platform for analyzing source code, bytecode, and binary executables" \
+      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern"
+
+ENV JOERN_HOME=/usr/local/bin \
+    JAVA_HOME="/etc/alternatives/jre_17" \
+    JAVA_17_HOME="/etc/alternatives/jre_17" \
+    JOERN_DATAFLOW_TRACKED_WIDTH=128 \
+    CLASSPATH=$CLASSPATH:/usr/local/bin: \
+    PATH=${PATH}:/opt/joern/joern-cli:/opt/joern/joern-cli/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin:/root/.local/bin:${JAVA_HOME}/bin:
+
+COPY . /usr/local/src/
+
+RUN microdnf install -y gcc git-core php php-cli python3 python3-devel pcre2 which tar zip unzip sudo \
+        java-17-openjdk-headless ncurses jq zlib graphviz \
+    && curl -LO https://github.com/joernio/joern/releases/latest/download/joern-install.sh \
+    && chmod +x ./joern-install.sh \
+    && ./joern-install.sh \
+    && useradd -ms /bin/bash joern \
+    && chown -R joern:joern /opt/joern \
+    && rm /joern-cli.zip /joern-install.sh \
+    && rm -rf /var/cache/yum \
+    && microdnf clean all
+
+WORKDIR /app
+
+ENTRYPOINT [ "joern" ]


### PR DESCRIPTION
Almalinux 9 and 8 images for joern. Almalinux uses RedHat UBI as the source and is enterprise friendly.

The workflow uses a schedule to publish the images with the tag `nightly`, `master`, and `latest` based on version tags.

After approving this PR, please visit the package settings and make all the packages public. GitHub would create packages as private by default and send a billing notice to upgrade.