### PR TITLE
jssrc2cpg: partially revert dynamic type hints

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -108,9 +108,7 @@ class AstCreator(
     scope.pushNewMethodScope(fullName, name, blockNode, None)
     localAstParentStack.push(blockNode)
 
-    val thisParam =
-      parameterInNode(astNodeInfo, "this", "this", 0, false, EvaluationStrategies.BY_VALUE)
-        .dynamicTypeHintFullName(typeHintForThisExpression())
+    val thisParam = parameterInNode(astNodeInfo, "this", "this", 0, isVariadic = false, EvaluationStrategies.BY_VALUE)
     scope.addVariable("this", thisParam, MethodScope)
 
     val methodChildren = astsForFile(astNodeInfo)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -416,7 +416,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       callNode(nodeInfo, s"$RequireKeyword(${sourceCallArgNode.code})", RequireKeyword, DispatchTypes.DYNAMIC_DISPATCH)
 
     val receiverNode = identifierNode(nodeInfo, RequireKeyword)
-    val thisNode     = identifierNode(nodeInfo, "this").dynamicTypeHintFullName(typeHintForThisExpression())
+    val thisNode     = identifierNode(nodeInfo, "this")
     scope.addVariableReference(thisNode.name, thisNode)
     val cAst = callAst(
       sourceCall,

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -65,7 +65,15 @@ trait AstForFunctionsCreator { this: AstCreator =>
             val localNode = newLocalNode(paramName, tpe).order(0)
             diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
           }
-          parameterInNode(nodeInfo, paramName, nodeInfo.code, index, true, EvaluationStrategies.BY_VALUE, Option(tpe))
+          parameterInNode(
+            nodeInfo,
+            paramName,
+            nodeInfo.code,
+            index,
+            isVariadic = true,
+            EvaluationStrategies.BY_VALUE,
+            Option(tpe)
+          )
         case AssignmentPattern =>
           val lhsElement  = nodeInfo.json("left")
           val rhsElement  = nodeInfo.json("right")
@@ -96,7 +104,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
                 lhsNodeInfo.code,
                 nodeInfo.code,
                 index,
-                false,
+                isVariadic = false,
                 EvaluationStrategies.BY_VALUE,
                 Option(tpe)
               )
@@ -214,7 +222,15 @@ trait AstForFunctionsCreator { this: AstCreator =>
 
           val name = nodeInfo.json("name").str
           val node =
-            parameterInNode(nodeInfo, name, nodeInfo.code, index, false, EvaluationStrategies.BY_VALUE, Option(tpe))
+            parameterInNode(
+              nodeInfo,
+              name,
+              nodeInfo.code,
+              index,
+              isVariadic = false,
+              EvaluationStrategies.BY_VALUE,
+              Option(tpe)
+            )
           scope.addVariable(name, node, MethodScope)
           node
         case TSParameterProperty =>
@@ -222,7 +238,15 @@ trait AstForFunctionsCreator { this: AstCreator =>
           val tpe           = typeFor(unpackedParam)
           val name          = unpackedParam.json("name").str
           val node =
-            parameterInNode(nodeInfo, name, nodeInfo.code, index, false, EvaluationStrategies.BY_VALUE, Option(tpe))
+            parameterInNode(
+              nodeInfo,
+              name,
+              nodeInfo.code,
+              index,
+              isVariadic = false,
+              EvaluationStrategies.BY_VALUE,
+              Option(tpe)
+            )
           scope.addVariable(name, node, MethodScope)
           node
         case _ =>
@@ -296,9 +320,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
     val virtualModifierNode = NewModifier().modifierType(ModifierTypes.VIRTUAL)
     methodAstParentStack.push(methodNode_)
 
-    val thisNode =
-      parameterInNode(func, "this", "this", 0, false, EvaluationStrategies.BY_VALUE)
-        .dynamicTypeHintFullName(typeHintForThisExpression())
+    val thisNode = parameterInNode(func, "this", "this", 0, isVariadic = false, EvaluationStrategies.BY_VALUE)
     scope.addVariable("this", thisNode, MethodScope)
 
     val paramNodes = if (hasKey(func.json, "parameters")) {
@@ -385,9 +407,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
     scope.pushNewMethodScope(methodFullName, methodName, blockNode, capturingRefNode)
     localAstParentStack.push(blockNode)
 
-    val thisNode =
-      parameterInNode(func, "this", "this", 0, false, EvaluationStrategies.BY_VALUE)
-        .dynamicTypeHintFullName(typeHintForThisExpression())
+    val thisNode = parameterInNode(func, "this", "this", 0, isVariadic = false, EvaluationStrategies.BY_VALUE)
     scope.addVariable("this", thisNode, MethodScope)
 
     val paramNodes = handleParameters(func.json("params").arr.toSeq, additionalBlockStatements)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -210,7 +210,7 @@ trait AstNodeBuilder { this: AstCreator =>
 
   protected def identifierNode(node: BabelNodeInfo, name: String): NewIdentifier = {
     val dynamicInstanceTypeOption = name match {
-      case "this"    => typeHintForThisExpression(Option(node)).headOption
+      case "this"    => dynamicInstanceTypeStack.headOption
       case "console" => Option(Defines.Console)
       case "Math"    => Option(Defines.Math)
       case _         => None

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -50,7 +50,7 @@ trait TypeHelper { this: AstCreator =>
     case NullLiteralTypeAnnotation    => code(flowType.json)
     case StringLiteralTypeAnnotation  => code(flowType.json)
     case GenericTypeAnnotation        => code(flowType.json("id"))
-    case ThisTypeAnnotation           => typeHintForThisExpression(Option(flowType)).headOption.getOrElse(Defines.Any);
+    case ThisTypeAnnotation           => dynamicInstanceTypeStack.headOption.getOrElse(Defines.Any)
     case NullableTypeAnnotation       => typeForTypeAnnotation(createBabelNodeInfo(flowType.json(TypeAnnotationKey)))
     case _                            => Defines.Any
   }
@@ -70,7 +70,7 @@ trait TypeHelper { this: AstCreator =>
     case TSIntrinsicKeyword  => code(tsType.json)
     case TSTypeReference     => code(tsType.json)
     case TSArrayType         => code(tsType.json)
-    case TSThisType          => typeHintForThisExpression(Option(tsType)).headOption.getOrElse(Defines.Any)
+    case TSThisType          => dynamicInstanceTypeStack.headOption.getOrElse(Defines.Any)
     case TSOptionalType      => typeForTypeAnnotation(createBabelNodeInfo(tsType.json(TypeAnnotationKey)))
     case TSRestType          => typeForTypeAnnotation(createBabelNodeInfo(tsType.json(TypeAnnotationKey)))
     case TSParenthesizedType => typeForTypeAnnotation(createBabelNodeInfo(tsType.json(TypeAnnotationKey)))
@@ -125,18 +125,6 @@ trait TypeHelper { this: AstCreator =>
     }
     registerType(tpe, tpe)
     tpe
-  }
-
-  protected def typeHintForThisExpression(node: Option[BabelNodeInfo] = None): Seq[String] = {
-    dynamicInstanceTypeStack.headOption match {
-      case Some(tpe) => Seq(tpe)
-      case None if node.isDefined =>
-        typeFor(node.get) match {
-          case t if t != Defines.Any && t != "this" => Seq(t)
-          case _                                    => rootTypeDecl.map(_.fullName).toSeq
-        }
-      case None => rootTypeDecl.map(_.fullName).toSeq
-    }
   }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -181,15 +181,6 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
   ): Set[String] =
     super.visitIdentifierAssignedToTypeRef(i, t, Option("this"))
 
-  override protected def postSetTypeInformation(): Unit = {
-    // often there are "this" identifiers with type hints but this can be set to a type hint if they meet the criteria
-    cu.ast.isIdentifier
-      .nameExact("this")
-      .where(_.typeFullNameExact(Defines.Any))
-      .filterNot(_.dynamicTypeHintFullName.isEmpty)
-      .foreach(setTypeFromTypeHints)
-  }
-
   protected override def storeIdentifierTypeInfo(i: Identifier, types: Seq[String]): Unit =
     super.storeIdentifierTypeInfo(i, types.map(_.stripSuffix(s"$pathSep${XDefines.ConstructorMethodName}")))
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -488,8 +488,6 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       param1.index shouldBe 0
       param1.name shouldBe "this"
       param1.code shouldBe "this"
-      param1.typeFullName shouldBe Defines.Any
-      param1.dynamicTypeHintFullName shouldBe Seq("code.js::program")
 
       param2.index shouldBe 1
       param2.name shouldBe "param1_0"
@@ -511,8 +509,6 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       param1.index shouldBe 0
       param1.name shouldBe "this"
       param1.code shouldBe "this"
-      param1.typeFullName shouldBe Defines.Any
-      param1.dynamicTypeHintFullName shouldBe Seq("code.js::program")
 
       param2.index shouldBe 1
       param2.name shouldBe "param1_0"
@@ -565,8 +561,6 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       thisIdentifier.name shouldBe "this"
       thisIdentifier.code shouldBe "this"
       thisIdentifier.argumentIndex shouldBe 1
-      thisIdentifier.typeFullName shouldBe Defines.Any
-      thisIdentifier.dynamicTypeHintFullName shouldBe Seq("code.js::program")
 
       val List(thisParameter) = cpg.method.name("foo").parameter.l
       thisParameter.name shouldBe "this"
@@ -749,8 +743,6 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
         val List(t, x, args) = method.parameter.l
         t.index shouldBe 0
         t.name shouldBe "this"
-        t.typeFullName shouldBe Defines.Any
-        t.dynamicTypeHintFullName shouldBe Seq("code.js::program")
         x.index shouldBe 1
         x.name shouldBe "x"
         x.typeFullName shouldBe Defines.Any
@@ -768,8 +760,6 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(t, x) = method.parameter.l
       t.index shouldBe 0
       t.name shouldBe "this"
-      t.typeFullName shouldBe Defines.Any
-      t.dynamicTypeHintFullName shouldBe Seq("code.js::program")
       x.index shouldBe 1
       x.name shouldBe "x"
       x.typeFullName shouldBe Defines.Any
@@ -791,8 +781,6 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(t, x) = method.parameter.l
       t.index shouldBe 0
       t.name shouldBe "this"
-      t.typeFullName shouldBe Defines.Any
-      t.dynamicTypeHintFullName shouldBe Seq("code.js::program")
       x.index shouldBe 1
       x.name shouldBe "x"
       x.typeFullName shouldBe Defines.Any
@@ -815,8 +803,6 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(t, x, y) = method.parameter.l
       t.index shouldBe 0
       t.name shouldBe "this"
-      t.typeFullName shouldBe Defines.Any
-      t.dynamicTypeHintFullName shouldBe Seq("code.js::program")
       x.index shouldBe 1
       x.name shouldBe "x"
       x.typeFullName shouldBe Defines.Any

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTest.scala
@@ -13,7 +13,7 @@ class TSTypesTest extends AbstractPassTest {
   ) { cpg =>
     val List(t) = cpg.identifier("this").l
     t.typeFullName shouldBe Defines.Any
-    t.dynamicTypeHintFullName shouldBe List("code.js::program")
+    t.dynamicTypeHintFullName shouldBe List()
   }
 
   "have correct types for this with proper surrounding type" in AstFixture(


### PR DESCRIPTION
- joernio/joern@eba81a2 - adds highly questionable type hints for 'this' outside explicit classes - reverted this
- joernio/joern@ea2046f - CS can't handle dynamic type hints coming from TS in this case here - reverted this partially

To make progress on: https://github.com/ShiftLeftSecurity/codescience/pull/7001