### PR TITLE
Move JavaParser ast creation into AstCreationPass to reduce code duplication

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -10,7 +10,7 @@ import io.joern.javasrc2cpg.passes.{
 }
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass, XTypeRecoveryConfig}
-import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
+import io.joern.x2cpg.X2CpgFrontend
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPassBase

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -1,12 +1,6 @@
 package io.joern.javasrc2cpg
 
 import better.files.File
-import com.github.javaparser.ParserConfiguration.LanguageLevel
-import com.github.javaparser.ast.CompilationUnit
-import com.github.javaparser.ast.Node.Parsedness
-import com.github.javaparser.symbolsolver.JavaSymbolSolver
-import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver
-import com.github.javaparser.{JavaParser, ParserConfiguration}
 import io.joern.javasrc2cpg.passes.{
   AstCreationPass,
   ConfigFileCreationPass,
@@ -14,29 +8,34 @@ import io.joern.javasrc2cpg.passes.{
   JavaTypeRecoveryPass,
   TypeInferencePass
 }
-import io.joern.javasrc2cpg.typesolvers.{CachingReflectionTypeSolver, EagerSourceTypeSolver, SimpleCombinedTypeSolver}
-import io.joern.javasrc2cpg.util.Delombok.DelombokMode
-import io.joern.javasrc2cpg.util.{Delombok, SourceRootFinder}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass, XTypeRecoveryConfig}
-import io.joern.x2cpg.utils.dependency.DependencyResolver
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPassBase
 import org.slf4j.LoggerFactory
 
-import java.nio.file.Paths
-import scala.collection.parallel.CollectionConverters._
 import scala.jdk.CollectionConverters._
-import scala.jdk.OptionConverters.RichOptional
-import scala.util.{Success, Try}
+import scala.util.Try
 
