### PR TITLE
add - ast for variable declaration and initialization

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -4,8 +4,9 @@ import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.parser.GoAstJsonParser.ParserResult
 import io.joern.gosrc2cpg.parser.ParserAst._
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
+import io.joern.x2cpg.datastructures.Scope
 import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder => X2CpgAstNodeBuilder}
-import io.shiftleft.codepropertygraph.generated.nodes.NewFile
+import io.shiftleft.codepropertygraph.generated.nodes.{NewFile, NewNode}
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 import ujson.Value
@@ -14,10 +15,14 @@ class AstCreator(val config: Config, val parserResult: ParserResult)
     extends AstCreatorBase(parserResult.filename)
     with AstForDeclarationCreator
     with AstForPrimitivesCreator
+    with AstForFunctionsCreator
+    with AstForStatementsCreator
     with AstCreatorHelper
     with X2CpgAstNodeBuilder[ParserNodeInfo, AstCreator] {
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])
+
+  protected val scope: Scope[String, (NewNode, String), NewNode] = new Scope()
 
   override def createAst(): DiffGraphBuilder = {
 
@@ -29,12 +34,14 @@ class AstCreator(val config: Config, val parserResult: ParserResult)
     diffGraph
   }
 
-  protected def astForNode(json: Value) = {
+  protected def astForNode(json: Value): Ast = {
     val nodeInfo = createParserNodeInfo(json)
     val output = nodeInfo.node match {
-      case GenDecl  => astForGenDecl(nodeInfo)
-      case BasicLit => astForLiteral(nodeInfo)
-      case _        => Ast()
+      case GenDecl if isImportDeclaration(nodeInfo) => astForImport(nodeInfo)
+      case BasicLit                                 => astForLiteral(nodeInfo)
+      case Ident                                    => astForIdentifier(nodeInfo)
+      case FuncDecl                                 => astForFuncDecl(nodeInfo)
+      case _                                        => Ast()
     }
     output
   }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,8 +1,9 @@
 package io.joern.gosrc2cpg.astcreation
 
-import io.joern.gosrc2cpg.parser.ParserAst.{ParserNode, fromString}
+import io.joern.gosrc2cpg.parser.ParserAst.{ImportSpec, ParserNode, fromString}
 import ujson.Value
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
+import io.joern.x2cpg.Ast
 import org.apache.commons.lang.StringUtils
 
 import scala.util.Try
@@ -35,5 +36,30 @@ trait AstCreatorHelper { this: AstCreator =>
   protected def line(node: Value): Option[Integer] = Try(node(ParserKeys.NodeLineNo).num).toOption.map(_.toInt)
 
   protected def column(node: Value): Option[Integer] = Try(node(ParserKeys.NodeLineNo).num).toOption.map(_.toInt)
+
+  def isImportDeclaration(genDecl: ParserNodeInfo) = {
+    Try(genDecl.json(ParserKeys.Specs).arr.map(createParserNodeInfo).exists(_.node == ImportSpec)).toOption
+      .getOrElse(false)
+  }
+  def astForImport(genDecl: ParserNodeInfo): Ast = {
+    genDecl.json(ParserKeys.Specs).arr.map(createParserNodeInfo).foreach { nodeInfo =>
+      nodeInfo.node match {
+        case ImportSpec =>
+          val basicLit       = createParserNodeInfo(nodeInfo.json(ParserKeys.Path))
+          val importedEntity = nodeInfo.json(ParserKeys.Path).obj(ParserKeys.Value).str
+          val importedAs =
+            Try(nodeInfo.json(ParserKeys.Name).obj(ParserKeys.Name).str).toOption.getOrElse(importedEntity)
+          val importedAsReplacement = if (importedEntity.equals(importedAs)) "" else s"$importedAs "
+          // This may be better way to add code for import node
+          val importNode =
+            newImportNode(s"import $importedAsReplacement$importedEntity", importedEntity, importedAs, basicLit)
+          // Adding import node directly because it is not a Ast Node
+          diffGraph.addNode(importNode)
+        case _ =>
+      }
+    }
+    // We add imports directly to the graph, so return empty Ast
+    Ast()
+  }
 
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -1,0 +1,49 @@
+package io.joern.gosrc2cpg.astcreation
+
+import io.joern.gosrc2cpg.parser.ParserAst.BlockStmt
+import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
+import io.joern.x2cpg.Ast
+import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
+import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterIn
+import ujson.Value
+
+trait AstForFunctionsCreator { this: AstCreator =>
+  def astForFuncDecl(funcDecl: ParserNodeInfo) = {
+
+    val filename       = "fileName"
+    val returnType     = "returnType"
+    val name           = funcDecl.json(ParserKeys.Name).obj(ParserKeys.Name).str
+    val fullname       = "fullname"
+    val templateParams = "templateParams"
+
+    val signature =
+      s"$returnType $fullname$templateParams {parameterListSignature(funcDef)}"
+
+    val code        = "code"
+    val methodNode_ = methodNode(funcDecl, name, code, fullname, Some(signature), filename)
+
+    // TODO Stub for parameter nodes, revisit when we focus on Method nodes
+    val parameterNodes = Seq[NewMethodParameterIn]()
+
+    // TODO Add relevant information to stack and cache
+
+    val astForMethod = methodAst(
+      methodNode_,
+      parameterNodes.map(Ast(_)),
+      astForMethodBody(funcDecl.json(ParserKeys.Body)),
+      newMethodReturnNode(returnType, None, line(funcDecl), column(funcDecl))
+    )
+    // TODO register type above
+    astForMethod
+  }
+
+  def astForMethodBody(body: Value) = {
+
+    val nodeInfo = createParserNodeInfo(body)
+    nodeInfo.node match {
+      case BlockStmt => astForBlockStatement(nodeInfo)
+      case _         => Ast()
+    }
+  }
+
+}

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -11,4 +11,20 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     Ast(literalNode(stringLiteral, code, code.trim))
   }
 
+  protected def astForIdentifier(ident: ParserNodeInfo) = {
+    val identifierName = ident.json(ParserKeys.Name).str
+
+    val variableOption = scope.lookupVariable(identifierName)
+    val identifierType = variableOption match {
+      case Some((_, variableTypeName)) => variableTypeName
+      case _                           => ""
+    }
+    val node = identifierNode(ident, identifierName, ident.json(ParserKeys.Name).str, identifierType)
+    variableOption match {
+      case Some((variable, _)) =>
+        Ast(node).withRefEdge(node, variable)
+      case None => Ast(node)
+    }
+  }
+
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,0 +1,69 @@
+package io.joern.gosrc2cpg.astcreation
+
+import io.joern.gosrc2cpg.parser.ParserAst.{DeclStmt, GenDecl, ValueSpec}
+import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
+import io.joern.x2cpg.Ast
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+
+import scala.util.Try
+
+trait AstForStatementsCreator { this: AstCreator =>
+  def astForBlockStatement(blockStmt: ParserNodeInfo) = {
+
+    val newBlockNode = blockNode(blockStmt)
+    scope.pushNewScope(newBlockNode)
+    val childAsts = Try(blockStmt.json(ParserKeys.List).arr.map(createParserNodeInfo).flatMap { parserNode =>
+      parserNode.node match {
+        case DeclStmt => astForDeclStatement(parserNode)
+        case _        => Seq(Ast())
+      }
+    }).toOption.getOrElse(Seq(Ast()))
+    scope.popScope()
+    blockAst(newBlockNode, childAsts.toList)
+  }
+
+  def astForDeclStatement(declStmt: ParserNodeInfo) = {
+    val nodeInfo = createParserNodeInfo(declStmt.json(ParserKeys.Decl))
+    nodeInfo.node match {
+      case GenDecl =>
+        nodeInfo.json(ParserKeys.Specs).arr.map(createParserNodeInfo).flatMap { parserNode =>
+          parserNode.node match {
+            case ValueSpec => astForValueSpec(parserNode)
+            case _         => Seq(Ast())
+          }
+        }
+    }
+  }
+
+  def astForValueSpec(valueSpec: ParserNodeInfo) = {
+
+    val localNodes = valueSpec.json(ParserKeys.Names).arr.map { parserNode =>
+      val localParserNode = createParserNodeInfo(parserNode)
+
+      val name = parserNode(ParserKeys.Name).str
+      val typ  = valueSpec.json(ParserKeys.Type).obj(ParserKeys.Name).str
+      val node = localNode(localParserNode, name, localParserNode.code, typ)
+      scope.addToScope(name, (node, typ))
+      Ast(node)
+    }
+
+    if (!valueSpec.json(ParserKeys.Values).isNull) {
+      val callNodes = (valueSpec.json(ParserKeys.Names).arr.toList zip valueSpec.json(ParserKeys.Values).arr.toList)
+        .map { case (lhs, rhs) => (createParserNodeInfo(lhs), createParserNodeInfo(rhs)) }
+        .map { case (lhsParserNode, rhsParserNode) =>
+          val cNode = callNode(
+            rhsParserNode,
+            lhsParserNode.code + rhsParserNode.code,
+            Operators.assignment,
+            Operators.assignment,
+            DispatchTypes.STATIC_DISPATCH
+          )
+          val arguments = Seq(astForIdentifier(lhsParserNode), astForNode(rhsParserNode.json))
+          callAst(cNode, arguments)
+        }
+      localNodes.toList ::: callNodes
+    } else
+      localNodes.toList
+  }
+
+}

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
@@ -16,20 +16,30 @@ object ParserAst {
   object GenDecl    extends ParserNode
   object ImportSpec extends ParserNode
   object BasicLit   extends ParserNode
-
-  object FuncDecl extends ParserNode
-
+  object FuncDecl   extends ParserNode
+  object BlockStmt  extends ParserNode
+  object DeclStmt   extends ParserNode
+  object ValueSpec  extends ParserNode
+  object Ident      extends ParserNode
+  object AssignStmt extends ParserNode
+  object ExprStmt   extends ParserNode
 }
 
 object ParserKeys {
 
   val Path         = "Path"
   val Value        = "Value"
+  val Values       = "Values"
   val Name         = "Name"
+  val Names        = "Names"
   val Specs        = "Specs"
   val Decls        = "Decls"
+  val Decl         = "Decl"
   val NodeFileName = "node_filename"
   val NodeType     = "node_type"
   val NodeLineNo   = "node_line_no"
   val NodeColNo    = "node_col_no"
+  val Type         = "Type"
+  val List         = "List"
+  val Body         = "Body"
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/AstCreationPassTests.scala
@@ -1,0 +1,85 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.semanticcpg.language._
+
+class AstCreationPassTests extends GoCodeToCpgSuite {
+
+  "Method Ast layout" should {
+
+    "be correct for decl assignment" in {
+      val cpg = code("""
+          |package main
+          |func main() {
+          |   var local int = 1
+          |}
+          |""".stripMargin)
+
+      inside(cpg.method.name("main").block.astChildren.l) { case List(local: Local, call: Call) =>
+        local.name shouldBe "local"
+        local.typeFullName shouldBe "int"
+        local.order shouldBe 1
+        call.name shouldBe Operators.assignment
+        call.order shouldBe 2
+        inside(call.astChildren.l) { case List(identifier: Identifier, literal: Literal) =>
+          identifier.name shouldBe "local"
+          identifier.typeFullName shouldBe "int"
+          identifier.order shouldBe 1
+          identifier.argumentIndex shouldBe 1
+          literal.code shouldBe "1"
+          // literal.typeFullName shouldBe "int"   Have commented this as this is not a stressing prlm
+          literal.order shouldBe 2
+          literal.argumentIndex shouldBe 2
+        }
+      }
+    }
+  }
+
+  "multiple declaration on single line" should {
+    val cpg = code("""
+        |package main
+        |func main(){
+        |   var  i, j int
+        |   var  f, salary float32 = 10.0, 20.0
+        |}
+        |""".stripMargin)
+    "create local and identifier nodes" in {
+      val locals      = cpg.local.l
+      val identifiers = cpg.identifier.l
+
+      locals.size shouldBe 4
+      locals.map(loc => (loc.name, loc.typeFullName)).l shouldBe List(
+        ("i", "int"),
+        ("j", "int"),
+        ("f", "float32"),
+        ("salary", "float32")
+      )
+
+      identifiers.size shouldBe 2
+      identifiers.map(loc => (loc.name, loc.typeFullName)).l shouldBe List(("f", "float32"), ("salary", "float32"))
+    }
+  }
+
+  "dynamic declaration" should {
+    val cpg = code("""
+        |package main
+        |func main(){
+        |   d := 43
+        |   c := "value"
+        |}
+        |""".stripMargin)
+    "have local and identifier nodes created" ignore {
+      val locals      = cpg.local.l
+      val identifiers = cpg.identifier.l
+
+      locals.size shouldBe 2
+      locals.map(loc => (loc.name, loc.typeFullName)).l shouldBe List(("d", "int"), ("c", "string"))
+
+      identifiers.size shouldBe 2
+      identifiers.map(loc => (loc.name, loc.typeFullName)).l shouldBe List(("d", "int"), ("c", "string"))
+    }
+  }
+
+}


### PR DESCRIPTION
This PR contains the following
- Ast node creation for Declaration and Initialization statements. Ex - `var local int = 1`
- Resolved name, typeFullName for initialized variables
- Refactoring to move out the code which adds Import Nodes