### PR TITLE
javasrc2cpg: Fix Placement of Type Recovery in CLI

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -11,6 +11,7 @@ val ZeroturnaroundVersion = "1.15"
 dependsOn(
   Projects.semanticcpg,
   Projects.macros,
+  Projects.javasrc2cpg,
   Projects.jssrc2cpg,
   Projects.pysrc2cpg,
   Projects.x2cpg % "compile->compile;test->test"

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -1,6 +1,9 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
+import io.joern.javasrc2cpg.{JavaSrc2Cpg, Main, Config}
+import io.joern.x2cpg.X2Cpg
+import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.Path
 import scala.util.Try
@@ -9,12 +12,20 @@ import scala.util.Try
   */
 case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("javasrc2cpg.bat") else rootPath.resolve("javasrc2cpg")
+  private var javaConfig: Option[Config] = None
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
   override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
+    javaConfig = X2Cpg.parseCommandLine(arguments.toArray, Main.getCmdLineParser, Config())
     runShellCommand(command.toString, arguments).map(_ => outputPath)
+  }
+
+  override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
+    if (javaConfig.forall(_.enableTypeRecovery))
+      JavaSrc2Cpg.typeRecoveryPasses(cpg, javaConfig).foreach(_.createAndApply())
+    super.applyPostProcessingPasses(cpg)
   }
 
   override def isAvailable: Boolean =

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -87,7 +87,6 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
       new TypeNodePass(astCreationPass.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
       new TypeInferencePass(cpg).createAndApply()
-      if (config.enableTypeRecovery) typeRecoveryPasses(cpg, Option(config)).foreach(_.createAndApply())
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -64,4 +64,6 @@ object Main extends X2CpgMain(cmdLineParser, new JavaSrc2Cpg()) {
   def run(config: Config, javasrc2Cpg: JavaSrc2Cpg): Unit = {
     javasrc2Cpg.run(config)
   }
+
+  def getCmdLineParser = cmdLineParser
 }


### PR DESCRIPTION
Optional type recovery was running before base passes, mostly because it was placed under the main AST gen-side and not as a post-processing pass. This has now been fixed.

Resolves #2609