### PR TITLE
rubysrc2cpg: fixes missing whitespace before proc-parameter

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -318,7 +318,7 @@ methodParameterPart
     ;
 
 parameters
-    :   mandatoryParameters (COMMA wsOrNl* optionalParameters)? (COMMA arrayParameter)? (COMMA procParameter)?
+    :   mandatoryParameters (COMMA wsOrNl* optionalParameters)? (COMMA WS* arrayParameter)? (COMMA WS* procParameter)?
     |   optionalParameters (COMMA wsOrNl* arrayParameter)? (COMMA wsOrNl* procParameter)?
     |   arrayParameter (COMMA wsOrNl* procParameter)?
     |   procParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -86,7 +86,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
              |      ;
              |  end""".stripMargin
       }
-      
+
       "it contains two parameters, the last of which a &-parameter" in {
         val code = "def foo(x, &y); end"
         printAst(_.primary(), code) shouldEqual

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -86,6 +86,37 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
              |      ;
              |  end""".stripMargin
       }
+      
+      "it contains two parameters, the last of which a &-parameter" in {
+        val code = "def foo(x, &y); end"
+        printAst(_.primary(), code) shouldEqual
+          """MethodDefinitionPrimary
+            | MethodDefinition
+            |  def
+            |  WsOrNl
+            |  SimpleMethodNamePart
+            |   DefinedMethodName
+            |    MethodName
+            |     MethodIdentifier
+            |      foo
+            |  MethodParameterPart
+            |   (
+            |   Parameters
+            |    MandatoryParameters
+            |     x
+            |    ,
+            |    ProcParameter
+            |     &
+            |     y
+            |   )
+            |  BodyStatement
+            |   CompoundStatement
+            |    Separators
+            |     Separator
+            |      ;
+            |  WsOrNl
+            |  end""".stripMargin
+      }
     }
   }
 }


### PR DESCRIPTION
Thanks @rahul-privado for bringing this up.