### PR TITLE
rubysrc2cpg: Fix for yield invocations

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -44,6 +44,7 @@ class AstCreator(filename: String, global: Global)
 
   protected val methodNamesWithYield = mutable.HashSet[String]()
   private val YIELD_SUFFIX           = "_yield"
+  private val UNRESOLVED_YIELD       = "unresolved_yield"
 
   protected def createIdentifierWithScope(
     ctx: ParserRuleContext,
@@ -1399,7 +1400,7 @@ class AstCreator(filename: String, global: Global)
       .flatMap(ast =>
         ast.nodes
           .filter(_.isInstanceOf[NewCall])
-          .filter(_.asInstanceOf[NewCall].name == "yield")
+          .filter(_.asInstanceOf[NewCall].name == UNRESOLVED_YIELD)
       )
       .foreach(node => {
         val yieldCallNode  = node.asInstanceOf[NewCall]
@@ -2005,9 +2006,9 @@ class AstCreator(filename: String, global: Global)
       val argsAst = astForArgumentsWithoutParenthesesContext(ctx.argumentsWithoutParentheses())
 
       val callNode = NewCall()
-        .name("yield")
+        .name(UNRESOLVED_YIELD)
         .code(ctx.getText)
-        .methodFullName("yield")
+        .methodFullName(UNRESOLVED_YIELD)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
@@ -2087,9 +2088,9 @@ class AstCreator(filename: String, global: Global)
     val argsAst = astForArgumentsContext(ctx.arguments())
 
     val callNode = NewCall()
-      .name("yield")
+      .name(UNRESOLVED_YIELD)
       .code(ctx.getText)
-      .methodFullName("yield")
+      .methodFullName(UNRESOLVED_YIELD)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -964,7 +964,9 @@ class AstCreator(filename: String, global: Global)
 
     if (blockName == "loop") {
       /*
-       * This block is for a do-while loop
+       * This block is for a do-while loop equivalent in Ruby
+       * NOT using a doWhileAst() here since this is not a real doWhile loop. Ruby does not have one
+       * This is more of a exit controlled loop block
        */
       val blockAst = astForBlockContext(ctx.block())
       blockAst ++ methodIdAst

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -280,14 +280,17 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |  yield(x,y)
         |end
         |
-        |yield_with_arguments { |arg1, arg2| puts "Yield block 1 #{arg1} and #{arg2}" }
-        |yield_with_arguments { |arg1, arg2| puts "Yield block 2 #{arg2} and #{arg1}" }
+        |yield_with_arguments { |arg1, arg2| puts1 "Yield block 1 #{arg1} and #{arg2}" }
+        |yield_with_arguments { |arg1, arg2| puts2 "Yield block 2 #{arg2} and #{arg1}" }
         |""".stripMargin)
 
     "be found" in {
       val src  = cpg.identifier.name("x").l
-      val sink = cpg.call.name("puts").l
-      sink.reachableByFlows(src).l.size shouldBe 4
+      val sink1 = cpg.call.name("puts1").l
+      sink1.reachableByFlows(src).l.size shouldBe 2
+
+      val sink2 = cpg.call.name("puts2").l
+      sink2.reachableByFlows(src).l.size shouldBe 2
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -272,20 +272,22 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through yield with argument without parenthesis" should {
+  "Data flow through yield with argument without parenthesis and multiple yield blocks" should {
     val cpg = code("""
         |def yield_with_arguments
-        |  a = "something"
-        |  yield a
+        |  x = "something"
+        |  y = "something_else"
+        |  yield(x,y)
         |end
         |
-        |yield_with_arguments { |arg| puts "Argument is #{arg}" }
+        |yield_with_arguments { |arg1, arg2| puts "Yield block 1 #{arg1} and #{arg2}" }
+        |yield_with_arguments { |arg1, arg2| puts "Yield block 2 #{arg2} and #{arg1}" }
         |""".stripMargin)
 
     "be found" in {
-      val src  = cpg.identifier.name("a").l
+      val src  = cpg.identifier.name("x").l
       val sink = cpg.call.name("puts").l
-      sink.reachableByFlows(src).l.size shouldBe 2
+      sink.reachableByFlows(src).l.size shouldBe 4
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -255,7 +255,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through yield with argument" ignore {
+  "Data flow through yield with argument" should {
     val cpg = code("""
         |def yield_with_arguments
         |  a = "something"
@@ -778,7 +778,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).l.size shouldBe 2
+      sink.reachableByFlows(source).l.size shouldBe 1
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -280,17 +280,38 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |  yield(x,y)
         |end
         |
-        |yield_with_arguments { |arg1, arg2| puts1 "Yield block 1 #{arg1} and #{arg2}" }
-        |yield_with_arguments { |arg1, arg2| puts2 "Yield block 2 #{arg2} and #{arg1}" }
+        |yield_with_arguments { |arg1, arg2| puts "Yield block 1 #{arg1} and #{arg2}" }
+        |yield_with_arguments { |arg1, arg2| puts "Yield block 2 #{arg2} and #{arg1}" }
         |""".stripMargin)
 
     "be found" in {
-      val src   = cpg.identifier.name("x").l
-      val sink1 = cpg.call.name("puts1").l
-      sink1.reachableByFlows(src).l.size shouldBe 2
+      val src  = cpg.identifier.name("x").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 4
+    }
+  }
 
-      val sink2 = cpg.call.name("puts2").l
-      sink2.reachableByFlows(src).l.size shouldBe 2
+  "Data flow through yield with argument and multiple yield blocks" ignore {
+    val cpg = code("""
+        |def yield_with_arguments
+        |  x = "something"
+        |  y = "something_else"
+        |  yield(x)
+        |  yield(y)
+        |end
+        |
+        |yield_with_arguments { |arg| puts "Yield block 1 #{arg}" }
+        |yield_with_arguments { |arg| puts "Yield block 2 #{arg}" }
+        |""".stripMargin)
+
+    "be found" in {
+      val src1  = cpg.identifier.name("x").l
+      val sink1 = cpg.call.name("puts").l
+      sink1.reachableByFlows(src1).l.size shouldBe 2
+
+      val src2  = cpg.identifier.name("y").l
+      val sink2 = cpg.call.name("puts").l
+      sink2.reachableByFlows(src2).l.size shouldBe 2
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -285,7 +285,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "be found" in {
-      val src  = cpg.identifier.name("x").l
+      val src   = cpg.identifier.name("x").l
       val sink1 = cpg.call.name("puts1").l
       sink1.reachableByFlows(src).l.size shouldBe 2
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -255,11 +255,28 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow through yield with argument" should {
+  "Data flow through yield with argument having parenthesis" should {
     val cpg = code("""
         |def yield_with_arguments
         |  a = "something"
         |  yield(a)
+        |end
+        |
+        |yield_with_arguments { |arg| puts "Argument is #{arg}" }
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("a").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
+  "Data flow through yield with argument without parenthesis" should {
+    val cpg = code("""
+        |def yield_with_arguments
+        |  a = "something"
+        |  yield a
         |end
         |
         |yield_with_arguments { |arg| puts "Argument is #{arg}" }
@@ -778,7 +795,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).l.size shouldBe 1
+      sink.reachableByFlows(source).l.size shouldBe 2
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -711,19 +711,5 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       identifierNode2.lineNumber shouldBe Some(3)
       identifierNode2.columnNumber shouldBe Some(0)
     }
-
-    "temp yield" in {
-      val cpg = code("")
-
-      val List(identifierNode1) = cpg.identifier.name("identifier1").l
-      identifierNode1.code shouldBe "identifier1"
-      identifierNode1.lineNumber shouldBe Some(2)
-      identifierNode1.columnNumber shouldBe Some(0)
-
-      val List(identifierNode2) = cpg.identifier.name("identifier2").l
-      identifierNode2.code shouldBe "identifier2"
-      identifierNode2.lineNumber shouldBe Some(3)
-      identifierNode2.columnNumber shouldBe Some(0)
-    }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -660,5 +660,19 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       identifierNode2.lineNumber shouldBe Some(3)
       identifierNode2.columnNumber shouldBe Some(0)
     }
+
+    "temp yield" in {
+      val cpg = code("")
+
+      val List(identifierNode1) = cpg.identifier.name("identifier1").l
+      identifierNode1.code shouldBe "identifier1"
+      identifierNode1.lineNumber shouldBe Some(2)
+      identifierNode1.columnNumber shouldBe Some(0)
+
+      val List(identifierNode2) = cpg.identifier.name("identifier2").l
+      identifierNode2.code shouldBe "identifier2"
+      identifierNode2.lineNumber shouldBe Some(3)
+      identifierNode2.columnNumber shouldBe Some(0)
+    }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -86,8 +86,8 @@ class ControlStructureTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "recognise all method nodes" in {
-      cpg.method.name("yield_with_args_method").size shouldBe 1
-      // TODO need to figure out how yield block should be connected to the method
+      cpg.method.name("yield_with_args_method").size shouldBe 2
+      // TODO add checks for method ref and call nodes
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -26,8 +26,6 @@ class ControlStructureTests extends RubyCode2CpgFixture {
   "CPG for code with doBlock iterating over a constant array and multiple params" should {
     val cpg = code("""
           |[1, 2, "three"].each do |n, m|
-          |
-          |
           |  expect {
           |  someObject.someMethod(n)
           |  someObject.someMethod(m)
@@ -86,8 +84,8 @@ class ControlStructureTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "recognise all method nodes" in {
-      cpg.method.name("yield_with_args_method").size shouldBe 2
-      cpg.methodRef.methodFullName(".*yield_with_args_method").size shouldBe 1
+      cpg.method.name("yield_with_args_method").size shouldBe 1
+      cpg.method.name("yield_with_args_method_yield").size shouldBe 1
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -87,7 +87,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
 
     "recognise all method nodes" in {
       cpg.method.name("yield_with_args_method").size shouldBe 2
-      // TODO add checks for method ref and call nodes
+      cpg.methodRef.methodFullName(".*yield_with_args_method").size shouldBe 1
     }
   }
 


### PR DESCRIPTION
1. Fix for yield invocations. Considered the method specific yield block as a new fake method and converted the yield call to a `CALL` node. The fake method is a new `METHOD` node with _yield suffixed to its name. A `METHODREF` of the fake method has been passed to it.
2. Removed lazy appending block methods. They can instead be put in the creation path
3. Test case changes for the same