### PR TITLE
Slicing Documentation: Towards Formalizing the Slices

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
@@ -6,16 +6,14 @@ import io.shiftleft.codepropertygraph.generated.PropertyNames
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 
-import scala.collection.mutable.ArrayBuffer
-
 object DataFlowSlicing {
 
-  def calculateDataFlowSlice(cpg: Cpg, config: DataFlowConfig): ProgramDataFlowSlice = {
-    val sliceMapping = (config.fileFilter match {
+  def calculateDataFlowSlice(cpg: Cpg, config: DataFlowConfig): Option[DataFlowSlice] = {
+    (config.fileFilter match {
       case Some(fileName) => cpg.file.nameExact(fileName).ast.isCall
       case None           => cpg.call
-    }).toBuffer.groupBy[Method] { _.method }.map { case (m: Method, calls: ArrayBuffer[Call]) =>
-      m.fullName -> calls.map { c =>
+    }).toBuffer
+      .map { c: Call =>
         val sinks = c.argument.l
 
         val sliceNodes = sinks.iterator.repeat(_.ddgIn)(_.maxDepth(config.sliceDepth).emit).dedup.l
@@ -26,9 +24,12 @@ object DataFlowSlicing {
           .toSet
         val methodToNodes = sliceNodes.groupBy(_.method).map { case (m, ns) => m.fullName -> ns.map(_.id()).toSet }
         DataFlowSlice(sliceNodes.map(cfgNodeToSliceNode).toSet, sliceEdges, methodToNodes)
-      }.toSet
-    }
-    ProgramDataFlowSlice(sliceMapping)
+      }
+      .reduceOption { (a, b) =>
+        val methodToChildNode = (a.methodToChildNode.keys ++ b.methodToChildNode.keys)
+          .map(k => k -> (a.methodToChildNode.getOrElse(k, Set.empty) ++ b.methodToChildNode.getOrElse(k, Set.empty)))
+        DataFlowSlice(a.nodes ++ b.nodes, a.edges ++ b.edges, methodToChildNode.toMap)
+      }
   }
 
   private def cfgNodeToSliceNode(cfgNode: CfgNode): SliceNode = {
@@ -40,8 +41,10 @@ object DataFlowSlicing {
       columnNumber = cfgNode.columnNumber.getOrElse(-1)
     )
     cfgNode match {
-      case n: Method => sliceNode.copy(name = n.name, typeFullName = n.methodReturn.typeFullName)
-      case n: Return => sliceNode.copy(name = "RET", typeFullName = n.method.methodReturn.typeFullName)
+      case n: Method    => sliceNode.copy(name = n.name, typeFullName = n.methodReturn.typeFullName)
+      case n: Return    => sliceNode.copy(name = "RET", typeFullName = n.method.methodReturn.typeFullName)
+      case n: MethodRef => sliceNode.copy(name = n.methodFullName, code = n.code)
+      case n: TypeRef   => sliceNode.copy(name = n.typeFullName, code = n.code)
       case n =>
         sliceNode.copy(
           name = n.property(PropertyNames.NAME, ""),

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
@@ -13,7 +13,7 @@ object DataFlowSlicing {
       case Some(fileName) => cpg.file.nameExact(fileName).ast.isCall
       case None           => cpg.call
     }).toBuffer
-      .map { c: Call =>
+      .map { (c: Call) =>
         val sinks = c.argument.l
 
         val sliceNodes = sinks.iterator.repeat(_.ddgIn)(_.maxDepth(config.sliceDepth).emit).dedup.l

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
@@ -41,7 +41,8 @@ package object slicing {
     override val dummyTypesEnabled: Boolean = false,
     override val fileFilter: Option[String] = None,
     minNumCalls: Int = 1,
-    excludeOperatorCalls: Boolean = false
+    excludeOperatorCalls: Boolean = false,
+    excludeMethodSource: Boolean = false
   ) extends BaseConfig
 
   /** A trait for all objects that represent a 1:1 relationship between the CPG and all the slices extracted.
@@ -141,6 +142,28 @@ package object slicing {
   implicit val encodeObjectUsageSlice: Encoder[ObjectUsageSlice] =
     Encoder.instance { case ObjectUsageSlice(c, p, r, a) =>
       Json.obj("targetObj" -> c.asJson, "definedBy" -> p.asJson, "invokedCalls" -> r.asJson, "argToCalls" -> a.asJson)
+    }
+
+  /** Packages the object usage slices along with the method source code.
+    *
+    * @param source
+    *   source code.
+    * @param slices
+    *   the object usage slices.
+    */
+  case class MethodUsageSlice(source: String, slices: Set[ObjectUsageSlice])
+
+  implicit val decodeMethodUsageSlice: Decoder[MethodUsageSlice] =
+    (c: HCursor) =>
+      for {
+        x <- c.downField("source").as[String]
+        y <- c.downField("slices").as[Set[ObjectUsageSlice]]
+      } yield {
+        MethodUsageSlice(x, y)
+      }
+  implicit val encodeMethodUsageSlice: Encoder[MethodUsageSlice] =
+    Encoder.instance { case MethodUsageSlice(x, y) =>
+      Json.obj("source" -> x.asJson, "slices" -> y.asJson)
     }
 
   /** Represents a component that carries data. This could be an identifier of a variable or method and supplementary
@@ -265,10 +288,8 @@ package object slicing {
     * @param userDefinedTypes
     *   the UDTs.
     */
-  case class ProgramUsageSlice(
-    objectSlices: Map[String, Set[ObjectUsageSlice]],
-    userDefinedTypes: List[UserDefinedType]
-  ) extends ProgramSlice {
+  case class ProgramUsageSlice(objectSlices: Map[String, MethodUsageSlice], userDefinedTypes: List[UserDefinedType])
+      extends ProgramSlice {
 
     def toJson: String = this.asJson.toString()
 
@@ -278,7 +299,7 @@ package object slicing {
   implicit val decodeProgramUsageSlice: Decoder[ProgramUsageSlice] =
     (c: HCursor) =>
       for {
-        o <- c.downField("objectSlices").as[Map[String, Set[ObjectUsageSlice]]]
+        o <- c.downField("objectSlices").as[Map[String, MethodUsageSlice]]
         u <- c.downField("userDefinedTypes").as[List[UserDefinedType]]
       } yield {
         ProgramUsageSlice(o, u)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
@@ -64,6 +64,11 @@ package object slicing {
     *   a mapping between method names and which nodes fall under them.
     */
   case class DataFlowSlice(nodes: Set[SliceNode], edges: Set[SliceEdge], methodToChildNode: Map[String, Set[Long]])
+      extends ProgramSlice {
+    def toJson: String = this.asJson.toString()
+
+    def toJsonPretty: String = this.asJson.spaces2
+  }
 
   implicit val encodeDataFlowSlice: Encoder[DataFlowSlice] = Encoder.instance {
     case DataFlowSlice(nodes, edges, methodToChildNode) =>
@@ -97,19 +102,6 @@ package object slicing {
 
   implicit val encodeSliceEdge: Encoder[SliceEdge] = Encoder.instance { case SliceEdge(src, dst, label) =>
     Json.obj("src" -> src.asJson, "dst" -> dst.asJson, "label" -> label.asJson)
-  }
-
-  /** The data-flow slices for the program grouped by procedure.
-    *
-    * @param dataFlowSlices
-    *   the mapped slices.
-    */
-  case class ProgramDataFlowSlice(dataFlowSlices: Map[String, Set[DataFlowSlice]]) extends ProgramSlice {
-
-    def toJson: String = this.asJson.toString()
-
-    def toJsonPretty: String = this.asJson.spaces2
-
   }
 
   /** A usage slice of an object at the start of its definition until its final usage.

--- a/joern-cli/JOERN_SLICE.md
+++ b/joern-cli/JOERN_SLICE.md
@@ -1,0 +1,130 @@
+# Joern Slice
+
+`JoernSlice` is the entrypoint for `joern-slice` and specifies ways to extract useful subsets of information from the
+CPG. Two modes are available:
+
+* **Data-flow**: This is a pretty standard backwards data-flow slicing command that starts at call arguments and slices 
+backwards to create a graph of slices. This is interprocedural and the paths are only limited by a depth argument with a
+default of 20.
+* **Usages**: This targets locals and parameters and traces what calls they make and in which calls they are used. This is
+useful for describing how a variable interacts in a procedure.
+
+## Schemas
+
+Each slicer outputs JSON, which allows the result to be ingested by other processes or libraries e.g. NetworkX.
+
+### Data-Flow
+
+This creates a graph with an additional mapping to denote the methods under which each node belongs:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "number",
+      "label": "string",
+      "name": "string",
+      "code": "string",
+      "typeFullName": "string",
+      "lineNumber": "number",
+      "columnNumber": "number"
+    },
+    ...
+  ],
+  "edges": [
+    {
+      "src": "number",
+      "dst": "number",
+      "label": "string"
+    }
+  ],
+  "methodToChildNode": {
+    "<method_name_a>": [
+      "node_id_1",
+      "node_id_2"
+    ],
+    "<method_name_b>": [],
+    ...
+  }
+}
+```
+
+### Usages
+
+The usages slice describes how a variable interacts within its procedure. This is perhaps a more "descriptive" slice
+in some ways. The variables are locals and parameters and the referencing identifiers are tracked to find what the
+variable calls and what calls it forms an argument of.
+
+```json
+{
+  "objectSlices": {
+    "<method_name_a>": [
+      {
+        "targetObj": {
+          "name": "identifier_name",
+          "typeFullName": "identifier_type",
+          "literal": "boolean"
+        },
+        "definedBy": {
+          "name": "identifier_name",
+          "typeFullName": "identifier_type",
+          "literal": "boolean"
+        },
+        "invokedCalls": [
+          {
+            "callName": "name_of_call",
+            "paramTypes": [
+              "type_of_param1",
+              "type_of_param2",
+              "type_of_paramN"
+            ],
+            "returnType": "return_type"
+          }
+        ],
+        "argToCalls": [
+          [
+            {
+              "callName": "name_of_call",
+              "paramTypes": [
+                "type_of_param1",
+                "type_of_param2",
+                "type_of_paramN"
+              ],
+              "returnType": "return_type"
+            },
+            "number_of_argument_targetObj_is_in"
+          ]
+        ]
+      }, 
+      ...
+    ],
+    "<method_name_b>": [
+      ...
+    ],
+    ...
+  },
+  "userDefinedTypes": [
+    {
+      "name": "type_name",
+      "fields": [
+        {
+          "name": "field_name",
+          "typeFullName": "type of the field",
+          "literal": "boolean"
+        }
+      ],
+      "procedures": [
+        {
+          "callName": "name_of_call",
+          "paramTypes": [
+            "type_of_param1",
+            "type_of_param2",
+            "type_of_paramN"
+          ],
+          "returnType": "return_type"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
@@ -16,7 +16,7 @@ object JoernSlice {
   import io.joern.dataflowengineoss.slicing._
 
   private val configParser = new scopt.OptionParser[BaseConfig]("joern-slice") {
-    head("Extract intra-procedural slices from the CPG.")
+    head("Extract various slices from the CPG.")
     help("help")
     arg[String]("cpg")
       .text("input CPG file name - defaults to `cpg.bin`")
@@ -89,6 +89,14 @@ object JoernSlice {
           .action((_, c) =>
             c match {
               case c: UsagesConfig => c.copy(excludeOperatorCalls = true)
+              case _               => c
+            }
+          ),
+        opt[Unit]("exclude-source")
+          .text(s"excludes method source code in the slices - defaults to false.")
+          .action((_, c) =>
+            c match {
+              case c: UsagesConfig => c.copy(excludeMethodSource = true)
               case _               => c
             }
           )

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
@@ -112,12 +112,12 @@ object JoernSlice {
           checkAndApplyOverlays(cpg)
           // Slice the CPG
           (config match {
-            case x: DataFlowConfig => Option(DataFlowSlicing.calculateDataFlowSlice(cpg, x))
+            case x: DataFlowConfig => DataFlowSlicing.calculateDataFlowSlice(cpg, x)
             case x: UsagesConfig   => Option(UsageSlicing.calculateUsageSlice(cpg, x))
             case _                 => None
           }) match {
             case Some(programSlice: ProgramSlice) => saveSlice(config.outFile, programSlice)
-            case None                             =>
+            case None                             => println("Empty slice, no file generated.")
           }
         }
       }

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernSliceTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernSliceTests.scala
@@ -19,7 +19,7 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
         .asInstanceOf[ProgramUsageSlice]
 
     "extract 'express.js' slice" in {
-      val Some(slice) = programSlice.objectSlices.get("main.js::program").flatMap(_.headOption)
+      val Some(slice) = programSlice.objectSlices.get("main.js::program").flatMap(_.slices.headOption)
       slice.definedBy shouldBe Some(DefComponent("express", "ANY"))
       slice.targetObj shouldBe DefComponent("app", "ANY")
 
@@ -54,7 +54,7 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
     }
 
     "extract 'Car' object instantiation" in {
-      val Some(slice) = programSlice.objectSlices.get("main.js::program:carTest").flatMap(_.headOption)
+      val Some(slice) = programSlice.objectSlices.get("main.js::program:carTest").flatMap(_.slices.headOption)
       slice.definedBy shouldBe Some(DefComponent("new Car", "ANY"))
       slice.targetObj shouldBe DefComponent("c", "main.js::program:Car")
 
@@ -82,7 +82,7 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
         .asInstanceOf[ProgramUsageSlice]
 
     "extract 'name' parameter slice from 'startScene'" in {
-      val Some(slice) = programSlice.objectSlices.get("main.ts::program:Game:startScene").flatMap(_.headOption)
+      val Some(slice) = programSlice.objectSlices.get("main.ts::program:Game:startScene").flatMap(_.slices.headOption)
       slice.definedBy shouldBe Some(DefComponent("name", "__ecma.String"))
       slice.targetObj shouldBe DefComponent("name", "__ecma.String")
 
@@ -95,7 +95,7 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
     }
 
     "extract 'loader' object slice from the main program" in {
-      val Some(slice) = programSlice.objectSlices.get("main.ts::program").flatMap(_.headOption)
+      val Some(slice) = programSlice.objectSlices.get("main.ts::program").flatMap(_.slices.headOption)
       slice.definedBy shouldBe Some(DefComponent("new Loader", "ANY"))
       slice.targetObj shouldBe DefComponent("loader", "ANY")
 
@@ -107,7 +107,8 @@ class JoernSliceTests extends AnyWordSpec with Matchers with AbstractJoernCliTes
     }
 
     "extract 'time' parameter slice from the lambda in 'loop'" in {
-      val Some(slice) = programSlice.objectSlices.get("main.ts::program:Game:loop:anonymous").flatMap(_.headOption)
+      val Some(slice) =
+        programSlice.objectSlices.get("main.ts::program:Game:loop:anonymous").flatMap(_.slices.headOption)
       slice.definedBy shouldBe Some(DefComponent("time", "__ecma.Number"))
       slice.targetObj shouldBe DefComponent("time", "__ecma.Number")
 


### PR DESCRIPTION
* Simplified data-flow slice
* Modified usages slice to include source code, the one that `joernti` [CodeTIDAL5](https://github.com/joernio/type-inference-models/blob/main/data/model_checkpoints/download_codet5_model.sh) uses
* Increased documentation on `JOERN_SLICE.md`

Note: This will be followed up by the TODO's laid out under `JOERN_SLICE.md`. For now, the usage slices here match `dave/joernti` and this is an effort to set a Joern version with a reproducible artifact following the work on [JoernTI](https://github.com/joernio/type-inference-models). A separate repository will be created to showcase this interaction as to not be something to maintain in Joern directly.