### PR TITLE
Unifying Import Resolution

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -28,6 +28,7 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
 
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
     new ImportsPass(cpg).createAndApply()
+    new ImportResolverPass(cpg).createAndApply()
     new DynamicTypeHintFullNamePass(cpg).createAndApply()
     new PythonInheritanceNamePass(cpg).createAndApply()
     new PythonTypeRecoveryPass(cpg, XTypeRecoveryConfig(enabledDummyTypes = !pyConfig.forall(_.disableDummyTypes)))

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -60,6 +60,7 @@ object JsSrc2Cpg {
     List(
       new JavaScriptInheritanceNamePass(cpg),
       new ConstClosurePass(cpg),
+      new ImportResolverPass(cpg),
       new JavaScriptTypeRecoveryPass(cpg, XTypeRecoveryConfig(enabledDummyTypes = !config.exists(_.disableDummyTypes))),
       new JavaScriptTypeHintCallLinker(cpg),
       new NaiveCallLinker(cpg)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ImportResolverPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ImportResolverPass.scala
@@ -1,0 +1,125 @@
+package io.joern.jssrc2cpg.passes
+
+import io.joern.x2cpg.passes.frontend.ImportsPass._
+import io.joern.x2cpg.passes.frontend.XImportResolverPass
+import io.joern.x2cpg.{Defines => XDefines}
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Method, MethodRef}
+import io.shiftleft.semanticcpg.language._
+
+import java.io.{File => JFile}
+import java.util.regex.{Matcher, Pattern}
+import scala.util.{Failure, Success, Try}
+
+class ImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
+
+  private val pathPattern = Pattern.compile("[\"']([\\w/.]+)[\"']")
+
+  override protected def optionalResolveImport(
+    fileName: String,
+    importCall: Call,
+    importedEntity: String,
+    importedAs: String,
+    diffGraph: DiffGraphBuilder
+  ): Unit = {
+    val pathSep     = ":"
+    val rawEntity   = importedEntity.stripPrefix("./")
+    val alias       = importedAs
+    val matcher     = pathPattern.matcher(rawEntity)
+    val sep         = Matcher.quoteReplacement(JFile.separator)
+    val root        = codeRoot + JFile.separator
+    val currentFile = s"$root$fileName"
+    // We want to know if the import is local since if an external name is used to match internal methods we may have
+    // false paths.
+    val isLocalImport = importedEntity.matches("^[.]+/?.*")
+    // TODO: At times there is an operation inside of a require, e.g. path.resolve(__dirname + "/../config/env/all.js")
+    //  this tries to recover the string but does not perform string constant propagation
+    val entity = if (matcher.find()) matcher.group(1) else rawEntity
+    val resolvedPath = better.files
+      .File(currentFile.stripSuffix(currentFile.split(sep).last), entity.split(pathSep).head)
+      .pathAsString
+      .stripPrefix(root)
+
+    val isImportingModule = !entity.contains(pathSep)
+
+    def targetModule = Try(
+      if (isLocalImport)
+        cpg
+          .file(s"${Pattern.quote(resolvedPath)}\\.?.*")
+          .method
+          .nameExact(":program")
+      else
+        Iterator.empty
+    ) match {
+      case Failure(_) =>
+        logger.warn(s"Unable to resolve import due to irregular regex at '$importedEntity'")
+        Iterator.empty
+      case Success(modules) => modules
+    }
+
+    def targetAssignments = targetModule
+      .nameExact(":program")
+      .ast
+      .assignment
+
+    val matchingExports = if (isImportingModule) {
+      // If we are importing the whole module, we need to load all entities
+      targetAssignments
+        .code(s"\\_tmp\\_\\d+\\.\\w+ =.*", "(module\\.)?exports.*")
+        .dedup
+        .l
+    } else {
+      // If we are importing a specific entity, then we look for it here
+      targetAssignments
+        .code("^(module.)?exports.*")
+        .where(_.argument.codeExact(alias))
+        .dedup
+        .l
+    }
+
+    (if (matchingExports.nonEmpty) {
+       matchingExports.flatMap { exp =>
+         exp.argument.l match {
+           case ::(expCall: Call, ::(b: Identifier, _))
+               if expCall.code.matches("^(module.)?exports[.]?.*") && b.name == alias =>
+             val moduleMethods      = targetModule.ast.isMethod.l
+             lazy val methodMatches = moduleMethods.name(b.name).l
+             lazy val constructorMatches =
+               moduleMethods.fullName(s".*${b.name}$pathSep${XDefines.ConstructorMethodName}$$").l
+             lazy val moduleExportsThisVariable = moduleMethods.ast.isLocal
+               .where(_.nameExact(b.name))
+               .nonEmpty
+             // Exported function with only the name of the function
+             val methodPaths =
+               if (methodMatches.nonEmpty) methodMatches.fullName.toSet
+               else constructorMatches.fullName.toSet
+             if (methodPaths.nonEmpty) {
+               methodPaths.flatMap(x => Set(ResolvedMethod(x, alias, Option("this")), ResolvedTypeDecl(x)))
+             } else if (moduleExportsThisVariable) {
+               Set(ResolvedMember(targetModule.fullName.head, b.name))
+             } else {
+               Set.empty
+             }
+           case ::(x: Call, ::(b: MethodRef, _)) =>
+             // Exported function with a method ref of the function
+             val methodName = x.argumentOption(2).map(_.code).getOrElse(b.referencedMethod.name)
+             val (callName, receiver) =
+               if (methodName == "exports") (alias, Option("this")) else (methodName, Option(alias))
+             b.referencedMethod.astParent.iterator
+               .collectAll[Method]
+               .fullName
+               .map(x => ResolvedTypeDecl(x))
+               .toSet ++ Set(ResolvedMethod(b.methodFullName, callName, receiver))
+           case ::(_, ::(y: Call, _)) =>
+             // Exported closure with a method ref within the AST of the RHS
+             y.ast.isMethodRef.map(mRef => ResolvedMethod(mRef.methodFullName, alias, Option("this"))).toSet
+           case _ =>
+             Set.empty[ResolvedImport]
+         }
+       }.toSet
+     } else {
+       Set(UnknownMethod(entity, alias, Option("this")), UnknownTypeDecl(entity))
+     }).foreach(x => resolvedImportToTag(x, importCall, diffGraph))
+  }
+
+}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ImportsPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ImportsPass.scala
@@ -1,11 +1,11 @@
 package io.joern.jssrc2cpg.passes
 
-import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.passes.frontend.XImportsPass
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.CpgPass
-import overflowdb.BatchedUpdate
+import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
 
 /** This pass creates `IMPORT` nodes by looking for calls to `require`. `IMPORT` nodes are linked to existing dependency
   * nodes, or, if no suitable dependency node exists, a dependency node is created.
@@ -15,17 +15,13 @@ import io.shiftleft.semanticcpg.language._
   *
   * TODO Dependency node creation is still missing.
   */
