### PR TITLE
rubysrc2cpg: support for Gemfile{.lock} as CONFIG_FILES(s)

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg
 
-import io.joern.rubysrc2cpg.passes.AstCreationPass
+import io.joern.rubysrc2cpg.passes.{AstCreationPass, ConfigPass}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
@@ -17,6 +17,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
   override def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
       new MetaDataPass(cpg, Languages.RUBYSRC, config.inputPath).createAndApply()
+      new ConfigPass(cpg, config.inputPath).createAndApply()
       val astCreationPass = new AstCreationPass(config.inputPath, cpg)
       astCreationPass.createAndApply()
       new TypeNodePass(astCreationPass.allUsedTypes(), cpg).createAndApply()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigPass.scala
@@ -1,0 +1,34 @@
+package io.joern.rubysrc2cpg.passes
+
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.utils.IOUtils
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+
+/** Creates the CONFIGURATION layer from any existing `Gemfile` or `Gemfile.lock` files found in `inputPath` at root
+  * level.
+  */
+class ConfigPass(cpg: Cpg, inputPath: String) extends ConcurrentWriterCpgPass[Path](cpg) {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def generateParts(): Array[Path] = lookForGemfiles(inputPath)
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, gemfilePath: Path): Unit = {
+    val configFileName     = gemfilePath.getFileName.toString
+    val configFileContents = IOUtils.readEntireFile(gemfilePath)
+    val configFileNode     = NewConfigFile().name(configFileName).content(configFileContents)
+    diffGraph.addNode(configFileNode)
+    logger.debug(s"Added file '$configFileName' as config.")
+  }
+
+  /** Returns the paths of any root-leveled `Gemfile` or `Gemfile.lock` file.
+    */
+  private def lookForGemfiles(inputPath: String): Array[Path] = {
+    val rootPath = File(inputPath)
+    val gemFiles = Set("Gemfile", "Gemfile.lock").map(rootPath / _)
+    gemFiles.filter(_.exists).filter(_.isRegularFile).map(_.path).toArray
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigPassTest.scala
@@ -1,0 +1,100 @@
+package io.joern.rubysrc2cpg.passes
+
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ConfigPassTest extends AnyWordSpec with Matchers {
+
+  "ConfigPass for Gemfile files" should {
+
+    "generate a ConfigFile accordingly" in {
+      File.usingTemporaryDirectory(prefix = "rubysrc2cpgTest") { dir =>
+        val gemfile = dir / "Gemfile"
+
+        val gemfileContents =
+          """
+            |source 'https://rubygems.org'
+            |gem 'json'
+            |""".stripMargin
+
+        gemfile.write(gemfileContents)
+
+        val cpg = Cpg.emptyCpg
+        new ConfigPass(cpg, dir.pathAsString).createAndApply()
+
+        val List(configGemfile) = cpg.configFile.l
+        configGemfile.name shouldBe "Gemfile"
+        configGemfile.content shouldBe gemfileContents
+      }
+    }
+
+    "ignore non-root Gemfile files" in {
+      File.usingTemporaryDirectory(prefix = "rubysrc2cpgTest") { dir =>
+        val subdir = dir / "subdir"
+        subdir.createDirectory()
+
+        val gemfile = subdir / "Gemfile"
+        val gemfileContents = "# ignore me"
+
+        gemfile.write(gemfileContents)
+
+        val cpg = Cpg.emptyCpg
+        new ConfigPass(cpg, dir.pathAsString).createAndApply()
+
+        cpg.configFile.l shouldBe Seq()
+      }
+    }
+  }
+
+  "ConfigPass for Gemfile.lock files" should {
+
+    "generate a ConfigFile accordingly" in {
+      File.usingTemporaryDirectory(prefix = "rubysrc2cpgTest") { dir =>
+        val gemfilelock = dir / "Gemfile.lock"
+
+        val gemfilelockContents =
+          """
+            |GEM
+            |  remote: https://rubygems.org/
+            |  specs:
+            |    CFPropertyList (3.0.1)
+            |
+            |PLATFORMS
+            |  ruby
+            |
+            |BUNDLED WITH
+            |   2.1.4
+            |""".stripMargin
+
+        gemfilelock.write(gemfilelockContents)
+
+        val cpg = Cpg.emptyCpg
+        new ConfigPass(cpg, dir.pathAsString).createAndApply()
+
+        val List(configGemfilelock) = cpg.configFile.l
+        configGemfilelock.name shouldBe "Gemfile.lock"
+        configGemfilelock.content shouldBe gemfilelockContents
+      }
+    }
+
+    "ignore non-root Gemfile.lock files" in {
+      File.usingTemporaryDirectory(prefix = "rubysrc2cpgTest") { dir =>
+        val subdir = dir / "subdir"
+        subdir.createDirectory()
+
+        val gemfilelock = subdir / "Gemfile.lock"
+        val gemfilelockContents = "# ignore me"
+
+        gemfilelock.write(gemfilelockContents)
+
+        val cpg = Cpg.emptyCpg
+        new ConfigPass(cpg, dir.pathAsString).createAndApply()
+
+        cpg.configFile.l shouldBe Seq()
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigPassTest.scala
@@ -12,22 +12,19 @@ class ConfigPassTest extends AnyWordSpec with Matchers {
 
     "generate a ConfigFile accordingly" in {
       File.usingTemporaryDirectory(prefix = "rubysrc2cpgTest") { dir =>
-        val gemfile = dir / "Gemfile"
-
+        val gemFileName = dir / "Gemfile"
         val gemfileContents =
           """
             |source 'https://rubygems.org'
             |gem 'json'
             |""".stripMargin
-
-        gemfile.write(gemfileContents)
+        gemFileName.write(gemfileContents)
 
         val cpg = Cpg.emptyCpg
         new ConfigPass(cpg, dir.pathAsString).createAndApply()
-
-        val List(configGemfile) = cpg.configFile.l
-        configGemfile.name shouldBe "Gemfile"
-        configGemfile.content shouldBe gemfileContents
+        val List(configFile) = cpg.configFile.l
+        configFile.name shouldBe "Gemfile"
+        configFile.content shouldBe gemfileContents
       }
     }
 
@@ -35,16 +32,13 @@ class ConfigPassTest extends AnyWordSpec with Matchers {
       File.usingTemporaryDirectory(prefix = "rubysrc2cpgTest") { dir =>
         val subdir = dir / "subdir"
         subdir.createDirectory()
-
-        val gemfile = subdir / "Gemfile"
-        val gemfileContents = "# ignore me"
-
-        gemfile.write(gemfileContents)
+        val gemFileName     = subdir / "Gemfile"
+        val gemFileContents = "# ignore me"
+        gemFileName.write(gemFileContents)
 
         val cpg = Cpg.emptyCpg
         new ConfigPass(cpg, dir.pathAsString).createAndApply()
-
-        cpg.configFile.l shouldBe Seq()
+        cpg.configFile.size shouldBe 0
       }
     }
   }
@@ -53,9 +47,8 @@ class ConfigPassTest extends AnyWordSpec with Matchers {
 
     "generate a ConfigFile accordingly" in {
       File.usingTemporaryDirectory(prefix = "rubysrc2cpgTest") { dir =>
-        val gemfilelock = dir / "Gemfile.lock"
-
-        val gemfilelockContents =
+        val gemFileName = dir / "Gemfile.lock"
+        val gemFileContents =
           """
             |GEM
             |  remote: https://rubygems.org/
@@ -68,15 +61,13 @@ class ConfigPassTest extends AnyWordSpec with Matchers {
             |BUNDLED WITH
             |   2.1.4
             |""".stripMargin
-
-        gemfilelock.write(gemfilelockContents)
+        gemFileName.write(gemFileContents)
 
         val cpg = Cpg.emptyCpg
         new ConfigPass(cpg, dir.pathAsString).createAndApply()
-
-        val List(configGemfilelock) = cpg.configFile.l
-        configGemfilelock.name shouldBe "Gemfile.lock"
-        configGemfilelock.content shouldBe gemfilelockContents
+        val List(configFile) = cpg.configFile.l
+        configFile.name shouldBe "Gemfile.lock"
+        configFile.content shouldBe gemFileContents
       }
     }
 
@@ -84,16 +75,13 @@ class ConfigPassTest extends AnyWordSpec with Matchers {
       File.usingTemporaryDirectory(prefix = "rubysrc2cpgTest") { dir =>
         val subdir = dir / "subdir"
         subdir.createDirectory()
+        val gemFileName     = subdir / "Gemfile.lock"
+        val gemFileContents = "# ignore me"
 
-        val gemfilelock = subdir / "Gemfile.lock"
-        val gemfilelockContents = "# ignore me"
-
-        gemfilelock.write(gemfilelockContents)
-
+        gemFileName.write(gemFileContents)
         val cpg = Cpg.emptyCpg
         new ConfigPass(cpg, dir.pathAsString).createAndApply()
-
-        cpg.configFile.l shouldBe Seq()
+        cpg.configFile.size shouldBe 0
       }
     }
   }


### PR DESCRIPTION
Stores the contents of any root-leveled `Gemfile` or `Gemfile.lock` files as CONFIG_FILE(s).

A future pass shall later process these CONFIG_FILE(s) in a similar manner to how pysrc2cpg handles `requirements.txt` files.