### PR TITLE
ossdataflowengine: fix edge case when tracking from receivers

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -82,7 +82,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
           List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
         ) ++ x.refsTo.capturedByMethodRef.referencedMethod.flatMap(m => usagesForName(x.name, m))
       case x: Call =>
-        (x._receiverIn.l ++ List(x)).collect { case y: CfgNode => y }
+        (x._receiverIn.l :+ x).collect { case y: CfgNode => y }
       case x => List(x).collect { case y: CfgNode => y }
     }
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -81,6 +81,8 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
         withFieldAndIndexAccesses(
           List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
         ) ++ x.refsTo.capturedByMethodRef.referencedMethod.flatMap(m => usagesForName(x.name, m))
+      case x: Call =>
+        (x._receiverIn.l ++ List(x)).collect { case y: CfgNode => y }
       case x => List(x).collect { case y: CfgNode => y }
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -446,4 +446,18 @@ class RegexDefinedFlowsDataFlowTests
     }
   }
 
+  "flows from receivers" should {
+    val cpg = code("""
+        |class Foo:
+        |   def func():
+        |      return "x"
+        |print(Foo.func())
+        |""".stripMargin)
+    "be found" in {
+      val src = cpg.call.code("Foo.func").l
+      val snk = cpg.call("print").l
+      snk.argument.reachableByFlows(src).size shouldBe 1
+    }
+  }
+
 }


### PR DESCRIPTION
This problem became apparent after https://github.com/joernio/joern/pull/2680 was merged: when using a receiver as a source, and we manage to track back all the way to an invocation on that receiver, we do not consider the call on that receiver to be a source as well. In fact, it's somewhat debatable whether we should. The reason I believe we should is that if we are unable to resolve the method, we will actually jump back to the receiver, while if we can resolve it, we don't. In order to be consistent regardless of whether the method can be resolved or not, this change is necessary.