### PR TITLE
x2cpg: rename node creation fns

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{ExpressionNew, NewNode}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.NodeBuilders.dependencyNode
+import io.joern.x2cpg.utils.NodeBuilders.newDependencyNode
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.utils.IOUtils
 import org.apache.commons.lang.StringUtils
@@ -401,7 +401,7 @@ trait AstCreatorHelper { this: AstCreator =>
     val allIncludes = iASTTranslationUnit.getIncludeDirectives.toIndexedSeq
     allIncludes.foreach { include =>
       val name            = include.getName.toString
-      val _dependencyNode = dependencyNode(name, name, IncludeKeyword)
+      val _dependencyNode = newDependencyNode(name, name, IncludeKeyword)
       val importNode      = newImportNode(nodeSignature(include), name, include)
       diffGraph.addNode(_dependencyNode)
       diffGraph.addEdge(importNode, _dependencyNode, EdgeTypes.IMPORTS)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstNodeBuilder.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.astcreation
 
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
+import io.joern.x2cpg.utils.NodeBuilders.{newMethodReturnNode => newMethodReturnNode_}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import org.apache.commons.lang.StringUtils
 import org.eclipse.cdt.core.dom.ast.{IASTLabelStatement, IASTNode}
@@ -77,7 +77,7 @@ trait AstNodeBuilder { this: AstCreator =>
   }
 
   protected def newMethodReturnNode(node: IASTNode, typeFullName: String): NewMethodReturn = {
-    newMethodReturnNode(typeFullName, None, line(node), column(node))
+    newMethodReturnNode_(typeFullName, None, line(node), column(node))
   }
 
   protected def newParameterInNode(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstNodeBuilder.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.astcreation
 
-import io.joern.x2cpg.utils.NodeBuilders.methodReturnNode
+import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.nodes._
 import org.apache.commons.lang.StringUtils
 import org.eclipse.cdt.core.dom.ast.{IASTLabelStatement, IASTNode}
@@ -77,7 +77,7 @@ trait AstNodeBuilder { this: AstCreator =>
   }
 
   protected def newMethodReturnNode(node: IASTNode, typeFullName: String): NewMethodReturn = {
-    methodReturnNode(typeFullName, None, line(node), column(node))
+    newMethodReturnNode(typeFullName, None, line(node), column(node))
   }
 
   protected def newParameterInNode(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/HeaderContentPass.scala
@@ -12,7 +12,7 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.utils.NodeBuilders.methodReturnNode
+import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import overflowdb.traversal.toNodeTraversal
 
 class HeaderContentPass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
@@ -46,7 +46,7 @@ class HeaderContentPass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
 
     val blockNode = NewBlock().typeFullName(Defines.anyTypeName)
 
-    val methodReturn = methodReturnNode(Defines.anyTypeName, line = None, column = None)
+    val methodReturn = newMethodReturnNode(Defines.anyTypeName, line = None, column = None)
 
     val ast = Ast(includesFile).withChild(
       Ast(namespaceBlock)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -90,13 +90,13 @@ import com.github.javaparser.symbolsolver.JavaSymbolSolver
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator
 import io.joern.javasrc2cpg.util.BindingTable.createBindingTable
 import io.joern.x2cpg.utils.NodeBuilders.{
-  annotationLiteralNode,
-  callNode,
-  fieldIdentifierNode => newFieldIdentifierNode,
-  identifierNode,
-  methodReturnNode,
-  modifierNode,
-  operatorCallNode
+  newAnnotationLiteralNode,
+  newCallNode,
+  newFieldIdentifierNode,
+  newIdentifierNode,
+  newMethodReturnNode,
+  newModifierNode,
+  newOperatorCallNode
 }
 import io.joern.javasrc2cpg.util.Scope.ScopeTypes.{BlockScope, MethodScope, NamespaceScope, TypeDeclScope}
 import io.joern.javasrc2cpg.util.Scope.WildcardImportName
@@ -480,7 +480,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .getOrElse(TypeConstants.Object)
     typeInfoCalc.registerType(typeFullName)
 
-    identifierNode(name, Some(typeFullName))
+    newIdentifierNode(name, Some(typeFullName))
   }
 
   private def identifierForResolvedTypeParameter(typeParameter: ResolvedTypeParameterDeclaration): NewIdentifier = {
@@ -489,7 +489,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .flatMap(typeInfoCalc.fullName)
       .getOrElse(TypeConstants.Object)
     typeInfoCalc.registerType(typeFullName)
-    identifierNode(name, Some(typeFullName))
+    newIdentifierNode(name, Some(typeFullName))
   }
 
   private def clinitAstFromStaticInits(staticInits: Seq[Ast]): Option[Ast] = {
@@ -541,10 +541,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     } else {
       None
     }
-    val accessModifier = accessModifierType.map(modifierNode)
+    val accessModifier = accessModifierType.map(newModifierNode)
 
     val abstractModifier =
-      Option.when(isInterface || typ.getMethods.asScala.exists(_.isAbstract))(modifierNode(ModifierTypes.ABSTRACT))
+      Option.when(isInterface || typ.getMethods.asScala.exists(_.isAbstract))(newModifierNode(ModifierTypes.ABSTRACT))
 
     List(accessModifier, abstractModifier).flatten
   }
@@ -700,9 +700,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val thisAst = Ast(thisNodeForMethod(typeFullName, lineNumber = None))
     val bodyAst = Ast(NewBlock()).withChildren(scopeStack.getMemberInitializers)
 
-    val returnNode = methodReturnNode(TypeConstants.Void, line = None, column = None)
+    val returnNode = newMethodReturnNode(TypeConstants.Void, line = None, column = None)
 
-    val modifiers = List(modifierNode(ModifierTypes.CONSTRUCTOR), modifierNode(ModifierTypes.PUBLIC))
+    val modifiers = List(newModifierNode(ModifierTypes.CONSTRUCTOR), newModifierNode(ModifierTypes.PUBLIC))
 
     methodAstWithAnnotations(constructorNode, Seq(thisAst), bodyAst, returnNode, modifiers)
   }
@@ -733,7 +733,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def modifiersForFieldDeclaration(decl: FieldDeclaration): Seq[Ast] = {
     val staticModifier =
-      Option.when(decl.isStatic)(modifierNode(ModifierTypes.STATIC))
+      Option.when(decl.isStatic)(newModifierNode(ModifierTypes.STATIC))
 
     val accessModifierType =
       if (decl.isPublic)
@@ -745,7 +745,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       else
         None
 
-    val accessModifier = accessModifierType.map(modifierNode)
+    val accessModifier = accessModifierType.map(newModifierNode)
 
     List(staticModifier, accessModifier).flatten.map(Ast(_))
   }
@@ -837,7 +837,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     lineNumber: Option[Integer]
   ): NewMethodParameterIn = {
     val typeFullName = typeInfoCalc.registerType(maybeTypeFullName.getOrElse(TypeConstants.Any))
-    NodeBuilders.thisParameterNode(typeFullName, maybeTypeFullName.toSeq, lineNumber)
+    NodeBuilders.newThisParameterNode(typeFullName, maybeTypeFullName.toSeq, lineNumber)
   }
 
   private def convertAnnotationValueExpr(expr: Expression): Option[Ast] = {
@@ -889,14 +889,14 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   private def astForAnnotationLiteralExpr(literalExpr: LiteralExpr): Ast = {
     val valueNode =
       literalExpr match {
-        case literal: StringLiteralExpr    => annotationLiteralNode(literal.getValue)
-        case literal: IntegerLiteralExpr   => annotationLiteralNode(literal.getValue)
-        case literal: BooleanLiteralExpr   => annotationLiteralNode(java.lang.Boolean.toString(literal.getValue))
-        case literal: CharLiteralExpr      => annotationLiteralNode(literal.getValue)
-        case literal: DoubleLiteralExpr    => annotationLiteralNode(literal.getValue)
-        case literal: LongLiteralExpr      => annotationLiteralNode(literal.getValue)
-        case _: NullLiteralExpr            => annotationLiteralNode("null")
-        case literal: TextBlockLiteralExpr => annotationLiteralNode(literal.getValue)
+        case literal: StringLiteralExpr    => newAnnotationLiteralNode(literal.getValue)
+        case literal: IntegerLiteralExpr   => newAnnotationLiteralNode(literal.getValue)
+        case literal: BooleanLiteralExpr   => newAnnotationLiteralNode(java.lang.Boolean.toString(literal.getValue))
+        case literal: CharLiteralExpr      => newAnnotationLiteralNode(literal.getValue)
+        case literal: DoubleLiteralExpr    => newAnnotationLiteralNode(literal.getValue)
+        case literal: LongLiteralExpr      => newAnnotationLiteralNode(literal.getValue)
+        case _: NullLiteralExpr            => newAnnotationLiteralNode("null")
+        case literal: TextBlockLiteralExpr => newAnnotationLiteralNode(literal.getValue)
       }
 
     Ast(valueNode)
@@ -971,7 +971,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     callableDeclaration match {
       case methodDeclaration: MethodDeclaration =>
         Option.when(methodDeclaration.isAbstract || (isInterfaceMethod && !methodDeclaration.isDefault)) {
-          modifierNode(ModifierTypes.ABSTRACT)
+          newModifierNode(ModifierTypes.ABSTRACT)
         }
 
       case _ => None
@@ -984,7 +984,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val abstractModifier = abstractModifierForCallable(methodDeclaration, isInterfaceMethod)
 
     val staticVirtualModifierType = if (methodDeclaration.isStatic) ModifierTypes.STATIC else ModifierTypes.VIRTUAL
-    val staticVirtualModifier     = Some(modifierNode(staticVirtualModifierType))
+    val staticVirtualModifier     = Some(newModifierNode(staticVirtualModifierType))
 
     val accessModifierType = if (methodDeclaration.isPublic) {
       Some(ModifierTypes.PUBLIC)
@@ -998,7 +998,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     } else {
       None
     }
-    val accessModifier = accessModifierType.map(modifierNode)
+    val accessModifier = accessModifierType.map(newModifierNode)
 
     List(accessModifier, abstractModifier, staticVirtualModifier).flatten
   }
@@ -1043,7 +1043,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     }
 
     val bodyAst = methodDeclaration.getBody.toScala.map(astForBlockStatement(_)).getOrElse(Ast(NewBlock()))
-    val methodReturn = methodReturnNode(
+    val methodReturn = newMethodReturnNode(
       returnTypeFullName.getOrElse(TypeConstants.Any),
       None,
       line(methodDeclaration.getType),
@@ -1062,7 +1062,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   private def constructorReturnNode(constructorDeclaration: ConstructorDeclaration): NewMethodReturn = {
     val line   = constructorDeclaration.getEnd.map(x => Integer.valueOf(x.line)).toScala
     val column = constructorDeclaration.getEnd.map(x => Integer.valueOf(x.column)).toScala
-    methodReturnNode(TypeConstants.Void, None, line, column)
+    newMethodReturnNode(TypeConstants.Void, None, line, column)
   }
 
   /** Constructor and Method declarations share a lot of fields, so this method adds the fields they have in common.
@@ -1339,8 +1339,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val iterableLocalAst = Ast(iterableLocalNode)
 
     val iterableAssignNode =
-      operatorCallNode(Operators.assignment, code = "", line = lineNo, typeFullName = iterableType)
-    val iterableAssignIdentifier = identifierNode(iterableName, iterableType, lineNo)
+      newOperatorCallNode(Operators.assignment, code = "", line = lineNo, typeFullName = iterableType)
+    val iterableAssignIdentifier = newIdentifierNode(iterableName, iterableType, lineNo)
     val iterableAssignArgs       = List(Ast(iterableAssignIdentifier), iterableAst)
     val iterableAssignAst =
       callAst(iterableAssignNode, iterableAssignArgs)
@@ -1367,13 +1367,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def nativeForEachIdxInitializerAst(lineNo: Option[Integer], idxLocal: NewLocal): Ast = {
     val idxName = idxLocal.name
-    val idxInitializerCallNode = operatorCallNode(
+    val idxInitializerCallNode = newOperatorCallNode(
       Operators.assignment,
       code = s"int $idxName = 0",
       line = lineNo,
       typeFullName = Some(TypeConstants.Int)
     )
-    val idxIdentifierArg = identifierNode(idxName, Some(idxLocal.typeFullName), lineNo)
+    val idxIdentifierArg = newIdentifierNode(idxName, Some(idxLocal.typeFullName), lineNo)
     val zeroLiteral =
       NewLiteral()
         .code("0")
@@ -1391,20 +1391,20 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   ): Ast = {
     val idxName = idxLocal.name
 
-    val compareNode = operatorCallNode(
+    val compareNode = newOperatorCallNode(
       Operators.lessThan,
       code = s"$idxName < ${iterableSource.name}.length",
       typeFullName = Some(TypeConstants.Boolean),
       line = lineNo
     )
-    val comparisonIdxIdentifier = identifierNode(idxName, Some(idxLocal.typeFullName), lineNo)
-    val comparisonFieldAccess = operatorCallNode(
+    val comparisonIdxIdentifier = newIdentifierNode(idxName, Some(idxLocal.typeFullName), lineNo)
+    val comparisonFieldAccess = newOperatorCallNode(
       Operators.fieldAccess,
       code = s"${iterableSource.name}.length",
       typeFullName = Some(TypeConstants.Int),
       line = lineNo
     )
-    val fieldAccessIdentifier      = identifierNode(iterableSource.name, iterableSource.typeFullName, lineNo)
+    val fieldAccessIdentifier      = newIdentifierNode(iterableSource.name, iterableSource.typeFullName, lineNo)
     val fieldAccessFieldIdentifier = newFieldIdentifierNode("length", lineNo)
     val fieldAccessArgs            = List(fieldAccessIdentifier, fieldAccessFieldIdentifier).map(Ast(_))
     val fieldAccessAst             = callAst(comparisonFieldAccess, fieldAccessArgs)
@@ -1419,13 +1419,13 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def nativeForEachIncrementAst(lineNo: Option[Integer], idxLocal: NewLocal): Ast = {
-    val incrementNode = operatorCallNode(
+    val incrementNode = newOperatorCallNode(
       Operators.postIncrement,
       code = s"${idxLocal.name}++",
       typeFullName = Some(TypeConstants.Int),
       line = lineNo
     )
-    val incrementArg    = identifierNode(idxLocal.name, Some(idxLocal.typeFullName), lineNo)
+    val incrementArg    = newIdentifierNode(idxLocal.name, Some(idxLocal.typeFullName), lineNo)
     val incrementArgAst = Ast(incrementArg)
     callAst(incrementNode, List(incrementArgAst))
       .withRefEdge(incrementArg, idxLocal)
@@ -1481,16 +1481,16 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     // solution for debugging.
     val lineNo = variableLocal.lineNumber
     val varAssignNode =
-      operatorCallNode(Operators.assignment, PropertyDefaults.Code, Some(variableLocal.typeFullName), lineNo)
+      newOperatorCallNode(Operators.assignment, PropertyDefaults.Code, Some(variableLocal.typeFullName), lineNo)
 
-    val targetNode = identifierNode(variableLocal.name, Some(variableLocal.typeFullName), lineNo)
+    val targetNode = newIdentifierNode(variableLocal.name, Some(variableLocal.typeFullName), lineNo)
 
     val indexAccessTypeFullName = iterable.typeFullName.map(_.replaceAll(raw"\[]", ""))
     val indexAccess =
-      operatorCallNode(Operators.indexAccess, PropertyDefaults.Code, indexAccessTypeFullName, lineNo)
+      newOperatorCallNode(Operators.indexAccess, PropertyDefaults.Code, indexAccessTypeFullName, lineNo)
 
-    val indexAccessIdentifier = identifierNode(iterable.name, iterable.typeFullName, lineNo)
-    val indexAccessIndex      = identifierNode(idxLocal.name, Some(idxLocal.typeFullName), lineNo)
+    val indexAccessIdentifier = newIdentifierNode(iterable.name, iterable.typeFullName, lineNo)
+    val indexAccessIndex      = newIdentifierNode(idxLocal.name, Some(idxLocal.typeFullName), lineNo)
 
     val indexAccessArgsAsts = List(indexAccessIdentifier, indexAccessIndex).map(Ast(_))
     val indexAccessAst      = callAst(indexAccess, indexAccessArgsAsts)
@@ -1575,11 +1575,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     lineNo: Option[Integer]
   ): Ast = {
     val iteratorAssignNode =
-      operatorCallNode(Operators.assignment, code = "", typeFullName = Some(TypeConstants.Iterator), line = lineNo)
-    val iteratorAssignIdentifier = identifierNode(iteratorLocalNode.name, Some(iteratorLocalNode.typeFullName), lineNo)
+      newOperatorCallNode(Operators.assignment, code = "", typeFullName = Some(TypeConstants.Iterator), line = lineNo)
+    val iteratorAssignIdentifier = newIdentifierNode(iteratorLocalNode.name, Some(iteratorLocalNode.typeFullName), lineNo)
 
     val iteratorCallNode =
-      callNode("iterator", iterableType, TypeConstants.Iterator, DispatchTypes.DYNAMIC_DISPATCH, lineNumber = lineNo)
+      newCallNode("iterator", iterableType, TypeConstants.Iterator, DispatchTypes.DYNAMIC_DISPATCH, lineNumber = lineNo)
 
     val actualIteratorAst = astsForExpression(iterExpr, expectedType = ExpectedType.empty).toList match {
       case Nil =>
@@ -1602,7 +1602,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def hasNextCallAstForForEach(iteratorLocalNode: NewLocal, lineNo: Option[Integer]): Ast = {
     val iteratorHasNextCallNode =
-      callNode(
+      newCallNode(
         "hasNext",
         Some(TypeConstants.Iterator),
         TypeConstants.Boolean,
@@ -1610,7 +1610,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         lineNumber = lineNo
       )
     val iteratorHasNextCallReceiver =
-      identifierNode(iteratorLocalNode.name, Some(iteratorLocalNode.typeFullName), lineNo)
+      newIdentifierNode(iteratorLocalNode.name, Some(iteratorLocalNode.typeFullName), lineNo)
 
     callAst(iteratorHasNextCallNode, base = Some(Ast(iteratorHasNextCallReceiver)))
       .withRefEdge(iteratorHasNextCallReceiver, iteratorLocalNode)
@@ -1620,18 +1620,18 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val lineNo          = variableLocal.lineNumber
     val forVariableType = variableLocal.typeFullName
     val varLocalAssignNode =
-      operatorCallNode(Operators.assignment, PropertyDefaults.Code, Some(forVariableType), lineNo)
-    val varLocalAssignIdentifier = identifierNode(variableLocal.name, Some(variableLocal.typeFullName), lineNo)
+      newOperatorCallNode(Operators.assignment, PropertyDefaults.Code, Some(forVariableType), lineNo)
+    val varLocalAssignIdentifier = newIdentifierNode(variableLocal.name, Some(variableLocal.typeFullName), lineNo)
 
     val iterNextCallNode =
-      callNode(
+      newCallNode(
         "next",
         Some(TypeConstants.Iterator),
         TypeConstants.Object,
         DispatchTypes.DYNAMIC_DISPATCH,
         lineNumber = lineNo
       )
-    val iterNextCallReceiver = identifierNode(iteratorLocalNode.name, Some(iteratorLocalNode.typeFullName), lineNo)
+    val iterNextCallReceiver = newIdentifierNode(iteratorLocalNode.name, Some(iteratorLocalNode.typeFullName), lineNo)
     val iterNextCallAst =
       callAst(iterNextCallNode, base = Some(Ast(iterNextCallReceiver)))
         .withRefEdge(iterNextCallReceiver, iteratorLocalNode)
@@ -1715,7 +1715,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .lineNumber(line(stmt))
         .columnNumber(column(stmt))
 
-    val modifier = Ast(modifierNode("SYNCHRONIZED"))
+    val modifier = Ast(newModifierNode("SYNCHRONIZED"))
 
     val exprAsts = astsForExpression(stmt.getExpression, ExpectedType.empty)
     val bodyAst  = astForBlockStatement(stmt.getBody)
@@ -1821,7 +1821,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
 
-    val callNode = operatorCallNode(
+    val callNode = newOperatorCallNode(
       operatorName,
       code = expr.toString,
       typeFullName = Some(typeFullName),
@@ -1837,7 +1837,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
-    val callNode = operatorCallNode(
+    val callNode = newOperatorCallNode(
       Operators.indexAccess,
       code = expr.toString,
       typeFullName = Some(typeFullName),
@@ -1862,7 +1862,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     maybeInitializerAst.getOrElse {
       val typeFullName = expressionReturnTypeFullName(expr).orElse(expectedType.fullName).getOrElse(TypeConstants.Any)
-      val callNode     = operatorCallNode(Operators.alloc, code = expr.toString, typeFullName = Some(typeFullName))
+      val callNode     = newOperatorCallNode(Operators.alloc, code = expr.toString, typeFullName = Some(typeFullName))
       val levelAsts = expr.getLevels.asScala.flatMap { lvl =>
         lvl.getDimension.toScala match {
           case Some(dimension) => astsForExpression(dimension, ExpectedType.Int)
@@ -1879,7 +1879,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
-    val callNode = operatorCallNode(
+    val callNode = newOperatorCallNode(
       Operators.arrayInitializer,
       code = expr.toString,
       typeFullName = Some(typeFullName),
@@ -1950,7 +1950,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
 
-    val callNode = operatorCallNode(
+    val callNode = newOperatorCallNode(
       operatorName,
       code = expr.toString,
       typeFullName = Some(typeFullName),
@@ -1968,7 +1968,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
 
-    val callNode = operatorCallNode(
+    val callNode = newOperatorCallNode(
       Operators.cast,
       code = expr.toString,
       typeFullName = Some(typeFullName),
@@ -2023,7 +2023,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val code = s"${targetAst.rootCodeOrEmpty} ${expr.getOperator.asString} ${argsAsts.rootCodeOrEmpty}"
 
-    val callNode = operatorCallNode(operatorName, code, Some(typeFullName), line(expr), column(expr))
+    val callNode = newOperatorCallNode(operatorName, code, Some(typeFullName), line(expr), column(expr))
 
     if (partialConstructorQueue.isEmpty) {
       val assignAst = callAst(callNode, targetAst ++ argsAsts)
@@ -2126,7 +2126,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .getOrElse(s"${Defines.UnresolvedNamespace}.${variable.getTypeAsString}")
       val code = s"$typeName $name = ${initializerAsts.rootCodeOrEmpty}"
 
-      val callNode = operatorCallNode(Operators.assignment, code, typeFullName, lineNumber, columnNumber)
+      val callNode = newOperatorCallNode(Operators.assignment, code, typeFullName, lineNumber, columnNumber)
 
       val targetAst = scopeStack.lookupVariable(name) match {
         case Some(nodeTypeInfo) if nodeTypeInfo.isField && !nodeTypeInfo.isStatic =>
@@ -2135,7 +2135,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
         case maybeCorrespNode =>
           val identifier =
-            identifierNode(name, Some(typeFullName.getOrElse(TypeConstants.Any)), line(variable), column(variable))
+            newIdentifierNode(name, Some(typeFullName.getOrElse(TypeConstants.Any)), line(variable), column(variable))
           Ast(identifier).withRefEdges(identifier, maybeCorrespNode.map(_.node).toList)
       }
 
@@ -2183,10 +2183,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def astForClassExpr(expr: ClassExpr): Ast = {
     val someTypeFullName = Some(TypeConstants.Class)
-    val callNode = operatorCallNode(Operators.fieldAccess, expr.toString, someTypeFullName, line(expr), column(expr))
+    val callNode = newOperatorCallNode(Operators.fieldAccess, expr.toString, someTypeFullName, line(expr), column(expr))
 
     val identifierType = typeInfoCalc.fullName(expr.getType)
-    val identifier     = identifierNode(expr.getTypeAsString, identifierType, line(expr), column(expr))
+    val identifier     = newIdentifierNode(expr.getTypeAsString, identifierType, line(expr), column(expr))
     val idAst          = Ast(identifier)
 
     val fieldIdentifier = NewFieldIdentifier()
@@ -2211,7 +2211,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
 
-    val callNode = operatorCallNode(Operators.conditional, expr.toString, Some(typeFullName), line(expr), column(expr))
+    val callNode = newOperatorCallNode(Operators.conditional, expr.toString, Some(typeFullName), line(expr), column(expr))
 
     callAst(callNode, condAst ++ thenAst ++ elseAst)
   }
@@ -2226,7 +2226,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
 
-    val callNode = operatorCallNode(Operators.fieldAccess, expr.toString, Some(typeFullName), line(expr), column(expr))
+    val callNode = newOperatorCallNode(Operators.fieldAccess, expr.toString, Some(typeFullName), line(expr), column(expr))
 
     val fieldIdentifier = expr.getName
     val identifierAsts  = astsForExpression(expr.getScope, ExpectedType.empty)
@@ -2242,7 +2242,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def astForInstanceOfExpr(expr: InstanceOfExpr): Ast = {
     val booleanTypeFullName = Some(TypeConstants.Boolean)
-    val callNode = operatorCallNode(Operators.instanceOf, expr.toString, booleanTypeFullName, line(expr), column(expr))
+    val callNode = newOperatorCallNode(Operators.instanceOf, expr.toString, booleanTypeFullName, line(expr), column(expr))
 
     val exprAst      = astsForExpression(expr.getExpression, ExpectedType.empty)
     val typeFullName = typeInfoCalc.fullName(expr.getType).getOrElse(TypeConstants.Any)
@@ -2266,7 +2266,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     columnNo: Option[Integer]
   ): Ast = {
     val typeFullName     = identifierType.orElse(Some(TypeConstants.Any)).map(typeInfoCalc.registerType)
-    val identifier       = identifierNode(identifierName, typeFullName, lineNo, columnNo)
+    val identifier       = newIdentifierNode(identifierName, typeFullName, lineNo, columnNo)
     val maybeCorrespNode = scopeStack.lookupVariable(identifierName).map(_.node)
 
     val fieldIdentifier = NewFieldIdentifier()
@@ -2277,7 +2277,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val fieldAccessCode = s"$identifierName.$fieldIdentifierName"
     val fieldAccess =
-      operatorCallNode(
+      newOperatorCallNode(
         Operators.fieldAccess,
         fieldAccessCode,
         returnType.orElse(Some(TypeConstants.Any)),
@@ -2321,7 +2321,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
       case _ =>
         val identifier =
-          identifierNode(name, typeFullName.orElse(Some(TypeConstants.Any)), line(nameExpr), column(nameExpr))
+          newIdentifierNode(name, typeFullName.orElse(Some(TypeConstants.Any)), line(nameExpr), column(nameExpr))
 
         val variableOption = scopeStack
           .lookupVariable(name)
@@ -2402,7 +2402,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val argumentTypes = argumentTypesForMethodLike(maybeResolvedExpr)
 
-    val allocNode = operatorCallNode(
+    val allocNode = newOperatorCallNode(
       Operators.alloc,
       expr.toString,
       typeFullName.orElse(Some(TypeConstants.Any)),
@@ -2448,12 +2448,12 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     val tempName = "$obj" ++ tempConstCount.toString
     tempConstCount += 1
-    val identifier    = identifierNode(tempName, Some(allocNode.typeFullName))
+    val identifier    = newIdentifierNode(tempName, Some(allocNode.typeFullName))
     val identifierAst = Ast(identifier)
 
     val allocAst = Ast(allocNode)
 
-    val assignmentNode = operatorCallNode(Operators.assignment, PropertyDefaults.Code, Some(allocNode.typeFullName))
+    val assignmentNode = newOperatorCallNode(Operators.assignment, PropertyDefaults.Code, Some(allocNode.typeFullName))
 
     val assignmentAst = callAst(assignmentNode, List(identifierAst, allocAst))
 
@@ -2475,7 +2475,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.fullName)
 
-    val identifier = identifierNode(expr.toString, typeFullName, line(expr), column(expr))
+    val identifier = newIdentifierNode(expr.toString, typeFullName, line(expr), column(expr))
     val thisParam  = scopeStack.lookupVariable(NameConstants.This)
 
     thisParam.foreach { nodeTypeInfo =>
@@ -2503,7 +2503,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       column(stmt)
     )
 
-    val thisNode = identifierNode(NameConstants.This, typeFullName.orElse(Some(TypeConstants.Any)))
+    val thisNode = newIdentifierNode(NameConstants.This, typeFullName.orElse(Some(TypeConstants.Any)))
     scopeStack.lookupVariable(NameConstants.This).foreach { thisParam =>
       diffGraph.addEdge(thisNode, thisParam.node, EdgeTypes.REF)
     }
@@ -2606,7 +2606,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
     Option.when(maybeScope.isDefined || dispatchType == DispatchTypes.DYNAMIC_DISPATCH) {
       val name = maybeScope.map(_.toString).getOrElse(NameConstants.This)
-      identifierNode(name, typeFullName, line(call), column(call))
+      newIdentifierNode(name, typeFullName, line(call), column(call))
     }
   }
 
@@ -2840,10 +2840,10 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val parameters = thisParam ++ parametersWithoutThis
 
     val lambdaMethodNode = createLambdaMethodNode(lambdaMethodName, parametersWithoutThis, returnType)
-    val returnNode       = methodReturnNode(returnType.getOrElse(TypeConstants.Any), None, line(expr), column(expr))
-    val virtualModifier  = Some(modifierNode(ModifierTypes.VIRTUAL))
-    val staticModifier   = Option.when(thisParam.isEmpty)(modifierNode(ModifierTypes.STATIC))
-    val privateModifier  = Some(modifierNode(ModifierTypes.PRIVATE))
+    val returnNode       = newMethodReturnNode(returnType.getOrElse(TypeConstants.Any), None, line(expr), column(expr))
+    val virtualModifier  = Some(newModifierNode(ModifierTypes.VIRTUAL))
+    val staticModifier   = Option.when(thisParam.isEmpty)(newModifierNode(ModifierTypes.STATIC))
+    val privateModifier  = Some(newModifierNode(ModifierTypes.PRIVATE))
 
     val modifiers = List(virtualModifier, staticModifier, privateModifier).flatten.map(Ast(_))
 
@@ -3054,7 +3054,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       case Success(_) if hasVariadicParameter =>
         val expectedVariadicTypeFullName = getExpectedParamType(tryResolvedDecl, paramCount - 1).fullName
         val (regularArgs, varargs)       = argsAsts.splitAt(paramCount - 1)
-        val arrayInitializer = operatorCallNode(
+        val arrayInitializer = newOperatorCallNode(
           Operators.arrayInitializer,
           Operators.arrayInitializer,
           expectedVariadicTypeFullName,
@@ -3142,7 +3142,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     typeInfoCalc.registerType(typeFullName)
 
     val identifier =
-      identifierNode(NameConstants.Super, Some(typeFullName), line(superExpr), column(superExpr))
+      newIdentifierNode(NameConstants.Super, Some(typeFullName), line(superExpr), column(superExpr))
         .name(NameConstants.This) // Necessary for closed source dataflow
 
     Ast(identifier)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -1576,7 +1576,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   ): Ast = {
     val iteratorAssignNode =
       newOperatorCallNode(Operators.assignment, code = "", typeFullName = Some(TypeConstants.Iterator), line = lineNo)
-    val iteratorAssignIdentifier = newIdentifierNode(iteratorLocalNode.name, Some(iteratorLocalNode.typeFullName), lineNo)
+    val iteratorAssignIdentifier =
+      newIdentifierNode(iteratorLocalNode.name, Some(iteratorLocalNode.typeFullName), lineNo)
 
     val iteratorCallNode =
       newCallNode("iterator", iterableType, TypeConstants.Iterator, DispatchTypes.DYNAMIC_DISPATCH, lineNumber = lineNo)
@@ -2211,7 +2212,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
 
-    val callNode = newOperatorCallNode(Operators.conditional, expr.toString, Some(typeFullName), line(expr), column(expr))
+    val callNode =
+      newOperatorCallNode(Operators.conditional, expr.toString, Some(typeFullName), line(expr), column(expr))
 
     callAst(callNode, condAst ++ thenAst ++ elseAst)
   }
@@ -2226,7 +2228,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
 
-    val callNode = newOperatorCallNode(Operators.fieldAccess, expr.toString, Some(typeFullName), line(expr), column(expr))
+    val callNode =
+      newOperatorCallNode(Operators.fieldAccess, expr.toString, Some(typeFullName), line(expr), column(expr))
 
     val fieldIdentifier = expr.getName
     val identifierAsts  = astsForExpression(expr.getScope, ExpectedType.empty)
@@ -2242,7 +2245,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
   private def astForInstanceOfExpr(expr: InstanceOfExpr): Ast = {
     val booleanTypeFullName = Some(TypeConstants.Boolean)
-    val callNode = newOperatorCallNode(Operators.instanceOf, expr.toString, booleanTypeFullName, line(expr), column(expr))
+    val callNode =
+      newOperatorCallNode(Operators.instanceOf, expr.toString, booleanTypeFullName, line(expr), column(expr))
 
     val exprAst      = astsForExpression(expr.getExpression, ExpectedType.empty)
     val typeFullName = typeInfoCalc.fullName(expr.getType).getOrElse(TypeConstants.Any)

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -721,7 +721,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
             .argumentIndex(0)
             .dynamicTypeHintFullName(Seq(parentType))
         case x: NewMethodParameterIn =>
-          NodeBuilders.thisParameterNode(parentType, Seq(parentType), line(method.tryResolve()))
+          NodeBuilders.newThisParameterNode(parentType, Seq(parentType), line(method.tryResolve()))
         case x => x
       })
     } else {
@@ -1085,7 +1085,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
   private def astForMethodReturn(methodDeclaration: SootMethod): Ast = {
     val typeFullName = registerType(methodDeclaration.getReturnType.toQuotedString)
     val methodReturnNode = NodeBuilders
-      .methodReturnNode(typeFullName, None, line(methodDeclaration), None)
+      .newMethodReturnNode(typeFullName, None, line(methodDeclaration), None)
       .order(methodDeclaration.getParameterCount + 2)
     Ast(methodReturnNode)
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -6,8 +6,8 @@ import io.joern.jssrc2cpg.parser.BabelJsonParser.ParseResult
 import io.joern.jssrc2cpg.parser.BabelAst._
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.datastructures.Stack.{Stack, _}
-import io.joern.x2cpg.utils.NodeBuilders.methodReturnNode
+import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.{Ast, AstCreatorBase}
 import io.joern.x2cpg.{AstNodeBuilder => X2CpgAstNodeBuilder}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
@@ -115,7 +115,7 @@ class AstCreator(
     val methodChildren = astsForFile(astNodeInfo)
     setArgumentIndices(methodChildren)
 
-    val methodReturn = methodReturnNode(Defines.Any, line = None, column = None)
+    val methodReturn = newMethodReturnNode(Defines.Any, line = None, column = None)
 
     localAstParentStack.pop()
     scope.popScope()

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -5,7 +5,7 @@ import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.utils.NodeBuilders.methodReturnNode
+import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
@@ -51,7 +51,7 @@ trait AstNodeBuilder { this: AstCreator =>
       .columnNumber(column)
 
   protected def createMethodReturnNode(func: BabelNodeInfo): NewMethodReturn = {
-    methodReturnNode(typeFor(func), line = func.lineNumber, column = func.columnNumber)
+    newMethodReturnNode(typeFor(func), line = func.lineNumber, column = func.columnNumber)
   }
 
   protected def setOrderExplicitly(ast: Ast, order: Int): Unit = {

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -11,7 +11,7 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.joern.x2cpg.{Ast, Defines}
 import io.joern.x2cpg.datastructures.Stack._
 import io.joern.x2cpg.utils.NodeBuilders
-import io.joern.x2cpg.utils.NodeBuilders.methodReturnNode
+import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 
 import java.util.UUID.randomUUID
 import org.jetbrains.kotlin.psi._
@@ -123,7 +123,7 @@ trait KtPsiToAst {
     parameters.zipWithIndex.map { case (valueParam, idx) =>
       val typeFullName = registerType(typeInfoProvider.typeFullName(valueParam, TypeConstants.any))
 
-      val thisParam = NodeBuilders.thisParameterNode(typeDecl.fullName, Seq())
+      val thisParam = NodeBuilders.newThisParameterNode(typeDecl.fullName, Seq())
       val thisIdentifier =
         identifierNode(Constants.this_, typeDecl.fullName).dynamicTypeHintFullName(Seq(typeDecl.fullName))
       val thisAst = Ast(thisIdentifier).withRefEdge(thisIdentifier, thisParam)
@@ -145,7 +145,7 @@ trait KtPsiToAst {
         methodNode(componentName, fullName, signature, relativizedPath),
         Seq(Ast(thisParam)),
         methodBlockAst,
-        methodReturnNode(typeFullName, None, None, None)
+        newMethodReturnNode(typeFullName, None, None, None)
       )
     }
   }
@@ -162,7 +162,7 @@ trait KtPsiToAst {
         methodNode(Constants.init, fullName, signature, relativizedPath, line(ctor), column(ctor))
       scope.pushNewScope(secondaryCtorMethodNode)
 
-      val ctorThisParam = NodeBuilders.thisParameterNode(classFullName, Seq(classFullName))
+      val ctorThisParam = NodeBuilders.newThisParameterNode(classFullName, Seq(classFullName))
       scope.addToScope(Constants.this_, ctorThisParam)
 
       val constructorParamsAsts = Seq(Ast(ctorThisParam)) ++
@@ -172,7 +172,7 @@ trait KtPsiToAst {
       scope.popScope()
 
       val ctorMethodReturnNode =
-        methodReturnNode(TypeConstants.void, None, line(ctor), column(ctor))
+        newMethodReturnNode(TypeConstants.void, None, line(ctor), column(ctor))
 
       // TODO: see if necessary to take the other asts for the ctorMethodBlock
       methodAst(secondaryCtorMethodNode, constructorParamsAsts, ctorMethodBlockAst.head, ctorMethodReturnNode)
@@ -240,7 +240,7 @@ trait KtPsiToAst {
       line(ktClass.getPrimaryConstructor),
       column(ktClass.getPrimaryConstructor)
     )
-    val ctorThisParam = NodeBuilders.thisParameterNode(classFullName, Seq(classFullName))
+    val ctorThisParam = NodeBuilders.newThisParameterNode(classFullName, Seq(classFullName))
     scope.addToScope(Constants.this_, ctorThisParam)
 
     val constructorParamsAsts = Seq(Ast(ctorThisParam)) ++ withIndex(constructorParams) { (p, idx) =>
@@ -255,7 +255,7 @@ trait KtPsiToAst {
     val anonymousInitExpressions = ktClass.getAnonymousInitializers.asScala
     val anonymousInitAsts        = anonymousInitExpressions.flatMap(astsForExpression(_, None))
 
-    val constructorMethodReturn = methodReturnNode(
+    val constructorMethodReturn = newMethodReturnNode(
       TypeConstants.void,
       None,
       line(ktClass.getPrimaryConstructor),
@@ -378,7 +378,7 @@ trait KtPsiToAst {
 
     val thisParameterMaybe = if (needsThisParameter) {
       val typeDeclFullName = registerType(typeInfoProvider.containingTypeDeclFullName(ktFn, TypeConstants.any))
-      val node             = NodeBuilders.thisParameterNode(typeDeclFullName, Seq(typeDeclFullName))
+      val node             = NodeBuilders.newThisParameterNode(typeDeclFullName, Seq(typeDeclFullName))
       scope.addToScope(Constants.this_, node)
       Option(node)
     } else None
@@ -401,7 +401,7 @@ trait KtPsiToAst {
     val otherBodyAsts     = bodyAsts.drop(1)
     val explicitTypeName  = Option(ktFn.getTypeReference).map(_.getText).getOrElse(TypeConstants.any)
     val typeFullName      = registerType(typeInfoProvider.returnType(ktFn, explicitTypeName))
-    val _methodReturnNode = methodReturnNode(typeFullName, None, line(ktFn), column(ktFn))
+    val _methodReturnNode = newMethodReturnNode(typeFullName, None, line(ktFn), column(ktFn))
 
     val modifierNodes =
       if (withVirtualModifier) Seq(modifierNode(ModifierTypes.VIRTUAL))
@@ -586,7 +586,7 @@ trait KtPsiToAst {
       lambdaMethodNode,
       parametersAsts,
       bodyAst,
-      methodReturnNode(returnTypeFullName, None, line(expr), column(expr))
+      newMethodReturnNode(returnTypeFullName, None, line(expr), column(expr))
     ).withChild(Ast(modifierNode(ModifierTypes.VIRTUAL)))
 
     val _methodRefNode =

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -9,11 +9,11 @@ import io.joern.x2cpg.utils.AstPropertiesUtil.RootProperties
 import io.joern.x2cpg.{Ast, AstCreatorBase}
 import io.joern.x2cpg.Defines.{StaticInitMethodName, UnresolvedNamespace, UnresolvedSignature}
 import io.joern.x2cpg.utils.NodeBuilders.{
-  fieldIdentifierNode,
-  identifierNode,
-  methodReturnNode,
-  modifierNode,
-  operatorCallNode
+  newFieldIdentifierNode,
+  newIdentifierNode,
+  newMethodReturnNode,
+  newModifierNode,
+  newOperatorCallNode
 }
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes.Call.PropertyDefaults
@@ -137,7 +137,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
   private def astForEchoStmt(echoStmt: PhpEchoStmt): Ast = {
     val args     = echoStmt.exprs.map(astForExpr)
     val code     = s"echo ${args.map(_.rootCodeOrEmpty).mkString(",")}"
-    val callNode = operatorCallNode("echo", code, line = line(echoStmt))
+    val callNode = newOperatorCallNode("echo", code, line = line(echoStmt))
     callAst(callNode, args)
   }
 
@@ -159,7 +159,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
   private def thisIdentifier(lineNumber: Option[Integer]): NewIdentifier = {
     val typ = scope.getEnclosingTypeDeclTypeName
-    identifierNode(NameConstants.This, typ, dynamicTypeHintFullName = typ.toList, line = lineNumber)
+    newIdentifierNode(NameConstants.This, typ, dynamicTypeHintFullName = typ.toList, line = lineNumber)
       .code(s"$$${NameConstants.This}")
   }
 
@@ -203,7 +203,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     val parameters = thisParam.toList ++ setParamIndices(decl.params.map(astForParam))
 
-    val modifiers = decl.modifiers.map(modifierNode)
+    val modifiers = decl.modifiers.map(newModifierNode)
     val modifierString = decl.modifiers match {
       case Nil  => ""
       case mods => s"${mods.mkString(" ")} "
@@ -228,7 +228,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case staticStmt: PhpStaticStmt => astsForStaticStmt(staticStmt)
       case stmt                      => astForStmt(stmt) :: Nil
     }
-    val methodReturn = methodReturnNode(returnType, line = line(decl), column = None)
+    val methodReturn = newMethodReturnNode(returnType, line = line(decl), column = None)
 
     val declLocals = scope.getLocalsInScope.map(Ast(_))
     val methodBody = blockAst(NewBlock(), declLocals ++ methodBodyStmts)
@@ -488,7 +488,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
   private def astForDeclareStmt(stmt: PhpDeclareStmt): Ast = {
     val declareAssignAsts = stmt.declares.map(astForDeclareItem)
     val declareCode       = s"${PhpOperators.declareFunc}(${declareAssignAsts.map(_.rootCodeOrEmpty).mkString(",")})"
-    val declareNode       = operatorCallNode(PhpOperators.declareFunc, declareCode, line = line(stmt))
+    val declareNode       = newOperatorCallNode(PhpOperators.declareFunc, declareCode, line = line(stmt))
     val declareAst        = callAst(declareNode, declareAssignAsts)
 
     stmt.stmts match {
@@ -503,11 +503,11 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
   }
 
   private def astForDeclareItem(item: PhpDeclareItem): Ast = {
-    val key   = identifierNode(item.key.name, typeFullName = None, line = line(item))
+    val key   = newIdentifierNode(item.key.name, typeFullName = None, line = line(item))
     val value = astForExpr(item.value)
     val code  = s"${key.name}=${value.rootCodeOrEmpty}"
 
-    val declareAssignment = operatorCallNode(Operators.assignment, code, line = line(item))
+    val declareAssignment = newOperatorCallNode(Operators.assignment, code, line = line(item))
     callAst(declareAssignment, Ast(key) :: value :: Nil)
   }
 
@@ -527,7 +527,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val name = PhpOperators.unset
     val args = stmt.vars.map(astForExpr)
     val code = s"$name(${args.map(_.rootCodeOrEmpty).mkString(", ")})"
-    val callNode = operatorCallNode(name, code, typeFullName = Option(TypeConstants.Void), line = line(stmt))
+    val callNode = newOperatorCallNode(name, code, typeFullName = Option(TypeConstants.Void), line = line(stmt))
       .methodFullName(PhpOperators.unset)
     callAst(callNode, args)
   }
@@ -539,7 +539,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val varsAsts = stmt.vars.map(astForExpr)
     val code     = s"${PhpOperators.global} ${varsAsts.map(_.rootCodeOrEmpty).mkString(", ")}"
 
-    val globalCallNode = operatorCallNode(PhpOperators.global, code, Option(TypeConstants.Void), line(stmt))
+    val globalCallNode = newOperatorCallNode(PhpOperators.global, code, Option(TypeConstants.Void), line(stmt))
 
     callAst(globalCallNode, varsAsts)
   }
@@ -562,7 +562,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val valueAst = astForExpr(value)
 
     val code     = s"${keyAst.rootCodeOrEmpty} => ${valueAst.rootCodeOrEmpty}"
-    val callNode = operatorCallNode(PhpOperators.doubleArrow, code, line = lineNo)
+    val callNode = newOperatorCallNode(PhpOperators.doubleArrow, code, line = lineNo)
     callAst(callNode, keyAst :: valueAst :: Nil)
   }
 
@@ -588,9 +588,9 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val isNullName = PhpOperators.isNull
     val valueAst   = astForExpr(stmt.valueVar)
     val isNullCode = s"$isNullName(${valueAst.rootCodeOrEmpty})"
-    val isNullCall = operatorCallNode(isNullName, isNullCode, Option(TypeConstants.Bool), line(stmt))
+    val isNullCall = newOperatorCallNode(isNullName, isNullCode, Option(TypeConstants.Bool), line(stmt))
       .methodFullName(PhpOperators.isNull)
-    val notIsNull    = operatorCallNode(Operators.logicalNot, s"!$isNullCode", line = line(stmt))
+    val notIsNull    = newOperatorCallNode(Operators.logicalNot, s"!$isNullCode", line = line(stmt))
     val isNullAst    = callAst(isNullCall, valueAst :: Nil)
     val conditionAst = callAst(notIsNull, isNullAst :: Nil)
 
@@ -643,7 +643,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     val valueAst = if (stmt.assignByRef) {
       val addressOfCode = s"&${currentCallAst.rootCodeOrEmpty}"
-      val addressOfCall = operatorCallNode(Operators.addressOf, addressOfCode, line = line(stmt))
+      val addressOfCall = newOperatorCallNode(Operators.addressOf, addressOfCode, line = line(stmt))
       callAst(addressOfCall, currentCallAst :: Nil)
     } else {
       currentCallAst
@@ -654,7 +654,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
   private def simpleAssignAst(target: Ast, source: Ast, lineNo: Option[Integer]): Ast = {
     val code     = s"${target.rootCodeOrEmpty} = ${source.rootCodeOrEmpty}"
-    val callNode = operatorCallNode(Operators.assignment, code, line = lineNo)
+    val callNode = newOperatorCallNode(Operators.assignment, code, line = lineNo)
     callAst(callNode, target :: source :: Nil)
   }
 
@@ -701,7 +701,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
       val defaultAssignAst = maybeValueAst.map { valueAst =>
         val valueCode  = s"static $code = ${valueAst.rootCodeOrEmpty}"
-        val assignNode = operatorCallNode(Operators.assignment, valueCode, line = line(stmt))
+        val assignNode = newOperatorCallNode(Operators.assignment, valueCode, line = line(stmt))
         callAst(assignNode, variableAst :: valueAst :: Nil)
       }
 
@@ -747,7 +747,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     scope.pushNewScope(typeDeclNode)
     val bodyStmts = astsForClassLikeBody(stmt.stmts, createDefaultConstructor)
-    val modifiers = stmt.modifiers.map(modifierNode).map(Ast(_))
+    val modifiers = stmt.modifiers.map(newModifierNode).map(Ast(_))
     scope.popScope()
 
     Ast(typeDeclNode).withChildren(modifiers).withChildren(bodyStmts)
@@ -824,7 +824,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     val signature = s"$UnresolvedSignature(0)"
 
-    val modifiers = List(ModifierTypes.VIRTUAL, ModifierTypes.PUBLIC, ModifierTypes.CONSTRUCTOR).map(modifierNode)
+    val modifiers = List(ModifierTypes.VIRTUAL, ModifierTypes.PUBLIC, ModifierTypes.CONSTRUCTOR).map(newModifierNode)
 
     val thisParam = thisParamAstForMethod(lineNumber = None)
 
@@ -837,7 +837,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     val methodBody = blockAst(NewBlock(), scope.getFieldInits)
 
-    val methodReturn = methodReturnNode(TypeConstants.Any, line = None, column = None)
+    val methodReturn = newMethodReturnNode(TypeConstants.Any, line = None, column = None)
 
     methodAstWithAnnotations(methodNode, thisParam :: Nil, methodBody, methodReturn, modifiers)
   }
@@ -845,30 +845,30 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
   private def astForMemberAssignment(memberNode: NewMember, valueExpr: PhpExpr, isField: Boolean): Ast = {
     val targetAst = if (isField) {
       val code            = s"$$this->${memberNode.name}"
-      val fieldAccessNode = operatorCallNode(Operators.fieldAccess, code, line = memberNode.lineNumber)
+      val fieldAccessNode = newOperatorCallNode(Operators.fieldAccess, code, line = memberNode.lineNumber)
       val identifier      = thisIdentifier(memberNode.lineNumber)
       val thisParam       = scope.lookupVariable(NameConstants.This)
-      val fieldIdentifier = fieldIdentifierNode(memberNode.name, memberNode.lineNumber)
+      val fieldIdentifier = newFieldIdentifierNode(memberNode.name, memberNode.lineNumber)
       callAst(fieldAccessNode, List(identifier, fieldIdentifier).map(Ast(_))).withRefEdges(identifier, thisParam.toList)
     } else {
       val identifierCode = memberNode.code.replaceAll("const ", "").replaceAll("case ", "")
-      val identifier = identifierNode(memberNode.name, Option(memberNode.typeFullName), line = memberNode.lineNumber)
+      val identifier = newIdentifierNode(memberNode.name, Option(memberNode.typeFullName), line = memberNode.lineNumber)
         .code(identifierCode)
       Ast(identifier).withRefEdge(identifier, memberNode)
     }
     val value = astForExpr(valueExpr)
 
     val assignmentCode = s"${targetAst.rootCodeOrEmpty} = ${value.rootCodeOrEmpty}"
-    val callNode       = operatorCallNode(Operators.assignment, assignmentCode, line = memberNode.lineNumber)
+    val callNode       = newOperatorCallNode(Operators.assignment, assignmentCode, line = memberNode.lineNumber)
 
     callAst(callNode, List(targetAst, value))
   }
 
   private def astsForConstStmt(stmt: PhpConstStmt): List[Ast] = {
     stmt.consts.map { constDecl =>
-      val finalModifier = Ast(modifierNode(ModifierTypes.FINAL))
+      val finalModifier = Ast(newModifierNode(ModifierTypes.FINAL))
       // `final const` is not allowed, so this is a safe way to represent constants in the CPG
-      val modifierAsts = finalModifier :: stmt.modifiers.map(modifierNode).map(Ast(_))
+      val modifierAsts = finalModifier :: stmt.modifiers.map(newModifierNode).map(Ast(_))
 
       val name      = constDecl.name.name
       val code      = s"const $name"
@@ -879,7 +879,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
   }
 
   private def astForEnumCase(stmt: PhpEnumCaseStmt): Ast = {
-    val finalModifier = Ast(modifierNode(ModifierTypes.FINAL))
+    val finalModifier = Ast(newModifierNode(ModifierTypes.FINAL))
 
     val name = stmt.name.name
     val code = s"case $name"
@@ -890,7 +890,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
   private def astsForPropertyStmt(stmt: PhpPropertyStmt): List[Ast] = {
     stmt.variables.map { varDecl =>
-      val modifierAsts = stmt.modifiers.map(modifierNode).map(Ast(_))
+      val modifierAsts = stmt.modifiers.map(newModifierNode).map(Ast(_))
 
       val name = varDecl.name.name
       astForConstOrFieldValue(
@@ -1025,7 +1025,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     val receiverAst = (targetAst, nameAst) match {
       case (Some(target), Some(n)) =>
-        val fieldAccess = operatorCallNode(Operators.fieldAccess, codePrefix, line = line(call))
+        val fieldAccess = newOperatorCallNode(Operators.fieldAccess, codePrefix, line = line(call))
         Option(callAst(fieldAccess, target :: n :: Nil))
       case (Some(target), None) => Option(target)
       case (None, Some(n))      => Option(n)
@@ -1098,7 +1098,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val symbol    = operatorSymbols.getOrElse(assignment.assignOp, assignment.assignOp)
     val code      = s"${targetAst.rootCodeOrEmpty} $symbol $refSymbol${sourceAst.rootCodeOrEmpty}"
 
-    val callNode = operatorCallNode(operatorName, code, line = line(assignment))
+    val callNode = newOperatorCallNode(operatorName, code, line = line(assignment))
     callAst(callNode, List(targetAst, sourceAst))
   }
 
@@ -1112,7 +1112,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
         Ast(NewLiteral().code(value).typeFullName(TypeConstants.Float).lineNumber(line(scalar)))
       case PhpEncapsed(parts, _) =>
         val callNode =
-          operatorCallNode(PhpOperators.encaps, code = /* TODO */ PhpOperators.encaps, line = line(scalar))
+          newOperatorCallNode(PhpOperators.encaps, code = /* TODO */ PhpOperators.encaps, line = line(scalar))
         val args = parts.map(astForExpr)
         callAst(callNode, args)
       case PhpEncapsedPart(value, _) =>
@@ -1130,7 +1130,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val symbol = operatorSymbols.getOrElse(binOp.operator, binOp.operator)
     val code   = s"${leftAst.rootCodeOrEmpty} $symbol ${rightAst.rootCodeOrEmpty}"
 
-    val callNode = operatorCallNode(binOp.operator, code, line = line(binOp))
+    val callNode = newOperatorCallNode(binOp.operator, code, line = line(binOp))
 
     callAst(callNode, List(leftAst, rightAst))
   }
@@ -1149,7 +1149,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       else
         s"$symbol${exprAst.rootCodeOrEmpty}"
 
-    val callNode = operatorCallNode(unaryOp.operator, code, line = line(unaryOp))
+    val callNode = newOperatorCallNode(unaryOp.operator, code, line = line(unaryOp))
 
     callAst(callNode, exprAst :: Nil)
   }
@@ -1163,7 +1163,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val expr    = astForExpr(castExpr.expr)
     val codeStr = s"(${castExpr.typ}) ${expr.rootCodeOrEmpty}"
 
-    val callNode = operatorCallNode(name = Operators.cast, codeStr, Option(castExpr.typ), line(castExpr))
+    val callNode = newOperatorCallNode(name = Operators.cast, codeStr, Option(castExpr.typ), line(castExpr))
 
     callAst(callNode, Ast(typ) :: expr :: Nil)
   }
