### PR TITLE
php2cpg: Add PhpParserBin option and better errors

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
@@ -6,7 +6,8 @@ import scopt.OParser
 
 /** Command line configuration parameters
   */
-final case class Config(phpIni: Option[String] = None, phpParserBin: Option[String] = None) extends X2CpgConfig[Config] {
+final case class Config(phpIni: Option[String] = None, phpParserBin: Option[String] = None)
+    extends X2CpgConfig[Config] {
   def withPhpIni(phpIni: String): Config = {
     copy(phpIni = Some(phpIni)).withInheritedFields(this)
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
@@ -6,9 +6,13 @@ import scopt.OParser
 
 /** Command line configuration parameters
   */
-final case class Config(phpIni: Option[String] = None) extends X2CpgConfig[Config] {
+final case class Config(phpIni: Option[String] = None, phpParserBin: Option[String] = None) extends X2CpgConfig[Config] {
   def withPhpIni(phpIni: String): Config = {
     copy(phpIni = Some(phpIni)).withInheritedFields(this)
+  }
+
+  def withPhpParserBin(phpParserBin: String): Config = {
+    copy(phpParserBin = Some(phpParserBin)).withInheritedFields(this)
   }
 }
 
@@ -23,7 +27,10 @@ private object Frontend {
       programName("php2cpg"),
       opt[String]("php-ini")
         .action((x, c) => c.withPhpIni(x))
-        .text("php.ini path used by php-parser. Defaults to php.ini shipped with Joern.")
+        .text("php.ini path used by php-parser. Defaults to php.ini shipped with Joern."),
+      opt[String]("php-parser-bin")
+        .action((x, c) => c.withPhpParserBin(x))
+        .text("path to php-parser.phar binary. Defaults to php-parser shipped with Joern.")
     )
   }
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -1,5 +1,6 @@
 package io.joern.php2cpg
 
+import io.joern.php2cpg.parser.PhpParser
 import io.joern.php2cpg.passes.{AstCreationPass, LocalCreationPass}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
@@ -9,6 +10,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import org.slf4j.LoggerFactory
 
+import scala.collection.mutable
 import scala.util.{Failure, Try, Success}
 import scala.util.matching.Regex
 import io.joern.php2cpg.passes.ClosureRefPass
@@ -33,19 +35,34 @@ class Php2Cpg extends X2CpgFrontend[Config] {
   }
 
   override def createCpg(config: Config): Try[Cpg] = {
-    if (isPhpVersionSupported) {
+    val errorMessages = mutable.ListBuffer[String]()
+
+    val parser = PhpParser.getParser(config)
+
+    if (parser.isEmpty) {
+      errorMessages.append("Could not initialize PhpParser")
+    }
+    if (!isPhpVersionSupported) {
+      errorMessages.append("PHP version not supported. Is PHP 8.1.0 or above installed and available on your path?")
+    }
+
+    if (errorMessages.isEmpty) {
       withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
         new MetaDataPass(cpg, Languages.PHP, config.inputPath).createAndApply()
-        val astCreationPass = new AstCreationPass(config, cpg)
+        val astCreationPass = new AstCreationPass(config, cpg, parser.get)
         astCreationPass.createAndApply()
         new TypeNodePass(astCreationPass.allUsedTypes, cpg).createAndApply()
         LocalCreationPass.allLocalCreationPasses(cpg).foreach(_.createAndApply())
         new ClosureRefPass(cpg).createAndApply()
       }
     } else {
-      logger.error(
-        "Skipping AST creation as php could not be executed. Is PHP 8.1.0 or above installed and available on your path?"
-      )
+      val errorOutput = (
+        "Skipping AST creation as php/php-parser could not be executed." ::
+          errorMessages.toList
+      ).mkString("\n- ")
+
+      logger.error(errorOutput)
+
       Failure(new RuntimeException("php not found or version not supported"))
     }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -10,76 +10,13 @@ import java.nio.file.Paths
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
-class PhpParser(config: Config) {
+class PhpParser private (phpParserPath: String, phpIniPath: String) {
 
-  private val PhpParserBinEnvVar = "PHP_PARSER_BIN"
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private lazy val defaultPhpIni: String = {
-    val iniContents = Source.fromResource("php.ini").getLines().mkString(System.lineSeparator())
-
-    val tmpIni = File.newTemporaryFile(suffix = "-php.ini").deleteOnExit()
-    tmpIni.writeText(iniContents)
-    tmpIni.canonicalPath
-  }
-
-  private lazy val defaultPhpParserBin: String = {
-      val dir =
-        Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
-          .toAbsolutePath
-          .toString
-
-      val fixedDir = new java.io.File(dir.substring(0, dir.indexOf("php2cpg"))).toString
-
-      Paths.get(fixedDir, "php2cpg", "bin", "php-parser.phar")
-        .toAbsolutePath
-        .toString
-  }
-
-  private def configOverrideOrDefaultPath(
-    identifier: String,
-    maybeOverride: Option[String],
-    defaultValue: => String
-  ): Option[String] = {
-    val pathString = maybeOverride match {
-      case Some(overridePath) if overridePath.nonEmpty =>
-        logger.debug(s"Using override path for $identifier: $overridePath")
-        overridePath
-
-      case _ =>
-        logger.debug(s"$identifier path not overridden. Using default: $defaultValue")
-        defaultValue
-    }
-
-    File(pathString) match {
-      case file if file.exists() && file.isRegularFile() => Some(file.canonicalPath)
-
-      case _ =>
-        logger.error(s"Invalid config for $identifier: $pathString")
-        None
-    }
-  }
-
-  private val maybePhpParserPath: Option[String] = {
-    val phpParserPathOverride =
-      config
-        .phpParserBin
-        .orElse(
-          Option(System.getenv(PhpParserBinEnvVar))
-        )
-
-    configOverrideOrDefaultPath("PhpParserBin", phpParserPathOverride, defaultPhpParserBin)
-  }
-
-  private val maybePhpIniPath: Option[String] = {
-    configOverrideOrDefaultPath("PhpIni", config.phpIni, defaultPhpIni)
-  }
-
-  private def phpParseCommand(filename: String): Option[String] = {
+  private def phpParseCommand(filename: String): String = {
     val phpParserCommands = "--with-recovery --resolve-names --json-dump"
-    for (phpParserPath <- maybePhpParserPath;
-         phpIniPath <- maybePhpIniPath)
-    yield s"php --php-ini $phpIniPath $phpParserPath $phpParserCommands $filename"
+    s"php --php-ini $phpIniPath $phpParserPath $phpParserCommands $filename"
   }
 
   def parseFile(inputPath: String, phpIniOverride: Option[String]): Option[PhpFile] = {
@@ -87,15 +24,15 @@ class PhpParser(config: Config) {
     val inputFilePath  = inputFile.canonicalPath
     val inputDirectory = inputFile.parent.canonicalPath
 
-    phpParseCommand(inputFilePath).flatMap { command =>
-      ExternalCommand.runMultiple(command, inputDirectory) match {
-        case Success(output) =>
-          processParserOutput(output, inputFilePath)
+    val command = phpParseCommand(inputFilePath)
 
-        case Failure(exception) =>
-          logger.error(s"Failure running php-parser with $command", exception.getMessage())
-          None
-      }
+    ExternalCommand.runMultiple(command, inputDirectory) match {
+      case Success(output) =>
+        processParserOutput(output, inputFilePath)
+
+      case Failure(exception) =>
+        logger.error(s"Failure running php-parser with $command", exception.getMessage())
+        None
     }
   }
 
@@ -134,5 +71,72 @@ class PhpParser(config: Config) {
         logger.error(s"Failed to generate intermediate AST for $filename", e)
         None
     }
+  }
+}
+
+object PhpParser {
+  private val logger = LoggerFactory.getLogger(this.getClass())
+
+  val PhpParserBinEnvVar = "PHP_PARSER_BIN"
+
+  private def defaultPhpIni: String = {
+    val iniContents = Source.fromResource("php.ini").getLines().mkString(System.lineSeparator())
+
+    val tmpIni = File.newTemporaryFile(suffix = "-php.ini").deleteOnExit()
+    tmpIni.writeText(iniContents)
+    tmpIni.canonicalPath
+  }
+
+  private def defaultPhpParserBin: String = {
+    val dir =
+      Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).toAbsolutePath.toString
+
+    val fixedDir = new java.io.File(dir.substring(0, dir.indexOf("php2cpg"))).toString
+
+    Paths.get(fixedDir, "php2cpg", "bin", "php-parser.phar").toAbsolutePath.toString
+  }
+
+  private def configOverrideOrDefaultPath(
+    identifier: String,
+    maybeOverride: Option[String],
+    defaultValue: => String
+  ): Option[String] = {
+    val pathString = maybeOverride match {
+      case Some(overridePath) if overridePath.nonEmpty =>
+        logger.debug(s"Using override path for $identifier: $overridePath")
+        overridePath
+
+      case _ =>
+        logger.debug(s"$identifier path not overridden. Using default: $defaultValue")
+        defaultValue
+    }
+
+    File(pathString) match {
+      case file if file.exists() && file.isRegularFile() => Some(file.canonicalPath)
+
+      case _ =>
+        logger.error(s"Invalid path for $identifier: $pathString")
+        None
+    }
+  }
+
+  private def maybePhpParserPath(config: Config): Option[String] = {
+    val phpParserPathOverride =
+      config.phpParserBin
+        .orElse(Option(System.getenv(PhpParserBinEnvVar)))
+
+    configOverrideOrDefaultPath("PhpParserBin", phpParserPathOverride, defaultPhpParserBin)
+  }
+
+  private def maybePhpIniPath(config: Config): Option[String] = {
+    configOverrideOrDefaultPath("PhpIni", config.phpIni, defaultPhpIni)
+  }
+
+  def getParser(config: Config): Option[PhpParser] = {
+    for (
+      phpParserPath <- maybePhpParserPath(config);
+      phpIniPath    <- maybePhpIniPath(config)
+    )
+      yield new PhpParser(phpParserPath, phpIniPath)
   }
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -15,6 +15,7 @@ import scala.jdk.CollectionConverters._
 class AstCreationPass(config: Config, cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
+  private val parser = new PhpParser(config)
   val global         = new Global()
 
   val PhpSourceFileExtensions: Set[String] = Set(".php")
@@ -23,7 +24,7 @@ class AstCreationPass(config: Config, cpg: Cpg) extends ConcurrentWriterCpgPass[
 
   override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
     val relativeFilename = File(config.inputPath).relativize(File(filename)).toString
-    PhpParser.parseFile(filename, config.phpIni) match {
+    parser.parseFile(filename, config.phpIni) match {
       case Some(parseResult) =>
         diffGraph.absorb(new AstCreator(relativeFilename, parseResult, global).createAst())
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -12,10 +12,9 @@ import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._
 
-class AstCreationPass(config: Config, cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg) {
+class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser) extends ConcurrentWriterCpgPass[String](cpg) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
-  private val parser = new PhpParser(config)
   val global         = new Global()
 
   val PhpSourceFileExtensions: Set[String] = Set(".php")


### PR DESCRIPTION
* Add a `--php-parser-bin` option to specify the path to php-parser
* Add better error messages if php-parser can't be initailzed with given php-parser-bin and php-ini paths
* Don't attempt ast creation if php-parser couldn't be initialized