### PR TITLE
Be more linient in AccessPath matching.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPath.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPath.scala
@@ -136,7 +136,8 @@ case class AccessPath(elements: Elements, exclusions: Seq[Elements]) {
       (elements.elements(idx), other.elements(idx)) match {
         case (VariableAccess, VariableAccess) | (_: ConstantAccess, VariableAccess) |
             (VariableAccess, _: ConstantAccess) | (VariablePointerShift, VariablePointerShift) |
-            (_: PointerShift, VariablePointerShift) | (VariablePointerShift, _: PointerShift) =>
+            (_: PointerShift, VariablePointerShift) | (VariablePointerShift, _: PointerShift) |
+      (VariableAccess, IndirectionAccess) | (IndirectionAccess, VariableAccess) =>
           overTainted = true
         case (thisElem, otherElem) =>
           if (thisElem != otherElem)

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/accesspath/AccessPathTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/accesspath/AccessPathTests.scala
@@ -69,7 +69,6 @@ class AccessPathTests extends AnyWordSpec {
     AccessPath(E("a"), Seq()).matchAndDiff(E("b", V)) shouldBe (NO_MATCH, E())
     AccessPath(E("a", V, "b"), Seq()).matchAndDiff(E("b", V, "a")) shouldBe (NO_MATCH, E())
     AccessPath(E("a", I), Seq()).matchAndDiff(E(I)) shouldBe (NO_MATCH, E())
-    AccessPath(E("a", I), Seq()).matchAndDiff(E("a", V)) shouldBe (NO_MATCH, E())
 
     AccessPath(E("a", "b"), Seq()).matchAndDiff(E("a")) shouldBe (PREFIX_MATCH, E("b"))
     AccessPath(E("a", V), Seq()).matchAndDiff(E("a")) shouldBe (PREFIX_MATCH, E(V))
@@ -81,6 +80,7 @@ class AccessPathTests extends AnyWordSpec {
 
     AccessPath(E("a"), Seq()).matchAndDiff(E(V)) shouldBe (VARIABLE_EXACT_MATCH, E())
     AccessPath(E(V), Seq()).matchAndDiff(E("a")) shouldBe (VARIABLE_EXACT_MATCH, E())
+    AccessPath(E(V), Seq()).matchAndDiff(E(I)) shouldBe (VARIABLE_EXACT_MATCH, E())
     AccessPath(E("a", "b"), Seq()).matchAndDiff(E("a", V)) shouldBe (VARIABLE_EXACT_MATCH, E())
     AccessPath(E(V, "b"), Seq()).matchAndDiff(E(V, "b")) shouldBe (VARIABLE_EXACT_MATCH, E())
     AccessPath(E("a", V), Seq()).matchAndDiff(E(V, V)) shouldBe (VARIABLE_EXACT_MATCH, E())


### PR DESCRIPTION
We consider IndirectionAccess and VariableAccess equal with overtaint.