### PR TITLE
jssrc2cpg: Handle Type Literal Params

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
@@ -295,6 +295,22 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
       userType.member.typeFullName.toSet shouldBe Set("__ecma.String", "string[]")
     }
 
+    "AST generation for dynamically defined type in a parameter" in TsAstFixture("""
+        |class Test {
+        |    run(credentials: { username: string; password: string; }): string {
+        |        console.log(credentials);
+        |        return ``;
+        |    }
+        |}
+        |""".stripMargin) { cpg =>
+      val Some(credentialsType) = cpg.typeDecl.nameExact("_anon_cdecl").headOption
+      credentialsType.fullName shouldBe "code.ts::program:Test:run:_anon_cdecl"
+      credentialsType.member.name.l shouldBe List("username", "password")
+      credentialsType.member.typeFullName.toSet shouldBe Set("__ecma.String")
+      val Some(credentialsParam) = cpg.parameter.nameExact("credentials").headOption
+      credentialsParam.typeFullName shouldBe "code.ts::program:Test:run:_anon_cdecl"
+    }
+
   }
 
 }


### PR DESCRIPTION
* Use the same logic of type aliases for type literal parameters
* Create anon class from type literal parameters and set the param to these