### PR TITLE
XTypeHintCallLinker: Separated Speculated Methods Stubs

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1,6 +1,7 @@
 package io.joern.pysrc2cpg.passes
 
 import io.joern.pysrc2cpg.PySrc2CpgFixture
+import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.semanticcpg.language._
 
 import java.io.File
@@ -35,9 +36,10 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
 
     "resolve 'z' identifier calls conservatively" in {
-      // TODO: These should have callee entries but the method stubs are not present here
       val List(zAppend) = cpg.call("append").l
       zAppend.methodFullName shouldBe "<unknownFullName>"
+      // Since we don't have method nodes with this full name, this should belong to the call linker namespace
+      zAppend.callee.astParentFullName.headOption shouldBe Some(XTypeHintCallLinker.namespace)
       zAppend.dynamicTypeHintFullName shouldBe Seq(
         "__builtin.dict.append",
         "__builtin.list.append",

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -2,8 +2,8 @@ package io.joern.x2cpg.passes.frontend
 
 import io.joern.x2cpg.passes.base.MethodStubCreator
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, MethodBase, NewMethod}
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import io.shiftleft.semanticcpg.language._
@@ -40,6 +40,7 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
     val callerAndCallees = calls.map(call => (call, calleeNames(call))).toList
     val methodMap        = mapMethods(callerAndCallees, builder)
     linkCallsToCallees(callerAndCallees, methodMap, builder)
+    linkSpeculativeNamespaceNodes(methodMap.view.values.collectAll[NewMethod], builder)
   }
 
   protected def mapMethods(
@@ -104,7 +105,7 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
       if (methodName.contains(pathSep) && methodName.length > methodName.lastIndexOf(pathSep) + 1)
         methodName.substring(methodName.lastIndexOf(pathSep) + 1)
       else methodName
-    MethodStubCreator
+    val stub = MethodStubCreator
       .createMethodStub(
         name,
         methodName,
@@ -112,8 +113,50 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
         DispatchTypes.DYNAMIC_DISPATCH.name(),
         call.argumentOut.size,
         builder,
-        isExternal
+        isExternal,
+        astParentFullName = XTypeHintCallLinker.namespace
       )
+    addTypeDeclInfo(stub, builder)
   }
+
+  /** Try to extract a type full name from the method full name, if one exists in the CPG then we are lucky and we use
+    * it, else we ignore for now.
+    */
+  protected def addTypeDeclInfo(stub: NewMethod, builder: DiffGraphBuilder): NewMethod = {
+    val nameIdx = stub.fullName.lastIndexOf(stub.name)
+    if (!stub.fullName.isBlank && !stub.fullName.startsWith("<operator") && nameIdx > 0) {
+      cpg.typeDecl.fullNameExact(stub.fullName.substring(0, nameIdx - 1)).headOption.foreach { typeDecl =>
+        stub
+          .astParentFullName(typeDecl.fullName)
+          .astParentType(NodeTypes.TYPE_DECL)
+        builder.addEdge(typeDecl, stub, EdgeTypes.AST)
+      }
+      stub
+    } else {
+      stub
+    }
+  }
+
+  /** Once we have connected methods that were speculatively generated and managed to correctly link to methods already
+    * in the CPG, we link the rest to the "speculativeMethods" namespace as a way to show that these may not actually
+    * exist.
+    */
+  protected def linkSpeculativeNamespaceNodes(newMethods: IterableOnce[NewMethod], builder: DiffGraphBuilder): Unit = {
+    val speculativeNamespace =
+      NewNamespaceBlock().name(XTypeHintCallLinker.namespace).fullName(XTypeHintCallLinker.namespace)
+
+    builder.addNode(speculativeNamespace)
+    newMethods
+      .filter(_.astParentFullName == XTypeHintCallLinker.namespace)
+      .foreach(m => builder.addEdge(speculativeNamespace, m, EdgeTypes.AST))
+  }
+}
+
+object XTypeHintCallLinker {
+
+  /** The shared namespace for all methods generated from the type recovery that may not exist with this exact full name
+    * in reality.
+    */
+  val namespace: String = "<speculatedMethods>"
 
 }


### PR DESCRIPTION
MethodStubs generated by the type recovery that end up not matching up to an existing method (or associate with a type that does not exist) will be associated with a special namespace.

Resolves #2673