### PR TITLE
make cpg.typ consistent

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeTests.scala
@@ -224,22 +224,22 @@ class TypeTests extends JavaSrcCode2CpgFixture {
   }
 
   "should allow traversing from member's TYPE to member" in {
-    val List(x) = cpg.typ("java.lang.Long").memberOfType.l
+    val List(x) = cpg.typ("Long").memberOfType.l
     x.name shouldBe "x"
   }
 
   "should allow traversing from return params TYPE to return param" in {
-    val List(x) = cpg.typ("java.lang.Integer").methodReturnOfType.l
+    val List(x) = cpg.typ("Integer").methodReturnOfType.l
     x.typeFullName shouldBe "java.lang.Integer"
   }
 
   "should allow traversing from params TYPE to param" in {
-    val List(x) = cpg.typ("java.lang.Object").parameterOfType.l
+    val List(x) = cpg.typ("Object").parameterOfType.l
     x.name shouldBe "param"
   }
 
   "should allow traversing from local's TYPE to local" in {
-    val List(x) = cpg.typ("java.lang.Double").localOfType.l
+    val List(x) = cpg.typ("Double").localOfType.l
     x.name shouldBe "y"
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/TypeTests.scala
@@ -48,17 +48,17 @@ class TypeTests extends JimpleCode2CpgFixture {
 //  }
 
   "should allow traversing from member's TYPE to member" in {
-    val List(x) = cpg.typ("java.lang.Long").memberOfType.l
+    val List(x) = cpg.typ("Long").memberOfType.l
     x.name shouldBe "x"
   }
 
   "should allow traversing from return params TYPE to return param" in {
-    val List(x) = cpg.typ("java.lang.Integer").methodReturnOfType.l
+    val List(x) = cpg.typ.fullName("java.lang.Integer").methodReturnOfType.l
     x.typeFullName shouldBe "java.lang.Integer"
   }
 
   "should allow traversing from params TYPE to param" in {
-    val List(x) = cpg.typ("java.lang.Object").parameterOfType.l
+    val List(x) = cpg.typ("Object").parameterOfType.l
     x.name shouldBe "param"
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/TypeTests.scala
@@ -55,7 +55,7 @@ class TypeTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     }
 
     "should allow traversing from params TYPE to param" in {
-      val List(x) = cpg.typ("java.lang.Object").parameterOfType.l
+      val List(x) = cpg.typ("Object").parameterOfType.l
       x.name shouldBe "x"
     }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -274,7 +274,7 @@ class NodeTypeStarters(cpg: Cpg) extends TraversalSource(cpg.graph) {
     */
   @Doc(info = "All used types with given name")
   def typ(name: String): Traversal[Type] =
-    typ.fullName(name)
+    typ.name(name)
 
   /** Traverse to all declarations, e.g., Set<T>
     */

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
@@ -42,7 +42,7 @@ class TypeTests extends AnyWordSpec with Matchers {
 
     "more than 0 members found by regex" in {
       def queryResult: List[Member] =
-        cpg.typeDecl.member.name(".*").toList
+        cpg.typ.member.name(".*").toList
 
       queryResult.size should be > 0
     }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
@@ -42,7 +42,7 @@ class TypeTests extends AnyWordSpec with Matchers {
 
     "more than 0 members found by regex" in {
       def queryResult: List[Member] =
-        cpg.typ.member.name(".*").toList
+        cpg.typeDecl.member.name(".*").toList
 
       queryResult.size should be > 0
     }


### PR DESCRIPTION
make cpg.typ consistent with the comment

https://github.com/joernio/joern/blob/9263414af3a55945376c7bf40a01fa60c462be06/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala#L273-L277

also consistent with 
- `cpg.typeDecl(<short-name>)`
- `cpg.call(<short-name>)`
