### PR TITLE
kotlin2cpg: change fullnames for qualified exprs

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -343,4 +343,20 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       c2.methodFullName shouldBe "mypkg.doSomething:void(mypkg.Base)"
     }
   }
+
+  "CPG for code with qualified-expression call with argument with type with upper bound" should {
+    val cpg = code("""
+        |package mypkg
+        |fun f1() {
+        |    val ns = sequenceOf("four", "three", "two", "one")
+        |    val ml = mutableListOf<String>()
+        |    ns.mapIndexedNotNullTo(ml, { i, s -> s })
+        |}
+        |""".stripMargin)
+
+    "should contain a METHOD node with correct METHOD_FULL_NAME set" in {
+      val List(c) = cpg.method.nameExact("mapIndexedNotNullTo").callIn.l
+      c.methodFullName shouldBe "kotlin.sequences.Sequence.mapIndexedNotNullTo:java.lang.Object(java.util.Collection,kotlin.Function2)"
+    }
+  }
 }


### PR DESCRIPTION
method fullnames for types with upper bounds found in qualified
expressions were previously not rendered correctly. that is, for the
following piece of code:
```
package mypkg
fun f1() {
    val ns = sequenceOf("four", "three", "two", "one")
    val ml = mutableListOf<String>()
    ns.mapIndexedNotNullTo(ml, { i, s -> s })
}
```
the call to `mapIndexedNotNullTo` had a METHOD_FULL_NAME of:
```
kotlin.sequences.Sequence.mapIndexedNotNullTo:java.lang.Object(java.lang.Object,kotlin.Function2)
```
instead of:
```
kotlin.sequences.Sequence.mapIndexedNotNullTo:java.lang.Object(java.util.Collection,kotlin.Function2)
```

signature from the docs:
```
inline fun <T, R : Any, C : MutableCollection<in R>> Sequence<T>.mapIndexedNotNullTo(
    destination: C,
    transform: (index: Int, T) -> R?
): C
```
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.sequences/map-indexed-not-null-to.html