### PR TITLE
Introduction of 'PASSTHROUGH' Mappings & Update Arg Name Semantics

### DIFF
--- a/changelog/passthrough_semantics.md
+++ b/changelog/passthrough_semantics.md
@@ -1,0 +1,38 @@
+# Pass Through Semantics & Update to Named Arguments (v1.2.20; June 2023)
+
+PR: https://github.com/joernio/joern/pull/2885
+
+## Summary
+
+We have implemented the `PassThroughMapping` as a shorthand way to denote a method behaviour that:
+
+* Doesn't cross taint parameters
+* All parameters may affect the return
+* Parameter numbers may be unbounded, e.g. `varargs`-style parameters
+
+Examples of these are Python's tuple literals, where these can have a dynamic number of parameters, and they do not
+cross-taint. This aims at reducing the number of false-positives that result from cross-tainting and unbounded
+parameters.
+
+In addition to this, the initial argument name feature of the flow definitions seemed a bit cumbersome, with one
+requiring defining two flows for the same parameter. e.g. 1 -> 1, "foo" -> 1. This change now forces the user to define
+both the parameter index and an optional name, i.e., you can no longer just have an argument name. This makes the 
+summary more "method"-centric and less "caller"-centric. Argument names still have precedence, so if argument index is 
+not appropriate due to type unpacking used by the method, then it may be left as some arbitrary value.
+
+Note: `PASSTHROUGH` this does not taint 0 -> 0, but can be combined with other mappings.
+
+## New Semantic Notation
+
+```
+"method" 1 -> 2, "foo" -> 2, 1 -> "bar", "foo" -> "bar"
+"<operator>.tupleLiteral" 1 -> 1, 2 -> 2, 3 -> 3, 4 -> 4, 1 -> -1, 2 -> -1, 3 -> -1, 4 -> -1  // etc.
+```
+
+### New Semantic Notation
+
+```
+"method" 1 "foo" -> 2 "bar"
+"<operator>.tupleLiteral" PASSTHROUGH
+"setProperty" PASSTHROUGH 0 -> 0
+```

--- a/dataflowengineoss/src/main/antlr4/io/joern/dataflowengineoss/Semantics.g4
+++ b/dataflowengineoss/src/main/antlr4/io/joern/dataflowengineoss/Semantics.g4
@@ -5,15 +5,19 @@ singleSemantic: methodName mapping* NEWLINE*;
 methodName : QUOTE name QUOTE;
 name : ~(NEWLINE|QUOTE)*?;
 
-mapping: src '->' dst;
+mapping: PASSTHROUGH | (src '->' dst);
 argName: QUOTE name QUOTE;
 argIdx: NUMBER;
-src: argName | argIdx;
-dst: argName | argIdx;
+src: argIdx (argName)?;
+dst: argIdx (argName)?;
+
+// Keywords
+
+PASSTHROUGH: 'PASSTHROUGH';
 
 // Lexing
 
- QUOTE : '"';
+QUOTE : '"';
 NUMBER: [-]?[0-9]+;
 NEWLINE          : '\r'? '\n';
 LINE_COMMENT : '#' .*? ('\n'|EOF)	-> channel(HIDDEN) ;

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -1,7 +1,6 @@
 package io.joern.dataflowengineoss
 
-import io.joern.dataflowengineoss.DefaultSemantics.F
-import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, PassThroughMapping, Semantics}
 import io.shiftleft.codepropertygraph.generated.Operators
 
 import scala.annotation.unused
@@ -17,6 +16,9 @@ object DefaultSemantics {
   }
 
   private def F = (x: String, y: List[(Int, Int)]) => FlowSemantic.from(x, y)
