### PR TITLE
Make pysrc2cpg compatible with closed source data flow tracker again.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -33,7 +33,7 @@ class ContextStack {
   }
 
   private class MethodContext(
-    val name: String,
+    val scopeName: Option[String],
     val astParent: nodes.NewNode,
     val order: AutoIncIndex,
     val isClassBodyMethod: Boolean = false,
@@ -46,7 +46,7 @@ class ContextStack {
   ) extends Context {}
 
   private class ClassContext(
-    val name: String,
+    val scopeName: Option[String],
     val astParent: nodes.NewNode,
     val order: AutoIncIndex,
     val variables: mutable.Map[String, nodes.NewNode] = mutable.Map.empty,
@@ -92,7 +92,7 @@ class ContextStack {
   }
 
   def pushMethod(
-    name: String,
+    scopeName: Option[String],
     methodNode: nodes.NewMethod,
     methodBlockNode: nodes.NewBlock,
     methodRefNode: Option[nodes.NewMethodRef]
@@ -100,15 +100,15 @@ class ContextStack {
     val isClassBodyMethod = stack.headOption.exists(_.isInstanceOf[ClassContext])
 
     val methodContext =
-      new MethodContext(name, methodNode, new AutoIncIndex(1), isClassBodyMethod, Some(methodBlockNode), methodRefNode)
+      new MethodContext(scopeName, methodNode, new AutoIncIndex(1), isClassBodyMethod, Some(methodBlockNode), methodRefNode)
     if (moduleMethodContext.isEmpty) {
       moduleMethodContext = Some(methodContext)
     }
     push(methodContext)
   }
 
-  def pushClass(name: String, classNode: nodes.NewTypeDecl): Unit = {
-    push(new ClassContext(name, classNode, new AutoIncIndex(1)))
+  def pushClass(scopeName: Option[String], classNode: nodes.NewTypeDecl): Unit = {
+    push(new ClassContext(scopeName, classNode, new AutoIncIndex(1)))
   }
 
   def pushSpecialContext(): Unit = {
@@ -243,7 +243,7 @@ class ContextStack {
     */
   def considerAsGlobalVariable(lhs: NewNode): Unit = {
     lhs match {
-      case n: NewIdentifier if findEnclosingMethodContext(stack).name == "<module>" =>
+      case n: NewIdentifier if findEnclosingMethodContext(stack).scopeName.contains("<module>") =>
         addGlobalVariable(n.name)
       case _ =>
     }
@@ -377,11 +377,11 @@ class ContextStack {
     stack
       .flatMap {
         case methodContext: MethodContext =>
-          Some(methodContext.name)
+          methodContext.scopeName
         case specialBlockContext: SpecialBlockContext =>
           None
         case classContext: ClassContext =>
-          Some(classContext.name)
+          classContext.scopeName
       }
       .reverse
       .mkString(".")
@@ -406,11 +406,9 @@ class ContextStack {
   }
 
   def isClassContext: Boolean = {
-    val stackTail = stack.tail
-    stackTail.nonEmpty && (stackTail.headOption match {
-      case Some(_: ClassContext) => true
-      case Some(x: MethodContext) => x.name.endsWith("<body>")
-      case _                     => false
+    stack.nonEmpty && (stack.head match {
+      case methodContext: MethodContext if methodContext.isClassBodyMethod => true
+      case _ => false
     })
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -100,7 +100,14 @@ class ContextStack {
     val isClassBodyMethod = stack.headOption.exists(_.isInstanceOf[ClassContext])
 
     val methodContext =
-      new MethodContext(scopeName, methodNode, new AutoIncIndex(1), isClassBodyMethod, Some(methodBlockNode), methodRefNode)
+      new MethodContext(
+        scopeName,
+        methodNode,
+        new AutoIncIndex(1),
+        isClassBodyMethod,
+        Some(methodBlockNode),
+        methodRefNode
+      )
     if (moduleMethodContext.isEmpty) {
       moduleMethodContext = Some(methodContext)
     }
@@ -408,7 +415,7 @@ class ContextStack {
   def isClassContext: Boolean = {
     stack.nonEmpty && (stack.head match {
       case methodContext: MethodContext if methodContext.isClassBodyMethod => true
-      case _ => false
+      case _                                                               => false
     })
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -376,13 +376,12 @@ class ContextStack {
   def qualName: String = {
     stack
       .flatMap {
-        case methodContext: MethodContext if !methodContext.isClassBodyMethod =>
+        case methodContext: MethodContext =>
           Some(methodContext.name)
         case specialBlockContext: SpecialBlockContext =>
           None
         case classContext: ClassContext =>
           Some(classContext.name)
-        case _: MethodContext => None
       }
       .reverse
       .mkString(".")
@@ -410,6 +409,7 @@ class ContextStack {
     val stackTail = stack.tail
     stackTail.nonEmpty && (stackTail.headOption match {
       case Some(_: ClassContext) => true
+      case Some(x: MethodContext) => x.name.endsWith("<body>")
       case _                     => false
     })
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -145,7 +145,6 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
     index.foreach(idx => methodParameterNode.index(idx))
-    methodParameterNode.dynamicTypeHintFullName(extractTypesFromHint(typeHint))
     addNodeToDiff(methodParameterNode)
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -288,10 +288,11 @@ class PythonAstVisitor(
     parameters: ast.Arguments,
     isStatic: Boolean
   ): () => MethodParameters = {
-    val startIndex = if (contextStack.isClassContext && !isStatic)
-      0
-    else
-      1
+    val startIndex =
+      if (contextStack.isClassContext && !isStatic)
+        0
+      else
+        1
 
     () => new MethodParameters(startIndex, convert(parameters, startIndex))
   }
@@ -304,7 +305,7 @@ class PythonAstVisitor(
     bodyProvider: () => Iterable[nodes.NewNode],
     returns: Option[ast.iexpr],
     isAsync: Boolean,
-    lineAndColumn: LineAndColumn,
+    lineAndColumn: LineAndColumn
   ): (nodes.NewMethod, nodes.NewMethodRef) = {
     val methodFullName = calculateFullNameFromContext(methodName)
 
@@ -322,7 +323,7 @@ class PythonAstVisitor(
         isAsync = true,
         Some(methodRefNode),
         returnTypeHint = None,
-        lineAndColumn,
+        lineAndColumn
       )
 
     (methodNode, methodRefNode)
@@ -341,7 +342,7 @@ class PythonAstVisitor(
     isAsync: Boolean,
     methodRefNode: Option[nodes.NewMethodRef],
     returnTypeHint: Option[String],
-    lineAndColumn: LineAndColumn,
+    lineAndColumn: LineAndColumn
   ): nodes.NewMethod = {
     val methodNode = nodeBuilder.methodNode(name, fullName, absFileName, lineAndColumn)
     edgeBuilder.astEdge(methodNode, contextStack.astParent, contextStack.order.getAndInc)
@@ -451,7 +452,7 @@ class PythonAstVisitor(
       bodyProvider = () => classDef.body.map(convert),
       None,
       isAsync = false,
-      lineAndColOf(classDef),
+      lineAndColOf(classDef)
     )
 
     contextStack.pop()
@@ -1383,7 +1384,7 @@ class PythonAstVisitor(
       () => Iterable.single(convert(new ast.Return(lambda.body, lambda.attributeProvider))),
       returns = None,
       isAsync = false,
-      lineAndColOf(lambda),
+      lineAndColOf(lambda)
     )
     methodRefNode
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -71,6 +71,42 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       xParameter.name shouldBe "x"
 
     }
+
+    "have correct full name for func1 method in class" in {
+      val cpg = code("""class Foo:
+                       |  def func1(self):
+                       |    pass
+                       |""".stripMargin)
+
+      val func1 = cpg.method.name("func1").head
+      func1.fullName shouldBe "Test0.py:<module>.Foo.func1"
+    }
+
+    "have correct full name for <body> method in class" in {
+      val cpg = code("""class Foo:
+                       |  pass
+                       |""".stripMargin)
+
+      val func1 = cpg.method.name("<body>").head
+      func1.fullName shouldBe "Test0.py:<module>.Foo.<body>"
+    }
+
+    "have correct parameter index for method in class" in {
+      val cpg = code("""class Foo:
+                       |  def method(self):
+                       |    pass
+                       |""".stripMargin)
+      cpg.method.name("method").parameter.name("self").index.head shouldBe 0
+    }
+
+    "have correct parameter index for static method in class" in {
+      val cpg = code("""class Foo:
+                       |  @staticmethod
+                       |  def method(x):
+                       |    pass
+                       |""".stripMargin)
+      cpg.method.name("method").parameter.name("x").index.head shouldBe 1
+    }
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -16,14 +16,9 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
                                                 |
                                                 |""".stripMargin)
 
-    "should have a MEMBER" in {
-      val List(member: Member) = cpg.member.name("x").l
-      member.code shouldBe "x"
-    }
-
     "should have the MEMBER attached to the class" in {
-      val List(typeDecl) = cpg.member.name("x").typeDecl.l
-      typeDecl.name shouldBe "Foo"
+      val List(member) = cpg.typeDecl.name("Foo").member.name("x").l
+      member.name shouldBe "x"
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/VariableReferencingCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/VariableReferencingCpgTests.scala
@@ -276,7 +276,6 @@ class VariableReferencingCpgTests extends AnyFreeSpec with Matchers {
       val fLocal = cpg.method.fullName("test.py:<module>.MyClass.f").local.name("x").head
       fLocal.closureBindingId shouldBe Some("test.py:<module>.MyClass.f:x")
 
-
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/VariableReferencingCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/VariableReferencingCpgTests.scala
@@ -262,17 +262,21 @@ class VariableReferencingCpgTests extends AnyFreeSpec with Matchers {
     lazy val cpg = Py2CpgTestContext.buildCpg("""x = 0
         |class MyClass():
         |  x = 1
-        |  def f():
+        |  def f(self):
         |    someFunc(x)
         |""".stripMargin)
 
     "test capturing to global x exists" in {
-      cpg.method.fullName.foreach(println)
-      val localNode = cpg.method.name("<module>").local.name("x").head
-      localNode._closureBindingViaRefIn.next().closureBindingId shouldBe Some("test.py:<module>.MyClass.f:x")
+      val moduleLocal = cpg.method.name("<module>").local.name("x").head
+      moduleLocal._closureBindingViaRefIn.next().closureBindingId shouldBe Some("test.py:<module>.MyClass.f:x")
 
-      val localInMyClassNode = cpg.method.name("MyClass").local.name("x").head
-      localInMyClassNode.referencingIdentifiers.lineNumber(5).hasNext shouldBe false
+      val bodyLocal = cpg.method.fullName("test.py:<module>.MyClass.<body>").local.name("x").head
+      bodyLocal.closureBindingId shouldBe None
+
+      val fLocal = cpg.method.fullName("test.py:<module>.MyClass.f").local.name("x").head
+      fLocal.closureBindingId shouldBe Some("test.py:<module>.MyClass.f:x")
+
+
     }
   }
 
@@ -287,7 +291,7 @@ class VariableReferencingCpgTests extends AnyFreeSpec with Matchers {
       val localNode = cpg.method.name("<module>").local.name("x").head
       localNode._closureBindingViaRefIn.hasNext shouldBe false
 
-      val localInMyClassNode = cpg.method.name("MyClass").local.name("x").head
+      val localInMyClassNode = cpg.method.name("<body>").local.name("x").head
       localInMyClassNode.referencingIdentifiers.lineNumber(4).code.head shouldBe "x"
     }
   }


### PR DESCRIPTION
This change roles back some of the changes made to ease type
propagation which collided with the needs of the closed source data flow tracker.

In order to keep at least so of the changes to ease type propagation, we added
more flexible scope naming.

This allows full names which so far were based on context and thus
structure to be independent from it.  In specific the <body> methods
scope will not be part of the full names of elements structurally below it.

Not all tests are passing yet. Note that the calls to `extractTypesFromHing`
have been removed which renders some of the type propagations assumptions
invalid.