@@ -1174,7 +1174,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val code = s"$name(${args.map(_.rootCodeOrEmpty).mkString(",")})"
 
     val callNode =
-      operatorCallNode(name, code, typeFullName = Option(TypeConstants.Bool), line = line(isSetExpr))
+      newOperatorCallNode(name, code, typeFullName = Option(TypeConstants.Bool), line = line(isSetExpr))
         .methodFullName(PhpOperators.issetFunc)
 
     callAst(callNode, args)
@@ -1185,7 +1185,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val code = s"$name(${arg.rootCodeOrEmpty})"
 
     val callNode =
-      operatorCallNode(name, code, typeFullName = Option(TypeConstants.Int), line = line(printExpr))
+      newOperatorCallNode(name, code, typeFullName = Option(TypeConstants.Int), line = line(printExpr))
         .methodFullName(PhpOperators.printFunc)
 
     callAst(callNode, arg :: Nil)
@@ -1202,7 +1202,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case None          => s"${conditionAst.rootCodeOrEmpty} ?: ${elseAst.rootCodeOrEmpty}"
     }
 
-    val callNode = operatorCallNode(operatorName, code, line = line(ternaryOp))
+    val callNode = newOperatorCallNode(operatorName, code, line = line(ternaryOp))
 
     val args = List(Option(conditionAst), maybeThenAst, Option(elseAst)).flatten
     callAst(callNode, args)
