### PR TITLE
rubysrc2cpg: improved regex literal support

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
@@ -11,13 +11,17 @@ abstract class RubyLexerBase(input: CharStream)
 
   /** The previously (non-WS) emitted token (in DEFAULT_CHANNEL.) */
   protected var previousNonWsToken: Option[Token] = None
+  
+  /** The previously emitted token (in DEFAULT_CHANNEL.)  */
+  protected var previousToken: Option[Token] = None
 
-  // Same original behaviour, just updating `previousNonWsToken`.
+  // Same original behaviour, just updating `previous{NonWs}Token`.
   override def nextToken: Token = {
     val token: Token = super.nextToken
     if (token.getChannel == Token.DEFAULT_CHANNEL && token.getType != WS) {
       previousNonWsToken = Some(token)
     }
+    previousToken = Some(token)
     token
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
@@ -11,8 +11,8 @@ abstract class RubyLexerBase(input: CharStream)
 
   /** The previously (non-WS) emitted token (in DEFAULT_CHANNEL.) */
   protected var previousNonWsToken: Option[Token] = None
-  
-  /** The previously emitted token (in DEFAULT_CHANNEL.)  */
+
+  /** The previously emitted token (in DEFAULT_CHANNEL.) */
   protected var previousToken: Option[Token] = None
 
   // Same original behaviour, just updating `previous{NonWs}Token`.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
@@ -56,17 +56,17 @@ trait RubyLexerRegexHandling { this: RubyLexerBase =>
   /** To be invoked when encountering `/`, deciding if it should emit a `REGULAR_EXPRESSION_START` token. */
   protected def isStartOfRegex: Boolean =
     regexTogglingTokens.contains(previousNonWsToken.map(_.getType).orNull) || isInCommandArgumentPosition
-  
-  /** Decides if the current `/` is being used as an argument to a command, based on the observation
-    * that such literals may not start with a WS. E.g. `puts /x/` is valid, but `puts / x/` is not. 
+
+  /** Decides if the current `/` is being used as an argument to a command, based on the observation that such literals
+    * may not start with a WS. E.g. `puts /x/` is valid, but `puts / x/` is not.
     */
   private def isInCommandArgumentPosition: Boolean = {
     val previousNonWsIsIdentifier = previousNonWsToken.map(_.getType).getOrElse(EOF) == LOCAL_VARIABLE_IDENTIFIER
-    val previousIsWs = previousToken.map(_.getType).getOrElse(EOF) == WS
-    val nextIsWs  = _input.LA(1) == ' '
+    val previousIsWs              = previousToken.map(_.getType).getOrElse(EOF) == WS
+    val nextIsWs                  = _input.LA(1) == ' '
     previousNonWsIsIdentifier && previousIsWs && !nextIsWs
   }
-  
+
   /** To be invoked when in `DEFAULT_MODE`, to check if we are in the context of a regular expression interpolation. */
   protected def isInRegularExpressionInterpolationMode: Boolean =
     _modeStack.size > 1 && _modeStack.peek == REGULAR_EXPRESSION_MODE

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.parser
 
 import io.joern.rubysrc2cpg.parser.RubyLexer._
+import org.antlr.v4.runtime.Recognizer.EOF
 
 trait RubyLexerRegexHandling { this: RubyLexerBase =>
 
@@ -54,8 +55,18 @@ trait RubyLexerRegexHandling { this: RubyLexerBase =>
 
   /** To be invoked when encountering `/`, deciding if it should emit a `REGULAR_EXPRESSION_START` token. */
   protected def isStartOfRegex: Boolean =
-    regexTogglingTokens.contains(previousNonWsToken.map(_.getType).orNull)
-
+    regexTogglingTokens.contains(previousNonWsToken.map(_.getType).orNull) || isInCommandArgumentPosition
+  
+  /** Decides if the current `/` is being used as an argument to a command, based on the observation
+    * that such literals may not start with a WS. E.g. `puts /x/` is valid, but `puts / x/` is not. 
+    */
+  private def isInCommandArgumentPosition: Boolean = {
+    val previousNonWsIsIdentifier = previousNonWsToken.map(_.getType).getOrElse(EOF) == LOCAL_VARIABLE_IDENTIFIER
+    val previousIsWs = previousToken.map(_.getType).getOrElse(EOF) == WS
+    val nextIsWs  = _input.LA(1) == ' '
+    previousNonWsIsIdentifier && previousIsWs && !nextIsWs
+  }
+  
   /** To be invoked when in `DEFAULT_MODE`, to check if we are in the context of a regular expression interpolation. */
   protected def isInRegularExpressionInterpolationMode: Boolean =
     _modeStack.size > 1 && _modeStack.peek == REGULAR_EXPRESSION_MODE

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -38,27 +38,25 @@ class RegexTests extends RubyParserAbstractTest {
             |        /""".stripMargin
       }
     }
-
-    // TODO: RubyLexer needs to properly identify regex literals as arguments to commands first.
-    "as the argument to a `puts` command" ignore {
+    
+    "as the argument to a `puts` command" should {
       val code = "puts //"
 
       "be parsed as such" in {
         printAst(_.expressionOrCommand(), code) shouldEqual
-          """ExpressionExpressionOrCommand
-            | InvocationExpressionOrCommand
-            |  SingleCommandOnlyInvocationWithoutParentheses
-            |   Command
-            |    MethodIdentifier
-            |     puts
-            |    ArgumentsWithoutParentheses
-            |     BlockExprAssocTypeArguments
-            |      Expressions
-            |       PrimaryExpression
-            |        LiteralPrimary
-            |         Literal
-            |          /
-            |          /""".stripMargin
+          """InvocationExpressionOrCommand
+            | SingleCommandOnlyInvocationWithoutParentheses
+            |  SimpleMethodCommand
+            |   MethodIdentifier
+            |    puts
+            |   ArgumentsWithoutParentheses
+            |    BlockExprAssocTypeArguments
+            |     Expressions
+            |      PrimaryExpression
+            |       LiteralPrimary
+            |        RegularExpressionLiteral
+            |         /
+            |         /""".stripMargin
       }
     }
 
@@ -155,28 +153,26 @@ class RegexTests extends RubyParserAbstractTest {
             |        /""".stripMargin
       }
     }
-
-    // TODO: RubyLexer needs to properly identify regex literals as arguments to commands first.
-    "as the argument to a `puts` command" ignore {
+    
+    "as the argument to a `puts` command" should {
       val code = "puts /(eu|us)/"
 
       "be parsed as such" in {
         printAst(_.expressionOrCommand(), code) shouldEqual
-          """ExpressionExpressionOrCommand
-            | InvocationExpressionOrCommand
-            |  SingleCommandOnlyInvocationWithoutParentheses
-            |   Command
-            |    MethodIdentifier
-            |     puts
-            |    ArgumentsWithoutParentheses
-            |     BlockExprAssocTypeArguments
-            |      Expressions
-            |       PrimaryExpression
-            |        LiteralPrimary
-            |         Literal
-            |          /
-            |          (eu|us)
-            |          /""".stripMargin
+          """InvocationExpressionOrCommand
+            | SingleCommandOnlyInvocationWithoutParentheses
+            |  SimpleMethodCommand
+            |   MethodIdentifier
+            |    puts
+            |   ArgumentsWithoutParentheses
+            |    BlockExprAssocTypeArguments
+            |     Expressions
+            |      PrimaryExpression
+            |       LiteralPrimary
+            |        RegularExpressionLiteral
+            |         /
+            |         (eu|us)
+            |         /""".stripMargin
       }
     }
 
@@ -271,42 +267,40 @@ class RegexTests extends RubyParserAbstractTest {
             |        /""".stripMargin
       }
     }
-
-    // TODO: RubyLexer needs to properly identify regex literals as arguments to commands first.
-    "as the argument to a `puts` command" ignore {
+    
+    "as the argument to a `puts` command" should {
       val code = "puts /x#{1}y/"
 
       "be parsed as such" in {
         printAst(_.expressionOrCommand(), code) shouldEqual
-          """ExpressionExpressionOrCommand
-            | InvocationExpressionOrCommand
-            |  SingleCommandOnlyInvocationWithoutParentheses
-            |   Command
-            |    MethodIdentifier
-            |     puts
-            |    ArgumentsWithoutParentheses
-            |     BlockExprAssocTypeArguments
-            |      Expressions
-            |       PrimaryExpression
-            |        RegexInterpolationPrimary
-            |         RegexInterpolation
-            |          /
-            |          x
-            |          InterpolatedRegexSequence
-            |           #{
-            |           CompoundStatement
-            |            Statements
-            |             ExpressionOrCommandStatement
-            |              ExpressionExpressionOrCommand
-            |               PrimaryExpression
-            |                LiteralPrimary
-            |                 Literal
-            |                  NumericLiteral
-            |                   UnsignedNumericLiteral
-            |                    1
-            |           }
-            |           y
-            |           /""".stripMargin
+          """InvocationExpressionOrCommand
+            | SingleCommandOnlyInvocationWithoutParentheses
+            |  SimpleMethodCommand
+            |   MethodIdentifier
+            |    puts
+            |   ArgumentsWithoutParentheses
+            |    BlockExprAssocTypeArguments
+            |     Expressions
+            |      PrimaryExpression
+            |       RegexInterpolationPrimary
+            |        RegexInterpolation
+            |         /
+            |         x
+            |         InterpolatedRegexSequence
+            |          #{
+            |          CompoundStatement
+            |           Statements
+            |            ExpressionOrCommandStatement
+            |             ExpressionExpressionOrCommand
+            |              PrimaryExpression
+            |               LiteralPrimary
+            |                NumericLiteralLiteral
+            |                 NumericLiteral
+            |                  UnsignedNumericLiteral
+            |                   1
+            |          }
+            |         y
+            |         /""".stripMargin
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -38,7 +38,7 @@ class RegexTests extends RubyParserAbstractTest {
             |        /""".stripMargin
       }
     }
-    
+
     "as the argument to a `puts` command" should {
       val code = "puts //"
 
@@ -153,7 +153,7 @@ class RegexTests extends RubyParserAbstractTest {
             |        /""".stripMargin
       }
     }
-    
+
     "as the argument to a `puts` command" should {
       val code = "puts /(eu|us)/"
 
@@ -267,7 +267,7 @@ class RegexTests extends RubyParserAbstractTest {
             |        /""".stripMargin
       }
     }
-    
+
     "as the argument to a `puts` command" should {
       val code = "puts /x#{1}y/"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -338,9 +338,16 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     val code = "x / y"
     tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, WS, SLASH, WS, LOCAL_VARIABLE_IDENTIFIER, EOF)
   }
