### PR TITLE
rubysrc2cpg: refactored pseudo-variables' AST

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -497,13 +497,13 @@ variableIdentifier
     ;
 
 pseudoVariableIdentifier
-    :   NIL
-    |   TRUE
-    |   FALSE
-    |   SELF
-    |   FILE__
-    |   LINE__
-    |   ENCODING__
+    :   NIL                                                                                                         # nilPseudoVariableIdentifier
+    |   TRUE                                                                                                        # truePseudoVariableIdentifier
+    |   FALSE                                                                                                       # falsePseudoVariableIdentifier
+    |   SELF                                                                                                        # selfPseudoVariableIdentifier
+    |   FILE__                                                                                                      # filePseudoVariableIdentifier
+    |   LINE__                                                                                                      # linePseudoVariableIdentifier
+    |   ENCODING__                                                                                                  # encodingPseudoVariableIdentifier
     ;
 
 scopedConstantReference

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.parser.RubyParser._
 import io.joern.rubysrc2cpg.parser.{RubyLexer, RubyParser}
+import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast.storeInDiffGraph
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
 import io.joern.x2cpg.datastructures.Global
@@ -19,20 +20,8 @@ import scala.jdk.CollectionConverters._
 
 class AstCreator(filename: String, global: Global)
     extends AstCreatorBase(filename)
