### PR TITLE
RubyParser: basic support for regex literals

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -95,6 +95,7 @@ primary
     |   hashConstructor                                                                                             # hashConstructorPrimary
     |   literal                                                                                                     # literalPrimary
     |   stringInterpolation                                                                                         # stringInterpolationPrimary
+    |   regexInterpolation                                                                                          # regexInterpolationPrimary
     |   IS_DEFINED LPAREN expressionOrCommand RPAREN                                                                # isDefinedPrimary
     |   SUPER argumentsWithParentheses? block?                                                                      # superExpressionPrimary
     |   primary LBRACK WS* indexingArguments? WS* RBRACK                                                            # indexingExpressionPrimary
@@ -519,6 +520,7 @@ literal
     |   symbol
     |   SINGLE_QUOTED_STRING_LITERAL
     |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END
+    |   REGULAR_EXPRESSION_START REGULAR_EXPRESSION_BODY? REGULAR_EXPRESSION_END
     ;
 
 symbol
@@ -538,6 +540,20 @@ stringInterpolation
 
 interpolatedStringSequence
     :   STRING_INTERPOLATION_BEGIN compoundStatement STRING_INTERPOLATION_END
+    ;
+
+// --------------------------------------------------------
+// Regex interpolation
+// --------------------------------------------------------
+
+regexInterpolation
+    :   REGULAR_EXPRESSION_START
+        (REGULAR_EXPRESSION_BODY | interpolatedRegexSequence)+
+        REGULAR_EXPRESSION_END
+    ;
+
+interpolatedRegexSequence
+    :   REGULAR_EXPRESSION_INTERPOLATION_BEGIN compoundStatement REGULAR_EXPRESSION_INTERPOLATION_END
     ;
 
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -532,11 +532,11 @@ symbol
 
 stringInterpolation
     :   DOUBLE_QUOTED_STRING_START
-        (DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE | interpolation)+
+        (DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE | interpolatedStringSequence)+
         DOUBLE_QUOTED_STRING_END
     ;
 
