### PR TITLE
c2cpg: remove the global lock

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -21,7 +21,7 @@ class C2Cpg extends X2CpgFrontend[Config] {
       new AstCreationPass(cpg, AstCreationPass.SourceFiles, config, report).createAndApply()
       new AstCreationPass(cpg, AstCreationPass.HeaderFiles, config, report).createAndApply()
       new TypeNodePass(CGlobal.typesSeen(), cpg).createAndApply()
-      new HeaderContentPass(cpg, config).createAndApply()
+      new HeaderContentPass(cpg).createAndApply()
       report.print()
     }
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -19,8 +19,7 @@ final case class Config(
   includeComments: Boolean = false,
   logProblems: Boolean = false,
   logPreprocessor: Boolean = false,
-  printIfDefsOnly: Boolean = false,
-  includePathsAutoDiscovery: Boolean = false
+  printIfDefsOnly: Boolean = false
 ) extends X2CpgConfig[Config] {
 
   def createPathForIgnore(ignore: String): String = {
@@ -75,7 +74,7 @@ private object Frontend {
         .hidden(),
       opt[Unit]("with-include-auto-discovery")
         .text("enables auto discovery of system header include paths")
-        .action((_, c) => c.copy(includePathsAutoDiscovery = true)),
+        .hidden(), // deprecated, its the default
       opt[String]("define")
         .unbounded()
         .text("define a name")

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.c2cpg.Config
-import io.joern.c2cpg.datastructures.CGlobal
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import overflowdb.BatchedUpdate.DiffGraphBuilder
@@ -64,7 +63,7 @@ class AstCreator(
   /** Creates an AST of all declarations found in the translation unit - wrapped in a fake method.
     */
   private def astInFakeMethod(fullName: String, path: String, iASTTranslationUnit: IASTTranslationUnit): Ast = {
-    val allDecls = iASTTranslationUnit.getDeclarations.toList
+    val allDecls = iASTTranslationUnit.getDeclarations.toList.filterNot(isIncludedNode)
     val name     = NamespaceTraversal.globalNamespaceName
 
     val fakeGlobalTypeDecl =
@@ -78,16 +77,7 @@ class AstCreator(
 
     val blockNode_ = blockNode(iASTTranslationUnit, Defines.empty, registerType(Defines.anyTypeName))
 
-    val declsAsts = allDecls.flatMap { stmt =>
-      CGlobal.getAstsFromAstCache(
-        diffGraph,
-        fileName(stmt),
-        filename,
-        line(stmt),
-        column(stmt),
-        astsForDeclaration(stmt)
-      )
-    }
+    val declsAsts = allDecls.flatMap(astsForDeclaration)
     setArgumentIndices(declsAsts)
 
     val methodReturn = newMethodReturnNode(iASTTranslationUnit, Defines.anyTypeName)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -98,7 +98,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
         }
       case null => Defines.anyTypeName
     }
-    val (name, fullname) = uniqueName("lambda", "", fullName(lambdaExpression), Some(lambdaExpression))
+    val (name, fullname) = uniqueName("lambda", "", fullName(lambdaExpression))
     val signature        = s"$returnType $fullname ${parameterListSignature(lambdaExpression)}"
     val code             = nodeSignature(lambdaExpression)
     val methodNode = newMethodNode(
@@ -209,7 +209,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
         (
           s.getDeclarators.headOption
             .map(n => ASTStringUtil.getSimpleName(n.getName))
-            .getOrElse(uniqueName("parameter", "", "", Some(parameter))._1),
+            .getOrElse(uniqueName("parameter", "", "")._1),
           nodeSignature(s),
           cleanType(typeForDeclSpecifier(s)),
           false

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -20,7 +20,7 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     val identifierName = ident match {
       case id: IASTIdExpression => ASTStringUtil.getSimpleName(id.getName)
       case id: IASTName if ASTStringUtil.getSimpleName(id).isEmpty && id.getBinding != null => id.getBinding.getName
-      case id: IASTName if ASTStringUtil.getSimpleName(id).isEmpty => uniqueName("name", "", "", Some(ident))._1
+      case id: IASTName if ASTStringUtil.getSimpleName(id).isEmpty => uniqueName("name", "", "")._1
       case _                                                       => nodeSignature(ident)
     }
     val variableOption = scope.lookupVariable(identifierName)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -35,12 +35,7 @@ trait AstForTypesCreator { this: AstCreator =>
 
   private def astForNamespaceDefinition(namespaceDefinition: ICPPASTNamespaceDefinition): Ast = {
     val (name, fullname) =
-      uniqueName(
-        "namespace",
-        namespaceDefinition.getName.getLastName.toString,
-        fullName(namespaceDefinition),
-        Some(namespaceDefinition)
-      )
+      uniqueName("namespace", namespaceDefinition.getName.getLastName.toString, fullName(namespaceDefinition))
     val code         = nodeSignature(namespaceDefinition)
     val cpgNamespace = newNamespaceBlockNode(namespaceDefinition, name, fullname, code, fileName(namespaceDefinition))
     scope.pushNewScope(cpgNamespace)
@@ -349,12 +344,7 @@ trait AstForTypesCreator { this: AstCreator =>
     val lineNumber   = line(typeSpecifier)
     val columnNumber = column(typeSpecifier)
     val (name, fullname) =
-      uniqueName(
-        "enum",
-        ASTStringUtil.getSimpleName(typeSpecifier.getName),
-        fullName(typeSpecifier),
-        Some(typeSpecifier)
-      )
+      uniqueName("enum", ASTStringUtil.getSimpleName(typeSpecifier.getName), fullName(typeSpecifier))
     val typeDecl = newTypeDeclNode(typeSpecifier, name, registerType(fullname), filename, nodeSignature(typeSpecifier))
 
     methodAstParentStack.push(typeDecl)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -122,10 +122,10 @@ trait MacroHandler { this: AstCreator =>
     * create a METHOD node with the correct location information.
     */
   private def fullName(macroDef: IASTPreprocessorMacroDefinition, argAsts: List[Ast]) = {
-    val name      = ASTStringUtil.getSimpleName(macroDef.getName)
-    val filename  = fileName(macroDef)
-    val lineNo    = line(macroDef).getOrElse(-1)
-    val lineNoEnd = lineEnd(macroDef).getOrElse(-1)
+    val name               = ASTStringUtil.getSimpleName(macroDef.getName)
+    val filename           = fileName(macroDef)
+    val lineNo: Integer    = line(macroDef).getOrElse(-1)
+    val lineNoEnd: Integer = lineEnd(macroDef).getOrElse(-1)
     s"$filename:$lineNo:$lineNoEnd:$name:${argAsts.size}"
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/CGlobal.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/datastructures/CGlobal.scala
@@ -1,83 +1,16 @@
 package io.joern.c2cpg.datastructures
 
 import io.joern.c2cpg.astcreation.Defines
-import io.joern.c2cpg.parser.FileDefaults
-import overflowdb.BatchedUpdate.DiffGraphBuilder
-import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.Global
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 object CGlobal extends Global {
-
-  private val headerAstCache: mutable.HashMap[String, mutable.HashSet[(Int, Int)]] =
-    mutable.HashMap.empty
-
-  val headerFileFullNameToPostfix: mutable.HashMap[String, Int] =
-    mutable.HashMap.empty
-
-  var usedVariablePostfix: Int = 0
-
-  def headerFiles: Set[String] = headerAstCache.keySet.toSet
 
   def typesSeen(): List[String] = {
     val types = usedTypes.keys().asScala.filterNot(_ == Defines.anyTypeName).toList
     usedTypes.clear()
     types
-  }
-
-  def shouldBeCleared(): Boolean = {
-    if (headerAstCache.nonEmpty) {
-      headerAstCache.clear()
-      headerFileFullNameToPostfix.clear()
-      true
-    } else {
-      false
-    }
-  }
-
-  def getAstsFromAstCache(
-    diffGraph: DiffGraphBuilder,
-    filename: String,
-    fromFilename: String,
-    linenumber: Option[Integer],
-    columnnumber: Option[Integer],
-    astCreatorFunction: => Seq[Ast]
-  ): Seq[Ast] = {
-    val (callCreatorFunc, addDirectlyToDiff) =
-      CGlobal.synchronized {
-        if (
-          FileDefaults
-            .isHeaderFile(filename) && filename != fromFilename && linenumber.isDefined && columnnumber.isDefined
-        ) {
-          if (!headerAstCache.contains(filename)) {
-            headerAstCache.put(filename, mutable.HashSet((linenumber.get, columnnumber.get)))
-            (true, true)
-          } else {
-            if (!headerAstCache(filename).contains((linenumber.get, columnnumber.get))) {
-              headerAstCache(filename).add((linenumber.get, columnnumber.get))
-              (true, true)
-            } else {
-              (false, false)
-            }
-          }
-        } else {
-          (true, false)
-        }
-      }
-
-    if (callCreatorFunc) {
-      val asts = astCreatorFunction
-      if (addDirectlyToDiff) {
-        asts.foreach(Ast.storeInDiffGraph(_, diffGraph))
-        Seq.empty
-      } else {
-        asts
-      }
-    } else {
-      Seq.empty
-    }
   }
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
@@ -12,8 +12,8 @@ object ParserConfig {
 
   def fromConfig(config: Config): ParserConfig = ParserConfig(
     config.includePaths.map(Paths.get(_).toAbsolutePath),
-    IncludeAutoDiscovery.discoverIncludePathsC(config),
-    IncludeAutoDiscovery.discoverIncludePathsCPP(config),
+    IncludeAutoDiscovery.discoverIncludePathsC(),
+    IncludeAutoDiscovery.discoverIncludePathsCPP(),
     config.defines.map {
       case define if define.contains("=") =>
         val s = define.split("=")

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -3,7 +3,6 @@ package io.joern.c2cpg.passes
 import better.files.File
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.astcreation.AstCreator
-import io.joern.c2cpg.datastructures.CGlobal
 import io.joern.c2cpg.parser.{CdtParser, FileDefaults}
 import io.joern.c2cpg.passes.AstCreationPass.InputFiles
 import io.joern.c2cpg.utils.{Report, TimeUtils}
@@ -39,11 +38,8 @@ class AstCreationPass(cpg: Cpg, forFiles: InputFiles, config: Config, report: Re
   private def sourceFiles: Set[String] =
     SourceFiles.determine(config.inputPath, FileDefaults.SOURCE_FILE_EXTENSIONS).toSet
 
-  private def headerFiles: Set[String] = {
-    val allHeaderFiles         = SourceFiles.determine(config.inputPath, FileDefaults.HEADER_FILE_EXTENSIONS).toSet
-    val alreadySeenHeaderFiles = CGlobal.headerFiles.map(SourceFiles.toAbsolutePath(_, config.inputPath))
-    allHeaderFiles -- alreadySeenHeaderFiles
-  }
+  private def headerFiles: Set[String] =
+    SourceFiles.determine(config.inputPath, FileDefaults.HEADER_FILE_EXTENSIONS).toSet
 
   private def isIgnoredByUserConfig(filePath: String): Boolean = {
     lazy val isInIgnoredFiles = config.ignoredFiles.exists {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -1,6 +1,5 @@
 package io.joern.c2cpg.utils
 
-import io.joern.c2cpg.Config
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, Paths}
@@ -64,10 +63,10 @@ object IncludeAutoDiscovery {
       Set.empty
   }
 
-  def discoverIncludePathsC(config: Config): Set[Path] = {
-    if (config.includePathsAutoDiscovery && systemIncludePathsC.nonEmpty) {
+  def discoverIncludePathsC(): Set[Path] = {
+    if (systemIncludePathsC.nonEmpty) {
       systemIncludePathsC
-    } else if (config.includePathsAutoDiscovery && systemIncludePathsC.isEmpty && gccAvailable()) {
+    } else if (systemIncludePathsC.isEmpty && gccAvailable()) {
       val includePathsC = discoverPaths(C_INCLUDE_COMMAND)
       if (includePathsC.nonEmpty) {
         logger.info(s"Using the following C system include paths:${includePathsC
@@ -80,10 +79,10 @@ object IncludeAutoDiscovery {
     }
   }
 
-  def discoverIncludePathsCPP(config: Config): Set[Path] = {
-    if (config.includePathsAutoDiscovery && systemIncludePathsCPP.nonEmpty) {
+  def discoverIncludePathsCPP(): Set[Path] = {
+    if (systemIncludePathsCPP.nonEmpty) {
       systemIncludePathsCPP
-    } else if (config.includePathsAutoDiscovery && systemIncludePathsCPP.isEmpty && gccAvailable()) {
+    } else if (systemIncludePathsCPP.isEmpty && gccAvailable()) {
       val includePathsCPP = discoverPaths(CPP_INCLUDE_COMMAND)
       if (includePathsCPP.nonEmpty) {
         logger.info(s"Using the following CPP system include paths:${includePathsCPP

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/ExcludeTest.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/ExcludeTest.scala
@@ -53,7 +53,7 @@ class ExcludeTest extends AnyWordSpec with Matchers with TableDrivenPropertyChec
     val cpg   = c2cpg.createCpg(finalConfig).get
 
     X2Cpg.applyDefaultOverlays(cpg)
-    cpg.file.nameNot(FileTraversal.UNKNOWN).name.l should contain theSameElementsAs expectedFiles.map(
+    cpg.file.nameNot(FileTraversal.UNKNOWN, "<includes>").name.l should contain theSameElementsAs expectedFiles.map(
       _.replace("/", java.io.File.separator)
     )
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/FileTests.scala
@@ -5,6 +5,8 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
+import scala.List
+
 class FileTests extends CCodeToCpgSuite {
 
   private val cpg = code("""
@@ -14,9 +16,9 @@ class FileTests extends CCodeToCpgSuite {
       |""".stripMargin)
 
   "should contain two file nodes in total, both with order=0" in {
-    cpg.file.order.l shouldBe List(0, 0)
+    cpg.file.nameNot("<includes>").order.l shouldBe List(0, 0)
     cpg.file.name(FileTraversal.UNKNOWN).size shouldBe 1
-    cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 1
+    cpg.file.nameNot(FileTraversal.UNKNOWN, "<includes>").size shouldBe 1
   }
 
   "should contain exactly one placeholder file node with `name=\"<unknown>\"/order=0`" in {
@@ -44,7 +46,8 @@ class FileTests extends CCodeToCpgSuite {
       .typeDecl
       .nameNot(NamespaceTraversal.globalNamespaceName)
       .name
-      .toSetMutable shouldBe Set("my_struct")
+      .l
+      .sorted shouldBe List("ANY", "int", "my_struct", "void")
   }
 
   "should allow traversing to namespaces" in {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/HeaderAstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/HeaderAstCreationPassTests.scala
@@ -48,9 +48,9 @@ class HeaderAstCreationPassTests extends CCodeToCpgSuite {
           // second time for the actual implementation in the source file
           // We do not de-duplicate this as line/column numbers differ
           m1.fullName shouldBe "main"
-          m1.filename shouldBe "main.h"
+          m1.filename shouldBe "main.c"
           m2.fullName shouldBe "main"
-          m2.filename shouldBe "main.c"
+          m2.filename shouldBe "main.h"
           printf.fullName shouldBe "printf"
       }
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
@@ -103,7 +103,7 @@ class ClassTypeTests extends CCodeToCpgSuite(FileDefaults.CPP_EXT) {
       x.inheritsFromTypeFullName shouldBe List()
       x.aliasTypeFullName shouldBe None
       x.order shouldBe -1
-      x.filename shouldBe FileTraversal.UNKNOWN
+      x.filename shouldBe "<includes>"
     }
 
     "should find exactly 1 internal type" in {


### PR DESCRIPTION
**Background info:**

Eclipse CDT copies (physically and transitively) all of the content from included header files into the resulting Eclipse CDT AST. Before this PR, we simply took that as is and generated a CPG for all of that.

**Implications:**

Thus, we had to take care of duplicated content (e.g., if the same header file is included into multiple different *.c files). We did that by checking the contents filename, line, and column number. That needed to happen inside a global lock as we are iterating over all input files in parallel. To no one's surprise, this was the big performance bottleneck in c2cpg. Generating stable names also proved difficult.

**Approach taken in this PR:**

We now filter out all nodes with a different origin filename than the one associated to the AST we are currently traversing. That's easy because Eclipse CDT copies all the content from included header files to a top-level location (`IASTTranslationUnit#getDeclarations`). With that, Eclipse CDT is still able to resolve macros, types, and all the other interesting stuff that comes with header files.

**Benefits of this PR:**

1) Massive performance increase as there is no global lock anymore.
2) Generating stable names is much easier as we do not have to check for duplicated content (which used to shift around when iterating files in parallel).
3) We can now enable scanning for system header files by default. Without this PR here a simple `#include<stdio.h>` results in half of your systems C header files being part of the CPG. Now that stuff is only used for CDTs internal type resolving and macro resolution which is exactly what we want.

**TODO:**

Needs more testing on real-world applications. VLC or Firefox source code is perhaps a valuable target, especially w.r.t. performance and memory consumption.