### PR TITLE
jssrc2cpg: Include Members for Dynamic Exported Types

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -60,6 +60,11 @@ trait AstForTypesCreator { this: AstCreator =>
           .getOrElse(Ast())
       }
 
+    val allClassMembers = classMembersForTypeAlias(alias).toList
+    // adding all class methods / functions and uninitialized, non-static members
+    allClassMembers
+      .filter(member => isClassMethodOrUninitializedMember(member) && !isStaticMember(member))
+      .map(m => astForClassMember(m, aliasTypeDeclNode))
     typeDeclNodeAst.root.foreach(diffGraph.addEdge(methodAstParentStack.head, _, EdgeTypes.AST))
     Ast(aliasTypeDeclNode)
   }
@@ -84,6 +89,9 @@ trait AstForTypesCreator { this: AstCreator =>
       allMembers.filterNot(isConstructor) ++ dynamicallyDeclaredMembers
     }
   }
+
+  private def classMembersForTypeAlias(alias: BabelNodeInfo): Seq[Value] =
+    Try(alias.json("typeAnnotation")("members").arr).toOption.toSeq.flatten
 
   private def createFakeConstructor(
     code: String,
@@ -183,6 +191,10 @@ trait AstForTypesCreator { this: AstCreator =>
       case ExpressionStatement if isInitializedMember(classElement) =>
         val memberNodeInfo = createBabelNodeInfo(nodeInfo.json("expression")("left")("property"))
         val name           = memberNodeInfo.code
+        memberNode(nodeInfo, name, nodeInfo.code, typeFullName)
+      case TSPropertySignature =>
+        val memberNodeInfo = createBabelNodeInfo(nodeInfo.json("key"))
+        val name           = memberNodeInfo.json("name").str
         memberNode(nodeInfo, name, nodeInfo.code, typeFullName)
       case _ =>
         val name = nodeInfo.node match {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -60,11 +60,10 @@ trait AstForTypesCreator { this: AstCreator =>
           .getOrElse(Ast())
       }
 
-    val allClassMembers = classMembersForTypeAlias(alias).toList
     // adding all class methods / functions and uninitialized, non-static members
-    allClassMembers
+    classMembersForTypeAlias(alias)
       .filter(member => isClassMethodOrUninitializedMember(member) && !isStaticMember(member))
-      .map(m => astForClassMember(m, aliasTypeDeclNode))
+      .foreach(m => astForClassMember(m, aliasTypeDeclNode))
     typeDeclNodeAst.root.foreach(diffGraph.addEdge(methodAstParentStack.head, _, EdgeTypes.AST))
     Ast(aliasTypeDeclNode)
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
@@ -1,7 +1,6 @@
 package io.joern.jssrc2cpg.passes.ast
 
-import io.joern.jssrc2cpg.passes.AbstractPassTest
-import io.joern.jssrc2cpg.passes.Defines
+import io.joern.jssrc2cpg.passes.{AbstractPassTest, Defines}
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.semanticcpg.language._
 
@@ -280,6 +279,20 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
         c.fullName shouldBe "code.ts::program:A:B:C"
         c.typeDecl.name("Foo").head.fullName shouldBe "code.ts::program:A:B:C:Foo"
       }
+    }
+
+    "AST generation for dynamically exported and defined class" in TsAstFixture("""
+        |export type User = {
+        |    email: string;
+        |    organizationIds: string[];
+        |    username: string;
+        |    name: string;
+        |    gender: string;
+        |}
+        |""".stripMargin) { cpg =>
+      val Some(userType) = cpg.typeDecl.name("User").headOption
+      userType.member.name.l shouldBe List("email", "organizationIds", "username", "name", "gender")
+      userType.member.typeFullName.toSet shouldBe Set("__ecma.String", "string[]")
     }
 
   }


### PR DESCRIPTION
Accommodates an edge case where objects exported as types did not have members. I hope this doesn't create members for everything that is defined as an object in this way, but perhaps that's not the worst thing.