### PR TITLE
remove traversal, attempt 3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -203,7 +203,7 @@ This issue affected 27 files in joern.
 There used to be a step `count: Traversal[Int]` that turns a traversal into a new traversal with a single integer element that contains the number of items in
 the original traversal.
 
-Unfortunately there is a nameclash with an existing `count` method on `IterableOnceOps`. The old code had no problem with that, since a direct 
+Unfortunately there is a name clash with an existing `count` method on `IterableOnceOps`. The old code had no problem with that, since a direct 
 member function shadows the mixin. Since we now use extension methods on vanilla iterators, we cannot shadow the mixin. We therefore renamed 
 the traversal step to `countTrav`, and the code should now read
 ```

--- a/NEWS.md
+++ b/NEWS.md
@@ -259,7 +259,7 @@ Instead of using some raw DSL, it is common to provide a fluent query-builder AP
 
 However, this was never how joern actually worked: As we can see in the above snippet, `topLevelExpressions` is defined as a function, not a `lazy val`. In other words, function calls like `.out`, and all the string handling, were never in practice amortized over multiple uses of the expression; nobody ever wrote a query optimizer / compiler; and it was never possible to reasonably use joern with a remote database, due to the involved latencies (joern code expects access latencies counted in nanoseconds, not milliseconds).
 
-Early versions of joern used Tinkerpop as a graph database. Tinkerpop internally represents nodes as individual hashtables. As such, the above was actually the "close to the metal" representation of how to e.g. follow the out-edges of type "AST".
+Early versions of joern used TinkerGraph as a graph database. TinkerGraph internally represents nodes as individual hashtables. As such, the above was actually the "close to the metal" representation of how to e.g. follow the out-edges of type "AST".
 
 This is incredibly wasteful in terms of memory: The relevant keys are known at compile time. Hence, overflowdb uses generated domain-specific classes, together with functions to access the relevant fields, like e.g.
 ```

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # News
 
-## The great Traversal removal (June 2023)
+## The great Traversal removal (v2.0.0; June 2023)
+PR: https://github.com/joernio/joern/pull/2784
 ### Summary
 We remove the `overflowdb.traversal.Traversal` class, and replace it with a type alias `type Traversal[+T] = scala.collection.Iterator[T]`.
 In tandem, we improve consistency between the types of quasi-Iterators that appear in common APIs. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -133,7 +133,7 @@ private def tagged[A <: StoredNode: ClassTag]: Traversal[A] =
     traversal.in(EdgeTypes.TAGGED_BY).collectAll[A].sortBy(_.id).iterator
 ```
 
-NB. It is advantageous to improve this line further, using the mode modern API:
+NB. It is advantageous to improve this line further, using the (domain specific) CPG API:
 ```
 private def tagged[A <: StoredNode: ClassTag]: Traversal[A] =
     traversal._taggedByIn.collectAll[A].sortBy(_.id).iterator

--- a/NEWS.md
+++ b/NEWS.md
@@ -257,7 +257,7 @@ Instead of using some raw DSL, it is common to provide a fluent query-builder AP
       .not(_.hasLabel(NodeTypes.LOCAL))
 ```
 
-However, this was never how joern actually worked: As we can see in the above snipped, `topLevelExpressions` is defined as a function, not a `lazy val`. In other words, function calls like `.out`, and all the string handling, were never in practice amortized over multiple uses of the expression; nobody ever wrote a query optimizer / compiler; and it was never possible to reasonably use joern with a remote database, due to the involved latencies (joern code expects access latencies counted in nanoseconds, not milliseconds).
+However, this was never how joern actually worked: As we can see in the above snippet, `topLevelExpressions` is defined as a function, not a `lazy val`. In other words, function calls like `.out`, and all the string handling, were never in practice amortized over multiple uses of the expression; nobody ever wrote a query optimizer / compiler; and it was never possible to reasonably use joern with a remote database, due to the involved latencies (joern code expects access latencies counted in nanoseconds, not milliseconds).
 
 Early versions of joern used Tinkerpop as a graph database. Tinkerpop internally represents nodes as individual hashtables. As such, the above was actually the "close to the metal" representation of how to e.g. follow the out-edges of type "AST".
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,9 @@ superclass of `Iterator`) that yield `Iterator`. Many old APIs that used to retu
 
 ### Migration guide
 The following is a list of examples of common fixes that were needed to adapt the joern codebase to this change, together with an explanation and
-the compiler errors. 
+the compiler errors. Downstream usages of joern likely have the same usage patterns, so this should help with the migration. 
+
+You can see the entire diff [here](https://github.com/joernio/joern/pull/2784/files)
 
 #### Superfluous `.asScala`
 ```

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## The great Traversal removal (June 2023)
 ### Summary
-We remove the `overflowdb.traversa.Traversal` class, and replace it with a type alias `type Traversal[+T] = scala.collection.Iterator[T]`.
+We remove the `overflowdb.traversal.Traversal` class, and replace it with a type alias `type Traversal[+T] = scala.collection.Iterator[T]`.
 In tandem, we improve consistency between the types of quasi-Iterators that appear in common APIs. 
 
 This improved consistency comes at a price -- this change is not backwards compatible. The needed adaptations are typically very superficial,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,238 @@
+# News
+## The great Traversal removal
+### Summary
+We remove the `overflowdb.traversa.Traversal` class, and replace it with a type alias `type Traversal[+T] = scala.collection.Iterator[T]`.
+In tandem, we improve consistency between the types of quasi-Iterators that appear in common APIs. 
+
+This improved consistency comes at a price -- this change is not backwards compatible. The needed adaptations are typically very superficial,
+often simply a change in imports. On the upside, this change is extremely unlikely to introduce bugs / semantic changes. Instead, it will cause
+compile errors. Unfortunately the compiler error messages are not always helpful in fixing the issue, so we have a handy migration guide.
+
+### Old model
+In the old world, our APIs returned a mix of `scala.collection.Iterator`, `java.util.Iterator` and `overflowdb.traversal.Traversal`. These three
+types are semantically equivalent -- they all are lazy with respect to operations like `.map` and side-effects, they are stateful, i.e. are 
+mutated in-place when advancing, and are not reusable.
+
+The mismatch between these classes is partially hidden from the user by extensive use of implicit conversions. These are implemented by wrapping;
+hence we often end up with a Traversal that wraps a scala Iterator that wraps a java Iterator that finally contains the actual iteration state.
+
+In addition to the directly provided features by `Traversal`, like the pervasively used shorthand `.l` for `.toList`, or complex query-language
+features like path-tracking or logic like `.where` or even graph-search (breadth-first or depth-first) with `.repeat`, `Traversal` mixes in scala's
+`IterableOps`. This provides pervasively used methods like `.head` alongside not-so-pervasively used methods like `.view` -- the latter being an 
+example that silently misbehave on `Traversal`, since `IterableOps` is designed for stateless collections that can be traversed multiple times.
+
+### New model
+`Traversal` is replaced by scala `Iterator`. Most functionality from `Traversal` is implemented as extension methods to `IterableOnce` (which is a
+superclass of `Iterator`) that yield `Iterator`. Many old APIs that used to return java iterators now return scala iterators.
+
+### Migration guide
+The following is a list of examples of common fixes that were needed to adapt the joern codebase to this change, together with an explanation and
+the compiler errors.
+
+#### Superfluous `.asScala`
+```
+[error] joern/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CdgGenerator.scala:14:15: value asScala is not a member of Iterator[io.shiftleft.codepropertygraph.generated.nodes.StoredNode]
+[error]     v._cdgOut.asScala
+```
+The offending code was
+```
+  override def expand(v: StoredNode): Iterator[Edge] = {
+    v._cdgOut.asScala
+      .filter(_.isInstanceOf[StoredNode])
+      .map(node => Edge(v, node, edgeType = edgeType))
+  }
+```
+The `.asScala` here used to create a scala Iterator that wraps the underlying java iterator that used to be returned by `_cdgOut`.
+
+We have changed the API such that `_cdgOut` now directly returns a scala iterator, no wrapping required. Hence the fix is to remove
+the superfluous `.asScala` call:
+```
+  override def expand(v: StoredNode): Iterator[Edge] = {
+    v._cdgOut
+      .filter(_.isInstanceOf[StoredNode])
+      .map(node => Edge(v, node, edgeType = edgeType))
+  }
+```
+Occurences of this issue in joern: 7
+
+### Missing `.asScala`
+```
+[error] joern/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala:18:21: value cast is not a member of java.util.Iterator[overflowdb.Node]
+[error] did you mean wait?
+[error]     cpg.graph.nodes.cast[StoredNode]
+```
+Some legacy API methods still return java iterators. We had an implicit conversion from java iterator to `Traversal` which was triggered in this case --
+java iterators have no member function named `cast`, and there is a unique conversion to a type that has such a member function.
+
+Now `cast` exists on an extension (`AnyVal`) class, and there is an implicit conversion from scala `IterableOnce` to this extension. This implicit conversion
+does not exist on java iterators; hence it is necessary to manually convert, i.e.
+```
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+...
+    cpg.graph.nodes.asScala.cast[StoredNode]
+
+```
+Occurences: 1
+
+
+#### Access to the `Traversal` companion object
+```
+[error] joern/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCallGraphGenerator.scala:10:5: not found: value Traversal
+[error]     Traversal(DotSerializer.dotGraph(None, callGraph))
+```
+The offending code was
+```
+  def dotCallGraph(cpg: Cpg): Traversal[String] = {
+    val callGraph = new CallGraphGenerator().generate(cpg)
+    Traversal(DotSerializer.dotGraph(None, callGraph))
+  }
+```
+This snipped used to call the apply-function of the `Traversal` companion object, as a factory function to produce a `Traversal` over a 
+single element. The return type of `dotCallGraph` does not require adjustment due to the type-alias that replaces the old Traversal class.
+Unfortunately the type-alias cannot redirect access to the old companion object (which does not exist anymore). Hence the fix is to use the
+`Iterator` companion object instead:
+```
+  def dotCallGraph(cpg: Cpg): Traversal[String] = {
+    val callGraph = new CallGraphGenerator().generate(cpg)
+    Iterator(DotSerializer.dotGraph(None, callGraph))
+  }
+```
+NB: In more performance-sensitive parts of the codebase, it is advisable to use the `Iterator.single` factory method instead of the
+`Iterator.apply` factory method, due to implementation details of the scala standard library: `Iterator.apply` is vararg and hence 
+introduces another layer of indirection via a one-element argument array. It is unclear why the implementors decided against a dedicated
+overload for the common case of one-element iterators.
+
+Almost the same issue can occur, and is fixed similarly, with `PathAwareTraversal`, yielding errors like
+```
+[error] joern/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala:18:7: not found: value PathAwareTraversal
+[error]       PathAwareTraversal.empty
+```
+Occurences: 15
+
+#### Reliance on implicit conversion to Traversal
+```
+[error] joern/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala:22:59: type mismatch;
+[error]  found   : Seq[A]
+[error]  required: io.shiftleft.semanticcpg.language.Traversal[A]
+[error]     (which expands to)  Iterator[A]
+[error]     traversal.in(EdgeTypes.TAGGED_BY).collectAll[A].sortBy(_.id)
+```
+The offending code was
+```
+  private def tagged[A <: StoredNode: ClassTag]: Traversal[A] =
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[A].sortBy(_.id)
+```
+The `sortBy` method on Traversal returns a `Seq`. This code used to work because there was an implicit conversion to `Traversal`.
+
+In this specific case, we need to make the conversion explicit, by using
+```
+  private def tagged[A <: StoredNode: ClassTag]: Traversal[A] =
+    traversal.in(EdgeTypes.TAGGED_BY).collectAll[A].sortBy(_.id).iterator
+```
+
+NB. It is advantageous to improve this line further, using the mode modern API:
+```
+  private def tagged[A <: StoredNode: ClassTag]: Traversal[A] =
+    traversal._taggedByIn.collectAll[A].sortBy(_.id).iterator
+```
+
+Another example happened in the following code:
+```
+val method           = methodReturn.method.head
+```
+Here, `methodReturn` was a single `MethodReturn` node, and `method` was a single `Method` node. The author of the offending snippet
+was evidently confused about the type and expected to have a `Traversal[Method]` in hand that contains the single required `Method`.
+This code used to compile, due to an implicit conversion from a single node to `Traversal[Node]`, and due to `Traversal[Node]` having the
+member function `head`, mixed in from `IterableOps`.
+
+Such code does not compile anymore. The solution is to remove the superfluous `.head` call, i.e.
+```
+val method           = methodReturn.method
+```
+
+Another example happened in the following code:
+```
+  def globalFromLiteral(lit: Literal): Traversal[Expression] = lit
+    .where(_.inAssignment.method.nameExact("<module>", ":package"))
+    .inAssignment
+    .argument(1)
+```
+This code used to work due to the same implicit conversion, `where` being a member method of `Traversal`. This now needs to be explicit, via either
+```
+  def globalFromLiteral(lit: Literal): Traversal[Expression] = Iterator(lit)
+    .where(_.inAssignment.method.nameExact("<module>", ":package"))
+    .inAssignment
+    .argument(1)
+```
+or the fluent
+```
+  def globalFromLiteral(lit: Literal): Traversal[Expression] = lit.start
+    .where(_.inAssignment.method.nameExact("<module>", ":package"))
+    .inAssignment
+    .argument(1)
+```
+
+Another example happened in the following snippets:
+```
+  implicit def toDdgNodeDot(traversal: IterableOnce[Method]): DdgNodeDot =
+    new DdgNodeDot(traversal)
+//...
+class DdgNodeDot(val traversal: Traversal[Method]) extends AnyVal {
+//...
+    ```
+This code used to work due to an implicit conversion from `IterableOnce` to `Traversal`. We do not have this implicit conversion anymore, and the code should instead read:
+```
+  implicit def toDdgNodeDot(traversal: IterableOnce[Method]): DdgNodeDot =
+    new DdgNodeDot(traversal.iterator)
+```
+This is an important design pattern in our extensions methods: We accept `IterableOnce` for our extensions, in order to avoid users
+having to type `.iterator` everywhere in their code, and we always produce `Iterator`, in order to make it easy to reason about the semantics.
+
+
+Occurences: 2
+
+
+#### Use of the `count` step
+```
+[error] joern/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala:90:54: missing argument list for method count in trait IterableOnceOps
+[error] Unapplied methods are only converted to functions when a function type is expected.
+[error] You can make this conversion explicit by writing `count _` or `count(_)` instead of `count`.
+[error]       .repeat(_.in(edgeType))(_.until(_.in(edgeType).count.filter(_ == 0)))
+```
+There used to be a step `count: Traversal[Int]` that turns a traversal into a new traversal with a single integer element that contains the number of items in
+the original traversal.
+
+Unfortunately there is a nameclash with an existing `count` method on `IterableOnceOps`. The old code had no problem with that, since a direct 
+member function shadows the mixin. Since we now use extension methods on vanilla iterators, we cannot shadow the mixin. We therefore renamed 
+the traversal step to `countTrav`, and the code should now read
+```
+      .repeat(_.in(edgeType))(_.until(_.in(edgeType).countTrav.filter(_ == 0)))
+```
+
+Occurences: 1
+
+#### Double import of Traversal and implicits
+```
+[error] joern/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala:11:12: reference to Traversal is ambiguous;
+[error] it is imported twice in the same scope by
+[error] import overflowdb.traversal._
+[error] and import io.shiftleft.semanticcpg.language._
+[error]   def tag: Traversal[Tag] = {
+```
+The import `import io.shiftleft.semanticcpg.language._` includes almost all things that are imported by `import overflowdb.traversal._`.
+These two imports were always conflicting, in the sense that the overflowdb import was redundant and stopped many things
+from working due to ambiguity problems. Now, many more things stop working with such broken imports.
+
+The fix is to remove the offending `import overflowdb.traversal._`.
+
+Occurences: 11
+
+#### Missing import of traversal extensions
+```
+[error] joern/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationParameterAssignTraversal.scala:21:8: value cast is not a member of Iterator[io.shiftleft.codepropertygraph.generated.nodes.AstNode]
+[error] did you mean wait?
+[error] possible cause: maybe a semicolon is missing before `value cast`?
+[error]       .cast[Expression]
+```
+Some operations on Traversal where implemented as member methods, as opposed to extension methods. These operations used to work without any imports of implicit conversions / extensions.
+These operations now need `import io.shiftleft.semanticcpg.language._` in order to work.

