### PR TITLE
Bug fix for astgen on windows

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -93,7 +93,8 @@ object AstGenRunner {
   }
 
   private def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
-    Try("astgen --version".!!).toOption.map(_.strip()) match {
+    val astgenPrefix = if (Environment.operatingSystem == Environment.OperatingSystemType.Windows) "cmd /C " else ""
+    Try(astgenPrefix + "astgen --version".!!).toOption.map(_.strip()) match {
       case Some(installedVersion)
           if installedVersion != "unknown" && VersionHelper.compare(installedVersion, astGenVersion) >= 0 =>
         logger.debug(s"Using local astgen v$installedVersion from systems PATH")


### PR DESCRIPTION
Looks like we need the `cmd /C ` prefix to make the astgen version detection work on windows.

```
joern> import scala.util.Try
import scala.util.Try

joern> import scala.sys.process.stringToProcess
import scala.sys.process.stringToProcess

joern> Try("astgen --version".!!)
res7: Try[String] = Failure(
  exception = java.io.IOException: Cannot run program "astgen": CreateProcess error=2, The system cannot find the file specified
)

joern>
```

```
joern> "cmd /C astgen --version".!!
res14: String = """3.1.0
"""
```

Please note to test this via github actions, requires powershell to be used as the shell `shell: pwsh`. Currently, the windows tests are run using bash here which might be using WSL or git bash or another emulator

https://github.com/joernio/joern/blob/master/.github/workflows/pr.yml#L20

cc: @mpollmeier @max-leuthaeuser 