### PR TITLE
Revert "Make pysrc2cpg compatible with closed source data flow tracke…

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -81,8 +81,6 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
         withFieldAndIndexAccesses(
           List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
         ) ++ x.refsTo.capturedByMethodRef.referencedMethod.flatMap(m => usagesForName(x.name, m))
-      case x: Call =>
-        (x._receiverIn.l :+ x).collect { case y: CfgNode => y }
       case x => List(x).collect { case y: CfgNode => y }
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
@@ -24,37 +24,34 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
       .mapValues(_.map(_._2))
 
     for {
-      methodReturn <- cpg.methodReturn.filter(x => x.typeFullName != Constants.ANY)
+      methodReturn <- cpg.methodReturn.filter(x => x.dynamicTypeHintFullName.nonEmpty)
+      typeHint     <- methodReturn.dynamicTypeHintFullName
       file         <- methodReturn.file
       imports      <- fileToImports.get(file.name)
+      importedEntity <- imports.filter { x =>
+        // TODO: Handle * imports correctly
+        x.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") }
+      }.importedEntity
     } {
-      val typeHint = methodReturn.typeFullName
-      imports
-        .filter { x =>
-          // TODO: Handle * imports correctly
-          x.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") }
-        }
-        .importedEntity
-        .foreach { importedEntity =>
-          setTypeHints(diffGraph, methodReturn, typeHint, typeHint, importedEntity)
-        }
+      setTypeHints(diffGraph, methodReturn, typeHint, typeHint, importedEntity)
     }
 
     for {
-      param   <- cpg.parameter.filter(x => x.typeFullName != Constants.ANY)
-      file    <- param.file
-      imports <- fileToImports.get(file.name)
-    } {
-      val typeHint = param.typeFullName
-      imports
+      param    <- cpg.parameter.filter(x => x.dynamicTypeHintFullName.nonEmpty)
+      typeHint <- param.dynamicTypeHintFullName
+      file     <- param.file
+      imports  <- fileToImports.get(file.name)
+      importDetails <- imports
         // TODO: Handle * imports correctly
         .filter(_.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") })
         .map(i => (i.importedEntity, i.importedAs))
-        .foreach {
-          case (Some(importedEntity), Some(importedAs)) =>
-            setTypeHints(diffGraph, param, typeHint, importedAs, importedEntity)
-          case _ =>
-        }
+    } {
+      importDetails match {
+        case (Some(importedEntity), Some(importedAs)) =>
+          setTypeHints(diffGraph, param, typeHint, importedAs, importedEntity)
+        case _ =>
+      }
+
     }
 
   }
@@ -76,7 +73,7 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
     cpg.typeDecl.fullName(s".*${Pattern.quote(pythonicTypeFullName)}").l match {
       case xs if xs.nonEmpty =>
         diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, xs.fullName.toSeq)
-      case _ => diffGraph.setNodeProperty(node, PropertyNames.TYPE_FULL_NAME, pythonicTypeFullName)
+      case _ => diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq(pythonicTypeFullName))
     }
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -140,47 +140,40 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .name(name)
       .code(name)
       .evaluationStrategy(EvaluationStrategies.BY_SHARING)
-      .typeFullName(extractTypesFromHint(typeHint).getOrElse(Constants.ANY))
+      .typeFullName(Constants.ANY)
       .isVariadic(isVariadic)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
     index.foreach(idx => methodParameterNode.index(idx))
+    methodParameterNode.dynamicTypeHintFullName(extractTypesFromHint(typeHint))
     addNodeToDiff(methodParameterNode)
   }
 
