### PR TITLE
XTypeRecovery: Improved Import/Existing JS Type Recovery

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/InheritanceFullNamePassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/InheritanceFullNamePassTests.scala
@@ -18,6 +18,9 @@ class InheritanceFullNamePassTests extends DataFlowCodeToCpgSuite {
         |    this.lyrics = lyrics;
         |  }
         |}
+        |
+        |const myMusician = new Musician('Rafi', 'song1');
+        |const myMusicWithLyrics = new MusicWithLyrics('Fido', 'song1', 'lyrics');
         |""".stripMargin,
       "inheritance.js"
     ).moreCode(
@@ -47,6 +50,13 @@ class InheritanceFullNamePassTests extends DataFlowCodeToCpgSuite {
       tgtType.inheritsFromTypeFullName.headOption shouldBe Some(
         Seq("domain", "music.js::program:Musician").mkString(File.separator)
       )
+    }
+
+    "identifiers instantiated from these types should have their fully resolved types" in {
+      val Some(musician)           = cpg.identifier.nameExact("myMusician").headOption
+      val Some(musicianWithLyrics) = cpg.identifier.nameExact("myMusicWithLyrics").headOption
+      musician.typeFullName shouldBe "domain/music.js::program:Musician"
+      musicianWithLyrics.typeFullName shouldBe "inheritance.js::program:MusicWithLyrics"
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -214,11 +214,9 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     )).filterNot(_.toUpperCase.matches("(UNKNOWN|ANY)")).toSet
 
   protected def prepopulateSymbolTableEntry(x: AstNode): Unit = x match {
-    case x: Identifier        => symbolTable.put(x, getTypes(x))
-    case x: Call              => symbolTable.put(x, (x.methodFullName +: x.dynamicTypeHintFullName).toSet)
-    case x: Local             => symbolTable.put(x, getTypes(x))
-    case x: MethodParameterIn => symbolTable.put(x, getTypes(x))
-    case _                    =>
+    case x @ (_: Identifier | _: Local | _: MethodParameterIn) => symbolTable.put(x, getTypes(x))
+    case x: Call => symbolTable.put(x, (x.methodFullName +: x.dynamicTypeHintFullName).toSet)
+    case _       =>
   }
 
   protected def hasTypes(node: AstNode): Boolean = node match {
@@ -826,16 +824,16 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
         case x: MethodParameterIn                => setTypeFromTypeHints(x)
         case x: MethodReturn                     => setTypeFromTypeHints(x)
         case x: Identifier if symbolTable.contains(x) =>
-          setTypeInformationForRecCall(x, x.inCall.headOption, x.inCall.argument.take(2).l)
+          setTypeInformationForRecCall(x, x.inCall.headOption, x.inCall.argument.l)
         case x: Call if symbolTable.contains(x) =>
           val typs =
             if (state.config.enabledDummyTypes) symbolTable.get(x).toSeq
             else symbolTable.get(x).filterNot(XTypeRecovery.isDummyType).toSeq
           storeCallTypeInfo(x, typs)
         case x: Identifier if symbolTable.contains(CallAlias(x.name)) && x.inCall.nonEmpty =>
-          setTypeInformationForRecCall(x, x.inCall.headOption, x.inCall.argument.take(2).l)
+          setTypeInformationForRecCall(x, x.inCall.headOption, x.inCall.argument.l)
         case x: Call if x.argument.headOption.exists(symbolTable.contains) =>
-          setTypeInformationForRecCall(x, x.inCall.headOption, x.inCall.argument.take(2).l)
+          setTypeInformationForRecCall(x, Option(x), x.argument.l)
         case _ =>
       }
     // Set types in an atomic way
@@ -845,55 +843,77 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   protected def createCallFromIdentifierTypeFullName(typeFullName: String, callName: String): String =
     s"$typeFullName$pathSep$callName"
 
-  /** TODO: Cleaning up using visitor patten
+  /** Sets type information for a receiver/call pattern.
     */
-  private def setTypeInformationForRecCall(x: AstNode, n: Option[Call], ms: List[AstNode]): Unit =
+  private def setTypeInformationForRecCall(x: AstNode, n: Option[Call], ms: List[AstNode]): Unit = {
     (n, ms) match {
       // Case 1: 'call' is an assignment from some dynamic dispatch call
       case (Some(call: Call), List(i: Identifier, c: Call)) if call.name.equals(Operators.assignment) =>
-        val idTypes   = if (symbolTable.contains(i)) symbolTable.get(i) else symbolTable.get(CallAlias(i.name))
-        val callTypes = symbolTable.get(c)
-        persistType(call, callTypes)
-        if (idTypes.nonEmpty || callTypes.nonEmpty) {
-          if (idTypes.equals(callTypes))
-            // Case 1.1: This is a function pointer or constructor
-            persistType(i, callTypes)
-          else
-            // Case 1.2: This is the return value of the function
-            persistType(i, idTypes)
-        }
+        setTypeForIdentifierAssignedToCall(call, i, c)
       // Case 1: 'call' is an assignment from some other data structure
       case (Some(call: Call), ::(i: Identifier, _)) if call.name.equals(Operators.assignment) =>
-        val idHints = symbolTable.get(i)
-        persistType(i, idHints)
-        persistType(call, idHints)
+        setTypeForIdentifierAssignedToDefault(call, i)
       // Case 2: 'i' is the receiver of 'call'
       case (Some(call: Call), ::(i: Identifier, _)) if !call.name.equals(Operators.fieldAccess) =>
-        val idHints   = symbolTable.get(i)
-        val callTypes = symbolTable.get(call)
-        persistType(i, idHints)
-        if (callTypes.isEmpty && !call.name.startsWith("<operator>"))
-          // For now, calls are treated as function pointers and thus the type should point to the method
-          persistType(call, idHints.map(t => createCallFromIdentifierTypeFullName(t, call.name)))
-        else {
-          persistType(call, callTypes)
-        }
+        setTypeForDynamicDispatchCall(call, i)
       // Case 3: 'i' is the receiver for a field access on member 'f'
       case (Some(fieldAccess: Call), List(i: Identifier, f: FieldIdentifier))
           if fieldAccess.name.equals(Operators.fieldAccess) =>
-        val idHints   = if (symbolTable.contains(i)) symbolTable.get(i) else symbolTable.get(CallAlias(i.name))
-        val callTypes = symbolTable.get(fieldAccess)
-        persistType(i, idHints)
-        persistType(fieldAccess, callTypes)
-        Traversal.from(fieldAccess.astParent).isCall.headOption match {
-          case Some(callFromFieldName) if symbolTable.contains(callFromFieldName) =>
-            persistType(callFromFieldName, symbolTable.get(callFromFieldName))
-          case _ =>
-        }
-        // This field may be a function pointer
-        handlePotentialFunctionPointer(fieldAccess, idHints, f.canonicalName, Option(i.name))
-      case _ => persistType(x, symbolTable.get(x))
+        setTypeForFieldAccess(fieldAccess, i, f)
+      case _ =>
     }
+    // Handle the node itself
+    x match {
+      case c: Call if c.name.startsWith("<operator") =>
+      case _                                         => persistType(x, symbolTable.get(x))
+    }
+  }
+
+  protected def setTypeForFieldAccess(fieldAccess: Call, i: Identifier, f: FieldIdentifier): Unit = {
+    val idHints   = if (symbolTable.contains(i)) symbolTable.get(i) else symbolTable.get(CallAlias(i.name))
+    val callTypes = symbolTable.get(fieldAccess)
+    persistType(i, idHints)
+    persistType(fieldAccess, callTypes)
+    fieldAccess.astParent.iterator.isCall.headOption match {
+      case Some(callFromFieldName) if symbolTable.contains(callFromFieldName) =>
+        persistType(callFromFieldName, symbolTable.get(callFromFieldName))
+      case _ =>
+    }
+    // This field may be a function pointer
+    handlePotentialFunctionPointer(fieldAccess, idHints, f.canonicalName, Option(i.name))
+  }
+
+  protected def setTypeForDynamicDispatchCall(call: Call, i: Identifier): Unit = {
+    val idHints   = symbolTable.get(i)
+    val callTypes = symbolTable.get(call)
+    persistType(i, idHints)
+    if (callTypes.isEmpty && !call.name.startsWith("<operator>"))
+      // For now, calls are treated as function pointers and thus the type should point to the method
+      persistType(call, idHints.map(t => createCallFromIdentifierTypeFullName(t, call.name)))
+    else {
+      persistType(call, callTypes)
+    }
+  }
+
+  protected def setTypeForIdentifierAssignedToDefault(call: Call, i: Identifier): Unit = {
+    val idHints = symbolTable.get(i)
+    persistType(i, idHints)
+    persistType(call, idHints)
+  }
+
+  protected def setTypeForIdentifierAssignedToCall(call: Call, i: Identifier, c: Call): Unit = {
+    val idTypes   = if (symbolTable.contains(i)) symbolTable.get(i) else symbolTable.get(CallAlias(i.name))
+    val callTypes = symbolTable.get(c)
+    persistType(call, callTypes)
+    if (idTypes.nonEmpty || callTypes.nonEmpty) {
+      if (idTypes.equals(callTypes))
+        // Case 1.1: This is a function pointer or constructor
+        persistType(i, callTypes)
+      else
+        // Case 1.2: This is the return value of the function
+        persistType(i, idTypes)
+    }
+  }
 
   protected def setTypeFromTypeHints(n: StoredNode): Unit = {
     val nodeType         = n.property(PropertyNames.TYPE_FULL_NAME, "ANY")
@@ -912,7 +932,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   ): Unit = {
     // Sometimes the function identifier is an argument to the call itself as a "base". In this case we don't need
     // a method ref. This happens in jssrc2cpg
-    if (funcPtr.astParent.collectAll[Call].exists(_.name == funcName)) return
+    if (funcPtr.astParent.iterator.collectAll[Call].exists(_.name == funcName)) return
 
     baseTypes
       .map(t => if (t.endsWith(funcName)) t else s"$t$pathSep$funcName")


### PR DESCRIPTION
* Improved patterns that match a variety of `export` patterns
* Improved handling of type prepopulation when type names are found in `typeFullName`
* Fixed bug where some nodes would slip through setType* patterns and not have their types set