### PR TITLE
jssrc2cpg: Fix Call on Closure Definition Name

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -41,6 +41,15 @@ trait AstForExpressionsCreator { this: AstCreator =>
         callExpr.lineNumber,
         callExpr.columnNumber
       )
+    // If the callee is a function itself, e.g. closure, then resolve this locally, if possible
+    callExpr.json.obj
+      .get("callee")
+      .map(createBabelNodeInfo)
+      .flatMap {
+        case callee if callee.node.isInstanceOf[FunctionLike] => functionNodeToNameAndFullName.get(callee)
+        case _                                                => None
+      }
+      .foreach { case (name, fullName) => callNode.name(name).methodFullName(fullName) }
     callAst(callNode, args, receiver = Option(receiverAst), base = Option(Ast(baseNode)))
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -223,6 +223,12 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
       val Some(x) = cpg.file("foo.js").ast.isCall.nameExact("getIncrementalInteger").headOption
       x.methodFullName shouldBe "util.js::program:getIncrementalInteger"
     }
+
+    "resolve the full name of the currying from the closure" in {
+      val Some(x) = cpg.file("util.js").ast.isCall.lineNumber(4).lastOption
+      x.name shouldBe "anonymous"
+      x.methodFullName shouldBe "util.js::program:anonymous"
+    }
   }
 
 }


### PR DESCRIPTION
When a closure is defined directly on an export, there is some kind of currying to enable the export to be a function pointer. This means that the "callee" is a function itself, which leads to the "name" property to be the whole function body. This fix checks the callee for being a function and resolves it locally using the `functionNodeToNameAndFullName` mapping. e.g. of bug (where `name` and `methodFullName` is now the name and path of the function):
Example of this in the wild: https://github.com/PubMatic/OpenWrap/blob/10cdc6557eb401e82db8d184602deb6f073653d0/src_new/util.js#L173
```
Call(
    id = 46774L,
    argumentIndex = 2,
    argumentName = None,
    code = """(function() {
	var count = 0;
	return function() {
		count++;
		return count;
	};
})()""",
    columnNumber = Some(value = 32),
    dispatchType = "DYNAMIC_DISPATCH",
    dynamicTypeHintFullName = ArraySeq(),
    lineNumber = Some(value = 142),
    methodFullName = """import("src_new/util.js"):function() {
	var count = 0;
	return function() {
		count++;
		return count;
	};
}""",
    name = """function() {
	var count = 0;
	return function() {
		count++;
		return count;
	};
}""",
    order = 2,
    signature = "",
    typeFullName = "ANY"
  )
```