### PR TITLE
Add php2cpg local creation and ClosureRefEdge passes

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -1,6 +1,6 @@
 package io.joern.php2cpg
 
-import io.joern.php2cpg.passes.AstCreationPass
+import io.joern.php2cpg.passes.{AstCreationPass, LocalCreationPass}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
@@ -38,6 +38,8 @@ class Php2Cpg extends X2CpgFrontend[Config] {
         val astCreationPass = new AstCreationPass(config, cpg)
         astCreationPass.createAndApply()
         new TypeNodePass(astCreationPass.allUsedTypes, cpg).createAndApply()
+        LocalCreationPass.allLocalCreationPasses(cpg).foreach(_.createAndApply())
+
       }
     } else {
       logger.error(

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Try, Success}
 import scala.util.matching.Regex
+import io.joern.php2cpg.passes.ClosureRefPass
 
 class Php2Cpg extends X2CpgFrontend[Config] {
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -39,7 +40,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
         astCreationPass.createAndApply()
         new TypeNodePass(astCreationPass.allUsedTypes, cpg).createAndApply()
         LocalCreationPass.allLocalCreationPasses(cpg).foreach(_.createAndApply())
-
+        new ClosureRefPass(cpg).createAndApply()
       }
     } else {
       logger.error(

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -250,8 +250,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
     }
     val methodReturn = newMethodReturnNode(returnType, line = line(decl), column = None)
 
-    val declLocals = scope.getLocalsInScope.map(Ast(_))
-    val methodBody = blockAst(blockNode(decl), declLocals ++ methodBodyStmts)
+    val methodBody = blockAst(blockNode(decl), methodBodyStmts)
 
     scope.popScope()
     methodAstWithAnnotations(method, parameters, methodBody, methodReturn, modifiers)
@@ -563,8 +562,8 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
   }
 
   private def astForForeachStmt(stmt: PhpForeachStmt): Ast = {
-    val iteratorAst   = astForExpr(stmt.iterExpr)
-    val iteratorLocal = getTmpLocal(stmt, maybeTypeFullName = None, lineNumber = line(stmt), prefix = "iter_")
+    val iteratorAst    = astForExpr(stmt.iterExpr)
+    val iterIdentifier = getTmpIdentifier(stmt, maybeTypeFullName = None, prefix = "iter_")
 
     val assignItemTargetAst = stmt.keyVar match {
       case Some(key) => astForKeyValPair(key, stmt.valueVar, line(stmt))
@@ -573,12 +572,11 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
 
     // Initializer asts
     // - Iterator assign
-    val iterIdent         = identifierAstFromLocal(iteratorLocal, line(stmt))
     val iterValue         = astForExpr(stmt.iterExpr)
-    val iteratorAssignAst = simpleAssignAst(iterIdent, iterValue, line(stmt))
+    val iteratorAssignAst = simpleAssignAst(Ast(iterIdentifier), iterValue, line(stmt))
 
     // - Assigned item assign
-    val itemInitAst = getItemAssignAstForForeach(stmt, assignItemTargetAst, iteratorLocal)
+    val itemInitAst = getItemAssignAstForForeach(stmt, assignItemTargetAst, iterIdentifier.copy)
 
     // Condition ast
     val isNullName = PhpOperators.isNull
@@ -591,7 +589,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
     val conditionAst = callAst(notIsNull, isNullAst :: Nil)
 
     // Update asts
-    val nextIterIdent = identifierAstFromLocal(iteratorLocal, line(stmt))
+    val nextIterIdent = Ast(iterIdentifier.copy)
     val nextSignature = "void()"
     val nextCallCode  = s"${nextIterIdent.rootCodeOrEmpty}->next()"
     val nextCallNode = callNode(
@@ -627,9 +625,9 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
   private def getItemAssignAstForForeach(
     stmt: PhpForeachStmt,
     assignItemTargetAst: Ast,
-    iteratorLocal: NewLocal
+    iteratorIdentifier: NewIdentifier
   ): Ast = {
-    val iteratorIdentifierAst = identifierAstFromLocal(iteratorLocal, line(stmt))
+    val iteratorIdentifierAst = Ast(iteratorIdentifier)
     val currentCallSignature  = s"$UnresolvedSignature(0)"
     val currentCallCode       = s"${iteratorIdentifierAst.rootCodeOrEmpty}->current()"
     val currentCallNode = callNode(
@@ -695,10 +693,11 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
         case _                               => code
       }
 
-      // Local will be added to the method via magic later. Just fix the code and line here.
-      scope.lookupVariable(name).collect { case local: NewLocal => local }.foreach { local =>
-        local.code(s"static ${local.code}")
-        local.lineNumber(line(stmt))
+      val local = localNode(stmt, name, s"static $code", variableAst.rootType.getOrElse(TypeConstants.Any))
+      scope.addToScope(local.name, local)
+
+      variableAst.root.collect { case identifier: NewIdentifier =>
+        diffGraph.addEdge(identifier, local, EdgeTypes.REF)
       }
 
       val defaultAssignAst = maybeValueAst.map { valueAst =>
@@ -707,7 +706,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
         callAst(assignNode, variableAst :: valueAst :: Nil)
       }
 
-      defaultAssignAst.toList
+      Ast(local) :: defaultAssignAst.toList
     }
   }
 
@@ -953,9 +952,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
   private def astForCall(call: PhpCallExpr): Ast = {
     val arguments = call.args.map(astForCallArg)
 
-    val isMethodCall = call.target.isDefined && !call.isStatic
-
-    val targetAst = Option.when(isMethodCall)(call.target.map(astForExpr)).flatten
+    val targetAst = Option.unless(call.isStatic)(call.target.map(astForExpr)).flatten
 
     val nameAst = Option.unless(call.methodName.isInstanceOf[PhpNameExpr])(astForExpr(call.methodName))
     val name =
@@ -971,7 +968,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
     val argsCode = arguments.map(_.rootCodeOrEmpty).mkString(",")
 
     val codePrefix =
-      if (isMethodCall && targetAst.isDefined)
+      if (!call.isStatic && targetAst.isDefined)
         codeForMethodCall(call, targetAst.get, name)
       else if (call.isStatic)
         codeForStaticMethodCall(call, name)
@@ -989,7 +986,7 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
     val fullName = call.target match {
       // Static method call with a known class name
       case Some(nameExpr: PhpNameExpr) if call.isStatic =>
-        s"${nameExpr.name}.$name:$UnresolvedSignature(${arguments.size})"
+        s"${nameExpr.name}${StaticMethodDelimiter}$name"
 
       case None if PhpBuiltins.FuncNames.contains(name) =>
         // No signature/namespace for MFN for builtin functions to ensure stable names as type info improves.
@@ -1048,17 +1045,8 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
   private def astForNameExpr(expr: PhpNameExpr): Ast = {
     val identifier = identifierNode(expr, expr.name, expr.name, TypeConstants.Any)
 
-    scope.lookupVariable(identifier.name) match {
-      case Some(declaringNode) =>
-        diffGraph.addEdge(identifier, declaringNode, EdgeTypes.REF)
-
-      case None =>
-        // With variable variables, it's possible to use a valid variable without having an obvious assignment to it.
-        // If a name is unknown at this point, assume it's a local that had a value assigned in some way at some point.
-
-        val local = localNode(expr, identifier.name, s"$$${identifier.code}", identifier.typeFullName)
-        scope.addToScope(local.name, local)
-        diffGraph.addEdge(identifier, local, EdgeTypes.REF)
+    scope.lookupVariable(identifier.name).foreach { declaringNode =>
+      diffGraph.addEdge(identifier, declaringNode, EdgeTypes.REF)
     }
 
     Ast(identifier)
@@ -1288,38 +1276,24 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
     callAst(callNode, args.toList)
   }
 
-  private def getTmpLocal(
+  private def getTmpIdentifier(
     originNode: PhpNode,
     maybeTypeFullName: Option[String],
-    lineNumber: Option[Integer],
     prefix: String = ""
-  ): NewLocal = {
-    val name = s"$prefix${getNewTmpName()}"
-
+  ): NewIdentifier = {
+    val name         = s"$prefix${getNewTmpName()}"
     val typeFullName = maybeTypeFullName.map(registerType).getOrElse(TypeConstants.Any)
-
-    val local = localNode(originNode, name, s"$$$name", typeFullName)
-
-    scope.addToScope(name, local)
-
-    local
-  }
-
-  private def identifierAstFromLocal(local: NewLocal, lineNumber: Option[Integer] = None): Ast = {
-    val typeFullName = Option(local.typeFullName).map(registerType)
-    val identifier = newIdentifierNode(local.name, typeFullName.getOrElse("ANY"), Seq(), lineNumber)
-      .code(s"$$${local.name}")
-    Ast(identifier).withRefEdge(identifier, local)
+    identifierNode(originNode, name, s"$$$name", typeFullName)
   }
 
   private def astForArrayExpr(expr: PhpArrayExpr): Ast = {
     val idxTracker   = new ArrayIndexTracker
     val typeFullName = registerType(TypeConstants.Array)
 
-    val tmpLocal = getTmpLocal(expr, Some(typeFullName), line(expr))
+    val tmpIdentifier = getTmpIdentifier(expr, Some(typeFullName))
 
     val itemAssignments = expr.items.flatMap {
-      case Some(item) => Option(assignForArrayItem(item, tmpLocal, idxTracker))
+      case Some(item) => Option(assignForArrayItem(item, tmpIdentifier.name, idxTracker))
       case None =>
         idxTracker.next // Skip an index
         None
@@ -1327,9 +1301,8 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
     val arrayBlock = blockNode(expr)
 
     Ast(arrayBlock)
-      .withChild(Ast(tmpLocal))
       .withChildren(itemAssignments)
-      .withChild(identifierAstFromLocal(tmpLocal))
+      .withChild(Ast(tmpIdentifier))
   }
 
   private def astForListExpr(expr: PhpListExpr): Ast = {
@@ -1532,16 +1505,15 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
         (Option(ast), name)
     }
 
-    val tmpLocal = getTmpLocal(expr, Option(className), line(expr))
+    val tmpIdentifier = getTmpIdentifier(expr, Option(className))
 
     // Alloc assign
     val allocCode       = s"$className.<alloc>()"
     val allocNode       = newOperatorCallNode(Operators.alloc, allocCode, Option(className), line(expr))
     val allocAst        = callAst(allocNode, base = maybeNameAst)
-    val allocAssignCode = s"${tmpLocal.code} = ${allocAst.rootCodeOrEmpty}"
+    val allocAssignCode = s"${tmpIdentifier.code} = ${allocAst.rootCodeOrEmpty}"
     val allocAssignNode = newOperatorCallNode(Operators.assignment, allocAssignCode, Option(className), line(expr))
-    val allocAssignIdentifier = identifierAstFromLocal(tmpLocal, line(expr))
-    val allocAssignAst        = callAst(allocAssignNode, allocAssignIdentifier :: allocAst :: Nil)
+    val allocAssignAst  = callAst(allocAssignNode, Ast(tmpIdentifier) :: allocAst :: Nil)
 
     // Init node
     val initArgs      = expr.args.map(astForCallArg)
@@ -1557,14 +1529,13 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
       Some(initSignature),
       Some(TypeConstants.Any)
     )
-    val initReceiver = identifierAstFromLocal(tmpLocal, line(expr))
+    val initReceiver = Ast(tmpIdentifier.copy)
     val initCallAst  = callAst(initCallNode, initArgs, base = Option(initReceiver))
 
     // Return identifier
-    val returnIdentifierAst = identifierAstFromLocal(tmpLocal, line(expr))
+    val returnIdentifierAst = Ast(tmpIdentifier.copy)
 
     Ast(blockNode(expr, "", TypeConstants.Any))
-      .withChild(Ast(tmpLocal))
       .withChild(allocAssignAst)
       .withChild(initCallAst)
       .withChild(returnIdentifierAst)
@@ -1590,9 +1561,9 @@ class AstCreator(filename: String, phpAst: PhpFile, global: Global)
         scalar
     }
   }
-  private def assignForArrayItem(item: PhpArrayItem, arrayLocal: NewLocal, idxTracker: ArrayIndexTracker): Ast = {
+  private def assignForArrayItem(item: PhpArrayItem, name: String, idxTracker: ArrayIndexTracker): Ast = {
     // It's perhaps a bit clumsy to reconstruct PhpExpr nodes here, but reuse astForArrayDimExpr for consistency
-    val variable = PhpVariable(PhpNameExpr(arrayLocal.name, item.attributes), item.attributes)
+    val variable = PhpVariable(PhpNameExpr(name, item.attributes), item.attributes)
 
     val dimension = item.key match {
       case Some(key: PhpSimpleScalar) => dimensionFromSimpleScalar(key, idxTracker)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
@@ -36,12 +36,8 @@ class ClosureRefPass(cpg: Cpg) extends ConcurrentWriterCpgPass[ClosureBinding](c
     }
   }
 
-  private def hasMethod(in: Traversal[AstNode]): Traversal[AstNode] = {
-    in.where(_.collectAll[Method])
-  }
-
   private def getMethod(methodRef: MethodRef): Option[Method] = {
-    methodRef.repeat(_.astParent)(_.until(hasMethod).emit(hasMethod)).collectAll[Method].headOption
+    methodRef.repeat(_.astParent)(_.until(_.isMethod).emit(_.isMethod)).isMethod.headOption
   }
 
   private def addRefToCapturedNode(

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
@@ -51,10 +51,11 @@ class ClosureRefPass(cpg: Cpg) extends ConcurrentWriterCpgPass[ClosureBinding](c
 
       case Some(method) =>
         closureBinding.closureOriginalName.foreach { name =>
+          lazy val locals = method.repeat(_.astChildren.filterNot(_.isMethod))(_.emit(_.isLocal)).collectAll[Local]
           val maybeCaptured =
             method.parameter
               .find(_.name == name)
-              .orElse(method.ast.collectAll[Local].find(_.name == name))
+              .orElse(locals.find(_.name == name))
 
           maybeCaptured.foreach { captured =>
             diffGraph.addEdge(closureBinding, captured, EdgeTypes.REF)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
@@ -1,0 +1,69 @@
+package io.joern.php2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Method, MethodRef}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language._
+import org.slf4j.LoggerFactory
+import overflowdb.traversal.Traversal
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode
+import io.shiftleft.codepropertygraph.generated.nodes.Local
+
+class ClosureRefPass(cpg: Cpg) extends ConcurrentWriterCpgPass[ClosureBinding](cpg) {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def generateParts(): Array[ClosureBinding] = cpg.all.collectAll[ClosureBinding].toArray
+
+  /** The AstCreator adds closureBindingIds and ClosureBindings for captured locals, but does not add the required REF
+    * edges from the ClosureBinding to the captured node since the captured node may be a Local that is created by the
+    * LocalCreationPass and does not exist during AST creation.
+    *
+    * This pass attempts to find the captured node in the method containing the MethodRef to the closure method, since
+    * that is the scope in which the closure would have originally been created.
+    */
+  override def runOnPart(diffGraph: DiffGraphBuilder, closureBinding: ClosureBinding): Unit = {
+    closureBinding.captureIn.collectAll[MethodRef].toList match {
+      case Nil =>
+        logger.error(s"No MethodRef corresponding to closureBinding ${closureBinding.closureBindingId}")
+
+      case methodRef :: Nil =>
+        addRefToCapturedNode(diffGraph, closureBinding, getMethod(methodRef))
+
+      case methodRefs =>
+        logger.error(s"Mutliple MethodRefs corresponding to closureBinding ${closureBinding.closureBindingId}")
+        logger.debug(s"${closureBinding.closureBindingId} MethodRefs = ${methodRefs}")
+    }
+  }
+
+  private def hasMethod(in: Traversal[AstNode]): Traversal[AstNode] = {
+    in.where(_.collectAll[Method])
+  }
+
+  private def getMethod(methodRef: MethodRef): Option[Method] = {
+    methodRef.repeat(_.astParent)(_.until(hasMethod).emit(hasMethod)).collectAll[Method].headOption
+  }
+
+  private def addRefToCapturedNode(
+    diffGraph: DiffGraphBuilder,
+    closureBinding: ClosureBinding,
+    method: Option[Method]
+  ): Unit = {
+    method match {
+      case None =>
+        logger.warn(s"No parent method for methodRef for ${closureBinding.closureBindingId}. REF edge will be missing")
+
+      case Some(method) =>
+        closureBinding.closureOriginalName.foreach { name =>
+          val maybeCaptured =
+            method.parameter
+              .find(_.name == name)
+              .orElse(method.ast.collectAll[Local].find(_.name == name))
+
+          maybeCaptured.foreach { captured =>
+            diffGraph.addEdge(closureBinding, captured, EdgeTypes.REF)
+          }
+        }
+    }
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/LocalCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/LocalCreationPass.scala
@@ -1,0 +1,128 @@
+package io.joern.php2cpg.passes
+
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  AstNode,
+  Call,
+  Identifier,
+  Method,
+  NamespaceBlock,
+  NewLocal,
+  NewNode,
+  TypeDecl
+}
+import io.shiftleft.semanticcpg.language._
+import io.joern.php2cpg.astcreation.AstCreator
+import io.joern.php2cpg.parser.Domain
+import io.joern.php2cpg.parser.Domain.PhpOperators
+import io.joern.x2cpg.AstNodeBuilder
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+
+object LocalCreationPass {
+  def allLocalCreationPasses(cpg: Cpg): Iterator[LocalCreationPass[_ <: AstNode]] =
+    Iterator(new NamespaceLocalPass(cpg), new MethodLocalPass(cpg))
+}
+
+abstract class LocalCreationPass[ScopeType <: AstNode](cpg: Cpg)
+    extends ConcurrentWriterCpgPass[ScopeType](cpg)
+    with AstNodeBuilder[AstNode, LocalCreationPass[ScopeType]] {
+  override protected def line(node: AstNode)                       = node.lineNumber
+  override protected def column(node: AstNode)                     = node.columnNumber
+  override protected def lineEnd(node: AstNode): Option[Integer]   = None
+  override protected def columnEnd(node: AstNode): Option[Integer] = None
+
+  protected def getIdentifiersInScope(node: AstNode): List[Identifier] = {
+    node match {
+      case identifier: Identifier                              => identifier :: Nil
+      case _: TypeDecl | _: Method | _: NamespaceBlock         => Nil
+      case _ if node.astChildren.isEmpty                       => Nil
+      case call: Call if call.name == PhpOperators.declareFunc =>
+        // TODO Handle declares properly
+        // but for now don't change behaviour.
+        Nil
+      case _ => node.astChildren.flatMap(getIdentifiersInScope).toList
+    }
+  }
+
+  protected def localsForIdentifiers(
+    identifierMap: Map[String, List[Identifier]]
+  ): List[(NewLocal, List[Identifier])] = {
+    identifierMap
+      .map { case identifierName -> identifiers =>
+        val code = s"$$$identifierName"
+        val local =
+          localNode(identifiers.head, identifierName, code, AstCreator.TypeConstants.Any, closureBindingId = None)
+        (local -> identifiers)
+      }
+      .toList
+      .sortBy { case (local, _) => local.name }
+  }
+
+  protected def addRefEdges(diffGraph: DiffGraphBuilder, localPairs: List[(NewLocal, List[Identifier])]): Unit = {
+    localPairs.foreach { case (local, identifiers) =>
+      identifiers.foreach { identifier =>
+        diffGraph.addEdge(identifier, local, EdgeTypes.REF)
+      }
+    }
+  }
+
+  protected def prependLocalsToBody(diffGraph: DiffGraphBuilder, bodyNode: AstNode, locals: List[NewLocal]): Unit = {
+    val originalChildren = bodyNode.astChildren.l
+
+    bodyNode.outE(EdgeTypes.AST).foreach(diffGraph.removeEdge)
+
+    locals.zipWithIndex.foreach { case (local, idx) =>
+      local.order(idx + 1)
+    }
+
+    val localCount = locals.size
+
+    originalChildren.foreach { node =>
+      diffGraph.setNodeProperty(node, PropertyNames.ORDER, node.order + localCount)
+    }
+
+    (locals ++ originalChildren).foreach { node =>
+      diffGraph.addEdge(bodyNode, node, EdgeTypes.AST)
+    }
+  }
+
+  protected def addLocalsToAst(
+    diffGraph: DiffGraphBuilder,
+    bodyNode: AstNode,
+    excludeIdentifierFn: Identifier => Boolean
+  ): Unit = {
+    val identifierMap =
+      getIdentifiersInScope(bodyNode)
+        .filter(_.refOut.isEmpty)
+        .filterNot(excludeIdentifierFn)
+        .groupBy(_.name)
+
+    val localPairs = localsForIdentifiers(identifierMap)
+
+    if (localPairs.nonEmpty) {
+      val locals = localPairs.map { case (local, _) => local }
+
+      addRefEdges(diffGraph, localPairs)
+      prependLocalsToBody(diffGraph, bodyNode, locals)
+    }
+  }
+}
+
+class NamespaceLocalPass(cpg: Cpg) extends LocalCreationPass[NamespaceBlock](cpg) {
+  override def generateParts(): Array[NamespaceBlock] = cpg.namespaceBlock.toArray
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, namespace: NamespaceBlock): Unit = {
+    addLocalsToAst(diffGraph, namespace, excludeIdentifierFn = _ => false)
+  }
+}
+
+class MethodLocalPass(cpg: Cpg) extends LocalCreationPass[Method](cpg) {
+  override def generateParts(): Array[Method] = cpg.method.internal.toArray
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, method: Method): Unit = {
+    val parameters = method.parameter.name.toSet
+    addLocalsToAst(diffGraph, method.body, excludeIdentifierFn = identifier => parameters.contains(identifier.name))
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ArrayTests.scala
@@ -70,21 +70,20 @@ class ArrayTests extends PhpCode2CpgFixture {
         |)
         |""".stripMargin)
 
-    inside(cpg.method.internal.body.astChildren.collectAll[Block].l) { case List(arrayBlock) =>
-      inside(arrayBlock.astChildren.l) {
-        case List(tmpLocal: Local, aAssign: Call, bAssign: Call, tmpIdent: Identifier) =>
-          tmpLocal.name shouldBe "tmp0"
-          tmpLocal.code shouldBe "$tmp0"
+    inside(cpg.method.internal.body.astChildren.l) { case List(tmpLocal: Local, arrayBlock: Block) =>
+      tmpLocal.name shouldBe "tmp0"
+      tmpLocal.code shouldBe "$tmp0"
 
-          aAssign.code shouldBe "$tmp0[\"A\"] = 1"
-          aAssign.lineNumber shouldBe Some(3)
+      inside(arrayBlock.astChildren.l) { case List(aAssign: Call, bAssign: Call, tmpIdent: Identifier) =>
+        aAssign.code shouldBe "$tmp0[\"A\"] = 1"
+        aAssign.lineNumber shouldBe Some(3)
 
-          bAssign.code shouldBe "$tmp0[\"B\"] = 2"
-          bAssign.lineNumber shouldBe Some(4)
+        bAssign.code shouldBe "$tmp0[\"B\"] = 2"
+        bAssign.lineNumber shouldBe Some(4)
 
-          tmpIdent.name shouldBe "tmp0"
-          tmpIdent.code shouldBe "$tmp0"
-          tmpIdent._localViaRefOut should contain(tmpLocal)
+        tmpIdent.name shouldBe "tmp0"
+        tmpIdent.code shouldBe "$tmp0"
+        tmpIdent._localViaRefOut should contain(tmpLocal)
       }
     }
   }
@@ -97,21 +96,20 @@ class ArrayTests extends PhpCode2CpgFixture {
         |)
         |""".stripMargin)
 
-    inside(cpg.method.internal.body.astChildren.collectAll[Block].l) { case List(arrayBlock) =>
-      inside(arrayBlock.astChildren.l) {
-        case List(tmpLocal: Local, aAssign: Call, bAssign: Call, tmpIdent: Identifier) =>
-          tmpLocal.name shouldBe "tmp0"
-          tmpLocal.code shouldBe "$tmp0"
+    inside(cpg.method.internal.body.astChildren.l) { case List(tmpLocal: Local, arrayBlock: Block) =>
+      tmpLocal.name shouldBe "tmp0"
+      tmpLocal.code shouldBe "$tmp0"
 
-          aAssign.code shouldBe "$tmp0[0] = \"A\""
-          aAssign.lineNumber shouldBe Some(3)
+      inside(arrayBlock.astChildren.l) { case List(aAssign: Call, bAssign: Call, tmpIdent: Identifier) =>
+        aAssign.code shouldBe "$tmp0[0] = \"A\""
+        aAssign.lineNumber shouldBe Some(3)
 
-          bAssign.code shouldBe "$tmp0[1] = \"B\""
-          bAssign.lineNumber shouldBe Some(4)
+        bAssign.code shouldBe "$tmp0[1] = \"B\""
+        bAssign.lineNumber shouldBe Some(4)
 
-          tmpIdent.name shouldBe "tmp0"
-          tmpIdent.code shouldBe "$tmp0"
-          tmpIdent._localViaRefOut should contain(tmpLocal)
+        tmpIdent.name shouldBe "tmp0"
+        tmpIdent.code shouldBe "$tmp0"
+        tmpIdent._localViaRefOut should contain(tmpLocal)
       }
     }
   }
@@ -123,11 +121,11 @@ class ArrayTests extends PhpCode2CpgFixture {
         |)
         |""".stripMargin)
 
-    inside(cpg.method.internal.body.astChildren.collectAll[Block].l) { case List(arrayBlock) =>
-      inside(arrayBlock.astChildren.l) { case List(tmpLocal: Local, assign: Call, tmpIdent: Identifier) =>
-        tmpLocal.name shouldBe "tmp0"
-        tmpLocal.code shouldBe "$tmp0"
+    inside(cpg.method.internal.body.astChildren.l) { case List(tmpLocal: Local, arrayBlock: Block) =>
+      tmpLocal.name shouldBe "tmp0"
+      tmpLocal.code shouldBe "$tmp0"
 
+      inside(arrayBlock.astChildren.l) { case List(assign: Call, tmpIdent: Identifier) =>
         assign.code shouldBe "$tmp0[2] = \"A\""
         inside(assign.argument.collectAll[Call].argument.l) { case List(array: Identifier, index: Literal) =>
           array.name shouldBe "tmp0"
@@ -157,10 +155,12 @@ class ArrayTests extends PhpCode2CpgFixture {
         |)
         |""".stripMargin)
 
-    inside(cpg.method.internal.body.astChildren.collectAll[Block].l) { case List(arrayBlock) =>
+    inside(cpg.method.internal.body.astChildren.l) { case List(tmpLocal: Local, arrayBlock: Block) =>
+      tmpLocal.name shouldBe "tmp0"
+      tmpLocal.code shouldBe "$tmp0"
+
       inside(arrayBlock.astChildren.l) {
         case List(
-              tmpLocal: Local,
               aAssign: Call,
               cAssign: Call,
               fourAssign: Call,
@@ -170,9 +170,6 @@ class ArrayTests extends PhpCode2CpgFixture {
               eightAssign: Call,
               tmpIdent: Identifier
             ) =>
-          tmpLocal.name shouldBe "tmp0"
-          tmpLocal.code shouldBe "$tmp0"
-
           aAssign.code shouldBe "$tmp0[\"A\"] = \"B\""
           cAssign.code shouldBe "$tmp0[0] = \"C\""
           fourAssign.code shouldBe "$tmp0[4] = \"D\""

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -78,8 +78,8 @@ class CallTests extends PhpCode2CpgFixture {
     }
 
     "not create an identifier for the class target" in {
-      inside (cpg.identifier.l) {
-        case List(xArg) => xArg.name shouldBe "x"
+      inside(cpg.identifier.l) { case List(xArg) =>
+        xArg.name shouldBe "x"
       }
     }
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -7,6 +7,7 @@ import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.Block
 
 class CallTests extends PhpCode2CpgFixture {
   "halt_compiler calls should be created correctly" in {
@@ -49,20 +50,36 @@ class CallTests extends PhpCode2CpgFixture {
     }
   }
 
-  "static method calls with simple names should be correct" in {
+  "static method calls with simple names" should {
     val cpg = code("<?php\nFoo::foo($x);")
 
-    inside(cpg.call.l) { case List(fooCall) =>
-      fooCall.name shouldBe "foo"
-      fooCall.methodFullName shouldBe s"Foo.foo:${Defines.UnresolvedSignature}(1)"
-      fooCall.receiver.isEmpty shouldBe true
-      fooCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      fooCall.lineNumber shouldBe Some(2)
-      fooCall.code shouldBe "Foo::foo($x)"
+    "have the correct method node defined" in {
+      inside(cpg.call.l) { case List(fooCall) =>
+        fooCall.name shouldBe "foo"
+        fooCall.methodFullName shouldBe s"Foo::foo"
+        fooCall.receiver.isEmpty shouldBe true
+        fooCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        fooCall.lineNumber shouldBe Some(2)
+        fooCall.code shouldBe "Foo::foo($x)"
+      }
+    }
 
-      inside(fooCall.argument.l) { case List(xArg: Identifier) =>
+    "have the correct arguments" in {
+      inside(cpg.call.argument.l) { case List(xArg: Identifier) =>
         xArg.name shouldBe "x"
         xArg.code shouldBe "$x"
+      }
+    }
+
+    "have the correct child nodes" in {
+      inside(cpg.call.astChildren.l) { case List(arg: Identifier) =>
+        arg.name shouldBe "x"
+      }
+    }
+
+    "not create an identifier for the class target" in {
+      inside (cpg.identifier.l) {
+        case List(xArg) => xArg.name shouldBe "x"
       }
     }
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
@@ -72,7 +72,7 @@ class ClosureTests extends PhpCode2CpgFixture {
       inside(closureMethod.body.astChildren.l) { case List(use1: Local, use2: Local, echoCall: Call) =>
         use1.name shouldBe "use1"
         use1.code shouldBe "$use1"
-        use1.closureBindingId.isEmpty shouldBe false
+        use1.closureBindingId shouldBe Some(s"foo.php:$expectedName:use1")
         inside(cpg.all.collectAll[ClosureBinding].filter(_.closureBindingId == use1.closureBindingId).l) {
           case List(closureBinding) =>
             closureBinding.closureOriginalName shouldBe Some("use1")
@@ -80,8 +80,17 @@ class ClosureTests extends PhpCode2CpgFixture {
 
         use2.name shouldBe "use2"
         use2.code shouldBe "&$use2"
+        use2.closureBindingId shouldBe Some(s"foo.php:$expectedName:use2")
 
         echoCall.code shouldBe "echo $value"
+      }
+    }
+
+    "have a ref edge from the closure binding for a use to the captured node" in {
+      inside(cpg.all.collectAll[ClosureBinding].filter(_.closureOriginalName.contains("use1")).l) {
+        case List(closureBinding) =>
+          val capturedNode = cpg.method.nameExact("<global>").local.name("use1").head
+          closureBinding.refOut.toList shouldBe List(capturedNode)
       }
     }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
@@ -16,6 +16,9 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   Local
 }
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode
+
+import scala.util.Try
 
 class ControlStructureTests extends PhpCode2CpgFixture {
   "switch statements" should {
@@ -1022,6 +1025,12 @@ class ControlStructureTests extends PhpCode2CpgFixture {
         }
       }
     }
+  }
+
+  "foreach statements should not create parentless identifiers" in {
+    val cpg = code("""<?php foreach($GLOBALS as $x) {}""")
+
+    cpg.all.collectAll[Identifier].filter(node => Try(node.astParent).isFailure).toList shouldBe Nil
   }
 
   "foreach statements with only simple values should be represented as a for" in {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -52,7 +52,7 @@ class MethodTests extends PhpCode2CpgFixture {
         |}
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").body.astChildren.l) { case List(xLocal: Local, yLocal: Local, xAssign: Call) =>
+    inside(cpg.method.name("foo").body.astChildren.l) { case List(xLocal: Local, xAssign: Call, yLocal: Local) =>
       xLocal.name shouldBe "x"
       xLocal.code shouldBe "static $x"
       xLocal.lineNumber shouldBe Some(3)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OperatorTests.scala
@@ -5,7 +5,7 @@ import io.joern.php2cpg.parser.Domain.{PhpDomainTypeConstants, PhpOperators}
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, TypeRef}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Local, TypeRef}
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -5,6 +5,7 @@ import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, Local, Member, Method}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.Block
 
 class TypeDeclTests extends PhpCode2CpgFixture {
 
@@ -55,38 +56,37 @@ class TypeDeclTests extends PhpCode2CpgFixture {
         |}
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").body.astChildren.isBlock.l) { case List(constructorBlock) =>
+    inside(cpg.method.name("foo").body.astChildren.l) { case List(tmpLocal: Local, constructorBlock: Block) =>
+      tmpLocal.name shouldBe "tmp0"
+      tmpLocal.code shouldBe "$tmp0"
+
       constructorBlock.lineNumber shouldBe Some(3)
 
-      inside(constructorBlock.astChildren.l) {
-        case List(tmpLocal: Local, allocAssign: Call, initCall: Call, tmpVar: Identifier) =>
-          tmpLocal.name shouldBe "tmp0"
-          tmpLocal.code shouldBe "$tmp0"
+      inside(constructorBlock.astChildren.l) { case List(allocAssign: Call, initCall: Call, tmpVar: Identifier) =>
+        allocAssign.methodFullName shouldBe Operators.assignment
+        inside(allocAssign.astChildren.l) { case List(tmpIdentifier: Identifier, allocCall: Call) =>
+          tmpIdentifier.name shouldBe "tmp0"
+          tmpIdentifier.code shouldBe "$tmp0"
+          tmpIdentifier._localViaRefOut should contain(tmpLocal)
 
-          allocAssign.methodFullName shouldBe Operators.assignment
-          inside(allocAssign.astChildren.l) { case List(tmpIdentifier: Identifier, allocCall: Call) =>
-            tmpIdentifier.name shouldBe "tmp0"
-            tmpIdentifier.code shouldBe "$tmp0"
-            tmpIdentifier._localViaRefOut should contain(tmpLocal)
+          allocCall.name shouldBe Operators.alloc
+          allocCall.methodFullName shouldBe Operators.alloc
+          allocCall.lineNumber shouldBe Some(3)
+          allocCall.code shouldBe "Foo.<alloc>()"
+        }
 
-            allocCall.name shouldBe Operators.alloc
-            allocCall.methodFullName shouldBe Operators.alloc
-            allocCall.lineNumber shouldBe Some(3)
-            allocCall.code shouldBe "Foo.<alloc>()"
-          }
-
-          initCall.name shouldBe "__construct"
-          initCall.methodFullName shouldBe s"Foo->__construct"
-          initCall.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
-          initCall.code shouldBe "Foo->__construct(42)"
-          inside(initCall.argument.l) { case List(tmpIdentifier: Identifier, literal: Literal) =>
-            tmpIdentifier.name shouldBe "tmp0"
-            tmpIdentifier.code shouldBe "$tmp0"
-            tmpIdentifier.argumentIndex shouldBe 0
-            tmpIdentifier._localViaRefOut should contain(tmpLocal)
-            literal.code shouldBe "42"
-            literal.argumentIndex shouldBe 1
-          }
+        initCall.name shouldBe "__construct"
+        initCall.methodFullName shouldBe s"Foo->__construct"
+        initCall.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
+        initCall.code shouldBe "Foo->__construct(42)"
+        inside(initCall.argument.l) { case List(tmpIdentifier: Identifier, literal: Literal) =>
+          tmpIdentifier.name shouldBe "tmp0"
+          tmpIdentifier.code shouldBe "$tmp0"
+          tmpIdentifier.argumentIndex shouldBe 0
+          tmpIdentifier._localViaRefOut should contain(tmpLocal)
+          literal.code shouldBe "42"
+          literal.argumentIndex shouldBe 1
+        }
       }
     }
   }


### PR DESCRIPTION
Since PHP doesn't require variable declarations, php2cpg would create a Local node on the first use of a new identifier in scope and add a ref edge from the identifier to the local. This approach works well if the identifier in question is added to the CPG, but this isn't always the case. This led to a situation where identifier nodes are added to the CPG (due to the ref edge being added), but not to the AST, leaving them without AST parents. 

This PR removes most Local creation from the AstCreator and creates them in a follow-up pass instead. This also means that locals captured by closures must be referenced separately, since the locals being referenced may not exist yet, so the ClosureRefPass adds these.

Resolves https://github.com/joernio/joern/issues/2732