@@ -1227,7 +1227,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val argType = argAst.rootType
     val code    = s"$name ${argAst.rootCodeOrEmpty}"
 
-    val callNode = operatorCallNode(name, code, argType, line(expr))
+    val callNode = newOperatorCallNode(name, code, argType, line(expr))
       .methodFullName(PhpOperators.cloneFunc)
 
     callAst(callNode, argAst :: Nil)
@@ -1239,7 +1239,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val code   = s"$name(${argAst.rootCodeOrEmpty})"
 
     val callNode =
-      operatorCallNode(name, code, typeFullName = Option(TypeConstants.Bool), line = line(expr))
+      newOperatorCallNode(name, code, typeFullName = Option(TypeConstants.Bool), line = line(expr))
         .methodFullName(PhpOperators.emptyFunc)
 
     callAst(callNode, argAst :: Nil)
@@ -1251,7 +1251,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val code   = s"$name(${argAst.rootCodeOrEmpty})"
 
     val callNode =
-      operatorCallNode(name, code, typeFullName = Option(TypeConstants.Bool), line = line(expr))
+      newOperatorCallNode(name, code, typeFullName = Option(TypeConstants.Bool), line = line(expr))
         .methodFullName(PhpOperators.evalFunc)
 
     callAst(callNode, argAst :: Nil)
