### PR TITLE
Make flows via statically dispatched methods work

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1192,12 +1192,13 @@ class AstCreator(filename: String, global: Global)
   }
 
   def astForCallNode(localIdentifier: TerminalNode): Seq[Ast] = {
-    val column = localIdentifier.getSymbol().getCharPositionInLine()
-    val line   = localIdentifier.getSymbol().getLine()
-    val name   = getActualMethodName(localIdentifier.getText)
+    val column         = localIdentifier.getSymbol().getCharPositionInLine()
+    val line           = localIdentifier.getSymbol().getLine()
+    val name           = getActualMethodName(localIdentifier.getText)
+    val methodFullName = s"$filename:$name"
     val callNode = NewCall()
       .name(name)
-      .methodFullName(name)
+      .methodFullName(methodFullName)
       .signature(localIdentifier.getText())
       .typeFullName(MethodFullNames.UnknownFullName)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1401,11 +1402,13 @@ class AstCreator(filename: String, global: Global)
     val astBody = astForBodyStatementContext(ctx.bodyStatement())
     popScope()
 
+    // TODO why is there a `callNode` here?
+
     val classPath = classStack.toList.mkString(".") + "."
     val methodNode = NewMethod()
       .code(callNode.code)
       .name(callNode.name)
-      .fullName(classPath + callNode.name)
+      .fullName(s"$filename:${callNode.name}")
       .columnNumber(callNode.columnNumber)
       .lineNumber(callNode.lineNumber)
       .filename(filename)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -31,4 +31,25 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       sink.reachableByFlows(source).l.size shouldBe 2
     }
   }
+
+  "Flow via call" should {
+    val cpg = code("""
+      |def print(content)
+      |puts content
+      |end
+      |
+      |def main
+      |n = 1
+      |print( n )
+      |end
+      |""".stripMargin)
+
+    "be found" in {
+      implicit val resolver: ICallResolver = NoResolve
+      val src                              = cpg.identifier.name("n").where(_.inCall.name("print")).l
+      val sink                             = cpg.method.name("puts").callIn.argument(1).l
+      sink.reachableByFlows(src).size shouldBe 1
+    }
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallGraphTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallGraphTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.shiftleft.semanticcpg.language._
 
 class CallGraphTests extends RubyCode2CpgFixture {
@@ -18,8 +19,11 @@ class CallGraphTests extends RubyCode2CpgFixture {
   "should identify call from `foo` to `bar`" in {
     val List(callToBar) = cpg.call("bar").l
     callToBar.name shouldBe "bar"
+    callToBar.methodFullName.matches(".*Test.*.rb:bar") shouldBe true
     callToBar.lineNumber shouldBe Some(7)
-    cpg.method("bar").caller.name.l shouldBe List("foo")
+    val List(bar: Method) = cpg.method("bar").internal.l
+    bar.fullName shouldBe callToBar.methodFullName
+    bar.caller.name.l shouldBe List("foo")
   }
 
 }


### PR DESCRIPTION
Right now, all call nodes in RUBY have dispatch-type "STATIC", however, prior to this commit, `METHOD` and corresponding `CALL` nodes did not have matching full names, which meant that call linking failed. This PR fixes that.

Follow-up work is required to handle dynamically dispatched calls in combination with the type propagator.