### PR TITLE
rubysrc2cpg: Last statement in method should be considered a return

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1332,10 +1332,10 @@ class AstCreator(filename: String, global: Global)
     val compoundStatementAsts = astForStatementsContext(ctx.compoundStatement().statements())
 
     val compoundStatementAstsWithReturn =
-      if (addReturnNode) {
+      if (addReturnNode && compoundStatementAsts.size > 0) {
         /*
          * Convert the last statement to a return AST if it is not already a return AST.
-         * If it is a return ASt leave it untouched.
+         * If it is a return AST leave it untouched.
          */
         val lastStmtIsAlreadyReturn = compoundStatementAsts.last.root match {
           case Some(value) => value.isInstanceOf[NewReturn]
@@ -1343,8 +1343,10 @@ class AstCreator(filename: String, global: Global)
         }
 
         if (!lastStmtIsAlreadyReturn) {
+          val len  = ctx.compoundStatement().statements().statement().size()
+          val code = ctx.compoundStatement().statements().statement().get(len - 1).getText
           val retNode = NewReturn()
-            .code(ctx.getText)
+            .code(code)
           val returnReplaced = returnAst(retNode, Seq[Ast](compoundStatementAsts.last))
           compoundStatementAsts.updated(compoundStatementAsts.size - 1, returnReplaced)
         } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -113,6 +113,7 @@ class AstCreator(filename: String, global: Global)
     val keyValueAssociation     = "<operator>.keyValueAssociation"
     val activeRecordAssociation = "<operator>.activeRecordAssociation"
     val undef                   = "<operator>.undef"
+    val yieldOp                 = "<operator>.yield"
   }
   private def getOperatorName(token: Token): String = token.getType match {
     case AMP                 => Operators.logicalAnd
@@ -1898,7 +1899,18 @@ class AstCreator(filename: String, global: Global)
 
   def astForYieldWithOptionalArgumentContext(ctx: YieldWithOptionalArgumentContext): Seq[Ast] = {
     if (ctx.arguments() == null) return Seq(Ast())
-    astForArgumentsContext(ctx.arguments())
+    val argsAst      = astForArgumentsContext(ctx.arguments())
+    val operatorName = RubyOperators.yieldOp
+    val callNode = NewCall()
+      .name(operatorName)
+      .code(ctx.getText)
+      .methodFullName(operatorName)
+      .signature("")
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .typeFullName(Defines.Any)
+      .lineNumber(ctx.YIELD().getSymbol().getLine())
+      .columnNumber(ctx.YIELD().getSymbol().getCharPositionInLine())
+    Seq(callAst(callNode, argsAst))
   }
 
   def astForYieldWithOptionalArgumentPrimaryContext(ctx: YieldWithOptionalArgumentPrimaryContext): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1342,7 +1342,10 @@ class AstCreator(filename: String, global: Global)
           case None        => false
         }
 
-        if (!lastStmtIsAlreadyReturn) {
+        if (
+          !lastStmtIsAlreadyReturn &&
+          ctx.compoundStatement().statements() != null
+        ) {
           val len  = ctx.compoundStatement().statements().statement().size()
           val code = ctx.compoundStatement().statements().statement().get(len - 1).getText
           val retNode = NewReturn()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1331,8 +1331,12 @@ class AstCreator(filename: String, global: Global)
   def astForBodyStatementContext(ctx: BodyStatementContext, addReturnNode: Boolean = false): Seq[Ast] = {
     val compoundStatementAsts = astForStatementsContext(ctx.compoundStatement().statements())
 
-    val lastStmtReturnAst =
+    val compoundStatementAstsWithReturn =
       if (addReturnNode) {
+        /*
+         * Convert the last statement to a return AST if it is not already a return AST.
+         * If it is a return ASt leave it untouched.
+         */
         val lastStmtIsAlreadyReturn = compoundStatementAsts.last.root match {
           case Some(value) => value.isInstanceOf[NewReturn]
           case None        => false
@@ -1341,19 +1345,20 @@ class AstCreator(filename: String, global: Global)
         if (!lastStmtIsAlreadyReturn) {
           val retNode = NewReturn()
             .code(ctx.getText)
-          Seq(returnAst(retNode, Seq[Ast](compoundStatementAsts.last)))
+          val returnReplaced = returnAst(retNode, Seq[Ast](compoundStatementAsts.last))
+          compoundStatementAsts.updated(compoundStatementAsts.size - 1, returnReplaced)
         } else {
-          Seq()
+          compoundStatementAsts
         }
       } else {
-        Seq()
+        compoundStatementAsts
       }
 
     val mainBodyAsts = if (ctx.ensureClause() != null) {
       val ensureAsts = astForStatementsContext(ctx.ensureClause().compoundStatement().statements())
-      compoundStatementAsts ++ lastStmtReturnAst ++ ensureAsts
+      compoundStatementAstsWithReturn ++ ensureAsts
     } else {
-      compoundStatementAsts ++ lastStmtReturnAst
+      compoundStatementAstsWithReturn
     }
 
     val rescueAsts = ctx

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 
 class DataFlowTests extends DataFlowCodeToCpgSuite {
 
-  "CPG for code with flow through a function and if-elseif-else" should {
+  "Data flow through if-elseif-else" should {
     val cpg = code("""
         |x = 2
         |a = x
@@ -164,6 +164,540 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       val src  = cpg.identifier.name("a").l
       val sink = cpg.call.name("puts").l
       sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through class method" ignore {
+    val cpg = code("""
+        |class MyClass
+        |  def print(text)
+        |    puts text
+        |  end
+        |end
+        |
+        |
+        |x = "some text"
+        |inst = MyClass.new
+        |inst.print(x)
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("a").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through module method" ignore {
+    val cpg = code("""
+        |module MyModule
+        |  def MyModule.print(text)
+        |    puts text
+        |  end
+        |end
+        |
+        |x = "some text"
+        |
+        |MyModule::print(x)
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("a").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through yield with argument" ignore {
+    val cpg = code("""
+        |def yield_with_arguments
+        |  a = "something"
+        |  yield(a)
+        |end
+        |
+        |yield_with_arguments { |arg| puts "Argument is #{arg}" }
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("a").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through a until loop" should {
+    val cpg = code("""
+        |i = 0
+        |num = 5
+        |
+        |until i < num
+        |   num = i + 3
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("i").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 3
+    }
+  }
+
+  "Data flow in through until modifier" should {
+    val cpg = code("""
+        |i = 0
+        |num = 5
+        |begin
+        |   num = i + 3
+        |end until i < num
+        |puts num
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("i").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 3
+    }
+  }
+
+  "Data flow through unless-else" should {
+    val cpg = code("""
+        |x = 2
+        |a = x
+        |b = 0
+        |
+        |unless a > 2
+        |    b = a + 3
+        |else
+        |    b = a + 9
+        |end
+        |
+        |puts(b)
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through case statement" ignore {
+    val cpg = code("""
+        |x = 2
+        |b = x
+        |
+        |case b
+        |when 1
+        |    puts b
+        |when 2
+        |    puts b
+        |when 3
+        |    puts b
+        |else
+        |    puts b
+        |end
+        |
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through do-while loop" should {
+    val cpg = code("""
+        |x = 0
+        |num = -1
+        |loop do
+        |   num = x + 1
+        |   x = x + 1
+        |   if x > 10
+        |     break
+        |   end
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through for loop" ignore {
+    val cpg = code("""
+          |x = 0
+          |arr = [1,2,3,4,5]
+          |num = 0
+          |for i in arr do
+          |   y = x + i
+          |   num = y*i
+          |end
+          |puts num
+          |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through for loop simple" should {
+    val cpg = code("""
+        |x = 0
+        |arr = [1,2,3,4,5]
+        |num = 0
+        |for i in arr do
+        |   num = x
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through for and next AFTER statement" should {
+    val cpg = code("""
+        |x = 0
+        |arr = [1,2,3,4,5]
+        |num = 0
+        |for i in arr do
+        |   num = x
+        |   next if i % 2 == 0
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through for and next BEFORE statement" ignore {
+    val cpg = code("""
+        |x = 0
+        |arr = [1,2,3,4,5]
+        |num = 0
+        |for i in arr do
+        |   next if i % 2 == 0
+        |   num = x
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through for and redo AFTER statement" should {
+    val cpg = code("""
+        |x = 0
+        |arr = [1,2,3,4,5]
+        |num = 0
+        |for i in arr do
+        |   num = x
+        |   redo if i % 2 == 0
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through for and redo BEFORE statement" ignore {
+    val cpg = code("""
+        |x = 0
+        |arr = [1,2,3,4,5]
+        |num = 0
+        |for i in arr do
+        |   redo if i % 2 == 0
+        |   num = x
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through for and retry AFTER statement" should {
+    val cpg = code("""
+        |x = 0
+        |arr = [1,2,3,4,5]
+        |num = 0
+        |for i in arr do
+        |   num = x
+        |   retry if i % 2 == 0
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through for and retry BEFORE statement" ignore {
+    val cpg = code("""
+        |x = 0
+        |arr = [1,2,3,4,5]
+        |num = 0
+        |for i in arr do
+        |   retry if i % 2 == 0
+        |   num = x
+        |end
+        |puts num
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through grouping expression" should {
+    val cpg = code("""
+        |x = 0
+        |y = (x==0)
+        |puts y
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through variable assigned a scoped constant" should {
+    val cpg = code("""
+        |MyConst = 10
+        |x = ::MyConst
+        |puts x
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through variable assigned a chained scoped constant" should {
+    val cpg = code("""
+        |MyConst = 10
+        |x = ::MyConst
+        |puts x
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through array constructor expressionsOnlyIndexingArguments" should {
+    val cpg = code("""
+        |x = 1
+        |array = [x,2]
+        |puts x
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 3
+    }
+  }
+
+  "Data flow through array constructor splattingOnlyIndexingArguments" should {
+    val cpg = code("""
+        |def foo(*splat_args)
+        |array = [*splat_args]
+        |puts array
+        |end
+        |
+        |x = 1
+        |y = 2
+        |y = foo(x,y)
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through array constructor expressionsAndSplattingIndexingArguments" should {
+    val cpg = code("""
+        |def foo(*splat_args)
+        |array = [1,2,*splat_args]
+        |puts array
+        |end
+        |
+        |x = 3
+        |foo(x)
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through array constructor associationsOnlyIndexingArguments" should {
+    val cpg = code("""
+        |def foo(arg)
+        |array = [1 => arg, 2 => arg]
+        |puts array
+        |end
+        |
+        |x = 3
+        |foo(x)
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through array constructor commandOnlyIndexingArguments" should {
+    val cpg = code("""
+        |def increment(arg)
+        |return arg + 1
+        |end
+        |
+        |x = 1
+        |array = [ increment(x), increment(x+1)]
+        |puts array
+        |
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 3
+    }
+  }
+
+  "Data flow through hash constructor" should {
+    val cpg = code("""
+        |def foo(arg)
+        |hash = {1 => arg, 2 => arg}
+        |puts hash
+        |end
+        |
+        |x = 3
+        |foo(x)
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through string interpolation" should {
+    val cpg = code("""
+        |x = 1
+        |str = "The source is #{x}"
+        |puts str
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through indexingExpressionPrimary" should {
+    val cpg = code("""
+        |x = [1,2,3]
+        |y = x[0]
+        |puts y
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through methodOnlyIdentifier usage" should {
+    val cpg = code("""
+        |x = 1
+        |y = SomeConstant! + x
+        |puts y
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through chainedInvocationPrimary usage" ignore {
+    val cpg = code("""
+        |x = 1
+        |
+        |[x, x+1].each do |number|
+        |  puts "#{number} was passed to the block"
+        |end
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through chainedInvocationWithoutArgumentsPrimary usage" should {
+    val cpg = code("""
+        |x = 1
+        |
+        |[1,2,3].each do
+        |  puts "Right here #{x}"
+        |end
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -72,6 +72,26 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
+  "Default Return via call with initialization" should {
+    val cpg = code("""
+        |def add(p)
+        |q = 5
+        |q = p
+        |q
+        |end
+        |
+        |n = 1
+        |ret = add(n)
+        |puts ret
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("n").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
   "Return via call w/o initialization" should {
     val cpg = code("""
         |def add(p)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -52,7 +52,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Return via call with initialization" should {
+  "Explicit return via call with initialization" should {
     val cpg = code("""
         |def add(p)
         |q = 5
@@ -72,7 +72,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Default Return via call with initialization" should {
+  "Implicit return via call with initialization" should {
     val cpg = code("""
         |def add(p)
         |q = 5


### PR DESCRIPTION
The last statement in a method should be considered a return if it is not already a return. Converted the last statement to `returnAST()` for this purpose. Associated unit test written as well.