### PR TITLE
Fix php > 8 requirement in php2cpg

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -18,8 +18,8 @@ class Php2Cpg extends X2CpgFrontend[Config] {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   private def isPhpVersionSupported: Boolean = {
-    // PHP 8.1.0 and above is required by Composer, which is used by PHP Parser
-    val phpVersionRegex = new Regex("^PHP (8\\.[1-9]\\.[0-9]|[9-9]\\d\\.\\d\\.\\d)")
+    // PHP 7.1.0 and above is required by Composer, which is used by PHP Parser
+    val phpVersionRegex = new Regex("^PHP ([78]\\.[1-9]\\.[0-9]|[9-9]\\d\\.\\d\\.\\d)")
     val result          = ExternalCommand.run("php --version", ".")
     result match {
       case Success(listString) =>
@@ -42,7 +42,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
       errorMessages.append("Could not initialize PhpParser")
     }
     if (!isPhpVersionSupported) {
-      errorMessages.append("PHP version not supported. Is PHP 8.1.0 or above installed and available on your path?")
+      errorMessages.append("PHP version not supported. Is PHP 7.1.0 or above installed and available on your path?")
     }
 
     if (errorMessages.isEmpty) {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -93,7 +93,7 @@ object PhpParser {
 
     val fixedDir = new java.io.File(dir.substring(0, dir.indexOf("php2cpg"))).toString
 
-    Paths.get(fixedDir, "php2cpg", "bin", "php-parser.phar").toAbsolutePath.toString
+    Paths.get(fixedDir, "php2cpg", "bin", "php-parser", "php-parser.php").toAbsolutePath.toString
   }
 
   private def configOverrideOrDefaultPath(


### PR DESCRIPTION
Due to how php-parser was packaged, there was a php > 8 requirement to run it, even though php-parser itself is supported by php > 7.1. This change brings in the fixed php-parser, while also introducing a versioning scheme for php-parser binaries.