### PR TITLE
pysrc2cpg: Revisit Type Decl Structuring & Member Handling

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -2,7 +2,6 @@ package io.joern.pysrc2cpg
 
 import io.joern.x2cpg.passes.frontend._
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 import io.shiftleft.semanticcpg.language._
@@ -267,13 +266,9 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     if (fa.method.name == "<module>") {
       Set(fa.method.fullName)
     } else if (fa.method.typeDecl.nonEmpty) {
-      val parentTypes =
-        fa.method.typeDecl.fullName.map(_.stripSuffix("<meta>")).toSeq
+      val parentTypes       = fa.method.typeDecl.fullName.toSeq
       val baseTypeFullNames = cpg.typeDecl.fullNameExact(parentTypes: _*).inheritsFromTypeFullName.toSeq
-      (parentTypes ++ baseTypeFullNames)
-        .map(_.concat("<meta>"))
-        .filterNot(_.toLowerCase.matches("(any|object)"))
-        .toSet
+      (parentTypes ++ baseTypeFullNames).filterNot(_.toLowerCase.matches("(any|object)")).toSet
     } else {
       super.getFieldParents(fa)
     }
@@ -293,11 +288,6 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     }).toSet
   }
 
-  override def persistMemberWithTypeDecl(typeFullName: String, memberName: String, types: Set[String]): Unit = {
-    val pythonName = convertTypeFullNameToPythonMeta(typeFullName)
-    super.persistMemberWithTypeDecl(pythonName, memberName, types)
-  }
-
   override def createCallFromIdentifierTypeFullName(typeFullName: String, callName: String): String = {
     lazy val tName = typeFullName.split("\\.").lastOption.getOrElse(typeFullName)
     typeFullName match {
@@ -308,17 +298,6 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
         Seq(t, callName).mkString(pathSep.toString)
       case _ => super.createCallFromIdentifierTypeFullName(typeFullName, callName)
     }
-  }
-
-  override def typeDeclTraversal(typeFullName: String): Traversal[TypeDecl] =
-    cpg.typeDecl.fullNameExact(convertTypeFullNameToPythonMeta(typeFullName))
-
-  private def convertTypeFullNameToPythonMeta(typeFullName: String): String = {
-    if (typeFullName.endsWith("<module>") || typeFullName.endsWith("<meta>")) typeFullName
-    else
-      (if (typeFullName.contains(pathSep))
-         typeFullName.substring(0, typeFullName.lastIndexOf(pathSep))
-       else typeFullName).concat("<meta>")
   }
 
   override protected def postSetTypeInformation(): Unit =
@@ -339,7 +318,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
         classMethod.parameter
           .nameExact("cls")
           .foreach { cls =>
-            val clsPath = classMethod.typeDecl.fullName.map(_.stripSuffix("<meta>")).toSet
+            val clsPath = classMethod.typeDecl.fullName.toSet
             symbolTable.put(LocalVar(cls.name), clsPath)
             if (cls.typeFullName == "ANY")
               builder.setNodeProperty(cls, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, clsPath.toSeq)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -21,9 +21,9 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
       member.code shouldBe "x"
     }
 
-    "should have the MEMBER attached to the meta class" in {
+    "should have the MEMBER attached to the class" in {
       val List(typeDecl) = cpg.member.name("x").typeDecl.l
-      typeDecl.name shouldBe "Foo<meta>"
+      typeDecl.name shouldBe "Foo"
     }
   }
 
@@ -40,9 +40,9 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
       member.code shouldBe "x"
     }
 
-    "should have the MEMBER attached to the meta class" in {
+    "should have the MEMBER attached to the class" in {
       val List(typeDecl) = cpg.member.name("x").typeDecl.l
-      typeDecl.name shouldBe "Foo<meta>"
+      typeDecl.name shouldBe "Foo"
     }
 
   }
@@ -61,9 +61,9 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
       member.code shouldBe "x"
     }
 
