### PR TITLE
rubysrc2Cpg: Operator and method corrections

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1028,9 +1028,9 @@ class AstCreator(filename: String, global: Global)
     val lhsExpressionAst = astForPrimaryContext(ctx.primary())
     val rhsExpressionAst = astForIndexingArgumentsContext(ctx.indexingArguments())
     val callNode = NewCall()
-      .name(ctx.LBRACK().getText + ctx.RBRACK().getText)
+      .name(Operators.indexAccess)
       .code(ctx.getText)
-      .methodFullName(MethodFullNames.OperatorPrefix + ctx.LBRACK().getText + ctx.RBRACK().getText)
+      .methodFullName(Operators.indexAccess)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
@@ -1250,13 +1250,19 @@ class AstCreator(filename: String, global: Global)
 
   def astForOperatorMethodNameContext(ctx: OperatorMethodNameContext): Seq[Ast] = {
 
+    /*
+     * This is for operator overloading for the class
+     */
     val terminalNode = ctx.children.asScala.head
       .asInstanceOf[TerminalNode]
 
+    val name           = ctx.getText
+    val methodFullName = s"$filename:$name"
+
     val callNode = NewCall()
-      .name(ctx.getText)
+      .name(name)
       .code(ctx.getText)
-      .methodFullName(MethodFullNames.OperatorPrefix + ctx.getText)
+      .methodFullName(methodFullName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
@@ -1280,7 +1286,7 @@ class AstCreator(filename: String, global: Global)
       val callNode = NewCall()
         .name(terminalNode.getText)
         .code(ctx.getText)
-        .methodFullName(MethodFullNames.OperatorPrefix + terminalNode.getText)
+        .methodFullName(terminalNode.getText)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1410,15 +1410,21 @@ class AstCreator(filename: String, global: Global)
     val astBody = astForBodyStatementContext(ctx.bodyStatement())
     popScope()
 
-    // TODO why is there a `callNode` here?
+    /*
+     * The method astForMethodNamePartContext() returns a call node in the AST.
+     * This is because it has been called from several places some of which need a call node.
+     * We will use fields from the call node to construct the method node. Post that,
+     * we will discard the call node since it is of no further use to us
+     */
 
     val classPath = classStack.toList.mkString(".") + "."
     val methodNode = NewMethod()
-      .code(callNode.code)
+      .code(ctx.getText)
       .name(callNode.name)
       .fullName(s"$filename:${callNode.name}")
       .columnNumber(callNode.columnNumber)
       .lineNumber(callNode.lineNumber)
+      .lineNumberEnd(ctx.END().getSymbol.getLine)
       .filename(filename)
     callNode.methodFullName(classPath + callNode.name)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -434,11 +434,26 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct code for a indexing expression" in {
-      val cpg = code("def some_method(index)\n some_map[index]\nend")
+      val cpg            = code("def some_method(index)\n some_map[index]\nend")
       val List(callNode) = cpg.call.name(Operators.indexAccess).l
       callNode.code shouldBe "some_map[index]"
       callNode.lineNumber shouldBe Some(2)
       callNode.columnNumber shouldBe Some(9)
+    }
+
+    "have correct code for overloaded index operator" in {
+      val cpg = code("""
+          |class MyClass
+          |def [](key)
+          |  @member_hash[key]
+          |end
+          |end
+          |""".stripMargin)
+
+      val List(callNode) = cpg.call.name(Operators.indexAccess).l
+      callNode.code shouldBe "@member_hash[key]"
+      callNode.lineNumber shouldBe Some(4)
+      callNode.columnNumber shouldBe Some(14)
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -441,7 +441,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode.columnNumber shouldBe Some(9)
     }
 
-    "have correct code for overloaded index operator" in {
+    "have correct code for overloaded index operator method" in {
       val cpg = code("""
           |class MyClass
           |def [](key)
@@ -450,10 +450,42 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
           |end
           |""".stripMargin)
 
-      val List(callNode) = cpg.call.name(Operators.indexAccess).l
-      callNode.code shouldBe "@member_hash[key]"
-      callNode.lineNumber shouldBe Some(4)
-      callNode.columnNumber shouldBe Some(14)
+      val List(methodNode) = cpg.method.name("\\[]").l
+      methodNode.code shouldBe "def [](key)\n  @member_hash[key]\nend"
+      methodNode.lineNumber shouldBe Some(3)
+      methodNode.lineNumberEnd shouldBe Some(5)
+      methodNode.columnNumber shouldBe Some(4)
+    }
+
+    "have correct code for overloaded equality operator method" in {
+      val cpg = code("""
+          |class MyClass
+          |def ==(other)
+          |  @my_member==other
+          |end
+          |end
+          |""".stripMargin)
+
+      val List(methodNode) = cpg.method.name("==").l
+      methodNode.code shouldBe "def ==(other)\n  @my_member==other\nend"
+      methodNode.lineNumber shouldBe Some(3)
+      methodNode.lineNumberEnd shouldBe Some(5)
+      methodNode.columnNumber shouldBe Some(4)
+    }
+
+    "have correct code for class method" in {
+      val cpg = code("""
+          |class MyClass
+          |def some_method(param)
+          |end
+          |end
+          |""".stripMargin)
+
+      val List(methodNode) = cpg.method.name("some_method").l
+      methodNode.code shouldBe "def some_method(param)\nend"
+      methodNode.lineNumber shouldBe Some(3)
+      methodNode.lineNumberEnd shouldBe Some(4)
+      methodNode.columnNumber shouldBe Some(4)
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -432,5 +432,13 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(2)
     }
+
+    "have correct code for a indexing expression" in {
+      val cpg = code("def some_method(index)\n some_map[index]\nend")
+      val List(callNode) = cpg.call.name(Operators.indexAccess).l
+      callNode.code shouldBe "some_map[index]"
+      callNode.lineNumber shouldBe Some(2)
+      callNode.columnNumber shouldBe Some(9)
+    }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IdentifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IdentifierTests.scala
@@ -300,7 +300,7 @@ class IdentifierTests extends RubyCode2CpgFixture {
           |""".stripMargin)
 
     "recognise all identifier and call nodes" in {
-      cpg.method.name("\\[]").size shouldBe 2
+      cpg.method.name("\\[]").size shouldBe 1
       cpg.method.name("\\[]=").size shouldBe 1
       cpg.call.name(Operators.assignment).size shouldBe 3
       cpg.method.name("initialize").size shouldBe 1


### PR DESCRIPTION
1. Indexing expression name correction
2. Operator method name correction
3. Properly set code and `lineNumberEnd` for method node
4. Unit tests for the above