--- a/NEWS.md
+++ b/NEWS.md
@@ -179,7 +179,7 @@ Another example happened in the following snippets:
 //...
 class DdgNodeDot(val traversal: Traversal[Method]) extends AnyVal {
 //...
-    ```
+```
 This code used to work due to an implicit conversion from `IterableOnce` to `Traversal`. We do not have this implicit conversion anymore, and the code should instead read:
 ```
   implicit def toDdgNodeDot(traversal: IterableOnce[Method]): DdgNodeDot =

--- a/NEWS.md
+++ b/NEWS.md
@@ -90,7 +90,7 @@ The offending code was
     Traversal(DotSerializer.dotGraph(None, callGraph))
   }
 ```
-This snipped used to call the apply-function of the `Traversal` companion object, as a factory function to produce a `Traversal` over a 
+This snippet used to call `Traversal:apply` as a factory function to produce a `Traversal` over a 
 single element. The return type of `dotCallGraph` does not require adjustment due to the type-alias that replaces the old Traversal class.
 Unfortunately the type-alias cannot redirect access to the old companion object (which does not exist anymore). Hence the fix is to use the
 `Iterator` companion object instead:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Documentation: https://docs.joern.io/
 Specification: https://cpg.joern.io
 
 ## News / Changelog
-We maintain a [dedicated page](NEWS.md) for news on API-breaking changes.
 
+- Joern v2.0.0 removes the `overflowdb.traversal.Traversal` class. This change is not completely backwards compatible. See [here](changelog/traversal_removal.md) for a detailed writeup.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Documentation: https://docs.joern.io/
 
 Specification: https://cpg.joern.io
 
+## News / Changelog
+We maintain a [dedicated page](NEWS.md) for news on API-breaking changes.
+
+
 ## Requirements
 
 - JDK 19 (other versions _might_ work, but have not been properly tested)

--- a/benchmarks/build.sbt
+++ b/benchmarks/build.sbt
@@ -1,6 +1,6 @@
 name := "benchmarks"
 
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.dataflowengineoss)
 dependsOn(Projects.semanticcpg)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.603+3-9285e218"
+val cpgVersion = "1.3.611"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.611"
+val cpgVersion = "1.3.612"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "2.13.8"
 