-  def extractTypesFromHint(typeHint: Option[ast.iexpr] = None): Option[String] = {
+  def extractTypesFromHint(typeHint: Option[ast.iexpr] = None): Seq[String] = {
     typeHint match {
       case Some(hint) =>
         val nameSequence = hint match {
-          case n: ast.Name => Option(n.id)
+          case n: ast.Name => Seq(n.id)
           // TODO: Definitely a place for follow up handling of generics - currently only take the polymorphic type
           //  without type args. To see the type arguments, see ast.Subscript.slice
           case attr: ast.Attribute =>
             extractTypesFromHint(Some(attr.value)).map { x => x + "." + attr.attr }
-          case n: ast.Subscript if n.value.isInstanceOf[ast.Name] => Option(n.value.asInstanceOf[ast.Name].id)
-          case _                                                  => None
+          case n: ast.Subscript if n.value.isInstanceOf[ast.Name] => Seq(n.value.asInstanceOf[ast.Name].id)
+          case _                                                  => Seq[String]()
         }
         nameSequence.map { typeName =>
           if (allBuiltinClasses.contains(typeName)) s"$builtinPrefix$typeName"
           else if (typingClassesV3.contains(typeName)) s"$typingPrefix$typeName"
           else typeName
         }
-      case _ => None
+      case _ =>
+        Seq()
     }
   }
 
-  def methodReturnNode(
-    staticTypeHint: Option[String],
-    dynamicTypeHintFullName: Option[String],
-    lineAndColumn: LineAndColumn
-  ): nodes.NewMethodReturn = {
+  def methodReturnNode(dynamicTypeHintFullName: Option[String], lineAndColumn: LineAndColumn): nodes.NewMethodReturn = {
     val methodReturnNode = NodeBuilders
-      .newMethodReturnNode(
-        staticTypeHint.getOrElse(Constants.ANY),
-        dynamicTypeHintFullName,
-        Some(lineAndColumn.line),
-        Some(lineAndColumn.column)
-      )
+      .newMethodReturnNode(Constants.ANY, dynamicTypeHintFullName, Some(lineAndColumn.line), Some(lineAndColumn.column))
       .evaluationStrategy(EvaluationStrategies.BY_SHARING)
 
     addNodeToDiff(methodReturnNode)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -4,7 +4,7 @@ import io.joern.pysrc2cpg.PythonAstVisitor.{builtinPrefix, metaClassSuffix}
 import io.joern.pysrc2cpg.memop._
 import io.joern.pythonparser.ast
 import io.shiftleft.codepropertygraph.generated._
-import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewMethod, NewNode, NewTypeDecl}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import scala.collection.mutable
@@ -97,7 +97,6 @@ class PythonAstVisitor(
       createMethod(
         "<module>",
         methodFullName,
-        Some("<module>"),
         parameterProvider = () => MethodParameters.empty(),
         bodyProvider = () => createBuiltinIdentifiers(memOpCalculator.names) ++ module.stmts.map(convert),
         returns = None,
@@ -216,7 +215,6 @@ class PythonAstVisitor(
       createIdentifierNode(functionDef.name, Store, lineAndColOf(functionDef))
     val (methodNode, methodRefNode) = createMethodAndMethodRef(
       functionDef.name,
-      Some(functionDef.name),
       createParameterProcessingFunction(functionDef.args, isStaticMethod(functionDef.decorator_list)),
       () => functionDef.body.map(convert),
       functionDef.returns,
@@ -255,7 +253,6 @@ class PythonAstVisitor(
       createIdentifierNode(functionDef.name, Store, lineAndColOf(functionDef))
     val (methodNode, methodRefNode) = createMethodAndMethodRef(
       functionDef.name,
-      Some(functionDef.name),
       createParameterProcessingFunction(functionDef.args, isStaticMethod(functionDef.decorator_list)),
       () => functionDef.body.map(convert),
       functionDef.returns,
@@ -288,27 +285,44 @@ class PythonAstVisitor(
     parameters: ast.Arguments,
     isStatic: Boolean
   ): () => MethodParameters = {
-    val startIndex =
-      if (contextStack.isClassContext && !isStatic)
-        0
-      else
-        1
+    val startIndex = if (contextStack.isClassContext && !isStatic) 0 else 1
 
     () => new MethodParameters(startIndex, convert(parameters, startIndex))
+  }
+
+  private def createMethodAndMethodRef(
+    methodName: String,
+    parameterProvider: () => MethodParameters,
+    bodyProvider: () => Iterable[nodes.NewNode],
+    returns: Option[ast.iexpr],
+    isAsync: Boolean,
+    lineAndColumn: LineAndColumn,
+    instanceTypeDecl: Option[nodes.NewTypeDecl] = None
+  ): (nodes.NewMethod, nodes.NewMethodRef) = {
+    val methodFullName = calculateFullNameFromContext(methodName)
+    createMethodAndMethodRef(
+      methodName,
+      methodFullName,
+      parameterProvider,
+      bodyProvider,
+      returns,
+      isAsync,
+      lineAndColumn,
+      instanceTypeDecl
+    )
   }
 
   // TODO handle returns
   private def createMethodAndMethodRef(
     methodName: String,
-    scopeName: Option[String],
+    methodFullName: String,
     parameterProvider: () => MethodParameters,
     bodyProvider: () => Iterable[nodes.NewNode],
     returns: Option[ast.iexpr],
     isAsync: Boolean,
-    lineAndColumn: LineAndColumn
+    lineAndColumn: LineAndColumn,
+    instanceTypeDecl: Option[nodes.NewTypeDecl]
   ): (nodes.NewMethod, nodes.NewMethodRef) = {
-    val methodFullName = calculateFullNameFromContext(methodName)
-
     val methodRefNode =
       nodeBuilder.methodRefNode("def " + methodName + "(...)", methodFullName, lineAndColumn)
 
@@ -316,14 +330,14 @@ class PythonAstVisitor(
       createMethod(
         methodName,
         methodFullName,
-        scopeName,
         parameterProvider,
         bodyProvider,
         returns,
         isAsync = true,
         Some(methodRefNode),
         returnTypeHint = None,
-        lineAndColumn
+        lineAndColumn,
+        instanceTypeDecl
       )
 
     (methodNode, methodRefNode)
@@ -335,14 +349,14 @@ class PythonAstVisitor(
   private def createMethod(
     name: String,
     fullName: String,
-    scopeName: Option[String],
     parameterProvider: () => MethodParameters,
     bodyProvider: () => Iterable[nodes.NewNode],
     returns: Option[ast.iexpr],
     isAsync: Boolean,
     methodRefNode: Option[nodes.NewMethodRef],
     returnTypeHint: Option[String],
-    lineAndColumn: LineAndColumn
+    lineAndColumn: LineAndColumn,
+    instanceTypeDecl: Option[NewTypeDecl] = None
   ): nodes.NewMethod = {
     val methodNode = nodeBuilder.methodNode(name, fullName, absFileName, lineAndColumn)
     edgeBuilder.astEdge(methodNode, contextStack.astParent, contextStack.order.getAndInc)
@@ -350,7 +364,7 @@ class PythonAstVisitor(
     val blockNode = nodeBuilder.blockNode("", lineAndColumn)
     edgeBuilder.astEdge(blockNode, methodNode, 1)
 
-    contextStack.pushMethod(scopeName, methodNode, blockNode, methodRefNode)
+    contextStack.pushMethod(name, methodNode, blockNode, methodRefNode)
 
     val virtualModifierNode = nodeBuilder.modifierNode(ModifierTypes.VIRTUAL)
     edgeBuilder.astEdge(virtualModifierNode, methodNode, 0)
@@ -363,8 +377,8 @@ class PythonAstVisitor(
       edgeBuilder.astEdge(parameterNode, methodNode, parameterOrder.getAndInc)
     }
 
-    val methodReturnNode =
-      nodeBuilder.methodReturnNode(nodeBuilder.extractTypesFromHint(returns), returnTypeHint, lineAndColumn)
+    val methodReturnNode = nodeBuilder.methodReturnNode(returnTypeHint, lineAndColumn)
+    methodReturnNode.dynamicTypeHintFullName(nodeBuilder.extractTypesFromHint(returns))
     edgeBuilder.astEdge(methodReturnNode, methodNode, 2)
 
     val bodyOrder = new AutoIncIndex(1)
@@ -374,16 +388,22 @@ class PythonAstVisitor(
 
     // For every method we create a corresponding TYPE and TYPE_DECL and
     // a binding for the method into TYPE_DECL.
-    val typeNode     = nodeBuilder.typeNode(name, fullName)
-    val typeDeclNode = nodeBuilder.typeDeclNode(name, fullName, absFileName, Seq(Constants.ANY), lineAndColumn)
+    val typeDeclNode = instanceTypeDecl match {
+      case Some(x) => x
+      case None =>
+        nodeBuilder.typeNode(name, fullName)
+        nodeBuilder.typeDeclNode(name, fullName, absFileName, Seq(Constants.ANY), lineAndColumn)
+    }
 
     // For every method that is a module, the local variables can be imported by other modules. This behaviour is
     // much like fields so they are to be linked as fields to this method type
     if (name == "<module>") contextStack.createMemberLinks(typeDeclNode, edgeBuilder.astEdge)
 
     contextStack.pop()
-    edgeBuilder.astEdge(typeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
-    createBinding(methodNode, typeDeclNode)
+    if (instanceTypeDecl.isEmpty) {
+      edgeBuilder.astEdge(typeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
+      createBinding(methodNode, typeDeclNode)
+    }
 
     methodNode
   }
@@ -444,21 +464,17 @@ class PythonAstVisitor(
     edgeBuilder.astEdge(instanceTypeDecl, contextStack.astParent, contextStack.order.getAndInc)
 
     // Create <body> function which contains the code defining the class
-    contextStack.pushClass(Some(classDef.name), instanceTypeDecl)
-    val classBodyFunctionName = "<body>"
+    contextStack.pushClass(classDef.name, instanceTypeDecl)
     val (_, methodRefNode) = createMethodAndMethodRef(
-      classBodyFunctionName,
-      scopeName = None,
+      instanceTypeDeclName,
+      instanceTypeDeclFullName,
       parameterProvider = () => MethodParameters.empty(),
       bodyProvider = () => classDef.body.map(convert),
       None,
       isAsync = false,
-      lineAndColOf(classDef)
+      lineAndColOf(classDef),
+      Option(instanceTypeDecl)
     )
-
-    contextStack.pop()
-
-    contextStack.pushClass(Some(classDef.name), metaTypeDeclNode)
 
     // Create meta class call handling method and bind it to meta class type.
     val functions = classDef.body.collect { case func: ast.FunctionDef => func }
@@ -478,20 +494,6 @@ class PythonAstVisitor(
         defaults = mutable.Seq.empty[ast.iexpr]
       )
     }
-
-    val metaClassCallHandlerMethod =
-      createMetaClassCallHandlerMethod(initParameters, metaTypeDeclName, metaTypeDeclFullName, instanceTypeDeclFullName)
-
-    createBinding(metaClassCallHandlerMethod, metaTypeDeclNode)
-
-    // Create fake __new__ regardless whether there is an actual implementation in the code.
-    // We do this to model the __init__ call in a visible way for the data flow tracker.
-    // This is done because very often the __init__ call is hidden in a super().__new__ call
-    // and we cant yet handle super().
-    val fakeNewMethod = createFakeNewMethod(initParameters)
-
-    val fakeNewMember = nodeBuilder.memberNode("<fakeNew>", fakeNewMethod.fullName)
-    edgeBuilder.astEdge(fakeNewMember, metaTypeDeclNode, contextStack.order.getAndInc)
 
     // Create binding into class instance type for each method.
     // Also create bindings into meta class type to enable calls like "MyClass.func(obj, p1)".
@@ -520,6 +522,24 @@ class PythonAstVisitor(
       case _ =>
       // All other body statements are currently ignored.
     }
+
+    contextStack.pop()
+
+    contextStack.pushClass(classDef.name, metaTypeDeclNode)
+
+    val metaClassCallHandlerMethod =
+      createMetaClassCallHandlerMethod(initParameters, metaTypeDeclName, metaTypeDeclFullName, instanceTypeDeclFullName)
+
+    createBinding(metaClassCallHandlerMethod, metaTypeDeclNode)
+
+    // Create fake __new__ regardless whether there is an actual implementation in the code.
+    // We do this to model the __init__ call in a visible way for the data flow tracker.
+    // This is done because very often the __init__ call is hidden in a super().__new__ call
+    // and we cant yet handle super().
+    val fakeNewMethod = createFakeNewMethod(initParameters)
+
+    val fakeNewMember = nodeBuilder.memberNode("<fakeNew>", fakeNewMethod.fullName)
+    edgeBuilder.astEdge(fakeNewMember, metaTypeDeclNode, contextStack.order.getAndInc)
 
     contextStack.pop()
 
@@ -585,7 +605,6 @@ class PythonAstVisitor(
     createMethod(
       adapterMethodName,
       adapterMethodFullName,
-      Some(adaptedMethodName),
       parameterProvider = () => {
         MethodParameters(
           0,
@@ -676,7 +695,6 @@ class PythonAstVisitor(
     createMethod(
       methodName,
       methodFullName,
-      Some(methodName),
       parameterProvider = () => {
         MethodParameters(1, convert(parametersWithoutSelf, 1))
       },
@@ -726,7 +744,6 @@ class PythonAstVisitor(
     createMethod(
       newMethodName,
       newMethodStubFullName,
-      Some(newMethodName),
       parameterProvider = () => {
         MethodParameters(
           0,
@@ -1377,15 +1394,14 @@ class PythonAstVisitor(
         lambdaCounter.toString
       }
 
-    val name = "<lambda>" + lambdaNumberSuffix
     val (_, methodRefNode) = createMethodAndMethodRef(
-      name,
-      Some(name),
+      "<lambda>" + lambdaNumberSuffix,
       createParameterProcessingFunction(lambda.args, isStatic = false),
       () => Iterable.single(convert(new ast.Return(lambda.body, lambda.attributeProvider))),
       returns = None,
       isAsync = false,
-      lineAndColOf(lambda)
+      lineAndColOf(lambda),
+      instanceTypeDecl = None
     )
     methodRefNode
   }
@@ -1866,8 +1882,10 @@ class PythonAstVisitor(
   def convert(name: ast.Name): nodes.NewNode = {
     val memoryOperation = memOpMap.get(name).get
     val identifier      = createIdentifierNode(name.id, memoryOperation, lineAndColOf(name))
-    if (contextStack.isClassContext && memoryOperation == Store) {
-      createAndRegisterMember(identifier.name, lineAndColOf(name))
+    contextStack.astParent match {
+      case _: NewMethod if contextStack.isClassContext && memoryOperation == Store =>
+        createAndRegisterMember(identifier.name, lineAndColOf(name))
+      case _ =>
     }
     identifier
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -1,5 +1,6 @@
 package io.joern.pysrc2cpg
 
+import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecovery.isDummyType
 import io.shiftleft.codepropertygraph.Cpg

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -84,10 +84,10 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     i.importedAs match {
       case Some(alias) =>
         symbolTable.put(CallAlias(alias), calleeNames)
-        symbolTable.put(LocalVar(alias), calleeNames.map(_.stripSuffix(s"${pathSep}__init__")))
+        symbolTable.put(LocalVar(alias), calleeNames)
       case None =>
         symbolTable.put(CallAlias(entityName), calleeNames)
-        symbolTable.put(LocalVar(entityName), calleeNames.map(_.stripSuffix(s"${pathSep}__init__")))
+        symbolTable.put(LocalVar(entityName), calleeNames)
     }
   }
 
@@ -326,11 +326,5 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     }
     super.prepopulateSymbolTable()
   }
-
-  override protected def visitIdentifierAssignedToTypeRef(i: Identifier, t: TypeRef, rec: Option[String]): Set[String] =
-    t.typ.referencedTypeDecl.astSiblings
-      .collectFirst { case td: TypeDecl => td }
-      .map(td => symbolTable.append(CallAlias(i.name, rec), Set(td.fullName)))
-      .getOrElse(super.visitIdentifierAssignedToTypeRef(i, t, rec))
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -71,42 +71,6 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       xParameter.name shouldBe "x"
 
     }
-
-    "have correct full name for func1 method in class" in {
-      val cpg = code("""class Foo:
-                       |  def func1(self):
-                       |    pass
-                       |""".stripMargin)
-
-      val func1 = cpg.method.name("func1").head
-      func1.fullName shouldBe "Test0.py:<module>.Foo.func1"
-    }
-
-    "have correct full name for <body> method in class" in {
-      val cpg = code("""class Foo:
-                       |  pass
-                       |""".stripMargin)
-
-      val func1 = cpg.method.name("<body>").head
-      func1.fullName shouldBe "Test0.py:<module>.Foo.<body>"
-    }
-
-    "have correct parameter index for method in class" in {
-      val cpg = code("""class Foo:
-                       |  def method(self):
-                       |    pass
-                       |""".stripMargin)
-      cpg.method.name("method").parameter.name("self").index.head shouldBe 0
-    }
-
-    "have correct parameter index for static method in class" in {
-      val cpg = code("""class Foo:
-                       |  @staticmethod
-                       |  def method(x):
-                       |    pass
-                       |""".stripMargin)
-      cpg.method.name("method").parameter.name("x").index.head shouldBe 1
-    }
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionDefCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionDefCpgTests.scala
@@ -154,7 +154,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func1")
         .parameter
-        .typeFullName
+        .dynamicTypeHintFullName
         .dedup
         .l shouldBe Seq("__builtin.int")
     }
@@ -163,7 +163,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func2")
         .parameter
-        .typeFullName
+        .dynamicTypeHintFullName
         .dedup
         .l shouldBe Seq("typing.Optional")
     }
@@ -172,7 +172,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func1")
         .methodReturn
-        .typeFullName
+        .dynamicTypeHintFullName
         .dedup
         .l shouldBe Seq("__builtin.float")
     }
@@ -181,7 +181,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func2")
         .methodReturn
-        .typeFullName
+        .dynamicTypeHintFullName
         .dedup
         .l shouldBe Seq("typing.List")
     }
@@ -190,7 +190,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func3")
         .parameter
-        .typeFullName
+        .dynamicTypeHintFullName
         .dedup
         .l shouldBe Seq("abc.Def")
     }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -16,9 +16,14 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
                                                 |
                                                 |""".stripMargin)
 
+    "should have a MEMBER" in {
+      val List(member: Member) = cpg.member.name("x").l
+      member.code shouldBe "x"
+    }
+
     "should have the MEMBER attached to the class" in {
-      val List(member) = cpg.typeDecl.name("Foo").member.name("x").l
-      member.name shouldBe "x"
+      val List(typeDecl) = cpg.member.name("x").typeDecl.l
+      typeDecl.name shouldBe "Foo"
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/VariableReferencingCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/VariableReferencingCpgTests.scala
@@ -262,20 +262,17 @@ class VariableReferencingCpgTests extends AnyFreeSpec with Matchers {
     lazy val cpg = Py2CpgTestContext.buildCpg("""x = 0
         |class MyClass():
         |  x = 1
-        |  def f(self):
+        |  def f():
         |    someFunc(x)
         |""".stripMargin)
 
     "test capturing to global x exists" in {
-      val moduleLocal = cpg.method.name("<module>").local.name("x").head
-      moduleLocal._closureBindingViaRefIn.next().closureBindingId shouldBe Some("test.py:<module>.MyClass.f:x")
+      cpg.method.fullName.foreach(println)
+      val localNode = cpg.method.name("<module>").local.name("x").head
+      localNode._closureBindingViaRefIn.next().closureBindingId shouldBe Some("test.py:<module>.MyClass.f:x")
 
-      val bodyLocal = cpg.method.fullName("test.py:<module>.MyClass.<body>").local.name("x").head
-      bodyLocal.closureBindingId shouldBe None
-
-      val fLocal = cpg.method.fullName("test.py:<module>.MyClass.f").local.name("x").head
-      fLocal.closureBindingId shouldBe Some("test.py:<module>.MyClass.f:x")
-
+      val localInMyClassNode = cpg.method.name("MyClass").local.name("x").head
+      localInMyClassNode.referencingIdentifiers.lineNumber(5).hasNext shouldBe false
     }
   }
 
@@ -290,7 +287,7 @@ class VariableReferencingCpgTests extends AnyFreeSpec with Matchers {
       val localNode = cpg.method.name("<module>").local.name("x").head
       localNode._closureBindingViaRefIn.hasNext shouldBe false
 
-      val localInMyClassNode = cpg.method.name("<body>").local.name("x").head
+      val localInMyClassNode = cpg.method.name("MyClass").local.name("x").head
       localInMyClassNode.referencingIdentifiers.lineNumber(4).code.head shouldBe "x"
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -446,18 +446,4 @@ class RegexDefinedFlowsDataFlowTests
     }
   }
 
-  "flows from receivers" should {
-    val cpg = code("""
-        |class Foo:
-        |   def func():
-        |      return "x"
-        |print(Foo.func())
-        |""".stripMargin)
-    "be found" in {
-      val src = cpg.call.code("Foo.func").l
-      val snk = cpg.call("print").l
-      snk.argument.reachableByFlows(src).size shouldBe 1
-    }
-  }
-
 }

--- a/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/slicing/UsageSlicing.scala
@@ -211,6 +211,7 @@ object UsageSlicing {
         case c if c.name.startsWith(Operators.assignment) && c.ast.isCall.name(Operators.alloc).nonEmpty => Some(c)
         case c if excludeOperatorCalls.get() && c.name.startsWith("<operator>")                          => None
         case c                                                                                           => Some(c)
+        case _                                                                                           => None
       }
       .dedup
       .toList


### PR DESCRIPTION
…r again. (#2680)"

This reverts commit 744fc309d7bc4a99856bf6cf61771482126967d0 and follow up change.

The reason is that is seems to cause trouble with the type propagation pass. @DavidBakerEffendi please pick this up as soon as possible so that we can get this change back in, otherwise there are known issues with the commercial engine.