### PR TITLE
Correctly Account for Method Names in TS Interfaces

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -490,7 +490,7 @@ trait AstForTypesCreator { this: AstCreator =>
           Seq(memberNode(nodeInfo, functionNode.name, nodeInfo.code, typeFullName, Seq(functionNode.fullName)))
         case _ =>
           val names = nodeInfo.node match {
-            case TSPropertySignature =>
+            case TSPropertySignature | TSMethodSignature =>
               if (hasKey(nodeInfo.json("key"), "value")) {
                 Seq(safeStr(nodeInfo.json("key"), "value").getOrElse(code(nodeInfo.json("key")("value"))))
               } else Seq(code(nodeInfo.json("key")))

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -481,7 +481,7 @@ trait AstForTypesCreator { this: AstCreator =>
       val nodeInfo     = createBabelNodeInfo(classElement)
       val typeFullName = typeFor(nodeInfo)
       val memberNodes = nodeInfo.node match {
-        case TSCallSignatureDeclaration =>
+        case TSCallSignatureDeclaration | TSMethodSignature =>
           val functionNode = createMethodDefinitionNode(nodeInfo)
           val bindingNode  = newBindingNode("", "", "")
           diffGraph.addEdge(typeDeclNode_, bindingNode, EdgeTypes.BINDS)

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
@@ -160,6 +160,7 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
         |  [propName: string]: any;
         |  "foo": string;
         |  (source: string, subString: string): boolean;
+        |  toString(): string;
         |}
         |""".stripMargin) { cpg =>
       inside(cpg.typeDecl("Greeter").l) { case List(greeter) =>
@@ -168,7 +169,7 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
         greeter.fullName shouldBe "code.ts::program:Greeter"
         greeter.filename shouldBe "code.ts"
         greeter.file.name.head shouldBe "code.ts"
-        inside(cpg.typeDecl("Greeter").member.l) { case List(greeting, name, propName, foo, anon) =>
+        inside(cpg.typeDecl("Greeter").member.l) { case List(greeting, name, propName, foo, anon, toString) =>
           greeting.name shouldBe "greeting"
           greeting.code shouldBe "greeting: string;"
           name.name shouldBe "name"
@@ -180,8 +181,10 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
           anon.name shouldBe "anonymous"
           anon.dynamicTypeHintFullName shouldBe Seq("code.ts::program:Greeter:anonymous")
           anon.code shouldBe "(source: string, subString: string): boolean;"
+          toString.name shouldBe "toString"
+          toString.code shouldBe "toString(): string;"
         }
-        inside(cpg.typeDecl("Greeter").method.l) { case List(constructor, anon) =>
+        inside(cpg.typeDecl("Greeter").method.l) { case List(constructor, anon, toString) =>
           constructor.name shouldBe io.joern.x2cpg.Defines.ConstructorMethodName
           constructor.fullName shouldBe s"code.ts::program:Greeter:${io.joern.x2cpg.Defines.ConstructorMethodName}"
           constructor.code shouldBe "new: Greeter"
@@ -191,6 +194,8 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
           anon.code shouldBe "(source: string, subString: string): boolean;"
           anon.parameter.name.l shouldBe List("this", "source", "subString")
           anon.parameter.code.l shouldBe List("this", "source: string", "subString: string")
+          toString.name shouldBe "toString"
+          toString.code shouldBe "toString(): string;"
         }
       }
     }


### PR DESCRIPTION
For example
```typescript
interface Symbol {
    /** Returns a string representation of an object. */
    toString(): string;

    /** Returns the primitive value of the specified object. */
    valueOf(): symbol;
}
```
The names of members for `Symbol` would be the full code. With this change, it would (more) correctly use the identifier name for `Member.name`.