### PR TITLE
c2cpg: fix (alias) type decl creation

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -312,21 +312,19 @@ trait AstCreatorHelper { this: AstCreator =>
         s"${fullName(namespace.getParent)}.${ASTStringUtil.getSimpleName(namespace.getName)}"
       case namespace: ICPPASTNamespaceDefinition if ASTStringUtil.getSimpleName(namespace.getName).isEmpty =>
         s"${fullName(namespace.getParent)}.${uniqueName("namespace", "", "")._1}"
-      case cppClass: ICPPASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(cppClass.getName).nonEmpty =>
-        s"${fullName(cppClass.getParent)}.${ASTStringUtil.getSimpleName(cppClass.getName)}"
-      case cppClass: ICPPASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(cppClass.getName).isEmpty =>
-        val name = cppClass.getParent match {
+      case compType: IASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(compType.getName).nonEmpty =>
+        s"${fullName(compType.getParent)}.${ASTStringUtil.getSimpleName(compType.getName)}"
+      case compType: IASTCompositeTypeSpecifier if ASTStringUtil.getSimpleName(compType.getName).isEmpty =>
+        val name = compType.getParent match {
           case decl: IASTSimpleDeclaration =>
             decl.getDeclarators.headOption
               .map(n => ASTStringUtil.getSimpleName(n.getName))
               .getOrElse(uniqueName("composite_type", "", "")._1)
           case _ => uniqueName("composite_type", "", "")._1
         }
-        s"${fullName(cppClass.getParent)}.$name"
+        s"${fullName(compType.getParent)}.$name"
       case enumSpecifier: IASTEnumerationSpecifier =>
         s"${fullName(enumSpecifier.getParent)}.${ASTStringUtil.getSimpleName(enumSpecifier.getName)}"
-      case c: IASTCompositeTypeSpecifier =>
-        s"${fullName(c.getParent)}.${ASTStringUtil.getSimpleName(c.getName)}"
       case f: ICPPASTLambdaExpression =>
         s"${fullName(f.getParent)}."
       case f: IASTFunctionDeclarator
@@ -377,10 +375,14 @@ trait AstCreatorHelper { this: AstCreator =>
           case other =>
             other.getName
         }
-      case d: IASTIdExpression           => lastNameOfQualifiedName(ASTStringUtil.getSimpleName(d.getName))
-      case u: IASTUnaryExpression        => shortName(u.getOperand)
-      case c: IASTFunctionCallExpression => shortName(c.getFunctionNameExpression)
-      case other                         => notHandledYet(other); ""
+      case d: IASTIdExpression            => lastNameOfQualifiedName(ASTStringUtil.getSimpleName(d.getName))
+      case u: IASTUnaryExpression         => shortName(u.getOperand)
+      case c: IASTFunctionCallExpression  => shortName(c.getFunctionNameExpression)
+      case s: IASTSimpleDeclSpecifier     => s.getRawSignature
+      case e: IASTEnumerationSpecifier    => ASTStringUtil.getSimpleName(e.getName)
+      case c: IASTCompositeTypeSpecifier  => ASTStringUtil.getSimpleName(c.getName)
+      case e: IASTElaboratedTypeSpecifier => ASTStringUtil.getSimpleName(e.getName)
+      case other                          => notHandledYet(other); ""
     }
     name
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -1005,7 +1005,7 @@ class AstCreationPassTests extends AbstractPassTest {
         |typedef struct foo {
         |} abc;
       """.stripMargin) { cpg =>
-      cpg.typeDecl.name("abc").aliasTypeFullName("foo").size shouldBe 1
+      cpg.typeDecl.name("foo").aliasTypeFullName("abc").size shouldBe 1
     }
 
     "be correct for struct with local" in AstFixture("""
@@ -1067,7 +1067,7 @@ class AstCreationPassTests extends AbstractPassTest {
         |typedef enum foo {
         |} abc;
       """.stripMargin) { cpg =>
-      cpg.typeDecl.name("abc").aliasTypeFullName("foo").size shouldBe 1
+      cpg.typeDecl.name("foo").aliasTypeFullName("abc").size shouldBe 1
     }
 
     "be correct for classes with friends" in AstFixture(

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/EnumTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/EnumTypeTests.scala
@@ -57,7 +57,7 @@ class EnumTypeTests extends CCodeToCpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
         case List(color, c) =>
           color.name shouldBe "color"
           color.code should startWith("typedef enum color")
-          color.aliasTypeFullName shouldBe None
+          color.aliasTypeFullName shouldBe Some("C")
           c.name shouldBe "C"
           c.aliasTypeFullName shouldBe Some("color")
           inside(color.astChildren.isMember.l) { case List(red, yellow, green, blue) =>

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/StructTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/StructTypeTests.scala
@@ -6,6 +6,20 @@ import io.shiftleft.semanticcpg.language._
 
 class StructTypeTests extends CCodeToCpgSuite {
 
+  "Typedef struct with member" should {
+    val cpg = code("""
+        |typedef struct {
+        |  uint32_t bar;
+        |} Foo;
+        |""".stripMargin)
+
+    "contain correct fields for all members" in {
+      val List(typeDeclNode) = cpg.typeDecl.nameExact("Foo").l
+      typeDeclNode.member.name.toSetImmutable shouldBe Set("bar")
+      typeDeclNode.member.typ.fullName.toSetImmutable shouldBe Set("uint32_t")
+    }
+  }
+
   "Struct with array members" should {
     val cpg = code("""
         |#define SIZE 5


### PR DESCRIPTION
Aliased type defs got their correct (alias) name now. This also solved lost type decls from anonymous structs. (https://discord.com/channels/832209896089976854/832229141355954176/1122999607501262959)