### PR TITLE
rubysrc2Cpg: Operator name correction

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -159,6 +159,7 @@ class AstCreator(filename: String, global: Global)
     case STAR                => Operators.multiplication
     case TILDE               => Operators.not
     case NOT                 => Operators.not
+    case STAR2               => Operators.exponentiation
     case _                   => Operators.arrayInitializer
   }
 
@@ -1741,7 +1742,15 @@ class AstCreator(filename: String, global: Global)
       val lhsAst = methodNameAsIdentiferQ.dequeue()
       Seq(callAst(callNode, Seq(lhsAst) ++ expressionAst))
     } else {
-      val operatorName = Operators.plus
+      val operatorName =
+        if (
+          ctx.op.getType == TILDE ||
+          ctx.op.getType == EMARK
+        ) {
+          getOperatorName(ctx.op)
+        } else {
+          Operators.plus
+        }
       val callNode = NewCall()
         .name(operatorName)
         .code(ctx.getText)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -152,9 +152,9 @@ class AstCreator(filename: String, global: Global)
     case LT2                 => Operators.shiftLeft
     case LTEQ                => Operators.lessEqualsThan
     case LTEQGT              => Operators.compare
-    case MINUS               => Operators.minus
+    case MINUS               => Operators.subtraction
     case PERCENT             => Operators.modulo
-    case PLUS                => Operators.plus
+    case PLUS                => Operators.addition
     case SLASH               => Operators.division
     case STAR                => Operators.multiplication
     case TILDE               => Operators.not
@@ -273,12 +273,13 @@ class AstCreator(filename: String, global: Global)
   }
 
   def astForSingleAssignmentExpressionContext(ctx: SingleAssignmentExpressionContext): Seq[Ast] = {
-    val rightAst = astForMultipleRightHandSideContext(ctx.multipleRightHandSide())
-    val leftAst  = astForSingleLeftHandSideContext(ctx.singleLeftHandSide())
+    val rightAst     = astForMultipleRightHandSideContext(ctx.multipleRightHandSide())
+    val leftAst      = astForSingleLeftHandSideContext(ctx.singleLeftHandSide())
+    val operatorName = getOperatorName(ctx.op)
     val callNode = NewCall()
-      .name(ctx.op.getText)
+      .name(operatorName)
       .code(ctx.op.getText)
-      .methodFullName(MethodFullNames.OperatorPrefix + ctx.op.getText)
+      .methodFullName(operatorName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
@@ -1482,12 +1483,13 @@ class AstCreator(filename: String, global: Global)
   }
 
   def astForMultipleAssignmentExpressionContext(ctx: MultipleAssignmentExpressionContext): Seq[Ast] = {
-    val lhsAsts = astForMultipleLeftHandSideContext(ctx.multipleLeftHandSide())
-    val rhsAsts = astForMultipleRightHandSideContext(ctx.multipleRightHandSide())
+    val lhsAsts      = astForMultipleLeftHandSideContext(ctx.multipleLeftHandSide())
+    val rhsAsts      = astForMultipleRightHandSideContext(ctx.multipleRightHandSide())
+    val operatorName = getOperatorName(ctx.EQ().getSymbol)
     val callNode = NewCall()
-      .name(ctx.EQ().getText)
+      .name(operatorName)
       .code(ctx.getText)
-      .methodFullName(MethodFullNames.OperatorPrefix + ctx.EQ().getText)
+      .methodFullName(operatorName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
@@ -1501,11 +1503,12 @@ class AstCreator(filename: String, global: Global)
   }
 
   def astForNotExpressionOrCommandContext(ctx: NotExpressionOrCommandContext): Seq[Ast] = {
-    val expAsts = astForExpressionOrCommandContext(ctx.expressionOrCommand())
+    val expAsts      = astForExpressionOrCommandContext(ctx.expressionOrCommand())
+    val operatorName = getOperatorName(ctx.NOT().getSymbol)
     val callNode = NewCall()
-      .name(ctx.NOT().getText)
+      .name(operatorName)
       .code(ctx.getText)
-      .methodFullName(MethodFullNames.OperatorPrefix + ctx.NOT().getText)
+      .methodFullName(operatorName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
@@ -1523,12 +1526,13 @@ class AstCreator(filename: String, global: Global)
   }
 
   def astForOrAndExpressionOrCommandContext(ctx: OrAndExpressionOrCommandContext): Seq[Ast] = {
-    val lhsAsts = astForExpressionOrCommandContext(ctx.expressionOrCommand().get(0))
-    val rhsAsts = astForExpressionOrCommandContext(ctx.expressionOrCommand().get(1))
+    val lhsAsts      = astForExpressionOrCommandContext(ctx.expressionOrCommand().get(0))
+    val rhsAsts      = astForExpressionOrCommandContext(ctx.expressionOrCommand().get(1))
+    val operatorName = getOperatorName(ctx.op)
     val callNode = NewCall()
-      .name(ctx.op.getText)
+      .name(operatorName)
       .code(ctx.getText)
-      .methodFullName(MethodFullNames.OperatorPrefix + ctx.op.getText)
+      .methodFullName(operatorName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
@@ -1541,10 +1545,11 @@ class AstCreator(filename: String, global: Global)
     val expressions            = ctx.expression()
     val baseExpressionAsts     = astForExpressionContext(expressions.get(0))
     val exponentExpressionAsts = astForExpressionContext(expressions.get(1))
+    val operatorName           = getOperatorName(ctx.STAR2().getSymbol)
     val callNode = NewCall()
-      .name(ctx.STAR2().getText)
+      .name(operatorName)
       .code(ctx.getText)
-      .methodFullName(MethodFullNames.OperatorPrefix + ctx.STAR2().getText)
+      .methodFullName(operatorName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
@@ -1573,10 +1578,11 @@ class AstCreator(filename: String, global: Global)
   ): Seq[Ast] = {
     val lhsExpressionAsts = astForExpressionContext(lhs)
     val rhsExpressionAsts = astForExpressionContext(rhs)
+    val operatorName      = getOperatorName(operatorToken)
     val callNode = NewCall()
-      .name(getOperatorName(operatorToken))
+      .name(operatorName)
       .code(code)
-      .methodFullName(MethodFullNames.OperatorPrefix + operatorToken.getText)
+      .methodFullName(operatorName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
@@ -1722,10 +1728,11 @@ class AstCreator(filename: String, global: Global)
        * This is incorrectly identified as a unary expression since the parser identifies the LHS as methodIdentifier
        * PLUS is to be interpreted as a binary operator
        */
+      val operatorName = getOperatorName(ctx.op)
       val callNode = NewCall()
-        .name(ctx.op.getText)
+        .name(operatorName)
         .code(ctx.getText)
-        .methodFullName(MethodFullNames.OperatorPrefix + ctx.op.getText)
+        .methodFullName(operatorName)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
@@ -1734,10 +1741,11 @@ class AstCreator(filename: String, global: Global)
       val lhsAst = methodNameAsIdentiferQ.dequeue()
       Seq(callAst(callNode, Seq(lhsAst) ++ expressionAst))
     } else {
+      val operatorName = Operators.plus
       val callNode = NewCall()
-        .name(ctx.op.getText)
+        .name(operatorName)
         .code(ctx.getText)
-        .methodFullName(MethodFullNames.OperatorPrefix + ctx.op.getText)
+        .methodFullName(operatorName)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
@@ -1754,10 +1762,11 @@ class AstCreator(filename: String, global: Global)
        * This is incorrectly identified as a unary expression since the parser identifies the LHS as methodIdentifier
        * PLUS is to be interpreted as a binary operator
        */
+      val operatorName = Operators.subtraction
       val callNode = NewCall()
-        .name(ctx.MINUS().getText)
+        .name(operatorName)
         .code(ctx.getText)
-        .methodFullName(MethodFullNames.OperatorPrefix + ctx.MINUS().getText)
+        .methodFullName(operatorName)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
@@ -1766,10 +1775,11 @@ class AstCreator(filename: String, global: Global)
       val lhsAst = methodNameAsIdentiferQ.dequeue()
       Seq(callAst(callNode, Seq(lhsAst) ++ expressionAst))
     } else {
+      val operatorName = Operators.minus
       val callNode = NewCall()
-        .name(ctx.MINUS().getText)
+        .name(operatorName)
         .code(ctx.getText)
-        .methodFullName(MethodFullNames.OperatorPrefix + ctx.MINUS().getText)
+        .methodFullName(operatorName)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -129,6 +129,11 @@ class AstCreator(filename: String, global: Global)
     diffGraph
   }
 
+  object RubyOperators {
+    val none            = "<operator>.none"
+    val patternMatch    = "<operator>.patternMatch"
+    val notPatternMatch = "<operator>.notPatternMatch"
+  }
   private def getOperatorName(token: Token): String = token.getType match {
     case AMP                 => Operators.logicalAnd
     case AMP2                => Operators.and
@@ -140,11 +145,11 @@ class AstCreator(filename: String, global: Global)
     case DOT3                => Operators.range
     case EMARK               => Operators.not
     case EMARKEQ             => Operators.notEquals
-    case EMARKTILDE          => "!~" // TODO pattern match
+    case EMARKTILDE          => RubyOperators.notPatternMatch
     case EQ                  => Operators.assignment
     case EQ2                 => Operators.equals
     case EQ3                 => Operators.is
-    case EQTILDE             => "=~" // TODO string to regex match
+    case EQTILDE             => RubyOperators.patternMatch
     case GT                  => Operators.greaterThan
     case GT2                 => Operators.logicalShiftRight
     case GTEQ                => Operators.greaterEqualsThan
@@ -160,7 +165,7 @@ class AstCreator(filename: String, global: Global)
     case TILDE               => Operators.not
     case NOT                 => Operators.not
     case STAR2               => Operators.exponentiation
-    case _                   => Operators.arrayInitializer
+    case _                   => RubyOperators.none
   }
 
   protected def line(ctx: ParserRuleContext): Option[Integer]      = Option(ctx.getStart.getLine)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -129,6 +129,39 @@ class AstCreator(filename: String, global: Global)
     diffGraph
   }
 
+  private def getOperatorName(token: Token): String = token.getType match {
+    case AMP                 => Operators.logicalAnd
+    case AMP2                => Operators.and
+    case ASSIGNMENT_OPERATOR => Operators.assignment
+    case BAR                 => Operators.logicalOr
+    case BAR2                => Operators.or
+    case CARET               => Operators.logicalOr
+    case DOT2                => Operators.range
+    case DOT3                => Operators.range
+    case EMARK               => Operators.not
+    case EMARKEQ             => Operators.notEquals
+    case EMARKTILDE          => "!~" // TODO pattern match
+    case EQ                  => Operators.assignment
+    case EQ2                 => Operators.equals
+    case EQ3                 => Operators.is
+    case EQTILDE             => "=~" // TODO string to regex match
+    case GT                  => Operators.greaterThan
+    case GT2                 => Operators.logicalShiftRight
+    case GTEQ                => Operators.greaterEqualsThan
+    case LT                  => Operators.lessThan
+    case LT2                 => Operators.shiftLeft
+    case LTEQ                => Operators.lessEqualsThan
+    case LTEQGT              => Operators.compare
+    case MINUS               => Operators.minus
+    case PERCENT             => Operators.modulo
+    case PLUS                => Operators.plus
+    case SLASH               => Operators.division
+    case STAR                => Operators.multiplication
+    case TILDE               => Operators.not
+    case NOT                 => Operators.not
+    case _                   => Operators.arrayInitializer
+  }
+
   protected def line(ctx: ParserRuleContext): Option[Integer]      = Option(ctx.getStart.getLine)
   protected def column(ctx: ParserRuleContext): Option[Integer]    = Option(ctx.getStart.getCharPositionInLine)
   protected def lineEnd(ctx: ParserRuleContext): Option[Integer]   = Option(ctx.getStop.getLine)
@@ -1541,7 +1574,7 @@ class AstCreator(filename: String, global: Global)
     val lhsExpressionAsts = astForExpressionContext(lhs)
     val rhsExpressionAsts = astForExpressionContext(rhs)
     val callNode = NewCall()
-      .name(operatorToken.getText)
+      .name(getOperatorName(operatorToken))
       .code(code)
       .methodFullName(MethodFullNames.OperatorPrefix + operatorToken.getText)
       .signature("")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -425,10 +425,10 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode.columnNumber shouldBe Some(2)
     }
 
-    "have correct code for a shift left expression" in {
-      val cpg            = code("x << y")
-      val List(callNode) = cpg.call.name(Operators.shiftLeft).l
-      callNode.code shouldBe "x << y"
+    "have correct code for a compare expression" in {
+      val cpg            = code("x <=> y")
+      val List(callNode) = cpg.call.name(Operators.compare).l
+      callNode.code shouldBe "x <=> y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(2)
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -377,7 +377,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode.columnNumber shouldBe Some(2)
     }
 
-    "have correct code for an assignment expression" in {
+    "have correct code for a assignment expression" in {
       val cpg            = code("x = y")
       val List(callNode) = cpg.call.name(Operators.assignment).l
       callNode.code shouldBe "="
@@ -385,10 +385,50 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode.columnNumber shouldBe Some(2)
     }
 
-    "have correct code for an equals expression" in {
+    "have correct code for a equals expression" in {
       val cpg            = code("x == y")
       val List(callNode) = cpg.call.name(Operators.equals).l
       callNode.code shouldBe "x == y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for a division expression" in {
+      val cpg            = code("x / y")
+      val List(callNode) = cpg.call.name(Operators.division).l
+      callNode.code shouldBe "x / y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for a modulo expression" in {
+      val cpg            = code("x % y")
+      val List(callNode) = cpg.call.name(Operators.modulo).l
+      callNode.code shouldBe "x % y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for a shift right expression" in {
+      val cpg            = code("x >> y")
+      val List(callNode) = cpg.call.name(Operators.logicalShiftRight).l
+      callNode.code shouldBe "x >> y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for a shift left expression" in {
+      val cpg            = code("x << y")
+      val List(callNode) = cpg.call.name(Operators.shiftLeft).l
+      callNode.code shouldBe "x << y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for a shift left expression" in {
+      val cpg            = code("x << y")
+      val List(callNode) = cpg.call.name(Operators.shiftLeft).l
+      callNode.code shouldBe "x << y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(2)
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.passes.ast
 
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 
 class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
@@ -117,7 +118,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a single left had side call" in {
       val cpg            = code("array[n] = 10")
-      val List(callNode) = cpg.call.name("<operator>.indexAccess").l
+      val List(callNode) = cpg.call.name(Operators.indexAccess).l
       callNode.code shouldBe "array[n]"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(5)
@@ -125,7 +126,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a binary expression" in {
       val cpg            = code("x+y")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.addition).l
       callNode.code shouldBe "x+y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(1)
@@ -133,7 +134,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a not expression" in {
       val cpg            = code("not y")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.not).l
       callNode.code shouldBe "not y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(0)
@@ -141,7 +142,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a power expression" in {
       val cpg            = code("x**y")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.exponentiation).l
       callNode.code shouldBe "x**y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(1)
@@ -149,7 +150,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a inclusive range expression" in {
       val cpg            = code("1..10")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.range).l
       callNode.code shouldBe "1..10"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(1)
@@ -157,7 +158,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a non-inclusive range expression" in {
       val cpg            = code("1...10")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.range).l
       callNode.code shouldBe "1...10"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(1)
@@ -165,7 +166,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a relational expression" in {
       val cpg            = code("x<y")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.lessThan).l
       callNode.code shouldBe "x<y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(1)
@@ -173,7 +174,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a unary exclamation expression" in {
       val cpg            = code("!y")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.not).l
       callNode.code shouldBe "!y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(0)
@@ -181,7 +182,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a unary tilde expression" in {
       val cpg            = code("~y")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.not).l
       callNode.code shouldBe "~y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(0)
@@ -189,7 +190,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a unary plus expression" in {
       val cpg            = code("+y")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.plus).l
       callNode.code shouldBe "+y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(0)
@@ -197,7 +198,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct code for a unary minus expression" in {
       val cpg            = code("-y")
-      val List(callNode) = cpg.call.l
+      val List(callNode) = cpg.call.name(Operators.minus).l
       callNode.code shouldBe "-y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(0)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -352,5 +352,45 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(0)
     }
+
+    "have correct code for a logical and expression" in {
+      val cpg            = code("x & y")
+      val List(callNode) = cpg.call.name(Operators.logicalAnd).l
+      callNode.code shouldBe "x & y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for a logical or with bar expression" in {
+      val cpg            = code("x | y")
+      val List(callNode) = cpg.call.name(Operators.logicalOr).l
+      callNode.code shouldBe "x | y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for a logical or with carat expression" in {
+      val cpg            = code("x ^ y")
+      val List(callNode) = cpg.call.name(Operators.logicalOr).l
+      callNode.code shouldBe "x ^ y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for an assignment expression" in {
+      val cpg            = code("x = y")
+      val List(callNode) = cpg.call.name(Operators.assignment).l
+      callNode.code shouldBe "="
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
+
+    "have correct code for an equals expression" in {
+      val cpg            = code("x == y")
+      val List(callNode) = cpg.call.name(Operators.equals).l
+      callNode.code shouldBe "x == y"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(2)
+    }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -112,9 +112,6 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       encoding.lineNumber shouldBe Some(1)
       encoding.columnNumber shouldBe Some(5)
     }
-  }
-
-  "Code field for simple fragments" should {
 
     "have correct code for a single left had side call" in {
       val cpg            = code("array[n] = 10")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IdentifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IdentifierTests.scala
@@ -301,7 +301,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
     "recognise all identifier and call nodes" in {
       cpg.method.name("\\[]").size shouldBe 2
       cpg.method.name("\\[]=").size shouldBe 1
-      cpg.call.name("=").size shouldBe 3
+      cpg.call.name("<operator>.assignment").size shouldBe 3
       cpg.method.name("initialize").size shouldBe 1
       cpg.call.name("to_s").size shouldBe 2
       cpg.call.name("new").size shouldBe 1
@@ -418,7 +418,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
     }
 
     "recognise all call nodes" in {
-      cpg.call.name("=").l.size shouldBe 3
+      cpg.call.name("<operator>.assignment").l.size shouldBe 3
     }
 
     "successfully plot ASTs" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IdentifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IdentifierTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 
 class IdentifierTests extends RubyCode2CpgFixture {
@@ -301,7 +302,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
     "recognise all identifier and call nodes" in {
       cpg.method.name("\\[]").size shouldBe 2
       cpg.method.name("\\[]=").size shouldBe 1
-      cpg.call.name("<operator>.assignment").size shouldBe 3
+      cpg.call.name(Operators.assignment).size shouldBe 3
       cpg.method.name("initialize").size shouldBe 1
       cpg.call.name("to_s").size shouldBe 2
       cpg.call.name("new").size shouldBe 1
@@ -418,7 +419,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
     }
 
     "recognise all call nodes" in {
-      cpg.call.name("<operator>.assignment").l.size shouldBe 3
+      cpg.call.name(Operators.assignment).l.size shouldBe 3
     }
 
     "successfully plot ASTs" in {


### PR DESCRIPTION
### Description

Used `Operator.XYZ` standard names and method fullnames for several operator nodes. More to be covered in another PR.

Got `cpg.assignment.l `working.