### PR TITLE
dataflowengineoss: Semantics for Named Arguments

### DIFF
--- a/dataflowengineoss/src/main/antlr4/io/joern/dataflowengineoss/Semantics.g4
+++ b/dataflowengineoss/src/main/antlr4/io/joern/dataflowengineoss/Semantics.g4
@@ -6,8 +6,10 @@ methodName : QUOTE name QUOTE;
 name : ~(NEWLINE|QUOTE)*?;
 
 mapping: src '->' dst;
-src: NUMBER;
-dst: NUMBER;
+argName: QUOTE name QUOTE;
+argIdx: NUMBER;
+src: argName | argIdx;
+dst: argName | argIdx;
 
 // Lexing
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -1,5 +1,6 @@
 package io.joern.dataflowengineoss
 
+import io.joern.dataflowengineoss.DefaultSemantics.F
 import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.shiftleft.codepropertygraph.generated.Operators
 
@@ -15,7 +16,7 @@ object DefaultSemantics {
     Semantics.fromList(list)
   }
 
-  private def F = FlowSemantic
+  private def F = (x: String, y: List[(Int, Int)]) => FlowSemantic.from(x, y)
 
   def operatorFlows: List[FlowSemantic] = List(
     F(Operators.addition, List((1, -1), (2, -1))),
@@ -55,7 +56,7 @@ object DefaultSemantics {
     F(Operators.postIncrement, List((1, 1), (1, -1))),
     F(Operators.preDecrement, List((1, 1), (1, -1))),
     F(Operators.preIncrement, List((1, 1), (1, -1))),
-    F(Operators.sizeOf, List()),
+    F(Operators.sizeOf, List.empty[(Int, Int)]),
 
     //  some of those operators have duplicate mappings due to a typo
     //  - see https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1630
@@ -67,7 +68,8 @@ object DefaultSemantics {
     F("<operators>.assignmentArithmeticShiftRight", List((2, 1), (1, 1))),
     F("<operators>.assignmentAnd", List((2, 1), (1, 1))),
     F("<operators>.assignmentOr", List((2, 1), (1, 1))),
-    F("<operators>.assignmentXor", List((2, 1), (1, 1)))
+    F("<operators>.assignmentXor", List((2, 1), (1, 1))),
+    F("<operator>.tupleLiteral", List((1, 1), (2, 2), (3, 3), (4, 4), (1, -1), (2, -1), (3, -1), (4, -1)))
   )
 
   /** Semantic summaries for common external C/C++ calls.
@@ -78,7 +80,7 @@ object DefaultSemantics {
     */
   def cFlows: List[FlowSemantic] = List(
     F("abs", List((1, 1), (1, -1))),
-    F("abort", List()),
+    F("abort", List.empty[(Int, Int)]),
     F("asctime", List((1, 1), (1, -1))),
     F("asctime_r", List((1, 1), (1, -1))),
     F("atof", List((1, 1), (1, -1))),
@@ -86,7 +88,7 @@ object DefaultSemantics {
     F("atol", List((1, 1), (1, -1))),
     F("calloc", List((1, -1), (2, -1))),
     F("ceil", List((1, 1), (1, 1))),
-    F("clock", List()),
+    F("clock", List.empty[(Int, Int)]),
     F("ctime", List((1, -1))),
     F("ctime64", List((1, -1))),
     F("ctime_r", List((1, -1))),

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
@@ -2,7 +2,7 @@ package io.joern.dataflowengineoss.passes.reachingdef
 
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.queryengine.Engine.isOutputArgOfInternalMethod
-import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.joern.dataflowengineoss.semanticsloader.{ParamMapping, PosArg, Semantics}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, Expression, StoredNode}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
@@ -39,7 +39,7 @@ object EdgeValidator {
     parentNode match {
       case call: Call =>
         val sem = semantics.forMethod(call.methodFullName)
-        sem.isDefined && !sem.get.mappings.map(_._2).contains(-1)
+        sem.isDefined && !sem.get.mappings.exists { case ParamMapping(_, PosArg(dst)) => dst == -1 }
       case _ =>
         false
     }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
@@ -39,7 +39,10 @@ object EdgeValidator {
     parentNode match {
       case call: Call =>
         val sem = semantics.forMethod(call.methodFullName)
-        sem.isDefined && !sem.get.mappings.exists { case ParamMapping(_, PosArg(dst)) => dst == -1 }
+        sem.isDefined && !sem.get.mappings.exists {
+          case ParamMapping(_, PosArg(dst)) => dst == -1
+          case _                            => false
+        }
       case _ =>
         false
     }

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/semanticsloader/ParserTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/semanticsloader/ParserTests.scala
@@ -21,7 +21,7 @@ class ParserTests extends AnyWordSpec with Matchers {
       semantics match {
         case List(x) =>
           x.methodFullName shouldBe "foo"
-          x.mappings shouldBe List((1, -1), (2, 3))
+          x.mappings shouldBe List(ParamMapping(PosArg(1), PosArg(-1)), ParamMapping(PosArg(2), PosArg(3)))
         case _ => fail()
       }
     }
@@ -44,6 +44,17 @@ class ParserTests extends AnyWordSpec with Matchers {
           y.methodFullName shouldBe "bar"
         case _ => fail()
       }
+    }
+
+    "parse named argument parameters" in new Fixture() {
+      private val semantics = parser.parse("\"foo\" \"param1\"->2 3->\"param2\"")
+      semantics.size shouldBe 1
+      semantics shouldBe List(
+        FlowSemantic(
+          "foo",
+          List(ParamMapping(NamedArg("param1"), PosArg(2)), ParamMapping(PosArg(3), NamedArg("param2")))
+        )
+      )
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SemanticTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SemanticTests.scala
@@ -13,10 +13,10 @@ import io.joern.x2cpg.Defines
 class SemanticTests
     extends JavaDataflowFixture(extraFlows =
       List(
-        FlowSemantic("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
-        FlowSemantic(s"ext.Library.killParam:${Defines.UnresolvedSignature}(1)", List.empty),
-        FlowSemantic("^ext\\.Library\\.taintNone:.*", List((0, 0), (1, 1)), regex = true),
-        FlowSemantic("^ext\\.Library\\.taint1to2:.*", List((1, 2)), regex = true)
+        FlowSemantic.from("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
+        FlowSemantic.from(s"ext.Library.killParam:${Defines.UnresolvedSignature}(1)", List.empty),
+        FlowSemantic.from("^ext\\.Library\\.taintNone:.*", List((0, 0), (1, 1)), regex = true),
+        FlowSemantic.from("^ext\\.Library\\.taint1to2:.*", List((1, 2)), regex = true)
       )
     ) {
   behavior of "Dataflow through custom semantics"

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/SemanticTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/SemanticTests.scala
@@ -8,8 +8,8 @@ import io.joern.x2cpg.Defines
 class SemanticTests
     extends JimpleDataFlowCodeToCpgSuite(extraFlows =
       List(
-        FlowSemantic("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
-        FlowSemantic("java.nio.file.Paths.get:.*\\(java.lang.String,.*\\)", List.empty, regex = true)
+        FlowSemantic.from("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
+        FlowSemantic.from("java.nio.file.Paths.get:.*\\(java.lang.String,.*\\)", List.empty, regex = true)
       )
     ) {
 


### PR DESCRIPTION
The current semantic definition only supports positional arguments which should correspond to the ordering of the callee parameter.

This is not always the case when named arguments are used, and this PR allows one to define strings as the names of the argument in the callee and match these up with other arguments whether named or positional.

When tracking a flow from a defined semantic, named arguments are given precedence over their positional counterparts.

A test in Python is added to verify flows through named arguments are no longer discarded.