### PR TITLE
rubysrc2cpg: fix multiple assignments

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate
 
 import java.util
-import scala.collection.mutable
+import scala.collection.{AbstractSeq, LinearSeq, mutable}
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
@@ -1445,20 +1445,21 @@ class AstCreator(filename: String, global: Global)
      */
     val assigns = lhsAsts.zip(rhsAsts)
     assigns.map { argPair =>
+      val lhsCode = argPair._1.nodes.headOption match {
+        case Some(id: NewIdentifier) => id.code
+        case Some(lit: NewLiteral)   => lit.code
+        case _                       => ""
+      }
+
+      val rhsCode = argPair._2.nodes.headOption match {
+        case Some(id: NewIdentifier) => id.code
+        case Some(lit: NewLiteral)   => lit.code
+        case _                       => ""
+      }
+
       val syntheticCallNode = NewCall()
         .name(operatorName)
-        .code(
-          argPair._1.nodes
-            .filter(_.isInstanceOf[NewIdentifier])
-            .head
-            .asInstanceOf[NewIdentifier]
-            .code + " = " +
-            argPair._2.nodes
-              .filter(_.isInstanceOf[NewIdentifier])
-              .head
-              .asInstanceOf[NewIdentifier]
-              .code
-        )
+        .code(lhsCode + " = " + rhsCode)
         .methodFullName(operatorName)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1440,7 +1440,7 @@ class AstCreator(filename: String, global: Global)
     val rhsAsts      = astForMultipleRightHandSideContext(ctx.multipleRightHandSide())
     val operatorName = getOperatorName(ctx.EQ().getSymbol)
 
-    /* If we get anything else than Identifier or Literal, we should ignore and
+    /* If we get anything other than Identifier or Literal, we should ignore and
      * rebuild  the ASTs
      * TODO: Model function calls also so we can capture their return in this
      */
@@ -1471,7 +1471,6 @@ class AstCreator(filename: String, global: Global)
         .name(operatorName)
         .code(lhsCode + " = " + rhsCode)
         .methodFullName(operatorName)
-        .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
         .lineNumber(ctx.EQ().getSymbol().getLine())

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -171,12 +171,12 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through multiple assignments" ignore {
+  "Data flow through multiple assignments" should {
     // TODO test a lot more multiple assignments
     val cpg = code("""
         |a = 1
         |b = 2
-        |c,d=a,b
+        |c, d = a, b
         |puts c
         |""".stripMargin)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AssignmentTests.scala
@@ -72,8 +72,9 @@ class AssignmentTests extends RubyCode2CpgFixture {
       cpg.literal.code("\"world\"").size shouldBe 1
     }
 
-    "recognise all call nodes" in {
-      cpg.call.name(Operators.assignment).size shouldBe 3
+    "recognise all assignment call nodes" in {
+      /* here we are also checking the synthetic assignment nodes for each element on both sides */
+      cpg.call.name(Operators.assignment).size shouldBe 8
     }
   }
 }


### PR DESCRIPTION
Fixes issues where multiple RHS/LHS values in assignments (eg. c, d = a, b) work properly with dataflows. This fixes the previously broken test case where flow from a to c was not working:

```
a = 1
b = 2
c, d = a, b
puts c
```

Also works with other cases where RHS values are in array. eg. a, b = [1, 2]. More complex cases will be tested and added in subsequent PRs