### PR TITLE
AstNode.astParent is not set for ast root - mark that in return type

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -65,8 +65,8 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
                        })
   }
 
-  def astParent: AstNode =
-    node._astIn.onlyChecked.asInstanceOf[AstNode]
+  def astParent: Option[AstNode] =
+    node._astIn.headOption.map(_.asInstanceOf[AstNode])
 
   /** Direct children of node in the AST. Siblings are ordered by their `order` fields
     */


### PR DESCRIPTION
the ast root doesn't have a parent:
```
cpg.method.head.astParent.astParent.astParent.astParent.astParent

java.util.NoSuchElementException
  at io.shiftleft.Implicits$JavaIteratorDeco$.onlyChecked$extension(Implicits.scala:43)
  at io.shiftleft.semanticcpg.language.nodemethods.AstNodeMethods$.astParent$extension(AstNodeMethods.scala:69)
  ... 39 elided
```

n.b. this isn't quite mergeable yet - I'll adapt downstream usage after
hearing your feedback...