### PR TITLE
Reintroduce Python Compatibility Changes

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -81,6 +81,8 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
         withFieldAndIndexAccesses(
           List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
         ) ++ x.refsTo.capturedByMethodRef.referencedMethod.flatMap(m => usagesForName(x.name, m))
+      case x: Call =>
+        (x._receiverIn.l :+ x).collect { case y: CfgNode => y }
       case x => List(x).collect { case y: CfgNode => y }
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
@@ -24,34 +24,37 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
       .mapValues(_.map(_._2))
 
     for {
-      methodReturn <- cpg.methodReturn.filter(x => x.dynamicTypeHintFullName.nonEmpty)
-      typeHint     <- methodReturn.dynamicTypeHintFullName
+      methodReturn <- cpg.methodReturn.filter(x => x.typeFullName != Constants.ANY)
       file         <- methodReturn.file
       imports      <- fileToImports.get(file.name)
-      importedEntity <- imports.filter { x =>
-        // TODO: Handle * imports correctly
-        x.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") }
-      }.importedEntity
     } {
-      setTypeHints(diffGraph, methodReturn, typeHint, typeHint, importedEntity)
+      val typeHint = methodReturn.typeFullName
+      imports
+        .filter { x =>
+          // TODO: Handle * imports correctly
+          x.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") }
+        }
+        .importedEntity
+        .foreach { importedEntity =>
+          setTypeHints(diffGraph, methodReturn, typeHint, typeHint, importedEntity)
+        }
     }
 
     for {
-      param    <- cpg.parameter.filter(x => x.dynamicTypeHintFullName.nonEmpty)
-      typeHint <- param.dynamicTypeHintFullName
-      file     <- param.file
-      imports  <- fileToImports.get(file.name)
-      importDetails <- imports
+      param   <- cpg.parameter.filter(x => x.typeFullName != Constants.ANY)
+      file    <- param.file
+      imports <- fileToImports.get(file.name)
+    } {
+      val typeHint = param.typeFullName
+      imports
         // TODO: Handle * imports correctly
         .filter(_.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") })
         .map(i => (i.importedEntity, i.importedAs))
-    } {
-      importDetails match {
-        case (Some(importedEntity), Some(importedAs)) =>
-          setTypeHints(diffGraph, param, typeHint, importedAs, importedEntity)
-        case _ =>
-      }
-
+        .foreach {
+          case (Some(importedEntity), Some(importedAs)) =>
+            setTypeHints(diffGraph, param, typeHint, importedAs, importedEntity)
+          case _ =>
+        }
     }
 
   }
@@ -73,7 +76,7 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
     cpg.typeDecl.fullName(s".*${Pattern.quote(pythonicTypeFullName)}").l match {
       case xs if xs.nonEmpty =>
         diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, xs.fullName.toSeq)
-      case _ => diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq(pythonicTypeFullName))
+      case _ => diffGraph.setNodeProperty(node, PropertyNames.TYPE_FULL_NAME, pythonicTypeFullName)
     }
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/DynamicTypeHintFullNamePass.scala
@@ -1,9 +1,10 @@
 package io.joern.pysrc2cpg
 
+import io.joern.x2cpg.passes.frontend.ImportStringHandling
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.PropertyNames
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
-import io.shiftleft.passes.CpgPass
+import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, MethodParameterIn, MethodReturn, StoredNode}
+import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate
 
@@ -13,51 +14,65 @@ import java.util.regex.{Matcher, Pattern}
 /** The type hints we pick up via the parser are not full names. This pass fixes that by retrieving the import for each
   * dynamic type hint and adjusting the dynamic type hint full name field accordingly.
   */
