### PR TITLE
dotgenerator: display Identifier in ControlStructure

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/ReachingDefTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/ReachingDefTests.scala
@@ -64,7 +64,7 @@ class ReachingDefTests extends DataFlowCodeToCpgSuite {
       id.name shouldBe "y"
 
       val List(ret) = cpg.method("foo").ast.isReturn.l
-      flowGraph.succ(ret).toSet shouldBe Set(paramOut1)
+      flowGraph.succ(ret).iterator.to(Set) shouldBe Set(paramOut1)
       flowGraph.succ(paramOut1) shouldBe List(paramOut2)
       flowGraph.succ(paramOut2) shouldBe List(fooMethod.methodReturn)
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/dotgenerator/DotCfgGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/dotgenerator/DotCfgGeneratorTests.scala
@@ -66,4 +66,34 @@ class DotCfgGeneratorTests extends CCodeToCpgSuite {
 
   }
 
+  "DotCfgGeneratorTest3" should {
+    val cpg = code("""
+        |int example(int a, int b, int c) {
+        |  int x = 3;
+        |  if(a) {
+        |    foo();
+        |  }
+        |  if(b) {
+        |    foo_2();
+        |  }
+        |  if (c) {
+        |    foo_3();
+        |  }
+        |}
+        |""".stripMargin)
+
+    "contain identifiers as conditions" in {
+      inside(cpg.method.name("example").dotCfg.l) { case List(dotStr) =>
+        dotStr should (
+          startWith("digraph \"example\" {") and
+            include("<(IDENTIFIER,a,if (a))<SUB>4</SUB>>") and
+            include("<(IDENTIFIER,b,if (b))<SUB>7</SUB>>") and
+            include("<(IDENTIFIER,c,if (c))<SUB>10</SUB>>") and
+            endWith("}\n")
+        )
+      }
+    }
+
+  }
+
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -11,7 +11,6 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
-import overflowdb.traversal.NodeOps
 import overflowdb.traversal.toNodeTraversal
 
 class AstCreationPassTests extends AbstractPassTest {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Dispatch
 import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.passes.controlflow.cfgcreation.Cfg.CfgEdgeType
 import overflowdb.BatchedUpdate.DiffGraphBuilder
-import overflowdb.traversal.Traversal
 
 /** Translation of abstract syntax trees into control flow graphs
   *

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/CpgCfgAdapter.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/CpgCfgAdapter.scala
@@ -2,8 +2,6 @@ package io.joern.x2cpg.passes.controlflow.cfgdominator
 
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 
-import scala.jdk.CollectionConverters._
-
 class CpgCfgAdapter extends CfgAdapter[StoredNode] {
   override def successors(node: StoredNode): IterableOnce[StoredNode] = {
     node._cfgOut

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/ReverseCpgCfgAdapter.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgdominator/ReverseCpgCfgAdapter.scala
@@ -2,8 +2,6 @@ package io.joern.x2cpg.passes.controlflow.cfgdominator
 
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 
-import scala.jdk.CollectionConverters._
-
 class ReverseCpgCfgAdapter extends CfgAdapter[StoredNode] {
   override def successors(node: StoredNode): IterableOnce[StoredNode] = {
     node._cfgIn

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/codepencegraph/CdgPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/codepencegraph/CdgPass.scala
@@ -42,7 +42,7 @@ class CdgPass(cpg: Cpg) extends ForkJoinParallelCpgPass[Method](cpg) {
           if (containsIn == null || !containsIn.hasNext) {
             logger.warn(s"Found CDG edge starting at $nodeLabel node. This is most likely caused by an invalid CFG.")
           } else {
-            val method = containsIn.next
+            val method = containsIn.next()
             logger.warn(
               s"Found CDG edge starting at $nodeLabel node. This is most likely caused by an invalid CFG." +
                 s" Method: ${method match {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/codepencegraph/CpgPostDomTreeAdapter.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/codepencegraph/CpgPostDomTreeAdapter.scala
@@ -2,7 +2,6 @@ package io.joern.x2cpg.passes.controlflow.codepencegraph
 
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.joern.x2cpg.passes.controlflow.cfgdominator.DomTreeAdapter
-import overflowdb.traversal._
 
 class CpgPostDomTreeAdapter extends DomTreeAdapter[StoredNode] {
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -167,7 +167,7 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
       NewNamespaceBlock().name(XTypeHintCallLinker.namespace).fullName(XTypeHintCallLinker.namespace)
 
     builder.addNode(speculativeNamespace)
-    newMethods
+    newMethods.iterator
       .filter(_.astParentFullName == XTypeHintCallLinker.namespace)
       .foreach(m => builder.addEdge(speculativeNamespace, m, EdgeTypes.AST))
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/LinkingUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/LinkingUtil.scala
@@ -13,7 +13,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import overflowdb.NodeDb
 import overflowdb.PropertyKey
-import overflowdb.traversal.Traversal
 import overflowdb.NodeRef
 import overflowdb.traversal._
 import overflowdb.traversal.ChainedImplicitsTemp._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CallGraphGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CallGraphGenerator.scala
@@ -11,7 +11,7 @@ class CallGraphGenerator {
 
   def generate(cpg: Cpg): Graph = {
     val subgraph = mutable.HashMap.empty[String, Seq[StoredNode]]
-    val vertices = cpg.all.collect { case m: Method => m }.l
+    val vertices = cpg.method.l
     val edges = for {
       srcMethod <- vertices
       _ = storeInSubgraph(srcMethod, subgraph)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CdgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CdgGenerator.scala
@@ -10,10 +10,7 @@ class CdgGenerator extends CfgGenerator {
 
   override val edgeType: String = EdgeTypes.CDG
 
-  override def expand(v: StoredNode): Iterator[Edge] = {
-    v._cdgOut
-      .filter(_.isInstanceOf[StoredNode])
-      .map(node => Edge(v, node, edgeType = edgeType))
-  }
+  override def expand(v: StoredNode): Iterator[Edge] =
+    v._cdgOut.map(node => Edge(v, node, edgeType = edgeType))
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
@@ -6,8 +6,6 @@ import io.shiftleft.semanticcpg.dotgenerator.DotSerializer.{Edge, Graph}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.Node
 
-import scala.jdk.CollectionConverters._
-
 class CfgGenerator {
 
   val edgeType: String = EdgeTypes.CFG
@@ -43,19 +41,21 @@ class CfgGenerator {
     )
   }
 
-  protected def expand(v: StoredNode): Iterator[Edge] = {
-    v._cfgOut
-      .filter(_.isInstanceOf[StoredNode])
-      .map(node => Edge(v, node, edgeType = edgeType))
+  protected def expand(v: StoredNode): Iterator[Edge] =
+    v._cfgOut.map(node => Edge(v, node, edgeType = edgeType))
+
+  private def isConditionInControlStructure(v: Node): Boolean = v match {
+    case id: Identifier => id.astParent.isControlStructure
+    case _              => false
   }
 
-  def cfgNodeShouldBeDisplayed(v: Node): Boolean = !(
-    v.isInstanceOf[Literal] ||
-      v.isInstanceOf[Identifier] ||
-      v.isInstanceOf[Block] ||
-      v.isInstanceOf[ControlStructure] ||
-      v.isInstanceOf[JumpTarget] ||
-      v.isInstanceOf[MethodParameterIn]
-  )
+  private def cfgNodeShouldBeDisplayed(v: Node): Boolean =
+    isConditionInControlStructure(v) ||
+      !(v.isInstanceOf[Literal] ||
+        v.isInstanceOf[Identifier] ||
+        v.isInstanceOf[Block] ||
+        v.isInstanceOf[ControlStructure] ||
+        v.isInstanceOf[JumpTarget] ||
+        v.isInstanceOf[MethodParameterIn])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/TypeHierarchyGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/TypeHierarchyGenerator.scala
@@ -11,8 +11,8 @@ class TypeHierarchyGenerator {
 
   def generate(cpg: Cpg): Graph = {
     val subgraph         = mutable.HashMap.empty[String, Seq[StoredNode]]
-    val vertices         = cpg.all.collect { case m: TypeDecl => m }.l
-    val typeToIsExternal = cpg.all.collect { case m: TypeDecl => m }.map { t => t.fullName -> t.isExternal }.toMap
+    val vertices         = cpg.typeDecl.l
+    val typeToIsExternal = vertices.map { t => t.fullName -> t.isExternal }.toMap
     val edges = for {
       srcTypeDecl <- vertices
       srcType     <- srcTypeDecl._typeViaRefIn.l

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -131,7 +131,6 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
 
 object AstNodeMethods {
 
-  import scala.jdk.CollectionConverters._
   private def lastExpressionInBlock(block: Block): Option[Expression] =
     block._astOut
       .collect {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -9,7 +9,6 @@ import org.json4s._
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.traversal.Traversal
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 


### PR DESCRIPTION
Structures like `int a; if(a) { foo(); }` are actually something like `int a; if(a!=null) { foo(); }`. Hence `a` is the condition in the CFG and should be displayed even if it's just an Identifier. This PR fixes that.

See: https://discord.com/channels/832209896089976854/832214243230744626/1115821653956513884

Also: some minor clean-ups.