### PR TITLE
kotlin2cpg: change fullnames for certain contructs

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -319,4 +319,28 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     }
   }
 
+  "CPG for code with call with argument with type with upper bound" should {
+    val cpg = code("""
+      |package mypkg
+      |open class Base
+      |class Second : Base()
+      |class Third : Base()
+      |
+      |fun <S:Base>doSomething(one: S) {
+      |    println(one)
+      |}
+      |fun f1() {
+      |    val s = Second()
+      |    val t = Third()
+      |    doSomething(s)
+      |    doSomething(t)
+      |}
+      |""".stripMargin)
+
+    "should contain a CALL node with arguments that have the argument name set" in {
+      val List(c1, c2) = cpg.call.code("doSomething.*").l
+      c1.methodFullName shouldBe "mypkg.doSomething:void(mypkg.Base)"
+      c2.methodFullName shouldBe "mypkg.doSomething:void(mypkg.Base)"
+    }
+  }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
@@ -133,4 +133,19 @@ class MethodTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       val List(_: Block)  = r.astChildren.l
     }
   }
+
+  "CPG for code with call with argument with type with upper bound" should {
+    val cpg = code("""
+      |package mypkg
+      |open class Base
+      |fun <S:Base>doSomething(one: S) {
+      |    println(one)
+      |}
+      |""".stripMargin)
+
+    "should contain a METHOD node with correct FULL_NAME set" in {
+      val List(m) = cpg.method.nameExact("doSomething").l
+      m.fullName shouldBe "mypkg.doSomething:void(mypkg.Base)"
+    }
+  }
 }


### PR DESCRIPTION
specifically around the use of type upper bounds