### PR TITLE
rubysrc2cpg: Block with parameters as dummy method

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -565,21 +565,30 @@ class AstCreator(filename: String, global: Global)
     }
 
     if (ctx.block() != null) {
-      val blockMethodName = methodNameAst.head.nodes.head
+      val blockName = methodNameAst.head.nodes.head
         .asInstanceOf[NewCall]
-        .name + terminalNode.getSymbol.getLine
+        .name
+      val blockMethodName = blockName + terminalNode.getSymbol.getLine
       val blockMethodNode =
         astForBlockContext(ctx.block(), Some(blockMethodName)).head.nodes.head
           .asInstanceOf[NewMethod]
+
       val callNode = NewCall()
-        .name(blockMethodNode.name)
+        .name(blockName)
         .methodFullName(blockMethodNode.fullName)
         .typeFullName(DynamicCallUnknownFullName)
-        .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .code(blockMethodNode.code)
         .lineNumber(blockMethodNode.lineNumber)
         .columnNumber(blockMethodNode.columnNumber)
-      Seq(callAst(callNode, baseAst))
+
+      val methodRefNode = NewMethodRef()
+        .methodFullName(blockMethodNode.fullName)
+        .typeFullName(DynamicCallUnknownFullName)
+        .code(blockMethodNode.code)
+        .lineNumber(blockMethodNode.lineNumber)
+        .columnNumber(blockMethodNode.columnNumber)
+
+      Seq(callAst(callNode, Seq(Ast(methodRefNode)), baseAst.headOption))
     } else {
       val callNode = methodNameAst.head.nodes
         .filter(node => node.isInstanceOf[NewCall])

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -728,7 +728,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).l.size shouldBe 3
+      sink.reachableByFlows(source).l.size shouldBe 2
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -689,7 +689,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through chainedInvocationPrimary usage" ignore {
+  "Data flow through chainedInvocationPrimary usage" should {
     val cpg = code("""
         |x = 1
         |
@@ -701,7 +701,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).l.size shouldBe 2
+      sink.reachableByFlows(source).l.size shouldBe 3
     }
   }
 
@@ -717,7 +717,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).l.size shouldBe 2
+      sink.reachableByFlows(source).l.size shouldBe 1
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -208,6 +208,33 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
+  "Data flow through class member" ignore {
+    val cpg = code("""
+        |class MyClass
+        | @instanceVariable
+        |
+        | def initialize(value)
+        |        @instanceVariable = value
+        | end
+        |
+        | def getValue()
+        |        @instanceVariable
+        | end
+        |end
+        |
+        |x = 12345
+        |inst = MyClass.new(x)
+        |y = inst.getValue
+        |puts y
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("x").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
   "Data flow through module method" should {
     val cpg = code("""
         |module MyModule

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -652,7 +652,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).l.size shouldBe 3
+      sink.reachableByFlows(source).l.size shouldBe 2
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -187,7 +187,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through class method" ignore {
+  "Data flow through class method" should {
     val cpg = code("""
         |class MyClass
         |  def print(text)
@@ -202,13 +202,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "be found" in {
-      val src  = cpg.identifier.name("a").l
+      val src  = cpg.identifier.name("x").l
       val sink = cpg.call.name("puts").l
       sink.reachableByFlows(src).l.size shouldBe 2
     }
   }
 
-  "Data flow through module method" ignore {
+  "Data flow through module method" should {
     val cpg = code("""
         |module MyModule
         |  def MyModule.print(text)
@@ -222,7 +222,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "be found" in {
-      val src  = cpg.identifier.name("a").l
+      val src  = cpg.identifier.name("x").l
       val sink = cpg.call.name("puts").l
       sink.reachableByFlows(src).l.size shouldBe 2
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -607,7 +607,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for chainedInvocationWithoutArgumentsPrimary" in {
       val cpg = code("object::foo do\nputs \"right here\"\nend")
 
-      val List(callNode1) = cpg.call.name("foo1").l
+      val List(callNode1) = cpg.call.name("foo").l
       callNode1.code shouldBe "puts \"right here\""
       callNode1.lineNumber shouldBe Some(1)
       callNode1.columnNumber shouldBe Some(3)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -607,10 +607,8 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for chainedInvocationWithoutArgumentsPrimary" in {
       val cpg = code("object::foo do\nputs \"right here\"\nend")
 
-      val List(callNode1) = cpg.call.name("foo").l
-      callNode1.code shouldBe "object::foo do\nputs \"right here\"\nend"
-      callNode1.lineNumber shouldBe Some(1)
-      callNode1.columnNumber shouldBe Some(6)
+      val List(callNode1) = cpg.call.name("foo1").l
+      callNode1.code shouldBe "puts \"right here\""
 
       val List(callNode2) = cpg.call.name("puts").l
       callNode2.code shouldBe "puts \"right here\""

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -609,6 +609,8 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
       val List(callNode1) = cpg.call.name("foo1").l
       callNode1.code shouldBe "puts \"right here\""
+      callNode1.lineNumber shouldBe Some(1)
+      callNode1.columnNumber shouldBe Some(3)
 
       val List(callNode2) = cpg.call.name("puts").l
       callNode2.code shouldBe "puts \"right here\""

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -18,7 +18,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     }
 
     "recognize all call nodes" in {
-      cpg.call.name("each2").size shouldBe 1
+      cpg.call.name("each").size shouldBe 1
       cpg.call.name("puts").size shouldBe 1
     }
   }
@@ -44,7 +44,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     }
 
     "recognize all call nodes" in {
-      cpg.call.name("each2").size shouldBe 1
+      cpg.call.name("each").size shouldBe 1
       cpg.call.name("someMethod").size shouldBe 2
       cpg.call.name("expect").size shouldBe 1
       cpg.call.name("to").size shouldBe 1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -13,12 +13,12 @@ class ControlStructureTests extends RubyCode2CpgFixture {
           |""".stripMargin)
 
     "recognise all identifier nodes" in {
-      cpg.identifier.name("n").size shouldBe 2
-      cpg.identifier.size shouldBe 2
+      cpg.identifier.name("n").size shouldBe 1
+      cpg.identifier.size shouldBe 1
     }
 
     "recognize all call nodes" in {
-      cpg.call.name("each").size shouldBe 1
+      // cpg.call.name("each").size shouldBe 1
       cpg.call.name("puts").size shouldBe 1
     }
   }
@@ -26,6 +26,8 @@ class ControlStructureTests extends RubyCode2CpgFixture {
   "CPG for code with doBlock iterating over a constant array and multiple params" should {
     val cpg = code("""
           |[1, 2, "three"].each do |n, m|
+          |
+          |
           |  expect {
           |  someObject.someMethod(n)
           |  someObject.someMethod(m)
@@ -35,13 +37,14 @@ class ControlStructureTests extends RubyCode2CpgFixture {
           |""".stripMargin)
 
     "recognise all identifier nodes" in {
-      cpg.identifier.name("n").size shouldBe 3
-      cpg.identifier.name("m").size shouldBe 2
-      cpg.identifier.size shouldBe 7
+      cpg.identifier.name("n").size shouldBe 2
+      cpg.identifier.name("m").size shouldBe 1
+      cpg.identifier.size shouldBe 5
+      cpg.method.name("fakeName").dotAst.l
     }
 
     "recognize all call nodes" in {
-      cpg.call.name("each").size shouldBe 1
+      // cpg.call.name("each").size shouldBe 1
       cpg.call.name("someMethod").size shouldBe 2
       cpg.call.name("expect").size shouldBe 1
       cpg.call.name("to").size shouldBe 1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -18,7 +18,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     }
 
     "recognize all call nodes" in {
-      // cpg.call.name("each").size shouldBe 1
+      cpg.call.name("each2").size shouldBe 1
       cpg.call.name("puts").size shouldBe 1
     }
   }
@@ -44,7 +44,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     }
 
     "recognize all call nodes" in {
-      // cpg.call.name("each").size shouldBe 1
+      cpg.call.name("each2").size shouldBe 1
       cpg.call.name("someMethod").size shouldBe 2
       cpg.call.name("expect").size shouldBe 1
       cpg.call.name("to").size shouldBe 1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FunctionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FunctionTests.scala
@@ -80,7 +80,7 @@ class FunctionTests extends RubyCode2CpgFixture {
       cpg.call.name(Operators.assignment).size shouldBe 3
       cpg.call.name("to_s").size shouldBe 2
       cpg.call.name("new").size shouldBe 1
-      cpg.call.size shouldBe 9
+      cpg.call.size shouldBe 8
     }
 
     "recognize all identifier nodes" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
@@ -45,7 +45,7 @@ class MiscTests extends RubyCode2CpgFixture {
 
     "recognise all identifier and call nodes" in {
       cpg.call.name("application").size shouldBe 1
-      cpg.call.name("configure").size shouldBe 1
+      cpg.call.name("configure2").size shouldBe 1
       cpg.call.name("new").size shouldBe 1
       cpg.call.name("<operator>.scopeResolution").size shouldBe 2
       cpg.identifier.name("Rails").size shouldBe 1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
@@ -45,7 +45,7 @@ class MiscTests extends RubyCode2CpgFixture {
 
     "recognise all identifier and call nodes" in {
       cpg.call.name("application").size shouldBe 1
-      cpg.call.name("configure2").size shouldBe 1
+      cpg.call.name("configure").size shouldBe 1
       cpg.call.name("new").size shouldBe 1
       cpg.call.name("<operator>.scopeResolution").size shouldBe 2
       cpg.identifier.name("Rails").size shouldBe 1


### PR DESCRIPTION
1. Block accepting arguments do not have a direct provision in the AST construction code. Modelled blocks with arguments as dummy method and calls to them as calls to these methods
2. `object.member` is not possible in Ruby and getter MUST be used. Hence, that case gets eliminated
3. Made corresponding UT changes. Block parameters were being incorrectly picked as identifiers. That got fixed.
4. Some UTs were not working because they were incorrectly written. Corrected them
