### PR TITLE
rubysrc2cpg: supports regexp literals, and refactors literals support in general

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -516,11 +516,11 @@ scopedConstantReference
 // --------------------------------------------------------
 
 literal
-    :   numericLiteral
-    |   symbol
-    |   SINGLE_QUOTED_STRING_LITERAL
-    |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END
-    |   REGULAR_EXPRESSION_START REGULAR_EXPRESSION_BODY? REGULAR_EXPRESSION_END
+    :   numericLiteral                                                                                              # numericLiteralLiteral
+    |   symbol                                                                                                      # symbolLiteral
+    |   SINGLE_QUOTED_STRING_LITERAL                                                                                # singleQuotedStringLiteral
+    |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END                # doubleQuotedStringLiteral
+    |   REGULAR_EXPRESSION_START REGULAR_EXPRESSION_BODY? REGULAR_EXPRESSION_END                                    # regularExpressionLiteral
     ;
 
 symbol

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -301,7 +301,7 @@ class AstCreator(filename: String, global: Global)
       astForChainedScopedConstantReferencePrimaryContext(ctx)
     case ctx: ArrayConstructorPrimaryContext          => astForArrayConstructorPrimaryContext(ctx)
     case ctx: HashConstructorPrimaryContext           => astForHashConstructorPrimaryContext(ctx)
-    case ctx: LiteralPrimaryContext                   => astForLiteralPrimaryContext(ctx)
+    case ctx: LiteralPrimaryContext                   => Seq(astForLiteralPrimaryContext(ctx))
     case ctx: StringInterpolationPrimaryContext       => astForStringInterpolationPrimaryContext(ctx)
     case ctx: IsDefinedPrimaryContext                 => astForIsDefinedPrimaryContext(ctx)
     case ctx: SuperExpressionPrimaryContext           => astForSuperExpressionPrimaryContext(ctx)
@@ -1138,44 +1138,14 @@ class AstCreator(filename: String, global: Global)
     }
   }
 
-  def astForLiteralPrimaryContext(ctx: LiteralPrimaryContext): Seq[Ast] = {
-    val lineStart   = line(ctx.literal())
-    val columnStart = column(ctx.literal())
-    if (ctx.literal().numericLiteral() != null) {
-      val text = ctx.getText
-      val node = NewLiteral()
-        .code(text)
-        .lineNumber(lineStart)
-        .columnNumber(columnStart)
-        .typeFullName(Defines.Numeric)
-        .dynamicTypeHintFullName(List(Defines.Numeric))
-      registerType(Defines.Numeric)
-      Seq(Ast(node))
-    } else if (ctx.literal().SINGLE_QUOTED_STRING_LITERAL() != null) {
-      val text = ctx.getText
-      val node = NewLiteral()
-        .code(text)
-        .lineNumber(lineStart)
-        .columnNumber(columnStart)
-        .typeFullName(Defines.String)
-        .dynamicTypeHintFullName(List(Defines.String))
-      Seq(Ast(node))
-    } else if (ctx.literal().DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE() != null) {
-      val text = ctx.literal().DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE().getText
-      val node = NewLiteral()
-        .code(text)
-        .lineNumber(lineStart)
-        .columnNumber(columnStart)
-        .typeFullName(Defines.String)
-        .dynamicTypeHintFullName(List(Defines.String))
-      registerType(Defines.String)
-      Seq(Ast(node))
-    } else if (ctx.literal().symbol() != null) {
-      astForSymbolContext(ctx.literal().symbol())
-    } else {
-      Seq(Ast())
+  def astForLiteralPrimaryContext(ctx: LiteralPrimaryContext): Ast =
+    ctx.literal() match {
+      case ctx: NumericLiteralLiteralContext => astForNumericLiteral(ctx.numericLiteral)
+      case ctx: SymbolLiteralContext => astForSymbolLiteral(ctx.symbol())
+      case ctx: SingleQuotedStringLiteralContext => astForSingleQuotedStringLiteral(ctx)
+      case ctx: DoubleQuotedStringLiteralContext => astForDoubleQuotedStringLiteral(ctx)
+      case ctx: RegularExpressionLiteralContext => astForRegularExpressionLiteral(ctx)
     }
-  }
 
   def astForSimpleMethodNamePartContext(ctx: SimpleMethodNamePartContext): Seq[Ast] = {
     astForDefinedMethodNameContext(ctx.definedMethodName())

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1140,11 +1140,11 @@ class AstCreator(filename: String, global: Global)
 
   def astForLiteralPrimaryContext(ctx: LiteralPrimaryContext): Ast =
     ctx.literal() match {
-      case ctx: NumericLiteralLiteralContext => astForNumericLiteral(ctx.numericLiteral)
-      case ctx: SymbolLiteralContext => astForSymbolLiteral(ctx.symbol())
+      case ctx: NumericLiteralLiteralContext     => astForNumericLiteral(ctx.numericLiteral)
+      case ctx: SymbolLiteralContext             => astForSymbolLiteral(ctx.symbol())
       case ctx: SingleQuotedStringLiteralContext => astForSingleQuotedStringLiteral(ctx)
       case ctx: DoubleQuotedStringLiteralContext => astForDoubleQuotedStringLiteral(ctx)
-      case ctx: RegularExpressionLiteralContext => astForRegularExpressionLiteral(ctx)
+      case ctx: RegularExpressionLiteralContext  => astForRegularExpressionLiteral(ctx)
     }
 
   def astForSimpleMethodNamePartContext(ctx: SimpleMethodNamePartContext): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -26,4 +26,25 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   protected def astForEncodingPseudoIdentifier(ctx: RubyParser.EncodingPseudoVariableIdentifierContext): Ast =
     Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Encoding))
