### PR TITLE
New slim image with less os packages and less jars

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -55,6 +55,27 @@ jobs:
           sbom: true
 
       - name: Extract metadata (tags, labels) for Docker
+        id: meta3
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/joernio/joern-slim
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ci/Dockerfile.slim
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta3.outputs.tags }}
+          labels: ${{ steps.meta3.outputs.labels }}
+          cache-from: type=gha,scope=joern-slim
+          cache-to: type=gha,mode=max,scope=joern-slim
+          provenance: true
+          sbom: true
+
+      - name: Extract metadata (tags, labels) for Docker
         id: meta2
         uses: docker/metadata-action@v4
         with:

--- a/ci/Dockerfile.alma
+++ b/ci/Dockerfile.alma
@@ -21,8 +21,6 @@ ENV JOERN_HOME=/usr/local/bin \
     CLASSPATH=$CLASSPATH:/usr/local/bin: \
     PATH=${PATH}:/opt/joern/joern-cli:/opt/joern/joern-cli/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin:/root/.local/bin:${JAVA_HOME}/bin:
 
-COPY . /usr/local/src/
-
 RUN microdnf install -y gcc git-core php php-cli python3 python3-devel pcre2 which tar zip unzip sudo \
         java-17-openjdk-headless ncurses jq zlib graphviz glibc-common glibc-all-langpacks \
     && curl -LO https://github.com/joernio/joern/releases/latest/download/joern-install.sh \

--- a/ci/Dockerfile.slim
+++ b/ci/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM almalinux/8-minimal:latest
+FROM almalinux/9-minimal:latest
 
 LABEL maintainer="joern" \
       org.opencontainers.image.authors="Team Joern" \
@@ -9,7 +9,7 @@ LABEL maintainer="joern" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="joern" \
       org.opencontainers.image.description="Joern is a platform for analyzing source code, bytecode, and binary executables" \
-      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8 joern"
+      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-slim joern"
 
 ENV JOERN_HOME=/usr/local/bin \
     LC_ALL=en_US.UTF-8 \
@@ -21,11 +21,15 @@ ENV JOERN_HOME=/usr/local/bin \
     CLASSPATH=$CLASSPATH:/usr/local/bin: \
     PATH=${PATH}:/opt/joern/joern-cli:/opt/joern/joern-cli/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin:/root/.local/bin:${JAVA_HOME}/bin:
 
-RUN microdnf install -y gcc git-core php php-cli python3 python3-devel pcre2 which tar zip unzip sudo \
-        java-17-openjdk-headless ncurses jq zlib graphviz glibc-common glibc-all-langpacks \
+RUN microdnf install -y php php-cli which tar zip unzip sudo \
+        java-17-openjdk-headless ncurses zlib graphviz glibc-common glibc-all-langpacks \
     && curl -LO https://github.com/joernio/joern/releases/latest/download/joern-install.sh \
     && chmod +x ./joern-install.sh \
-    && ./joern-install.sh \
+    && ./joern-install.sh --without-plugins \
+    && curl -LO https://github.com/qarmin/czkawka/releases/download/5.1.0/linux_czkawka_cli \
+    && chmod +x linux_czkawka_cli \
+    && linux_czkawka_cli dup -e /opt/joern/joern-cli/lib --directories /opt/joern/joern-cli -x jar -L -s hash -f results.txt -D AEO \
+    && rm linux_czkawka_cli results.txt \
     && useradd -ms /bin/bash joern \
     && chown -R joern:joern /opt/joern \
     && rm /joern-cli.zip /joern-install.sh \


### PR DESCRIPTION
Firstly, COPY of the source code isn't required in any image. Then using the tool `czkawka` I delete newer jars alone excluding `/opt/joern/joern-cli/lib`.

```
❯ docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-slim
Compiling /app/(console)
creating workspace directory: /app/workspace

     ██╗ ██████╗ ███████╗██████╗ ███╗   ██╗
     ██║██╔═══██╗██╔════╝██╔══██╗████╗  ██║
     ██║██║   ██║█████╗  ██████╔╝██╔██╗ ██║
██   ██║██║   ██║██╔══╝  ██╔══██╗██║╚██╗██║
╚█████╔╝╚██████╔╝███████╗██║  ██║██║ ╚████║
 ╚════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝
Version: 1.1.1698
Type `help` or `browse(help)` to begin

joern>
```

Nearly 1 GB is trimmed from the exploded image.

```
❯ docker images
REPOSITORY                                                           TAG                    IMAGE ID       CREATED          SIZE
ghcr.io/joernio/joern-slim                                           latest                 714347401ae2   2 minutes ago    1.86GB
<none>                                                               <none>                 6b47a09273fe   8 minutes ago    1.83GB
<none>                                                               <none>                 6fce718b8701   9 minutes ago    1.83GB
<none>                                                               <none>                 05327a0d208c   11 minutes ago   2.13GB
ghcr.io/joernio/joern                                                master                 acce268a90b2   4 hours ago      2.89GB
```