### PR TITLE
NaiveCallLinker in Python & JavaScript

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -1,7 +1,8 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
-import io.joern.jssrc2cpg.JsSrc2Cpg
+import io.joern.jssrc2cpg.{Config, Frontend, JsSrc2Cpg}
+import io.joern.x2cpg.X2Cpg
 import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.Path
@@ -9,11 +10,13 @@ import scala.util.Try
 
 case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("jssrc2cpg.bat") else rootPath.resolve("jssrc2cpg.sh")
+  private var jsConfig: Option[Config] = None
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
   override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
+    jsConfig = X2Cpg.parseCommandLine(arguments.toArray, Frontend.cmdLineParser, Config())
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
@@ -21,7 +24,7 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
     command.toFile.exists
 
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
-    JsSrc2Cpg.postProcessingPasses(cpg).foreach(_.createAndApply())
+    JsSrc2Cpg.postProcessingPasses(cpg, jsConfig).foreach(_.createAndApply())
     cpg
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -4,6 +4,7 @@ import io.joern.console.FrontendConfig
 import io.joern.pysrc2cpg._
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.passes.base.AstLinkerPass
+import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.shiftleft.codepropertygraph.Cpg
 
@@ -32,7 +33,7 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
     new PythonTypeRecoveryPass(cpg, XTypeRecoveryConfig(enabledDummyTypes = !pyConfig.forall(_.disableDummyTypes)))
       .createAndApply()
     new PythonTypeHintCallLinker(cpg).createAndApply()
-    new PythonNaiveCallLinker(cpg).createAndApply()
+    new NaiveCallLinker(cpg).createAndApply()
 
     // Some of passes above create new methods, so, we
     // need to run the ASTLinkerPass one more time

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -7,6 +7,7 @@ import io.joern.jssrc2cpg.passes._
 import io.joern.jssrc2cpg.utils.{AstGenRunner, Report}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
+import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.joern.x2cpg.utils.HashUtil
 import io.shiftleft.codepropertygraph.Cpg
@@ -60,7 +61,8 @@ object JsSrc2Cpg {
       new JavaScriptInheritanceNamePass(cpg),
       new ConstClosurePass(cpg),
       new JavaScriptTypeRecoveryPass(cpg, XTypeRecoveryConfig(enabledDummyTypes = !config.exists(_.disableDummyTypes))),
-      new JavaScriptTypeHintCallLinker(cpg)
+      new JavaScriptTypeHintCallLinker(cpg),
+      new NaiveCallLinker(cpg)
     )
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
@@ -31,7 +31,7 @@ final case class Config(
   override def withOutputPath(x: String): Config = copy(outputPath = x)
 }
 
-private object Frontend {
+object Frontend {
   implicit val defaultConfig: Config = Config()
 
   val cmdLineParser: OParser[Unit, Config] = {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -79,7 +79,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
         }
         .flatMap {
           case (t, ts) if Set(t) == ts => Set(t)
-          case (_, ts)                 => ts.map(_.replaceAll("\\.", pathSep.toString))
+          case (_, ts)                 => ts.map(_.replaceAll("\\.(?!js::program)", pathSep.toString))
         }
       p match {
         case _: MethodParameterIn => symbolTable.put(p, resolvedHints)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -5,6 +5,7 @@ import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.passes.base.AstLinkerPass
+import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
@@ -39,7 +40,7 @@ class PySrcTestCpg extends TestCpg with PythonFrontend {
     new DynamicTypeHintFullNamePass(this).createAndApply()
     new PythonTypeRecoveryPass(this).createAndApply()
     new PythonTypeHintCallLinker(this).createAndApply()
-    new PythonNaiveCallLinker(this).createAndApply()
+    new NaiveCallLinker(this).createAndApply()
 
     // Some of passes above create new methods, so, we
     // need to run the ASTLinkerPass one more time

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/NaiveCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/NaiveCallLinker.scala
@@ -1,4 +1,4 @@
-package io.joern.pysrc2cpg
+package io.joern.x2cpg.passes.callgraph
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
@@ -6,11 +6,11 @@ import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.jIteratortoTraversal
 
-/** Link remaining unlinked Python calls to methods only by their name (not full name)
+/** Link remaining unlinked calls to methods only by their name (not full name)
   * @param cpg
   *   the target code property graph.
   */
-class PythonNaiveCallLinker(cpg: Cpg) extends CpgPass(cpg) {
+class NaiveCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     val methodNameToNode = cpg.method.toList.groupBy(_.name)


### PR DESCRIPTION
* Converted `PythonNaiveCallLinker` to `NaiveCallLinker` as it is pretty simple and language agnostic
* Added this to JS as it deals with the remaining function calls that aren't dynamically dispatched off of objects as `XTypeHintCallLinker` does
* Fixed regex pattern in `JavaScriptTyeRecovery` where code such as `main.js` would be converted to `main:js`
* Added workaround for JS postprocessing passes to have access to `FrontendConfig` similar to in Python. Again this should probably have a better long-term solution