### PR TITLE
XTypeRecovery: Fix Accidental Arg/Call Mix Up

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -842,8 +842,6 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
         Traversal.from(fieldAccess.astParent).isCall.headOption match {
           case Some(callFromFieldName) if symbolTable.contains(callFromFieldName) =>
             persistType(callFromFieldName, symbolTable.get(callFromFieldName))
-          case Some(callFromFieldName) if idHints.nonEmpty =>
-            persistType(callFromFieldName, idHints.map(it => createCallFromIdentifierTypeFullName(it, f.canonicalName)))
           case _ =>
         }
         // This field may be a function pointer


### PR DESCRIPTION
Fixed code where a call occurring in another call has its receiver declaring type assigned to the parent call declaring type.