-    "should have the MEMBER attached to the meta class" in {
+    "should have the MEMBER attached to the class" in {
       val List(typeDecl) = cpg.member.name("x").typeDecl.l
-      typeDecl.name shouldBe "Foo<meta>"
+      typeDecl.name shouldBe "Foo"
       typeDecl.lineNumber shouldBe Some(2)
       typeDecl.columnNumber shouldBe Some(1)
     }
@@ -93,7 +93,7 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
         |""".stripMargin)
 
     "should only render the LHS of the expression as the member and not the RHS" in {
-      cpg.typeDecl("SocialToken<meta>").member.name.l shouldBe List("app", "account", "<fakeNew>")
+      cpg.typeDecl("SocialToken").member.name.l shouldBe List("app", "account")
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -302,7 +302,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     val List(method: Method) = cpg.identifier.name("foo").inAssignment.source.isCall.callee.l
     method.fullName shouldBe "models.py:<module>.Foo.__init__"
     val List(typeDeclFullName) = method.typeDecl.fullName.l
-    typeDeclFullName shouldBe "models.py:<module>.Foo<meta>"
+    typeDeclFullName shouldBe "models.py:<module>.Foo"
   }
 
   "lookup of __init__ call even when hidden in base class" in {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -611,17 +611,17 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
       sb.toString()
     }
 
-    fa.astChildren.l match {
-      case List(i: Identifier, f: FieldIdentifier) if i.name.matches("(self|this)") => wrapName(f.canonicalName)
-      case List(i: Identifier, f: FieldIdentifier) => wrapName(s"${i.name}$pathSep${f.canonicalName}")
-      case List(c: Call, f: FieldIdentifier) if c.name.equals(Operators.fieldAccess) =>
+    fa.argumentOut.l match {
+      case ::(i: Identifier, ::(f: FieldIdentifier, _)) if i.name.matches("(self|this)") => wrapName(f.canonicalName)
+      case ::(i: Identifier, ::(f: FieldIdentifier, _)) => wrapName(s"${i.name}$pathSep${f.canonicalName}")
+      case ::(c: Call, ::(f: FieldIdentifier, _)) if c.name.equals(Operators.fieldAccess) =>
         wrapName(getFieldName(new FieldAccess(c), suffix = f.canonicalName))
-      case List(c: Call, f: FieldIdentifier) if getTypesFromCall(c).nonEmpty =>
+      case ::(c: Call, ::(f: FieldIdentifier, _)) if getTypesFromCall(c).nonEmpty =>
         // TODO: Handle this case better
         wrapName(s"${getTypesFromCall(c).head}$pathSep${f.canonicalName}")
-      case List(f: FieldIdentifier, c: Call) if c.name.equals(Operators.fieldAccess) =>
+      case ::(f: FieldIdentifier, ::(c: Call, _)) if c.name.equals(Operators.fieldAccess) =>
         wrapName(getFieldName(new FieldAccess(c), prefix = f.canonicalName))
-      case List(c: Call, f: FieldIdentifier) =>
+      case ::(c: Call, ::(f: FieldIdentifier, _)) =>
         // TODO: Handle this case better
         val callCode = if (c.code.contains("(")) c.code.substring(c.code.indexOf("(")) else c.code
         XTypeRecovery.dummyMemberType(callCode, f.canonicalName, pathSep)
@@ -693,24 +693,24 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     */
   protected def visitIdentifierAssignedToFieldLoad(i: Identifier, fa: FieldAccess): Set[String] = {
     val fieldName = getFieldName(fa)
-    fa.astChildren.l match {
-      case List(base: Identifier, fi: FieldIdentifier) if symbolTable.contains(LocalVar(base.name)) =>
+    fa.argumentOut.l match {
+      case ::(base: Identifier, ::(fi: FieldIdentifier, _)) if symbolTable.contains(LocalVar(base.name)) =>
         // Get field from global table if referenced as a variable
         val localTypes = symbolTable.get(LocalVar(base.name))
         associateInterproceduralTypes(i, base, fi, fieldName, localTypes)
-      case List(base: Identifier, fi: FieldIdentifier) if symbolTable.contains(LocalVar(fieldName)) =>
+      case ::(base: Identifier, ::(fi: FieldIdentifier, _)) if symbolTable.contains(LocalVar(fieldName)) =>
         val localTypes = symbolTable.get(LocalVar(fieldName))
         associateInterproceduralTypes(i, base, fi, fieldName, localTypes)
-      case List(base: Identifier, fi: FieldIdentifier) =>
+      case ::(base: Identifier, ::(fi: FieldIdentifier, _)) =>
         val dummyTypes = Set(s"$fieldName$pathSep${XTypeRecovery.DummyReturnType}")
         associateInterproceduralTypes(i, base, fi, fieldName, dummyTypes)
-      case List(c: Call, f: FieldIdentifier) if c.name.equals(Operators.fieldAccess) =>
+      case ::(c: Call, ::(fi: FieldIdentifier, _)) if c.name.equals(Operators.fieldAccess) =>
         val baseName = getFieldName(new FieldAccess(c))
         // Build type regardless of length
         // TODO: This is more prone to giving dummy values as it does not do global look-ups
         //  but this is okay for now
         val buf = mutable.ArrayBuffer.empty[String]
-        for (segment <- baseName.split(pathSep) ++ Array(f.canonicalName)) {
+        for (segment <- baseName.split(pathSep) ++ Array(fi.canonicalName)) {
           val types =
             if (buf.isEmpty) symbolTable.get(LocalVar(segment))
             else buf.flatMap(t => symbolTable.get(LocalVar(s"$t$pathSep$segment"))).toSet
@@ -724,10 +724,10 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
           }
         }
         associateTypes(i, buf.toSet)
-      case List(call: Call, f: FieldIdentifier) =>
+      case ::(call: Call, ::(fi: FieldIdentifier, _)) =>
         assignTypesToCall(
           call,
-          Set(fieldName.stripSuffix(s"${XTypeRecovery.DummyMemberLoad}$pathSep${f.canonicalName}"))
+          Set(fieldName.stripSuffix(s"${XTypeRecovery.DummyMemberLoad}$pathSep${fi.canonicalName}"))
         )
       case _ =>
         logger.warn(s"Unable to assign identifier '${i.name}' to field load '$fieldName' @ ${debugLocation(i)}")
@@ -837,7 +837,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
           case _ =>
         }
         // This field may be a function pointer
-        handlePotentialFunctionPointer(fieldAccess, idHints, f.canonicalName, f.argumentIndex, Option(i.name))
+        handlePotentialFunctionPointer(fieldAccess, idHints, f.canonicalName, Option(i.name))
       case _ => persistType(x, symbolTable.get(x))
     }
 
@@ -857,7 +857,6 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     funcPtr: Expression,
     baseTypes: Set[String],
     funcName: String,
-    argIdx: Int,
     baseName: Option[String] = None
   ): Unit = {
     // Sometimes the function identifier is an argument to the call itself as a "base". In this case we don't need
@@ -873,7 +872,6 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
           NewMethodRef()
             .code(s"${baseName.map(_.appended(pathSep)).getOrElse("")}$funcName")
             .methodFullName(m.fullName)
-            .argumentIndex(argIdx + 1)
             .lineNumber(funcPtr.lineNumber)
             .columnNumber(funcPtr.columnNumber)
         )
@@ -889,8 +887,13 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
             builder.addNode(mRef)
             builder.addEdge(mRef, m, EdgeTypes.REF)
             builder.addEdge(inCall, mRef, EdgeTypes.AST)
-            if (inCall.isInstanceOf[Call]) builder.addEdge(inCall, mRef, EdgeTypes.ARGUMENT)
-            mRef.argumentIndex(inCall.astChildren.size)
+            inCall match {
+              case x: Call =>
+                builder.addEdge(x, mRef, EdgeTypes.ARGUMENT)
+                mRef.argumentIndex(x.argumentOut.size + 1)
+              case x =>
+                mRef.argumentIndex(x.astChildren.size + 1)
+            }
           }
         addedNodes.add((funcPtr.id(), s"${mRef.label()}$pathSep${mRef.methodFullName}"))
       }
@@ -903,7 +906,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
       x match {
         case i: Identifier if symbolTable.contains(i) =>
           if (isField(i)) persistMemberType(i, filteredTypes)
-          handlePotentialFunctionPointer(i, filteredTypes, i.name, i.argumentIndex)
+          handlePotentialFunctionPointer(i, filteredTypes, i.name)
         case _ =>
       }
     }


### PR DESCRIPTION
* Revisit #2501 where a bug was found that methods AST parent was the <meta> type but the path was the true type decl.
* Solution was to aggregate concrete method and members to the true type decl where <fakeNew> and other meta-related stuff goes under the <meta> type
* This results in simplified code under type recovery and a small adjustment in the data-flow engine source calculation
* XTypeRecovery now pattern matches arguments against cons operators instead of exact lists to silence some noisy warnings