-class ImportsPass(cpg: Cpg) extends CpgPass(cpg) {
+class ImportsPass(cpg: Cpg) extends XImportsPass(cpg) {
 
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
-    cpg
-      .call("require")
-      .flatMap { x => x.inAssignment.codeNot("var .*").map(y => (x, y)) }
-      .foreach { case (call, assignment) =>
-        val importedAs     = assignment.target.code
-        val importedEntity = X2Cpg.stripQuotes(call.argument(1).code)
-        createImportNodeAndLink(importedEntity, importedAs, Option(call), diffGraph)
-      }
-  }
+  override protected val importCallName: String = "require"
+
+  override protected def importCallToPart(x: Call): Iterator[(Call, Assignment)] =
+    x.inAssignment.codeNot("var .*").map(y => (x, y))
+
+  override protected def importedEntityFromCall(call: Call): String = X2Cpg.stripQuotes(call.argument(1).code)
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -10,10 +10,6 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.FieldAccess
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
-import java.io.{File => JFile}
-import java.util.regex.{Matcher, Pattern}
-import scala.util.{Failure, Success, Try}
-
 class JavaScriptTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())
     extends XTypeRecoveryPass[File](cpg, config) {
   override protected def generateRecoveryPass(state: XTypeRecoveryState): XTypeRecovery[File] =
@@ -47,8 +43,6 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
 
   override protected def isConstructor(name: String): Boolean =
     !name.isBlank && (name.charAt(0).isUpper || name.endsWith("factory"))
-
-  lazy private val pathPattern = Pattern.compile("[\"']([\\w/.]+)[\"']")
 
   override protected def prepopulateSymbolTableEntry(x: AstNode): Unit = x match {
     case x @ (_: Identifier | _: Local | _: MethodParameterIn)
@@ -93,113 +87,6 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
           builder.setNodeProperty(p, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, resolvedHints)
         case _ =>
       }
-    }
-  }
-
-  override protected def visitImport(i: Import): Unit = for {
-    rawEntity <- i.importedEntity.map(_.stripPrefix("./"))
-    alias     <- i.importedAs
-  } {
-    val matcher = pathPattern.matcher(rawEntity)
-    val sep     = Matcher.quoteReplacement(JFile.separator)
-    val currentFile = codeRoot + (cu match {
-      case x: File => x.name
-      case _       => cu.file.name.headOption.getOrElse("")
-    })
-    // We want to know if the import is local since if an external name is used to match internal methods we may have
-    // false paths.
-    val isLocalImport = i.importedEntity.exists(_.matches("^[.]+/?.*"))
-    // TODO: At times there is an operation inside of a require, e.g. path.resolve(__dirname + "/../config/env/all.js")
-    //  this tries to recover the string but does not perform string constant propagation
-    val entity = if (matcher.find()) matcher.group(1) else rawEntity
-    val resolvedPath = better.files
-      .File(currentFile.stripSuffix(currentFile.split(sep).last), entity.split(":").head)
-      .pathAsString
-      .stripPrefix(codeRoot)
-
-    val isImportingModule = !entity.contains(":")
-
-    def targetModule = Try(
-      if (isLocalImport)
-        cpg
-          .file(s"${Pattern.quote(resolvedPath)}\\.?.*")
-          .method
-      else
-        Iterator.empty
-    ) match {
-      case Failure(_) =>
-        logger.warn(s"Unable to resolve import due to irregular regex at '${i.importedEntity.getOrElse("")}'")
-        Iterator.empty
-      case Success(modules) => modules
-    }
-
-    def targetAssignments = targetModule
-      .nameExact(":program")
-      .ast
-      .assignment
-
-    val matchingExports = if (isImportingModule) {
-      // If we are importing the whole module, we need to load all entities
-      targetAssignments
-        .code(s"\\_tmp\\_\\d+\\.\\w+ =.*", "(module\\.)?exports.*")
-        .dedup
-        .l
-    } else {
-      // If we are importing a specific entity, then we look for it here
-      targetAssignments
-        .code("^(module.)?exports.*")
-        .where(_.argument.codeExact(alias))
-        .dedup
-        .l
-    }
-
-    if (matchingExports.nonEmpty) {
-      matchingExports.flatMap { exp =>
-        exp.argument.l match {
-          case ::(expCall: Call, ::(b: Identifier, _)) if expCall.code.matches("^(module.)?exports[.]?.*") =>
-            val moduleMethods      = targetModule.ast.isMethod.l
-            lazy val methodMatches = moduleMethods.name(b.name).l
-            lazy val constructorMatches =
-              moduleMethods.fullName(s".*${b.name}$pathSep${XDefines.ConstructorMethodName}$$").l
-            lazy val variableMatches = cpg
-              .file(s"${Pattern.quote(resolvedPath)}\\.?.*")
-              .method
-              .ast
-              .isIdentifier
-              .name(b.name)
-              .flatMap(i => i.typeFullName +: i.dynamicTypeHintFullName)
-              .filterNot(_ == Defines.Any)
-              .toSet
-            // Exported function with only the name of the function
-            val methodPaths =
-              if (methodMatches.nonEmpty) methodMatches.fullName.toSet
-              else constructorMatches.fullName.toSet
-            if (methodPaths.nonEmpty) {
-              symbolTable.append(CallAlias(alias, Option("this")), methodPaths)
-              symbolTable.append(LocalVar(alias), methodPaths)
-            } else {
-              symbolTable.append(LocalVar(alias), variableMatches)
-            }
-          case ::(x: Call, ::(b: MethodRef, _)) =>
-            // Exported function with a method ref of the function
-            val methodName = x.argumentOption(2).map(_.code).getOrElse(b.referencedMethod.name)
-            if (methodName == "exports") symbolTable.append(CallAlias(alias, Option("this")), Set(b.methodFullName))
-            else symbolTable.append(CallAlias(methodName, Option(alias)), Set(b.methodFullName))
-            symbolTable.append(LocalVar(alias), b.referencedMethod.astParent.iterator.collectAll[Method].fullName.toSet)
-          case ::(_, ::(y: Call, _)) =>
-            // Exported closure with a method ref within the AST of the RHS
-            y.ast.isMethodRef.flatMap { mRef =>
-              val methodName = mRef.referencedMethod.name
-              symbolTable.append(CallAlias(methodName, Option(alias)), Set(mRef.methodFullName))
-            }
-          case _ =>
-            Set.empty[String]
-        }
-      }.toSet
-    } else {
-      val default = Set(entity)
-      symbolTable.append(LocalVar(alias), default)
-      symbolTable.append(CallAlias(alias, Option("this")), default)
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportResolverPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportResolverPass.scala
@@ -60,7 +60,7 @@ class ImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
       def toResolvedImport(cpg: Cpg): Seq[ResolvedImport] = {
         val resolvedEntities =
           traversal.flatMap(x => cpg.typeDecl.fullNameExact(x) ++ cpg.method.fullNameExact(x)).collect {
-            case x: Method   => ResolvedMethod(x.fullName, alias, Some("self"))
+            case x: Method   => ResolvedMethod(x.fullName, alias)
             case x: TypeDecl => ResolvedTypeDecl(x.fullName)
           }
         if (resolvedEntities.isEmpty) {
@@ -129,7 +129,7 @@ class ImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
       case x: ResolvedMethod if isMaybeConstructor =>
         Seq(ResolvedMethod(Seq(x.fullName, "__init__").mkString(pathSep), alias), ResolvedTypeDecl(x.fullName))
       // If we import the type, we also import the constructor
-      case x: ResolvedTypeDecl if !x.fullName.endsWith("<module>") =>
+      case x: ResolvedTypeDecl if isMaybeConstructor =>
         Seq(x, ResolvedMethod(Seq(x.fullName, "__init__").mkString(pathSep), alias))
       // If we can determine the import is a constructor, then it is likely not a member
       case x: UnknownImport if isMaybeConstructor =>

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportResolverPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportResolverPass.scala
@@ -1,0 +1,140 @@
+package io.joern.pysrc2cpg
+
+import better.files.{File => BFile}
+import io.joern.x2cpg.passes.frontend.ImportsPass._
+import io.joern.x2cpg.passes.frontend.XImportResolverPass
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.semanticcpg.language._
+
+import java.io.{File => JFile}
+import java.util.regex.{Matcher, Pattern}
+
+class ImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
+
+  override protected def optionalResolveImport(
+    fileName: String,
+    importCall: Call,
+    importedEntity: String,
+    importedAs: String,
+    diffGraph: DiffGraphBuilder
+  ): Unit = {
+    val (namespace, entityName) = if (importedEntity.contains(".")) {
+      val splitName = importedEntity.split('.').toSeq
+      val namespace = importedEntity.stripSuffix(s".${splitName.last}")
+      (relativizeNamespace(namespace, fileName), splitName.last)
+    } else {
+      ("", importedEntity)
+    }
+
+    resolveEntities(namespace, entityName, importedAs).foreach(x => resolvedImportToTag(x, importCall, diffGraph))
+  }
+
+  private def relativizeNamespace(path: String, fileName: String): String = if (path.startsWith(".")) {
+    // TODO: pysrc2cpg does not link files to the correct namespace nodes
+    val sep = Matcher.quoteReplacement(JFile.separator)
+    // The below gives us the full path of the relative "."
+    val relativeNamespace =
+      if (fileName.contains(JFile.separator))
+        fileName.substring(0, fileName.lastIndexOf(JFile.separator)).replaceAll(sep, ".")
+      else ""
+    (if (path.length > 1) relativeNamespace + path.replaceAll(sep, ".")
+     else relativeNamespace).stripPrefix(".")
+  } else path
+
+  /** For an import - given by its module path and the name of the imported function or module - determine the possible
+    * callee names.
+    *
+    * @param path
+    *   the module path.
+    * @param expEntity
+    *   the name of the imported entity. This could be a function, module, or variable/field.
+    * @param alias
+    *   how the imported entity is named.
+    * @return
+    *   the possible callee names
+    */
+  private def resolveEntities(path: String, expEntity: String, alias: String): Set[ResolvedImport] = {
+
+    implicit class ResolvedNodeExt(val traversal: Seq[String]) {
+      def toResolvedImport(cpg: Cpg): Seq[ResolvedImport] = {
+        val resolvedEntities =
+          traversal.flatMap(x => cpg.typeDecl.fullNameExact(x) ++ cpg.method.fullNameExact(x)).collect {
+            case x: Method   => ResolvedMethod(x.fullName, alias, Some("self"))
+            case x: TypeDecl => ResolvedTypeDecl(x.fullName)
+          }
+        if (resolvedEntities.isEmpty) {
+          traversal.filterNot(_.contains("__init__.py")).map(x => UnknownImport(x))
+        } else {
+          resolvedEntities
+        }
+      }
+    }
+
+    implicit class CalleeAsInitExt(val name: String) {
+      def asInit: String = if (name.contains("__init__.py")) name
+      else name.replace(".py", s"${JFile.separator}__init__.py")
+
+      def withInit: Seq[String] = Seq(name, name.asInit)
+    }
+
+    val pathSep            = "."
+    val sep                = Matcher.quoteReplacement(JFile.separator)
+    val isMaybeConstructor = expEntity.split("\\.").lastOption.exists(s => s.nonEmpty && s.charAt(0).isUpper)
+
+    lazy val membersMatchingImports: List[(TypeDecl, Member)] = cpg.typeDecl
+      .fullName(s".*${Pattern.quote(path)}.*")
+      .flatMap(t =>
+        t.member.nameExact(expEntity).headOption match {
+          case Some(member) => Option((t, member))
+          case None         => None
+        }
+      )
+      .toList
+
+    (path match {
+      case "" if expEntity.contains(".") =>
+        // Case 1: Qualified path: import foo.bar => (bar.py or bar/__init__.py)
+        val splitFunc = expEntity.split("\\.")
+        val name      = splitFunc.tail.mkString(".")
+        s"${splitFunc(0)}.py:<module>$pathSep$name".withInit.toResolvedImport(cpg)
+      case "" =>
+        // Case 2: import of a module: import foo => (foo.py or foo/__init__.py)
+        s"$expEntity.py:<module>".withInit.toResolvedImport(cpg)
+      case _ if membersMatchingImports.nonEmpty =>
+        // Case 3: import of a variable: from api import db => (api.py or foo.__init__.py) @ identifier(db)
+        membersMatchingImports.map {
+          case (t, m) if t.method.nameExact(m.name).nonEmpty =>
+            ResolvedMethod(t.method.nameExact(m.name).fullName.head, alias)
+          case (t, m) if t.astSiblings.isMethod.fullNameExact(t.fullName).ast.isTypeDecl.nameExact(m.name).nonEmpty =>
+            ResolvedTypeDecl(
+              t.astSiblings.isMethod.fullNameExact(t.fullName).ast.isTypeDecl.nameExact(m.name).fullName.head
+            )
+          case (t, m) => ResolvedMember(t.fullName, m.name)
+        }
+      case _ =>
+        // Case 4:  Import from module using alias, e.g. import bar from foo as faz
+        val fileOrDir = BFile(codeRoot) / path
+        val pyFile    = BFile(codeRoot) / s"$path.py"
+        fileOrDir match {
+          case f if f.isDirectory && !pyFile.exists =>
+            Seq(s"${path.replaceAll("\\.", sep)}${java.io.File.separator}$expEntity.py:<module>").toResolvedImport(cpg)
+          case f if f.isDirectory && (f / s"$expEntity.py").exists =>
+            Seq(s"${(f / s"$expEntity.py").pathAsString.stripPrefix(codeRoot)}:<module>").toResolvedImport(cpg)
+          case _ =>
+            s"${path.replaceAll("\\.", sep)}.py:<module>$pathSep$expEntity".withInit.toResolvedImport(cpg)
+        }
+    }).flatMap {
+      // If we import the constructor, we also import the type
+      case x: ResolvedMethod if isMaybeConstructor =>
+        Seq(ResolvedMethod(Seq(x.fullName, "__init__").mkString(pathSep), alias), ResolvedTypeDecl(x.fullName))
+      // If we import the type, we also import the constructor
+      case x: ResolvedTypeDecl if !x.fullName.endsWith("<module>") =>
+        Seq(x, ResolvedMethod(Seq(x.fullName, "__init__").mkString(pathSep), alias))
+      // If we can determine the import is a constructor, then it is likely not a member
+      case x: UnknownImport if isMaybeConstructor =>
+        Seq(UnknownMethod(Seq(x.path, "__init__").mkString(pathSep), alias), UnknownTypeDecl(x.path))
+      case x => Seq(x)
+    }.toSet
+  }
+}

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
@@ -1,28 +1,22 @@
 package io.joern.pysrc2cpg
 
-import io.joern.x2cpg.Imports.createImportNodeAndLink
+import better.files.{File => BFile}
+import io.joern.x2cpg.passes.frontend.ImportsPass._
+import io.joern.x2cpg.passes.frontend.XImportsPass
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.passes.CpgPass
-import overflowdb.BatchedUpdate
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
 
-class ImportsPass(cpg: Cpg) extends CpgPass(cpg) {
-  override def run(diffGraph: BatchedUpdate.DiffGraphBuilder): Unit = {
-    val importsAndAssignments = cpg
-      .call("import")
-      .flatMap { x =>
-        x.inAssignment.map(y => (x, y))
-      }
+import java.io.{File => JFile}
+import java.util.regex.{Matcher, Pattern}
+class ImportsPass(cpg: Cpg) extends XImportsPass(cpg) {
 
-    importsAndAssignments.foreach { case (call, assignment) =>
-      val importedEntity = importedEntityFromCall(call)
-      val importedAs     = assignment.target.code
-      createImportNodeAndLink(importedEntity, importedAs, Some(call), diffGraph)
-    }
-  }
+  override protected val importCallName: String = "import"
 
-  def importedEntityFromCall(call: Call): String = {
+  override protected def importCallToPart(x: Call): Iterator[(Call, Assignment)] = x.inAssignment.map(y => (x, y))
+
+  override def importedEntityFromCall(call: Call): String = {
     call.argument.code.l match {
       case List("", what)       => what
       case List(where, what)    => s"$where.$what"
@@ -30,6 +24,126 @@ class ImportsPass(cpg: Cpg) extends CpgPass(cpg) {
       case List(where, what, _) => s"$where.$what"
       case _                    => ""
     }
+  }
+
+  override protected def optionalResolveImport(
+    fileName: String,
+    importCall: Call,
+    importedEntity: String,
+    importedAs: String,
+    diffGraph: DiffGraphBuilder
+  ): Unit = {
+    val (namespace, entityName) = if (importedEntity.contains(".")) {
+      val splitName = importedEntity.split('.').toSeq
+      val namespace = importedEntity.stripSuffix(s".${splitName.last}")
+      (relativizeNamespace(namespace, fileName), splitName.last)
+    } else {
+      ("", importedEntity)
+    }
+
+    resolveEntities(namespace, entityName).foreach {
+      case ResolvedMember(basePath, memberName, label) =>
+        importCall.start.newTagNodePair(label, s"$basePath.$memberName").store()(diffGraph)
+      case ResolvedMethod(fullName, label) =>
+        importCall.start.newTagNodePair(label, fullName).store()(diffGraph)
+      case ResolvedTypeDecl(fullName, label) =>
+        importCall.start.newTagNodePair(label, fullName).store()(diffGraph)
+      case UnknownMethod(fullName, label) =>
+        importCall.start.newTagNodePair(label, fullName).store()(diffGraph)
+      case UnknownTypeDecl(fullName, label) =>
+        importCall.start.newTagNodePair(label, fullName).store()(diffGraph)
+      case UnknownImport(path, label) =>
+        importCall.start.newTagNodePair(label, path).store()(diffGraph)
+    }
+  }
+
+  private def relativizeNamespace(path: String, fileName: String): String = if (path.startsWith(".")) {
+    // TODO: pysrc2cpg does not link files to the correct namespace nodes
+    val sep = Matcher.quoteReplacement(JFile.separator)
+    // The below gives us the full path of the relative "."
+    val relativeNamespace =
+      if (fileName.contains(JFile.separator))
+        fileName.substring(0, fileName.lastIndexOf(JFile.separator)).replaceAll(sep, ".")
+      else ""
+    (if (path.length > 1) relativeNamespace + path.replaceAll(sep, ".")
+     else relativeNamespace).stripPrefix(".")
+  } else path
+
+  /** For an import - given by its module path and the name of the imported function or module - determine the possible
+    * callee names.
+    *
+    * @param path
+    *   the module path.
+    * @param expEntity
+    *   the name of the imported entity. This could be a function, module, or variable/field.
+    * @return
+    *   the possible callee names
+    */
+  private def resolveEntities(path: String, expEntity: String): Set[ResolvedImport] = {
+    implicit class CalleeAsInitExt(val name: String) {
+      def asInit: String = if (name.contains("__init__.py")) name
+      else name.replace(".py", s"${JFile.separator}__init__.py")
+
+      def withInit: Seq[String] = Seq(name, name.asInit)
+    }
+
+    val pathSep            = "."
+    val sep                = Matcher.quoteReplacement(JFile.separator)
+    val isMaybeConstructor = expEntity.split("\\.").lastOption.exists(s => s.nonEmpty && s.charAt(0).isUpper)
+
+    lazy val membersMatchingImports: List[(TypeDecl, Member)] = cpg.typeDecl
+      .fullName(s".*${Pattern.quote(path)}.*")
+      .flatMap(t =>
+        t.member.nameExact(expEntity).headOption match {
+          case Some(member) => Option((t, member))
+          case None         => None
+        }
+      )
+      .toList
+
+    (path match {
+      case "" if expEntity.contains(".") =>
+        // Case 1: Qualified path: import foo.bar => (bar.py or bar/__init__.py)
+        val splitFunc = expEntity.split("\\.")
+        val name      = splitFunc.tail.mkString(".")
+        s"${splitFunc(0)}.py:<module>$pathSep$name".withInit.toResolvedImport(cpg)
+      case "" =>
+        // Case 2: import of a module: import foo => (foo.py or foo/__init__.py)
+        s"$expEntity.py:<module>".withInit.toResolvedImport(cpg)
+      case _ if membersMatchingImports.nonEmpty =>
+        // Case 3: import of a variable: from api import db => (api.py or foo.__init__.py) @ identifier(db)
+        membersMatchingImports.map {
+          case (t, m) if t.method.nameExact(m.name).nonEmpty => ResolvedMethod(t.method.nameExact(m.name).fullName.head)
+          case (t, m) if t.astSiblings.isMethod.fullNameExact(t.fullName).ast.isTypeDecl.nameExact(m.name).nonEmpty =>
+            ResolvedTypeDecl(
+              t.astSiblings.isMethod.fullNameExact(t.fullName).ast.isTypeDecl.nameExact(m.name).fullName.head
+            )
+          case (t, m) => ResolvedMember(t.fullName, m.name)
+        }
+      case _ =>
+        // Case 4:  Import from module using alias, e.g. import bar from foo as faz
+        val fileOrDir = BFile(codeRoot) / path
+        val pyFile    = BFile(codeRoot) / s"$path.py"
+        fileOrDir match {
+          case f if f.isDirectory && !pyFile.exists =>
+            Seq(s"${path.replaceAll("\\.", sep)}${java.io.File.separator}$expEntity.py:<module>").toResolvedImport(cpg)
+          case f if f.isDirectory && (f / s"$expEntity.py").exists =>
+            Seq(s"${(f / s"$expEntity.py").pathAsString.stripPrefix(codeRoot)}:<module>").toResolvedImport(cpg)
+          case _ =>
+            s"${path.replaceAll("\\.", sep)}.py:<module>$pathSep$expEntity".withInit.toResolvedImport(cpg)
+        }
+    }).flatMap {
+      // If we import the constructor, we also import the type
+      case x: ResolvedMethod if isMaybeConstructor =>
+        Seq(ResolvedMethod(Seq(x.fullName, "__init__").mkString(pathSep)), ResolvedTypeDecl(x.fullName))
+      // If we import the type, we also import the constructor
+      case x: ResolvedTypeDecl if !x.fullName.endsWith("<module>") =>
+        Seq(x, ResolvedMethod(Seq(x.fullName, "__init__").mkString(pathSep)))
+      // If we can determine the import is a constructor, then it is likely not a member
+      case x: UnknownImport if isMaybeConstructor =>
+        Seq(UnknownMethod(Seq(x.path, "__init__").mkString(pathSep)), UnknownTypeDecl(x.path))
+      case x => Seq(x)
+    }.toSet
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
@@ -1,15 +1,11 @@
 package io.joern.pysrc2cpg
 
-import better.files.{File => BFile}
-import io.joern.x2cpg.passes.frontend.ImportsPass._
 import io.joern.x2cpg.passes.frontend.XImportsPass
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
 
-import java.io.{File => JFile}
-import java.util.regex.{Matcher, Pattern}
 class ImportsPass(cpg: Cpg) extends XImportsPass(cpg) {
 
   override protected val importCallName: String = "import"
@@ -24,126 +20,6 @@ class ImportsPass(cpg: Cpg) extends XImportsPass(cpg) {
       case List(where, what, _) => s"$where.$what"
       case _                    => ""
     }
-  }
-
-  override protected def optionalResolveImport(
-    fileName: String,
-    importCall: Call,
-    importedEntity: String,
-    importedAs: String,
-    diffGraph: DiffGraphBuilder
-  ): Unit = {
-    val (namespace, entityName) = if (importedEntity.contains(".")) {
-      val splitName = importedEntity.split('.').toSeq
-      val namespace = importedEntity.stripSuffix(s".${splitName.last}")
-      (relativizeNamespace(namespace, fileName), splitName.last)
-    } else {
-      ("", importedEntity)
-    }
-
-    resolveEntities(namespace, entityName).foreach {
-      case ResolvedMember(basePath, memberName, label) =>
-        importCall.start.newTagNodePair(label, s"$basePath.$memberName").store()(diffGraph)
-      case ResolvedMethod(fullName, label) =>
-        importCall.start.newTagNodePair(label, fullName).store()(diffGraph)
-      case ResolvedTypeDecl(fullName, label) =>
-        importCall.start.newTagNodePair(label, fullName).store()(diffGraph)
-      case UnknownMethod(fullName, label) =>
-        importCall.start.newTagNodePair(label, fullName).store()(diffGraph)
-      case UnknownTypeDecl(fullName, label) =>
-        importCall.start.newTagNodePair(label, fullName).store()(diffGraph)
-      case UnknownImport(path, label) =>
-        importCall.start.newTagNodePair(label, path).store()(diffGraph)
-    }
-  }
-
-  private def relativizeNamespace(path: String, fileName: String): String = if (path.startsWith(".")) {
-    // TODO: pysrc2cpg does not link files to the correct namespace nodes
-    val sep = Matcher.quoteReplacement(JFile.separator)
-    // The below gives us the full path of the relative "."
-    val relativeNamespace =
-      if (fileName.contains(JFile.separator))
-        fileName.substring(0, fileName.lastIndexOf(JFile.separator)).replaceAll(sep, ".")
-      else ""
-    (if (path.length > 1) relativeNamespace + path.replaceAll(sep, ".")
-     else relativeNamespace).stripPrefix(".")
-  } else path
-
-  /** For an import - given by its module path and the name of the imported function or module - determine the possible
-    * callee names.
-    *
-    * @param path
-    *   the module path.
-    * @param expEntity
-    *   the name of the imported entity. This could be a function, module, or variable/field.
-    * @return
-    *   the possible callee names
-    */
-  private def resolveEntities(path: String, expEntity: String): Set[ResolvedImport] = {
-    implicit class CalleeAsInitExt(val name: String) {
-      def asInit: String = if (name.contains("__init__.py")) name
-      else name.replace(".py", s"${JFile.separator}__init__.py")
-
-      def withInit: Seq[String] = Seq(name, name.asInit)
-    }
-
-    val pathSep            = "."
-    val sep                = Matcher.quoteReplacement(JFile.separator)
-    val isMaybeConstructor = expEntity.split("\\.").lastOption.exists(s => s.nonEmpty && s.charAt(0).isUpper)
-
-    lazy val membersMatchingImports: List[(TypeDecl, Member)] = cpg.typeDecl
-      .fullName(s".*${Pattern.quote(path)}.*")
-      .flatMap(t =>
-        t.member.nameExact(expEntity).headOption match {
-          case Some(member) => Option((t, member))
-          case None         => None
-        }
-      )
-      .toList
-
-    (path match {
-      case "" if expEntity.contains(".") =>
-        // Case 1: Qualified path: import foo.bar => (bar.py or bar/__init__.py)
-        val splitFunc = expEntity.split("\\.")
-        val name      = splitFunc.tail.mkString(".")
-        s"${splitFunc(0)}.py:<module>$pathSep$name".withInit.toResolvedImport(cpg)
-      case "" =>
-        // Case 2: import of a module: import foo => (foo.py or foo/__init__.py)
-        s"$expEntity.py:<module>".withInit.toResolvedImport(cpg)
-      case _ if membersMatchingImports.nonEmpty =>
-        // Case 3: import of a variable: from api import db => (api.py or foo.__init__.py) @ identifier(db)
-        membersMatchingImports.map {
-          case (t, m) if t.method.nameExact(m.name).nonEmpty => ResolvedMethod(t.method.nameExact(m.name).fullName.head)
-          case (t, m) if t.astSiblings.isMethod.fullNameExact(t.fullName).ast.isTypeDecl.nameExact(m.name).nonEmpty =>
-            ResolvedTypeDecl(
-              t.astSiblings.isMethod.fullNameExact(t.fullName).ast.isTypeDecl.nameExact(m.name).fullName.head
-            )
-          case (t, m) => ResolvedMember(t.fullName, m.name)
-        }
-      case _ =>
-        // Case 4:  Import from module using alias, e.g. import bar from foo as faz
-        val fileOrDir = BFile(codeRoot) / path
-        val pyFile    = BFile(codeRoot) / s"$path.py"
-        fileOrDir match {
-          case f if f.isDirectory && !pyFile.exists =>
-            Seq(s"${path.replaceAll("\\.", sep)}${java.io.File.separator}$expEntity.py:<module>").toResolvedImport(cpg)
-          case f if f.isDirectory && (f / s"$expEntity.py").exists =>
-            Seq(s"${(f / s"$expEntity.py").pathAsString.stripPrefix(codeRoot)}:<module>").toResolvedImport(cpg)
-          case _ =>
-            s"${path.replaceAll("\\.", sep)}.py:<module>$pathSep$expEntity".withInit.toResolvedImport(cpg)
-        }
-    }).flatMap {
-      // If we import the constructor, we also import the type
-      case x: ResolvedMethod if isMaybeConstructor =>
-        Seq(ResolvedMethod(Seq(x.fullName, "__init__").mkString(pathSep)), ResolvedTypeDecl(x.fullName))
-      // If we import the type, we also import the constructor
-      case x: ResolvedTypeDecl if !x.fullName.endsWith("<module>") =>
-        Seq(x, ResolvedMethod(Seq(x.fullName, "__init__").mkString(pathSep)))
-      // If we can determine the import is a constructor, then it is likely not a member
-      case x: UnknownImport if isMaybeConstructor =>
-        Seq(UnknownMethod(Seq(x.path, "__init__").mkString(pathSep)), UnknownTypeDecl(x.path))
-      case x => Seq(x)
-    }.toSet
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -51,36 +51,30 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
   override val symbolTable: SymbolTable[LocalKey] = new SymbolTable[LocalKey](fromNodeToLocalPythonKey)
 
   override def visitImport(i: Import): Unit = {
+    if (i.importedAs.isDefined && i.importedEntity.isDefined) {
+      import io.joern.x2cpg.passes.frontend.ImportsPass._
 
-    def relativizeNamespace(path: String) = if (path.startsWith(".")) {
-      // TODO: pysrc2cpg does not link files to the correct namespace nodes
-      val fileName = i.file.name.headOption.getOrElse("").stripPrefix(codeRoot)
-      val sep      = Matcher.quoteReplacement(JFile.separator)
-      // The below gives us the full path of the relative "."
-      val relativeNamespace =
-        if (fileName.contains(JFile.separator))
-          fileName.substring(0, fileName.lastIndexOf(JFile.separator)).replaceAll(sep, ".")
-        else ""
-      (if (path.length > 1) relativeNamespace + path.replaceAll(sep, ".")
-       else relativeNamespace).stripPrefix(".")
-    } else path
-
-    val importedEntity = i.importedEntity.getOrElse("")
-    val (namespace, entityName) = if (importedEntity.contains(".")) {
-      val splitName = importedEntity.split('.').toSeq
-      val namespace = importedEntity.stripSuffix(s".${splitName.last}")
-      (relativizeNamespace(namespace), splitName.last)
-    } else {
-      ("", importedEntity)
-    }
-    val calleeNames = extractPossibleCalleeNames(namespace, entityName)
-    i.importedAs match {
-      case Some(alias) =>
-        symbolTable.put(CallAlias(alias), calleeNames)
-        symbolTable.put(LocalVar(alias), calleeNames.map(_.stripSuffix(s"${pathSep}__init__")))
-      case None =>
-        symbolTable.put(CallAlias(entityName), calleeNames)
-        symbolTable.put(LocalVar(entityName), calleeNames.map(_.stripSuffix(s"${pathSep}__init__")))
+      val entityName = i.importedAs.get
+      i.call.tag.flatMap(ResolvedImport.tagToResolvedImport).foreach {
+        case ResolvedMethod(fullName, _)   => symbolTable.put(CallAlias(entityName), fullName)
+        case ResolvedTypeDecl(fullName, _) => symbolTable.put(LocalVar(entityName), fullName)
+        case ResolvedMember(basePath, memberName, _) =>
+          val memberTypes = cpg.typeDecl
+            .fullNameExact(basePath)
+            .member
+            .nameExact(memberName)
+            .flatMap(m => m.typeFullName +: m.dynamicTypeHintFullName)
+            .filterNot(_ == "ANY")
+            .toSet
+          symbolTable.put(LocalVar(entityName), memberTypes)
+        case UnknownMethod(fullName, _) =>
+          symbolTable.put(CallAlias(entityName), fullName)
+        case UnknownTypeDecl(fullName, _) =>
+          symbolTable.put(LocalVar(entityName), fullName)
+        case UnknownImport(path, _) =>
+          symbolTable.put(CallAlias(entityName), path)
+          symbolTable.put(LocalVar(entityName), path)
+      }
     }
   }
 
@@ -93,105 +87,6 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
           case None       => super.visitAssignments(a)
         }
       case _ => super.visitAssignments(a)
-    }
-  }
-
-  /** For an import - given by its module path and the name of the imported function or module - determine the possible
-    * callee names.
-    *
-    * @param path
-    *   the module path.
-    * @param expEntity
-    *   the name of the imported entity. This could be a function, module, or variable/field.
-    * @return
-    *   the possible callee names
-    */
-  private def extractPossibleCalleeNames(path: String, expEntity: String): Set[String] = {
-    val sep = Matcher.quoteReplacement(JFile.separator)
-
-    lazy val methodsWithExportEntityAsIdentifier: List[String] = cpg.typeDecl
-      .fullName(s".*${Pattern.quote(path)}.*")
-      .where(_.member.nameExact(expEntity))
-      .fullName
-      .toList
-
-    val procedureName = path match {
-      case "" if expEntity.contains(".") =>
-        // Case 1: Qualified path: import foo.bar => (bar.py or bar/__init__.py)
-        val splitFunc = expEntity.split("\\.")
-        val name      = splitFunc.tail.mkString(".")
-        s"${splitFunc(0)}.py:<module>$pathSep$name"
-      case "" =>
-        // Case 2: import of a module: import foo => (foo.py or foo/__init__.py)
-        s"$expEntity.py:<module>"
-      case _ if methodsWithExportEntityAsIdentifier.nonEmpty =>
-        // Case 3: import of a variable: from api import db => (api.py or foo.__init__.py) @ identifier(db)
-        methodsWithExportEntityAsIdentifier.map(f => s"$f<var>$expEntity").head
-      case _ =>
-        // Case 4:  Import from module using alias, e.g. import bar from foo as faz
-        val fileOrDir = BFile(codeRoot) / path
-        val pyFile    = BFile(codeRoot) / s"$path.py"
-        fileOrDir match {
-          case f if f.isDirectory && !pyFile.exists =>
-            s"${path.replaceAll("\\.", sep)}${java.io.File.separator}$expEntity.py:<module>"
-          case f if f.isDirectory && (f / s"$expEntity.py").exists =>
-            s"${(f / s"$expEntity.py").pathAsString}:<module>"
-          case _ =>
-            s"${path.replaceAll("\\.", sep)}.py:<module>$pathSep$expEntity"
-        }
-    }
-
-    /** The two ways that this procedure could be resolved to in Python. */
-    def possibleCalleeNames(procedureName: String, isMaybeConstructor: Boolean, isFieldOrVar: Boolean): Set[String] = {
-      val pythonicFormGuesses =
-        cpg.typeDecl.fullName(s".*${Pattern.quote(procedureName)}").fullName.toSet match {
-          case xs if xs.nonEmpty => xs
-          case _                 => Seq(procedureName)
-        }
-      if (isMaybeConstructor)
-        pythonicFormGuesses.map(p => Seq(p, "__init__").mkString(pathSep.toString)).toSet
-      else if (isFieldOrVar) {
-        val Array(m, v) = procedureName.split("<var>")
-        cpg.typeDecl.fullNameExact(m).member.nameExact(v).headOption match {
-          case Some(i) => (i.typeFullName +: i.dynamicTypeHintFullName).filterNot(_ == Constants.ANY).toSet
-          case None    => Set.empty
-        }
-      } else
-        Set(procedureName, fullNameAsInit) ++ pythonicFormGuesses
-    }
-
-    /** the full name of the procedure where it's assumed that it is defined within an <code>__init.py__</code> of the
-      * module.
-      */
-    def fullNameAsInit: String =
-      if (procedureName.contains("__init__.py")) procedureName
-      else procedureName.replace(".py", s"${JFile.separator}__init__.py")
-
-    val isMaybeConstructor = expEntity.split("\\.").lastOption.exists(s => s.nonEmpty && s.charAt(0).isUpper)
-    possibleCalleeNames(procedureName, isMaybeConstructor, procedureName.contains("<var>"))
-      .map(_.replaceAll("<var>", pathSep.toString))
-  }
-
-  override def postVisitImports(): Unit = {
-    symbolTable.view.foreach { case (k, v) =>
-      val ms = cpg.method.fullNameExact(v.toSeq: _*).l
-      val ts = cpg.typeDecl.fullNameExact(v.toSeq: _*).l
-      // In case a method has been incorrectly determined to be a constructor based on the heuristic
-
-      val nonConstructorV = v.toSeq
-        .map(_.replaceAll("<var>", pathSep.toString).stripSuffix(s"${pathSep}__init__"))
-      val tsNonConstructor = cpg.method.fullNameExact(nonConstructorV: _*).l
-
-      if (ts.nonEmpty)
-        symbolTable.put(k, ts.fullName.toSet)
-      else if (ms.nonEmpty)
-        symbolTable.put(k, ms.fullName.toSet)
-      else if (!tsNonConstructor.forall(_.name == "<module>"))
-        symbolTable.put(k, tsNonConstructor.fullName.toSet)
-      else {
-        // This is likely external and we will ignore the init variant to be consistent
-        symbolTable.put(k, symbolTable(k).filterNot(_.contains("__init__.py")))
-      }
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -36,6 +36,7 @@ class PySrcTestCpg extends TestCpg with PythonFrontend {
   override def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
     new ImportsPass(this).createAndApply()
+    new ImportResolverPass(this).createAndApply()
     new PythonInheritanceNamePass(this).createAndApply()
     new DynamicTypeHintFullNamePass(this).createAndApply()
     new PythonTypeRecoveryPass(this).createAndApply()

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -354,9 +354,8 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |""".stripMargin).cpg
 
     "resolve correct imports via tag nodes" in {
-      val List(logging) = cpg.call.where(_.referencedImports).tag.toList
-      logging.name shouldBe "UNKNOWN_IMPORT"
-      logging.value shouldBe "logging.py:<module>"
+      val List(logging: UnknownImport) = cpg.call.where(_.referencedImports).tag.toResolvedImport.toList
+      logging.path shouldBe "logging.py:<module>"
     }
 
     "provide a dummy type" in {
@@ -378,11 +377,10 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |""".stripMargin).cpg
 
     "resolve correct imports via tag nodes" in {
-      val List(error, request) = cpg.call.where(_.referencedImports).tag.toList
-      error.name shouldBe "UNKNOWN_IMPORT"
-      error.value shouldBe "urllib.py:<module>.error"
-      request.name shouldBe "UNKNOWN_IMPORT"
-      request.value shouldBe "urllib.py:<module>.request"
+      val List(error: UnknownImport, request: UnknownImport) =
+        cpg.call.where(_.referencedImports).tag.toResolvedImport.toList
+      error.path shouldBe "urllib.py:<module>.error"
+      request.path shouldBe "urllib.py:<module>.request"
     }
 
     "reasonably determine the constructor type" in {
@@ -446,7 +444,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       b.fullName shouldBe "MongoConnection.py:<module>.MongoConnection.__init__"
       c.fullName shouldBe "pymongo.py:<module>.MongoClient.__init__"
       d.fullName shouldBe "pymongo.py:<module>.MongoClient"
-      e.path shouldBe "django/conf.py:<module>.settings"
+      e.path shouldBe Seq("django", "conf.py:<module>.settings").mkString(File.separator)
     }
 
     "recover a potential type for `self.collection` using the assignment at `get_collection` as a type hint" in {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/SymbolTable.scala
@@ -100,6 +100,9 @@ class SymbolTable[K <: SBKey](val keyFromNode: AstNode => Option[K]) {
   def append(node: AstNode, typeFullName: String): Set[String] =
     append(node, Set(typeFullName))
 
+  def append(node: K, typeFullName: String): Set[String] =
+    append(node, Set(typeFullName))
+
   def append(node: AstNode, typeFullNames: Set[String]): Set[String] = keyFromNode(node) match {
     case Some(key) => append(key, typeFullNames)
     case None      => Set.empty

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportResolverPass.scala
@@ -1,0 +1,127 @@
+package io.joern.x2cpg.passes.frontend
+
+import io.joern.x2cpg.passes.frontend.ImportsPass.ResolvedImport
+import io.joern.x2cpg.passes.frontend.ImportsPass.ResolvedImport._
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Import, Tag}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language._
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.io.{File => JFile}
+
+abstract class XImportResolverPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Import](cpg) {
+
+  protected val logger: Logger   = LoggerFactory.getLogger(this.getClass)
+  protected val codeRoot: String = cpg.metaData.root.headOption.getOrElse(JFile.separator)
+
+  override def generateParts(): Array[Import] = cpg.imports.toArray
+
+  override def runOnPart(builder: DiffGraphBuilder, part: Import): Unit = for {
+    call <- part.call
+    fileName = call.file.name.headOption.getOrElse("<unknown>").stripPrefix(codeRoot)
+    importedAs     <- part.importedAs
+    importedEntity <- part.importedEntity
+  } {
+    optionalResolveImport(fileName, call, importedEntity, importedAs, builder)
+  }
+
+  protected def optionalResolveImport(
+    fileName: String,
+    importCall: Call,
+    importedEntity: String,
+    importedAs: String,
+    diffGraph: DiffGraphBuilder
+  ): Unit
+
+  protected def resolvedImportToTag(x: ResolvedImport, importCall: Call, diffGraph: DiffGraphBuilder): Unit =
+    importCall.start.newTagNodePair(x.label, x.serialize).store()(diffGraph)
+
+}
+
+object ImportsPass {
+
+  sealed trait ResolvedImport {
+    def label: String
+
+    def serialize: String
+  }
+
+  implicit class TagToResolvedImportExt(traversal: Traversal[Tag]) {
+    def toResolvedImport: Traversal[ResolvedImport] =
+      traversal.flatMap(ResolvedImport.tagToResolvedImport)
+  }
+
+  object ResolvedImport {
+
+    val RESOLVED_METHOD    = "RESOLVED_METHOD"
+    val RESOLVED_TYPE_DECL = "RESOLVED_TYPE_DECL"
+    val RESOLVED_MEMBER    = "RESOLVED_MEMBER"
+    val UNKNOWN_METHOD     = "UNKNOWN_METHOD"
+    val UNKNOWN_TYPE_DECL  = "UNKNOWN_TYPE_DECL"
+    val UNKNOWN_IMPORT     = "UNKNOWN_IMPORT"
+
+    val OPT_FULL_NAME = "FULL_NAME"
+    val OPT_ALIAS     = "ALIAS"
+    val OPT_RECEIVER  = "RECEIVER"
+    val OPT_BASE_PATH = "BASE_PATH"
+    val OPT_NAME      = "NAME"
+
+    def tagToResolvedImport(tag: Tag): Option[ResolvedImport] = Option(tag.name match {
+      case RESOLVED_METHOD =>
+        val opts = valueToOptions(tag.value)
+        ResolvedMethod(opts(OPT_FULL_NAME), opts(OPT_ALIAS), opts.get(OPT_RECEIVER))
+      case RESOLVED_TYPE_DECL => ResolvedTypeDecl(tag.value)
+      case RESOLVED_MEMBER =>
+        val opts = valueToOptions(tag.value)
+        ResolvedMember(opts(OPT_BASE_PATH), opts(OPT_NAME))
+      case UNKNOWN_METHOD =>
+        val opts = valueToOptions(tag.value)
+        UnknownMethod(opts(OPT_FULL_NAME), opts(OPT_ALIAS), opts.get(OPT_RECEIVER))
+      case UNKNOWN_TYPE_DECL => UnknownTypeDecl(tag.value)
+      case UNKNOWN_IMPORT    => UnknownImport(tag.value)
+      case _                 => null
+    })
+
+    private def valueToOptions(x: String): Map[String, String] =
+      x.split(',').grouped(2).map(xs => xs(0) -> xs(1)).toMap
+  }
+
+  case class ResolvedMethod(
+    fullName: String,
+    alias: String,
+    receiver: Option[String] = None,
+    override val label: String = RESOLVED_METHOD
+  ) extends ResolvedImport {
+    override def serialize: String =
+      s"$OPT_FULL_NAME,$fullName,$OPT_ALIAS,$alias" + receiver.map(r => s",$OPT_RECEIVER,$r").getOrElse("")
+  }
+
+  case class ResolvedTypeDecl(fullName: String, override val label: String = RESOLVED_TYPE_DECL)
+      extends ResolvedImport {
+    override def serialize: String = fullName
+  }
+
+  case class ResolvedMember(basePath: String, memberName: String, override val label: String = RESOLVED_MEMBER)
+      extends ResolvedImport {
+    override def serialize: String = s"$OPT_BASE_PATH,$basePath,$OPT_NAME,$memberName"
+  }
+
+  case class UnknownMethod(
+    fullName: String,
+    alias: String,
+    receiver: Option[String] = None,
+    override val label: String = UNKNOWN_METHOD
+  ) extends ResolvedImport {
+    override def serialize: String =
+      s"$OPT_FULL_NAME,$fullName,$OPT_ALIAS,$alias" + receiver.map(r => s",$OPT_RECEIVER,$r").getOrElse("")
+  }
+
+  case class UnknownTypeDecl(fullName: String, override val label: String = UNKNOWN_TYPE_DECL) extends ResolvedImport {
+    override def serialize: String = fullName
+  }
+
+  case class UnknownImport(path: String, override val label: String = UNKNOWN_IMPORT) extends ResolvedImport {
+    override def serialize: String = path
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportsPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportsPass.scala
@@ -1,0 +1,107 @@
+package io.joern.x2cpg.passes.frontend
+
+import io.joern.x2cpg.Imports.createImportNodeAndLink
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, Tag, TypeDecl}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
+
+import java.io.{File => JFile}
+
+abstract class XImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[(Call, Assignment)](cpg) {
+
+  protected val importCallName: String
+  protected val codeRoot: String = cpg.metaData.root.headOption.getOrElse(JFile.separator)
+
+  override def generateParts(): Array[(Call, Assignment)] = cpg
+    .call(importCallName)
+    .flatMap(importCallToPart)
+    .toArray
+
+  protected def importCallToPart(x: Call): Iterator[(Call, Assignment)]
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, part: (Call, Assignment)): Unit = {
+    val (call, assignment) = part
+    val importedEntity     = importedEntityFromCall(call)
+    val importedAs         = assignment.target.code
+    createImportNodeAndLink(importedEntity, importedAs, Some(call), diffGraph)
+    optionalResolveImport(
+      call.file.name.headOption.getOrElse("<unknown>").stripPrefix(codeRoot),
+      call,
+      importedEntity,
+      importedAs,
+      diffGraph
+    )
+  }
+
+  protected def importedEntityFromCall(call: Call): String
+
+  protected def optionalResolveImport(
+    fileName: String,
+    importCall: Call,
+    importedEntity: String,
+    importedAs: String,
+    diffGraph: DiffGraphBuilder
+  ): Unit = {}
+
+}
+
+object ImportsPass {
+
+  implicit class ResolvedNodeExt(val traversal: Seq[String]) {
+    def toResolvedImport(cpg: Cpg): Seq[ResolvedImport] = {
+      val resolvedEntities =
+        traversal.flatMap(x => cpg.typeDecl.fullNameExact(x) ++ cpg.method.fullNameExact(x)).collect {
+          case x: Method   => ResolvedMethod(x.fullName)
+          case x: TypeDecl => ResolvedTypeDecl(x.fullName)
+        }
+      if (resolvedEntities.isEmpty) {
+        traversal.filterNot(_.contains("__init__.py")).map(x => UnknownImport(x))
+      } else {
+        resolvedEntities
+      }
+    }
+  }
+
+  sealed trait ResolvedImport {
+    def label: String
+  }
+
+  object ResolvedImport {
+
+    val RESOLVED_METHOD    = "RESOLVED_METHOD"
+    val RESOLVED_TYPE_DECL = "RESOLVED_TYPE_DECL"
+    val RESOLVED_MEMBER    = "RESOLVED_MEMBER"
+    val UNKNOWN_METHOD     = "UNKNOWN_METHOD"
+    val UNKNOWN_TYPE_DECL  = "UNKNOWN_TYPE_DECL"
+    val UNKNOWN_IMPORT     = "UNKNOWN_IMPORT"
+
+    def tagToResolvedImport(tag: Tag): Option[ResolvedImport] = Option(tag.name match {
+      case RESOLVED_METHOD    => ResolvedMethod(tag.value)
+      case RESOLVED_TYPE_DECL => ResolvedTypeDecl(tag.value)
+      case RESOLVED_MEMBER =>
+        val splitTag       = tag.value.split('.')
+        val (base, member) = ((splitTag diff Seq(splitTag.last)).mkString("."), splitTag.last)
+        ResolvedMember(base, member)
+      case UNKNOWN_METHOD    => UnknownMethod(tag.value)
+      case UNKNOWN_TYPE_DECL => UnknownTypeDecl(tag.value)
+      case UNKNOWN_IMPORT    => UnknownImport(tag.value)
+      case _                 => null
+    })
+  }
+
+  case class ResolvedMethod(fullName: String, override val label: String = "RESOLVED_METHOD") extends ResolvedImport
+
+  case class ResolvedTypeDecl(fullName: String, override val label: String = "RESOLVED_TYPE_DECL")
+      extends ResolvedImport
+
+  case class ResolvedMember(basePath: String, memberName: String, override val label: String = "RESOLVED_MEMBER")
+      extends ResolvedImport
+
+  case class UnknownMethod(fullName: String, override val label: String = "UNKNOWN_METHOD") extends ResolvedImport
+
+  case class UnknownTypeDecl(fullName: String, override val label: String = "UNKNOWN_TYPE_DECL") extends ResolvedImport
+
+  case class UnknownImport(path: String, override val label: String = "UNKNOWN_IMPORT") extends ResolvedImport
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportsPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportsPass.scala
@@ -2,17 +2,14 @@ package io.joern.x2cpg.passes.frontend
 
 import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, Tag, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
 
-import java.io.{File => JFile}
-
 abstract class XImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[(Call, Assignment)](cpg) {
 
   protected val importCallName: String
-  protected val codeRoot: String = cpg.metaData.root.headOption.getOrElse(JFile.separator)
 
   override def generateParts(): Array[(Call, Assignment)] = cpg
     .call(importCallName)
@@ -26,82 +23,8 @@ abstract class XImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[(Call, Ass
     val importedEntity     = importedEntityFromCall(call)
     val importedAs         = assignment.target.code
     createImportNodeAndLink(importedEntity, importedAs, Some(call), diffGraph)
-    optionalResolveImport(
-      call.file.name.headOption.getOrElse("<unknown>").stripPrefix(codeRoot),
-      call,
-      importedEntity,
-      importedAs,
-      diffGraph
-    )
   }
 
   protected def importedEntityFromCall(call: Call): String
 
-  protected def optionalResolveImport(
-    fileName: String,
-    importCall: Call,
-    importedEntity: String,
-    importedAs: String,
-    diffGraph: DiffGraphBuilder
-  ): Unit = {}
-
-}
-
-object ImportsPass {
-
-  implicit class ResolvedNodeExt(val traversal: Seq[String]) {
-    def toResolvedImport(cpg: Cpg): Seq[ResolvedImport] = {
-      val resolvedEntities =
-        traversal.flatMap(x => cpg.typeDecl.fullNameExact(x) ++ cpg.method.fullNameExact(x)).collect {
-          case x: Method   => ResolvedMethod(x.fullName)
-          case x: TypeDecl => ResolvedTypeDecl(x.fullName)
-        }
-      if (resolvedEntities.isEmpty) {
-        traversal.filterNot(_.contains("__init__.py")).map(x => UnknownImport(x))
-      } else {
-        resolvedEntities
-      }
-    }
-  }
-
-  sealed trait ResolvedImport {
-    def label: String
-  }
-
-  object ResolvedImport {
-
-    val RESOLVED_METHOD    = "RESOLVED_METHOD"
-    val RESOLVED_TYPE_DECL = "RESOLVED_TYPE_DECL"
-    val RESOLVED_MEMBER    = "RESOLVED_MEMBER"
-    val UNKNOWN_METHOD     = "UNKNOWN_METHOD"
-    val UNKNOWN_TYPE_DECL  = "UNKNOWN_TYPE_DECL"
-    val UNKNOWN_IMPORT     = "UNKNOWN_IMPORT"
-
-    def tagToResolvedImport(tag: Tag): Option[ResolvedImport] = Option(tag.name match {
-      case RESOLVED_METHOD    => ResolvedMethod(tag.value)
-      case RESOLVED_TYPE_DECL => ResolvedTypeDecl(tag.value)
-      case RESOLVED_MEMBER =>
-        val splitTag       = tag.value.split('.')
-        val (base, member) = ((splitTag diff Seq(splitTag.last)).mkString("."), splitTag.last)
-        ResolvedMember(base, member)
-      case UNKNOWN_METHOD    => UnknownMethod(tag.value)
-      case UNKNOWN_TYPE_DECL => UnknownTypeDecl(tag.value)
-      case UNKNOWN_IMPORT    => UnknownImport(tag.value)
-      case _                 => null
-    })
-  }
-
-  case class ResolvedMethod(fullName: String, override val label: String = "RESOLVED_METHOD") extends ResolvedImport
-
-  case class ResolvedTypeDecl(fullName: String, override val label: String = "RESOLVED_TYPE_DECL")
-      extends ResolvedImport
-
-  case class ResolvedMember(basePath: String, memberName: String, override val label: String = "RESOLVED_MEMBER")
-      extends ResolvedImport
-
-  case class UnknownMethod(fullName: String, override val label: String = "UNKNOWN_METHOD") extends ResolvedImport
-
-  case class UnknownTypeDecl(fullName: String, override val label: String = "UNKNOWN_TYPE_DECL") extends ResolvedImport
-
-  case class UnknownImport(path: String, override val label: String = "UNKNOWN_IMPORT") extends ResolvedImport
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -273,9 +273,9 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
 
     ResolvedImport.tagToResolvedImport(resolvedImport).foreach {
       case ResolvedMethod(fullName, alias, receiver, _) =>
-        symbolTable.put(CallAlias(alias, receiver), fullName)
+        symbolTable.append(CallAlias(alias, receiver), fullName)
       case ResolvedTypeDecl(fullName, _) =>
-        symbolTable.put(LocalVar(alias), fullName)
+        symbolTable.append(LocalVar(alias), fullName)
       case ResolvedMember(basePath, memberName, _) =>
         val matchingIdentifiers = cpg.method.fullNameExact(basePath).local
         val matchingMembers     = cpg.typeDecl.fullNameExact(basePath).member
@@ -287,14 +287,14 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
           )
           .filterNot(_ == "ANY")
           .toSet
-        symbolTable.put(LocalVar(alias), memberTypes)
+        symbolTable.append(LocalVar(alias), memberTypes)
       case UnknownMethod(fullName, alias, receiver, _) =>
-        symbolTable.put(CallAlias(alias, receiver), fullName)
+        symbolTable.append(CallAlias(alias, receiver), fullName)
       case UnknownTypeDecl(fullName, _) =>
-        symbolTable.put(LocalVar(alias), fullName)
+        symbolTable.append(LocalVar(alias), fullName)
       case UnknownImport(path, _) =>
-        symbolTable.put(CallAlias(alias), path)
-        symbolTable.put(LocalVar(alias), path)
+        symbolTable.append(CallAlias(alias), path)
+        symbolTable.append(LocalVar(alias), path)
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -266,11 +266,36 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   /** Visits an import and stores references in the symbol table as both an identifier and call.
     */
   protected def visitImport(i: Import): Unit = for {
-    entity <- i.importedEntity
-    alias  <- i.importedAs
+    resolvedImport <- i.call.tag
+    alias          <- i.importedAs
   } {
-    symbolTable.append(LocalVar(alias), Set(entity))
-    symbolTable.append(CallAlias(alias), Set(entity))
+    import io.joern.x2cpg.passes.frontend.ImportsPass._
+
+    ResolvedImport.tagToResolvedImport(resolvedImport).foreach {
+      case ResolvedMethod(fullName, alias, receiver, _) =>
+        symbolTable.put(CallAlias(alias, receiver), fullName)
+      case ResolvedTypeDecl(fullName, _) =>
+        symbolTable.put(LocalVar(alias), fullName)
+      case ResolvedMember(basePath, memberName, _) =>
+        val matchingIdentifiers = cpg.method.fullNameExact(basePath).local
+        val matchingMembers     = cpg.typeDecl.fullNameExact(basePath).member
+        val memberTypes = (matchingMembers ++ matchingIdentifiers)
+          .nameExact(memberName)
+          .flatMap(x =>
+            x.property(PropertyNames.TYPE_FULL_NAME, "ANY") +:
+              x.property(PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, Seq.empty)
+          )
+          .filterNot(_ == "ANY")
+          .toSet
+        symbolTable.put(LocalVar(alias), memberTypes)
+      case UnknownMethod(fullName, alias, receiver, _) =>
+        symbolTable.put(CallAlias(alias, receiver), fullName)
+      case UnknownTypeDecl(fullName, _) =>
+        symbolTable.put(LocalVar(alias), fullName)
+      case UnknownImport(path, _) =>
+        symbolTable.put(CallAlias(alias), path)
+        symbolTable.put(LocalVar(alias), path)
+    }
   }
 
   /** The initial import setting is over-approximated, so this step checks the CPG for any matches and prunes against


### PR DESCRIPTION
Import resolution until now has been integrated into the type recovery pass. The type recovery pass is an iterate-and-propagate algorithm, where import resolution would be run every iteration for every file. Since the type recovery operates on a fork-join concurrency (since inter-file writing is involved), whereas the import resolution alone is mostly read-only, there is room for optimization. The following changes are made:
* Introduced the `XImportPass` class, which unifies the two `ImportPass` classes from `jssrc2cpg` and `pysrc2cpg`, and implements them using the `ConcurrentWriterCpgPass`.
* Introduced a `XImportResolutionPass` class, which uses the `Tag` node feature to resolve the entities that the `ImportNode`s refer to. The values of the `Tag` node are serialized versions of a `ResolvedImport` trait which is implemented under `XImportResolutionPass` as a number of classes which map the CPG entities being imported (or indicates when they're unknown or are external). `XImportResolutionPass` implements `ConcurrentWriterCpgPass`.
* Removed the import recovery from the `jssrc2cpg` and `pysrc2cpg`'s `XTypeRecovery` implementations and instead added import parsing of these `Tag` nodes in `XTypeRecovery` themselves.

The result is a fast, parallel, import resolution that is run exactly once and a much simpler type recovery that focuses only on the context of the compilation unit for the iterate-and-propagate recovery algorithm.

Breaking changes: `jssrc2cpg.passes.ImportResolutionPass` and `pysrc2cpg.ImportResolutionPass` need to be included after their respective `ImportPass`.