### PR TITLE
jssrc2cpg: Closures Assigned to Mutable Var

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
@@ -2,7 +2,7 @@ package io.joern.jssrc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.PropertyNames
-import io.shiftleft.codepropertygraph.generated.nodes.{Method, MethodRef}
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Method, MethodRef}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
@@ -10,8 +10,18 @@ import overflowdb.traversal._
 /** A pass that identifies assignments of closures to constants and updates `METHOD` nodes accordingly.
   */
 class ConstClosurePass(cpg: Cpg) extends CpgPass(cpg) {
+
+  // Keeps track of how many times an identifier has been on the LHS of an assignment, by name
+  protected lazy val identifiersAssignedCount: Map[String, Int] =
+    cpg.assignment.target.collectAll[Identifier].name.groupCount
+
   override def run(diffGraph: DiffGraphBuilder): Unit = {
-    // Handle const closures
+    handleConstClosures(diffGraph)
+    handleClosuresDefinedAtExport(diffGraph)
+    handleClosuresAssignedToMutableVar(diffGraph)
+  }
+
+  protected def handleConstClosures(diffGraph: DiffGraphBuilder): Unit =
     for {
       assignment      <- cpg.assignment
       name            <- assignment.filter(_.code.startsWith("const ")).target.isIdentifier.name
@@ -21,7 +31,8 @@ class ConstClosurePass(cpg: Cpg) extends CpgPass(cpg) {
     } {
       updateClosures(diffGraph, method, methodRef, enclosingMethod, name)
     }
-    // Handle closures defined at exports
+
+  protected def handleClosuresDefinedAtExport(diffGraph: DiffGraphBuilder): Unit =
     for {
       assignment <- cpg.assignment
       name <- assignment.filter(_.code.startsWith("export")).target.isCall.argument.isFieldIdentifier.canonicalName.l
@@ -31,7 +42,20 @@ class ConstClosurePass(cpg: Cpg) extends CpgPass(cpg) {
     } {
       updateClosures(diffGraph, method, methodRef, enclosingMethod, name)
     }
-  }
+
+  protected def handleClosuresAssignedToMutableVar(diffGraph: DiffGraphBuilder): Unit =
+    // Handle closures assigned to mutable variables
+    for {
+      assignment      <- cpg.assignment
+      name            <- assignment.start.code("^(var|let) .*").target.isIdentifier.name
+      methodRef       <- assignment.start.source.ast.isMethodRef
+      method          <- methodRef.referencedMethod
+      enclosingMethod <- assignment.start.method.fullName
+    } {
+      // Conservatively update closures, i.e, if we only find 1 assignment where this variable is on the LHS
+      if (identifiersAssignedCount.getOrElse(name, -1) == 1)
+        updateClosures(diffGraph, method, methodRef, enclosingMethod, name)
+    }
 
   private def updateClosures(
     diffGraph: DiffGraphBuilder,

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConstClosurePassTests.scala
@@ -31,4 +31,31 @@ class ConstClosurePassTests extends DataFlowCodeToCpgSuite {
     m.fullName.endsWith("program:foo") shouldBe true
   }
 
+  "mutable variables assigned to closures" should {
+    val cpg = code("""
+        |var foo = function() {};
+        |foo();
+        |
+        |var bar = function() {};
+        |bar();
+        |bar = 2;
+        |""".stripMargin)
+
+    "be treated as a constant if not reassigned in the CPG" in {
+      val List(foo) = cpg.method.name("foo").l
+      foo.name shouldBe "foo"
+      foo.fullName.endsWith("program:foo") shouldBe true
+      val Some(fooCall) = cpg.call("foo").headOption
+      fooCall.methodFullName.endsWith("program:foo") shouldBe true
+    }
+
+    "keep the identifier assigned to the anonymous name if it is reassigned later" in {
+      val List(bar) = cpg.method.name("anonymous1").l
+      bar.name shouldBe "anonymous1"
+      bar.fullName.endsWith("program:anonymous1") shouldBe true
+      val Some(barCall) = cpg.call("bar").headOption
+      barCall.methodFullName.endsWith("program:anonymous1") shouldBe true
+    }
+  }
+
 }


### PR DESCRIPTION
If a closure is assigned to a mutable variable, and it is effectively treated as a constant (i.e. no reassignments), then set the closure names to the target name.