-class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
-    val fileToImports = cpg.imports.l
-      .flatMap { imp =>
-        imp.call.file.l.map { f => f.name -> imp }
-      }
-      .groupBy(_._1)
-      .view
-      .mapValues(_.map(_._2))
+class DynamicTypeHintFullNamePass(cpg: Cpg) extends ForkJoinParallelCpgPass[CfgNode](cpg) {
 
-    for {
-      methodReturn <- cpg.methodReturn.filter(x => x.typeFullName != Constants.ANY)
-      file         <- methodReturn.file
-      imports      <- fileToImports.get(file.name)
-    } {
+  private case class ImportScope(entity: Option[String], alias: Option[String])
+
+  private val fileToImports = cpg.imports.l
+    .flatMap(imp => imp.call.file.l.map { f => f.name -> imp })
+    .groupBy(_._1)
+    .view
+    .mapValues(_.map { case (_, imp) =>
+      ImportScope(imp.importedEntity, imp.importedAs)
+    })
+
+  override def generateParts(): Array[CfgNode] =
+    (cpg.methodReturn.filter(x => x.typeFullName != Constants.ANY) ++ cpg.parameter.filter(x =>
+      x.typeFullName != Constants.ANY
+    )).toArray
+
+  override def runOnPart(builder: DiffGraphBuilder, part: CfgNode): Unit =
+    part match {
+      case x: MethodReturn      => runOnMethodReturn(builder, x)
+      case x: MethodParameterIn => runOnMethodParameter(builder, x)
+      case _                    =>
+    }
+
+  private def runOnMethodReturn(diffGraph: DiffGraphBuilder, methodReturn: MethodReturn): Unit =
+    methodReturn.file.foreach { file =>
       val typeHint = methodReturn.typeFullName
+      val imports = fileToImports.getOrElse(file.name, List.empty) ++ methodReturn.method.typeDecl
+        .map(td => ImportScope(Option(pythonicTypeNameToImport(td.fullName)), Option(td.name)))
+        .toList
       imports
         .filter { x =>
           // TODO: Handle * imports correctly
-          x.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") }
+          x.alias.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") }
         }
-        .importedEntity
+        .flatMap(_.entity)
         .foreach { importedEntity =>
           setTypeHints(diffGraph, methodReturn, typeHint, typeHint, importedEntity)
         }
     }
 
-    for {
-      param   <- cpg.parameter.filter(x => x.typeFullName != Constants.ANY)
-      file    <- param.file
-      imports <- fileToImports.get(file.name)
-    } {
+  private def runOnMethodParameter(diffGraph: DiffGraphBuilder, param: MethodParameterIn): Unit =
+    param.file.foreach { file =>
       val typeHint = param.typeFullName
+      val imports = fileToImports.getOrElse(file.name, List.empty) ++ param.method.typeDecl
+        .map(td => ImportScope(Option(pythonicTypeNameToImport(td.fullName)), Option(td.name)))
+        .toList
       imports
         // TODO: Handle * imports correctly
-        .filter(_.importedAs.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") })
-        .map(i => (i.importedEntity, i.importedAs))
+        .filter(_.alias.exists { imported => typeHint.matches(Pattern.quote(imported) + "(\\..+)*") })
         .foreach {
-          case (Some(importedEntity), Some(importedAs)) =>
+          case ImportScope(Some(importedEntity), Some(importedAs)) =>
             setTypeHints(diffGraph, param, typeHint, importedAs, importedEntity)
           case _ =>
         }
     }
 
-  }
+  private def pythonicTypeNameToImport(fullName: String): String =
+    fullName.replaceFirst("\\.py:<module>", "").replaceAll(Pattern.quote(File.separator), ".")
 
   private def setTypeHints(
     diffGraph: BatchedUpdate.DiffGraphBuilder,
@@ -66,17 +81,21 @@ class DynamicTypeHintFullNamePass(cpg: Cpg) extends CpgPass(cpg) {
     alias: String,
     importedEntity: String
   ) = {
-    val typeFullName = typeHint.replaceFirst(Pattern.quote(alias), importedEntity)
-    val typeFilePath = typeFullName.replaceAll("\\.", Matcher.quoteReplacement(File.separator))
-    val pythonicTypeFullName = typeFullName.split("\\.").lastOption match {
+    val importFullPath   = ImportStringHandling.combinedPath(importedEntity, typeHint)
+    val typeHintFullName = typeHint.replaceFirst(Pattern.quote(alias), importedEntity)
+    val typeFilePath     = typeHintFullName.replaceAll("\\.", Matcher.quoteReplacement(File.separator))
+    val pythonicTypeFullName = importFullPath.split("\\.").lastOption match {
       case Some(typeName) =>
         typeFilePath.stripSuffix(s"${File.separator}$typeName").concat(s".py:<module>.$typeName")
-      case None => typeFullName
+      case None => typeHintFullName
     }
     cpg.typeDecl.fullName(s".*${Pattern.quote(pythonicTypeFullName)}").l match {
+      case xs if xs.sizeIs == 1 =>
+        diffGraph.setNodeProperty(node, PropertyNames.TYPE_FULL_NAME, xs.fullName.head)
       case xs if xs.nonEmpty =>
         diffGraph.setNodeProperty(node, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, xs.fullName.toSeq)
-      case _ => diffGraph.setNodeProperty(node, PropertyNames.TYPE_FULL_NAME, pythonicTypeFullName)
+      case _ =>
+        diffGraph.setNodeProperty(node, PropertyNames.TYPE_FULL_NAME, pythonicTypeFullName)
     }
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -140,40 +140,47 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .name(name)
       .code(name)
       .evaluationStrategy(EvaluationStrategies.BY_SHARING)
-      .typeFullName(Constants.ANY)
+      .typeFullName(extractTypesFromHint(typeHint).getOrElse(Constants.ANY))
       .isVariadic(isVariadic)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
     index.foreach(idx => methodParameterNode.index(idx))
-    methodParameterNode.dynamicTypeHintFullName(extractTypesFromHint(typeHint))
     addNodeToDiff(methodParameterNode)
   }
 
-  def extractTypesFromHint(typeHint: Option[ast.iexpr] = None): Seq[String] = {
+  def extractTypesFromHint(typeHint: Option[ast.iexpr] = None): Option[String] = {
     typeHint match {
       case Some(hint) =>
         val nameSequence = hint match {
-          case n: ast.Name => Seq(n.id)
+          case n: ast.Name => Option(n.id)
           // TODO: Definitely a place for follow up handling of generics - currently only take the polymorphic type
           //  without type args. To see the type arguments, see ast.Subscript.slice
           case attr: ast.Attribute =>
             extractTypesFromHint(Some(attr.value)).map { x => x + "." + attr.attr }
-          case n: ast.Subscript if n.value.isInstanceOf[ast.Name] => Seq(n.value.asInstanceOf[ast.Name].id)
-          case _                                                  => Seq[String]()
+          case n: ast.Subscript if n.value.isInstanceOf[ast.Name] => Option(n.value.asInstanceOf[ast.Name].id)
+          case _                                                  => None
         }
         nameSequence.map { typeName =>
           if (allBuiltinClasses.contains(typeName)) s"$builtinPrefix$typeName"
           else if (typingClassesV3.contains(typeName)) s"$typingPrefix$typeName"
           else typeName
         }
-      case _ =>
-        Seq()
+      case _ => None
     }
   }
 
-  def methodReturnNode(dynamicTypeHintFullName: Option[String], lineAndColumn: LineAndColumn): nodes.NewMethodReturn = {
+  def methodReturnNode(
+    staticTypeHint: Option[String],
+    dynamicTypeHintFullName: Option[String],
+    lineAndColumn: LineAndColumn
+  ): nodes.NewMethodReturn = {
     val methodReturnNode = NodeBuilders
-      .newMethodReturnNode(Constants.ANY, dynamicTypeHintFullName, Some(lineAndColumn.line), Some(lineAndColumn.column))
+      .newMethodReturnNode(
+        staticTypeHint.getOrElse(Constants.ANY),
+        dynamicTypeHintFullName,
+        Some(lineAndColumn.line),
+        Some(lineAndColumn.column)
+      )
       .evaluationStrategy(EvaluationStrategies.BY_SHARING)
 
     addNodeToDiff(methodReturnNode)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -158,7 +158,9 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
           case attr: ast.Attribute =>
             extractTypesFromHint(Some(attr.value)).map { x => x + "." + attr.attr }
           case n: ast.Subscript if n.value.isInstanceOf[ast.Name] => Option(n.value.asInstanceOf[ast.Name].id)
-          case _                                                  => None
+          case n: ast.Constant if n.value.isInstanceOf[ast.StringConstant] =>
+            Option(n.value.asInstanceOf[ast.StringConstant].value)
+          case _ => None
         }
         nameSequence.map { typeName =>
           if (allBuiltinClasses.contains(typeName)) s"$builtinPrefix$typeName"

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -1,6 +1,5 @@
 package io.joern.pysrc2cpg
 
-import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecovery.isDummyType
 import io.shiftleft.codepropertygraph.Cpg

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -71,6 +71,42 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       xParameter.name shouldBe "x"
 
     }
+
+    "have correct full name for func1 method in class" in {
+      val cpg = code("""class Foo:
+                       |  def func1(self):
+                       |    pass
+                       |""".stripMargin)
+
+      val func1 = cpg.method.name("func1").head
+      func1.fullName shouldBe "Test0.py:<module>.Foo.func1"
+    }
+
+    "have correct full name for <body> method in class" in {
+      val cpg = code("""class Foo:
+                       |  pass
+                       |""".stripMargin)
+
+      val func1 = cpg.method.name("<body>").head
+      func1.fullName shouldBe "Test0.py:<module>.Foo.<body>"
+    }
+
+    "have correct parameter index for method in class" in {
+      val cpg = code("""class Foo:
+                       |  def method(self):
+                       |    pass
+                       |""".stripMargin)
+      cpg.method.name("method").parameter.name("self").index.head shouldBe 0
+    }
+
+    "have correct parameter index for static method in class" in {
+      val cpg = code("""class Foo:
+                       |  @staticmethod
+                       |  def method(x):
+                       |    pass
+                       |""".stripMargin)
+      cpg.method.name("method").parameter.name("x").index.head shouldBe 1
+    }
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionDefCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionDefCpgTests.scala
@@ -154,7 +154,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func1")
         .parameter
-        .dynamicTypeHintFullName
+        .typeFullName
         .dedup
         .l shouldBe Seq("__builtin.int")
     }
@@ -163,7 +163,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func2")
         .parameter
-        .dynamicTypeHintFullName
+        .typeFullName
         .dedup
         .l shouldBe Seq("typing.Optional")
     }
@@ -172,7 +172,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func1")
         .methodReturn
-        .dynamicTypeHintFullName
+        .typeFullName
         .dedup
         .l shouldBe Seq("__builtin.float")
     }
@@ -181,7 +181,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func2")
         .methodReturn
-        .dynamicTypeHintFullName
+        .typeFullName
         .dedup
         .l shouldBe Seq("typing.List")
     }
@@ -190,7 +190,7 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
       cpg.method
         .name("func3")
         .parameter
-        .dynamicTypeHintFullName
+        .typeFullName
         .dedup
         .l shouldBe Seq("abc.Def")
     }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MemberCpgTests.scala
@@ -16,14 +16,9 @@ class MemberCpgTests extends AnyFreeSpec with Matchers {
                                                 |
                                                 |""".stripMargin)
 
-    "should have a MEMBER" in {
-      val List(member: Member) = cpg.member.name("x").l
-      member.code shouldBe "x"
-    }
-
     "should have the MEMBER attached to the class" in {
-      val List(typeDecl) = cpg.member.name("x").typeDecl.l
-      typeDecl.name shouldBe "Foo"
+      val List(member) = cpg.typeDecl.name("Foo").member.name("x").l
+      member.name shouldBe "x"
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -446,4 +446,18 @@ class RegexDefinedFlowsDataFlowTests
     }
   }
 
+  "flows from receivers" should {
+    val cpg = code("""
+        |class Foo:
+        |   def func():
+        |      return "x"
+        |print(Foo.func())
+        |""".stripMargin)
+    "be found" in {
+      val src = cpg.call.code("Foo.func").l
+      val snk = cpg.call("print").l
+      snk.argument.reachableByFlows(src).size shouldBe 1
+    }
+  }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -894,4 +894,65 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
+  "Static class calls from imported types" should {
+    lazy val cpg = code(
+      """
+        |from db.redis import RedisDB
+        |
+        |class FooServer():
+        |
+        | async def callback(self):
+        |   await RedisDB.instance().set("apiuserscache", json.dumps(resp), expires=1800)
+        |
+        |   redis = await RedisDB.instance().get_redis()
+        |   await redis.publish_json(123, {})
+        |""".stripMargin,
+      "fooserver.py"
+    ).moreCode(
+      """
+        |import aioredis
+        |
+        |class RedisDB(object):
+        |    _instance = None
+        |
+        |    @classmethod
+        |    def instance(cls) -> 'RedisDB':
+        |        if cls._instance is None:
+        |            cls._instance = cls.__new__(cls)
+        |            cls.redis = None
+        |        return cls._instance
+        |
+        |    @classmethod
+        |    async def get_redis(cls) -> aioredis.Redis:
+        |       pass
+        |
+        |    async def set(self, key: str, value: str, expires: int = 0):
+        |        redis = await self.get_redis()
+        |        await redis.set(key, value, expire=expires)
+        |""".stripMargin,
+      Seq("db", "redis.py").mkString(File.separator)
+    )
+
+    "assert the method properties in RedisDB, especially quoted type hints" in {
+      val Some(redisDB)                    = cpg.typeDecl.nameExact("RedisDB").method.nameExact("<body>").headOption
+      val List(instanceM, getRedisM, setM) = redisDB.astOut.isMethod.nameExact("instance", "get_redis", "set").l
+
+      instanceM.methodReturn.typeFullName shouldBe Seq("db", "redis.py:<module>.RedisDB").mkString(File.separator)
+      getRedisM.methodReturn.typeFullName shouldBe "aioredis.py:<module>.Redis"
+      setM.methodReturn.typeFullName shouldBe "ANY"
+    }
+
+    "be able to generate an appropriate dummy value" in {
+      val Some(redisSet) = cpg.call.code(".*set.*apiuserscache.*").headOption
+      redisSet.methodFullName shouldBe Seq("db", "redis.py:<module>.RedisDB.set").mkString(File.separator)
+    }
+
+    "be able to handle a simple call off an alias" in {
+      val Some(redisGet) = cpg.call.nameExact("publish_json").headOption
+      redisGet.methodFullName shouldBe Seq("db", "redis.py:<module>.RedisDB.get_redis.publish_json").mkString(
+        File.separator
+      )
+    }
+  }
+
 }


### PR DESCRIPTION
* Reverted [commit 4691b4a](https://github.com/joernio/joern/commit/4691b4a54b23d23d4e6aa3193bb703cfb7398b57)
* Added tests that were resulting in some failure
* Added support for string constant type hints (idk how but this is valid Python)
* Using `ForkJoinParallelCpgPass` for `DynamicTypeHintFullNamePass`
* Making sure that `DynamicTypeHintFullNamePass` considers types within the current scope