### PR TITLE
pysrc2cpg: Arg Index for Named Arguments

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/EdgeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/EdgeBuilder.scala
@@ -36,11 +36,11 @@ class EdgeBuilder(diffGraph: DiffGraphBuilder) {
     addArgumentIndex(dstNode, argIndex)
   }
 
-  def argumentEdge(dstNode: nodes.NewNode, srcNode: nodes.NewNode, argName: String): Unit = {
+  def argumentEdge(dstNode: nodes.NewNode, srcNode: nodes.NewNode, argName: String, argIndex: Int): Unit = {
     diffGraph.addEdge(srcNode, dstNode, EdgeTypes.ARGUMENT)
     // We need to fill something according to the CPG spec. But the spec also says that argument
-    // index is ignored if argument name is provided. So we just put -1.
-    addArgumentIndex(dstNode, -1)
+    // index is ignored if argument name is provided.
+    addArgumentIndex(dstNode, argIndex)
     addArgumentName(dstNode, argName)
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -265,7 +265,7 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
 
     keywordArguments.foreach { case (keyword: String, argumentNode) =>
       edgeBuilder.astEdge(argumentNode, callNode, order = index)
-      edgeBuilder.argumentEdge(argumentNode, callNode, argName = keyword)
+      edgeBuilder.argumentEdge(argumentNode, callNode, argName = keyword, argIndex = index)
       index += 1
     }
 
@@ -304,7 +304,7 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
 
     keywordArguments.foreach { case (keyword: String, argumentNode) =>
       edgeBuilder.astEdge(argumentNode, callNode, order = argIndex + 1)
-      edgeBuilder.argumentEdge(argumentNode, callNode, argName = keyword)
+      edgeBuilder.argumentEdge(argumentNode, callNode, argName = keyword, argIndex)
       argIndex += 1
     }
 
@@ -372,7 +372,7 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
 
     keywordArguments.foreach { case (keyword: String, argumentNode) =>
       edgeBuilder.astEdge(argumentNode, callNode, order = argIndex)
-      edgeBuilder.argumentEdge(argumentNode, callNode, argName = keyword)
+      edgeBuilder.argumentEdge(argumentNode, callNode, argName = keyword, argIndex = argIndex)
       argIndex += 1
     }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
@@ -73,7 +73,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
       val namedArg = callNode.astChildren.order(3).isIdentifier.head
       namedArg.code shouldBe "c"
-      namedArg.argumentIndex shouldBe -1
+      namedArg.argumentIndex shouldBe 3
       namedArg.argumentName shouldBe Some("namedPar")
     }
   }
@@ -145,7 +145,7 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
       val namedArg = callNode.astChildren.order(4).isIdentifier.head
       namedArg.code shouldBe "c"
-      namedArg.argumentIndex shouldBe -1
+      namedArg.argumentIndex shouldBe 3
       namedArg.argumentName shouldBe Some("namedPar")
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -332,7 +332,8 @@ class RegexDefinedFlowsDataFlowTests
       extraFlows = List(
         FlowSemantic("^path.*<module>\\.sanitizer$", List((0, 0), (1, 1)), regex = true),
         FlowSemantic("^foo.*<module>\\.sanitizer.*", List((0, 0), (1, 1)), regex = true),
-        FlowSemantic("^foo.*\\.create_sanitizer\\.<returnValue>\\.sanitize", List((0, 0), (1, 1)), regex = true)
+        FlowSemantic("^foo.*\\.create_sanitizer\\.<returnValue>\\.sanitize", List((0, 0), (1, 1)), regex = true),
+        FlowSemantic("requests.py:<module>.post", List((0, -1), (0, 0), (1, -1), (1, 1), (2, -1), (2, 2)))
       )
     ) {
 
@@ -399,6 +400,26 @@ class RegexDefinedFlowsDataFlowTests
       sink.reachableBy(source).size shouldBe 0
     }
 
+  }
+
+  "flows to parameterized arguments" should {
+    val cpg = code("""
+        |import requests
+        |def foo():
+        |    orderId = "Mysource"
+        |    item = orderId
+        |    response = requests.post(
+        |            url="https://rest.marketingcloudapis.com/data/v1/async",
+        |            body=item
+        |        )
+        |""".stripMargin)
+
+    "have summarized flows accurately pass parameterized argument behaviour" in {
+      val source = cpg.identifier("orderId")
+      val sink   = cpg.call("post")
+
+      sink.reachableBy(source).size shouldBe 2
+    }
   }
 
 }


### PR DESCRIPTION
While according to the comments, arg index is ignored for named arguments, but the data-flow engine relies on argument index regardless for defining semantics. This PR adds the index to enable data-flow engine users to define the semantics of the flows.

Note: While named arguments can move parameters around out-of-order, perhaps the data-flow engine should match the semantic arguments on the method stub and not the call site.