@@ -1262,7 +1262,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val args = expr.expr.map(astForExpr)
     val code = s"$name(${args.map(_.rootCodeOrEmpty).getOrElse("")})"
 
-    val callNode = operatorCallNode(name, code, Option(TypeConstants.Void), line(expr))
+    val callNode = newOperatorCallNode(name, code, Option(TypeConstants.Void), line(expr))
       .methodFullName(PhpOperators.exitFunc)
 
     callAst(callNode, args.toList)
@@ -1284,7 +1284,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
   }
 
   private def identifierAstFromLocal(local: NewLocal, lineNumber: Option[Integer] = None): Ast = {
-    val identifier = identifierNode(local.name, typeFullName = Option(local.typeFullName), lineNumber)
+    val identifier = newIdentifierNode(local.name, typeFullName = Option(local.typeFullName), lineNumber)
       .code(s"$$${local.name}")
     Ast(identifier).withRefEdge(identifier, local)
   }
@@ -1335,7 +1335,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val name     = PhpOperators.listFunc
     val args     = expr.items.flatten.map { item => astForExpr(item.value) }
     val listCode = s"$name(${args.map(_.rootCodeOrEmpty).mkString(",")})"
-    val listNode = operatorCallNode(name, listCode, line = line(expr))
+    val listNode = newOperatorCallNode(name, listCode, line = line(expr))
       .methodFullName(PhpOperators.listFunc)
 
     callAst(listNode, args)
