### PR TITLE
adapt to misc cpg changes, especially diffgraph

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.601"
+val cpgVersion = "1.3.603+0-032d2377+20230522-1001"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/MetaDataPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/MetaDataPass.scala
@@ -3,11 +3,10 @@ package io.joern.ghidra2cpg.passes
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{Languages, nodes}
 import io.shiftleft.passes.CpgPass
-import overflowdb.BatchedUpdate
 
 class MetaDataPass(filename: String, cpg: Cpg) extends CpgPass(cpg) {
 
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
     diffGraph.addNode(
       nodes
         .NewTypeDecl()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeRecoveryPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeRecoveryPass.scala
@@ -3,11 +3,9 @@ package io.joern.javasrc2cpg.passes
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend._
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.{CpgDiffGraphBuilder, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.BatchedUpdate.DiffGraphBuilder
-import overflowdb.traversal.Traversal
 
 class JavaTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())
     extends XTypeRecoveryPass[Method](cpg, config) {
@@ -30,7 +28,7 @@ private class JavaTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTyp
   )
 }
 
-private class RecoverForJavaFile(cpg: Cpg, cu: Method, builder: DiffGraphBuilder, state: XTypeRecoveryState)
+private class RecoverForJavaFile(cpg: Cpg, cu: Method, builder: CpgDiffGraphBuilder, state: XTypeRecoveryState)
     extends RecoverForXCompilationUnit[Method](cpg, cu, builder, state) {
 
   private def javaNodeToLocalKey(n: AstNode): Option[LocalKey] = n match {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ImportsPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ImportsPass.scala
@@ -4,7 +4,6 @@ import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.joern.x2cpg.X2Cpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.CpgPass
-import overflowdb.BatchedUpdate
 import io.shiftleft.semanticcpg.language._
 
 /** This pass creates `IMPORT` nodes by looking for calls to `require`. `IMPORT` nodes are linked to existing dependency
@@ -17,7 +16,7 @@ import io.shiftleft.semanticcpg.language._
   */
 class ImportsPass(cpg: Cpg) extends CpgPass(cpg) {
 
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
     cpg
       .call("require")
       .flatMap { x => x.inAssignment.codeNot("var .*").map(y => (x, y)) }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -4,10 +4,9 @@ import io.joern.x2cpg.Defines.ConstructorMethodName
 import io.joern.x2cpg.passes.frontend._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.{CpgDiffGraphBuilder, Operators, PropertyNames}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.FieldAccess
-import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import java.io.{File => JFile}
 import java.util.regex.{Matcher, Pattern}
@@ -37,7 +36,7 @@ private class JavaScriptTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extend
 
 }
 
-private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, state: XTypeRecoveryState)
+private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: CpgDiffGraphBuilder, state: XTypeRecoveryState)
     extends RecoverForXCompilationUnit[File](cpg, cu, builder, state) {
 
   override protected val pathSep = ':'

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
@@ -1,11 +1,10 @@
 package io.joern.pysrc2cpg
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.{CpgDiffGraphBuilder, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
-import overflowdb.BatchedUpdate
 
 import java.io.File
 import java.util.regex.{Matcher, Pattern}
@@ -14,7 +13,7 @@ import java.util.regex.{Matcher, Pattern}
   * dynamic type hint and adjusting the dynamic type hint full name field accordingly.
   */
 class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
     val fileToImports = cpg.imports.l
       .flatMap { imp =>
         imp.call.file.l.map { f => f.name -> imp }
@@ -57,7 +56,7 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   private def setTypeHints(
-    diffGraph: BatchedUpdate.DiffGraphBuilder,
+    diffGraph: CpgDiffGraphBuilder,
     node: StoredNode,
     typeHint: String,
     alias: String,

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
@@ -4,11 +4,10 @@ import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.passes.CpgPass
-import overflowdb.BatchedUpdate
 import io.shiftleft.semanticcpg.language._
 
 class ImportsPass(cpg: Cpg) extends CpgPass(cpg) {
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
     val importsAndAssignments = cpg
       .call("import")
       .flatMap { x =>

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -3,12 +3,10 @@ package io.joern.pysrc2cpg
 import io.joern.x2cpg.passes.frontend._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.{CpgDiffGraphBuilder, Operators, PropertyNames}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.FieldAccess
-import overflowdb.BatchedUpdate.DiffGraphBuilder
-import overflowdb.traversal.Traversal
 
 import java.io.{File => JFile}
 import java.nio.file.Paths
@@ -42,7 +40,7 @@ private class PythonTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XT
 
 /** Performs type recovery from the root of a compilation unit level
   */
-private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, state: XTypeRecoveryState)
+private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: CpgDiffGraphBuilder, state: XTypeRecoveryState)
     extends RecoverForXCompilationUnit[File](cpg, cu, builder, state) {
 
   /** Replaces the `this` prefix with the Pythonic `self` prefix for instance methods of functions local to this

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -4,11 +4,9 @@ import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.base.MethodStubCreator.createMethodStub
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, EvaluationStrategies, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.{CpgDiffGraphBuilder, DispatchTypes, EdgeTypes, EvaluationStrategies, NodeTypes}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
-import overflowdb.BatchedUpdate
-import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import scala.collection.mutable
 import scala.util.Try
@@ -24,7 +22,7 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
   private val methodFullNameToNode   = mutable.LinkedHashMap[String, Method]()
   private val methodToParameterCount = mutable.LinkedHashMap[CallSummary, Int]()
 
-  override def run(dstGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+  override def run(dstGraph: DiffGraphBuilder): Unit = {
     for (method <- cpg.method) {
       methodFullNameToNode.put(method.fullName, method)
     }
@@ -81,7 +79,7 @@ object MethodStubCreator {
     signature: String,
     dispatchType: String,
     parameterCount: Int,
-    dstGraph: DiffGraphBuilder,
+    dstGraph: CpgDiffGraphBuilder,
     isExternal: Boolean = true,
     astParentType: String = NodeTypes.NAMESPACE_BLOCK,
     astParentFullName: String = "<global>"

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
@@ -4,7 +4,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.PropertyNames
 import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn.PropertyDefaults
 import io.shiftleft.passes.CpgPass
-import overflowdb.BatchedUpdate
 import io.shiftleft.semanticcpg.language._
 
 /** Old CPGs use the `order` field to indicate the parameter index while newer CPGs use the `parameterIndex` field. This
@@ -12,7 +11,7 @@ import io.shiftleft.semanticcpg.language._
   */
 class ParameterIndexCompatPass(cpg: Cpg) extends CpgPass(cpg) {
 
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+  override def run(diffGraph: DiffGraphBuilder): Unit = {
     cpg.parameter.foreach { param =>
       if (param.index == PropertyDefaults.Index) {
         diffGraph.setNodeProperty(param, PropertyNames.INDEX, param.order)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -3,15 +3,12 @@ package io.joern.x2cpg.passes.frontend
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.{CpgDiffGraphBuilder, EdgeTypes, Operators, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.{Assignment, FieldAccess}
 import org.slf4j.{Logger, LoggerFactory}
-import overflowdb.BatchedUpdate
-import overflowdb.BatchedUpdate.DiffGraphBuilder
-import overflowdb.traversal.Traversal
 
 import java.util.concurrent.RecursiveTask
 import java.util.concurrent.atomic.AtomicBoolean
@@ -66,7 +63,7 @@ abstract class XTypeRecoveryPass[CompilationUnitType <: AstNode](
   config: XTypeRecoveryConfig = XTypeRecoveryConfig()
 ) extends CpgPass(cpg) {
 
-  override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit = {
+  override def run(builder: DiffGraphBuilder): Unit = {
     val stopEarly = new AtomicBoolean(false)
     val state     = XTypeRecoveryState(config, stopEarly = stopEarly)
     try {
@@ -171,7 +168,7 @@ object XTypeRecovery {
 abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   cpg: Cpg,
   cu: CompilationUnitType,
-  builder: DiffGraphBuilder,
+  builder: CpgDiffGraphBuilder,
   state: XTypeRecoveryState
 ) extends RecursiveTask[Boolean] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -4,13 +4,12 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Properties
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
-import overflowdb.BatchedUpdate
 
 object Overlays {
 
   def appendOverlayName(cpg: Cpg, overlayName: String): Unit = {
     new CpgPass(cpg) {
-      override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+      override def run(diffGraph: DiffGraphBuilder): Unit = {
         cpg.metaData.headOption match {
           case Some(metaData) =>
             val newValue = metaData.overlays :+ overlayName
@@ -24,7 +23,7 @@ object Overlays {
 
   def removeLastOverlayName(cpg: Cpg): Unit = {
     new CpgPass(cpg) {
-      override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
+      override def run(diffGraph: DiffGraphBuilder): Unit = {
         cpg.metaData.headOption match {
           case Some(metaData) =>
             val newValue = metaData.overlays.dropRight(1)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
@@ -2,10 +2,9 @@ package io.shiftleft.semanticcpg
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Languages, ModifierTypes}
+import io.shiftleft.codepropertygraph.generated.{CpgDiffGraphBuilder, EdgeTypes, Languages, ModifierTypes}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
-import overflowdb.BatchedUpdate
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 package object testing {
@@ -199,11 +198,11 @@ package object testing {
       graph.addNode(newNode)
     }
 
-    def withCustom(f: (DiffGraphBuilder, Cpg) => Unit): MockCpg = {
-      val diffGraph = new DiffGraphBuilder
+    def withCustom(f: (CpgDiffGraphBuilder, Cpg) => Unit): MockCpg = {
+      val diffGraph = new CpgDiffGraphBuilder
       f(diffGraph, cpg)
       class MyPass extends CpgPass(cpg) {
-        override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit = {
+        override def run(builder: DiffGraphBuilder): Unit = {
           builder.absorb(diffGraph)
         }
       }


### PR DESCRIPTION
Upstream: https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/211 https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1706

This makes us compatible again with the fact that diffgraph is now schema-aware. Feature changes (Operator-extension revamp, use of generated node-starters) will come in separate PRs.