### PR TITLE
rubysrc2cpg: fixes precedence of additive binary ops versus commands

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -47,10 +47,10 @@ statement
 // --------------------------------------------------------
 
 expressionOrCommand
-    :   (EMARK wsOrNl*)? invocationWithoutParentheses                                                               # invocationExpressionOrCommand
+    :   expression                                                                                                  # expressionExpressionOrCommand
+    |   (EMARK wsOrNl*)? invocationWithoutParentheses                                                               # invocationExpressionOrCommand
     |   NOT wsOrNl* expressionOrCommand                                                                             # notExpressionOrCommand
     |   <assoc=right> expressionOrCommand WS* op=(OR | AND) wsOrNl* expressionOrCommand                             # orAndExpressionOrCommand
-    |   expression                                                                                                  # expressionExpressionOrCommand
     ;
 
 expression

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -1,0 +1,72 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import com.sun.org.apache.xalan.internal.extensions.ExpressionContext
+import io.joern.rubysrc2cpg.parser.RubyParser._
+import io.joern.x2cpg.Ast
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+trait AstForExpressionsCreator { this: AstCreator =>
+
+  protected def astForPowerExpression(ctx: PowerExpressionContext): Ast = {
+    val argsAst = ctx.expression().asScala.flatMap(astForExpressionContext)
+    val call =
+      callNode(ctx, ctx.getText, Operators.exponentiation, Operators.exponentiation, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argsAst.toList)
+  }
+
+  protected def astForOrExpression(ctx: OperatorOrExpressionContext): Ast = {
+    val argsAst = ctx.expression().asScala.flatMap(astForExpressionContext)
+    val call    = callNode(ctx, ctx.getText, Operators.or, Operators.or, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argsAst.toList)
+  }
+
+  protected def astForAndExpression(ctx: OperatorAndExpressionContext): Ast = {
+    val argsAst = ctx.expression().asScala.flatMap(astForExpressionContext)
+    val call    = callNode(ctx, ctx.getText, Operators.and, Operators.and, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argsAst.toList)
+  }
+
+  protected def astForUnaryExpression(ctx: UnaryExpressionContext): Ast = ctx.op.getType match {
+    case TILDE => astForUnaryTildeExpression(ctx)
+    case PLUS  => astForUnaryPlusExpression(ctx)
+    case EMARK => astForUnaryNotExpression(ctx)
+  }
+
+  protected def astForUnaryPlusExpression(ctx: UnaryExpressionContext): Ast = {
+    val argsAst = astForExpressionContext(ctx.expression())
+    val call    = callNode(ctx, ctx.getText, Operators.plus, Operators.plus, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argsAst)
+  }
+
+  protected def astForUnaryTildeExpression(ctx: UnaryExpressionContext): Ast = {
+    val argsAst = astForExpressionContext(ctx.expression())
+    val call    = callNode(ctx, ctx.getText, Operators.not, Operators.not, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argsAst)
+  }
+
+  protected def astForUnaryNotExpression(ctx: UnaryExpressionContext): Ast = {
+    val argsAst = astForExpressionContext(ctx.expression())
+    val call    = callNode(ctx, ctx.getText, Operators.not, Operators.not, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argsAst)
+  }
+
+  protected def astForAdditiveExpression(ctx: AdditiveExpressionContext): Ast = ctx.op.getType match {
+    case PLUS  => astForAdditivePlusExpression(ctx)
+    case MINUS => astForAdditiveMinusExpression(ctx)
+  }
+
+  protected def astForAdditivePlusExpression(ctx: AdditiveExpressionContext): Ast = {
+    val argsAst = ctx.expression().asScala.flatMap(astForExpressionContext)
+    val call    = callNode(ctx, ctx.getText, Operators.addition, Operators.addition, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argsAst.toList)
+  }
+
+  protected def astForAdditiveMinusExpression(ctx: AdditiveExpressionContext): Ast = {
+    val argsAst = ctx.expression().asScala.flatMap(astForExpressionContext)
+    val call = callNode(ctx, ctx.getText, Operators.subtraction, Operators.subtraction, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argsAst.toList)
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -279,7 +279,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       val List(callNode) = cpg.call.name(Operators.addition).l
       callNode.code shouldBe "x+y"
       callNode.lineNumber shouldBe Some(1)
-      callNode.columnNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(0)
     }
 
     "have correct structure for a not expression" in {
@@ -295,7 +295,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       val List(callNode) = cpg.call.name(Operators.exponentiation).l
       callNode.code shouldBe "x**y"
       callNode.lineNumber shouldBe Some(1)
-      callNode.columnNumber shouldBe Some(1)
+      callNode.columnNumber shouldBe Some(0)
     }
 
     "have correct structure for a inclusive range expression" in {
@@ -518,17 +518,17 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a addition expression with space before addition" in {
       val cpg            = code("x + y")
       val List(callNode) = cpg.call.name(Operators.addition).l
-      callNode.code shouldBe "x+y"
+      callNode.code shouldBe "x + y"
       callNode.lineNumber shouldBe Some(1)
-      callNode.columnNumber shouldBe Some(2)
+      callNode.columnNumber shouldBe Some(0)
     }
 
     "have correct structure for a addition expression with space before subtraction" in {
       val cpg            = code("x - y")
       val List(callNode) = cpg.call.name(Operators.subtraction).l
-      callNode.code shouldBe "x-y"
+      callNode.code shouldBe "x - y"
       callNode.lineNumber shouldBe Some(1)
-      callNode.columnNumber shouldBe Some(2)
+      callNode.columnNumber shouldBe Some(0)
     }
 
     "have correct structure for object's method access (chainedInvocationPrimary)" in {


### PR DESCRIPTION
* Gave expressions higher precedence than commands, so as to properly distinguish between `x + y` (the traditional binary operation) and `x(+ y)` (the call of `x` with argument `+y`)
* The previous change allowed us to remove some patch logic and fix unit-tests (.code and .line properties, specifically)
* There is still some boilerplate code in the refactored code (and some names could also be improved, I reckon), but let's refactor as much as possible before tackling that as well.