+
+  protected def astForNumericLiteral(ctx: RubyParser.NumericLiteralContext): Ast = {
+    val numericTypeName = if (isFloatLiteral(ctx.unsignedNumericLiteral)) Defines.Float else Defines.Integer
+    Ast(literalNode(ctx, ctx.getText, numericTypeName))
+  }
+
+  protected def astForSymbolLiteral(ctx: RubyParser.SymbolContext): Ast =
+    Ast(literalNode(ctx, ctx.getText, Defines.Symbol))
+
+  protected def astForSingleQuotedStringLiteral(ctx: RubyParser.SingleQuotedStringLiteralContext): Ast =
+    Ast(literalNode(ctx, ctx.getText, Defines.String))
+
+  protected def astForDoubleQuotedStringLiteral(ctx: RubyParser.DoubleQuotedStringLiteralContext): Ast =
+    Ast(literalNode(ctx, ctx.getText, Defines.String))
+
+  protected def astForRegularExpressionLiteral(ctx: RubyParser.RegularExpressionLiteralContext): Ast =
+    Ast(literalNode(ctx, ctx.getText, Defines.Regexp))
+
+  private def isFloatLiteral(ctx: RubyParser.UnsignedNumericLiteralContext): Boolean =
+    Option(ctx.FLOAT_LITERAL_WITH_EXPONENT).isDefined || Option(ctx.FLOAT_LITERAL_WITHOUT_EXPONENT).isDefined
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -19,7 +19,7 @@ object Defines {
   val Hash: String  = "Hash"
 
   val Encoding: String = "Encoding"
-  val Regexp: String = "Regexp"
+  val Regexp: String   = "Regexp"
 
   // TODO: The following shall be moved out eventually.
   val ModifierRedo: String  = "redo"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -19,6 +19,7 @@ object Defines {
   val Hash: String  = "Hash"
 
   val Encoding: String = "Encoding"
+  val Regexp: String = "Regexp"
 
   // TODO: The following shall be moved out eventually.
   val ModifierRedo: String  = "redo"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -47,7 +47,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |   Expressions
             |    PrimaryExpression
             |     LiteralPrimary
-            |      Literal
+            |      NumericLiteralLiteral
             |       NumericLiteral
             |        UnsignedNumericLiteral
             |         1
@@ -75,7 +75,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |     WsOrNl
             |     PrimaryExpression
             |      LiteralPrimary
-            |       Literal
+            |       NumericLiteralLiteral
             |        NumericLiteral
             |         UnsignedNumericLiteral
             |          1
@@ -95,7 +95,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |   Expressions
             |    PrimaryExpression
             |     LiteralPrimary
-            |      Literal
+            |      SymbolLiteral
             |       Symbol
             |        :region
             |  )""".stripMargin
@@ -114,7 +114,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |   Expressions
             |    PrimaryExpression
             |     LiteralPrimary
-            |      Literal
+            |      SymbolLiteral
             |       Symbol
             |        :region
             |  ,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -74,7 +74,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
              |      =
              |      PrimaryExpression
              |       LiteralPrimary
-             |        Literal
+             |        NumericLiteralLiteral
              |         NumericLiteral
              |          UnsignedNumericLiteral
              |           1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -10,7 +10,7 @@ class RegexTests extends RubyParserAbstractTest {
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
           """LiteralPrimary
-            | Literal
+            | RegularExpressionLiteral
             |  /
             |  /""".stripMargin
       }
@@ -33,7 +33,7 @@ class RegexTests extends RubyParserAbstractTest {
             |    ExpressionExpressionOrCommand
             |     PrimaryExpression
             |      LiteralPrimary
-            |       Literal
+            |       RegularExpressionLiteral
             |        /
             |        /""".stripMargin
       }