@@ -1522,10 +1522,10 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     // Alloc assign
     val allocCode             = s"$className.<alloc>()"
-    val allocNode             = operatorCallNode(Operators.alloc, allocCode, Option(className), line(expr))
+    val allocNode             = newOperatorCallNode(Operators.alloc, allocCode, Option(className), line(expr))
     val allocAst              = callAst(allocNode, base = maybeNameAst)
     val allocAssignCode       = s"${tmpLocal.code} = ${allocAst.rootCodeOrEmpty}"
-    val allocAssignNode       = operatorCallNode(Operators.assignment, allocAssignCode, Option(className), line(expr))
+    val allocAssignNode       = newOperatorCallNode(Operators.assignment, allocAssignCode, Option(className), line(expr))
     val allocAssignIdentifier = identifierAstFromLocal(tmpLocal, line(expr))
     val allocAssignAst        = callAst(allocAssignNode, allocAssignIdentifier :: allocAst :: Nil)
 
@@ -1592,7 +1592,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
     val assignCode = s"${dimFetchAst.rootCodeOrEmpty} = ${valueAst.rootCodeOrEmpty}"
 
-    val assignNode = operatorCallNode(Operators.assignment, assignCode, line = line(item))
+    val assignNode = newOperatorCallNode(Operators.assignment, assignCode, line = line(item))
 
     callAst(assignNode, dimFetchAst :: valueAst :: Nil)
   }