-val cpgVersion = "1.3.600"
+val cpgVersion = "1.3.603+3-9285e218"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/console/src/main/scala/io/joern/console/scan/package.scala
+++ b/console/src/main/scala/io/joern/console/scan/package.scala
@@ -14,7 +14,7 @@ package object scan {
 
   implicit class ScannerStarters(val cpg: Cpg) extends AnyVal {
     def finding: Traversal[Finding] =
-      cpg.graph.nodes(NodeTypes.FINDING).cast[Finding]
+      overflowdb.traversal.InitialTraversal.from[Finding](cpg.graph, NodeTypes.FINDING)
   }
 
   implicit class QueryWrapper(q: Query) {

--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -1,6 +1,6 @@
 name := "dataflowengineoss"
 
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.semanticcpg, Projects.x2cpg)
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -13,7 +13,6 @@ import io.joern.dataflowengineoss.queryengine.{
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
 import scala.collection.mutable
 import scala.collection.parallel.CollectionConverters._
 
@@ -35,14 +34,14 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     result
   }
 
-  def reachableBy[NodeType](sourceTravs: Traversal[NodeType]*)(implicit context: EngineContext): Traversal[NodeType] = {
+  def reachableBy[NodeType](sourceTravs: IterableOnce[NodeType]*)(implicit context: EngineContext): Traversal[NodeType] = {
     val sources = sourceTravsToStartingPoints(sourceTravs: _*)
     val reachedSources =
       reachableByInternal(sources).map(_.path.head.node)
-    Traversal.from(reachedSources).cast[NodeType]
+    reachedSources.cast[NodeType]
   }
 
-  def reachableByFlows[A](sourceTravs: Traversal[A]*)(implicit context: EngineContext): Traversal[Path] = {
+  def reachableByFlows[A](sourceTravs: IterableOnce[A]*)(implicit context: EngineContext): Traversal[Path] = {
     val sources        = sourceTravsToStartingPoints(sourceTravs: _*)
     val startingPoints = sources.map(_.startingPoint)
     val paths = reachableByInternal(sources).par
@@ -62,7 +61,7 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
       .dedup
       .flatten
       .toVector
-    paths.to(Traversal)
+    paths.iterator
   }
 
   def reachableByDetailed[NodeType](

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -34,7 +34,9 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     result
   }
 
-  def reachableBy[NodeType](sourceTravs: IterableOnce[NodeType]*)(implicit context: EngineContext): Traversal[NodeType] = {
+  def reachableBy[NodeType](
+    sourceTravs: IterableOnce[NodeType]*
+  )(implicit context: EngineContext): Traversal[NodeType] = {
     val sources = sourceTravsToStartingPoints(sourceTravs: _*)
     val reachedSources =
       reachableByInternal(sources).map(_.path.head.node)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/dotextension/DdgNodeDot.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/dotextension/DdgNodeDot.scala
@@ -6,8 +6,7 @@ import io.joern.dataflowengineoss.dotgenerator.{DotCpg14Generator, DotDdgGenerat
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language.dotextension.{ImageViewer, Shared}
-import overflowdb.traversal.Traversal
-
+import io.shiftleft.semanticcpg.language._
 class DdgNodeDot(val traversal: Traversal[Method]) extends AnyVal {
 
   def dotDdg(implicit semantics: Semantics = DefaultSemantics()): Traversal[String] =

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
@@ -3,7 +3,6 @@ package io.joern.dataflowengineoss.language.nodemethods
 import io.joern.dataflowengineoss.semanticsloader._
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, Method}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
 
 class ExpressionMethods[NodeType <: Expression](val node: NodeType) extends AnyVal {
 
@@ -40,7 +39,7 @@ class ExpressionMethods[NodeType <: Expression](val node: NodeType) extends AnyV
     *   true if these nodes are arguments to the same call, false if otherwise.
     */
   def isArgToSameCallWith(other: Expression): Boolean =
-    node.astParent.collectAll[Call].headOption.equals(other.astParent.collectAll[Call].headOption)
+    node.astParent.start.collectAll[Call].headOption.equals(other.astParent.start.collectAll[Call].headOption)
 
   /** Determines if this node has a flow to the given target node in the defined semantics.
     * @param tgt

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
@@ -17,7 +17,9 @@ class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends An
     */
   def astNode: AstNode = node
 
-  def reachableBy[NodeType](sourceTravs: IterableOnce[NodeType]*)(implicit context: EngineContext): Traversal[NodeType] =
+  def reachableBy[NodeType](sourceTravs: IterableOnce[NodeType]*)(implicit
+    context: EngineContext
+  ): Traversal[NodeType] =
     node.start.reachableBy(sourceTravs: _*)
 
   def ddgIn(implicit semantics: Semantics = DefaultSemantics()): Traversal[CfgNode] = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
@@ -7,7 +7,6 @@ import io.joern.dataflowengineoss.queryengine.{Engine, EngineContext, PathElemen
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language.{toExpressionMethods, _}
 import io.shiftleft.semanticcpg.utils.MemberAccess
-import overflowdb.traversal.{Traversal, _}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -18,7 +17,7 @@ class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends An
     */
   def astNode: AstNode = node
 
-  def reachableBy[NodeType](sourceTravs: Traversal[NodeType]*)(implicit context: EngineContext): Traversal[NodeType] =
+  def reachableBy[NodeType](sourceTravs: IterableOnce[NodeType]*)(implicit context: EngineContext): Traversal[NodeType] =
     node.start.reachableBy(sourceTravs: _*)
 
   def ddgIn(implicit semantics: Semantics = DefaultSemantics()): Traversal[CfgNode] = {
@@ -61,7 +60,7 @@ class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends An
     withInvisible: Boolean,
     cache: mutable.HashMap[CfgNode, Vector[PathElement]]
   )(implicit semantics: Semantics): Traversal[PathElement] = {
-    val result = ddgInPathElemInternal(path, withInvisible, cache).to(Traversal)
+    val result = ddgInPathElemInternal(path, withInvisible, cache).iterator
     result
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/package.scala
@@ -14,12 +14,12 @@ package object language {
     new ExpressionMethods(node)
 
   implicit def toExtendedCfgNode[NodeType <: CfgNode](traversal: IterableOnce[NodeType]): ExtendedCfgNode =
-    new ExtendedCfgNode(traversal)
+    new ExtendedCfgNode(traversal.iterator)
 
   implicit def toDdgNodeDot(traversal: IterableOnce[Method]): DdgNodeDot =
-    new DdgNodeDot(traversal)
+    new DdgNodeDot(traversal.iterator)
 
   implicit def toDdgNodeDotSingle(method: Method): DdgNodeDot =
-    new DdgNodeDot(Traversal.fromSingle(method))
+    new DdgNodeDot(method.start)
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -2,11 +2,10 @@ package io.joern
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Expression, Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
 
 package object dataflowengineoss {
 
-  def globalFromLiteral(lit: Literal): Traversal[Expression] = lit
+  def globalFromLiteral(lit: Literal): Traversal[Expression] = lit.start
     .where(_.inAssignment.method.nameExact("<module>", ":package"))
     .inAssignment
     .argument(1)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
@@ -5,7 +5,6 @@ import io.joern.dataflowengineoss.queryengine.Engine.isOutputArgOfInternalMethod
 import io.joern.dataflowengineoss.semanticsloader.{ParamMapping, PosArg, Semantics}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, Expression, StoredNode}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 object EdgeValidator {
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -221,7 +221,7 @@ object Engine {
             val sameCallSite   = parentNode.inCall.l == childNode.start.inCall.l
             val visible = if (sameCallSite) {
               val semanticExists         = parentNode.semanticsForCallByArg.nonEmpty
-              val internalMethodsForCall = parentNodeCall.flatMap(methodsForCall).to(Traversal).internal
+              val internalMethodsForCall = parentNodeCall.flatMap(methodsForCall).internal
               (semanticExists && parentNode.isDefined) || internalMethodsForCall.isEmpty
             } else {
               parentNode.isDefined
@@ -242,7 +242,6 @@ object Engine {
     arg.inCall.l match {
       case List(call) =>
         methodsForCall(call)
-          .to(Traversal)
           .internal
           .isNotStub
           .nonEmpty && semanticsForCall(call).isEmpty
@@ -273,7 +272,6 @@ object Engine {
 
   def argToOutputParams(arg: Expression): Traversal[MethodParameterOut] = {
     argToMethods(arg)
-      .to(Traversal)
       .parameter
       .index(arg.argumentIndex)
       .asOutput
@@ -291,7 +289,6 @@ object Engine {
 
   def isCallToInternalMethod(call: Call): Boolean = {
     methodsForCall(call)
-      .to(Traversal)
       .internal
       .nonEmpty
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -241,10 +241,7 @@ object Engine {
   def isOutputArgOfInternalMethod(arg: Expression)(implicit semantics: Semantics): Boolean = {
     arg.inCall.l match {
       case List(call) =>
-        methodsForCall(call)
-          .internal
-          .isNotStub
-          .nonEmpty && semanticsForCall(call).isEmpty
+        methodsForCall(call).internal.isNotStub.nonEmpty && semanticsForCall(call).isEmpty
       case _ =>
         false
     }
@@ -271,8 +268,7 @@ object Engine {
   }
 
   def argToOutputParams(arg: Expression): Traversal[MethodParameterOut] = {
-    argToMethods(arg)
-      .parameter
+    argToMethods(arg).parameter
       .index(arg.argumentIndex)
       .asOutput
   }
@@ -288,9 +284,7 @@ object Engine {
   }
 
   def isCallToInternalMethod(call: Call): Boolean = {
-    methodsForCall(call)
-      .internal
-      .nonEmpty
+    methodsForCall(call).internal.nonEmpty
   }
   def isCallToInternalMethodWithoutSemantic(call: Call)(implicit semantics: Semantics): Boolean = {
     isCallToInternalMethod(call) && semanticsForCall(call).isEmpty

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -20,7 +20,7 @@ object SourcesToStartingPoints {
 
   private val log = LoggerFactory.getLogger(SourcesToStartingPoints.getClass)
 
-  def sourceTravsToStartingPoints[NodeType](sourceTravs: Traversal[NodeType]*): List[StartingPointWithSource] = {
+  def sourceTravsToStartingPoints[NodeType](sourceTravs: IterableOnce[NodeType]*): List[StartingPointWithSource] = {
     val fjp = ForkJoinPool.commonPool()
     try {
       fjp.invoke(new SourceTravsToStartingPointsTask(sourceTravs: _*)).distinct
@@ -34,14 +34,14 @@ object SourcesToStartingPoints {
 
 }
 
-class SourceTravsToStartingPointsTask[NodeType](sourceTravs: Traversal[NodeType]*)
+class SourceTravsToStartingPointsTask[NodeType](sourceTravs: IterableOnce[NodeType]*)
     extends RecursiveTask[List[StartingPointWithSource]] {
 
   private val log = LoggerFactory.getLogger(this.getClass)
 
   override def compute(): List[StartingPointWithSource] = {
     val sources: List[StoredNode] = sourceTravs
-      .flatMap(_.toList)
+      .flatMap(_.iterator.toList)
       .collect { case n: StoredNode => n }
       .dedup
       .toList
@@ -117,7 +117,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
                 x.argument(2).isFieldIdentifier.canonicalNameExact(identifier.name)
               case fieldIdentifier: FieldIdentifier =>
                 x.argument(2).isFieldIdentifier.canonicalNameExact(fieldIdentifier.canonicalName)
-              case _ => List()
+              case _ => Iterator.empty
             }
           }
           .takeWhile(notLeftHandOfAssignment)
@@ -195,7 +195,7 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
   }
 
   private def isTargetInAssignment(identifier: Identifier): List[Identifier] = {
-    Traversal(identifier).argumentIndex(1).where(_.inAssignment).l
+    identifier.start.argumentIndex(1).where(_.inAssignment).l
   }
 
   private def notLeftHandOfAssignment(x: Expression): Boolean = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, MethodParameterIn, MethodParameterOut, Return}
 import io.shiftleft.semanticcpg.language.NoResolve
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{NodeOps, Traversal}
 
 /** Creation of new tasks from results of completed tasks.
   */
@@ -72,7 +71,6 @@ class TaskCreator(context: EngineContext) {
   private def paramToArgsOfCallers(param: MethodParameterIn): List[Expression] =
     NoResolve
       .getMethodCallsites(param.method)
-      .to(Traversal)
       .collectAll[Call]
       .argument(param.index)
       .l
@@ -99,10 +97,10 @@ class TaskCreator(context: EngineContext) {
 
       val methodReturns = outCall.toList
         .flatMap(x => NoResolve.getCalledMethods(x).methodReturn.map(y => (x, y)))
-        .to(Traversal)
+        .iterator
 
       methodReturns.flatMap { case (call, methodReturn) =>
-        val method           = methodReturn.method.head
+        val method           = methodReturn.method
         val returnStatements = methodReturn._reachingDefIn.toList.collect { case r: Return => r }
         if (method.isExternal || method.start.isStub.nonEmpty) {
           val newPath = path

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskSolver.scala
@@ -3,7 +3,7 @@ package io.joern.dataflowengineoss.queryengine
 import io.joern.dataflowengineoss.queryengine.QueryEngineStatistics.{PATH_CACHE_HITS, PATH_CACHE_MISSES}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language.{toCfgNodeMethods, toExpressionMethods}
+import io.shiftleft.semanticcpg.language.{toCfgNodeMethods, toExpressionMethods, _}
 
 import java.util.concurrent.Callable
 import scala.collection.mutable

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/UsageSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/UsageSlicing.scala
@@ -4,7 +4,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
 
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{ForkJoinPool, RecursiveTask}
@@ -104,7 +103,7 @@ object UsageSlicing {
                           .nameExact("<operator>.new")
                           .lastOption
                           .map(_.argument)
-                          .getOrElse(Traversal.empty)
+                          .getOrElse(Iterator.empty)
                       else baseCall.argument)
           .collect { case n: Expression if n.argumentIndex > 0 => n }
           .flatMap {

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -1,6 +1,6 @@
 name               := "c2cpg"
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.semanticcpg, Projects.dataflowengineoss % Test, Projects.x2cpg % "compile->compile;test->test")
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -757,9 +757,9 @@ class AstCreationPassTests extends AbstractPassTest {
       val List(expressionListCall)   = bracketedPrimaryCall.argument.isCall.l
       expressionListCall.name shouldBe "<operator>.expressionList"
 
-      val List(arg1) = expressionListCall.argument(1).collectAll[Call].l
+      val List(arg1) = expressionListCall.argument(1).start.collectAll[Call].l
       arg1.code shouldBe "__sync_synchronize()"
-      val List(arg2) = expressionListCall.argument(2).collectAll[Call].l
+      val List(arg2) = expressionListCall.argument(2).start.collectAll[Call].l
       arg2.code shouldBe "foo(x)"
     }
 
@@ -1688,8 +1688,8 @@ class AstCreationPassTests extends AbstractPassTest {
           call2.argument.code.l shouldBe List("2", "10")
           call3.code shouldBe "[3 ... 9] = 15"
           call3.name shouldBe Operators.assignment
-          val List(desCall) = call3.argument(1).collectAll[Call].l
-          val List(value)   = call3.argument(2).collectAll[Literal].l
+          val List(desCall) = call3.argument(1).start.collectAll[Call].l
+          val List(value)   = call3.argument(2).start.collectAll[Literal].l
           value.code shouldBe "15"
           desCall.name shouldBe Operators.arrayInitializer
           desCall.code shouldBe "[3 ... 9]"
@@ -1727,8 +1727,8 @@ class AstCreationPassTests extends AbstractPassTest {
           call2.argument.code.l shouldBe List("2", "10")
           call3.code shouldBe "[3 ... 9] = 15"
           call3.name shouldBe Operators.assignment
-          val List(desCall) = call3.argument(1).collectAll[Call].l
-          val List(value)   = call3.argument(2).collectAll[Literal].l
+          val List(desCall) = call3.argument(1).start.collectAll[Call].l
+          val List(value)   = call3.argument(2).start.collectAll[Literal].l
           value.code shouldBe "15"
           desCall.name shouldBe Operators.arrayInitializer
           desCall.code shouldBe "[3 ... 9]"

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/NodeTypeStarterQueryTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/NodeTypeStarterQueryTests.scala
@@ -4,7 +4,6 @@ import io.joern.c2cpg.testfixtures.CCodeToCpgSuite
 import io.shiftleft.codepropertygraph.generated.{Languages, NodeTypes}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
-import overflowdb.traversal._
 
 /** The following tests show in detail how queries can be started. For all node types, for which it seems reasonable,
   * all nodes of that type can be used as a starting point, e.g., `cpg.method` starts at all methods while `cpg.local`

--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -1,7 +1,7 @@
 name := "javasrc2cpg"
 
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -99,7 +99,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
         .argument(0)
         .l match {
         case List(thisNode: Identifier) =>
-          thisNode.outE.collectAll[Ref].map(_.inNode).l match {
+          thisNode._refOut.l match {
             case List(paramNode: MethodParameterIn) =>
               paramNode.name shouldBe "this"
               paramNode.method.fullName shouldBe s"Foo.${io.joern.x2cpg.Defines.ConstructorMethodName}:void()"

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
@@ -602,7 +602,7 @@ class NewControlStructureTests extends JavaSrcCode2CpgFixture {
       iteratorCall.order shouldBe 2
       iteratorCall.argumentIndex shouldBe 2
 
-      iteratorCall.argument(0).l match {
+      iteratorCall.argument(0).start.l match {
         case List(items: Identifier) =>
           items.name shouldBe "items"
           items.typeFullName shouldBe "java.util.List"
@@ -631,7 +631,7 @@ class NewControlStructureTests extends JavaSrcCode2CpgFixture {
       conditionCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       conditionCall.order shouldBe 1
 
-      conditionCall.argument(0).l match {
+      conditionCall.argument(0).start.l match {
         case List(receiver: Identifier) =>
           receiver.name shouldBe "$iterLocal0"
           receiver.typeFullName shouldBe "java.util.Iterator"
@@ -688,7 +688,7 @@ class NewControlStructureTests extends JavaSrcCode2CpgFixture {
       assignSource.typeFullName shouldBe "java.lang.Object"
       assignSource.order shouldBe 2
       assignSource.argumentIndex shouldBe 2
-      assignSource.argument(0).l match {
+      assignSource.argument(0).start.l match {
         case List(iterIdent: Identifier) =>
           iterIdent.name shouldBe "$iterLocal0"
           iterIdent.typeFullName shouldBe "java.util.Iterator"
@@ -834,7 +834,7 @@ class ControlStructureTests extends JavaSrcCode2CpgFixture {
     val thenBody = thenBlock.astChildren.head.asInstanceOf[Call]
     thenBody.code shouldBe "x = 42"
     thenBody.argument.head.code shouldBe "x"
-    thenBody.argument.tail.head.code shouldBe "42"
+    thenBody.argument.l.tail.head.code shouldBe "42"
     thenBody.order shouldBe 1
 
     elseBlock.code shouldBe "else"

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -126,14 +126,14 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
           val fallbackLocal = cpg.method.name(".*lambda.*").local.name("fallback").head
           fallbackClosureBinding.closureBindingId shouldBe fallbackLocal.closureBindingId
 
-          fallbackClosureBinding.outE.collectAll[Ref].map(_.inNode()).l match {
+          fallbackClosureBinding._refOut.l match {
             case List(capturedParam: MethodParameterIn) =>
               capturedParam.name shouldBe "fallback"
               capturedParam.method.fullName shouldBe "Foo.test1:void(java.lang.String,java.lang.String)"
             case result => fail(s"Expected single capturedParam but got $result")
           }
 
-          fallbackClosureBinding.inE.collectAll[Capture].map(_.outNode()).l match {
+          fallbackClosureBinding._captureIn.l match {
             case List(outMethod: MethodRef) =>
               outMethod.methodFullName shouldBe "Foo.lambda$0:java.lang.String(java.lang.String)"
             case result => fail(s"Expected single METHOD_REF but got $result")
@@ -559,14 +559,14 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
           val capturedLocal = cpg.method.name(".*lambda.*").local.name("captured").head
           capturedClosureBinding.closureBindingId shouldBe capturedLocal.closureBindingId
 
-          capturedClosureBinding.outE.collectAll[Ref].map(_.inNode()).l match {
+          capturedClosureBinding._refOut.l match {
             case List(capturedParam: MethodParameterIn) =>
               capturedParam.name shouldBe "captured"
               capturedParam.method.fullName shouldBe "TestClass.test:Foo(java.lang.String)"
             case result => fail(s"Expected single capturedParam but got $result")
           }
 
-          capturedClosureBinding.inE.collectAll[Capture].map(_.outNode()).l match {
+          capturedClosureBinding._captureIn.l match {
             case List(outMethod: MethodRef) =>
               outMethod.methodFullName shouldBe "TestClass.lambda$0:java.lang.String(java.lang.Integer,java.lang.Integer)"
             case result => fail(s"Expected single out METHOD_REF but got $result")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MetaDataTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MetaDataTests.scala
@@ -3,7 +3,6 @@ package io.joern.javasrc2cpg.querying
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class MetaDataTests extends JavaSrcCode2CpgFixture {
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
@@ -3,7 +3,6 @@ package io.joern.javasrc2cpg.querying
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
   "non generic method" should {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
@@ -2,7 +2,6 @@ package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 import java.io.File
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/NamespaceBlockTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/NamespaceBlockTests.scala
@@ -2,7 +2,6 @@ package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class NamespaceBlockTests extends JavaSrcCode2CpgFixture {
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/MemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/MemberTests.scala
@@ -1,7 +1,6 @@
 package io.joern.javasrc2cpg.querying.dataflow
 
 import io.joern.javasrc2cpg.testfixtures.{JavaDataflowFixture, JavaSrcCode2CpgFixture}
-import overflowdb.traversal._
 import io.joern.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
@@ -65,7 +65,7 @@ class StaticMemberTests extends JavaDataflowFixture {
     if (sources.size <= 0) {
       fail("Could not find any sources")
     }
-   sources.iterator
+    sources.iterator
   }
 
   it should "find a path for `MALICIOUS` data from different class via a variable" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
@@ -65,7 +65,7 @@ class StaticMemberTests extends JavaDataflowFixture {
     if (sources.size <= 0) {
       fail("Could not find any sources")
     }
-    Traversal.from(sources)
+   sources.iterator
   }
 
   it should "find a path for `MALICIOUS` data from different class via a variable" in {

--- a/joern-cli/frontends/jimple2cpg/build.sbt
+++ b/joern-cli/frontends/jimple2cpg/build.sbt
@@ -1,7 +1,7 @@
 name := "jimple2cpg"
 
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/StaticMemberTests.scala
@@ -65,7 +65,7 @@ class StaticMemberTests extends JimpleDataFlowCodeToCpgSuite {
       if (sources.size <= 0) {
         fail("Could not find any sources")
       }
-     sources.iterator
+      sources.iterator
     }
 
     "find a path for `MALICIOUS` data from different class via a variable" in {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/StaticMemberTests.scala
@@ -65,7 +65,7 @@ class StaticMemberTests extends JimpleDataFlowCodeToCpgSuite {
       if (sources.size <= 0) {
         fail("Could not find any sources")
       }
-      Traversal.from(sources)
+     sources.iterator
     }
 
     "find a path for `MALICIOUS` data from different class via a variable" in {

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -5,7 +5,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 
 name               := "jssrc2cpg"
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConstClosurePass.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated.PropertyNames
 import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Method, MethodRef}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 /** A pass that identifies assignments of closures to constants and updates `METHOD` nodes accordingly.
   */

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ImportsPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ImportsPassTests.scala
@@ -22,7 +22,7 @@ class ImportsPassTests extends Code2CpgFixture(() => new TestCpgWithoutDataFlow(
       val List(assignment) = call.inAssignment.l
       assignment.code shouldBe "var barOrBaz = require('./bar.js')"
       assignment.target.code shouldBe "barOrBaz"
-      val List(source) = assignment.source.l
+      val source = assignment.source
       source shouldBe call
     }
 
@@ -38,7 +38,7 @@ class ImportsPassTests extends Code2CpgFixture(() => new TestCpgWithoutDataFlow(
       val List(assignment) = call.inAssignment.l
       assignment.code shouldBe "barOrBaz = require('./bar.js')"
       assignment.target.code shouldBe "barOrBaz"
-      val List(source) = assignment.source.l
+      val source = assignment.source
       source shouldBe call
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -1121,12 +1121,12 @@ class MixedAstCreationPassTest extends AbstractPassTest {
 
       val List(restCall) = destructionBlock.astChildren.isCall.nameExact("<operator>.spread").l
       restCall.code shouldBe "...rest"
-      val List(tmpArg) = restCall.argument(1).l.isCall.l
+      val List(tmpArg) = restCall.argument(1).start.isCall.l
       tmpArg.code shouldBe "_tmp_0[1]"
       tmpArg.name shouldBe Operators.indexAccess
       tmpArg.astChildren.isIdentifier.nameExact("_tmp_0").size shouldBe 1
       tmpArg.astChildren.isLiteral.codeExact("1").size shouldBe 1
-      val List(restArg) = restCall.argument(2).l.isIdentifier.l
+      val List(restArg) = restCall.argument(2).start.isIdentifier.l
       restArg.code shouldBe "rest"
 
       val List(tmpReturnIdentifier) = destructionBlock.astChildren.isIdentifier.l

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1538,11 +1538,11 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
     val List(call) = node.astChildren.isCall.codeExact(s"_tmp_0.$keyName = $assignedValue").l
     call.methodFullName shouldBe Operators.assignment
 
-    val List(tmpAccess) = call.argument(1).l.isCall.l
+    val List(tmpAccess) = call.argument(1).start.isCall.l
     tmpAccess.code shouldBe s"_tmp_0.$keyName"
     tmpAccess.methodFullName shouldBe Operators.fieldAccess
     tmpAccess.argumentIndex shouldBe 1
-    val List(value) = call.argument(2).l
+    val List(value) = call.argument(2).start.l
     value.code shouldBe assignedValue
 
     val List(leftHandSideTmpId) = tmpAccess.astChildren.isIdentifier.nameExact("_tmp_0").l

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -8,6 +8,7 @@ import io.joern.kotlin2cpg.types.{AnonymousObjectContext, CallKinds, TypeConstan
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.{Ast, Defines}
 import io.joern.x2cpg.datastructures.Stack._
 import io.joern.x2cpg.utils.NodeBuilders
@@ -22,7 +23,6 @@ import io.joern.x2cpg.utils.NodeBuilders.{
 import java.util.UUID.randomUUID
 import org.jetbrains.kotlin.psi._
 import org.jetbrains.kotlin.lexer.{KtToken, KtTokens}
-import overflowdb.traversal.iterableToTraversal
 
 import scala.annotation.unused
 import scala.jdk.CollectionConverters._

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -28,7 +28,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
       cb.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       cb.closureBindingId should not be None
 
-      cb.outE.collectAll[Ref].size shouldBe 1
+      cb._refOut.size shouldBe 1
     }
 
     "should contain a CALL node with the signature of the lambda" in {
@@ -65,7 +65,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
       cb.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       cb.closureBindingId should not be None
 
-      cb.outE.collectAll[Ref].size shouldBe 1
+      cb._refOut.size shouldBe 1
     }
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalClassesTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalClassesTests.scala
@@ -3,7 +3,6 @@ package io.joern.kotlin2cpg.querying
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.iterableToTraversal
 
 class LocalClassesTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 

--- a/joern-cli/frontends/php2cpg/build.sbt
+++ b/joern-cli/frontends/php2cpg/build.sbt
@@ -4,7 +4,7 @@ import scala.util.Properties.isWin
 name := "php2cpg"
 
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 val phpParserVersion = "4.15.6"
 val phpParserBinName = "php-parser.phar"

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Method, M
 import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.LoggerFactory
-import overflowdb.traversal.Traversal
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
 import io.shiftleft.codepropertygraph.generated.nodes.Local
@@ -37,7 +36,7 @@ class ClosureRefPass(cpg: Cpg) extends ConcurrentWriterCpgPass[ClosureBinding](c
   }
 
   private def getMethod(methodRef: MethodRef): Option[Method] = {
-    methodRef.repeat(_.astParent)(_.until(_.isMethod).emit(_.isMethod)).isMethod.headOption
+    methodRef.start.repeat(_.astParent)(_.until(_.isMethod).emit(_.isMethod)).isMethod.headOption
   }
 
   private def addRefToCapturedNode(
@@ -51,7 +50,7 @@ class ClosureRefPass(cpg: Cpg) extends ConcurrentWriterCpgPass[ClosureBinding](c
 
       case Some(method) =>
         closureBinding.closureOriginalName.foreach { name =>
-          lazy val locals = method.repeat(_.astChildren.filterNot(_.isMethod))(_.emit(_.isLocal)).collectAll[Local]
+          lazy val locals = method.start.repeat(_.astChildren.filterNot(_.isMethod))(_.emit(_.isLocal)).collectAll[Local]
           val maybeCaptured =
             method.parameter
               .find(_.name == name)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
@@ -50,7 +50,8 @@ class ClosureRefPass(cpg: Cpg) extends ConcurrentWriterCpgPass[ClosureBinding](c
 
       case Some(method) =>
         closureBinding.closureOriginalName.foreach { name =>
-          lazy val locals = method.start.repeat(_.astChildren.filterNot(_.isMethod))(_.emit(_.isLocal)).collectAll[Local]
+          lazy val locals =
+            method.start.repeat(_.astChildren.filterNot(_.isMethod))(_.emit(_.isLocal)).collectAll[Local]
           val maybeCaptured =
             method.parameter
               .find(_.name == name)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
@@ -1071,7 +1071,7 @@ class ControlStructureTests extends PhpCode2CpgFixture {
         currentCall.name shouldBe "current"
         currentCall.methodFullName shouldBe s"Iterator.current"
         currentCall.code shouldBe "$iter_tmp0->current()"
-        inside(currentCall.argument(0).l) { case List(iterRecv: Identifier) =>
+        inside(currentCall.argument(0).start.l) { case List(iterRecv: Identifier) =>
           iterRecv.name shouldBe "iter_tmp0"
           iterRecv.argumentIndex shouldBe 0
         }
@@ -1089,7 +1089,7 @@ class ControlStructureTests extends PhpCode2CpgFixture {
       nextCall.name shouldBe "next"
       nextCall.methodFullName shouldBe "Iterator.next"
       nextCall.code shouldBe "$iter_tmp0->next()"
-      inside(nextCall.argument(0).l) { case List(iterTmp: Identifier) =>
+      inside(nextCall.argument(0).start.l) { case List(iterTmp: Identifier) =>
         iterTmp.name shouldBe "iter_tmp0"
         iterTmp.code shouldBe "$iter_tmp0"
         iterTmp.argumentIndex shouldBe 0
@@ -1143,7 +1143,7 @@ class ControlStructureTests extends PhpCode2CpgFixture {
           currentCall.name shouldBe "current"
           currentCall.methodFullName shouldBe s"Iterator.current"
           currentCall.code shouldBe "$iter_tmp0->current()"
-          inside(currentCall.argument(0).l) { case List(iterRecv: Identifier) =>
+          inside(currentCall.argument(0).start.l) { case List(iterRecv: Identifier) =>
             iterRecv.name shouldBe "iter_tmp0"
             iterRecv.argumentIndex shouldBe 0
           }
@@ -1200,7 +1200,7 @@ class ControlStructureTests extends PhpCode2CpgFixture {
         currentCall.name shouldBe "current"
         currentCall.methodFullName shouldBe s"Iterator.current"
         currentCall.code shouldBe "$iter_tmp0->current()"
-        inside(currentCall.argument(0).l) { case List(iterRecv: Identifier) =>
+        inside(currentCall.argument(0).start.l) { case List(iterRecv: Identifier) =>
           iterRecv.name shouldBe "iter_tmp0"
           iterRecv.argumentIndex shouldBe 0
         }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -19,7 +19,7 @@ class MethodTests extends PhpCode2CpgFixture {
       fooMethod.lineNumber shouldBe Some(2)
       fooMethod.code shouldBe "function foo()"
 
-      inside(fooMethod.methodReturn.l) { case List(methodReturn) =>
+      inside(fooMethod.methodReturn.start.l) { case List(methodReturn) =>
         methodReturn.typeFullName shouldBe "int"
         methodReturn.code shouldBe "RET"
         methodReturn.lineNumber shouldBe Some(2)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -102,7 +102,7 @@ class TypeDeclTests extends PhpCode2CpgFixture {
       alloc.name shouldBe Operators.alloc
       alloc.methodFullName shouldBe Operators.alloc
       alloc.code shouldBe "$x.<alloc>()"
-      inside(alloc.argument(0).l) { case List(xIdentifier: Identifier) =>
+      inside(alloc.argument(0).start.l) { case List(xIdentifier: Identifier) =>
         xIdentifier.name shouldBe "x"
         xIdentifier.code shouldBe "$x"
       }

--- a/joern-cli/frontends/pysrc2cpg/build.sbt
+++ b/joern-cli/frontends/pysrc2cpg/build.sbt
@@ -1,7 +1,7 @@
 name := "pysrc2cpg"
 
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -12,14 +12,14 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       cpg.typ.name("Foo").fullName.head shouldBe "Test0.py:<module>.Foo"
       val typeDecl = cpg.typeDecl.name("Foo").head
       typeDecl.fullName shouldBe "Test0.py:<module>.Foo"
-      typeDecl.astParent.head shouldBe cpg.method.name("<module>").head
+      typeDecl.astParent shouldBe cpg.method.name("<module>").head
     }
 
     "have correct meta class type and typeDecl" in {
       cpg.typ.name("Foo<meta>").fullName.head shouldBe "Test0.py:<module>.Foo<meta>"
       val typeDecl = cpg.typeDecl.name("Foo<meta>").head
       typeDecl.fullName shouldBe "Test0.py:<module>.Foo<meta>"
-      typeDecl.astParent.head shouldBe cpg.method.name("<module>").head
+      typeDecl.astParent shouldBe cpg.method.name("<module>").head
     }
 
     "have correct meta class call handler type and typeDecl" in {
@@ -27,7 +27,7 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
         "Test0.py:<module>.Foo.<metaClassCallHandler>"
       val typeDecl = cpg.typeDecl.name("<metaClassCallHandler>").head
       typeDecl.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
-      typeDecl.astParent.head shouldBe cpg.typeDecl.name("Foo<meta>").head
+      typeDecl.astParent shouldBe cpg.typeDecl.name("Foo<meta>").head
     }
 
     "have correct fake new type and typeDecl" in {
@@ -35,7 +35,7 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
         "Test0.py:<module>.Foo.<fakeNew>"
       val typeDecl = cpg.typeDecl.name("<fakeNew>").head
       typeDecl.fullName shouldBe "Test0.py:<module>.Foo.<fakeNew>"
-      typeDecl.astParent.head shouldBe cpg.typeDecl.name("Foo<meta>").head
+      typeDecl.astParent shouldBe cpg.typeDecl.name("Foo<meta>").head
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -69,7 +69,7 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
     }
 
     "should have the MEMBER fn attached to the meta class and have col+line no" in {
-      val List(memberFn) = cpg.typeDecl("Foo").where(node => node.member.name("replace").l).l
+      val List(memberFn) = cpg.typeDecl("Foo").where(node => node.member.name("replace")).l
       memberFn.fullName shouldBe "test.py:<module>.Foo"
       memberFn.lineNumber shouldBe Some(2)
       memberFn.columnNumber shouldBe Some(1)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -136,7 +136,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "resolve 'User' field types" in {
       val List(id, firstname, age, address) =
-        cpg.identifier.nameExact("id", "firstname", "age", "address").takeRight(4).l
+        cpg.identifier.nameExact("id", "firstname", "age", "address").l.takeRight(4)
       id.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.Column"
       firstname.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.Column"
       age.typeFullName shouldBe "flask_sqlalchemy.py:<module>.SQLAlchemy.Column"

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -1,7 +1,7 @@
 name := "rubysrc2cpg"
 
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 

--- a/joern-cli/frontends/x2cpg/build.sbt
+++ b/joern-cli/frontends/x2cpg/build.sbt
@@ -1,6 +1,6 @@
 name               := "x2cpg"
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.semanticcpg)
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ContainsEdgePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ContainsEdgePass.scala
@@ -22,7 +22,7 @@ class ContainsEdgePass(cpg: Cpg) extends ConcurrentWriterCpgPass[AstNode](cpg) {
     val queue = mutable.ArrayDeque[StoredNode](source)
     while (queue.nonEmpty) {
       val parent = queue.removeHead()
-      for (nextNode <- parent._astOut.asScala) {
+      for (nextNode <- parent._astOut) {
         if (isDestinationType(nextNode)) dstGraph.addEdge(source, nextNode, EdgeTypes.CONTAINS)
         if (!isSourceType(nextNode)) queue.append(nextNode)
       }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -379,7 +379,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     */
   protected def cfgForDoStatement(node: ControlStructure): Cfg = {
     val bodyCfg      = node.astChildren.where(_.order(1)).headOption.map(cfgFor).getOrElse(Cfg.empty)
-    val conditionCfg = Traversal.fromSingle(node).condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val conditionCfg = node.condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
     val innerCfg     = bodyCfg ++ conditionCfg
 
     val diffGraphs =
@@ -403,9 +403,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     * are optional.
     */
   protected def cfgForWhileStatement(node: ControlStructure): Cfg = {
-    val conditionCfg = Traversal.fromSingle(node).condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
-    val trueCfg      = Traversal.fromSingle(node).whenTrue.headOption.map(cfgFor).getOrElse(Cfg.empty)
-    val falseCfg     = Traversal.fromSingle(node).whenFalse.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val conditionCfg =node.condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val trueCfg      = node.whenTrue.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val falseCfg     =node.whenFalse.headOption.map(cfgFor).getOrElse(Cfg.empty)
 
     val diffGraphs = edgesFromFringeTo(conditionCfg, trueCfg.entryNode) ++
       edgesFromFringeTo(trueCfg, falseCfg.entryNode) ++
@@ -427,8 +427,8 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
   /** CFG creation for switch statements of the form `switch { case condition: ... }`.
     */
   protected def cfgForSwitchStatement(node: ControlStructure): Cfg = {
-    val conditionCfg = Traversal.fromSingle(node).condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
-    val bodyCfg      = Traversal.fromSingle(node).whenTrue.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val conditionCfg = node.condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val bodyCfg      = node.whenTrue.headOption.map(cfgFor).getOrElse(Cfg.empty)
 
     cfgForSwitchLike(conditionCfg, bodyCfg :: Nil)
   }
@@ -436,9 +436,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
   /** CFG creation for if statements of the form `if(condition) body`, optionally followed by `else body2`.
     */
   protected def cfgForIfStatement(node: ControlStructure): Cfg = {
-    val conditionCfg = Traversal.fromSingle(node).condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
-    val trueCfg      = Traversal.fromSingle(node).whenTrue.headOption.map(cfgFor).getOrElse(Cfg.empty)
-    val falseCfg     = Traversal.fromSingle(node).whenFalse.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val conditionCfg = node.condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val trueCfg      = node.whenTrue.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val falseCfg     = node.whenFalse.headOption.map(cfgFor).getOrElse(Cfg.empty)
 
     val diffGraphs = edgesFromFringeTo(conditionCfg, trueCfg.entryNode) ++
       edgesFromFringeTo(conditionCfg, falseCfg.entryNode)
@@ -472,8 +472,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     */
   protected def cfgForTryStatement(node: ControlStructure): Cfg = {
     val maybeTryBlock =
-      Traversal
-        .fromSingle(node)
+        node
         .astChildren
         .where(_.order(1))
         .where(_.astChildren) // Filter out empty `try` bodies
@@ -482,8 +481,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     val tryBodyCfg: Cfg = maybeTryBlock.map(cfgFor).getOrElse(Cfg.empty)
 
     val catchBodyCfgs: List[Cfg] =
-      Traversal
-        .fromSingle(node)
+      node
         .astChildren
         .where(_.order(2))
         .toList match {
@@ -492,8 +490,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
       }
 
     val maybeFinallyBodyCfg: List[Cfg] =
-      Traversal
-        .fromSingle(node)
+        node
         .astChildren
         .where(_.order(3))
         .map(cfgFor)
@@ -563,8 +560,8 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
   /** CFG creation for match expressions of the form `match { case condition: expr ... }`
     */
   protected def cfgForMatchExpression(node: ControlStructure): Cfg = {
-    val conditionCfg = Traversal.fromSingle(node).condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
-    val bodyCfgs     = Traversal.fromSingle(node).whenTrue.headOption.map(cfgsForMatchCases).getOrElse(Nil)
+    val conditionCfg = node.condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val bodyCfgs     = node.whenTrue.headOption.map(cfgsForMatchCases).getOrElse(Nil)
 
     cfgForSwitchLike(conditionCfg, bodyCfgs)
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -403,9 +403,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     * are optional.
     */
   protected def cfgForWhileStatement(node: ControlStructure): Cfg = {
-    val conditionCfg =node.condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val conditionCfg = node.condition.headOption.map(cfgFor).getOrElse(Cfg.empty)
     val trueCfg      = node.whenTrue.headOption.map(cfgFor).getOrElse(Cfg.empty)
-    val falseCfg     =node.whenFalse.headOption.map(cfgFor).getOrElse(Cfg.empty)
+    val falseCfg     = node.whenFalse.headOption.map(cfgFor).getOrElse(Cfg.empty)
 
     val diffGraphs = edgesFromFringeTo(conditionCfg, trueCfg.entryNode) ++
       edgesFromFringeTo(trueCfg, falseCfg.entryNode) ++
@@ -472,8 +472,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     */
   protected def cfgForTryStatement(node: ControlStructure): Cfg = {
     val maybeTryBlock =
-        node
-        .astChildren
+      node.astChildren
         .where(_.order(1))
         .where(_.astChildren) // Filter out empty `try` bodies
         .headOption
@@ -481,8 +480,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     val tryBodyCfg: Cfg = maybeTryBlock.map(cfgFor).getOrElse(Cfg.empty)
 
     val catchBodyCfgs: List[Cfg] =
-      node
-        .astChildren
+      node.astChildren
         .where(_.order(2))
         .toList match {
         case Nil  => List(Cfg.empty)
@@ -490,8 +488,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
       }
 
     val maybeFinallyBodyCfg: List[Cfg] =
-        node
-        .astChildren
+      node.astChildren
         .where(_.order(3))
         .map(cfgFor)
         .headOption // Assume there can only be one

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/CpgCfgAdapter.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/CpgCfgAdapter.scala
@@ -6,10 +6,10 @@ import scala.jdk.CollectionConverters._
 
 class CpgCfgAdapter extends CfgAdapter[StoredNode] {
   override def successors(node: StoredNode): IterableOnce[StoredNode] = {
-    node._cfgOut.asScala
+    node._cfgOut
   }
 
   override def predecessors(node: StoredNode): IterableOnce[StoredNode] = {
-    node._cfgIn.asScala
+    node._cfgIn
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/ReverseCpgCfgAdapter.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/ReverseCpgCfgAdapter.scala
@@ -6,10 +6,10 @@ import scala.jdk.CollectionConverters._
 
 class ReverseCpgCfgAdapter extends CfgAdapter[StoredNode] {
   override def successors(node: StoredNode): IterableOnce[StoredNode] = {
-    node._cfgIn.asScala
+    node._cfgIn
   }
 
   override def predecessors(node: StoredNode): IterableOnce[StoredNode] = {
-    node._cfgOut.asScala
+    node._cfgOut
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/LinkingUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/LinkingUtil.scala
@@ -57,7 +57,7 @@ trait LinkingUtil {
   ): Unit = {
     var loggedDeprecationWarning = false
     val dereference              = Dereference(cpg)
-    Traversal(cpg.graph.nodes(srcLabels: _*)).foreach { srcNode =>
+    cpg.graph.nodes(srcLabels: _*).foreach { srcNode =>
       // If the source node does not have any outgoing edges of this type
       // This check is just required for backward compatibility
       if (srcNode.outE(edgeType).isEmpty) {
@@ -116,7 +116,7 @@ trait LinkingUtil {
   ): Unit = {
     var loggedDeprecationWarning = false
     val dereference              = Dereference(cpg)
-    Traversal(cpg.graph.nodes(srcLabels: _*)).cast[SRC_NODE_TYPE].foreach { srcNode =>
+    cpg.graph.nodes(srcLabels: _*).asScala.cast[SRC_NODE_TYPE].foreach { srcNode =>
       if (!srcNode.outE(edgeType).hasNext) {
         getDstFullNames(srcNode).foreach { dstFullName =>
           val dereferenceDstFullName = dereference.dereferenceTypeFullName(dstFullName)

--- a/joern-cli/src/main/resources/scripts/c/const-ish.sc
+++ b/joern-cli/src/main/resources/scripts/c/const-ish.sc
@@ -1,9 +1,3 @@
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Member, Method}
-import io.joern.dataflowengineoss.language._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
-
 @main def main() = {
   cpg.method.internal.filter { method =>
     method.start.assignment.target

--- a/joern-cli/src/main/resources/scripts/c/malloc-leak.sc
+++ b/joern-cli/src/main/resources/scripts/c/malloc-leak.sc
@@ -1,9 +1,3 @@
-import io.shiftleft.codepropertygraph.Cpg
-import io.joern.dataflowengineoss.language._
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
-import overflowdb.traversal._
-
 @main def main() = {
   def allocated            = cpg.call("malloc").inAssignment.target.dedup
   def freed                = cpg.call("free").argument(1)

--- a/joern-cli/src/main/resources/scripts/c/malloc-overflow.sc
+++ b/joern-cli/src/main/resources/scripts/c/malloc-overflow.sc
@@ -1,9 +1,3 @@
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
-
 @main def main(): List[Call] = {
   cpg
     .call("malloc")

--- a/joern-cli/src/main/resources/scripts/c/pointer-to-int.sc
+++ b/joern-cli/src/main/resources/scripts/c/pointer-to-int.sc
@@ -1,10 +1,3 @@
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, FieldIdentifier, Identifier, Literal}
-import io.shiftleft.codepropertygraph.generated.{Operators, nodes}
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension._
-import overflowdb.traversal._
-
 private def expressionIsPointer(argument: Expression, isSubExpression: Boolean = false): Boolean = {
   argument match {
     case identifier: Identifier =>

--- a/joern-cli/src/main/resources/scripts/c/syscalls.sc
+++ b/joern-cli/src/main/resources/scripts/c/syscalls.sc
@@ -1,7 +1,3 @@
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.semanticcpg.language._
-
 // Up-to-date as of Kernel version 4.11
 private val linuxSyscalls: Set[String] = Set(
   "_llseek",

--- a/joern-cli/src/main/resources/scripts/c/userspace-memory-access.sc
+++ b/joern-cli/src/main/resources/scripts/c/userspace-memory-access.sc
@@ -1,7 +1,3 @@
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.semanticcpg.language._
-
 // Find more information at http://www.makelinux.net/ldd3/ (Chapter 3)
 // and https://www.kernel.org/doc/html/latest/core-api/mm-api.html
 private val calls: Set[String] = Set(

--- a/joern-cli/src/main/resources/scripts/general/list-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/general/list-funcs.sc
@@ -14,8 +14,6 @@
    List("<operator>.indirectMemberAccess", "<operator>.assignment", "free_list", "free", "<operator>.notEquals")
  */
 
-import io.shiftleft.semanticcpg.language._
-
 @main def main(): List[String] = {
   cpg.method.name.l
 }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernFlow.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernFlow.scala
@@ -47,7 +47,7 @@ object JoernFlow {
 
       debugOut("Determining flows...")
       sinks.foreach { s =>
-        List(s).to(Traversal).reachableByFlows(sources.to(Traversal)).p.foreach(println)
+        List(s).reachableByFlows(sources.iterator).p.foreach(println)
       }
       debugOut("[DONE]")
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernVectors.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernVectors.scala
@@ -17,7 +17,7 @@ import scala.util.hashing.MurmurHash3
 
 class BagOfPropertiesForNodes extends EmbeddingGenerator[AstNode, (String, String)] {
   override def structureToString(pair: (String, String)): String = pair._1 + ":" + pair._2
-  override def extractObjects(cpg: Cpg): Traversal[AstNode] = cpg.graph.V.collect { case x: AstNode => x }
+  override def extractObjects(cpg: Cpg): Traversal[AstNode]      = cpg.graph.V.collect { case x: AstNode => x }
   override def enumerateSubStructures(obj: AstNode): List[(String, String)] = {
     val relevantFieldTypes = Set(PropertyNames.NAME, PropertyNames.FULL_NAME, PropertyNames.CODE)
     val relevantFields = obj

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernVectors.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernVectors.scala
@@ -17,7 +17,7 @@ import scala.util.hashing.MurmurHash3
 
 class BagOfPropertiesForNodes extends EmbeddingGenerator[AstNode, (String, String)] {
   override def structureToString(pair: (String, String)): String = pair._1 + ":" + pair._2
-  override def extractObjects(cpg: Cpg): Traversal[AstNode] = Traversal(cpg.graph.V.collect { case x: AstNode => x })
+  override def extractObjects(cpg: Cpg): Traversal[AstNode] = cpg.graph.V.collect { case x: AstNode => x }
   override def enumerateSubStructures(obj: AstNode): List[(String, String)] = {
     val relevantFieldTypes = Set(PropertyNames.NAME, PropertyNames.FULL_NAME, PropertyNames.CODE)
     val relevantFields = obj

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -1,7 +1,7 @@
 name := "macros"
 
 scalaVersion       := "2.13.8"
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 dependsOn(Projects.semanticcpg % Test)
 

--- a/querydb/src/main/scala/io/joern/scanners/android/ExternalStorage.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/ExternalStorage.scala
@@ -29,7 +29,7 @@ object ExternalStorage extends QueryBundle {
         def externalStorageReads =
           if (cpg.appManifest.hasReadExternalStoragePermission.nonEmpty)
             cpg.getExternalStorageDir
-          else Traversal.empty
+          else Iterator.empty
         def dexClassLoadersWithExternalStorageInit =
           cpg.dexClassLoader
             .where(

--- a/querydb/src/main/scala/io/joern/scanners/android/Intents.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/Intents.scala
@@ -29,7 +29,7 @@ object Intents extends QueryBundle {
           exportedActivities.method.call.name("getIntent").typeFullName("android.content.Intent")
         def runtimeExecCalls =
           cpg.call.name("exec").typeFullName("java.lang.Process")
-        runtimeExecCalls.where(_.argument.reachableBy(getIntentCalls)).l
+        runtimeExecCalls.where(_.argument.reachableBy(getIntentCalls)).l.iterator
       }),
       tags = List(QueryTags.android),
       multiFileCodeExamples = MultiFileCodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/android/JavaScriptInterface.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/JavaScriptInterface.scala
@@ -36,7 +36,7 @@ object JavaScriptInterface extends QueryBundle {
         val appUsesCleartextTraffic = cpg.appManifest.usesCleartextTraffic.nonEmpty
         def exposedJavaScriptInterfaceObjects =
           if (appUsesCleartextTraffic) webViewsWithInsecureLoadUrlCalls.addJavascriptInterfaceCalls.argument(1)
-          else Traversal.empty
+          else Iterator.empty
         val exposedJavaScriptInterfaceObjectNames = exposedJavaScriptInterfaceObjects.collect {
           case ident: Identifier => ident.typeFullName
           case call: Call        => call.typeFullName
@@ -46,7 +46,7 @@ object JavaScriptInterface extends QueryBundle {
             .where(_.typeDecl.filter { node => exposedJavaScriptInterfaceObjectNames.exists(_ == node.fullName) })
         def runtimeExecCalls =
           cpg.call.name("exec").typeFullName("java.lang.Process")
-        runtimeExecCalls.where(_.argument.reachableBy(exposedJavaScriptInterfaceMethods.parameter)).l
+        runtimeExecCalls.where(_.argument.reachableBy(exposedJavaScriptInterfaceMethods.parameter)).l.iterator
       }),
       tags = List(QueryTags.android),
       multiFileCodeExamples = MultiFileCodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/android/Misconfigurations.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/Misconfigurations.scala
@@ -222,7 +222,7 @@ object Misconfigurations extends QueryBundle {
         )
           satisfiesConfig
         else
-          Traversal.empty
+          Iterator.empty
       }),
       tags = List(QueryTags.android, QueryTags.cryptography, QueryTags.misconfiguration)
     )

--- a/querydb/src/main/scala/io/joern/scanners/android/UnprotectedAppParts.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/UnprotectedAppParts.scala
@@ -31,7 +31,8 @@ object UnprotectedAppParts extends QueryBundle {
             def sink               = startActivityCalls.whereNot(_.controlledBy.astParent.isControlStructure).argument
             sink.reachableByFlows(c).nonEmpty
           }
-          .l.iterator
+          .l
+          .iterator
       }),
       tags = List(QueryTags.android),
       codeExamples = CodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/android/UnprotectedAppParts.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/UnprotectedAppParts.scala
@@ -31,7 +31,7 @@ object UnprotectedAppParts extends QueryBundle {
             def sink               = startActivityCalls.whereNot(_.controlledBy.astParent.isControlStructure).argument
             sink.reachableByFlows(c).nonEmpty
           }
-          .l
+          .l.iterator
       }),
       tags = List(QueryTags.android),
       codeExamples = CodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/c/HeapBasedOverflow.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/HeapBasedOverflow.scala
@@ -30,14 +30,19 @@ object HeapBasedOverflow extends QueryBundle {
         val src =
           cpg.method(".*malloc$").callIn.where(_.argument(1).arithmetic).l
 
-        cpg.method("(?i)memcpy").callIn.l.filter { memcpyCall =>
-          memcpyCall
-            .argument(1)
-            .reachableBy(src)
-            .where(_.inAssignment.target.codeExact(memcpyCall.argument(1).code))
-            .whereNot(_.argument(1).codeExact(memcpyCall.argument(3).code))
-            .hasNext
-        }.iterator
+        cpg
+          .method("(?i)memcpy")
+          .callIn
+          .l
+          .filter { memcpyCall =>
+            memcpyCall
+              .argument(1)
+              .reachableBy(src)
+              .where(_.inAssignment.target.codeExact(memcpyCall.argument(1).code))
+              .whereNot(_.argument(1).codeExact(memcpyCall.argument(3).code))
+              .hasNext
+          }
+          .iterator
       }),
       tags = List(QueryTags.integers, QueryTags.default),
       codeExamples = CodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/c/HeapBasedOverflow.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/HeapBasedOverflow.scala
@@ -37,7 +37,7 @@ object HeapBasedOverflow extends QueryBundle {
             .where(_.inAssignment.target.codeExact(memcpyCall.argument(1).code))
             .whereNot(_.argument(1).codeExact(memcpyCall.argument(3).code))
             .hasNext
-        }
+        }.iterator
       }),
       tags = List(QueryTags.integers, QueryTags.default),
       codeExamples = CodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
@@ -200,7 +200,7 @@ object UseAfterFree extends QueryBundle {
             val assignedPostDom = postDom.isIdentifier
               .where(_.inAssignment)
               .codeExact(freedIdentifierCode)
-              .flatMap(id => Traversal.fromSingle(id) ++ id.postDominatedBy)
+              .flatMap(id => Iterator.single(id) ++ id.postDominatedBy)
 
             postDom
               .removedAll(assignedPostDom)

--- a/querydb/src/main/scala/io/joern/scanners/ghidra/UserInputIntoDangerousFunctions.scala
+++ b/querydb/src/main/scala/io/joern/scanners/ghidra/UserInputIntoDangerousFunctions.scala
@@ -25,7 +25,7 @@ object UserInputIntoDangerousFunctions extends QueryBundle {
         def source =
           cpg.call.methodFullName("getenv").cfgNext.isCall.argument(2)
         def sink = cpg.method.fullName("strcpy").parameter.index(2)
-        sink.reachableBy(source).l
+        sink.reachableBy(source).l.iterator
       }),
       tags = List(QueryTags.badfn)
     )

--- a/querydb/src/main/scala/io/joern/scanners/java/CertificateChecks.scala
+++ b/querydb/src/main/scala/io/joern/scanners/java/CertificateChecks.scala
@@ -42,7 +42,7 @@ object CertificateChecks extends QueryBundle {
           case _ => false
         }
         def skipPrologue(node: nodes.CfgNode): Traversal[nodes.CfgNode] =
-          Traversal.fromSingle(node).repeat(_.cfgNext)(_.until(_.filter(!isPrologue(_))))
+          node.start.repeat(_.cfgNext)(_.until(_.filter(!isPrologue(_))))
 
         cpg.method
           .nameExact(validators.keys.toSeq: _*)

--- a/querydb/src/main/scala/io/joern/scanners/java/CryptographyMisuse.scala
+++ b/querydb/src/main/scala/io/joern/scanners/java/CryptographyMisuse.scala
@@ -32,7 +32,7 @@ object CryptographyMisuse extends QueryBundle {
         def sink =
           cpg.method.fullName("java.security.MessageDigest.getInstance.*").parameter
 
-        sink.reachableBy(source).l
+        sink.reachableBy(source).l.iterator
       }),
       tags = List(QueryTags.cryptography, QueryTags.default),
       codeExamples = CodeExamples(
@@ -70,7 +70,7 @@ object CryptographyMisuse extends QueryBundle {
         def sink =
           cpg.method.fullName("javax.crypto.spec.PBEKeySpec.<init>.*").parameter
 
-        sink.reachableBy(source).dedup.filter(f => Integer.parseInt(f.code) < 1000).l
+        sink.reachableBy(source).dedup.filter(f => Integer.parseInt(f.code) < 1000).l.iterator
       }),
       tags = List(QueryTags.cryptography, QueryTags.default),
       codeExamples = CodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/java/SQLInjection.scala
+++ b/querydb/src/main/scala/io/joern/scanners/java/SQLInjection.scala
@@ -32,7 +32,7 @@ object SQLInjection extends QueryBundle {
 
         def sink = cpg.method.name("query").parameter.order(1)
 
-        sink.reachableBy(source).l
+        sink.reachableBy(source).l.iterator
       }),
       tags = List(QueryTags.sqlInjection, QueryTags.default)
     )

--- a/querydb/src/main/scala/io/joern/scanners/kotlin/NetworkProtocols.scala
+++ b/querydb/src/main/scala/io/joern/scanners/kotlin/NetworkProtocols.scala
@@ -26,7 +26,7 @@ object NetworkProtocols extends QueryBundle {
           .fullNameExact("java.net.URL.<init>:void(java.lang.String)")
           .callIn
           .where(_.argument.isLiteral.code("^[^h]*http:.*"))
-          .l
+          .l.iterator
       }),
       tags = List(QueryTags.insecureNetworkTraffic, QueryTags.android),
       codeExamples = CodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/kotlin/NetworkProtocols.scala
+++ b/querydb/src/main/scala/io/joern/scanners/kotlin/NetworkProtocols.scala
@@ -26,7 +26,8 @@ object NetworkProtocols extends QueryBundle {
           .fullNameExact("java.net.URL.<init>:void(java.lang.String)")
           .callIn
           .where(_.argument.isLiteral.code("^[^h]*http:.*"))
-          .l.iterator
+          .l
+          .iterator
       }),
       tags = List(QueryTags.insecureNetworkTraffic, QueryTags.android),
       codeExamples = CodeExamples(

--- a/querydb/src/main/scala/io/joern/scanners/php/SQLInjection.scala
+++ b/querydb/src/main/scala/io/joern/scanners/php/SQLInjection.scala
@@ -32,7 +32,7 @@ object SQLInjection extends QueryBundle {
 
         def sink = cpg.call.name("query").filter(_.receiver.nonEmpty).argument
 
-        sink.reachableBy(source).l
+        sink.reachableBy(source).l.iterator
       }),
       tags = List(QueryTags.remoteCodeExecution, QueryTags.default)
     )

--- a/querydb/src/main/scala/io/joern/scanners/php/ShellExec.scala
+++ b/querydb/src/main/scala/io/joern/scanners/php/ShellExec.scala
@@ -32,7 +32,7 @@ object ShellExec extends QueryBundle {
 
         def sink = cpg.call.name("shell_exec").argument
 
-        sink.reachableBy(source).l
+        sink.reachableBy(source).l.iterator
       }),
       tags = List(QueryTags.remoteCodeExecution, QueryTags.default)
     )

--- a/querydb/src/test/scala/io/joern/scanners/android/UnprotectedAppPartsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/android/UnprotectedAppPartsTests.scala
@@ -3,7 +3,6 @@ package io.joern.scanners.android
 import io.joern.console.scan._
 import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
 import io.joern.suites.KotlinQueryTestSuite
-import overflowdb.traversal.iterableToTraversal
 import io.shiftleft.semanticcpg.language._
 
 class UnprotectedAppPartsTests extends KotlinQueryTestSuite(UnprotectedAppParts) {

--- a/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreePostUsage.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreePostUsage.scala
@@ -4,7 +4,6 @@ import io.joern.suites.CQueryTestSuite
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.console.scan._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.iterableToTraversal
 
 class UseAfterFreePostUsage extends CQueryTestSuite(UseAfterFree) {
 

--- a/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreeReturnTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/c/UseAfterFreeReturnTests.scala
@@ -4,7 +4,6 @@ import io.joern.suites.CQueryTestSuite
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.console.scan._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.iterableToTraversal
 
 class UseAfterFreeReturnTests extends CQueryTestSuite(UseAfterFree) {
 

--- a/querydb/src/test/scala/io/joern/scanners/kotlin/NetworkProtocolsTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/kotlin/NetworkProtocolsTests.scala
@@ -3,8 +3,7 @@ package io.joern.scanners.kotlin
 import io.joern.console.scan._
 import io.joern.suites.KotlinQueryTestSuite
 import io.shiftleft.codepropertygraph.generated.nodes.Call
-import overflowdb.traversal.iterableToTraversal
-
+import io.shiftleft.semanticcpg.language._
 class NetworkProtocolsTests extends KotlinQueryTestSuite(NetworkProtocols) {
 
   "should find calls relevant to insecure network protocol usage" in {

--- a/querydb/src/test/scala/io/joern/suites/GhidraQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/GhidraQueryTestSuite.scala
@@ -8,7 +8,6 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.joern.console.Query
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.utils.ProjectRoot
-import overflowdb.traversal.iterableToTraversal
 
 class GhidraQueryTestSuite[QB <: QueryBundle](val queryBundle: QB) extends DataFlowBinToCpgSuite {
   val argumentProvider              = new QDBArgumentProvider(3)

--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -1,6 +1,6 @@
 name := "semanticcpg"
 
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+crossScalaVersions := Seq("2.13.8", "3.3.0")
 
 libraryDependencies ++= Seq(
   "io.shiftleft"  %% "codepropertygraph" % Versions.cpg,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CdgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CdgGenerator.scala
@@ -11,7 +11,7 @@ class CdgGenerator extends CfgGenerator {
   override val edgeType: String = EdgeTypes.CDG
 
   override def expand(v: StoredNode): Iterator[Edge] = {
-    v._cdgOut.asScala
+    v._cdgOut
       .filter(_.isInstanceOf[StoredNode])
       .map(node => Edge(v, node, edgeType = edgeType))
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
@@ -44,7 +44,7 @@ class CfgGenerator {
   }
 
   protected def expand(v: StoredNode): Iterator[Edge] = {
-    v._cfgOut.asScala
+    v._cfgOut
       .filter(_.isInstanceOf[StoredNode])
       .map(node => Edge(v, node, edgeType = edgeType))
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCallGraphGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCallGraphGenerator.scala
@@ -7,7 +7,7 @@ object DotCallGraphGenerator {
 
   def dotCallGraph(cpg: Cpg): Traversal[String] = {
     val callGraph = new CallGraphGenerator().generate(cpg)
-    Traversal(DotSerializer.dotGraph(None, callGraph))
+    Iterator(DotSerializer.dotGraph(None, callGraph))
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotTypeHierarchyGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotTypeHierarchyGenerator.scala
@@ -7,7 +7,7 @@ object DotTypeHierarchyGenerator {
 
   def dotTypeHierarchy(cpg: Cpg): Traversal[String] = {
     val typeHierarchy = new TypeHierarchyGenerator().generate(cpg)
-    Traversal(DotSerializer.dotGraph(None, typeHierarchy))
+    Iterator(DotSerializer.dotGraph(None, typeHierarchy))
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/AccessPathHandling.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/AccessPathHandling.scala
@@ -138,7 +138,7 @@ object AccessPathHandling {
   }
 
   def lastExpressionInBlock(block: Block): Option[Expression] =
-    block._astOut.asScala
+    block._astOut
       .collect {
         case node: Expression if !node.isInstanceOf[Local] && !node.isInstanceOf[Method] => node
       }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
@@ -20,7 +20,7 @@ trait ICallResolver {
   def getCalledMethods(callsite: CallRepr): Iterable[Method] = {
     triggerCallsiteResolution(callsite)
     val combined = mutable.ArrayBuffer.empty[Method]
-    callsite._callOut.asScala.foreach(method => combined.append(method.asInstanceOf[Method]))
+    callsite._callOut.foreach(method => combined.append(method.asInstanceOf[Method]))
     combined.appendAll(getResolvedCalledMethods(callsite))
 
     combined
@@ -29,7 +29,7 @@ trait ICallResolver {
   /** Same as getCalledMethods but with traversal return type.
     */
   def getCalledMethodsAsTraversal(callsite: CallRepr): Traversal[Method] =
-    getCalledMethods(callsite).to(Traversal)
+    getCalledMethods(callsite).iterator
 
   /** Get callsites of the given method. This internally calls triggerMethodResolution.
     */
@@ -40,7 +40,7 @@ trait ICallResolver {
     // a certain method which could be overriden. If we are looking for the call sites of
     // such a statically asserted method, we find it twice and thus deduplicate here.
     val combined = mutable.LinkedHashSet.empty[CallRepr]
-    method._callIn.asScala.foreach(call => combined.add(call.asInstanceOf[CallRepr]))
+    method._callIn.foreach(call => combined.add(call.asInstanceOf[CallRepr]))
     combined.addAll(getResolvedMethodCallsites(method))
 
     combined.toBuffer
@@ -49,7 +49,7 @@ trait ICallResolver {
   /** Same as getMethodCallsites but with traversal return type.
     */
   def getMethodCallsitesAsTraversal(method: Method): Traversal[CallRepr] =
-    getMethodCallsites(method).to(Traversal)
+    getMethodCallsites(method).iterator
 
   /** Starts data flow tracking to find all method which could be called at the given callsite. The result is stored in
     * the resolver internal cache.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -87,7 +87,7 @@ class NodeSteps[NodeType <: StoredNode](val traversal: Traversal[NodeType]) exte
   /* follow the incoming edges of the given type as long as possible */
   protected def walkIn(edgeType: String): Traversal[Node] =
     traversal
-      .repeat(_.in(edgeType))(_.until(_.in(edgeType).count.filter(_ == 0)))
+      .repeat(_.in(edgeType))(_.until(_.in(edgeType).countTrav.filter(_ == 0)))
 
   @Doc(
     info = "Tag node with `tagName`",

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -6,7 +6,9 @@ import io.shiftleft.codepropertygraph.generated.{NodeTypes, Properties}
 import overflowdb._
 import overflowdb.traversal.help
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, TraversalSource, InitialTraversal}
+import overflowdb.traversal.{InitialTraversal, TraversalSource}
+
+import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 @help.TraversalSource
 class NodeTypeStarters(cpg: Cpg) extends TraversalSource(cpg.graph) {
@@ -15,7 +17,7 @@ class NodeTypeStarters(cpg: Cpg) extends TraversalSource(cpg.graph) {
     */
   @Doc(info = "All nodes of the graph")
   override def all: Traversal[StoredNode] =
-    cpg.graph.nodes.cast[StoredNode]
+    cpg.graph.nodes.asScala.cast[StoredNode]
 
   /** Traverse to all annotations
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
@@ -19,5 +19,5 @@ class TagTraversal(val traversal: Traversal[Tag]) extends AnyVal {
   def file: Traversal[File]                       = tagged[File]
 
   private def tagged[A <: StoredNode: ClassTag]: Traversal[A] =
-    traversal.in(EdgeTypes.TAGGED_BY).collectAll[A].sortBy(_.id)
+    traversal._taggedByIn.collectAll[A].sortBy(_.id).iterator
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/LocalTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/LocalTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.android
 
 import io.shiftleft.codepropertygraph.generated.nodes.Local
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class LocalTraversal(val traversal: Traversal[Local]) extends AnyVal {
   def callsEnableJS =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/MethodTraversal.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.semanticcpg.language.android
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import overflowdb.traversal._
 import io.shiftleft.semanticcpg.language._
 
 class MethodTraversal(val traversal: Traversal[nodes.Method]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/package.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{ConfigFile, Literal, Local, Method}
-import overflowdb.traversal.Traversal
 
 /** Language extensions for android. */
 package object android {
@@ -11,21 +10,21 @@ package object android {
     new NodeTypeStarters(cpg)
 
   implicit def singleToLocalExt[A <: Local](a: A): LocalTraversal =
-    new LocalTraversal(Traversal.fromSingle(a))
+    new LocalTraversal(Iterator.single(a))
 
   implicit def iterOnceToLocalExt[A <: Local](a: IterableOnce[A]): LocalTraversal =
-    new LocalTraversal(iterableToTraversal(a))
+    new LocalTraversal(a.iterator)
 
   implicit def singleToConfigFileExt[A <: ConfigFile](a: A): ConfigFileTraversal =
-    new ConfigFileTraversal(Traversal.fromSingle(a))
+    new ConfigFileTraversal(Iterator.single(a))
 
   implicit def iterOnceToConfigFileExt[A <: ConfigFile](a: IterableOnce[A]): ConfigFileTraversal =
-    new ConfigFileTraversal(iterableToTraversal(a))
+    new ConfigFileTraversal(a.iterator)
 
   implicit def singleToMethodExt[A <: Method](a: A): MethodTraversal =
-    new MethodTraversal(Traversal.fromSingle(a))
+    new MethodTraversal(Iterator.single(a))
 
   implicit def iterOnceToMethodExt[A <: Method](a: IterableOnce[A]): MethodTraversal =
-    new MethodTraversal(iterableToTraversal(a))
+    new MethodTraversal(a.iterator)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/MethodTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.bindingextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Method, TypeDecl}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/TypeDeclTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.bindingextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Method, TypeDecl}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/CallTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.callgraphextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Import, Method}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class CallTraversal(val traversal: Traversal[Call]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
@@ -19,8 +19,7 @@ class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
     } else {
       sinkMethods
         .repeat(
-          _.flatMap(callResolver.getMethodCallsitesAsTraversal)
-            ._containsIn // expand to method
+          _.flatMap(callResolver.getMethodCallsitesAsTraversal)._containsIn // expand to method
         )(_.dedup.emit(_.collect {
           case method: Method if sourceMethods.contains(method) => method
         }))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
@@ -15,12 +15,12 @@ class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
     val sinkMethods   = traversal.dedup
 
     if (sourceMethods.isEmpty || sinkMethods.isEmpty) {
-      PathAwareTraversal.empty
+      Iterator.empty[Method].enablePathTracking
     } else {
       sinkMethods
         .repeat(
           _.flatMap(callResolver.getMethodCallsitesAsTraversal)
-            .in(EdgeTypes.CONTAINS) // expand to method
+            ._containsIn // expand to method
         )(_.dedup.emit(_.collect {
           case method: Method if sourceMethods.contains(method) => method
         }))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.Implicits.JavaIteratorDeco
+import io.shiftleft.Implicits.IterableOnceDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
@@ -71,7 +71,7 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
   /** Direct children of node in the AST. Siblings are ordered by their `order` fields
     */
   def astChildren: Traversal[AstNode] =
-    node._astOut.cast[AstNode].sortBy(_.order)
+    node._astOut.cast[AstNode].sortBy(_.order).iterator
 
   /** Siblings of this node in the AST, ordered by their `order` fields
     */
@@ -81,7 +81,7 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
   /** Nodes of the AST rooted in this node, including the node itself.
     */
   def ast: Traversal[AstNode] =
-    Traversal.fromSingle(node).ast
+    Iterator.single(node).ast
 
   /** Textual representation of AST node
     */
@@ -133,7 +133,7 @@ object AstNodeMethods {
 
   import scala.jdk.CollectionConverters._
   private def lastExpressionInBlock(block: Block): Option[Expression] =
-    block._astOut.asScala
+    block._astOut
       .collect {
         case node: Expression if !node.isInstanceOf[Local] && !node.isInstanceOf[Method] => node
       }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -14,7 +14,6 @@ class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLoca
       .collect {
         case expr: Expression if expr.argumentIndex == index => expr
       }
-      .to(Traversal)
 
   def argument: Traversal[Expression] =
     node._argumentOut.collectAll[Expression]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.Implicits.JavaIteratorDeco
+import io.shiftleft.Implicits.IterableOnceDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
@@ -13,34 +13,34 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
   /** Successors in the CFG
     */
   def cfgNext: Traversal[CfgNode] = {
-    Traversal.fromSingle(node).cfgNext
+    Iterator.single(node).cfgNext
   }
 
   /** Maps each node in the traversal to a traversal returning its n successors.
     */
   def cfgNext(n: Int): Traversal[CfgNode] = n match {
-    case 0 => Traversal()
+    case 0 => Iterator.empty
     case _ => cfgNext.flatMap(x => List(x) ++ x.cfgNext(n - 1))
   }
 
   /** Maps each node in the traversal to a traversal returning its n predecessors.
     */
   def cfgPrev(n: Int): Traversal[CfgNode] = n match {
-    case 0 => Traversal()
+    case 0 => Iterator.empty
     case _ => cfgPrev.flatMap(x => List(x) ++ x.cfgPrev(n - 1))
   }
 
   /** Predecessors in the CFG
     */
   def cfgPrev: Traversal[CfgNode] = {
-    Traversal.fromSingle(node).cfgPrev
+    Iterator.single(node).cfgPrev
   }
 
   /** Recursively determine all nodes on which this CFG node is control-dependent.
     */
   def controlledBy: Traversal[CfgNode] = {
     expandExhaustively { v =>
-      v._cdgIn.asScala
+      v._cdgIn
     }
   }
 
@@ -48,7 +48,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     */
   def controls: Traversal[CfgNode] = {
     expandExhaustively { v =>
-      v._cdgOut.asScala
+      v._cdgOut
     }
   }
 
@@ -56,7 +56,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     */
   def dominatedBy: Traversal[CfgNode] = {
     expandExhaustively { v =>
-      v._dominateIn.asScala
+      v._dominateIn
     }
   }
 
@@ -64,7 +64,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     */
   def dominates: Traversal[CfgNode] = {
     expandExhaustively { v =>
-      v._dominateOut.asScala
+      v._dominateOut
     }
   }
 
@@ -72,7 +72,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     */
   def postDominatedBy: Traversal[CfgNode] = {
     expandExhaustively { v =>
-      v._postDominateIn.asScala
+      v._postDominateIn
     }
   }
 
@@ -80,7 +80,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     */
   def postDominates: Traversal[CfgNode] = {
     expandExhaustively { v =>
-      v._postDominateOut.asScala
+      v._postDominateOut
     }
   }
 
@@ -92,7 +92,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     *   the traversal of this node if it passes through the included set.
     */
   def passes(included: Set[CfgNode]): Traversal[CfgNode] =
-    Traversal.fromSingle(node).filter(_.postDominatedBy.exists(included.contains))
+    Iterator.single(node).filter(_.postDominatedBy.exists(included.contains))
 
   /** Using the post dominator tree, will determine if this node passes through the excluded set of nodes and filter it
     * out.
@@ -102,7 +102,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     *   the traversal of this node if it does not pass through the excluded set.
     */
   def passesNot(excluded: Set[CfgNode]): Traversal[CfgNode] =
-    Traversal.fromSingle(node).filterNot(_.postDominatedBy.exists(excluded.contains))
+    Iterator.single(node).filterNot(_.postDominatedBy.exists(excluded.contains))
 
   private def expandExhaustively(expand: CfgNode => Iterator[StoredNode]): Traversal[CfgNode] = {
     var controllingNodes = List.empty[CfgNode]
@@ -121,7 +121,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
         }
       }
     }
-    Traversal.from(controllingNodes)
+    controllingNodes.iterator
   }
 
   def method: Method = node match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.Implicits.JavaIteratorDeco
+import io.shiftleft.Implicits.IterableOnceDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.NodeExtension
@@ -49,21 +49,21 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
   }
 
   def isArgument: Traversal[Expression] = {
-    if (node._argumentIn.hasNext) Traversal(node)
-    else Traversal.empty
+    if (node._argumentIn.hasNext) Iterator.single(node)
+    else Iterator.empty
   }
 
   def inCall: Traversal[Call] =
     node._argumentIn.headOption match {
-      case Some(c: Call) => Traversal(c)
-      case _             => Traversal.empty
+      case Some(c: Call) => Iterator.single(c)
+      case _             => Iterator.empty
     }
 
   def parameter(implicit callResolver: ICallResolver): Traversal[MethodParameterIn] =
     for {
-      call          <- node._argumentIn.asScala
+      call          <- node._argumentIn
       calledMethods <- callResolver.getCalledMethods(call.asInstanceOf[CallRepr])
-      paramIn       <- calledMethods._astOut.asScala.collectAll[MethodParameterIn]
+      paramIn       <- calledMethods._astOut.collectAll[MethodParameterIn]
       if paramIn.index == node.argumentIndex
     } yield paramIn
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LocalMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LocalMethods.scala
@@ -13,5 +13,5 @@ class LocalMethods(val local: Local) extends AnyVal with NodeExtension with HasL
   /** The method hosting this local variable
     */
   def method: Traversal[Method] =
-    Traversal.fromSingle(local).method
+    Iterator.single(local).method
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -39,20 +39,20 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
     */
   def reversePostOrder: Traversal[CfgNode] = {
     def expand(x: CfgNode) = { x.cfgNext.iterator }
-    Traversal.from(NodeOrdering.reverseNodeList(NodeOrdering.postOrderNumbering(method, expand).toList))
+    NodeOrdering.reverseNodeList(NodeOrdering.postOrderNumbering(method, expand).toList).iterator
   }
 
   /** List of CFG nodes in post order
     */
   def postOrder: Traversal[CfgNode] = {
     def expand(x: CfgNode) = { x.cfgNext.iterator }
-    Traversal.from(NodeOrdering.nodeList(NodeOrdering.postOrderNumbering(method, expand).toList))
+    NodeOrdering.nodeList(NodeOrdering.postOrderNumbering(method, expand).toList).iterator
   }
 
   /** The type declaration associated with this method, e.g., the class it is defined in.
     */
   def definingTypeDecl: Option[TypeDecl] =
-    Traversal.fromSingle(method).definingTypeDecl.headOption
+    Iterator.single(method).definingTypeDecl.headOption
 
   /** The type declaration associated with this method, e.g., the class it is defined in. Alias for 'definingTypeDecl'
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
@@ -3,7 +3,6 @@ package io.shiftleft.semanticcpg.language.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodReturn, NewLocation, Type}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, _}
-import overflowdb.traversal.{Traversal, iterableToTraversal}
 
 class MethodReturnMethods(val node: MethodReturn) extends AnyVal with NodeExtension with HasLocation {
   override def location: NewLocation = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
@@ -3,18 +3,16 @@ package io.shiftleft.semanticcpg.language.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 
 class StoredNodeMethods(val node: StoredNode) extends AnyVal with NodeExtension {
   def tag: Traversal[Tag] = {
-    node._taggedByOut.asScala
-      .map(_.asInstanceOf[Tag])
+    node._taggedByOut
+      .cast[Tag]
       .distinctBy(tag => (tag.name, tag.value))
-      .to(Traversal)
   }
 
   def file: Traversal[File] =
-    Traversal.fromSingle(node).file
+    Iterator.single(node).file
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Identifier}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 import overflowdb.traversal.help.Doc
 
 class ArrayAccessTraversal(val traversal: Traversal[OpNodes.ArrayAccess]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{help, _}
+import overflowdb.traversal.help
 
 @help.Traversal(elementType = classOf[OpNodes.Assignment])
 class AssignmentTraversal(val traversal: Traversal[OpNodes.Assignment]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 import overflowdb.traversal.help.{Doc, TraversalSource}
 
 /** Steps that allow traversing from `cpg` to operators.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 import overflowdb.traversal.help.Doc
 
 class OpAstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 import overflowdb.traversal.help.Doc
 
 class TargetTraversal(val traversal: Traversal[Expression]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
@@ -24,8 +24,8 @@ class ArrayAccessMethods(val arrayAccess: OpNodes.ArrayAccess) extends AnyVal {
 
   def simpleName: Traversal[String] = {
     arrayAccess.array match {
-      case id: Identifier => Traversal(id.name)
-      case _              => Traversal()
+      case id: Identifier => Iterator.single(id.name)
+      case _              => Iterator.empty
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
@@ -14,7 +14,7 @@ class FieldAccessMethods(val arrayAccess: OpNodes.FieldAccess) extends AnyVal {
       case x: Identifier => x.typ.referencedTypeDecl
       case x: Literal    => x.typ.referencedTypeDecl
       case x: Call       => x.fieldAccess.member.typ.referencedTypeDecl
-      case _             => Traversal()
+      case _             => Iterator.empty
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -55,119 +55,119 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
   // here.
 
   implicit def singleToTypeTrav[A <: Type](a: A): TypeTraversal =
-    new TypeTraversal(Traversal.fromSingle(a))
+    new TypeTraversal(Iterator.single(a))
   implicit def iterOnceToTypeTrav[A <: Type](a: IterableOnce[A]): TypeTraversal =
-    new TypeTraversal(iterableToTraversal(a))
+    new TypeTraversal(a.iterator)
 
   implicit def singleToTypeDeclTrav[A <: TypeDecl](a: A): TypeDeclTraversal =
-    new TypeDeclTraversal(Traversal.fromSingle(a))
+    new TypeDeclTraversal(Iterator.single(a))
   implicit def iterOnceToTypeDeclTrav[A <: TypeDecl](a: IterableOnce[A]): TypeDeclTraversal =
-    new TypeDeclTraversal(iterableToTraversal(a))
+    new TypeDeclTraversal(a.iterator)
 
   implicit def iterOnceToOriginalCallTrav[A <: Call](a: IterableOnce[A]): OriginalCall =
-    new OriginalCall(iterableToTraversal(a))
+    new OriginalCall(a.iterator)
 
   implicit def singleToControlStructureTrav[A <: ControlStructure](a: A): ControlStructureTraversal =
-    new ControlStructureTraversal(Traversal.fromSingle(a))
+    new ControlStructureTraversal(Iterator.single(a))
   implicit def iterOnceToControlStructureTrav[A <: ControlStructure](a: IterableOnce[A]): ControlStructureTraversal =
-    new ControlStructureTraversal(iterableToTraversal(a))
+    new ControlStructureTraversal(a.iterator)
 
   implicit def singleToIdentifierTrav[A <: Identifier](a: A): IdentifierTraversal =
-    new IdentifierTraversal(Traversal.fromSingle(a))
+    new IdentifierTraversal(Iterator.single(a))
   implicit def iterOnceToIdentifierTrav[A <: Identifier](a: IterableOnce[A]): IdentifierTraversal =
-    new IdentifierTraversal(iterableToTraversal(a))
+    new IdentifierTraversal(a.iterator)
 
   implicit def singleToAnnotationTrav[A <: Annotation](a: A): AnnotationTraversal =
-    new AnnotationTraversal(Traversal.fromSingle(a))
+    new AnnotationTraversal(Iterator.single(a))
   implicit def iterOnceToAnnotationTrav[A <: Annotation](a: IterableOnce[A]): AnnotationTraversal =
-    new AnnotationTraversal(iterableToTraversal(a))
+    new AnnotationTraversal(a.iterator)
 
   implicit def singleToDependencyTrav[A <: Dependency](a: A): DependencyTraversal =
-    new DependencyTraversal(Traversal.fromSingle(a))
+    new DependencyTraversal(Iterator.single(a))
 
   implicit def iterToDependencyTrav[A <: Dependency](a: IterableOnce[A]): DependencyTraversal =
-    new DependencyTraversal(iterableToTraversal(a))
+    new DependencyTraversal(a.iterator)
 
   implicit def singleToAnnotationParameterAssignTrav[A <: AnnotationParameterAssign](
     a: A
   ): AnnotationParameterAssignTraversal =
-    new AnnotationParameterAssignTraversal(Traversal.fromSingle(a))
+    new AnnotationParameterAssignTraversal(Iterator.single(a))
   implicit def iterOnceToAnnotationParameterAssignTrav[A <: AnnotationParameterAssign](
     a: IterableOnce[A]
   ): AnnotationParameterAssignTraversal =
-    new AnnotationParameterAssignTraversal(iterableToTraversal(a))
+    new AnnotationParameterAssignTraversal(a.iterator)
 
-  implicit def toMember(traversal: IterableOnce[Member]): MemberTraversal = new MemberTraversal(traversal)
-  implicit def toLocal(traversal: IterableOnce[Local]): LocalTraversal    = new LocalTraversal(traversal)
-  implicit def toMethod(traversal: IterableOnce[Method]): OriginalMethod  = new OriginalMethod(traversal)
+  implicit def toMember(traversal: IterableOnce[Member]): MemberTraversal = new MemberTraversal(traversal.iterator)
+  implicit def toLocal(traversal: IterableOnce[Local]): LocalTraversal    = new LocalTraversal(traversal.iterator)
+  implicit def toMethod(traversal: IterableOnce[Method]): OriginalMethod  = new OriginalMethod(traversal.iterator)
 
   implicit def singleToMethodParameterInTrav[A <: MethodParameterIn](a: A): MethodParameterTraversal =
-    new MethodParameterTraversal(Traversal.fromSingle(a))
+    new MethodParameterTraversal(Iterator.single(a))
   implicit def iterOnceToMethodParameterInTrav[A <: MethodParameterIn](a: IterableOnce[A]): MethodParameterTraversal =
-    new MethodParameterTraversal(iterableToTraversal(a))
+    new MethodParameterTraversal(a.iterator)
 
   implicit def singleToMethodParameterOutTrav[A <: MethodParameterOut](a: A): MethodParameterOutTraversal =
-    new MethodParameterOutTraversal(Traversal.fromSingle(a))
+    new MethodParameterOutTraversal(Iterator.single(a))
   implicit def iterOnceToMethodParameterOutTrav[A <: MethodParameterOut](
     a: IterableOnce[A]
   ): MethodParameterOutTraversal =
-    new MethodParameterOutTraversal(iterableToTraversal(a))
+    new MethodParameterOutTraversal(a.iterator)
 
   implicit def iterOnceToMethodReturnTrav[A <: MethodReturn](a: IterableOnce[A]): MethodReturnTraversal =
-    new MethodReturnTraversal(iterableToTraversal(a))
+    new MethodReturnTraversal(a.iterator)
 
   implicit def singleToNamespaceTrav[A <: Namespace](a: A): NamespaceTraversal =
-    new NamespaceTraversal(Traversal.fromSingle(a))
+    new NamespaceTraversal(Iterator.single(a))
   implicit def iterOnceToNamespaceTrav[A <: Namespace](a: IterableOnce[A]): NamespaceTraversal =
-    new NamespaceTraversal(iterableToTraversal(a))
+    new NamespaceTraversal(a.iterator)
 
   implicit def singleToNamespaceBlockTrav[A <: NamespaceBlock](a: A): NamespaceBlockTraversal =
-    new NamespaceBlockTraversal(Traversal.fromSingle(a))
+    new NamespaceBlockTraversal(Iterator.single(a))
   implicit def iterOnceToNamespaceBlockTrav[A <: NamespaceBlock](a: IterableOnce[A]): NamespaceBlockTraversal =
-    new NamespaceBlockTraversal(iterableToTraversal(a))
+    new NamespaceBlockTraversal(a.iterator)
 
   implicit def singleToFileTrav[A <: File](a: A): FileTraversal =
-    new FileTraversal(Traversal.fromSingle(a))
+    new FileTraversal(Iterator.single(a))
   implicit def iterOnceToFileTrav[A <: File](a: IterableOnce[A]): FileTraversal =
-    new FileTraversal(iterableToTraversal(a))
+    new FileTraversal(a.iterator)
 
   implicit def singleToImportTrav[A <: Import](a: A): ImportTraversal =
-    new ImportTraversal(Traversal.fromSingle(a))
+    new ImportTraversal(Iterator.single(a))
 
   implicit def iterToImportTrav[A <: Import](a: IterableOnce[A]): ImportTraversal =
-    new ImportTraversal(iterableToTraversal(a))
+    new ImportTraversal(a.iterator)
 
   // Call graph extension
   implicit def singleToMethodTravCallGraphExt[A <: Method](a: A): MethodTraversal =
-    new MethodTraversal(Traversal.fromSingle(a))
+    new MethodTraversal(Iterator.single(a))
   implicit def iterOnceToMethodTravCallGraphExt[A <: Method](a: IterableOnce[A]): MethodTraversal =
-    new MethodTraversal(iterableToTraversal(a))
+    new MethodTraversal(a.iterator)
   implicit def singleToCallTrav[A <: Call](a: A): CallTraversal =
-    new CallTraversal(Traversal.fromSingle(a))
+    new CallTraversal(Iterator.single(a))
   implicit def iterOnceToCallTrav[A <: Call](a: IterableOnce[A]): CallTraversal =
-    new CallTraversal(iterableToTraversal(a))
+    new CallTraversal(a.iterator)
   // / Call graph extension
 
   // Binding extensions
   implicit def singleToBindingMethodTrav[A <: Method](a: A): BindingMethodTraversal =
-    new BindingMethodTraversal(Traversal.fromSingle(a))
+    new BindingMethodTraversal(Iterator.single(a))
   implicit def iterOnceToBindingMethodTrav[A <: Method](a: IterableOnce[A]): BindingMethodTraversal =
-    new BindingMethodTraversal(iterableToTraversal(a))
+    new BindingMethodTraversal(a.iterator)
 
   implicit def singleToBindingTypeDeclTrav[A <: TypeDecl](a: A): BindingTypeDeclTraversal =
-    new BindingTypeDeclTraversal(Traversal.fromSingle(a))
+    new BindingTypeDeclTraversal(Iterator.single(a))
   implicit def iterOnceToBindingTypeDeclTrav[A <: TypeDecl](a: IterableOnce[A]): BindingTypeDeclTraversal =
-    new BindingTypeDeclTraversal(iterableToTraversal(a))
+    new BindingTypeDeclTraversal(a.iterator)
 
   implicit def singleToAstNodeDot[A <: AstNode](a: A): AstNodeDot[A] =
-    new AstNodeDot(Traversal.fromSingle(a))
+    new AstNodeDot(Iterator.single(a))
   implicit def iterOnceToAstNodeDot[A <: AstNode](a: IterableOnce[A]): AstNodeDot[A] =
-    new AstNodeDot(iterableToTraversal(a))
+    new AstNodeDot(a.iterator)
 
   implicit def singleToCfgNodeDot[A <: Method](a: A): CfgNodeDot =
-    new CfgNodeDot(Traversal.fromSingle(a))
+    new CfgNodeDot(Iterator.single(a))
   implicit def iterOnceToCfgNodeDot[A <: Method](a: IterableOnce[A]): CfgNodeDot =
-    new CfgNodeDot(iterableToTraversal(a))
+    new CfgNodeDot(a.iterator)
 
   implicit def graphToInterproceduralDot(cpg: Cpg): InterproceduralNodeDot =
     new InterproceduralNodeDot(cpg)
@@ -176,14 +176,14 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
     * considered a historical accident. We only keep it around because we want to preserve `reachableBy(Node*)`, which
     * unfortunately (due to type erasure) can't be an overload of `reachableBy(Traversal*)`.
     *
-    * In most places you should explicitly call `Traversal.fromSingle` instead of relying on this implicit.
+    * In most places you should explicitly call `Iterator.single` instead of relying on this implicit.
     */
   implicit def toTraversal[NodeType <: StoredNode](node: NodeType): Traversal[NodeType] =
-    Traversal.fromSingle(node)
+    Iterator.single(node)
 
   implicit def toSteps[A](trav: Traversal[A]): Steps[A] = new Steps(trav)
   implicit def iterOnceToNodeSteps[A <: StoredNode](a: IterableOnce[A]): NodeSteps[A] =
-    new NodeSteps[A](iterableToTraversal(a))
+    new NodeSteps[A](a.iterator)
 
   implicit def toNewNodeTrav[NodeType <: NewNode](trav: Traversal[NodeType]): NewNodeSteps[NodeType] =
     new NewNodeSteps[NodeType](trav)
@@ -193,61 +193,61 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
 
   // ~ EvalType accessors
   implicit def singleToEvalTypeAccessorsLocal[A <: Local](a: A): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](Traversal.fromSingle(a))
+    new EvalTypeAccessors[A](Iterator.single(a))
   implicit def iterOnceToEvalTypeAccessorsLocal[A <: Local](a: IterableOnce[A]): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](iterableToTraversal(a))
+    new EvalTypeAccessors[A](a.iterator)
 
   implicit def singleToEvalTypeAccessorsMember[A <: Member](a: A): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](Traversal.fromSingle(a))
+    new EvalTypeAccessors[A](Iterator.single(a))
   implicit def iterOnceToEvalTypeAccessorsMember[A <: Member](a: IterableOnce[A]): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](iterableToTraversal(a))
+    new EvalTypeAccessors[A](a.iterator)
 
   implicit def singleToEvalTypeAccessorsMethod[A <: Method](a: A): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](Traversal.fromSingle(a))
+    new EvalTypeAccessors[A](Iterator.single(a))
   implicit def iterOnceToEvalTypeAccessorsMethod[A <: Method](a: IterableOnce[A]): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](iterableToTraversal(a))
+    new EvalTypeAccessors[A](a.iterator)
 
   implicit def singleToEvalTypeAccessorsParameterIn[A <: MethodParameterIn](a: A): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](Traversal.fromSingle(a))
+    new EvalTypeAccessors[A](Iterator.single(a))
   implicit def iterOnceToEvalTypeAccessorsParameterIn[A <: MethodParameterIn](
     a: IterableOnce[A]
   ): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](iterableToTraversal(a))
+    new EvalTypeAccessors[A](a.iterator)
 
   implicit def singleToEvalTypeAccessorsParameterOut[A <: MethodParameterOut](a: A): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](Traversal.fromSingle(a))
+    new EvalTypeAccessors[A](Iterator.single(a))
   implicit def iterOnceToEvalTypeAccessorsParameterOut[A <: MethodParameterOut](
     a: IterableOnce[A]
   ): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](iterableToTraversal(a))
+    new EvalTypeAccessors[A](a.iterator)
 
   implicit def singleToEvalTypeAccessorsMethodReturn[A <: MethodReturn](a: A): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](Traversal.fromSingle(a))
+    new EvalTypeAccessors[A](Iterator.single(a))
   implicit def iterOnceToEvalTypeAccessorsMethodReturn[A <: MethodReturn](a: IterableOnce[A]): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](iterableToTraversal(a))
+    new EvalTypeAccessors[A](a.iterator)
 
   implicit def singleToEvalTypeAccessorsExpression[A <: Expression](a: A): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](Traversal.fromSingle(a))
+    new EvalTypeAccessors[A](Iterator.single(a))
   implicit def iterOnceToEvalTypeAccessorsExpression[A <: Expression](a: IterableOnce[A]): EvalTypeAccessors[A] =
-    new EvalTypeAccessors[A](iterableToTraversal(a))
+    new EvalTypeAccessors[A](a.iterator)
 
   // EvalType accessors ~
 
   // ~ Modifier accessors
   implicit def singleToModifierAccessorsMember[A <: Member](a: A): ModifierAccessors[A] =
-    new ModifierAccessors[A](Traversal.fromSingle(a))
+    new ModifierAccessors[A](Iterator.single(a))
   implicit def iterOnceToModifierAccessorsMember[A <: Member](a: IterableOnce[A]): ModifierAccessors[A] =
-    new ModifierAccessors[A](iterableToTraversal(a))
+    new ModifierAccessors[A](a.iterator)
 
   implicit def singleToModifierAccessorsMethod[A <: Method](a: A): ModifierAccessors[A] =
-    new ModifierAccessors[A](Traversal.fromSingle(a))
+    new ModifierAccessors[A](Iterator.single(a))
   implicit def iterOnceToModifierAccessorsMethod[A <: Method](a: IterableOnce[A]): ModifierAccessors[A] =
-    new ModifierAccessors[A](iterableToTraversal(a))
+    new ModifierAccessors[A](a.iterator)
 
   implicit def singleToModifierAccessorsTypeDecl[A <: TypeDecl](a: A): ModifierAccessors[A] =
-    new ModifierAccessors[A](Traversal.fromSingle(a))
+    new ModifierAccessors[A](Iterator.single(a))
   implicit def iterOnceToModifierAccessorsTypeDecl[A <: TypeDecl](a: IterableOnce[A]): ModifierAccessors[A] =
-    new ModifierAccessors[A](iterableToTraversal(a))
+    new ModifierAccessors[A](a.iterator)
   // Modifier accessors ~
 
   implicit class NewNodeTypeDeco[NodeType <: NewNode](val node: NodeType) extends AnyVal {
@@ -255,26 +255,26 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
     /** Start a new traversal from this node
       */
     def start: Traversal[NodeType] =
-      Traversal.fromSingle(node)
+      Iterator.single(node)
   }
 
   implicit def toExpression[A <: Expression](a: IterableOnce[A]): ExpressionTraversal[A] =
-    new ExpressionTraversal[A](iterableToTraversal(a))
+    new ExpressionTraversal[A](a.iterator)
 }
 
 trait LowPrioImplicits extends overflowdb.traversal.Implicits {
   implicit def singleToCfgNodeTraversal[A <: CfgNode](a: A): CfgNodeTraversal[A] =
-    new CfgNodeTraversal[A](Traversal.fromSingle(a))
+    new CfgNodeTraversal[A](Iterator.single(a))
   implicit def iterOnceToCfgNodeTraversal[A <: CfgNode](a: IterableOnce[A]): CfgNodeTraversal[A] =
-    new CfgNodeTraversal[A](iterableToTraversal(a))
+    new CfgNodeTraversal[A](a.iterator)
 
   implicit def singleToAstNodeTraversal[A <: AstNode](a: A): AstNodeTraversal[A] =
-    new AstNodeTraversal[A](Traversal.fromSingle(a))
+    new AstNodeTraversal[A](Iterator.single(a))
   implicit def iterOnceToAstNodeTraversal[A <: AstNode](a: IterableOnce[A]): AstNodeTraversal[A] =
-    new AstNodeTraversal[A](iterableToTraversal(a))
+    new AstNodeTraversal[A](a.iterator)
 
   implicit def singleToDeclarationNodeTraversal[A <: Declaration](a: A): DeclarationTraversal[A] =
-    new DeclarationTraversal[A](Traversal.fromSingle(a))
+    new DeclarationTraversal[A](Iterator.single(a))
   implicit def iterOnceToDeclarationNodeTraversal[A <: Declaration](a: IterableOnce[A]): DeclarationTraversal[A] =
-    new DeclarationTraversal[A](iterableToTraversal(a))
+    new DeclarationTraversal[A](a.iterator)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 /** A call site
   */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -43,7 +43,7 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
   /** Direct children of node in the AST. Siblings are ordered by their `order` fields
     */
   def astChildren: Traversal[AstNode] =
-    traversal.flatMap(_.astChildren).sortBy(_.order)
+    traversal.flatMap(_.astChildren).sortBy(_.order).iterator
 
   /** Parent AST node
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -25,16 +25,16 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
 
   @Doc(info = "Nodes directly reachable via outgoing CFG edges")
   def cfgNext: Traversal[CfgNode] =
-    traversal
-      ._cfgOut.filterNot(_.isInstanceOf[MethodReturn])
+    traversal._cfgOut
+      .filterNot(_.isInstanceOf[MethodReturn])
       .cast[CfgNode]
 
   /** Traverse to previous expression in CFG.
     */
   @Doc(info = "Nodes directly reachable via incoming CFG edges")
   def cfgPrev: Traversal[CfgNode] =
-    traversal
-      ._cfgIn.filterNot(_.isInstanceOf[MethodReturn])
+    traversal._cfgIn
+      .filterNot(_.isInstanceOf[MethodReturn])
       .cast[CfgNode]
 
   /** All nodes reachable in the CFG by up to n forward expansions

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.{help}
 import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[CfgNode])
@@ -26,8 +26,7 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
   @Doc(info = "Nodes directly reachable via outgoing CFG edges")
   def cfgNext: Traversal[CfgNode] =
     traversal
-      .out(EdgeTypes.CFG)
-      .not(_.hasLabel(NodeTypes.METHOD_RETURN))
+      ._cfgOut.filterNot(_.isInstanceOf[MethodReturn])
       .cast[CfgNode]
 
   /** Traverse to previous expression in CFG.
@@ -35,8 +34,7 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
   @Doc(info = "Nodes directly reachable via incoming CFG edges")
   def cfgPrev: Traversal[CfgNode] =
     traversal
-      .in(EdgeTypes.CFG)
-      .not(_.hasLabel(NodeTypes.METHOD))
+      ._cfgIn.filterNot(_.isInstanceOf[MethodReturn])
       .cast[CfgNode]
 
   /** All nodes reachable in the CFG by up to n forward expansions

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/DeclarationTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/DeclarationTraversal.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
 import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Declaration, MethodRef, TypeRef}
-import overflowdb.traversal.{Traversal, help, jIteratortoTraversal}
+import overflowdb.traversal._
 
 /** A declaration, such as a local or parameter.
   */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
@@ -59,8 +59,7 @@ class ExpressionTraversal[NodeType <: Expression](val traversal: Traversal[NodeT
   /** Traverse to enclosing method
     */
   def method: Traversal[Method] =
-    traversal
-      ._containsIn
+    traversal._containsIn
       .flatMap {
         case x: Method   => x.start
         case x: TypeDecl => x.astParent

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
@@ -60,9 +60,9 @@ class ExpressionTraversal[NodeType <: Expression](val traversal: Traversal[NodeT
     */
   def method: Traversal[Method] =
     traversal
-      .in(EdgeTypes.CONTAINS)
+      ._containsIn
       .flatMap {
-        case x: Method   => Traversal.from(x)
+        case x: Method   => x.start
         case x: TypeDecl => x.astParent
       }
       .collectAll[Method]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
@@ -14,7 +14,7 @@ class EvalTypeAccessors[A <: AstNode](val traversal: Traversal[A]) extends AnyVa
   }
 
   def evalType(regexes: String*): Traversal[A] =
-    if (regexes.isEmpty) Traversal.empty
+    if (regexes.isEmpty) Iterator.empty
     else {
       val regexes0 = regexes.map(_.r).toSet
       traversal.where(evalType(_).filter(value => regexes0.exists(_.matches(value))))
@@ -24,7 +24,7 @@ class EvalTypeAccessors[A <: AstNode](val traversal: Traversal[A]) extends AnyVa
     traversal.where(evalType(_).filter(_ == value))
 
   def evalTypeExact(values: String*): Traversal[A] =
-    if (values.isEmpty) Traversal.empty
+    if (values.isEmpty) Iterator.empty
     else {
       val valuesSet = values.to(Set)
       traversal.where(evalType(_).filter(valuesSet.contains))
@@ -34,7 +34,7 @@ class EvalTypeAccessors[A <: AstNode](val traversal: Traversal[A]) extends AnyVa
     traversal.where(evalType(_).filterNot(_.matches(regex)))
 
   def evalTypeNot(regexes: String*): Traversal[A] =
-    if (regexes.isEmpty) Traversal.empty
+    if (regexes.isEmpty) Iterator.empty
     else {
       val regexes0 = regexes.map(_.r).toSet
       traversal.where(evalType(_).filter(value => !regexes0.exists(_.matches(value))))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationParameterAssignTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationParameterAssignTraversal.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language._
 
 /** An annotation parameter-assignment, e.g., `foo=value` in @Test(foo=value)
   */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/ImportTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/ImportTraversal.scala
@@ -3,13 +3,12 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Import, NamespaceBlock}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 class ImportTraversal(val traversal: Traversal[Import]) extends AnyVal {
 
   /** Traverse to the call that represents the import in the AST
     */
-  def call: Traversal[Call] = traversal.in(EdgeTypes.IS_CALL_FOR_IMPORT).cast[Call]
+  def call: Traversal[Call] = traversal._isCallForImportIn.cast[Call]
 
   def namespaceBlock: Traversal[NamespaceBlock] =
     call.method.namespaceBlock

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{help, Traversal}
+import overflowdb.traversal.help
 
 import scala.jdk.CollectionConverters._
 
@@ -32,7 +32,7 @@ class MethodParameterTraversal(val traversal: Traversal[MethodParameterIn]) exte
     for {
       paramIn <- traversal
       call    <- callResolver.getMethodCallsites(paramIn.method)
-      arg     <- Traversal.from(call._argumentOut).collectAll[Expression]
+      arg     <- call._argumentOut.collectAll[Expression]
       if arg.argumentIndex == paramIn.index
     } yield arg
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.help
 import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[MethodReturn])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -10,7 +10,7 @@ import overflowdb.traversal.{Traversal, help, toElementTraversal, toNodeTraversa
 /** A method, function, or procedure
   */
 @help.Traversal(elementType = classOf[Method])
-class MethodTraversal(val iterableOnce: IterableOnce[Method]) extends AnyVal {
+class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
 
   /** Traverse to annotations of method
     */
@@ -77,7 +77,7 @@ class MethodTraversal(val iterableOnce: IterableOnce[Method]) extends AnyVal {
   @Doc(info = "Type this method is defined in")
   def definingTypeDecl: Traversal[TypeDecl] =
     traversal
-      .repeat(_.in(EdgeTypes.AST))(_.until(_.hasLabel(NodeTypes.TYPE_DECL)))
+      .repeat(_._astIn)(_.until(_.collectAll[TypeDecl] ))
       .cast[TypeDecl]
 
   /** The type declaration associated with this method, e.g., the class it is defined in. Alias for 'definingTypeDecl'
@@ -90,18 +90,18 @@ class MethodTraversal(val iterableOnce: IterableOnce[Method]) extends AnyVal {
   @Doc(info = "Method this method is defined in")
   def definingMethod: Traversal[Method] =
     traversal
-      .repeat(_.in(EdgeTypes.AST))(_.until(_.hasLabel(NodeTypes.METHOD)))
+      .repeat(_._astIn)(_.until(_.collectAll[Method]))
       .cast[Method]
 
   /** Traverse only to methods that are stubs, e.g., their code is not available or the method body is empty.
     */
   def isStub: Traversal[Method] =
-    traversal.where(_.not(_.out(EdgeTypes.CFG).not(_.hasLabel(NodeTypes.METHOD_RETURN))))
+    traversal.where(_.not(_._cfgOut.not(_.collectAll[MethodReturn])))
 
   /** Traverse only to methods that are not stubs.
     */
   def isNotStub: Traversal[Method] =
-    traversal.where(_.out(EdgeTypes.CFG).not(_.hasLabel(NodeTypes.METHOD_RETURN)))
+    traversal.where(_._cfgOut.not(_.collectAll[MethodReturn]))
 
   /** Traverse only to methods that accept variadic arguments.
     */
@@ -130,10 +130,10 @@ class MethodTraversal(val iterableOnce: IterableOnce[Method]) extends AnyVal {
   @Doc(info = "Top level expressions (\"Statements\")")
   def topLevelExpressions: Traversal[Expression] =
     traversal
-      .out(EdgeTypes.AST)
-      .hasLabel(NodeTypes.BLOCK)
-      .out(EdgeTypes.AST)
-      .not(_.hasLabel(NodeTypes.LOCAL))
+      ._astOut
+      .collectAll[Block]
+      ._astOut
+      .not(_.collectAll[Local])
       .cast[Expression]
 
   @Doc(info = "Control flow graph nodes")
@@ -154,30 +154,22 @@ class MethodTraversal(val iterableOnce: IterableOnce[Method]) extends AnyVal {
   /** Traverse to namespace */
   @Doc(info = "Namespace this method is declared in")
   def namespace: Traversal[Namespace] = {
-    traversal.choose(_.astParentType) {
-      case NamespaceBlock.Label =>
-        // some language frontends don't have a TYPE_DECL for a METHOD
-        _.astParent.collectAll[NamespaceBlock].namespace
-      case _ =>
-        // other language frontends always embed their method in a TYPE_DECL
-        _.definingTypeDecl.namespace
-    }
+    traversal.namespaceBlock.namespace
   }
 
   /** Traverse to namespace block */
   @Doc(info = "Namespace block this method is declared in")
   def namespaceBlock: Traversal[NamespaceBlock] = {
-    traversal.choose(_.astParentType) {
-      case NamespaceBlock.Label =>
+    traversal.flatMap{
+      m => m.astIn.headOption match {
         // some language frontends don't have a TYPE_DECL for a METHOD
-        _.astParent.collectAll[NamespaceBlock]
-      case _ =>
+        case Some(namespaceBlock: NamespaceBlock) => namespaceBlock.start
         // other language frontends always embed their method in a TYPE_DECL
-        _.definingTypeDecl.namespaceBlock
+        case _ => m.definingTypeDecl.namespaceBlock
+      }
     }
   }
 
   def numberOfLines: Traversal[Int] = traversal.map(_.numberOfLines)
 
-  private def traversal = Traversal.from(iterableOnce)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -77,7 +77,7 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
   @Doc(info = "Type this method is defined in")
   def definingTypeDecl: Traversal[TypeDecl] =
     traversal
-      .repeat(_._astIn)(_.until(_.collectAll[TypeDecl] ))
+      .repeat(_._astIn)(_.until(_.collectAll[TypeDecl]))
       .cast[TypeDecl]
 
   /** The type declaration associated with this method, e.g., the class it is defined in. Alias for 'definingTypeDecl'
@@ -129,8 +129,7 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
 
   @Doc(info = "Top level expressions (\"Statements\")")
   def topLevelExpressions: Traversal[Expression] =
-    traversal
-      ._astOut
+    traversal._astOut
       .collectAll[Block]
       ._astOut
       .not(_.collectAll[Local])
@@ -160,8 +159,8 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
   /** Traverse to namespace block */
   @Doc(info = "Namespace block this method is declared in")
   def namespaceBlock: Traversal[NamespaceBlock] = {
-    traversal.flatMap{
-      m => m.astIn.headOption match {
+    traversal.flatMap { m =>
+      m.astIn.headOption match {
         // some language frontends don't have a TYPE_DECL for a METHOD
         case Some(namespaceBlock: NamespaceBlock) => namespaceBlock.start
         // other language frontends always embed their method in a TYPE_DECL

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -11,6 +11,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.traversal.Traversal
 
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+
 class StepsTest extends AnyWordSpec with Matchers {
 
   private val cpg: Cpg = MockCpg()
@@ -39,7 +41,7 @@ class StepsTest extends AnyWordSpec with Matchers {
 
     "filter with traversal on cpg type" in {
       def allMethods    = cpg.method.l
-      val publicMethods = allMethods.to(Traversal).where(_.isPublic)
+      val publicMethods = allMethods.where(_.isPublic)
       allMethods.size should be > publicMethods.toList.size
     }
 
@@ -145,7 +147,7 @@ class StepsTest extends AnyWordSpec with Matchers {
 
     "use default `toString` if nothing else applies" in {
       case class Foo(i: Int)
-      val steps: Steps[Foo] = new Steps(Traversal.fromSingle(Foo(42)))
+      val steps: Steps[Foo] = new Steps(Iterator.single(Foo(42)))
       steps.p.head shouldBe "Foo(42)"
     }
 
@@ -204,13 +206,13 @@ class StepsTest extends AnyWordSpec with Matchers {
     "provides generic help" when {
       "using verbose mode" when {
         "traversing nodes" in {
-          val methodTraversal = Traversal.empty[Method]
+          val methodTraversal = Iterator.empty[Method]
           methodTraversal.helpVerbose should include(".l")
           methodTraversal.helpVerbose should include(".label")
         }
 
         "traversing non-nodes" in {
-          val stringTraversal = Traversal.empty[String]
+          val stringTraversal = Iterator.empty[String]
           stringTraversal.helpVerbose should include(".l")
           stringTraversal.helpVerbose should not include ".label"
         }
@@ -268,6 +270,7 @@ class StepsTest extends AnyWordSpec with Matchers {
     def methodParameterOut =
       cpg.graph
         .nodes(NodeTypes.METHOD_PARAMETER_OUT)
+        .asScala
         .cast[MethodParameterOut]
         .name("param1")
     methodParameterOut.typ.name.head shouldBe "paramtype"
@@ -289,7 +292,7 @@ class StepsTest extends AnyWordSpec with Matchers {
     file.typeDecl.name.head shouldBe "AClass"
     file.head.typeDecl.name.head shouldBe "AClass"
 
-    def block = cpg.graph.nodes(NodeTypes.BLOCK).cast[Block].typeFullName("int")
+    def block = cpg.graph.nodes(NodeTypes.BLOCK).asScala.cast[Block].typeFullName("int")
     block.local.name.size shouldBe 1
     block.flatMap(_.local.name).size shouldBe 1
 


### PR DESCRIPTION
The third attempt at removing Traversal, this time with a detailed migration guide in a new changelog. Please do read the `News.md` file. The thing may be too verbose?

This PR is WIP in the sense that its upstream is not in yet -- I think we first need to review how happy we are with the documentation and the amount of breakage (we might want to change some upstream things to further improve compat here?).