-  
+
   "Invocation of command with regex literal" should "not be confused with binary division" in {
     val code = "puts /x/"
-    tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, WS, REGULAR_EXPRESSION_START, REGULAR_EXPRESSION_BODY, REGULAR_EXPRESSION_END, EOF)
+    tokenize(code) shouldBe Seq(
+      LOCAL_VARIABLE_IDENTIFIER,
+      WS,
+      REGULAR_EXPRESSION_START,
+      REGULAR_EXPRESSION_BODY,
+      REGULAR_EXPRESSION_END,
+      EOF
+    )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -338,4 +338,9 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     val code = "x / y"
     tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, WS, SLASH, WS, LOCAL_VARIABLE_IDENTIFIER, EOF)
   }
+  
+  "Invocation of command with regex literal" should "not be confused with binary division" in {
+    val code = "puts /x/"
+    tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, WS, REGULAR_EXPRESSION_START, REGULAR_EXPRESSION_BODY, REGULAR_EXPRESSION_END, EOF)
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -275,6 +275,22 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(8)
     }
+    
+    "have correct structure for a single-line regular expression literal passed as argument to a command" in {
+      val cpg = code("puts /x/")
+      
+      val List(callNode) = cpg.call.l
+      callNode.code shouldBe "puts /x/"
+      callNode.name shouldBe "puts"
+      callNode.lineNumber shouldBe Some(1)
+
+      val List(literalArg: Literal) = callNode.argument.l
+      literalArg.argumentIndex shouldBe 1
+      literalArg.typeFullName shouldBe Defines.Regexp
+      literalArg.code shouldBe "/x/"
+      literalArg.lineNumber shouldBe Some(1)
+      
+    }
 
     "have correct structure for a single left had side call" in {
       val cpg            = code("array[n] = 10")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -275,10 +275,10 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(8)
     }
-    
+
     "have correct structure for a single-line regular expression literal passed as argument to a command" in {
       val cpg = code("puts /x/")
-      
+
       val List(callNode) = cpg.call.l
       callNode.code shouldBe "puts /x/"
       callNode.name shouldBe "puts"
@@ -289,7 +289,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literalArg.typeFullName shouldBe Defines.Regexp
       literalArg.code shouldBe "/x/"
       literalArg.lineNumber shouldBe Some(1)
-      
+
     }
 
     "have correct structure for a single left had side call" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -289,7 +289,6 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literalArg.typeFullName shouldBe Defines.Regexp
       literalArg.code shouldBe "/x/"
       literalArg.lineNumber shouldBe Some(1)
-
     }
 
     "have correct structure for a single left had side call" in {


### PR DESCRIPTION
* Now regex literals are properly identified when used as arguments to commands