@@ -1602,10 +1602,10 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val valueCode = exprAst.rootCodeOrEmpty
 
     if (item.byRef) {
-      val parentCall = operatorCallNode(Operators.addressOf, s"&$valueCode", line = line(item))
+      val parentCall = newOperatorCallNode(Operators.addressOf, s"&$valueCode", line = line(item))
       callAst(parentCall, exprAst :: Nil)
     } else if (item.unpack) {
-      val parentCall = operatorCallNode(PhpOperators.unpack, s"...$valueCode", line = line(item))
+      val parentCall = newOperatorCallNode(PhpOperators.unpack, s"...$valueCode", line = line(item))
       callAst(parentCall, exprAst :: Nil)
     } else {
       exprAst
@@ -1620,11 +1620,11 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
       case Some(dimension) =>
         val dimensionAst = astForExpr(dimension)
         val code         = s"$variableCode[${dimensionAst.rootCodeOrEmpty}]"
-        val accessNode   = operatorCallNode(Operators.indexAccess, code, line = line(expr))
+        val accessNode   = newOperatorCallNode(Operators.indexAccess, code, line = line(expr))
         callAst(accessNode, variableAst :: dimensionAst :: Nil)
 
       case None =>
-        val accessNode = operatorCallNode(PhpOperators.emptyArrayIdx, s"$variableCode[]", line = line(expr))
+        val accessNode = newOperatorCallNode(PhpOperators.emptyArrayIdx, s"$variableCode[]", line = line(expr))
         callAst(accessNode, variableAst :: Nil)
     }
   }
