### PR TITLE
rubysrc2cpg: clean-up the AST construction of `super` calls a bit

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -128,15 +128,16 @@ trait AstForExpressionsCreator { this: AstCreator =>
     val ifNode  = controlStructureNode(ctx, ControlStructureTypes.IF, ctx.getText)
     controlStructureAst(ifNode, testAst.headOption, thenAst ++ elseAst)
   }
-  
+
   protected def astForSuperExpression(ctx: SuperExpressionPrimaryContext): Ast =
     astForSuperCall(ctx, astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses))
 
   // TODO: Handle the optional block.
   // NOTE: `super` is quite complicated semantically speaking. We'll need
   //       to revisit how to represent them.
-  protected def astForSuperCall(ctx: ParserRuleContext, arguments: Seq[Ast]) : Ast = {
-    val call = callNode(ctx, ctx.getText, RubyOperators.superKeyword, RubyOperators.superKeyword, DispatchTypes.STATIC_DISPATCH)
+  protected def astForSuperCall(ctx: ParserRuleContext, arguments: Seq[Ast]): Ast = {
+    val call =
+      callNode(ctx, ctx.getText, RubyOperators.superKeyword, RubyOperators.superKeyword, DispatchTypes.STATIC_DISPATCH)
     callAst(call, arguments.toList)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.parser.RubyParser._
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
+import org.antlr.v4.runtime.ParserRuleContext
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -127,15 +128,16 @@ trait AstForExpressionsCreator { this: AstCreator =>
     val ifNode  = controlStructureNode(ctx, ControlStructureTypes.IF, ctx.getText)
     controlStructureAst(ifNode, testAst.headOption, thenAst ++ elseAst)
   }
+  
+  protected def astForSuperExpression(ctx: SuperExpressionPrimaryContext): Ast =
+    astForSuperCall(ctx, astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses))
 
   // TODO: Handle the optional block.
   // NOTE: `super` is quite complicated semantically speaking. We'll need
   //       to revisit how to represent them.
-  protected def astForSuperExpression(ctx: SuperExpressionPrimaryContext): Ast = {
-    val argsAst = astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses)
-    val call =
-      callNode(ctx, ctx.getText, RubyOperators.superKeyword, RubyOperators.superKeyword, DispatchTypes.STATIC_DISPATCH)
-    callAst(call, argsAst.toList)
+  protected def astForSuperCall(ctx: ParserRuleContext, arguments: Seq[Ast]) : Ast = {
+    val call = callNode(ctx, ctx.getText, RubyOperators.superKeyword, RubyOperators.superKeyword, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, arguments.toList)
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -151,9 +151,8 @@ trait AstForStatementsCreator { this: AstCreator =>
     callAst(call, argsAst.toList)
   }
 
-  protected def astForSuperCommand(ctx: SuperCommandContext): Seq[Ast] = {
-    astForArgumentsWithoutParenthesesContext(ctx.argumentsWithoutParentheses())
-  }
+  protected def astForSuperCommand(ctx: SuperCommandContext): Ast =
+    astForSuperCall(ctx, astForArgumentsWithoutParenthesesContext(ctx.argumentsWithoutParentheses))
 
   protected def astForYieldCommand(ctx: YieldCommandContext): Seq[Ast] = {
     val argsAst = astForArgumentsWithoutParenthesesContext(ctx.argumentsWithoutParentheses())
@@ -224,7 +223,7 @@ trait AstForStatementsCreator { this: AstCreator =>
 
   protected def astForCommand(ctx: CommandContext): Seq[Ast] = ctx match {
     case ctx: YieldCommandContext        => astForYieldCommand(ctx)
-    case ctx: SuperCommandContext        => astForSuperCommand(ctx)
+    case ctx: SuperCommandContext        => Seq(astForSuperCommand(ctx))
     case ctx: SimpleMethodCommandContext => astForSimpleMethodCommand(ctx)
     case ctx: MemberAccessCommandContext => astForMemberAccessCommand(ctx)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.passes.ast
 
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.Identifier
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
 import io.shiftleft.semanticcpg.language._
 
@@ -755,6 +755,36 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       identifierNode2.code shouldBe "identifier2"
       identifierNode2.lineNumber shouldBe Some(3)
       identifierNode2.columnNumber shouldBe Some(0)
+    }
+    
+    // NOTE: The representation for `super` may change, in order to accommodate its meaning.
+    //       But until then, modelling it as a call seems the appropriate thing to do.
+    "have correct structure for `super` expression call without block" in {
+      val cpg = code("super(1)")
+      
+      val List(callNode) = cpg.call.l
+      callNode.code shouldBe "super(1)"
+      callNode.name shouldBe "<operator>.super"
+      callNode.lineNumber shouldBe Some(1)
+      
+      val List(literalArg: Literal) = callNode.argument.l
+      literalArg.argumentIndex shouldBe 1
+      literalArg.code shouldBe "1"
+      literalArg.lineNumber shouldBe Some(1)
+    }
+
+    "have correct structure for `super` command call without block" in {
+      val cpg = code("super 1")
+
+      val List(callNode) = cpg.call.l
+      callNode.code shouldBe "super 1"
+      callNode.name shouldBe "<operator>.super"
+      callNode.lineNumber shouldBe Some(1)
+
+      val List(literalArg: Literal) = callNode.argument.l
+      literalArg.argumentIndex shouldBe 1
+      literalArg.code shouldBe "1"
+      literalArg.lineNumber shouldBe Some(1)
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -756,17 +756,17 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       identifierNode2.lineNumber shouldBe Some(3)
       identifierNode2.columnNumber shouldBe Some(0)
     }
-    
+
     // NOTE: The representation for `super` may change, in order to accommodate its meaning.
     //       But until then, modelling it as a call seems the appropriate thing to do.
     "have correct structure for `super` expression call without block" in {
       val cpg = code("super(1)")
-      
+
       val List(callNode) = cpg.call.l
       callNode.code shouldBe "super(1)"
       callNode.name shouldBe "<operator>.super"
       callNode.lineNumber shouldBe Some(1)
-      
+
       val List(literalArg: Literal) = callNode.argument.l
       literalArg.argumentIndex shouldBe 1
       literalArg.code shouldBe "1"


### PR DESCRIPTION
* Unified the handling of `super` commands and `super` expressions into a common `astForSuperCall`.