### PR TITLE
XTypeRecovery: Use Return Nodes As MethodReturn Hints

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -74,7 +74,14 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
       methodNames
         .flatMap(methodMap.get)
         .filter(m => call.callee(NoResolve).fullNameExact(m.fullName).isEmpty)
-        .foreach { m => builder.addEdge(call, m, EdgeTypes.CALL) }
+        .foreach { m =>
+          builder.addEdge(call, m, EdgeTypes.CALL)
+          m match {
+            case method: Method =>
+              builder.setNodeProperty(call, PropertyNames.TYPE_FULL_NAME, method.methodReturn.typeFullName)
+            case _ =>
+          }
+        }
       setCallees(call, methodNames, builder)
     }
   }


### PR DESCRIPTION
* Parses available types around `Return` nodes and stores them as type hints in the callee `MethodReturn`
* Currently only handles simple calls and literals