### PR TITLE
Do not add AST children to member nodes

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -709,20 +709,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val entryNode = memberNode(entry, entry.getNameAsString, entry.toString, typeFullName.getOrElse("ANY"))
 
     val name = s"${typeFullName.getOrElse(Defines.UnresolvedNamespace)}.${Defines.ConstructorMethodName}"
-    val args = entry.getArguments.asScala.map { argument =>
-      val children = astsForExpression(argument, ExpectedType.empty)
-      val callNode =
-        NewCall()
-          .name(name)
-          .methodFullName(name)
-          .dispatchType(DispatchTypes.STATIC_DISPATCH)
-          .code(entry.toString)
-          .lineNumber(line(entry))
-          .columnNumber(column(entry))
-      callAst(callNode, children)
-    }
 
-    Ast(entryNode).withChildren(args)
+    Ast(entryNode)
   }
 
   private def modifiersForFieldDeclaration(decl: FieldDeclaration): Seq[Ast] = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
@@ -62,17 +62,9 @@ class EnumTests extends JavaSrcCode2CpgFixture {
     l.code shouldBe "java.lang.String label"
 
     r.code shouldBe "RED(\"Red\")"
-    r.astChildren.isCall.size shouldBe 1
-    val call = r.astChildren.isCall.head
-    call.name shouldBe s"Color.${io.joern.x2cpg.Defines.ConstructorMethodName}"
-    call.methodFullName shouldBe s"Color.${io.joern.x2cpg.Defines.ConstructorMethodName}"
-    call.order shouldBe 1
-    call.astChildren.size shouldBe 1
-    call.astChildren.head shouldBe a[Literal]
-    call.astChildren.head.code shouldBe "\"Red\""
+    r.astChildren.size shouldBe 0
 
     b.code shouldBe "BLUE(\"Blue\")"
-    b.astChildren.astChildren.size shouldBe 1
-    b.astChildren.astChildren.head.code shouldBe "\"Blue\""
+    b.astChildren.astChildren.size shouldBe 0
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
@@ -7,6 +7,34 @@ import io.shiftleft.semanticcpg.language._
 import org.scalatest.Ignore
 
 class NewMemberTests extends JavaSrcCode2CpgFixture {
+  "members with anonymous classes should not result in subtrees to the member node" in {
+    val cpg = code("""
+        |class Foo {
+        |  Foo x = new Foo() {
+        |    @Override
+        |    void foo() {}
+        |  }
+        |
+        |  void foo() {}
+        |}""".stripMargin)
+    cpg.member.name("x").astChildren.size shouldBe 0
+  }
+
+  "enum entries with anonymous classes should not result in subtrees to the member node" in {
+    val cpg = code("""
+        |enum Foo {
+        |  X(12) {
+        |    @Override
+        |    void foo() {}
+        |  }
+        |
+        |  private Foo(int x) {}
+        |
+        |  void foo() {}
+        |}""".stripMargin)
+    cpg.member.name("x").astChildren.size shouldBe 0
+  }
+
   "non-static member initializers" should {
     "only be added once per constructor" in {
       val cpg = code("""


### PR DESCRIPTION
This is a temporary hack, pending proper handling of enum args and anonymous classes.