+
+  private def PTF(x: String, ys: List[(Int, Int)] = List.empty): FlowSemantic =
+    FlowSemantic(x).copy(mappings = FlowSemantic.from(x, ys).mappings :+ PassThroughMapping)
 
   def operatorFlows: List[FlowSemantic] = List(
     F(Operators.addition, List((1, -1), (2, -1))),
@@ -55,7 +57,7 @@ object DefaultSemantics {
     F(Operators.postDecrement, List((1, 1), (1, -1))),
     F(Operators.postIncrement, List((1, 1), (1, -1))),
     F(Operators.preDecrement, List((1, 1), (1, -1))),
-    F(Operators.preIncrement, List((1, 1), (1, -1))),
+    PTF(Operators.preIncrement, List((1, 1), (1, -1))),
     F(Operators.sizeOf, List.empty[(Int, Int)]),
 
     //  some of those operators have duplicate mappings due to a typo
@@ -69,7 +71,12 @@ object DefaultSemantics {
     F("<operators>.assignmentAnd", List((2, 1), (1, 1))),
     F("<operators>.assignmentOr", List((2, 1), (1, 1))),
     F("<operators>.assignmentXor", List((2, 1), (1, 1))),
-    F("<operator>.tupleLiteral", List((1, 1), (2, 2), (3, 3), (4, 4), (1, -1), (2, -1), (3, -1), (4, -1)))
+
+    // Language specific operators
+    PTF("<operator>.tupleLiteral"),
+    PTF("<operator>.dictLiteral"),
+    PTF("<operator>.setLiteral"),
+    PTF("<operator>.listLiteral")
   )
 
   /** Semantic summaries for common external C/C++ calls.
@@ -95,7 +102,7 @@ object DefaultSemantics {
     F("ctime64_r", List((1, -1))),
     F("difftime", List((1, -1), (2, -1))),
     F("difftime64", List((1, -1), (2, -1))),
-    F("div", List((1, 1), (1, -1), (2, 2), (2, -1))),
+    PTF("div"),
     F("exit", List((1, 1))),
     F("exp", List((1, -1))),
     F("fabs", List((1, -1))),
@@ -118,16 +125,13 @@ object DefaultSemantics {
   /** Semantic summaries for common external Java calls.
     */
   def javaFlows: List[FlowSemantic] = List(
-    F("java.lang.String.split:java.lang.String[](java.lang.String)", List((0, 0), (0, -1), (1, 1), (1, -1))),
-    F(
-      "java.lang.String.split:java.lang.String[](java.lang.String,int)",
-      List((0, 0), (0, -1), (1, 1), (1, -1), (2, -1))
-    ),
-    F("java.lang.String.compareTo:int(java.lang.String)", List((0, 0), (0, -1), (0, -1), (1, -1))),
+    PTF("java.lang.String.split:java.lang.String[](java.lang.String)", List((0, 0))),
+    PTF("java.lang.String.split:java.lang.String[](java.lang.String,int)", List((0, 0))),
+    PTF("java.lang.String.compareTo:int(java.lang.String)", List((0, 0))),
     F("java.io.PrintWriter.print:void(java.lang.String)", List((0, 0), (1, 1))),
     F("java.io.PrintWriter.println:void(java.lang.String)", List((0, 0), (1, 1))),
     F("java.io.PrintStream.println:void(java.lang.String)", List((0, 0), (1, 1))),
-    F("java.io.PrintStream.print:void(java.lang.String)", List((0, 0), (0, -1), (1, 1))),
+    PTF("java.io.PrintStream.print:void(java.lang.String)", List((0, 0))),
     F("android.text.TextUtils.isEmpty:boolean(java.lang.String)", List((0, -1), (1, -1))),
     F("java.sql.PreparedStatement.prepareStatement:java.sql.PreparedStatement(java.lang.String)", List((1, -1))),
     F("java.sql.PreparedStatement.prepareStatement:setDouble(int,double)", List((1, 1), (2, 2))),

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -57,7 +57,7 @@ object DefaultSemantics {
     F(Operators.postDecrement, List((1, 1), (1, -1))),
     F(Operators.postIncrement, List((1, 1), (1, -1))),
     F(Operators.preDecrement, List((1, 1), (1, -1))),
-    PTF(Operators.preIncrement, List((1, 1), (1, -1))),
+    F(Operators.preIncrement, List((1, 1), (1, -1))),
     F(Operators.sizeOf, List.empty[(Int, Int)]),
 
     //  some of those operators have duplicate mappings due to a typo

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
@@ -2,7 +2,7 @@ package io.joern.dataflowengineoss.passes.reachingdef
 
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.queryengine.Engine.isOutputArgOfInternalMethod
-import io.joern.dataflowengineoss.semanticsloader.{ParamMapping, PosArg, Semantics}
+import io.joern.dataflowengineoss.semanticsloader.{FlowMapping, ParameterNode, PassThroughMapping, Semantics}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, Expression, StoredNode}
 import io.shiftleft.semanticcpg.language._
 
@@ -39,8 +39,9 @@ object EdgeValidator {
       case call: Call =>
         val sem = semantics.forMethod(call.methodFullName)
         sem.isDefined && !sem.get.mappings.exists {
-          case ParamMapping(_, PosArg(dst)) => dst == -1
-          case _                            => false
+          case FlowMapping(_, ParameterNode(dst, _)) => dst == -1
+          case PassThroughMapping                    => true
+          case _                                     => false
         }
       case _ =>
         false

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/semanticsloader/ParserTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/semanticsloader/ParserTests.scala
@@ -21,7 +21,10 @@ class ParserTests extends AnyWordSpec with Matchers {
       semantics match {
         case List(x) =>
           x.methodFullName shouldBe "foo"
-          x.mappings shouldBe List(ParamMapping(PosArg(1), PosArg(-1)), ParamMapping(PosArg(2), PosArg(3)))
+          x.mappings shouldBe List(
+            FlowMapping(ParameterNode(1), ParameterNode(-1)),
+            FlowMapping(ParameterNode(2), ParameterNode(3))
+          )
         case _ => fail()
       }
     }
@@ -47,14 +50,15 @@ class ParserTests extends AnyWordSpec with Matchers {
     }
 
     "parse named argument parameters" in new Fixture() {
-      private val semantics = parser.parse("\"foo\" \"param1\"->2 3->\"param2\"")
+      private val semantics = parser.parse("\"foo\" 1 \"param1\"->2 3-> 2 \"param2\"")
       semantics.size shouldBe 1
-      semantics shouldBe List(
-        FlowSemantic(
-          "foo",
-          List(ParamMapping(NamedArg("param1"), PosArg(2)), ParamMapping(PosArg(3), NamedArg("param2")))
-        )
-      )
+      semantics shouldBe List(FlowSemantic("foo", List(FlowMapping(1, "param1", 2), FlowMapping(3, 2, "param2"))))
+    }
+
+    "parse a passthrough mapping" in new Fixture() {
+      private val semantics = parser.parse("\"foo\" PASSTHROUGH 0 -> 0")
+      semantics.size shouldBe 1
+      semantics shouldBe List(FlowSemantic("foo", List(PassThroughMapping, FlowMapping(0, 0))))
     }
   }
 


### PR DESCRIPTION
* Added a `PASSTHROUGH` mapping that represents an instance where parameters are not sanitized, may affect the return value, and do not cross-taint. e.g. `foo(1, 2) = 1 -> 1, 2 -> 2, 1 -> -1, 2 -> -1`. `0->0` is not included, but can be added as a mapping.
* Made it compulsory to add a parameter index if using an argument name in the semantics. This makes the summary more "method"-centric and less "caller"-centric. Argument names still have precedence, so if the argument index is not appropriate due to type unpacking used by the method, then it may be left as some arbitrary value.
* Added `PASSTHROUGH` for Python's set, dict, tuple, and list literals

Open to discussions!

Resolves #2663