@@ -1633,7 +1633,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val childAst = astForExpr(expr.expr)
 
     val code         = s"@${childAst.rootCodeOrEmpty}"
-    val suppressNode = operatorCallNode(PhpOperators.errorSuppress, code, line = line(expr))
+    val suppressNode = newOperatorCallNode(PhpOperators.errorSuppress, code, line = line(expr))
     childAst.rootType.foreach(suppressNode.typeFullName(_))
 
     callAst(suppressNode, childAst :: Nil)
@@ -1644,7 +1644,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val classAst = astForExpr(expr.className)
 
     val code           = s"${exprAst.rootCodeOrEmpty} instanceof ${classAst.rootCodeOrEmpty}"
-    val instanceOfNode = operatorCallNode(Operators.instanceOf, code, Option(TypeConstants.Bool), line(expr))
+    val instanceOfNode = newOperatorCallNode(Operators.instanceOf, code, Option(TypeConstants.Bool), line(expr))
 
     callAst(instanceOfNode, exprAst :: classAst :: Nil)
   }
@@ -1653,7 +1653,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val objExprAst = astForExpr(expr.expr)
 
     val fieldAst = expr.name match {
-      case name: PhpNameExpr => Ast(fieldIdentifierNode(name.name, line(expr)))
+      case name: PhpNameExpr => Ast(newFieldIdentifierNode(name.name, line(expr)))
       case other             => astForExpr(other)
     }
 
@@ -1666,7 +1666,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
         "->"
 
     val code            = s"${objExprAst.rootCodeOrEmpty}$accessSymbol${fieldAst.rootCodeOrEmpty}"
-    val fieldAccessNode = operatorCallNode(Operators.fieldAccess, code, line = line(expr))
+    val fieldAccessNode = newOperatorCallNode(Operators.fieldAccess, code, line = line(expr))
 
     callAst(fieldAccessNode, objExprAst :: fieldAst :: Nil)
   }
@@ -1674,7 +1674,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
   private def astForIncludeExpr(expr: PhpIncludeExpr): Ast = {
     val exprAst  = astForExpr(expr.expr)
     val code     = s"${expr.includeType} ${exprAst.rootCodeOrEmpty}"
-    val callNode = operatorCallNode(expr.includeType, code, line = line(expr))
+    val callNode = newOperatorCallNode(expr.includeType, code, line = line(expr))
 
     callAst(callNode, exprAst :: Nil)
   }