@@ -78,7 +78,7 @@ class RegexTests extends RubyParserAbstractTest {
             |     Expressions
             |      PrimaryExpression
             |       LiteralPrimary
-            |        Literal
+            |        RegularExpressionLiteral
             |         /
             |         /
             |    )""".stripMargin
@@ -94,7 +94,7 @@ class RegexTests extends RubyParserAbstractTest {
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
           """LiteralPrimary
-            | Literal
+            | RegularExpressionLiteral
             |  /
             |  (eu|us)
             |  /""".stripMargin
@@ -118,7 +118,7 @@ class RegexTests extends RubyParserAbstractTest {
             |    ExpressionExpressionOrCommand
             |     PrimaryExpression
             |      LiteralPrimary
-            |       Literal
+            |       RegularExpressionLiteral
             |        /
             |        (eu|us)
             |        /""".stripMargin
@@ -165,7 +165,7 @@ class RegexTests extends RubyParserAbstractTest {
             |     Expressions
             |      PrimaryExpression
             |       LiteralPrimary
-            |        Literal
+            |        RegularExpressionLiteral
             |         /
             |         (eu|us)
             |         /
@@ -193,7 +193,7 @@ class RegexTests extends RubyParserAbstractTest {
               |      ExpressionExpressionOrCommand
               |       PrimaryExpression
               |        LiteralPrimary
-              |         Literal
+              |         NumericLiteralLiteral
               |          NumericLiteral
               |           UnsignedNumericLiteral
               |            1
@@ -231,7 +231,7 @@ class RegexTests extends RubyParserAbstractTest {
             |            ExpressionExpressionOrCommand
             |             PrimaryExpression
             |              LiteralPrimary
-            |               Literal
+            |               NumericLiteralLiteral
             |                NumericLiteral
             |                 UnsignedNumericLiteral
             |                  1
@@ -306,7 +306,7 @@ class RegexTests extends RubyParserAbstractTest {
             |             ExpressionExpressionOrCommand
             |              PrimaryExpression
             |               LiteralPrimary
-            |                Literal
+            |                NumericLiteralLiteral
             |                 NumericLiteral
             |                  UnsignedNumericLiteral
             |                   1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -10,7 +10,7 @@ class StringTests extends RubyParserAbstractTest {
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
           """LiteralPrimary
-            | Literal
+            | SingleQuotedStringLiteral
             |  ''""".stripMargin
       }
     }
@@ -24,7 +24,7 @@ class StringTests extends RubyParserAbstractTest {
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
           """LiteralPrimary
-            | Literal
+            | DoubleQuotedStringLiteral
             |  "
             |  """".stripMargin
       }
@@ -47,7 +47,7 @@ class StringTests extends RubyParserAbstractTest {
             |      ExpressionExpressionOrCommand
             |       PrimaryExpression
             |        LiteralPrimary
-            |         Literal
+            |         NumericLiteralLiteral
             |          NumericLiteral
             |           UnsignedNumericLiteral
             |            1
@@ -72,7 +72,7 @@ class StringTests extends RubyParserAbstractTest {
             |      ExpressionExpressionOrCommand
             |       PrimaryExpression
             |        LiteralPrimary
-            |         Literal
+            |         NumericLiteralLiteral
             |          NumericLiteral
             |           UnsignedNumericLiteral
             |            1
@@ -85,7 +85,7 @@ class StringTests extends RubyParserAbstractTest {
             |      ExpressionExpressionOrCommand
             |       PrimaryExpression
             |        LiteralPrimary
-            |         Literal
+            |         NumericLiteralLiteral
             |          NumericLiteral
             |           UnsignedNumericLiteral
             |            2

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/SymbolTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/SymbolTests.scala
@@ -8,7 +8,7 @@ class SymbolTests extends RubyParserAbstractTest {
 
       def symbolLiteralParseTreeText(symbolName: String): String =
         s"""LiteralPrimary
-           | Literal
+           | SymbolLiteral
            |  Symbol
            |   $symbolName""".stripMargin
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -49,6 +49,60 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literal.columnNumber shouldBe Some(1)
     }
 
+    "have correct structure for an unsigned, hexadecimal integer literal" in {
+      val cpg = code("0xabc")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "0xabc"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for an unsigned, binary integer literal" in {
+      val cpg = code("0b01")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "0b01"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a -integer, binary literal" in {
+      val cpg = code("-0b01")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "-0b01"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a +integer, binary literal" in {
+      val cpg = code("+0b01")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "+0b01"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a -integer, hexadecimal literal" in {
+      val cpg = code("-0xa")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "-0xa"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a +integer, hexadecimal literal" in {
+      val cpg = code("+0xa")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "+0xa"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
     "have correct structure for `nil` literal" in {
       val cpg           = code("puts nil")
       val List(literal) = cpg.literal.l
@@ -111,6 +165,52 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       encoding.lineNumber shouldBe Some(1)
       encoding.columnNumber shouldBe Some(5)
     }
+
+    "have correct structure for a single-line double-quoted string literal" in {
+      val cpg = code("\"hello\"")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.String
+      literal.code shouldBe "\"hello\""
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a single-line single-quoted string literal" in {
+      val cpg = code("'hello'")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.String
+      literal.code shouldBe "'hello'"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for an identifier symbol literal" in {
+      val cpg = code(":someSymbolName")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Symbol
+      literal.code shouldBe ":someSymbolName"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a single-quoted-string symbol literal" in {
+      val cpg = code(":'someSymbolName'")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Symbol
+      literal.code shouldBe ":'someSymbolName'"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a single-line regular expression literal" in {
+      val cpg = code("/(eu|us)/")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Regexp
+      literal.code shouldBe "/(eu|us)/"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
   }
 
   "Code field for simple fragments" should {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -49,11 +49,47 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literal.columnNumber shouldBe Some(1)
     }
 
-    "have correct structure for an unsigned, hexadecimal integer literal" in {
-      val cpg = code("0xabc")
+    "have correct structure for an unsigned, decimal float literal" in {
+      val cpg = code("3.14")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
-      literal.code shouldBe "0xabc"
+      literal.typeFullName shouldBe Defines.Float
+      literal.code shouldBe "3.14"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a +float, decimal literal" in {
+      val cpg = code("+3.14")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Float
+      literal.code shouldBe "+3.14"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for a -float, decimal literal" in {
+      val cpg = code("-3.14")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Float
+      literal.code shouldBe "-3.14"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for an unsigned, decimal float literal with unsigned exponent" in {
+      val cpg = code("3e10")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Float
+      literal.code shouldBe "3e10"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for an unsigned, decimal float literal with -exponent" in {
+      val cpg = code("12e-10")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Float
+      literal.code shouldBe "12e-10"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
     }
@@ -81,6 +117,15 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "+0b01"
+      literal.lineNumber shouldBe Some(1)
+      literal.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for an unsigned, hexadecimal integer literal" in {
+      val cpg = code("0xabc")
+      val List(literal) = cpg.literal.l
+      literal.typeFullName shouldBe Defines.Integer
+      literal.code shouldBe "0xabc"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -50,7 +50,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for an unsigned, decimal float literal" in {
-      val cpg = code("3.14")
+      val cpg           = code("3.14")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Float
       literal.code shouldBe "3.14"
@@ -59,7 +59,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a +float, decimal literal" in {
-      val cpg = code("+3.14")
+      val cpg           = code("+3.14")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Float
       literal.code shouldBe "+3.14"
@@ -68,7 +68,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a -float, decimal literal" in {
-      val cpg = code("-3.14")
+      val cpg           = code("-3.14")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Float
       literal.code shouldBe "-3.14"
@@ -77,7 +77,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for an unsigned, decimal float literal with unsigned exponent" in {
-      val cpg = code("3e10")
+      val cpg           = code("3e10")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Float
       literal.code shouldBe "3e10"
@@ -86,7 +86,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for an unsigned, decimal float literal with -exponent" in {
-      val cpg = code("12e-10")
+      val cpg           = code("12e-10")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Float
       literal.code shouldBe "12e-10"
@@ -95,7 +95,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for an unsigned, binary integer literal" in {
-      val cpg = code("0b01")
+      val cpg           = code("0b01")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "0b01"
@@ -104,7 +104,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a -integer, binary literal" in {
-      val cpg = code("-0b01")
+      val cpg           = code("-0b01")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "-0b01"
@@ -113,7 +113,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a +integer, binary literal" in {
-      val cpg = code("+0b01")
+      val cpg           = code("+0b01")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "+0b01"
@@ -122,7 +122,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for an unsigned, hexadecimal integer literal" in {
-      val cpg = code("0xabc")
+      val cpg           = code("0xabc")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "0xabc"
@@ -131,7 +131,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a -integer, hexadecimal literal" in {
-      val cpg = code("-0xa")
+      val cpg           = code("-0xa")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "-0xa"
@@ -140,7 +140,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a +integer, hexadecimal literal" in {
-      val cpg = code("+0xa")
+      val cpg           = code("+0xa")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Integer
       literal.code shouldBe "+0xa"
@@ -212,7 +212,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a single-line double-quoted string literal" in {
-      val cpg = code("\"hello\"")
+      val cpg           = code("\"hello\"")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.String
       literal.code shouldBe "\"hello\""
@@ -221,7 +221,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a single-line single-quoted string literal" in {
-      val cpg = code("'hello'")
+      val cpg           = code("'hello'")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.String
       literal.code shouldBe "'hello'"
@@ -230,7 +230,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for an identifier symbol literal" in {
-      val cpg = code(":someSymbolName")
+      val cpg           = code(":someSymbolName")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Symbol
       literal.code shouldBe ":someSymbolName"
@@ -239,7 +239,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a single-quoted-string symbol literal" in {
-      val cpg = code(":'someSymbolName'")
+      val cpg           = code(":'someSymbolName'")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Symbol
       literal.code shouldBe ":'someSymbolName'"
@@ -248,7 +248,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a single-line regular expression literal" in {
-      val cpg = code("/(eu|us)/")
+      val cpg           = code("/(eu|us)/")
       val List(literal) = cpg.literal.l
       literal.typeFullName shouldBe Defines.Regexp
       literal.code shouldBe "/(eu|us)/"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IdentifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IdentifierTests.scala
@@ -413,8 +413,8 @@ class IdentifierTests extends RubyCode2CpgFixture {
       cpg.literal.code("1").l.size shouldBe 1
       cpg.literal.code("2").l.size shouldBe 1
       cpg.literal.code("3").l.size shouldBe 1
-      cpg.literal.code("hello").l.size shouldBe 1
-      cpg.literal.code("world").l.size shouldBe 1
+      cpg.literal.code("\"hello\"").l.size shouldBe 1
+      cpg.literal.code("\"world\"").l.size shouldBe 1
     }
 
     "recognise all call nodes" in {
@@ -496,8 +496,8 @@ class IdentifierTests extends RubyCode2CpgFixture {
       cpg.literal.code("1").l.size shouldBe 1
       cpg.literal.code("2").l.size shouldBe 2
       cpg.literal.code("0").l.size shouldBe 1
-      cpg.literal.code("x is 1").l.size shouldBe 1
-      cpg.literal.code("I can't guess the number").l.size shouldBe 1
+      cpg.literal.code("\"x is 1\"").l.size shouldBe 1
+      cpg.literal.code("\"I can't guess the number\"").l.size shouldBe 1
     }
   }
 
@@ -531,8 +531,8 @@ class IdentifierTests extends RubyCode2CpgFixture {
     "recognise all literal nodes" in {
       cpg.identifier.name("x").l.size shouldBe 2
       cpg.literal.code("2").l.size shouldBe 1
-      cpg.literal.code("x is less than or equal to 2").l.size shouldBe 1
-      cpg.literal.code("x is greater than 2").l.size shouldBe 1
+      cpg.literal.code("\"x is less than or equal to 2\"").l.size shouldBe 1
+      cpg.literal.code("\"x is greater than 2\"").l.size shouldBe 1
     }
 
     "recognise all call nodes" in {
@@ -564,18 +564,18 @@ class IdentifierTests extends RubyCode2CpgFixture {
 
     "recognise all literal nodes" in {
       cpg.identifier.name("choice").l.size shouldBe 2
-      cpg.literal.code("1").l.size shouldBe 1
-      cpg.literal.code("2").l.size shouldBe 1
-      cpg.literal.code("3").l.size shouldBe 1
-      cpg.literal.code("4").l.size shouldBe 1
-      cpg.literal.code("5").l.size shouldBe 2
-      cpg.literal.code("6").l.size shouldBe 1
-      cpg.literal.code("7").l.size shouldBe 1
-      cpg.literal.code("8").l.size shouldBe 1
-      cpg.literal.code("1 or 2").l.size shouldBe 1
-      cpg.literal.code("3 or 4").l.size shouldBe 1
-      cpg.literal.code("5 or 6").l.size shouldBe 1
-      cpg.literal.code("7 or 8").l.size shouldBe 1
+      cpg.literal.code("\"1\"").l.size shouldBe 1
+      cpg.literal.code("\"2\"").l.size shouldBe 1
+      cpg.literal.code("\"3\"").l.size shouldBe 1
+      cpg.literal.code("\"4\"").l.size shouldBe 1
+      cpg.literal.code("\"5\"").l.size shouldBe 2
+      cpg.literal.code("\"6\"").l.size shouldBe 1
+      cpg.literal.code("\"7\"").l.size shouldBe 1
+      cpg.literal.code("\"8\"").l.size shouldBe 1
+      cpg.literal.code("\"1 or 2\"").l.size shouldBe 1
+      cpg.literal.code("\"3 or 4\"").l.size shouldBe 1
+      cpg.literal.code("\"5 or 6\"").l.size shouldBe 1
+      cpg.literal.code("\"7 or 8\"").l.size shouldBe 1
     }
 
     "recognise all call nodes" in {
@@ -604,7 +604,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
 
     "recognise all literal nodes" in {
       cpg.identifier.name("str").l.size shouldBe 3
-      cpg.literal.code("some_string").l.size shouldBe 1
+      cpg.literal.code("\"some_string\"").l.size shouldBe 1
       cpg.literal.code("'String contains numbers'").l.size shouldBe 1
       cpg.literal.code("'String contains letters'").l.size shouldBe 1
       cpg.literal.code("'String does not contain numbers & letters'").l.size shouldBe 1
@@ -633,7 +633,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
         .name("x")
         .l
         .size shouldBe 4 // FIXME this shows as 3 when the puts is the first loop statemnt. Find why
-      cpg.literal.code("In the loop").l.size shouldBe 1
+      cpg.literal.code("\"In the loop\"").l.size shouldBe 1
     }
 
     "recognise all call nodes" in {
@@ -659,7 +659,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
         .name("x")
         .l
         .size shouldBe 4 // FIXME this shows as 3 when the puts is the first loop statemnt. Find why
-      cpg.literal.code("In the loop").l.size shouldBe 1
+      cpg.literal.code("\"In the loop\"").l.size shouldBe 1
     }
 
     "recognise all call nodes" in {
@@ -758,11 +758,11 @@ class IdentifierTests extends RubyCode2CpgFixture {
 
     "recognise all literal nodes" in {
       cpg.literal
-        .code("team_id")
+        .code("\"team_id\"")
         .l
         .size shouldBe 1
       cpg.literal
-        .code("location_id")
+        .code("\"location_id\"")
         .l
         .size shouldBe 1
     }
@@ -813,7 +813,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
 
     "recognise all literal nodes" in {
       cpg.literal
-        .code("Inside the method")
+        .code("\"Inside the method\"")
         .l
         .size shouldBe 1
     }


### PR DESCRIPTION
* Simplifies `astForLiteralPrimaryContext` by naming each literal alternative explicitly (in RubyParser.g4)
* The `.code` property for strings was not including the `"` or `'` characters. We fix that here.
* Adds `/regexp/` literals as LITERAL nodes.