### PR TITLE
rubysrc2cpg: More fixes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -3,8 +3,10 @@ package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.parser.RubyParser._
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
-import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewControlStructure}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewCall, NewControlStructure, NewIdentifier}
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 trait AstForStatementsCreator { this: AstCreator =>
 
@@ -16,8 +18,24 @@ trait AstForStatementsCreator { this: AstCreator =>
   }
 
   protected def astForUndefStatement(ctx: UndefStatementContext): Ast = {
-    // TODO to be implemented
-    Ast()
+    val undefMethods =
+      ctx
+        .definedMethodNameOrSymbol()
+        .asScala
+        .flatMap(astForDefinedMethodNameOrSymbolContext(_))
+        .toSeq
+
+    val operatorName = RubyOperators.undef
+    val callNode = NewCall()
+      .name(operatorName)
+      .code(ctx.getText)
+      .methodFullName(operatorName)
+      .signature("")
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .typeFullName(Defines.Any)
+      .lineNumber(ctx.UNDEF().getSymbol().getLine())
+      .columnNumber(ctx.UNDEF().getSymbol().getCharPositionInLine())
+    callAst(callNode, undefMethods)
   }
 
   protected def astForBeginStatement(ctx: BeginStatementContext): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -617,6 +617,48 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode2.lineNumber shouldBe Some(2)
       callNode2.columnNumber shouldBe Some(0)
     }
-  }
 
+    "have correct structure for require with an expression" in {
+      val cpg = code("Dir[Rails.root.join('a', 'b', '**', '*.rb')].each { |f| require f }")
+
+      val List(callNode) = cpg.call.name("require").l
+      callNode.code shouldBe "require f"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(56)
+    }
+
+    "have correct structure in the body of module definition" in {
+      val cpg = code("module MyModule\ndef some_method\nend\nprivate\nend")
+
+      val List(callNode) = cpg.method.name("some_method").l
+      callNode.code shouldBe "def some_method\nend"
+      callNode.lineNumber shouldBe Some(2)
+      callNode.columnNumber shouldBe Some(4)
+
+      cpg.identifier.name("private").l.size shouldBe 0
+    }
+
+    "have correct structure for undef" in {
+      val cpg = code("undef method1,method2")
+
+      val List(callNode) = cpg.call.name("<operator>.undef").l
+      callNode.code shouldBe "undef method1,method2"
+      callNode.lineNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(0)
+    }
+
+    "have correct structure for class definition with body having only identifiers" in {
+      val cpg = code("class MyClass\nidentifier1\nidentifier2\nend")
+
+      val List(identifierNode1) = cpg.identifier.name("identifier1").l
+      identifierNode1.code shouldBe "identifier1"
+      identifierNode1.lineNumber shouldBe Some(2)
+      identifierNode1.columnNumber shouldBe Some(0)
+
+      val List(identifierNode2) = cpg.identifier.name("identifier2").l
+      identifierNode2.code shouldBe "identifier2"
+      identifierNode2.lineNumber shouldBe Some(3)
+      identifierNode2.columnNumber shouldBe Some(0)
+    }
+  }
 }


### PR DESCRIPTION
1. undef implementation
2. Crashfix for class body containing direct identifiers
3. Crashfix for import having an expression instead of a literal
4. Unit tests with the above

Some Ruby repositories that I usually import to test are now again getting imported with this PR without exceptions