### PR TITLE
Trim eclipse deps

### DIFF
--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -5,10 +5,11 @@ crossScalaVersions := Seq("2.13.8", "3.3.0")
 dependsOn(Projects.semanticcpg, Projects.dataflowengineoss % Test, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
-  "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
-  "com.diffplug.spotless"   % "spotless-eclipse-cdt"       % "10.5.0",
-  "org.jline"               % "jline"                      % "3.23.0",
-  "org.scalatest"          %% "scalatest"                  % Versions.scalatest % Test
+  "org.scala-lang.modules" %% "scala-parallel-collections"       % "1.0.4",
+  "org.eclipse.platform"    % "org.eclipse.equinox.common"       % "3.18.0",
+  "org.eclipse.platform"    % "org.eclipse.core.resources"       % "3.19.0",
+  "org.jline"               % "jline"                            % "3.23.0",
+  "org.scalatest"          %% "scalatest"                        % Versions.scalatest % Test
 )
 
 dependencyOverrides ++= Seq(

--- a/joern-cli/frontends/c2cpg/lib/README.md
+++ b/joern-cli/frontends/c2cpg/lib/README.md
@@ -1,0 +1,3 @@
+org.eclipse.cdt.core downloaded from
+
+https://download.eclipse.org/tools/cdt/releases/11.2/cdt-11.2.0/plugins/


### PR DESCRIPTION
c2cpg currently depends on a spotless plugin which brings several unnecessary dependencies. Further, the version of eclipse cdt used is 10.5.0

```
io.joern:c2cpg_2.13:0.0.0+2243-1f34d46e [S]
  +-com.diffplug.spotless:spotless-eclipse-cdt:10.5.0
  | +-com.diffplug.spotless:spotless-eclipse-base:3.5.2
  | | +-org.eclipse.platform:org.eclipse.core.resources:3.19.0
  | | | +-org.eclipse.platform:org.eclipse.core.filesystem:1.10.0
  | | | | +-org.eclipse.platform:org.eclipse.equinox.common:3.18.0
  | | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.400
  | | | | |
  | | | | +-org.eclipse.platform:org.eclipse.equinox.registry:3.11.200
  | | | | | +-org.eclipse.platform:org.eclipse.equinox.common:3.18.0
  | | | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.400
  | | | | | |
  | | | | | +-org.eclipse.platform:org.eclipse.equinox.common:[3.15.100,4.0.0)..
  | | | | |
  | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.400
  | | | |
  | | | +-org.eclipse.platform:org.eclipse.core.runtime:3.27.0
  | | | | +-org.eclipse.platform:org.eclipse.core.contenttype:3.9.0
  | | | | | +-org.eclipse.platform:org.eclipse.equinox.common:3.18.0
  | | | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.400
  | | | | | |
  | | | | | +-org.eclipse.platform:org.eclipse.equinox.preferences:3.10.200
  | | | | | | +-org.eclipse.platform:org.eclipse.equinox.common:3.17.100 (evic..
  | | | | | | +-org.eclipse.platform:org.eclipse.equinox.common:3.18.0
  | | | | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.400
  | | | | | | |
  | | | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.300 (evicted by: 3...
  | | | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.400
  | | | | | | +-org.osgi:org.osgi.service.prefs:1.1.2
  | | | | | |   +-org.osgi:osgi.annotation:8.0.1
  | | | | | |
  | | | | | +-org.eclipse.platform:org.eclipse.equinox.registry:3.11.200
  | | | | | | +-org.eclipse.platform:org.eclipse.equinox.common:3.18.0
  | | | | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.400
  | | | | | | |
  | | | | | | +-org.eclipse.platform:org.eclipse.equinox.common:[3.15.100,4.0...
  | | | | | |
  | | | | | +-org.eclipse.platform:org.eclipse.osgi:3.18.400
```

This large dependency tree could be reduced to just 3 eclipse packages. 1 jar called cdt.core is currently unavailable on maven central and needs to be downloaded and published locally or in a custom repository.

```
"org.eclipse.platform"    % "org.eclipse.equinox.common"       % "3.18.0",
"org.eclipse.platform"    % "org.eclipse.core.resources"       % "3.19.0",
```

The tests fail with this PR since a custom `MacroArgumentExtractor` is no longer available in CDT 11.2.0. Please investigate whether such a workaround is necessary with 11.2

## Why is trimming necessary

With this PR, the size of the [atom](https://github.com/AppThreat/atom) distributable reduces from 80 MB to 60 MB without losing functionality. The extra space could be used to pack another frontend since there is a limit of 100 MB per package on npm and PyPI.

As an added bonus, log4j could be upgraded since we no longer need the problematic osgi library.

cc: @fabsx00 
