### PR TITLE
Performance Improvement: Inheritance and Type Recovery

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -20,19 +20,18 @@ class JavaScriptTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRe
 }
 
 private class JavaScriptTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
-  override def compilationUnit: Traversal[File] = cpg.file
+  override def generateParts: Array[File] = cpg.file.toArray
 
-  override def generateRecoveryForCompilationUnitTask(
-    unit: File,
-    builder: DiffGraphBuilder
-  ): RecoverForXCompilationUnit[File] =
-    new RecoverForJavaScriptFile(
-      cpg,
-      unit,
-      builder,
-      state.copy(config =
-        state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-      )
+  override def runOnPart(builder: DiffGraphBuilder, unit: File): Unit =
+    changeTracker.addOne(
+      new RecoverForJavaScriptFile(
+        cpg,
+        unit,
+        builder,
+        state.copy(config =
+          state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
+        )
+      ).compute()
     )
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -23,19 +23,18 @@ class PythonTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecove
 
 private class PythonTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
 
-  override def compilationUnit: Traversal[File] = cpg.file
+  override def generateParts: Array[File] = cpg.file.toArray
 
-  override def generateRecoveryForCompilationUnitTask(
-    unit: File,
-    builder: DiffGraphBuilder
-  ): RecoverForXCompilationUnit[File] =
-    new RecoverForPythonFile(
-      cpg,
-      unit,
-      builder,
-      state.copy(config =
-        state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-      )
+  override def runOnPart(builder: DiffGraphBuilder, unit: File): Unit =
+    changeTracker.addOne(
+      new RecoverForPythonFile(
+        cpg,
+        unit,
+        builder,
+        state.copy(config =
+          state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
+        )
+      ).compute()
     )
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XInheritanceFullNamePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XInheritanceFullNamePass.scala
@@ -30,7 +30,7 @@ abstract class XInheritanceFullNamePass(cpg: Cpg) extends ConcurrentWriterCpgPas
 
   // Regex matching is expensive...
   private val typeRegexCache: TrieMap[String, Pattern] = TrieMap.empty[String, Pattern]
-  private val relativePathPattern                      = Pattern.compile("^[.]+/?.*")
+  private val relativePathPattern                      = Pattern.compile("^[.]+/?.*$")
 
   override def generateParts(): Array[TypeDecl] =
     cpg.typeDecl
@@ -70,8 +70,8 @@ abstract class XInheritanceFullNamePass(cpg: Cpg) extends ConcurrentWriterCpgPas
       n match {
         case x if x.contains(pathSep) =>
           val splitName = x.split(pathSep)
-          Pattern.compile(s".*${Pattern.quote(splitName.head)}.*${Pattern.quote(splitName.last)}$$")
-        case x => Pattern.compile(s".*${Pattern.quote(x)}$$")
+          Pattern.compile(s"^.*${Pattern.quote(splitName.head)}.*${Pattern.quote(splitName.last)}$$")
+        case x => Pattern.compile(s"^.*${Pattern.quote(x)}$$")
       }
     }
   )

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XInheritanceFullNamePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XInheritanceFullNamePass.scala
@@ -4,72 +4,86 @@ import io.joern.x2cpg.passes.base.TypeDeclStubCreator
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
-import io.shiftleft.passes.CpgPass
+import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.shiftleft.semanticcpg.language._
 
 import java.io.File
 import java.nio.file.Paths
 import java.util.regex.{Matcher, Pattern}
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
 /** Using some basic heuristics, will try to resolve type full names from types found within the CPG. Requires
   * ImportPass as a pre-requisite.
   */
