### PR TITLE
throttle releases: only one per day by default

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,14 +1,9 @@
 name: Upload Container image
 
 on:
-  schedule:
-  - cron: "0 */12 * * *"
   push:
-    branches:
-     - master
     tags:
       - 'v*'
-  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: release
 on:
-  push:
-    branches: [master, main]
-    tags: ["*"]
+  schedule:
+    - cron: "0 7 * * *" # run once daily
+  workflow_dispatch:    # allow to manually trigger this workflow
 jobs:
   release:
     concurrency: release

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '19'
       - name: Upgrade all (internal) dependencies
         run: ./updateDependencies.sh --non-interactive
       - run: sbt clean +test

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Almalinux 9 requires the CPU to support SSE4.2. For kvm64 VM use the Almalinux 8
 docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8 joern
 ```
 
+## Releases
+A new release is [created automatically](.github/workflows/release.yml) once per day. Contributers can also manually run the [release workflow](https://github.com/joernio/joern/actions/workflows/release.yml) if they need the release sooner. 
+
 ## Developers: IDE setup
 
 ### Intellij IDEA


### PR DESCRIPTION
It's a great problem to have, but we really don't want to release 10x
a day (for each commit). Contributors can still manually trigger a
release in github actions.