@@ -1683,7 +1683,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val args = expr.parts.map(astForExpr)
     val code = s"`${args.map(_.rootCodeOrEmpty).mkString("").replaceAll("\"", "")}`"
 
-    val callNode = operatorCallNode(PhpOperators.shellExec, code, line = line(expr))
+    val callNode = newOperatorCallNode(PhpOperators.shellExec, code, line = line(expr))
       .methodFullName(PhpOperators.shellExec)
 
     callAst(callNode, args)
@@ -1693,21 +1693,21 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val target              = astForExpr(expr.className)
     val fieldIdentifierName = expr.constantName.map(_.name).getOrElse(NameConstants.Unknown)
 
-    val fieldIdentifier = fieldIdentifierNode(fieldIdentifierName, line(expr))
+    val fieldIdentifier = newFieldIdentifierNode(fieldIdentifierName, line(expr))
 
     val fieldAccessCode = s"${target.rootCodeOrEmpty}::${fieldIdentifier.code}"
 
-    val fieldAccessCall = operatorCallNode(Operators.fieldAccess, fieldAccessCode, line = line(expr))
+    val fieldAccessCall = newOperatorCallNode(Operators.fieldAccess, fieldAccessCode, line = line(expr))
 
     callAst(fieldAccessCall, List(target, Ast(fieldIdentifier)))
   }
 
   private def astForConstFetchExpr(expr: PhpConstFetchExpr): Ast = {
 
-    val identifier      = identifierNode(NamespaceTraversal.globalNamespaceName, typeFullName = None, line = line(expr))
-    val fieldIdentifier = fieldIdentifierNode(expr.name.name, line = line(expr))
+    val identifier      = newIdentifierNode(NamespaceTraversal.globalNamespaceName, typeFullName = None, line = line(expr))
+    val fieldIdentifier = newFieldIdentifierNode(expr.name.name, line = line(expr))
 
-    val fieldAccessNode = operatorCallNode(Operators.fieldAccess, code = expr.name.name, line = line(expr))
+    val fieldAccessNode = newOperatorCallNode(Operators.fieldAccess, code = expr.name.name, line = line(expr))
     val args            = List(identifier, fieldIdentifier).map(Ast(_))
 
     callAst(fieldAccessNode, args)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -1521,11 +1521,11 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
     val tmpLocal = getTmpLocal(Option(className), line(expr))
 
     // Alloc assign
-    val allocCode             = s"$className.<alloc>()"
-    val allocNode             = newOperatorCallNode(Operators.alloc, allocCode, Option(className), line(expr))
-    val allocAst              = callAst(allocNode, base = maybeNameAst)
-    val allocAssignCode       = s"${tmpLocal.code} = ${allocAst.rootCodeOrEmpty}"
-    val allocAssignNode       = newOperatorCallNode(Operators.assignment, allocAssignCode, Option(className), line(expr))
+    val allocCode       = s"$className.<alloc>()"
+    val allocNode       = newOperatorCallNode(Operators.alloc, allocCode, Option(className), line(expr))
+    val allocAst        = callAst(allocNode, base = maybeNameAst)
+    val allocAssignCode = s"${tmpLocal.code} = ${allocAst.rootCodeOrEmpty}"
+    val allocAssignNode = newOperatorCallNode(Operators.assignment, allocAssignCode, Option(className), line(expr))
     val allocAssignIdentifier = identifierAstFromLocal(tmpLocal, line(expr))
     val allocAssignAst        = callAst(allocAssignNode, allocAssignIdentifier :: allocAst :: Nil)
 
@@ -1704,7 +1704,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global) extends AstC
 
   private def astForConstFetchExpr(expr: PhpConstFetchExpr): Ast = {
 
-    val identifier      = newIdentifierNode(NamespaceTraversal.globalNamespaceName, typeFullName = None, line = line(expr))
+    val identifier = newIdentifierNode(NamespaceTraversal.globalNamespaceName, typeFullName = None, line = line(expr))
     val fieldIdentifier = newFieldIdentifierNode(expr.name.name, line = line(expr))
 
     val fieldAccessNode = newOperatorCallNode(Operators.fieldAccess, code = expr.name.name, line = line(expr))

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -173,7 +173,7 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
 
   def methodReturnNode(dynamicTypeHintFullName: Option[String], lineAndColumn: LineAndColumn): nodes.NewMethodReturn = {
     val methodReturnNode = NodeBuilders
-      .methodReturnNode(Constants.ANY, dynamicTypeHintFullName, Some(lineAndColumn.line), Some(lineAndColumn.column))
+      .newMethodReturnNode(Constants.ANY, dynamicTypeHintFullName, Some(lineAndColumn.line), Some(lineAndColumn.column))
       .evaluationStrategy(EvaluationStrategies.BY_SHARING)
 
     addNodeToDiff(methodReturnNode)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -50,7 +50,7 @@ class AstCreator(filename: String, global: Global) extends AstCreatorBase(filena
     val variableName = token.getText
     val line         = token.getLine
     val column       = token.getCharPositionInLine
-    val node         = newIdentifierNode(variableName, None, Some(line), Some(column), List(varType)).typeFullName(varType)
+    val node = newIdentifierNode(variableName, None, Some(line), Some(column), List(varType)).typeFullName(varType)
     Ast(node)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -3,7 +3,7 @@ import io.joern.rubysrc2cpg.parser.RubyParser._
 import io.joern.rubysrc2cpg.parser.{RubyLexer, RubyParser}
 import io.joern.x2cpg.Ast.storeInDiffGraph
 import io.joern.x2cpg.datastructures.Global
-import io.joern.x2cpg.utils.NodeBuilders.identifierNode
+import io.joern.x2cpg.utils.NodeBuilders.newIdentifierNode
 import io.joern.x2cpg.{Ast, AstCreatorBase}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import org.antlr.v4.runtime.tree.TerminalNode
@@ -50,7 +50,7 @@ class AstCreator(filename: String, global: Global) extends AstCreatorBase(filena
     val variableName = token.getText
     val line         = token.getLine
     val column       = token.getCharPositionInLine
-    val node         = identifierNode(variableName, None, Some(line), Some(column), List(varType)).typeFullName(varType)
+    val node         = newIdentifierNode(variableName, None, Some(line), Some(column), List(varType)).typeFullName(varType)
     Ast(node)
   }
 
@@ -393,7 +393,7 @@ class AstCreator(filename: String, global: Global) extends AstCreatorBase(filena
     if (ctx.LOCAL_VARIABLE_IDENTIFIER() != null) {
       val localVar  = ctx.LOCAL_VARIABLE_IDENTIFIER()
       val varSymbol = localVar.getSymbol()
-      val node = identifierNode(
+      val node = newIdentifierNode(
         varSymbol.getText,
         None,
         Some(varSymbol.getLine()),
@@ -439,7 +439,7 @@ class AstCreator(filename: String, global: Global) extends AstCreatorBase(filena
     if (ctx.LOCAL_VARIABLE_IDENTIFIER() != null) {
       val localVar  = ctx.LOCAL_VARIABLE_IDENTIFIER()
       val varSymbol = localVar.getSymbol()
-      val node = identifierNode(
+      val node = newIdentifierNode(
         varSymbol.getText,
         None,
         Some(varSymbol.getLine()),
@@ -519,7 +519,7 @@ class AstCreator(filename: String, global: Global) extends AstCreatorBase(filena
     val seqNodes = localVarList
       .map(localVar => {
         val varSymbol = localVar.getSymbol()
-        identifierNode(
+        newIdentifierNode(
           varSymbol.getText,
           None,
           Some(varSymbol.getLine()),

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -1,7 +1,7 @@
 package io.joern.x2cpg
 
 import io.joern.x2cpg.passes.frontend.MetaDataPass
-import io.joern.x2cpg.utils.NodeBuilders.methodReturnNode
+import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, ModifierTypes}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
@@ -97,7 +97,7 @@ abstract class AstCreatorBase(filename: String) {
     }
     val staticModifier = NewModifier().modifierType(ModifierTypes.STATIC)
     val body           = blockAst(NewBlock(), initAsts)
-    val methodReturn   = methodReturnNode(returnType, None, None, None)
+    val methodReturn   = newMethodReturnNode(returnType, None, None, None)
     methodAst(methodNode, Nil, body, methodReturn, List(staticModifier))
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -13,6 +13,11 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
 }
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies}
 
+/**
+  * NodeBuilders helps with node creation and is intended to be used when functions from `x2cpg.AstCreatorBase`
+  * are not appropriate; for example, in cases in which the node's line and column are _not_ set from
+  * the base ASTNode type of a specific frontend.
+  */
 object NodeBuilders {
 
   private def composeCallSignature(returnType: String, argumentTypes: Iterable[String]): String = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -13,10 +13,9 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
 }
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies}
 
-/**
-  * NodeBuilders helps with node creation and is intended to be used when functions from `x2cpg.AstCreatorBase`
-  * are not appropriate; for example, in cases in which the node's line and column are _not_ set from
-  * the base ASTNode type of a specific frontend.
+/** NodeBuilders helps with node creation and is intended to be used when functions from `x2cpg.AstCreatorBase` are not
+  * appropriate; for example, in cases in which the node's line and column are _not_ set from the base ASTNode type of a
+  * specific frontend.
   */
 object NodeBuilders {
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -24,12 +24,12 @@ object NodeBuilders {
     s"$typeDeclPrefix$name:$signature"
   }
 
-  def annotationLiteralNode(name: String): NewAnnotationLiteral =
+  def newAnnotationLiteralNode(name: String): NewAnnotationLiteral =
     NewAnnotationLiteral()
       .name(name)
       .code(name)
 
-  def callNode(
+  def newCallNode(
     methodName: String,
     typeDeclFullName: Option[String],
     returnTypeFullName: String,
@@ -52,13 +52,13 @@ object NodeBuilders {
       .columnNumber(columnNumber)
   }
 
-  def dependencyNode(name: String, groupId: String, version: String): NewDependency =
+  def newDependencyNode(name: String, groupId: String, version: String): NewDependency =
     NewDependency()
       .name(name)
       .dependencyGroupId(groupId)
       .version(version)
 
-  def fieldIdentifierNode(
+  def newFieldIdentifierNode(
     name: String,
     line: Option[Integer] = None,
     column: Option[Integer] = None
@@ -70,7 +70,7 @@ object NodeBuilders {
       .columnNumber(column)
   }
 
-  def identifierNode(
+  def newIdentifierNode(
     name: String,
     typeFullName: Option[String],
     line: Option[Integer] = None,
@@ -88,9 +88,9 @@ object NodeBuilders {
     identifier
   }
 
-  def modifierNode(modifierType: String): NewModifier = NewModifier().modifierType(modifierType)
+  def newModifierNode(modifierType: String): NewModifier = NewModifier().modifierType(modifierType)
 
-  def operatorCallNode(
+  def newOperatorCallNode(
     name: String,
     code: String,
     typeFullName: Option[String] = None,
@@ -108,7 +108,7 @@ object NodeBuilders {
       .columnNumber(column)
   }
 
-  def thisParameterNode(
+  def newThisParameterNode(
     typeFullName: String,
     dynamicTypeHintFullName: Seq[String] = Seq.empty,
     line: Option[Integer] = None,
@@ -128,7 +128,7 @@ object NodeBuilders {
 
   /** Create a method return node
     */
-  def methodReturnNode(
+  def newMethodReturnNode(
     typeFullName: String,
     dynamicTypeHintFullName: Option[String] = None,
     line: Option[Integer],


### PR DESCRIPTION
The idea is to have two consistent ways of generating nodes:
1. The `AstNodeBuilder` trait which provides fns with signatures similar to: `aTypeOfNode(PROP1, PROP2, PROP3)`
2. The `NodeBuilders` object which provides fns with signatures similar to: `newATypeOfNode(PROP1, PROP2, PROP3, LINE, COLUMN)`