### PR TITLE
jssrc2cpg: Fix Flows from Module-Level Literal

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -169,11 +169,13 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       .or(
         _.method.nameExact(Defines.StaticInitMethodName, Defines.ConstructorMethodName, "__init__"),
         // in language such as Python, where assignments for members can be directly under a type decl
-        _.method.typeDecl.where(_.member)
+        _.method.typeDecl
       )
       .target
       .flatMap {
-        case identifier: Identifier if lit.method.typeDecl.member.name.toSet.contains(identifier.name) =>
+        case identifier: Identifier
+            // If these are the same, then the parent method is the module-level type
+            if Option(identifier.method.fullName) == identifier.method.typeDecl.fullName.headOption =>
           List(identifier)
         case call: Call if call.name == Operators.fieldAccess => call.ast.isFieldIdentifier.l
         case _                                                => List[Expression]()

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -175,7 +175,9 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       .flatMap {
         case identifier: Identifier
             // If these are the same, then the parent method is the module-level type
-            if Option(identifier.method.fullName) == identifier.method.typeDecl.fullName.headOption =>
+            if Option(identifier.method.fullName) == identifier.method.typeDecl.fullName.headOption ||
+              // If a member shares the name of the identifier then we consider this as a member
+              lit.method.typeDecl.member.name.toSet.contains(identifier.name) =>
           List(identifier)
         case call: Call if call.name == Operators.fieldAccess => call.ast.isFieldIdentifier.l
         case _                                                => List[Expression]()

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -3,7 +3,7 @@ package io.joern.dataflowengineoss.queryengine
 import io.joern.dataflowengineoss.globalFromLiteral
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{Operators, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.allAssignmentTypes
@@ -80,7 +80,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       case x: Identifier =>
         withFieldAndIndexAccesses(
           List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
-        )
+        ) ++ x.refsTo.capturedByMethodRef.referencedMethod.flatMap(m => usagesForName(x.name, m))
       case x => List(x).collect { case y: CfgNode => y }
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -640,7 +640,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
 
     val iSrc = cpg.method("foo").ast.isIdentifier.name("x").lineNumber(4).l
     iSrc.size shouldBe 1
-    sink1.reachableBy(iSrc).size shouldBe 1
+    sink1.reachableBy(iSrc).dedup.size shouldBe 1
 
     val lSrc = cpg.method("foo").ast.isLiteral.code("1").lineNumber(4).l
     lSrc.size shouldBe 1
@@ -662,7 +662,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     snk.reachableByFlows(src) should have size 1
   }
 
-  "Flow from a module-level literal to a call captured by a closure" in {
+  "Flow from a module-level literal to a call captured by a closure" should {
     val cpg = code("""
         |import axios from 'axios';
         |import { User } from './user';
@@ -674,8 +674,26 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
         |};
         |""".stripMargin)
 
-    val source = cpg.literal(".*https://test-api-service.com.*").l
-    val sinks  = cpg.call.code("axios.post\\(.*").l
-    sinks.reachableBy(source).size shouldBe 1
+    val sink = cpg.call.code("axios.post\\(.*").l
+
+    "literal to captured closure" in {
+      val literalSource = cpg.literal.codeExact("\"https://test-api-service.com\"").l
+      literalSource.size shouldBe 1
+      sink.reachableBy(literalSource).size shouldBe 1
+    }
+
+    "identifiers to captured closure" in {
+      val identifierSource = cpg.identifier.nameExact("API_Endpoint").lineNumber(5).l
+      identifierSource.size shouldBe 1
+      sink.reachableBy(identifierSource).size shouldBe 1
+      sink.reachableByFlows(identifierSource).p.foreach(println)
+    }
+
+    "identifiers in the arg of the call" in {
+      val identifierSource = cpg.identifier.nameExact("API_Endpoint").lineNumber(8).l
+      identifierSource.size shouldBe 1
+      sink.reachableBy(identifierSource).size shouldBe 1
+      sink.reachableByFlows(identifierSource).p.foreach(println)
+    }
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -661,4 +661,21 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
     def snk = cpg.identifier("sink")
     snk.reachableByFlows(src) should have size 1
   }
+
+  "Flow from a module-level literal to a call captured by a closure" in {
+    val cpg = code("""
+        |import axios from 'axios';
+        |import { User } from './user';
+        |
+        |const API_Endpoint = "https://test-api-service.com";
+        |
+        |export const createUser = (user: User) => {
+        |  return axios.post(API_Endpoint + "/user", user);
+        |};
+        |""".stripMargin)
+
+    val source = cpg.literal(".*https://test-api-service.com.*").l
+    val sinks  = cpg.call.code("axios.post\\(.*").l
+    sinks.reachableBy(source).size shouldBe 1
+  }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -211,7 +211,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
 
     val iSrc = cpg.method("foo").ast.isIdentifier.name("x").lineNumber(4).l
     iSrc.size shouldBe 1
-    sink1.reachableBy(iSrc).size shouldBe 1
+    sink1.reachableBy(iSrc).dedup.size shouldBe 1
 
     val lSrc = cpg.method("foo").ast.isLiteral.code("1").lineNumber(4).l
     lSrc.size shouldBe 1


### PR DESCRIPTION
Fix flow from module-level literal assigned to an identifier and used in a call captured by a child closure.