-abstract class XInheritanceFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
+abstract class XInheritanceFullNamePass(cpg: Cpg) extends ConcurrentWriterCpgPass[TypeDecl](cpg) {
 
   protected val pathSep: Char       = '.'
   protected val fileModuleSep: Char = ':'
   protected val moduleName: String
   protected val fileExt: String
 
-  protected val typeDeclMap: mutable.Map[String, TypeDeclBase] =
-    mutable.HashMap.from[String, TypeDeclBase](cpg.typeDecl.map(t => t.fullName -> t))
+  protected val typeDeclMap: TrieMap[String, TypeDeclBase] =
+    TrieMap.from[String, TypeDeclBase](cpg.typeDecl.map(t => t.fullName -> t))
   protected val typeMap: mutable.Map[String, TypeBase] =
     mutable.HashMap.from[String, TypeBase](cpg.typ.map(t => t.fullName -> t))
 
-  override def run(builder: DiffGraphBuilder): Unit = {
+  // Regex matching is expensive...
+  private val typeRegexCache: TrieMap[String, Pattern] = TrieMap.empty[String, Pattern]
+  private val relativePathPattern                      = Pattern.compile("^[.]+/?.*")
+
+  override def generateParts(): Array[TypeDecl] =
     cpg.typeDecl
       .filterNot(t => inheritsNothingOfInterest(t.inheritsFromTypeFullName))
-      .foreach { t =>
-        val resolvedTypeDecls = resolveInheritedTypeFullName(t, builder)
-        if (resolvedTypeDecls.nonEmpty) {
-          val fullNames = resolvedTypeDecls.map(_.fullName)
-          builder.setNodeProperty(t, PropertyNames.INHERITS_FROM_TYPE_FULL_NAME, fullNames)
-          fullNames.flatMap(typeMap.get).foreach(tgt => builder.addEdge(t, tgt, EdgeTypes.INHERITS_FROM))
-        }
-      }
+      .toArray
+
+  override def runOnPart(builder: DiffGraphBuilder, source: TypeDecl): Unit = {
+    val resolvedTypeDecls = resolveInheritedTypeFullName(source, builder)
+    if (resolvedTypeDecls.nonEmpty) {
+      val fullNames = resolvedTypeDecls.map(_.fullName)
+      builder.setNodeProperty(source, PropertyNames.INHERITS_FROM_TYPE_FULL_NAME, fullNames)
+      fullNames.flatMap(typeMap.get).foreach(tgt => builder.addEdge(source, tgt, EdgeTypes.INHERITS_FROM))
+    }
   }
 
   protected def inheritsNothingOfInterest(inheritedTypes: Seq[String]): Boolean =
     inheritedTypes == Seq("ANY") || inheritedTypes == Seq("object") || inheritedTypes.isEmpty
 
+  private def extractTypeDeclFromNode(node: AstNode): Option[String] = node match {
+    case x: Call if x.isCallForImportOut.nonEmpty =>
+      x.isCallForImportOut.importedEntity.map {
+        case imp if relativePathPattern.matcher(imp).matches() =>
+          imp.split(pathSep).toList match {
+            case head :: next =>
+              (Paths.get(head).normalize().toString +: next).mkString(pathSep.toString)
+            case Nil =>
+              Paths.get(imp).normalize().toString
+          }
+        case imp => imp
+      }.headOption
+    case x: TypeDecl if typeDeclMap.contains(x.fullName) => Option(x.fullName)
+    case _                                               => None
+  }
+
+  private def nameToPattern(n: String): Pattern = typeRegexCache.getOrElseUpdate(
+    n, {
+      n match {
+        case x if x.contains(pathSep) =>
+          val splitName = x.split(pathSep)
+          Pattern.compile(s".*${Pattern.quote(splitName.head)}.*${Pattern.quote(splitName.last)}$$")
+        case x => Pattern.compile(s".*${Pattern.quote(x)}$$")
+      }
+    }
+  )
+
   protected def resolveInheritedTypeFullName(td: TypeDecl, builder: DiffGraphBuilder): Seq[TypeDeclBase] = {
     val qualifiedNamesInScope = td.file.ast
-      .flatMap {
-        case x: Call if x.isCallForImportOut.nonEmpty =>
-          x.isCallForImportOut.importedEntity.map {
-            case imp if imp.matches("^[.]+/?.*") =>
-              imp.split(pathSep).toList match {
-                case ::(head, next) =>
-                  (Paths.get(head).normalize().toString +: next).mkString(pathSep.toString)
-                case Nil =>
-                  Paths.get(imp).normalize().toString
-              }
-            case imp => imp
-          }
-        case x: TypeDecl if typeDeclMap.contains(x.fullName) => Option(x.fullName)
-        case _                                               => None
-      }
+      .flatMap(extractTypeDeclFromNode)
       .filterNot(_.endsWith(moduleName))
       .l
-    val matchersInScope = qualifiedNamesInScope.map {
-      case x if x.contains(pathSep) =>
-        val splitName = x.split(pathSep)
-        s".*${Pattern.quote(splitName.head)}.*${Pattern.quote(splitName.last)}"
-      case x => s".*${Pattern.quote(x)}"
-    }.distinct
+    val matchersInScope = qualifiedNamesInScope.map(nameToPattern).distinct
     val validTypeDecls =
-      typeDeclMap.filter { case (name, _) => matchersInScope.exists(m => name.matches(m)) }.values.toList
+      typeDeclMap.filter { case (name, _) => matchersInScope.exists(m => m.matcher(name).matches()) }.values.toList
     val filteredTypes = validTypeDecls.filter(vt => td.inheritsFromTypeFullName.contains(vt.name))
     if (filteredTypes.isEmpty) {
       // Usually in the case of inheriting external types

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -4,7 +4,7 @@ import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators, PropertyNames}
-import io.shiftleft.passes.CpgPass
+import io.shiftleft.passes.{ConcurrentWriterCpgPass, CpgPass}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.{Assignment, FieldAccess}
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 /** @param iterations
   *   the number of iterations to run.
@@ -110,34 +111,17 @@ abstract class XTypeRecoveryPass[CompilationUnitType <: AstNode](
   * @tparam CompilationUnitType
   *   the AstNode type used to represent a compilation unit of the language.
   */
-abstract class XTypeRecovery[CompilationUnitType <: AstNode](cpg: Cpg, state: XTypeRecoveryState) extends CpgPass(cpg) {
+abstract class XTypeRecovery[CompilationUnitType <: AstNode](cpg: Cpg, state: XTypeRecoveryState)
+    extends ConcurrentWriterCpgPass[CompilationUnitType](cpg) {
 
-  override def run(builder: DiffGraphBuilder): Unit = {
-    val changesWereMade = compilationUnit
-      .map(unit => generateRecoveryForCompilationUnitTask(unit, builder).fork())
-      .map(_.get())
+  protected def changeTracker: ArrayBuffer[Boolean] = mutable.ArrayBuffer.empty[Boolean]
+
+  override def finish(): Unit = {
+    val changesWereMade = changeTracker
       .reduceOption((a, b) => a || b)
       .getOrElse(false)
     if (!changesWereMade) state.stopEarly.set(true)
   }
-
-  /** @return
-    *   the compilation units as per how the language is compiled. e.g. file.
-    */
-  def compilationUnit: Traversal[CompilationUnitType]
-
-  /** A factory method to generate a [[RecoverForXCompilationUnit]] task with the given parameters.
-    * @param unit
-    *   the compilation unit.
-    * @param builder
-    *   the graph builder.
-    * @return
-    *   a forkable [[RecoverForXCompilationUnit]] task.
-    */
-  def generateRecoveryForCompilationUnitTask(
-    unit: CompilationUnitType,
-    builder: DiffGraphBuilder
-  ): RecoverForXCompilationUnit[CompilationUnitType]
 
 }
 
@@ -795,7 +779,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
         val callPaths    = symbolTable.get(head)
         val returnValues = methodReturnValues(callPaths.toSeq)
         if (returnValues.isEmpty)
-          callPaths.map(_.concat(pathSep + XTypeRecovery.DummyReturnType))
+          callPaths.map(c => s"$c$pathSep${XTypeRecovery.DummyReturnType}")
         else
           returnValues
       case ::(head: Call, Nil) if head.argumentOut.headOption.exists(symbolTable.contains) =>


### PR DESCRIPTION
Both passes initially started out as small, rudimentary passes but have become more and more powerful in what they offer and, as such, how expensive they are. They were designed on `CpgPass` which is ideally for small tasks, but these were now moved to `ConcurrentWriterPass` which exploits the independent task nature of how these passes operate. 

* Inheritance pass caches its expensive regex matching strategy and now uses `ConcurrentWriterPass`
* `XTypeRecoveryPass` now uses `ConcurrentWriterPass` but it could perhaps be re-designed around this better further down the line