-    with AstNodeBuilder[ParserRuleContext, AstCreator] {
-
-  object Defines {
-    val Any: String           = "ANY"
-    val Number: String        = "number"
-    val String: String        = "string"
-    val Boolean: String       = "boolean"
-    val Hash: String          = "hash"
-    val Array: String         = "array"
-    val Symbol: String        = "symbol"
-    val ModifierRedo: String  = "redo"
-    val ModifierRetry: String = "retry"
-    var ModifierNext: String  = "next"
-  }
+    with AstNodeBuilder[ParserRuleContext, AstCreator]
+    with AstForPrimitivesCreator {
 
   object MethodFullNames {
     val OperatorPrefix = "<operator>."
@@ -76,12 +65,12 @@ class AstCreator(filename: String, global: Global)
     scopeStack.top.varToIdentiferMap.contains(name)
   }
 
-  private def createIdentiferWithScope(
+  protected def createIdentifierWithScope(
     ctx: ParserRuleContext,
     name: String,
     code: String,
     typeFullName: String,
-    dynamicTypeHints: Seq[String]
+    dynamicTypeHints: Seq[String] = Seq()
   ): NewIdentifier = {
     val newNode = identifierNode(ctx, name, code, typeFullName, dynamicTypeHints)
     setIdentiferInScope(newNode)
@@ -155,7 +144,7 @@ class AstCreator(filename: String, global: Global)
     val terminalNode = ctx.children.asScala.map(_.asInstanceOf[TerminalNode]).head
     val token        = terminalNode.getSymbol
     val variableName = token.getText
-    val node         = createIdentiferWithScope(ctx, variableName, variableName, Defines.Any, List[String]())
+    val node         = createIdentifierWithScope(ctx, variableName, variableName, Defines.Any, List[String]())
     setIdentiferInScope(node)
     Seq(Ast(node))
   }
@@ -189,7 +178,7 @@ class AstCreator(filename: String, global: Global)
       }
       val varSymbol = localVar.getSymbol()
       val node =
-        createIdentiferWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
+        createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
       val yAst = Ast(node)
 
       val callNode = NewCall()
@@ -741,8 +730,8 @@ class AstCreator(filename: String, global: Global)
     val primaryAst = astForPrimaryContext(ctx.primary())
     val localVar   = ctx.CONSTANT_IDENTIFIER()
     val varSymbol  = localVar.getSymbol()
-    val node       = createIdentiferWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
-    val constAst   = Ast(node)
+    val node     = createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
+    val constAst = Ast(node)
 
     val callNode = NewCall()
       .name(ctx.COLON2().getText)
@@ -1158,9 +1147,9 @@ class AstCreator(filename: String, global: Global)
         .code(text)
         .lineNumber(lineStart)
         .columnNumber(columnStart)
-        .typeFullName(Defines.Number)
-        .dynamicTypeHintFullName(List(Defines.Number))
-      registerType(Defines.Number)
+        .typeFullName(Defines.Numeric)
+        .dynamicTypeHintFullName(List(Defines.Numeric))
+      registerType(Defines.Numeric)
       Seq(Ast(node))
     } else if (ctx.literal().SINGLE_QUOTED_STRING_LITERAL() != null) {
       val text = ctx.getText
@@ -1227,7 +1216,7 @@ class AstCreator(filename: String, global: Global)
       val varSymbol = localVar.getSymbol()
       if (lookupIdentiferInScope(varSymbol.getText)) {
         val node =
-          createIdentiferWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
+          createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
         Seq(Ast(node))
       } else {
         astForCallNode(localVar, code)
@@ -1237,7 +1226,7 @@ class AstCreator(filename: String, global: Global)
       val varSymbol = localVar.getSymbol()
       if (lookupIdentiferInScope(varSymbol.getText)) {
         val node =
-          createIdentiferWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
+          createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
         Seq(Ast(node))
       } else {
         astForCallNode(localVar, code)
@@ -1297,13 +1286,13 @@ class AstCreator(filename: String, global: Global)
       val localVar  = ctx.LOCAL_VARIABLE_IDENTIFIER()
       val varSymbol = localVar.getSymbol()
       val node =
-        createIdentiferWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
+        createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
       Seq(Ast(node))
     } else if (ctx.CONSTANT_IDENTIFIER() != null) {
       val localVar  = ctx.CONSTANT_IDENTIFIER()
       val varSymbol = localVar.getSymbol()
       val node =
-        createIdentiferWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
+        createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
       Seq(Ast(node))
     } else {
       Seq(Ast())
@@ -1378,7 +1367,7 @@ class AstCreator(filename: String, global: Global)
     localVarList
       .map(localVar => {
         val varSymbol = localVar.getSymbol()
-        createIdentiferWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, Seq[String](Defines.Any))
+        createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, Seq[String](Defines.Any))
         val param = NewMethodParameterIn()
           .name(varSymbol.getText)
           .code(varSymbol.getText)
@@ -1559,7 +1548,7 @@ class AstCreator(filename: String, global: Global)
   def astForSimpleScopedConstantReferencePrimaryContext(ctx: SimpleScopedConstantReferencePrimaryContext): Seq[Ast] = {
     val localVar  = ctx.CONSTANT_IDENTIFIER()
     val varSymbol = localVar.getSymbol()
-    val node      = createIdentiferWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
+    val node      = createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
 
     val callNode = NewCall()
       .name(ctx.COLON2().getText)
@@ -1780,27 +1769,21 @@ class AstCreator(filename: String, global: Global)
     Seq(ast)
   }
 
-  def astForPseudoVariableIdentifierContext(ctx: PseudoVariableIdentifierContext): Seq[Ast] = {
-    val node = {
-      if (ctx.TRUE() != null) { ctx.TRUE() }
-      else if (ctx.NIL() != null) { ctx.NIL() }
-      else if (ctx.FALSE() != null) { ctx.FALSE() }
-      else if (ctx.SELF() != null) { ctx.SELF() }
-      else if (ctx.FILE__() != null) { ctx.FILE__() }
-      else if (ctx.LINE__() != null) { ctx.LINE__() }
-      else if (ctx.ENCODING__() != null) { ctx.ENCODING__() }
-      else return Seq(Ast())
-    }
-
-    val astNode = createIdentiferWithScope(ctx, ctx.getText, ctx.getText, Defines.Any, List(Defines.Any))
-    Seq(Ast(astNode))
+  private def astForPseudoVariableIdentifierContext(ctx: PseudoVariableIdentifierContext): Ast = ctx match {
+    case ctx: NilPseudoVariableIdentifierContext      => astForNilLiteral(ctx)
+    case ctx: TruePseudoVariableIdentifierContext     => astForTrueLiteral(ctx)
+    case ctx: FalsePseudoVariableIdentifierContext    => astForFalseLiteral(ctx)
+    case ctx: SelfPseudoVariableIdentifierContext     => astForSelfPseudoIdentifier(ctx)
+    case ctx: FilePseudoVariableIdentifierContext     => astForFilePseudoIdentifier(ctx)
+    case ctx: LinePseudoVariableIdentifierContext     => astForLinePseudoIdentifier(ctx)
+    case ctx: EncodingPseudoVariableIdentifierContext => astForEncodingPseudoIdentifier(ctx)
   }
 
   def astForVariableRefenceContext(ctx: RubyParser.VariableReferenceContext): Seq[Ast] = {
     if (ctx.variableIdentifier() != null) {
       astForVariableIdentifierContext(ctx.variableIdentifier())
     } else {
-      astForPseudoVariableIdentifierContext(ctx.pseudoVariableIdentifier())
+      Seq(astForPseudoVariableIdentifierContext(ctx.pseudoVariableIdentifier()))
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -1,0 +1,29 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.rubysrc2cpg.parser.RubyParser
+import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.x2cpg.Ast
+
+trait AstForPrimitivesCreator { this: AstCreator =>
+
+  protected def astForNilLiteral(ctx: RubyParser.NilPseudoVariableIdentifierContext): Ast =
+    Ast(literalNode(ctx, ctx.getText, Defines.NilClass))
+
+  protected def astForTrueLiteral(ctx: RubyParser.TruePseudoVariableIdentifierContext): Ast =
+    Ast(literalNode(ctx, ctx.getText, Defines.TrueClass))
+
+  protected def astForFalseLiteral(ctx: RubyParser.FalsePseudoVariableIdentifierContext): Ast =
+    Ast(literalNode(ctx, ctx.getText, Defines.FalseClass))
+
+  protected def astForSelfPseudoIdentifier(ctx: RubyParser.SelfPseudoVariableIdentifierContext): Ast =
+    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Object))
+
+  protected def astForFilePseudoIdentifier(ctx: RubyParser.FilePseudoVariableIdentifierContext): Ast =
+    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.String))
+
+  protected def astForLinePseudoIdentifier(ctx: RubyParser.LinePseudoVariableIdentifierContext): Ast =
+    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Integer))
+
+  protected def astForEncodingPseudoIdentifier(ctx: RubyParser.EncodingPseudoVariableIdentifierContext): Ast =
+    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Encoding))
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -1,0 +1,27 @@
+package io.joern.rubysrc2cpg.passes
+
+object Defines {
+  val Any: String    = "ANY"
+  val Object: String = "Object"
+
+  val NilClass: String   = "NilClass"
+  val TrueClass: String  = "TrueClass"
+  val FalseClass: String = "FalseClass"
+
+  val Numeric: String = "Numeric"
+  val Integer: String = "Integer"
+  val Float: String   = "Float"
+
+  val String: String = "String"
+  val Symbol: String = "Symbol"
+
+  val Array: String = "Array"
+  val Hash: String  = "Hash"
+
+  val Encoding: String = "Encoding"
+
+  // TODO: The following shall be moved out eventually.
+  val ModifierRedo: String  = "redo"
+  val ModifierRetry: String = "retry"
+  var ModifierNext: String  = "next"
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -12,7 +12,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       val cpg = code("""puts 123""")
 
       val List(commandCall) = cpg.call.l
-      val List(arg) = commandCall.argument.isLiteral.l
+      val List(arg)         = commandCall.argument.isLiteral.l
 
       commandCall.code shouldBe "puts 123"
       commandCall.lineNumber shouldBe Some(1)
@@ -24,7 +24,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     // TODO: Should have type Defines.Integer
     "have correct structure for an unsigned, decimal integer literal" ignore {
-      val cpg = code("123")
+      val cpg           = code("123")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "123"
@@ -34,7 +34,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     // TODO: Should have type Defines.Integer
     "have correct structure for a +integer, decimal literal" ignore {
-      val cpg = code("+1")
+      val cpg           = code("+1")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "+1"
@@ -44,7 +44,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     // TODO: Should have type Defines.Integer
     "have correct structure for a -integer, decimal literal" ignore {
-      val cpg = code("-1")
+      val cpg           = code("-1")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "-1"
@@ -53,7 +53,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for `nil` literal" in {
-      val cpg = code("puts nil")
+      val cpg           = code("puts nil")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.NilClass
       literal.code shouldBe "nil"
@@ -62,7 +62,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for `true` literal" in {
-      val cpg = code("puts true")
+      val cpg           = code("puts true")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.TrueClass
       literal.code shouldBe "true"
@@ -71,7 +71,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for `false` literal" in {
-      val cpg = code("puts false")
+      val cpg           = code("puts false")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.FalseClass
       literal.code shouldBe "false"
@@ -80,7 +80,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for `self` identifier" in {
-      val cpg = code("puts self")
+      val cpg        = code("puts self")
       val List(self) = cpg.identifier.l
       self.typeFullName shouldBe Defines.Object
       self.code shouldBe "self"
@@ -89,7 +89,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for `__FILE__` identifier" in {
-      val cpg = code("puts __FILE__")
+      val cpg        = code("puts __FILE__")
       val List(file) = cpg.identifier.l
       file.typeFullName shouldBe Defines.String
       file.code shouldBe "__FILE__"
@@ -98,7 +98,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for `__LINE__` identifier" in {
-      val cpg = code("puts __LINE__")
+      val cpg        = code("puts __LINE__")
       val List(line) = cpg.identifier.l
       line.typeFullName shouldBe Defines.Integer
       line.code shouldBe "__LINE__"
@@ -107,7 +107,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for `__ENCODING__` identifier" in {
-      val cpg = code("puts __ENCODING__")
+      val cpg            = code("puts __ENCODING__")
       val List(encoding) = cpg.identifier.l
       encoding.typeFullName shouldBe Defines.Encoding
       encoding.code shouldBe "__ENCODING__"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -21,8 +21,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       arg.lineNumber shouldBe Some(1)
       arg.columnNumber shouldBe Some(5)
     }
-
-    // TODO: Should have type Defines.Integer
+    
     "have correct structure for an unsigned, decimal integer literal" ignore {
       val cpg           = code("123")
       val List(literal) = cpg.literal.l
@@ -32,7 +31,6 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literal.columnNumber shouldBe Some(1)
     }
 
-    // TODO: Should have type Defines.Integer
     "have correct structure for a +integer, decimal literal" ignore {
       val cpg           = code("+1")
       val List(literal) = cpg.literal.l
@@ -42,7 +40,6 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literal.columnNumber shouldBe Some(1)
     }
 
-    // TODO: Should have type Defines.Integer
     "have correct structure for a -integer, decimal literal" ignore {
       val cpg           = code("-1")
       val List(literal) = cpg.literal.l

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.passes.ast
 
+import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
 
@@ -11,7 +12,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       val cpg = code("""puts 123""")
 
       val List(commandCall) = cpg.call.l
-      val List(arg)         = commandCall.argument.isLiteral.l
+      val List(arg) = commandCall.argument.isLiteral.l
 
       commandCall.code shouldBe "puts 123"
       commandCall.lineNumber shouldBe Some(1)
@@ -20,6 +21,98 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       arg.lineNumber shouldBe Some(1)
       arg.columnNumber shouldBe Some(5)
     }
-  }
 
+    // TODO: Should have type Defines.Integer
+    "have correct structure for an unsigned, decimal integer literal" ignore {
+      val cpg = code("123")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "123"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(1)
+    }
+
+    // TODO: Should have type Defines.Integer
+    "have correct structure for a +integer, decimal literal" ignore {
+      val cpg = code("+1")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "+1"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(1)
+    }
+
+    // TODO: Should have type Defines.Integer
+    "have correct structure for a -integer, decimal literal" ignore {
+      val cpg = code("-1")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "-1"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(1)
+    }
+
+    "have correct structure for `nil` literal" in {
+      val cpg = code("puts nil")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.NilClass
+      literal.code shouldBe "nil"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(5)
+    }
+
+    "have correct structure for `true` literal" in {
+      val cpg = code("puts true")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.TrueClass
+      literal.code shouldBe "true"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(5)
+    }
+
+    "have correct structure for `false` literal" in {
+      val cpg = code("puts false")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.FalseClass
+      literal.code shouldBe "false"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(5)
+    }
+
+    "have correct structure for `self` identifier" in {
+      val cpg = code("puts self")
+      val List(self) = cpg.identifier.l
+      self.typeFullName shouldBe Defines.Object
+      self.code shouldBe "self"
+      self.lineNumber shouldBe Some(1)
+      self.columnNumber shouldBe Some(5)
+    }
+
+    "have correct structure for `__FILE__` identifier" in {
+      val cpg = code("puts __FILE__")
+      val List(file) = cpg.identifier.l
+      file.typeFullName shouldBe Defines.String
+      file.code shouldBe "__FILE__"
+      file.lineNumber shouldBe Some(1)
+      file.columnNumber shouldBe Some(5)
+    }
+
+    "have correct structure for `__LINE__` identifier" in {
+      val cpg = code("puts __LINE__")
+      val List(line) = cpg.identifier.l
+      line.typeFullName shouldBe Defines.Integer
+      line.code shouldBe "__LINE__"
+      line.lineNumber shouldBe Some(1)
+      line.columnNumber shouldBe Some(5)
+    }
+
+    "have correct structure for `__ENCODING__` identifier" in {
+      val cpg = code("puts __ENCODING__")
+      val List(encoding) = cpg.identifier.l
+      encoding.typeFullName shouldBe Defines.Encoding
+      encoding.code shouldBe "__ENCODING__"
+      encoding.lineNumber shouldBe Some(1)
+      encoding.columnNumber shouldBe Some(5)
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -21,7 +21,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       arg.lineNumber shouldBe Some(1)
       arg.columnNumber shouldBe Some(5)
     }
-    
+
     "have correct structure for an unsigned, decimal integer literal" ignore {
       val cpg           = code("123")
       val List(literal) = cpg.literal.l


### PR DESCRIPTION
* Moved `AstCreator.Defines` into a separate object. Also renamed/added/deleted a few fields. E.g. In Ruby, there is no "Boolean" class, but "TrueClass" and "FalseClass".
* Renamed Defines.Number to Defines.Numeric (following Ruby)
* Completely rewrote `astForPseudoVariableIdentifier` following jssrc2cpg's scheme of an `AstForPrimitivesCreator` trait.