### PR TITLE
XTypeRecovery: Extend Field Accesses to Return Hints

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -3,7 +3,6 @@ package io.joern.pysrc2cpg
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecovery.isDummyType
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodBase}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
@@ -19,23 +18,13 @@ class PythonTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
     case typ => typ
   }
 
-  override protected def linkCallsToCallees(
-    callerAndCallees: List[(Call, Seq[String])],
-    methodMap: Map[String, MethodBase],
-    builder: DiffGraphBuilder
-  ): Unit = {
-    // Link edges to method nodes
-    callerAndCallees.foreach { case (call, methodNames) =>
-      methodNames
-        .flatMap(methodMap.get)
-        .foreach { m => builder.addEdge(call, m, EdgeTypes.CALL) }
-      if (methodNames.sizeIs == 1) {
-        setCallees(call, methodNames, builder)
-      } else if (methodNames.sizeIs > 1) {
-        val nonDummyMethodNames =
-          methodNames.filterNot(x => isDummyType(x) || x.startsWith(PythonAstVisitor.builtinPrefix + "None"))
-        setCallees(call, nonDummyMethodNames, builder)
-      }
+  override def setCallees(call: Call, methodNames: Seq[String], builder: DiffGraphBuilder): Unit = {
+    if (methodNames.sizeIs == 1) {
+      super.setCallees(call, methodNames, builder)
+    } else if (methodNames.sizeIs > 1) {
+      val nonDummyMethodNames =
+        methodNames.filterNot(x => isDummyType(x) || x.startsWith(PythonAstVisitor.builtinPrefix + "None"))
+      super.setCallees(call, nonDummyMethodNames, builder)
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -884,9 +884,11 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "be able to use field accesses as type hints" in {
       val Some(c) = cpg.identifier("c").headOption
-      c.typeFullName shouldBe "lib/connector.py:<module>.Connector"
+      c.typeFullName shouldBe Seq("lib", "connector.py:<module>.Connector").mkString(File.separator)
       val Some(getBotoClient) = cpg.call.nameExact("getBotoClient").headOption
-      getBotoClient.methodFullName shouldBe "lib/connector.py:<module>.Connector.getBotoClient"
+      getBotoClient.methodFullName shouldBe Seq("lib", "connector.py:<module>.Connector.getBotoClient").mkString(
+        File.separator
+      )
       val Some(getS3Object) = cpg.call.nameExact("getS3Object").headOption
       getS3Object.methodFullName shouldBe "boto.<returnValue>.getS3Object"
     }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -855,4 +855,41 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
+  "Recovered values that are returned in methods" should {
+    lazy val cpg = code(
+      """
+        |class Connector:
+        |
+        |	botoClient = boto("s3")
+        |
+        |	def makeDbCall():
+        |		pass
+        |
+        |	def getBotoClient(self):
+        |		return self.botoClient
+        |
+        |""".stripMargin,
+      Seq("lib", "connector.py").mkString(File.separator)
+    ).moreCode(
+      """
+        |from lib.connector import Connector
+        |
+        |class Impl:
+        |
+        |	c = Connector()
+        |	c.getBotoClient().getS3Object()
+        |""".stripMargin,
+      "impl.py"
+    )
+
+    "be able to use field accesses as type hints" in {
+      val Some(c) = cpg.identifier("c").headOption
+      c.typeFullName shouldBe "lib/connector.py:<module>.Connector"
+      val Some(getBotoClient) = cpg.call.nameExact("getBotoClient").headOption
+      getBotoClient.methodFullName shouldBe "lib/connector.py:<module>.Connector.getBotoClient"
+      val Some(getS3Object) = cpg.call.nameExact("getS3Object").headOption
+      getS3Object.methodFullName shouldBe "boto.<returnValue>.getS3Object"
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -15,6 +15,7 @@ import overflowdb.traversal.Traversal
 
 import java.util.concurrent.RecursiveTask
 import java.util.concurrent.atomic.AtomicBoolean
+import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
@@ -774,9 +775,10 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
       (m.methodReturn.typeFullName +: m.methodReturn.dynamicTypeHintFullName)
         .filterNot(_ == "ANY")
     )
-    ret.astChildren.l match {
+    @tailrec
+    def extractTypes(xs: List[CfgNode]): Set[String] = xs match {
       case ::(head: Literal, Nil) if head.typeFullName != "ANY" =>
-        existingTypes.addOne(head.typeFullName)
+        Set(head.typeFullName)
       case ::(head: Call, Nil) if head.name == Operators.fieldAccess =>
         val fieldAccess = new FieldAccess(head)
         val (sym, ts)   = getSymbolFromCall(fieldAccess)
@@ -787,20 +789,25 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
           .flatMap(m => m.typeFullName +: m.dynamicTypeHintFullName)
           .filterNot(_ == "ANY")
           .toSet
-        if (cpgTypes.nonEmpty) {
-          existingTypes.addAll(cpgTypes)
-        } else {
-          existingTypes.addAll(symbolTable.get(sym))
-        }
+        if (cpgTypes.nonEmpty) cpgTypes
+        else symbolTable.get(sym)
       case ::(head: Call, Nil) if symbolTable.contains(head) =>
-        existingTypes.addAll(symbolTable.get(head))
+        val callPaths    = symbolTable.get(head)
+        val returnValues = methodReturnValues(callPaths.toSeq)
+        if (returnValues.isEmpty)
+          callPaths.map(_.concat(pathSep + XTypeRecovery.DummyReturnType))
+        else
+          returnValues
       case ::(head: Call, Nil) if head.argumentOut.headOption.exists(symbolTable.contains) =>
-        val speculatedCallTypes = symbolTable
+        symbolTable
           .get(head.argumentOut.head)
           .map(t => Seq(t, head.name, XTypeRecovery.DummyReturnType).mkString(pathSep.toString))
-        existingTypes.addAll(speculatedCallTypes)
-      case _ =>
+      case ::(head: Call, Nil) =>
+        extractTypes(head.argument.l)
+      case _ => Set.empty
     }
+    val returnTypes = extractTypes(ret.argumentOut.l)
+    existingTypes.addAll(returnTypes)
     builder.setNodeProperty(ret.method.methodReturn, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, existingTypes)
   }
 


### PR DESCRIPTION
If a call is a field access below a return, attempts to resolve the type of the field on the CPG or symbol table and use it as a type hint on the method return.