-case class SourceDirectoryInfo(typeSolverSourceDirs: List[String], sourceFiles: List[SourceFileInfo])
-case class SplitDirectories(analysisSourceDir: String, typesSourceDir: String)
-case class SplitJpAsts(analysisAsts: List[JpAstWithMeta], typesAsts: List[JpAstWithMeta])
-case class SourceFileInfo(analysisFileName: String, originalFilename: String)
-case class JpAstWithMeta(fileInfo: SourceFileInfo, compilationUnit: CompilationUnit)
+class JavaSrc2Cpg extends X2CpgFrontend[Config] {
+  import JavaSrc2Cpg._
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def createCpg(config: Config): Try[Cpg] = {
+    withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
+      new MetaDataPass(cpg, language, config.inputPath).createAndApply()
+      val astCreationPass = new AstCreationPass(config, cpg)
+      astCreationPass.createAndApply()
+      new ConfigFileCreationPass(cpg).createAndApply()
+      new TypeNodePass(astCreationPass.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
+      new TypeInferencePass(cpg).createAndApply()
+    }
+  }
+
+}
 
 object JavaSrc2Cpg {
   val language: String = Languages.JAVASRC
@@ -45,188 +44,10 @@ object JavaSrc2Cpg {
   val sourceFileExtensions: Set[String] = Set(".java")
   def apply(): JavaSrc2Cpg              = new JavaSrc2Cpg()
 
-  def getDependencyList(config: Config): Seq[String] = {
-    val codeDir = config.inputPath
-    if (config.fetchDependencies) {
-      DependencyResolver.getDependencies(Paths.get(codeDir)) match {
-        case Some(deps) => deps.toSeq
-        case None =>
-          logger.warn(s"Could not fetch dependencies for project at path $codeDir")
-          Seq()
-      }
-    } else {
-      logger.info("dependency resolving disabled")
-      Seq()
-    }
-  }
-
   def typeRecoveryPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = {
     List(
       new JavaTypeRecoveryPass(cpg, XTypeRecoveryConfig(enabledDummyTypes = !config.exists(_.disableDummyTypes))),
       new JavaTypeHintCallLinker(cpg)
     )
   }
-}
-
-class JavaSrc2Cpg extends X2CpgFrontend[Config] {
-  import JavaSrc2Cpg._
-
-  private val logger = LoggerFactory.getLogger(this.getClass)
-  override def createCpg(config: Config): Try[Cpg] = {
-    withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
-      new MetaDataPass(cpg, language, config.inputPath).createAndApply()
-
-      val sourceDirectories = getSourcePathsWithDelombok(config)
-      val javaparserAsts    = getSplitJavaparserAsts(sourceDirectories, config)
-      val symbolSolver      = createSymbolSolver(javaparserAsts.typesAsts, config)
-      javaparserAsts.analysisAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
-      javaparserAsts.typesAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
-
-      val astCreationPass = new AstCreationPass(javaparserAsts.analysisAsts, config, cpg, symbolSolver)
-      astCreationPass.createAndApply()
-      new ConfigFileCreationPass(cpg).createAndApply()
-      new TypeNodePass(astCreationPass.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
-      new TypeInferencePass(cpg).createAndApply()
-    }
-  }
-
-  /** Will extract source files from the given path if it is a directory, or in the case of a single file, will check
-    * the file's extension and return a singleton list of the file if the file extension is supported.
-    * @param sourcePath
-    *   the input directory or source file.
-    * @return
-    *   a list of all source files.
-    */
-  private def getSourcesFromDir(sourcePath: String): List[String] = {
-    val f = File(sourcePath)
-    if (f.isDirectory)
-      SourceRootFinder.getSourceRoots(sourcePath).flatMap(SourceFiles.determine(_, sourceFileExtensions))
-    else if (f.hasExtension && f.extension.exists(f => sourceFileExtensions.contains(f)))
-      List(sourcePath)
-    else
-      List.empty
-  }
-
-  private def parseFile(filename: String): Option[CompilationUnit] = {
-    val config      = new ParserConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE)
-    val parseResult = new JavaParser(config).parse(new java.io.File(filename))
-
-    parseResult.getProblems.asScala.toList match {
-      case Nil => // Just carry on as usual
-      case problems =>
-        logger.warn(s"Encountered problems while parsing file $filename:")
-        problems.foreach { problem =>
-          logger.warn(s"- ${problem.getMessage}")
-        }
-    }
-
-    parseResult.getResult.toScala match {
-      case Some(result) if result.getParsed == Parsedness.PARSED => Some(result)
-      case _ =>
-        logger.warn(s"Failed to parse file $filename")
-        None
-    }
-  }
-
-  private def escapeBackslash(path: String): String = {
-    path.replaceAll(raw"\\", raw"\\\\")
-  }
-
-  private def getSplitJavaparserAsts(sourceDirectories: SplitDirectories, config: Config): SplitJpAsts = {
-    val analysisSources = getSourcesFromDir(sourceDirectories.analysisSourceDir)
-    val typesSources    = getSourcesFromDir(sourceDirectories.typesSourceDir)
-
-    val analysisAstsMap = analysisSources.par.flatMap { sourceFilename =>
-      val originalFilename =
-        Paths.get(sourceDirectories.analysisSourceDir).relativize(Paths.get(sourceFilename)).toString
-      val sourceFileInfo  = SourceFileInfo(sourceFilename, originalFilename)
-      val maybeParsedFile = parseFile(sourceFilename)
-
-      maybeParsedFile.map(cu => sourceFilename -> JpAstWithMeta(sourceFileInfo, cu))
-    }.toMap
-
-    val analysisAsts = analysisAstsMap.values.toList
-    val typesAsts = typesSources.par.flatMap { sourceFilename =>
-      val sourceFileInfo = SourceFileInfo(sourceFilename, sourceFilename)
-      analysisAstsMap
-        .get(sourceFilename)
-        .map(_.compilationUnit)
-        .orElse(parseFile(sourceFilename))
-        .map(cu => JpAstWithMeta(sourceFileInfo, cu))
-    }.toList
-
-    SplitJpAsts(analysisAsts, typesAsts)
-  }
-
-  private def getSourcePathsWithDelombok(config: Config): SplitDirectories = {
-    val dependencies        = getDependencyList(config)
-    val delombokMode        = getDelombokMode(config)
-    val hasLombokDependency = dependencies.exists(_.contains("lombok"))
-    val originalSourcesDir  = File(config.inputPath).canonicalPath
-    lazy val delombokDir    = Delombok.run(originalSourcesDir, config.delombokJavaHome)
-
-    delombokMode match {
-      case DelombokMode.Default if hasLombokDependency =>
-        logger.info(s"Analysing delomboked code as lombok dependency was found.")
-        SplitDirectories(delombokDir, delombokDir)
-
-      case DelombokMode.RunDelombok =>
-        SplitDirectories(delombokDir, delombokDir)
-
-      case DelombokMode.TypesOnly =>
-        SplitDirectories(originalSourcesDir, delombokDir)
-
-      case _ => SplitDirectories(originalSourcesDir, originalSourcesDir)
-    }
-  }
-
-  private def getDelombokMode(config: Config): DelombokMode = {
-    config.delombokMode.map(_.toLowerCase) match {
-      case None                 => DelombokMode.Default
-      case Some("no-delombok")  => DelombokMode.NoDelombok
-      case Some("default")      => DelombokMode.Default
-      case Some("types-only")   => DelombokMode.TypesOnly
-      case Some("run-delombok") => DelombokMode.RunDelombok
-      case Some(value) =>
-        logger.warn(s"Found unrecognised delombok mode `$value`. Using default instead.")
-        DelombokMode.Default
-    }
-  }
-
-  private def recursiveJarsFromPath(path: String): List[String] = {
-    Try(File(path)) match {
-      case Success(file) if file.isDirectory =>
-        file.listRecursively
-          .map(_.canonicalPath)
-          .filter(_.endsWith(".jar"))
-          .toList
-
-      case Success(file) if file.canonicalPath.endsWith(".jar") =>
-        List(file.canonicalPath)
-
-      case _ =>
-        Nil
-    }
-  }
-
-  private def createSymbolSolver(typesAsts: List[JpAstWithMeta], config: Config): JavaSymbolSolver = {
-    val combinedTypeSolver   = new SimpleCombinedTypeSolver()
-    val reflectionTypeSolver = new CachingReflectionTypeSolver()
-    combinedTypeSolver.add(reflectionTypeSolver)
-
-    val sourceTypeSolver = EagerSourceTypeSolver(typesAsts, combinedTypeSolver)
-    // The sourceTypeSolver will often be the fastest due to there being no possibility of encountering a SOE on lookup.
-    combinedTypeSolver.prepend(sourceTypeSolver)
-
-    // Add solvers for inference jars
-    val jarsList = config.inferenceJarPaths.flatMap(recursiveJarsFromPath).toList
-    (jarsList ++ getDependencyList(config))
-      .flatMap { path =>
-        Try(new JarTypeSolver(path)).toOption
-      }
-      .foreach { combinedTypeSolver.add(_) }
-
-    new JavaSymbolSolver(combinedTypeSolver)
-  }
-
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -13,7 +13,8 @@ final case class Config(
   delombokJavaHome: Option[String] = None,
   delombokMode: Option[String] = None,
   enableTypeRecovery: Boolean = false,
-  disableDummyTypes: Boolean = false
+  disableDummyTypes: Boolean = false,
+  jdkPath: Option[String] = None
 ) extends X2CpgConfig[Config] {
   def withInferenceJarPaths(paths: Set[String]): Config = {
     copy(inferenceJarPaths = paths).withInheritedFields(this)
@@ -42,6 +43,10 @@ final case class Config(
   def withDisableDummyTypes(value: Boolean): Config = {
     copy(disableDummyTypes = value).withInheritedFields(this)
   }
+
+  def withJdkPath(path: String): Config = {
+    copy(jdkPath = Some(path)).withInheritedFields(this)
+  }
 }
 
 private object Frontend {
@@ -64,7 +69,7 @@ private object Frontend {
         .action((path, c) => c.withDelombokJavaHome(path)),
       opt[String]("delombok-mode")
         .text("""Specifies how delombok should be executed. Options are
-				| no-delombok => to not run delombok under any circumstances.
+                 | no-delombok => to not run delombok under any circumstances.
                  | default => run delombok if a lombok dependency is found and analyse delomboked code.
                  | types-only => to run delombok, but use it for type information only
                  | run-delombok => to force run delombok and analyse delomboked code.""".stripMargin)
@@ -76,7 +81,10 @@ private object Frontend {
       opt[Unit]("no-dummyTypes")
         .hidden()
         .action((_, c) => c.withDisableDummyTypes(true))
-        .text("disable generation of dummy types during type recovery")
+        .text("disable generation of dummy types during type recovery"),
+      opt[String]("jdk-path")
+        .action((path, c) => c.withJdkPath(path))
+        .text("JDK used for resolving builtin Java types. If not set, current classpath will be used")
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -1,37 +1,30 @@
 package io.joern.javasrc2cpg.passes
 
+import better.files.File
+import com.github.javaparser.{JavaParser, ParserConfiguration}
+import com.github.javaparser.ParserConfiguration.LanguageLevel
+import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ast.Node.Parsedness
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.ConcurrentWriterCpgPass
-import io.joern.javasrc2cpg.Config
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver
+import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
+import io.joern.javasrc2cpg.passes.AstCreationPass.getSplitJavaparserAsts
+import io.joern.javasrc2cpg.typesolvers.{CachingReflectionTypeSolver, EagerSourceTypeSolver, SimpleCombinedTypeSolver}
+import io.joern.javasrc2cpg.util.{Delombok, SourceRootFinder}
+import io.joern.javasrc2cpg.util.Delombok.DelombokMode
+import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.datastructures.Global
-import org.slf4j.LoggerFactory
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.joern.x2cpg.utils.dependency.DependencyResolver
-import java.nio.file.Paths
-import io.joern.javasrc2cpg.typesolvers.CachingReflectionTypeSolver
-import better.files.File
-import java.net.URLClassLoader
-import io.joern.javasrc2cpg.typesolvers.SimpleCombinedTypeSolver
-import io.joern.javasrc2cpg.typesolvers.EagerSourceTypeSolver
-import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver
-import scala.util.Try
-import scala.util.Success
-import io.joern.javasrc2cpg.util.SourceRootFinder
-import io.joern.javasrc2cpg.JavaSrc2Cpg
-import com.github.javaparser.ast.CompilationUnit
-import com.github.javaparser.ParserConfiguration
-import com.github.javaparser.ParserConfiguration.LanguageLevel
-import com.github.javaparser.JavaParser
-import io.joern.x2cpg.SourceFiles
-import io.joern.javasrc2cpg.passes.AstCreationPass.getSplitJavaparserAsts
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import org.slf4j.LoggerFactory
 
-import scala.jdk.OptionConverters.RichOptional
-import scala.jdk.CollectionConverters._
+import java.nio.file.Paths
 import scala.collection.parallel.CollectionConverters._
-import io.joern.javasrc2cpg.util.Delombok
-import io.joern.javasrc2cpg.util.Delombok.DelombokMode
-import com.github.javaparser.ast.Node.Parsedness
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptional
+import scala.util.{Success, Try}
 
 case class SourceDirectoryInfo(typeSolverSourceDirs: List[String], sourceFiles: List[SourceFileInfo])
 case class SplitDirectories(analysisSourceDir: String, typesSourceDir: String)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -3,17 +3,59 @@ package io.joern.javasrc2cpg.passes
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
-import io.joern.javasrc2cpg.{Config, JpAstWithMeta}
+import io.joern.javasrc2cpg.Config
 import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
+import io.joern.x2cpg.utils.dependency.DependencyResolver
+import java.nio.file.Paths
+import io.joern.javasrc2cpg.typesolvers.CachingReflectionTypeSolver
+import better.files.File
+import java.net.URLClassLoader
+import io.joern.javasrc2cpg.typesolvers.SimpleCombinedTypeSolver
+import io.joern.javasrc2cpg.typesolvers.EagerSourceTypeSolver
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver
+import scala.util.Try
+import scala.util.Success
+import io.joern.javasrc2cpg.util.SourceRootFinder
+import io.joern.javasrc2cpg.JavaSrc2Cpg
+import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ParserConfiguration
+import com.github.javaparser.ParserConfiguration.LanguageLevel
+import com.github.javaparser.JavaParser
+import io.joern.x2cpg.SourceFiles
+import io.joern.javasrc2cpg.passes.AstCreationPass.getSplitJavaparserAsts
 
-class AstCreationPass(asts: List[JpAstWithMeta], config: Config, cpg: Cpg, symbolSolver: JavaSymbolSolver)
+import scala.jdk.OptionConverters.RichOptional
+import scala.jdk.CollectionConverters._
+import scala.collection.parallel.CollectionConverters._
+import io.joern.javasrc2cpg.util.Delombok
+import io.joern.javasrc2cpg.util.Delombok.DelombokMode
+import com.github.javaparser.ast.Node.Parsedness
+
+case class SourceDirectoryInfo(typeSolverSourceDirs: List[String], sourceFiles: List[SourceFileInfo])
+case class SplitDirectories(analysisSourceDir: String, typesSourceDir: String)
+case class SplitJpAsts(analysisAsts: List[JpAstWithMeta], typesAsts: List[JpAstWithMeta])
+case class SourceFileInfo(analysisFileName: String, originalFilename: String)
+case class JpAstWithMeta(fileInfo: SourceFileInfo, compilationUnit: CompilationUnit)
+
+class AstCreationPass(config: Config, cpg: Cpg, preCreatedAsts: Option[SplitJpAsts] = None)
     extends ConcurrentWriterCpgPass[JpAstWithMeta](cpg) {
 
   val global: Global = new Global()
   private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
+  private val javaparserAsts = preCreatedAsts.getOrElse {
+    val sourceDirectories = getSourcePathsWithDelombok()
+    getSplitJavaparserAsts(sourceDirectories)
+  }
+  private val symbolSolver = createAndInjectSymbolSolver(javaparserAsts)
+
   override def generateParts(): Array[JpAstWithMeta] = {
+    val asts = javaparserAsts.analysisAsts.toArray
+    if (asts.isEmpty) {
+      throw new RuntimeException(s"Could not find any Java files at input path ${config.inputPath}")
+    }
     logger.info(s"Found ${asts.size} files.")
     asts.toArray
   }
@@ -24,4 +66,171 @@ class AstCreationPass(asts: List[JpAstWithMeta], config: Config, cpg: Cpg, symbo
     diffGraph.absorb(new AstCreator(originalFilename, result, global, symbolSolver).createAst())
   }
 
+  private def getDependencyList(): List[String] = {
+    val codeDir = config.inputPath
+    if (config.fetchDependencies) {
+      DependencyResolver.getDependencies(Paths.get(codeDir)) match {
+        case Some(deps) => deps.toList
+        case None =>
+          logger.warn(s"Could not fetch dependencies for project at path $codeDir")
+          List()
+      }
+    } else {
+      logger.info("dependency resolving disabled")
+      List()
+    }
+  }
+
+  private def createAndInjectSymbolSolver(jpAsts: SplitJpAsts): JavaSymbolSolver = {
+    val symbolSolver = createSymbolSolver(jpAsts.typesAsts)
+    javaparserAsts.analysisAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
+    javaparserAsts.typesAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
+    symbolSolver
+  }
+
+  private def createSymbolSolver(typesAsts: List[JpAstWithMeta]): JavaSymbolSolver = {
+    val dependencyList = getDependencyList()
+
+    val combinedTypeSolver   = new SimpleCombinedTypeSolver()
+    val reflectionTypeSolver = new CachingReflectionTypeSolver()
+    combinedTypeSolver.add(reflectionTypeSolver)
+
+    val sourceTypeSolver = EagerSourceTypeSolver(typesAsts, combinedTypeSolver)
+    // The sourceTypeSolver will often be the fastest due to there being no possibility of encountering a SOE on lookup.
+    combinedTypeSolver.prepend(sourceTypeSolver)
+
+    // Add solvers for inference jars
+    val jarsList = config.inferenceJarPaths.flatMap(recursiveJarsFromPath).toList
+    (jarsList ++ dependencyList)
+      .flatMap { path =>
+        Try(new JarTypeSolver(path)).toOption
+      }
+      .foreach { combinedTypeSolver.add(_) }
+
+    new JavaSymbolSolver(combinedTypeSolver)
+  }
+
+  private def recursiveJarsFromPath(path: String): List[String] = {
+    Try(File(path)) match {
+      case Success(file) if file.isDirectory =>
+        file.listRecursively
+          .map(_.canonicalPath)
+          .filter(_.endsWith(".jar"))
+          .toList
+
+      case Success(file) if file.canonicalPath.endsWith(".jar") =>
+        List(file.canonicalPath)
+
+      case _ =>
+        Nil
+    }
+  }
+
+  private def escapeBackslash(path: String): String = {
+    path.replaceAll(raw"\\", raw"\\\\")
+  }
+
+  private def getSourcePathsWithDelombok(): SplitDirectories = {
+    val dependencies        = getDependencyList()
+    val delombokMode        = getDelombokMode()
+    val hasLombokDependency = dependencies.exists(_.contains("lombok"))
+    val originalSourcesDir  = File(config.inputPath).canonicalPath
+    lazy val delombokDir    = Delombok.run(originalSourcesDir, config.delombokJavaHome)
+
+    delombokMode match {
+      case DelombokMode.Default if hasLombokDependency =>
+        logger.info(s"Analysing delomboked code as lombok dependency was found.")
+        SplitDirectories(delombokDir, delombokDir)
+
+      case DelombokMode.RunDelombok =>
+        SplitDirectories(delombokDir, delombokDir)
+
+      case DelombokMode.TypesOnly =>
+        SplitDirectories(originalSourcesDir, delombokDir)
+
+      case _ => SplitDirectories(originalSourcesDir, originalSourcesDir)
+    }
+  }
+
+  private def getDelombokMode(): DelombokMode = {
+    config.delombokMode.map(_.toLowerCase) match {
+      case None                 => DelombokMode.Default
+      case Some("no-delombok")  => DelombokMode.NoDelombok
+      case Some("default")      => DelombokMode.Default
+      case Some("types-only")   => DelombokMode.TypesOnly
+      case Some("run-delombok") => DelombokMode.RunDelombok
+      case Some(value) =>
+        logger.warn(s"Found unrecognised delombok mode `$value`. Using default instead.")
+        DelombokMode.Default
+    }
+  }
+
+}
+
+object AstCreationPass {
+  private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
+
+  def getSplitJavaparserAsts(sourceDirectories: SplitDirectories): SplitJpAsts = {
+    val analysisSources = getSourcesFromDir(sourceDirectories.analysisSourceDir)
+    val typesSources    = getSourcesFromDir(sourceDirectories.typesSourceDir)
+
+    val analysisAstsMap = analysisSources.par.flatMap { sourceFilename =>
+      val originalFilename =
+        Paths.get(sourceDirectories.analysisSourceDir).relativize(Paths.get(sourceFilename)).toString
+      val sourceFileInfo  = SourceFileInfo(sourceFilename, originalFilename)
+      val maybeParsedFile = parseFile(sourceFilename)
+
+      maybeParsedFile.map(cu => sourceFilename -> JpAstWithMeta(sourceFileInfo, cu))
+    }.toMap
+
+    val analysisAsts = analysisAstsMap.values.toList
+    val typesAsts = typesSources.par.flatMap { sourceFilename =>
+      val sourceFileInfo = SourceFileInfo(sourceFilename, sourceFilename)
+      analysisAstsMap
+        .get(sourceFilename)
+        .map(_.compilationUnit)
+        .orElse(parseFile(sourceFilename))
+        .map(cu => JpAstWithMeta(sourceFileInfo, cu))
+    }.toList
+
+    SplitJpAsts(analysisAsts, typesAsts)
+  }
+
+  /** Will extract source files from the given path if it is a directory, or in the case of a single file, will check
+    * the file's extension and return a singleton list of the file if the file extension is supported.
+    * @param sourcePath
+    *   the input directory or source file.
+    * @return
+    *   a list of all source files.
+    */
+  private def getSourcesFromDir(sourcePath: String): List[String] = {
+    val f = File(sourcePath)
+    if (f.isDirectory)
+      SourceRootFinder.getSourceRoots(sourcePath).flatMap(SourceFiles.determine(_, JavaSrc2Cpg.sourceFileExtensions))
+    else if (f.hasExtension && f.extension.exists(f => JavaSrc2Cpg.sourceFileExtensions.contains(f)))
+      List(sourcePath)
+    else
+      List.empty
+  }
+
+  private def parseFile(filename: String): Option[CompilationUnit] = {
+    val config      = new ParserConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE)
+    val parseResult = new JavaParser(config).parse(new java.io.File(filename))
+
+    parseResult.getProblems.asScala.toList match {
+      case Nil => // Just carry on as usual
+      case problems =>
+        logger.warn(s"Encountered problems while parsing file $filename:")
+        problems.foreach { problem =>
+          logger.warn(s"- ${problem.getMessage}")
+        }
+    }
+
+    parseResult.getResult.toScala match {
+      case Some(result) if result.getParsed == Parsedness.PARSED => Some(result)
+      case _ =>
+        logger.warn(s"Failed to parse file $filename")
+        None
+    }
+  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -54,7 +54,7 @@ class AstCreationPass(config: Config, cpg: Cpg, preCreatedAsts: Option[SplitJpAs
   override def generateParts(): Array[JpAstWithMeta] = {
     val asts = javaparserAsts.analysisAsts.toArray
     if (asts.isEmpty) {
-      throw new RuntimeException(s"Could not find any Java files at input path ${config.inputPath}")
+      throw new RuntimeException(s"Could not find any parseable Java files at input path ${config.inputPath}")
     }
     logger.info(s"Found ${asts.size} files.")
     asts.toArray

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.body.TypeDeclaration
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade
 import com.github.javaparser.symbolsolver.model.resolution.{SymbolReference, TypeSolver}
-import io.joern.javasrc2cpg.JpAstWithMeta
+import io.joern.javasrc2cpg.passes.JpAstWithMeta
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
@@ -13,10 +13,11 @@ class NewMemberTests extends JavaSrcCode2CpgFixture {
         |  Foo x = new Foo() {
         |    @Override
         |    void foo() {}
-        |  }
+        |  };
         |
         |  void foo() {}
         |}""".stripMargin)
+    cpg.member.size shouldBe 1
     cpg.member.name("x").astChildren.size shouldBe 0
   }
 
@@ -55,12 +56,13 @@ class NewMemberTests extends JavaSrcCode2CpgFixture {
         |  X(12) {
         |    @Override
         |    void foo() {}
-        |  }
+        |  };
         |
         |  private Foo(int x) {}
         |
         |  void foo() {}
         |}""".stripMargin)
+    cpg.member.size shouldBe 1
     cpg.member.name("x").astChildren.size shouldBe 0
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/interop/JavasrcInterop.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/interop/JavasrcInterop.scala
@@ -1,11 +1,11 @@
 package io.joern.kotlin2cpg.interop
 
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
-import io.joern.javasrc2cpg.{JpAstWithMeta, SplitJpAsts, SourceFileInfo, SplitDirectories, Config => JavaSrcConfig}
+import io.joern.javasrc2cpg.{Config => JavaSrcConfig}
+import io.joern.javasrc2cpg.passes.{SplitJpAsts, SourceFileInfo, SplitDirectories}
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.Node.Parsedness
-import io.joern.javasrc2cpg.typesolvers.{CachingReflectionTypeSolver, EagerSourceTypeSolver, SimpleCombinedTypeSolver}
-import io.joern.javasrc2cpg.JavaSrc2Cpg.sourceFileExtensions
+import io.joern.javasrc2cpg.JavaSrc2Cpg
 import io.joern.javasrc2cpg.util.SourceRootFinder
 
 import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
@@ -29,94 +29,14 @@ object JavasrcInterop {
   def astCreationPass(paths: List[String], cpg: Cpg): JavaSrcAstCreationPass = {
     val javaSrcConfig  = JavaSrcConfig()
     val javaParserAsts = JavasrcInterop.javaParserAsts(paths, javaSrcConfig.inputPath)
-    val symbolSolver   = JavasrcInterop.symbolSolver(javaParserAsts)
-    new JavaSrcAstCreationPass(javaParserAsts.analysisAsts, javaSrcConfig, cpg, symbolSolver)
-  }
-
-  private def symbolSolver(javaParserAsts: SplitJpAsts): JavaSymbolSolver = {
-    val symbolSolver = createSymbolSolver(javaParserAsts.typesAsts)
-    javaParserAsts.analysisAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
-    javaParserAsts.typesAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
-    symbolSolver
+    new JavaSrcAstCreationPass(javaSrcConfig, cpg, Some(javaParserAsts))
   }
 
   private def javaParserAsts(paths: Seq[String], inputPath: String): SplitJpAsts = {
     paths.foldLeft(SplitJpAsts(List(), List())) { (acc, p) =>
       val splitDirectories = SplitDirectories(p, p)
-      val splitParserAsts  = getSplitJavaparserAsts(splitDirectories, inputPath)
+      val splitParserAsts  = JavaSrcAstCreationPass.getSplitJavaparserAsts(splitDirectories)
       SplitJpAsts(acc.analysisAsts ++ splitParserAsts.analysisAsts, acc.typesAsts ++ splitParserAsts.typesAsts)
     }
-  }
-
-  private def parseFile(filename: String): Option[CompilationUnit] = {
-    val config      = new ParserConfiguration().setLanguageLevel(LanguageLevel.BLEEDING_EDGE)
-    val parseResult = new JavaParser(config).parse(new java.io.File(filename))
-
-    parseResult.getProblems.asScala.toList match {
-      case Nil => // Just carry on as usual
-      case problems =>
-        logger.warn(s"Encountered problems while parsing file $filename:")
-        problems.foreach { problem =>
-          logger.warn(s"- ${problem.getMessage}")
-        }
-    }
-
-    parseResult.getResult.toScala match {
-      case Some(result) if result.getParsed == Parsedness.PARSED => Some(result)
-      case _ =>
-        logger.warn(s"Failed to parse file $filename")
-        None
-    }
-  }
-
-  private def getSourcesFromDir(sourcePath: String): List[String] = {
-    val f = File(sourcePath)
-    if (f.isDirectory)
-      SourceRootFinder.getSourceRoots(sourcePath).flatMap(SourceFiles.determine(_, sourceFileExtensions))
-    else if (f.hasExtension && f.extension.exists(f => sourceFileExtensions.contains(f)))
-      List(sourcePath)
-    else
-      List.empty
-  }
-
-  private def escapeBackslash(path: String): String = {
-    path.replaceAll(raw"\\", raw"\\\\")
-  }
-
-  private def getSplitJavaparserAsts(sourceDirectories: SplitDirectories, inputPath: String): SplitJpAsts = {
-    val analysisSources = getSourcesFromDir(sourceDirectories.analysisSourceDir)
-    val typesSources    = getSourcesFromDir(sourceDirectories.typesSourceDir)
-
-    val analysisAstsMap = analysisSources.par.flatMap { sourceFilename =>
-      val originalFilename =
-        Paths.get(sourceDirectories.analysisSourceDir).relativize(Paths.get(sourceFilename)).toString
-      val sourceFileInfo  = SourceFileInfo(sourceFilename, originalFilename)
-      val maybeParsedFile = parseFile(sourceFilename)
-
-      maybeParsedFile.map(cu => sourceFilename -> JpAstWithMeta(sourceFileInfo, cu))
-    }.toMap
-
-    val analysisAsts = analysisAstsMap.values.toList
-    val typesAsts = typesSources.par.flatMap { sourceFilename =>
-      val sourceFileInfo = SourceFileInfo(sourceFilename, sourceFilename)
-      analysisAstsMap
-        .get(sourceFilename)
-        .map(_.compilationUnit)
-        .orElse(parseFile(sourceFilename))
-        .map(cu => JpAstWithMeta(sourceFileInfo, cu))
-    }.toList
-
-    SplitJpAsts(analysisAsts, typesAsts)
-  }
-
-  private def createSymbolSolver(typesAsts: List[JpAstWithMeta]): JavaSymbolSolver = {
-    val combinedTypeSolver   = new SimpleCombinedTypeSolver()
-    val reflectionTypeSolver = new CachingReflectionTypeSolver()
-    combinedTypeSolver.add(reflectionTypeSolver)
-
-    val sourceTypeSolver = EagerSourceTypeSolver(typesAsts, combinedTypeSolver)
-    combinedTypeSolver.prepend(sourceTypeSolver)
-
-    new JavaSymbolSolver(combinedTypeSolver)
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/interop/JavasrcInterop.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/interop/JavasrcInterop.scala
@@ -1,25 +1,11 @@
 package io.joern.kotlin2cpg.interop
 
-import com.github.javaparser.symbolsolver.JavaSymbolSolver
-import io.joern.javasrc2cpg.{Config => JavaSrcConfig}
-import io.joern.javasrc2cpg.passes.{SplitJpAsts, SourceFileInfo, SplitDirectories}
-import com.github.javaparser.ast.CompilationUnit
-import com.github.javaparser.ast.Node.Parsedness
-import io.joern.javasrc2cpg.JavaSrc2Cpg
-import io.joern.javasrc2cpg.util.SourceRootFinder
-
-import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
-import scala.jdk.OptionConverters.RichOptional
-import com.github.javaparser.ParserConfiguration.LanguageLevel
-import com.github.javaparser.{JavaParser, ParserConfiguration}
-import org.slf4j.LoggerFactory
-
-import scala.jdk.CollectionConverters.CollectionHasAsScala
 import better.files.File
-import io.joern.x2cpg.SourceFiles
-import io.shiftleft.codepropertygraph.Cpg
+import io.joern.javasrc2cpg.passes.{SplitDirectories, SplitJpAsts}
 import io.joern.javasrc2cpg.passes.{AstCreationPass => JavaSrcAstCreationPass}
-import java.nio.file.Paths
+import io.joern.javasrc2cpg.{Config => JavaSrcConfig}
+import io.shiftleft.codepropertygraph.Cpg
+import org.slf4j.LoggerFactory
 
 object JavasrcInterop {
   private val logger = LoggerFactory.getLogger(getClass)


### PR DESCRIPTION
`JavaSrcInterop` was re-implementing a lot of javasrc functionality that actually belongs in the javasrc2cpg `AstCreationPass`. This PR moves the relevant code into the ACP and removes the duplicate code from `JavaSrcInterop`