### PR TITLE
c2cpg: exit early on old JREs

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -80,7 +80,7 @@ class CdtParser(config: Config) extends ParseProblemsLogger with PreprocessorSta
         )
       } catch {
         case u: UnsupportedClassVersionError =>
-          logger.error("c2cpg requires at least JRE-19 to run. Please check your Java Runtime Environment!", u)
+          logger.error("c2cpg requires at least JRE-17 to run. Please check your Java Runtime Environment!", u)
           System.exit(1)
           ParseResult(None, failure = Option(u)) // return value to make the compiler happy
         case e: Throwable =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory
 
 import java.nio.file.{NoSuchFileException, Path}
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success, Try}
 
 object CdtParser {
 
@@ -65,22 +64,27 @@ class CdtParser(config: Config) extends ParseProblemsLogger with PreprocessorSta
   private def parseInternal(file: Path): ParseResult = {
     val realPath = File(file)
     if (realPath.isRegularFile) { // handling potentially broken symlinks
-      val fileContent         = readFileAsFileContent(realPath.path)
-      val fileContentProvider = new CustomFileContentProvider(headerFileFinder)
-      val lang                = createParseLanguage(realPath.path)
-      val scannerInfo         = createScannerInfo(realPath.path)
-      Try(lang.getASTTranslationUnit(fileContent, scannerInfo, fileContentProvider, null, opts, log)) match {
-        case Failure(e) =>
+      try {
+        val fileContent         = readFileAsFileContent(realPath.path)
+        val fileContentProvider = new CustomFileContentProvider(headerFileFinder)
+        val lang                = createParseLanguage(realPath.path)
+        val scannerInfo         = createScannerInfo(realPath.path)
+        val translationUnit = lang.getASTTranslationUnit(fileContent, scannerInfo, fileContentProvider, null, opts, log)
+        val problems        = CPPVisitor.getProblems(translationUnit)
+        if (parserConfig.logProblems) logProblems(problems.toList)
+        if (parserConfig.logPreprocessor) logPreprocessorStatements(translationUnit)
+        ParseResult(
+          Option(translationUnit),
+          preprocessorErrorCount = translationUnit.getPreprocessorProblemsCount,
+          problems = problems.length
+        )
+      } catch {
+        case u: UnsupportedClassVersionError =>
+          logger.error("c2cpg requires at least JRE-19 to run. Please check your Java Runtime Environment!", u)
+          System.exit(1)
+          ParseResult(None, failure = Option(u)) // return value to make the compiler happy
+        case e: Throwable =>
           ParseResult(None, failure = Option(e))
-        case Success(translationUnit) =>
-          val problems = CPPVisitor.getProblems(translationUnit)
-          if (parserConfig.logProblems) logProblems(problems.toList)
-          if (parserConfig.logPreprocessor) logPreprocessorStatements(translationUnit)
-          ParseResult(
-            Option(translationUnit),
-            preprocessorErrorCount = translationUnit.getPreprocessorProblemsCount,
-            problems = problems.length
-          )
       }
     } else {
       ParseResult(


### PR DESCRIPTION
We now exit with 1 if the JRE c2cpg runs on is < JRE 17.