### PR TITLE
ARM 64 version isn't required for slim and alma8

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: .
           file: ci/Dockerfile.slim
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta3.outputs.tags }}
           labels: ${{ steps.meta3.outputs.labels }}
@@ -87,7 +87,7 @@ jobs:
         with:
           context: .
           file: ci/Dockerfile.alma8
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta2.outputs.tags }}
           labels: ${{ steps.meta2.outputs.labels }}


### PR DESCRIPTION
ARM 64 version isn't required for slim and alma8