### PR TITLE
Add php2cpg ast parent info and ANY type as placeholder

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -1,7 +1,7 @@
 package io.joern.php2cpg
 
 import io.joern.php2cpg.parser.PhpParser
-import io.joern.php2cpg.passes.{AstCreationPass, LocalCreationPass}
+import io.joern.php2cpg.passes.{AnyTypePass, AstCreationPass, AstParentInfoPass, ClosureRefPass, LocalCreationPass}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable
 import scala.util.{Failure, Try, Success}
 import scala.util.matching.Regex
-import io.joern.php2cpg.passes.ClosureRefPass
 
 class Php2Cpg extends X2CpgFrontend[Config] {
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -51,6 +50,8 @@ class Php2Cpg extends X2CpgFrontend[Config] {
         new MetaDataPass(cpg, Languages.PHP, config.inputPath).createAndApply()
         val astCreationPass = new AstCreationPass(config, cpg, parser.get)
         astCreationPass.createAndApply()
+        new AstParentInfoPass(cpg).createAndApply()
+        new AnyTypePass(cpg).createAndApply()
         new TypeNodePass(astCreationPass.allUsedTypes, cpg).createAndApply()
         LocalCreationPass.allLocalCreationPasses(cpg).foreach(_.createAndApply())
         new ClosureRefPass(cpg).createAndApply()

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AnyTypePass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AnyTypePass.scala
@@ -1,0 +1,22 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.astcreation.AstCreator
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode
+import io.shiftleft.codepropertygraph.generated.nodes.Call.PropertyDefaults
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language._
+
+// TODO This is a hack for a customer issue. Either extend this to handle type full names properly,
+//  or do it elsewhere.
+class AnyTypePass(cpg: Cpg) extends ConcurrentWriterCpgPass[AstNode](cpg) {
+
+  override def generateParts(): Array[AstNode] = {
+    cpg.has(PropertyNames.TYPE_FULL_NAME, PropertyDefaults.TypeFullName).collectAll[AstNode].toArray
+  }
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, node: AstNode): Unit = {
+    diffGraph.setNodeProperty(node, PropertyNames.TYPE_FULL_NAME, AstCreator.TypeConstants.Any)
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstParentInfoPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstParentInfoPass.scala
@@ -1,0 +1,38 @@
+package io.joern.php2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, NamespaceBlock, Method, TypeDecl}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language._
+
+class AstParentInfoPass(cpg: Cpg) extends ConcurrentWriterCpgPass[AstNode](cpg) {
+
+  override def generateParts(): Array[AstNode] = {
+    (cpg.method ++ cpg.typeDecl).toArray
+  }
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, node: AstNode): Unit = {
+    findParent(node).foreach { parentNode =>
+      val astParentType     = parentNode.label
+      val astParentFullName = parentNode.property(PropertyNames.FULL_NAME)
+
+      diffGraph.setNodeProperty(node, PropertyNames.AST_PARENT_TYPE, astParentType)
+      diffGraph.setNodeProperty(node, PropertyNames.AST_PARENT_FULL_NAME, astParentFullName)
+    }
+  }
+
+  private def hasValidContainingNodes(nodes: Iterator[AstNode]): Iterator[AstNode] = {
+    nodes.collect {
+      case m: Method         => m
+      case t: TypeDecl       => t
+      case n: NamespaceBlock => n
+    }
+  }
+
+  def findParent(node: AstNode): Option[AstNode] = {
+    node.start
+      .repeat(_.astParent)(_.until(hasValidContainingNodes(_)).emit(hasValidContainingNodes(_)))
+      .find(_ != node)
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -9,15 +9,20 @@ import io.shiftleft.semanticcpg.language._
 class MethodTests extends PhpCode2CpgFixture {
 
   "method nodes should be created with the correct fields" in {
-    val cpg = code("""<?php
+    val cpg = code(
+      """<?php
      |function foo(): int {}
-     |""".stripMargin)
+     |""".stripMargin,
+      fileName = "foo.php"
+    )
 
     inside(cpg.method.name("foo").l) { case List(fooMethod) =>
       fooMethod.fullName shouldBe s"foo"
       fooMethod.signature shouldBe s"${Defines.UnresolvedSignature}(0)"
       fooMethod.lineNumber shouldBe Some(2)
       fooMethod.code shouldBe "function foo()"
+      fooMethod.astParentType shouldBe "METHOD"
+      fooMethod.astParentFullName.endsWith("<global>") shouldBe true
 
       inside(fooMethod.methodReturn.start.l) { case List(methodReturn) =>
         methodReturn.typeFullName shouldBe "int"


### PR DESCRIPTION
* Add ast parent info for general linking
* Replace all `<empty>` type full names in the ast with `ANY` in an attempt to avoid the DynamicTypeLinker crash.