### PR TITLE
jimple2cpg: Dump Implementation

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -188,7 +188,11 @@ class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCr
           Seq(createThisNode(methodDeclaration, NewMethodParameterIn())) ++ withOrder(methodBody.getParameterLocals) {
             (p, order) => astForParameter(p, order, methodDeclaration, parameterAnnotations)
           }
-        Ast(methodNode.lineNumberEnd(methodBody.toString.split('\n').filterNot(_.isBlank).length))
+        Ast(
+          methodNode
+            .lineNumberEnd(methodBody.toString.split('\n').filterNot(_.isBlank).length)
+            .code(methodBody.toString)
+        )
           .withChildren(astsForModifiers(methodDeclaration))
           .withChildren(parameterAsts)
           .withChildren(astsForHostTags(methodDeclaration))

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
@@ -57,7 +57,23 @@ class ConstructorInvocationTests extends JimpleCode2CpgFixture {
       case List(cons: Method) =>
         cons.fullName shouldBe "Foo.<init>:void(int)"
         cons.signature shouldBe "void(int)"
-        cons.code shouldBe "Foo(int x)"
+        cons.code.trim shouldBe
+          """public void <init>(int)
+            |    {
+            |        int x;
+            |        Foo this;
+            |
+            |        this := @this: Foo;
+            |
+            |        x := @parameter0: int;
+            |
+            |        specialinvoke this.<java.lang.Object: void <init>()>();
+            |
+            |        this.<Foo: int x> = x;
+            |
+            |        return;
+            |    }
+            |""".stripMargin.trim
         cons.parameter.size shouldBe 2
         val objParam = cons.parameter.index(0).head
         objParam.name shouldBe "this"
@@ -76,14 +92,46 @@ class ConstructorInvocationTests extends JimpleCode2CpgFixture {
       case List(cons1: Method, cons2: Method) =>
         cons1.fullName shouldBe "Bar.<init>:void(int)"
         cons1.signature shouldBe "void(int)"
-        cons1.code shouldBe "Bar(int x)"
+        cons1.code.trim shouldBe
+          """public void <init>(int)
+            |    {
+            |        int x;
+            |        Bar this;
+            |
+            |        this := @this: Bar;
+            |
+            |        x := @parameter0: int;
+            |
+            |        specialinvoke this.<Foo: void <init>(int)>(x);
+            |
+            |        return;
+            |    }
+            |""".stripMargin.trim
         cons1.parameter.size shouldBe 2
         cons1.parameter.index(0).head.name shouldBe "this"
         cons1.parameter.index(1).head.name shouldBe "x"
 
         cons2.fullName shouldBe "Bar.<init>:void(int,int)"
         cons2.signature shouldBe "void(int,int)"
-        cons2.code shouldBe "Bar(int x, int y)"
+        cons2.code.trim shouldBe
+          """public void <init>(int, int)
+            |    {
+            |        Bar this;
+            |        int x, y, $stack3;
+            |
+            |        this := @this: Bar;
+            |
+            |        x := @parameter0: int;
+            |
+            |        y := @parameter1: int;
+            |
+            |        $stack3 = x + y;
+            |
+            |        specialinvoke this.<Bar: void <init>(int)>($stack3);
+            |
+            |        return;
+            |    }
+            |""".stripMargin.trim
         cons2.parameter.size shouldBe 3
         cons2.parameter.index(0).head.name shouldBe "this"
         cons2.parameter.index(1).head.name shouldBe "x"

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/ConstructorInvocationTests.scala
@@ -57,23 +57,7 @@ class ConstructorInvocationTests extends JimpleCode2CpgFixture {
       case List(cons: Method) =>
         cons.fullName shouldBe "Foo.<init>:void(int)"
         cons.signature shouldBe "void(int)"
-        cons.code.trim shouldBe
-          """public void <init>(int)
-            |    {
-            |        int x;
-            |        Foo this;
-            |
-            |        this := @this: Foo;
-            |
-            |        x := @parameter0: int;
-            |
-            |        specialinvoke this.<java.lang.Object: void <init>()>();
-            |
-            |        this.<Foo: int x> = x;
-            |
-            |        return;
-            |    }
-            |""".stripMargin.trim
+        cons.code.trim.startsWith("public void <init>(int)") shouldBe true
         cons.parameter.size shouldBe 2
         val objParam = cons.parameter.index(0).head
         objParam.name shouldBe "this"
@@ -92,46 +76,14 @@ class ConstructorInvocationTests extends JimpleCode2CpgFixture {
       case List(cons1: Method, cons2: Method) =>
         cons1.fullName shouldBe "Bar.<init>:void(int)"
         cons1.signature shouldBe "void(int)"
-        cons1.code.trim shouldBe
-          """public void <init>(int)
-            |    {
-            |        int x;
-            |        Bar this;
-            |
-            |        this := @this: Bar;
-            |
-            |        x := @parameter0: int;
-            |
-            |        specialinvoke this.<Foo: void <init>(int)>(x);
-            |
-            |        return;
-            |    }
-            |""".stripMargin.trim
+        cons1.code.trim.startsWith("public void <init>(int)") shouldBe true
         cons1.parameter.size shouldBe 2
         cons1.parameter.index(0).head.name shouldBe "this"
         cons1.parameter.index(1).head.name shouldBe "x"
 
         cons2.fullName shouldBe "Bar.<init>:void(int,int)"
         cons2.signature shouldBe "void(int,int)"
-        cons2.code.trim shouldBe
-          """public void <init>(int, int)
-            |    {
-            |        Bar this;
-            |        int x, y, $stack3;
-            |
-            |        this := @this: Bar;
-            |
-            |        x := @parameter0: int;
-            |
-            |        y := @parameter1: int;
-            |
-            |        $stack3 = x + y;
-            |
-            |        specialinvoke this.<Bar: void <init>(int)>($stack3);
-            |
-            |        return;
-            |    }
-            |""".stripMargin.trim
+        cons2.code.trim.startsWith("public void <init>(int, int)") shouldBe true
         cons2.parameter.size shouldBe 3
         cons2.parameter.index(0).head.name shouldBe "this"
         cons2.parameter.index(1).head.name shouldBe "x"

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
@@ -19,21 +19,7 @@ class MethodTests extends JimpleCode2CpgFixture {
     val List(x) = cpg.method.nameNot(io.joern.x2cpg.Defines.ConstructorMethodName).isExternal(false).l
     x.name shouldBe "foo"
     x.fullName shouldBe "Foo.foo:int(int,int)"
-    x.code.trim shouldBe
-      """    int foo(int, int)
-        |    {
-        |        int param1, param2;
-        |        Foo this;
-        |
-        |        this := @this: Foo;
-        |
-        |        param1 := @parameter0: int;
-        |
-        |        param2 := @parameter1: int;
-        |
-        |        return 1;
-        |    }
-        |""".stripMargin.trim
+    x.code.trim.startsWith("int foo(int, int)") shouldBe true
     x.signature shouldBe "int(int,int)"
     x.isExternal shouldBe false
     x.order shouldBe 1

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
@@ -15,23 +15,25 @@ class MethodTests extends JimpleCode2CpgFixture {
       | }
       |""".stripMargin).cpg
 
-  /* The equivalent Jimple code looks like
-    int foo(int, int)
-    {
-        int param1, param2;
-        Foo this;
-        this := @this: Foo;
-        param1 := @parameter0: int;
-        param2 := @parameter1: int;
-        return 1;
-    }
-   */
-
   "should contain exactly one non-stub method node with correct fields" in {
     val List(x) = cpg.method.nameNot(io.joern.x2cpg.Defines.ConstructorMethodName).isExternal(false).l
     x.name shouldBe "foo"
     x.fullName shouldBe "Foo.foo:int(int,int)"
-    x.code shouldBe "int foo(int param1, int param2)"
+    x.code shouldBe
+      """    int foo(int, int)
+        |    {
+        |        int param1, param2;
+        |        Foo this;
+        |
+        |        this := @this: Foo;
+        |
+        |        param1 := @parameter0: int;
+        |
+        |        param2 := @parameter1: int;
+        |
+        |        return 1;
+        |    }
+        |""".stripMargin
     x.signature shouldBe "int(int,int)"
     x.isExternal shouldBe false
     x.order shouldBe 1

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodTests.scala
@@ -19,7 +19,7 @@ class MethodTests extends JimpleCode2CpgFixture {
     val List(x) = cpg.method.nameNot(io.joern.x2cpg.Defines.ConstructorMethodName).isExternal(false).l
     x.name shouldBe "foo"
     x.fullName shouldBe "Foo.foo:int(int,int)"
-    x.code shouldBe
+    x.code.trim shouldBe
       """    int foo(int, int)
         |    {
         |        int param1, param2;
@@ -33,7 +33,7 @@ class MethodTests extends JimpleCode2CpgFixture {
         |
         |        return 1;
         |    }
-        |""".stripMargin
+        |""".stripMargin.trim
     x.signature shouldBe "int(int,int)"
     x.isExternal shouldBe false
     x.order shouldBe 1

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/SynchronizedTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/SynchronizedTests.scala
@@ -37,7 +37,7 @@ class SynchronizedTests extends JimpleCode2CpgFixture {
   "it should create a enter/exit monitor nodes" in {
     val List(method: Method) = cpg.method.name("bar").l
     // 'l2' aliases 'this' so there is never an 'entermonitor l2'
-    val List(enterThis, exit1, exit2) = method.ast.filter(_.code.contains("monitor")).l
+    val List(enterThis, exit1, exit2) = method.ast.collectAll[Unknown].filter(_.code.contains("monitor")).l
 
     enterThis.code shouldBe "entermonitor this"
     enterThis.order shouldBe 6

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -7,9 +7,7 @@ import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Paths
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object CodeDumper {
 
@@ -18,7 +16,7 @@ object CodeDumper {
   val arrow: CharSequence = "/* <=== */ "
 
   private val supportedLanguages =
-    Set(Languages.C, Languages.NEWC, Languages.GHIDRA, Languages.JAVASRC, Languages.JSSRC)
+    Set(Languages.C, Languages.NEWC, Languages.GHIDRA, Languages.JAVA, Languages.JAVASRC, Languages.JSSRC)
 
   private def toAbsolutePath(path: String, rootPath: String): String = {
     val absolutePath = Paths.get(path) match {
@@ -52,7 +50,7 @@ object CodeDumper {
         method
           .collect {
             case m: Method if m.lineNumber.isDefined && m.lineNumberEnd.isDefined =>
-              val rawCode = if (lang == Languages.GHIDRA) { m.code }
+              val rawCode = if (lang == Languages.GHIDRA || lang == Languages.JAVA) { m.code }
               else {
                 val filename = rootPath.map(toAbsolutePath(location.filename, _)).getOrElse(location.filename)
                 code(filename, m.lineNumber.get, m.lineNumberEnd.get, location.lineNumber)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/SourceHighlighter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/SourceHighlighter.scala
@@ -17,7 +17,7 @@ object SourceHighlighter {
   def highlight(source: Source): Option[String] = {
     val langFlag = source.language match {
       case Languages.C | Languages.NEWC | Languages.GHIDRA => "-sC"
-      case Languages.JAVASRC                               => "-sJava"
+      case Languages.JAVA | Languages.JAVASRC              => "-sJava"
       case Languages.JSSRC | Languages.JAVASCRIPT          => "-sJavascript"
       case other => throw new RuntimeException(s"Attempting to call highlighter on unsupported language: $other")
     }


### PR DESCRIPTION
Storing full Jimple code bodies in `Method.code` to enable implementation body dumps for internal code.