-interpolation
+interpolatedStringSequence
     :   STRING_INTERPOLATION_BEGIN compoundStatement STRING_INTERPOLATION_END
     ;
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -138,7 +138,7 @@ class AstCreator(filename: String, global: Global)
   def astForStringInterpolationPrimaryContext(ctx: StringInterpolationPrimaryContext): Ast = {
     val varAsts = ctx
       .stringInterpolation()
-      .interpolation()
+      .interpolatedStringSequence()
       .asScala
       .map(inter => {
         astForStatementsContext(inter.compoundStatement().statements())

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -1,0 +1,320 @@
+package io.joern.rubysrc2cpg.parser
+
+class RegexTests extends RubyParserAbstractTest {
+
+  "An empty regex literal" when {
+
+    "by itself" should {
+      val code = "//"
+
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """LiteralPrimary
+            | Literal
+            |  /
+            |  /""".stripMargin
+      }
+    }
+
+    "on the RHS of an assignment" should {
+      val code = "x = //"
+
+      "be parsed as a single assignment to a regex literal" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | SingleAssignmentExpression
+            |  VariableIdentifierOnlySingleLeftHandSide
+            |   VariableIdentifier
+            |    x
+            |  =
+            |  WsOrNl
+            |  MultipleRightHandSide
+            |   ExpressionOrCommands
+            |    ExpressionExpressionOrCommand
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       Literal
+            |        /
+            |        /""".stripMargin
+      }
+    }
+
+    // TODO: RubyLexer needs to properly identify regex literals as arguments to commands first.
+    "as the argument to a `puts` command" ignore {
+      val code = "puts //"
+
+      "be parsed as such" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | InvocationExpressionOrCommand
+            |  SingleCommandOnlyInvocationWithoutParentheses
+            |   Command
+            |    MethodIdentifier
+            |     puts
+            |    ArgumentsWithoutParentheses
+            |     BlockExprAssocTypeArguments
+            |      Expressions
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         Literal
+            |          /
+            |          /""".stripMargin
+      }
+    }
+
+    "as the argument to an parenthesized invocation" should {
+      val code = "puts(//)"
+
+      "be parsed as such" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | PrimaryExpression
+            |  InvocationWithParenthesesPrimary
+            |   MethodIdentifier
+            |    puts
+            |   ArgsOnlyArgumentsWithParentheses
+            |    (
+            |    BlockExprAssocTypeArguments
+            |     Expressions
+            |      PrimaryExpression
+            |       LiteralPrimary
+            |        Literal
+            |         /
+            |         /
+            |    )""".stripMargin
+      }
+    }
+  }
+
+  "A non-interpolated regex literal" when {
+
+    "by itself" should {
+      val code = "/(eu|us)/"
+
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """LiteralPrimary
+            | Literal
+            |  /
+            |  (eu|us)
+            |  /""".stripMargin
+      }
+    }
+
+    "on the RHS of an assignment" should {
+      val code = "x = /(eu|us)/"
+
+      "be parsed as a single assignment to a regex literal" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | SingleAssignmentExpression
+            |  VariableIdentifierOnlySingleLeftHandSide
+            |   VariableIdentifier
+            |    x
+            |  =
+            |  WsOrNl
+            |  MultipleRightHandSide
+            |   ExpressionOrCommands
+            |    ExpressionExpressionOrCommand
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       Literal
+            |        /
+            |        (eu|us)
+            |        /""".stripMargin
+      }
+    }
+
+    // TODO: RubyLexer needs to properly identify regex literals as arguments to commands first.
+    "as the argument to a `puts` command" ignore {
+      val code = "puts /(eu|us)/"
+
+      "be parsed as such" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | InvocationExpressionOrCommand
+            |  SingleCommandOnlyInvocationWithoutParentheses
+            |   Command
+            |    MethodIdentifier
+            |     puts
+            |    ArgumentsWithoutParentheses
+            |     BlockExprAssocTypeArguments
+            |      Expressions
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         Literal
+            |          /
+            |          (eu|us)
+            |          /""".stripMargin
+      }
+    }
+
+    "as the argument to an parenthesized invocation" should {
+      val code = "puts(/(eu|us)/)"
+
+      "be parsed as such" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | PrimaryExpression
+            |  InvocationWithParenthesesPrimary
+            |   MethodIdentifier
+            |    puts
+            |   ArgsOnlyArgumentsWithParentheses
+            |    (
+            |    BlockExprAssocTypeArguments
+            |     Expressions
+            |      PrimaryExpression
+            |       LiteralPrimary
+            |        Literal
+            |         /
+            |         (eu|us)
+            |         /
+            |    )""".stripMargin
+      }
+    }
+  }
+
+  "A (numeric literal)-interpolated regex literal" when {
+
+    "by itself" should {
+      val code = "/x#{1}y/"
+
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """RegexInterpolationPrimary
+              | RegexInterpolation
+              |  /
+              |  x
+              |  InterpolatedRegexSequence
+              |   #{
+              |   CompoundStatement
+              |    Statements
+              |     ExpressionOrCommandStatement
+              |      ExpressionExpressionOrCommand
+              |       PrimaryExpression
+              |        LiteralPrimary
+              |         Literal
+              |          NumericLiteral
+              |           UnsignedNumericLiteral
+              |            1
+              |   }
+              |  y
+              |  /""".stripMargin
+      }
+    }
+
+    "on the RHS of an assignment" should {
+      val code = "x = /x#{1}y/"
+
+      "be parsed as a single assignment to a regex literal" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | SingleAssignmentExpression
+            |  VariableIdentifierOnlySingleLeftHandSide
+            |   VariableIdentifier
+            |    x
+            |  =
+            |  WsOrNl
+            |  MultipleRightHandSide
+            |   ExpressionOrCommands
+            |    ExpressionExpressionOrCommand
+            |     PrimaryExpression
+            |      RegexInterpolationPrimary
+            |       RegexInterpolation
+            |        /
+            |        x
+            |        InterpolatedRegexSequence
+            |         #{
+            |         CompoundStatement
+            |          Statements
+            |           ExpressionOrCommandStatement
+            |            ExpressionExpressionOrCommand
+            |             PrimaryExpression
+            |              LiteralPrimary
+            |               Literal
+            |                NumericLiteral
+            |                 UnsignedNumericLiteral
+            |                  1
+            |         }
+            |        y
+            |        /""".stripMargin
+      }
+    }
+
+    // TODO: RubyLexer needs to properly identify regex literals as arguments to commands first.
+    "as the argument to a `puts` command" ignore {
+      val code = "puts /x#{1}y/"
+
+      "be parsed as such" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | InvocationExpressionOrCommand
+            |  SingleCommandOnlyInvocationWithoutParentheses
+            |   Command
+            |    MethodIdentifier
+            |     puts
+            |    ArgumentsWithoutParentheses
+            |     BlockExprAssocTypeArguments
+            |      Expressions
+            |       PrimaryExpression
+            |        RegexInterpolationPrimary
+            |         RegexInterpolation
+            |          /
+            |          x
+            |          InterpolatedRegexSequence
+            |           #{
+            |           CompoundStatement
+            |            Statements
+            |             ExpressionOrCommandStatement
+            |              ExpressionExpressionOrCommand
+            |               PrimaryExpression
+            |                LiteralPrimary
+            |                 Literal
+            |                  NumericLiteral
+            |                   UnsignedNumericLiteral
+            |                    1
+            |           }
+            |           y
+            |           /""".stripMargin
+      }
+    }
+
+    "as the argument to an parenthesized invocation" should {
+      val code = "puts(/x#{1}y/)"
+
+      "be parsed as such" in {
+        printAst(_.expressionOrCommand(), code) shouldEqual
+          """ExpressionExpressionOrCommand
+            | PrimaryExpression
+            |  InvocationWithParenthesesPrimary
+            |   MethodIdentifier
+            |    puts
+            |   ArgsOnlyArgumentsWithParentheses
+            |    (
+            |    BlockExprAssocTypeArguments
+            |     Expressions
+            |      PrimaryExpression
+            |       RegexInterpolationPrimary
+            |        RegexInterpolation
+            |         /
+            |         x
+            |         InterpolatedRegexSequence
+            |          #{
+            |          CompoundStatement
+            |           Statements
+            |            ExpressionOrCommandStatement
+            |             ExpressionExpressionOrCommand
+            |              PrimaryExpression
+            |               LiteralPrimary
+            |                Literal
+            |                 NumericLiteral
+            |                  UnsignedNumericLiteral
+            |                   1
+            |          }
+            |         y
+            |         /
+            |    )""".stripMargin
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -244,6 +244,20 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     tokenize(code) shouldBe Seq(REGULAR_EXPRESSION_START, REGULAR_EXPRESSION_END, EOF)
   }
 
+  "Empty regex literal on the RHS of an assignment" should "be recognized as such" in {
+    // This test exists to check if RubyLexer properly decided between SLASH and REGULAR_EXPRESSION_START
+    val code = "x = //"
+    tokenize(code) shouldBe Seq(
+      LOCAL_VARIABLE_IDENTIFIER,
+      WS,
+      EQ,
+      WS,
+      REGULAR_EXPRESSION_START,
+      REGULAR_EXPRESSION_END,
+      EOF
+    )
+  }
+
   "Regex literals without metacharacters" should "be recognized as such" in {
     val eg = Seq("/regexp/", "/a regexp/")
     all(eg.map(tokenize)) shouldBe Seq(REGULAR_EXPRESSION_START, REGULAR_EXPRESSION_BODY, REGULAR_EXPRESSION_END, EOF)
@@ -290,6 +304,20 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       PLUS,
       DECIMAL_INTEGER_LITERAL,
       REGULAR_EXPRESSION_INTERPOLATION_END,
+      REGULAR_EXPRESSION_END,
+      EOF
+    )
+  }
+
+  "Interpolated (with a local variable) regex literal containing also textual body elements" should "be recognized as such" in {
+    val code = "/x\\.#{foo}\\./"
+    tokenize(code) shouldBe Seq(
+      REGULAR_EXPRESSION_START,
+      REGULAR_EXPRESSION_BODY,
+      REGULAR_EXPRESSION_INTERPOLATION_BEGIN,
+      LOCAL_VARIABLE_IDENTIFIER,
+      REGULAR_EXPRESSION_INTERPOLATION_END,
+      REGULAR_EXPRESSION_BODY,
       REGULAR_EXPRESSION_END,
       EOF
     )

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -39,7 +39,7 @@ class StringTests extends RubyParserAbstractTest {
             | StringInterpolation
             |  "
             |  text=
-            |  Interpolation
+            |  InterpolatedStringSequence
             |   #{
             |   CompoundStatement
             |    Statements
@@ -64,7 +64,7 @@ class StringTests extends RubyParserAbstractTest {
           """StringInterpolationPrimary
             | StringInterpolation
             |  "
-            |  Interpolation
+            |  InterpolatedStringSequence
             |   #{
             |   CompoundStatement
             |    Statements
@@ -77,7 +77,7 @@ class StringTests extends RubyParserAbstractTest {
             |           UnsignedNumericLiteral
             |            1
             |   }
-            |  Interpolation
+            |  InterpolatedStringSequence
             |   #{
             |   CompoundStatement
             |    Statements


### PR DESCRIPTION
* Supports (potentially interpolated) regex literals in the parser
* RubyParser.g4: renamed `interpolation` as `interpolatedStringSequence`, to avoid any confusion with regex literals' own interpolation sub-production (now named `interpolatedRegexSequence`)
* RubyLexerBase: refactored the predicate for deciding when to start a regex literal by using "sentinel" tokens more explicitly. This approach will need to be reconsidered, as it can't be exhaustive. But fortunately this is contained exclusively in RubyLexer 