### PR TITLE
Increase Memory Alloc and Constrain Test Tasks

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,2 @@
 -J-Xms3G
--J-Xmx3G
+-J-Xmx4G

--- a/build.sbt
+++ b/build.sbt
@@ -85,9 +85,6 @@ ThisBuild / resolvers ++= Seq(
 )
 
 ThisBuild / Test / fork := true
-Global / concurrentRestrictions := Seq(
-  Tags.limit(Tags.Test, java.lang.Runtime.getRuntime.availableProcessors() * 2),
-)
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 

--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,9 @@ ThisBuild / resolvers ++= Seq(
 )
 
 ThisBuild / Test / fork := true
+Global / concurrentRestrictions := Seq(
+  Tags.limit(Tags.Test, java.lang.Runtime.getRuntime.availableProcessors() * 2),
+)
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 


### PR DESCRIPTION
Many of the runners on the CI/CD are aborting the test suites on occasion. This is likely to the scaling number of tests and parallelism of the test execution demanding more memory as development continues.

I've set the task limit on tests to be 2 x available cores and updated the memory via `.sbtopts`.

Alternatively I can update the memory in the CI/CD via
```
- name: Increase memory allocation
  run: echo "SBT_OPTS=Xmx4G Xms4G" >> $GITHUB_ENV
````