### PR TITLE
trim querydb dependencies: fix testDistro.sh

### DIFF
--- a/querydb/build.sbt
+++ b/querydb/build.sbt
@@ -5,9 +5,6 @@ enablePlugins(JavaAppPackaging)
 dependsOn(
   Projects.console,
   Projects.macros,
-  Projects.ghidra2cpg,
-  Projects.javasrc2cpg,
-  Projects.kotlin2cpg,
   Projects.ghidra2cpg  % "test->test",
   Projects.javasrc2cpg % "test->test",
   Projects.kotlin2cpg  % "test->test",
@@ -16,9 +13,6 @@ dependsOn(
 )
 
 libraryDependencies ++= Seq(
-  "com.lihaoyi"      %% "sourcecode" % "0.3.0",
-  "com.lihaoyi"      %% "upickle"    % "1.6.0",
-  "com.github.scopt" %% "scopt"      % "4.1.0",
   "org.scalatest"    %% "scalatest"  % Versions.scalatest % Test
 )
 


### PR DESCRIPTION
Querydb shipped a number of frontends in it's regular classpath, which
is causing problems with the usual suspects log4j/slf4j (see error below).
The main culprit is probably ghidra which ships an older version of log4j
in a fat jar.

```
Loading base CPG from:
/home/mp/Projects/shiftleft/joern/workspace/c/cpg.bin.tmp
java.lang.NoSuchMethodError: 'java.lang.ClassLoader[]
org.apache.logging.log4j.util.LoaderUtil.getClassLoaders()'
        at
org.apache.logging.log4j.core.impl.ThreadContextDataInjector.getServiceProviders(ThreadContextDataInjector.java:83)
        at
org.apache.logging.log4j.core.impl.ThreadContextDataInjector.initServiceProviders(ThreadContextDataInjector.java:73)
        at
org.apache.logging.log4j.core.impl.ThreadContextDataInjector.getProviders(ThreadContextDataInjector.java:285)
```