### PR TITLE
rubysrc2cpg: Fix for METHOD node being passed to CALL nodes as argument

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -57,6 +57,8 @@ class AstCreator(protected val filename: String, global: Global, packageContext:
    */
   protected val UNRESOLVED_YIELD = "unresolved_yield"
 
+  protected val blockMethods = ListBuffer[Ast]()
+
   protected def createIdentifierWithScope(
     ctx: ParserRuleContext,
     name: String,
@@ -82,7 +84,7 @@ class AstCreator(protected val filename: String, global: Global, packageContext:
     val statementCtx = programCtx.compoundStatement().statements()
     scope.pushNewScope(())
     val statementAsts = if (statementCtx != null) {
-      astForStatements(statementCtx)
+      astForStatements(statementCtx) ++ blockMethods
     } else {
       List[Ast](Ast())
     }
@@ -560,6 +562,8 @@ class AstCreator(protected val filename: String, global: Global, packageContext:
         blockMethodAsts.head.nodes.head
           .asInstanceOf[NewMethod]
 
+      blockMethods.addOne(blockMethodAsts.head)
+
       val callNode = NewCall()
         .name(blockName)
         .methodFullName(blockMethodNode.fullName)
@@ -575,7 +579,7 @@ class AstCreator(protected val filename: String, global: Global, packageContext:
         .lineNumber(blockMethodNode.lineNumber)
         .columnNumber(blockMethodNode.columnNumber)
 
-      Seq(callAst(callNode, Seq(Ast(methodRefNode)), baseAst.headOption)) ++ blockMethodAsts
+      Seq(callAst(callNode, Seq(Ast(methodRefNode)), baseAst.headOption))
     } else {
       val callNode = methodNameAst.head.nodes
         .filter(node => node.isInstanceOf[NewCall])

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
@@ -232,4 +232,32 @@ class MiscTests extends RubyCode2CpgFixture {
         .size shouldBe 1
     }
   }
+
+  "CPG for code with chained constants as argument" should {
+    val cpg = code("""
+        |SomeFramework.someMethod SomeModule::SomeSubModule::submoduleMethod do
+        |puts "nothing important"
+        |end
+        |""".stripMargin)
+
+    "recognise all method nodes" in {
+      cpg.method
+        .name("submoduleMethod2")
+        .size shouldBe 1
+    }
+
+    "recognise all call nodes" in {
+      cpg.call
+        .name("submoduleMethod")
+        .size shouldBe 1
+
+      cpg.call
+        .name("puts")
+        .size shouldBe 1
+
+      cpg.call
+        .name("<operator>.scopeResolution")
+        .size shouldBe 1
+    }
+  }
 }


### PR DESCRIPTION
The fake `METHOD` nodes being returned after creation through the call stack results in them being passed as argument to `CALL` nodes eventually as the stack unwinds. The below exception is seen

` Edge with type='ARGUMENT' with direction='IN' not supported by nodeType='METHOD'
`
Reintroduced putting the `METHOD` nodes in a separate list to be appended lazily to get rid of this exception. Also introduced a unit test for the same.
