### PR TITLE
Make sure `lone identifier optimization` respects `return`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -72,7 +72,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Return via call w/o initialization" ignore {
+  "Return via call w/o initialization" should {
     val cpg = code("""
         |def add(p)
         |q = p


### PR DESCRIPTION
We previously removed lone identifiers even if they actually also appeared in `return` statements. That was incorrect but not triggered when the affected identifier was a local or parameter. The bug became apparent because in the ruby frontend, locals are currently missing. While we should add locals to the ruby CPG, this fix should be made nonetheless and it fixes a missing flow we were observing.
 