### PR TITLE
Recover types for deconstructed field access structures

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -194,7 +194,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
         }
       }.toSet
     } else {
-      val default = Set(entity).map(_.replaceAll("/", sep))
+      val default = Set(entity)
       symbolTable.append(LocalVar(alias), default)
       symbolTable.append(CallAlias(alias, Option("this")), default)
     }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -364,4 +364,30 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
     }
   }
 
+  "Temporary variables inserted to produce a three-address code structure" should {
+
+    lazy val cpg = code(
+      """
+        |import { HttpClient } from '@angular/common/http';
+        |
+        |@Injectable({
+        |  providedIn: 'root',
+        |})
+        |export class SharedService {
+        |  private http: HttpClient = new HttpClient();
+        |  saveUserFeedback(payload) {
+        |    return this.http.post('https://google.com', payload);
+        |  }
+        |}
+        |""".stripMargin,
+      "foo.ts"
+    )
+
+    "have their calls from a field access structure successfully recovered" in {
+      cpg.identifier("_tmp_2").typeFullName.headOption shouldBe Some("@angular/common/http:HttpClient")
+      cpg.call("post").methodFullName.headOption shouldBe Some("@angular/common/http:HttpClient:post")
+    }
+
+  }
+
 }


### PR DESCRIPTION
* Testing and verifying behaviour around recovering types for field accesses that end up using temp variables to achieve 3-address code
* Cleaned up some code in `XTypeRecovery` to be more Scala-like