### PR TITLE
rubysrc2cpg: Modelled for loop as a while loop

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -839,17 +839,17 @@ class AstCreator(filename: String, global: Global)
   }
 
   def astForForExpressionContext(ctx: ForExpressionContext): Seq[Ast] = {
-    val forVarAst  = astForForVariableContext(ctx.forVariable())
+    val initAst    = astForForVariableContext(ctx.forVariable())
     val forCondAst = astForExpressionOrCommand(ctx.expressionOrCommand())
+    val bodyAsts   = astForDoClauseContext(ctx.doClause())
 
-    val forNode = NewControlStructure()
-      .controlStructureType(ControlStructureTypes.FOR)
-      .code(ctx.getText)
-      .lineNumber(ctx.FOR().getSymbol.getLine)
-      .columnNumber(ctx.FOR().getSymbol.getCharPositionInLine)
-    val doClauseAst = astForDoClauseContext(ctx.doClause())
-
-    val ast = forAst(forNode, Seq(), forVarAst, forCondAst, Seq(), doClauseAst)
+    val ast = whileAst(
+      Some(forCondAst.head),
+      bodyAsts,
+      Some(ctx.getText),
+      Some(ctx.FOR().getSymbol.getLine),
+      Some(ctx.FOR().getSymbol.getCharPositionInLine)
+    ).withChild(initAst.head)
     Seq(ast)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -348,7 +348,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through for loop" ignore {
+  "Data flow through for loop" should {
     val cpg = code("""
           |x = 0
           |arr = [1,2,3,4,5]
@@ -404,7 +404,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through for and next BEFORE statement" ignore {
+  "Data flow through for and next BEFORE statement" should {
     val cpg = code("""
         |x = 0
         |arr = [1,2,3,4,5]
@@ -442,7 +442,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through for and redo BEFORE statement" ignore {
+  "Data flow through for and redo BEFORE statement" should {
     val cpg = code("""
         |x = 0
         |arr = [1,2,3,4,5]
@@ -480,7 +480,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through for and retry BEFORE statement" ignore {
+  "Data flow through for and retry BEFORE statement" should {
     val cpg = code("""
         |x = 0
         |arr = [1,2,3,4,5]
@@ -712,6 +712,23 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |[1,2,3].each do
         |  puts "Right here #{x}"
         |end
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through invocationWithBlockOnlyPrimary usage" should {
+    val cpg = code("""
+        |def hello(&block)
+        |  block.call
+        |end
+        |
+        |x = "hello"
+        |hello { puts x }
         |""".stripMargin)
 
     "find flows to the sink" in {


### PR DESCRIPTION
The control structure usage done for Ruby for for loop was like C ( since that has the only wrapper usage for for loop ) but the iterator is not present in Ruby. Nor is the post loop update AST relevant in Ruby. The Ruby for control structure usage was resulting in a incorrect CFG.

Ruby for loop is similar to Python. No FOR control structure is used in the Python front end. For has been modelled as a while in the Python frontend. Did something similar here without introducing dummy (`tmp`) variables and got things working. CFG now looks sane.