### PR TITLE
jssrc2cpg: Handle Destructured Params

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -154,7 +154,9 @@ trait AstForFunctionsCreator { this: AstCreator =>
           param
         case ObjectPattern =>
           val paramName = generateUnusedVariableName(usedVariableNames, s"param$index")
-          val tpe       = typeFor(nodeInfo)
+          // Handle de-structured parameters declared as `{ username: string; password: string; }`
+          val typeDecl = astForTypeAlias(nodeInfo)
+          val tpe      = typeDecl.root.collect { case t: NewTypeDecl => t.fullName }.getOrElse(typeFor(nodeInfo))
           val param = parameterInNode(
             nodeInfo,
             paramName,

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
@@ -311,6 +311,19 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
       credentialsParam.typeFullName shouldBe "code.ts::program:Test:run:_anon_cdecl"
     }
 
+    "AST generation for destructured type in a parameter" in TsAstFixture("""
+        |function apiCall({ username, password }) {
+        |    log(`${username}: ${password}`);
+        |}
+        |""".stripMargin) { cpg =>
+      val Some(credentialsType) = cpg.typeDecl.nameExact("_anon_cdecl").headOption
+      credentialsType.fullName shouldBe "code.ts::program:apiCall:_anon_cdecl"
+      credentialsType.member.name.l shouldBe List("username", "password")
+      credentialsType.member.typeFullName.toSet shouldBe Set(Defines.Any)
+      val Some(credentialsParam) = cpg.parameter.nameExact("param1_0").headOption
+      credentialsParam.typeFullName shouldBe "code.ts::program:apiCall:_anon_cdecl"
+    }
+
   }
 
 }


### PR DESCRIPTION
Following the logic of type aliases, and dynamic types in parameters, added support for destructured params