### PR TITLE
Flow From Identifier Receiver Source

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -78,9 +78,12 @@ class SourceToStartingPoints(src: StoredNode) extends RecursiveTask[List[CfgNode
       case x: Declaration =>
         List(x).collectAll[CfgNode].toList
       case x: Identifier =>
-        withFieldAndIndexAccesses(
+        (withFieldAndIndexAccesses(
           List(x).collectAll[CfgNode].toList ++ x.refsTo.collectAll[Local].flatMap(sourceToStartingPoints)
-        ) ++ x.refsTo.capturedByMethodRef.referencedMethod.flatMap(m => usagesForName(x.name, m))
+        ) ++ x.refsTo.capturedByMethodRef.referencedMethod.flatMap(m => usagesForName(x.name, m))).flatMap {
+          case x: Call => sourceToStartingPoints(x)
+          case x       => List(x)
+        }
       case x: Call =>
         (x._receiverIn.l :+ x).collect { case y: CfgNode => y }
       case x => List(x).collect { case y: CfgNode => y }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -460,4 +460,18 @@ class RegexDefinedFlowsDataFlowTests
     }
   }
 
+  "flows from receivers directly" should {
+    val cpg = code("""
+        |class Foo:
+        |   def func():
+        |      return "x"
+        |print(Foo.func())
+        |""".stripMargin)
+    "be found" in {
+      val src = cpg.identifier("Foo").l
+      val snk = cpg.call("print").l
+      snk.reachableByFlows(src).size shouldBe 2
+    }
+  }
+
 }


### PR DESCRIPTION
Extended the fix #2722 by testing when the source is an identifier and accommodating this case