### PR TITLE
kotlin2cpg: fix fullnames around object exprs

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/psi/PsiUtils.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/psi/PsiUtils.scala
@@ -1,6 +1,15 @@
 package io.joern.kotlin2cpg.psi
 
-import org.jetbrains.kotlin.psi.{KtDestructuringDeclaration, KtDestructuringDeclarationEntry}
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.{
+  KtCallExpression,
+  KtDestructuringDeclaration,
+  KtDestructuringDeclarationEntry,
+  KtElement,
+  KtNamedFunction,
+  KtObjectLiteralExpression,
+  KtProperty
+}
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -10,6 +19,34 @@ object PsiUtils {
     val underscore = "_"
     expr.getEntries.asScala.filterNot(_.getText == underscore).toSeq
   }
+
+  def objectIdxMaybe(psiElem: PsiElement, containing: PsiElement) =
+    containing match {
+      case t: KtNamedFunction =>
+        val anonymousObjects =
+          t.getBodyBlockExpression.getStatements.asScala.toSeq.collect {
+            case pt: KtProperty =>
+              pt.getDelegateExpressionOrInitializer match {
+                case ol: KtObjectLiteralExpression => Some(ol.getObjectDeclaration)
+                case _                             => None
+              }
+            case c: KtCallExpression =>
+              c.getValueArguments.asScala
+                .map(_.getArgumentExpression)
+                .collect {
+                  case ol: KtObjectLiteralExpression => Some(ol.getObjectDeclaration)
+                  case _                             => None
+                }
+                .flatten
+            case _ => Seq()
+          }.flatten
+        var outIdx: Option[Int] = None
+        anonymousObjects.zipWithIndex.foreach { case (elem: PsiElement, idx) =>
+          if (elem == psiElem) outIdx = Some(idx + 1)
+        }
+        outIdx
+      case _ => None
+    }
 }
 
 class PsiUtils {}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
@@ -85,6 +85,9 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
       secondTd.name shouldBe "anonymous_obj"
       secondTd.fullName shouldBe "mypkg.foo$object$1"
       secondTd.inheritsFromTypeFullName shouldBe Seq("mypkg.AnInterface")
+      val List(firstMethod: Method, secondMethod: Method) = secondTd.boundMethod.l
+      firstMethod.fullName shouldBe "mypkg.foo$object$1.doSomething:void(java.lang.String)"
+      secondMethod.fullName shouldBe "mypkg.foo$object$1.<init>:void()"
     }
 
     "contain a LOCAL node with the correct props set" in {
@@ -103,7 +106,7 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
     "contain an IDENTIFIER node for the argument representing the object literal" in {
       val List(firstArg: Identifier, _: Identifier) = cpg.call.code("does.*").argument.l
       firstArg.name shouldBe "tmp_obj_1"
-      firstArg.typeFullName shouldBe "ANY"
+      firstArg.typeFullName shouldBe "mypkg.foo$object$1"
     }
   }
 }


### PR DESCRIPTION
METHOD nodes of inline object expressions found at callsites as arguments did not have the correct METHOD_FULL_NAME property set.