### PR TITLE
Point Symbol to Non-Meta Type Ref + Contains Edge Fix 

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -324,7 +324,8 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
   override protected def visitIdentifierAssignedToTypeRef(i: Identifier, t: TypeRef, rec: Option[String]): Set[String] =
     t.typ.referencedTypeDecl.astSiblings
       .collectFirst { case td: TypeDecl => td }
-      .map(td => symbolTable.append(CallAlias(i.name, rec), Set(td.fullName)))
+      .map(_.fullName.stripSuffix("<meta>"))
+      .map(td => symbolTable.append(CallAlias(i.name, rec), Set(td)))
       .getOrElse(super.visitIdentifierAssignedToTypeRef(i, t, rec))
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -322,10 +322,10 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
   }
 
   override protected def visitIdentifierAssignedToTypeRef(i: Identifier, t: TypeRef, rec: Option[String]): Set[String] =
-    t.typ.referencedTypeDecl.astSiblings
-      .collectFirst { case td: TypeDecl => td }
+    t.typ.referencedTypeDecl
       .map(_.fullName.stripSuffix("<meta>"))
       .map(td => symbolTable.append(CallAlias(i.name, rec), Set(td)))
+      .headOption
       .getOrElse(super.visitIdentifierAssignedToTypeRef(i, t, rec))
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -958,7 +958,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
             builder.addNode(mRef)
             builder.addEdge(mRef, m, EdgeTypes.REF)
             builder.addEdge(inCall, mRef, EdgeTypes.AST)
-            builder.addEdge(mRef, funcPtr.method, EdgeTypes.CONTAINS)
+            builder.addEdge(funcPtr.method, mRef, EdgeTypes.CONTAINS)
             inCall match {
               case x: Call =>
                 builder.addEdge(x, mRef, EdgeTypes.ARGUMENT)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -958,6 +958,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
             builder.addNode(mRef)
             builder.addEdge(mRef, m, EdgeTypes.REF)
             builder.addEdge(inCall, mRef, EdgeTypes.AST)
+            builder.addEdge(mRef, funcPtr.method, EdgeTypes.CONTAINS)
             inCall match {
               case x: Call =>
                 builder.addEdge(x, mRef, EdgeTypes.ARGUMENT)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -937,16 +937,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     baseTypes
       .map(t => if (t.endsWith(funcName)) t else s"$t$pathSep$funcName")
       .flatMap(p => cpg.method.fullNameExact(p))
-      .map { m =>
-        (
-          m,
-          NewMethodRef()
-            .code(s"${baseName.map(_.appended(pathSep)).getOrElse("")}$funcName")
-            .methodFullName(m.fullName)
-            .lineNumber(funcPtr.lineNumber)
-            .columnNumber(funcPtr.columnNumber)
-        )
-      }
+      .map(m => m -> createMethodRef(baseName, funcName, m.fullName, funcPtr.lineNumber, funcPtr.columnNumber))
       .filterNot { case (_, mRef) =>
         addedNodes.contains((funcPtr.id(), s"${mRef.label()}$pathSep${mRef.methodFullName}"))
       }
@@ -955,20 +946,40 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
           .filterNot(_.astChildren.isMethodRef.methodFullNameExact(mRef.methodFullName).nonEmpty)
           .foreach { inCall =>
             state.changesWereMade.compareAndSet(false, true)
-            builder.addNode(mRef)
-            builder.addEdge(mRef, m, EdgeTypes.REF)
-            builder.addEdge(inCall, mRef, EdgeTypes.AST)
-            builder.addEdge(funcPtr.method, mRef, EdgeTypes.CONTAINS)
-            inCall match {
-              case x: Call =>
-                builder.addEdge(x, mRef, EdgeTypes.ARGUMENT)
-                mRef.argumentIndex(x.argumentOut.size + 1)
-              case x =>
-                mRef.argumentIndex(x.astChildren.size + 1)
-            }
+            integrateMethodRef(funcPtr, m, mRef, inCall)
           }
-        addedNodes.add((funcPtr.id(), s"${mRef.label()}$pathSep${mRef.methodFullName}"))
       }
+  }
+
+  private def createMethodRef(
+    baseName: Option[String],
+    funcName: String,
+    methodFullName: String,
+    lineNo: Option[Integer],
+    columnNo: Option[Integer]
+  ): NewMethodRef =
+    NewMethodRef()
+      .code(s"${baseName.map(_.appended(pathSep)).getOrElse("")}$funcName")
+      .methodFullName(methodFullName)
+      .lineNumber(lineNo)
+      .columnNumber(columnNo)
+
+  /** Integrate this method ref node into the CPG according to schema rules. Since we're adding this after the base
+    * passes, we need to add the necessary linking manually.
+    */
+  private def integrateMethodRef(funcPtr: Expression, m: Method, mRef: NewMethodRef, inCall: AstNode) = {
+    builder.addNode(mRef)
+    builder.addEdge(mRef, m, EdgeTypes.REF)
+    builder.addEdge(inCall, mRef, EdgeTypes.AST)
+    builder.addEdge(funcPtr.method, mRef, EdgeTypes.CONTAINS)
+    inCall match {
+      case x: Call =>
+        builder.addEdge(x, mRef, EdgeTypes.ARGUMENT)
+        mRef.argumentIndex(x.argumentOut.size + 1)
+      case x =>
+        mRef.argumentIndex(x.astChildren.size + 1)
+    }
+    addedNodes.add((funcPtr.id(), s"${mRef.label()}$pathSep${mRef.methodFullName}"))
   }
 
   protected def persistType(x: StoredNode, types: Set[String]): Unit = {


### PR DESCRIPTION
* When an identifier is given a type reference, strip the <meta> suffix if one is present
* If a new node is created as a result of the type recovery, attach the contains edge appropriately