### PR TITLE
Refactor php2cpg file AST creation

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -735,8 +735,12 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
     val inheritsFrom = (stmt.extendsNames ++ stmt.implementedInterfaces).map(_.name)
     val code         = codeForClassStmt(stmt, name)
 
-    val includeGlobalNamespacePrefix = name.name == NamespaceTraversal.globalNamespaceName
-    val fullName                     = prependNamespacePrefix(name.name, includeGlobalNamespacePrefix)
+    val fullName =
+      if (name.name == NamespaceTraversal.globalNamespaceName)
+        globalNamespace.fullName
+      else {
+        prependNamespacePrefix(name.name)
+      }
 
     val typeDecl = typeDeclNode(stmt, name.name, fullName, filename, code, inherits = inheritsFrom)
 
@@ -807,7 +811,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
     astForMethodDecl(constructorDecl, fieldInits, isConstructor = true)
   }
 
-  private def prependNamespacePrefix(name: String, includeGlobalFullName: Boolean = false): String = {
+  private def prependNamespacePrefix(name: String): String = {
     scope.getEnclosingNamespaceNames.filterNot(_ == NamespaceTraversal.globalNamespaceName) match {
       case Nil   => name
       case names => names.appended(name).mkString(NamespaceDelimiter)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -154,7 +154,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
       aLocal.code shouldBe "$a"
       aLocal.lineNumber shouldBe Some(1)
 
-      inside(aLocal.method) { case List(globalMethod) =>
+      inside(aLocal.method.l) { case List(globalMethod) =>
         globalMethod.name shouldBe "<global>"
         globalMethod.fullName shouldBe "foo.php:<global>"
       }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -2,6 +2,7 @@ package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.Method
 
 class NamespaceTests extends PhpCode2CpgFixture {
   "namespaces should be able to contain statements as top-level AST children" in {
@@ -143,5 +144,20 @@ class NamespaceTests extends PhpCode2CpgFixture {
       "bar.php:<global>",
       "foo.php:<global>"
     )
+  }
+
+  "global variables should have AST in edges from the enclosing global method" in {
+    val cpg = code("""<?php $a = 1;""", fileName = "foo.php")
+
+    inside(cpg.local.l) { case List(aLocal) =>
+      aLocal.name shouldBe "a"
+      aLocal.code shouldBe "$a"
+      aLocal.lineNumber shouldBe Some(1)
+
+      inside(aLocal.method) { case List(globalMethod) =>
+        globalMethod.name shouldBe "<global>"
+        globalMethod.fullName shouldBe "foo.php:<global>"
+      }
+    }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
@@ -587,7 +587,7 @@ class OperatorTests extends PhpCode2CpgFixture {
   "declare calls with non-empty statement lists should have the correct block structure" in {
     val cpg = code("""<?php
         |declare(ticks=1) {
-        |  echo $x;
+        |  echo "Hello, world!";
         |}
         |""".stripMargin)
 
@@ -600,7 +600,7 @@ class OperatorTests extends PhpCode2CpgFixture {
 
     inside(declareBlock.astChildren.l) { case List(declareCall: Call, echoCall: Call) =>
       declareCall.code shouldBe "declare(ticks=1)"
-      echoCall.code shouldBe "echo $x"
+      echoCall.code shouldBe "echo \"Hello, world!\""
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -240,4 +240,10 @@ class TypeDeclTests extends PhpCode2CpgFixture {
       }
     }
   }
+
+  "the global type decl should have the correct name" in {
+    val cpg = code("<?php echo 0;", fileName = "foo.php")
+
+    cpg.typeDecl.nameExact("<global>").fullName.l shouldBe List("foo.php:<global>")
+  }
 }


### PR DESCRIPTION
With these changes, we re-use the existing `astForClassLike` and `astForMethodDecl` methods to create the ASTs for the fake global method and typeDecl.

This also fixes https://github.com/joernio/joern/issues/2710