### PR TITLE
JavaScriptTypeRecovery: Fix Local Import Regex

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -66,7 +66,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
     })
     // We want to know if the import is local since if an external name is used to match internal methods we may have
     // false paths.
-    val isLocalImport = i.importedEntity.exists(_.matches("^[.]+\\/?.*"))
+    val isLocalImport = i.importedEntity.exists(_.matches("^[.]+/?.*"))
     // TODO: At times there is an operation inside of a require, e.g. path.resolve(__dirname + "/../config/env/all.js")
     //  this tries to recover the string but does not perform string constant propagation
     val entity = if (matcher.find()) matcher.group(1) else rawEntity

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -66,7 +66,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
     })
     // We want to know if the import is local since if an external name is used to match internal methods we may have
     // false paths.
-    val isLocalImport = i.importedEntity.exists(_.matches("^[.]*/?.*"))
+    val isLocalImport = i.importedEntity.exists(_.matches("^[.]+\\/?.*"))
     // TODO: At times there is an operation inside of a require, e.g. path.resolve(__dirname + "/../config/env/all.js")
     //  this tries to recover the string but does not perform string constant propagation
     val entity = if (matcher.find()) matcher.group(1) else rawEntity


### PR DESCRIPTION
Replace `*` with `+` to avoid false positives. The `*` means that no dot is necessary, which is not the case for relative imports.

```
isLocalImport=true
./log4js
../log4js

isLocalImport=false
log4js
/log4js
```
