### PR TITLE
[rubysrc2cpg] Fix Class Stack & Method Full Names

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -14,6 +14,7 @@ dependsOn(
   Projects.javasrc2cpg,
   Projects.jssrc2cpg,
   Projects.pysrc2cpg,
+  Projects.rubysrc2cpg,
   Projects.x2cpg % "compile->compile;test->test"
 )
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/RubyCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/RubyCpgGenerator.scala
@@ -1,6 +1,8 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
+import io.joern.rubysrc2cpg.RubySrc2Cpg
+import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.Path
 import scala.util.Try
@@ -17,4 +19,10 @@ case class RubyCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
     command.toFile.exists
 
   override def isJvmBased = true
+
+  override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
+    RubySrc2Cpg.postProcessingPasses(cpg).foreach(_.createAndApply())
+    cpg
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -6,10 +6,12 @@ import io.joern.rubysrc2cpg.utils.PackageTable
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.datastructures.Global
+import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.utils.ExternalCommand
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.passes.CpgPassBase
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Paths}
@@ -59,4 +61,10 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
       }
     }
   }
+}
+
+object RubySrc2Cpg {
+
+  def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = List(new NaiveCallLinker(cpg))
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1140,7 +1140,6 @@ class AstCreator(
      * TODO Dave: ^ This seems like it needs a re-design, it is confusing
      */
 
-    val classPath      = classStack.reverse.mkString(".")
     val methodFullName = classStack.reverse :+ callNode.name mkString ":"
     val methodNode = NewMethod()
       .code(ctx.getText)
@@ -1153,6 +1152,10 @@ class AstCreator(
     callNode.methodFullName(methodFullName)
 
     val classType = if (classStack.isEmpty) "Standalone" else classStack.top
+    val classPath = classStack.reverse.toList match {
+      case head :: xs => xs.mkString(":")
+      case _          => ""
+    }
     packageContext.packageTable.addPackageMethod(packageContext.moduleName, callNode.name, classPath, classType)
 
     // process yield calls.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1153,8 +1153,8 @@ class AstCreator(
 
     val classType = if (classStack.isEmpty) "Standalone" else classStack.top
     val classPath = classStack.reverse.toList match {
-      case head :: xs => xs.mkString(":")
-      case _          => ""
+      case _ :: xs => xs.mkString(":") + ":"
+      case _       => ""
     }
     packageContext.packageTable.addPackageMethod(packageContext.moduleName, callNode.name, classPath, classType)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,0 +1,18 @@
+package io.joern.rubysrc2cpg.astcreation
+
+trait AstCreatorHelper { this: AstCreator =>
+
+  import GlobalTypes._
+
+  def isBuiltin(x: String): Boolean = builtinFunctions.contains(x)
+
+  def prefixAsBuiltin(x: String): String = s"$builtinPrefix:$x"
+
+}
+
+object GlobalTypes {
+  val builtinPrefix = "__builtin"
+  // https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html
+  // TODO: Complete this list
+  val builtinFunctions = Set("puts", "chomp", "exec")
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -1,0 +1,129 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.rubysrc2cpg.parser.RubyParser.{
+  ClassDefinitionPrimaryContext,
+  ClassOrModuleReferenceContext,
+  ScopedConstantReferenceContext
+}
+import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.x2cpg.Ast
+import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewIdentifier, NewTypeDecl}
+
+trait AstForTypesCreator { this: AstCreator =>
+
+  def astForClassDeclaration(ctx: ClassDefinitionPrimaryContext): Seq[Ast] = {
+    val baseClassName = if (ctx.classDefinition().expressionOrCommand() != null) {
+      val parentClassNameAst = astForExpressionOrCommand(ctx.classDefinition().expressionOrCommand())
+      val nameNode = parentClassNameAst.head.nodes
+        .filter(node => node.isInstanceOf[NewIdentifier])
+        .head
+        .asInstanceOf[NewIdentifier]
+      Some(nameNode.name)
+    } else {
+      None
+    }
+
+    val className = ctx.className(baseClassName)
+    if (className != Defines.Any) {
+      classStack.push(className)
+      val fullName = classStack.reverse.mkString(":")
+
+      val bodyAst = astForBodyStatementContext(ctx.classDefinition().bodyStatement())
+      val bodyAstSansModifiers = bodyAst
+        .filterNot(ast => {
+          val nodes = ast.nodes
+            .filter(_.isInstanceOf[NewIdentifier])
+
+          if (nodes.size == 1) {
+            val varName = nodes
+              .map(_.asInstanceOf[NewIdentifier].name)
+              .head
+            varName == "public" || varName == "protected" || varName == "private"
+          } else {
+            false
+          }
+        })
+
+      if (classStack.nonEmpty) {
+        classStack.pop()
+      }
+
+      val typeDeclNode = NewTypeDecl()
+        .name(className)
+        .fullName(fullName)
+      Seq(Ast(typeDeclNode).withChildren(bodyAstSansModifiers))
+    } else {
+      Seq.empty
+    }
+  }
+
+  def astForClassExpression(ctx: ClassDefinitionPrimaryContext): Seq[Ast] = {
+    // TODO test for this is pending due to lack of understanding to generate an example
+    val astExprOfCommand = astForExpressionOrCommand(ctx.classDefinition().expressionOrCommand())
+    val astBodyStatement = astForBodyStatementContext(ctx.classDefinition().bodyStatement())
+    val blockNode = NewBlock()
+      .code(ctx.getText)
+    val bodyBlockAst = blockAst(blockNode, astBodyStatement.toList)
+    astExprOfCommand ++ Seq(bodyBlockAst)
+  }
+
+  def astForClassOrModuleReferenceContext(
+    ctx: ClassOrModuleReferenceContext,
+    baseClassName: Option[String] = None
+  ): Seq[Ast] = {
+    val className = ctx.className(baseClassName)
+
+    if (className != Defines.Any) {
+      classStack.push(className)
+    }
+    Seq(Ast())
+  }
+
+  private def getClassNameScopedConstantReferenceContext(ctx: ScopedConstantReferenceContext): String = {
+    val classTerminalNode = ctx.CONSTANT_IDENTIFIER()
+
+    if (ctx.primary() != null) {
+      val primaryAst = astForPrimaryContext(ctx.primary())
+      val moduleNameNode = primaryAst.head.nodes
+        .filter(node => node.isInstanceOf[NewIdentifier])
+        .head
+        .asInstanceOf[NewIdentifier]
+      val moduleName = moduleNameNode.name
+      moduleName + "." + classTerminalNode.getText
+    } else {
+      classTerminalNode.getText
+    }
+  }
+
+  def astsForClassMembers(): Seq[Ast] = {
+    ???
+  }
+
+  implicit class ClassDefinitionPrimaryContextExt(val ctx: ClassDefinitionPrimaryContext) {
+
+    def hasClassDefinition: Boolean = Option(ctx.classDefinition()).isDefined
+
+    def className(baseClassName: Option[String] = None): String =
+      Option(ctx.classDefinition())
+        .map(_.classOrModuleReference())
+        .map(_.className(baseClassName))
+        .getOrElse(Defines.Any)
+  }
+
+  implicit class ClassOrModuleReferenceContextExt(val ctx: ClassOrModuleReferenceContext) {
+
+    def hasScopedConstantReference: Boolean = Option(ctx.scopedConstantReference()).isDefined
+
+    def className(baseClassName: Option[String] = None): String =
+      if (ctx.hasScopedConstantReference)
+        getClassNameScopedConstantReferenceContext(ctx.scopedConstantReference())
+      else
+        Option(ctx.CONSTANT_IDENTIFIER()).map(_.getText) match {
+          case Some(className) if baseClassName.isDefined => s"${baseClassName.get}.$className"
+          case Some(className)                            => className
+          case None                                       => Defines.Any
+        }
+
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
@@ -5,6 +5,7 @@ import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.datastructures.Global
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language._
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
@@ -21,6 +22,8 @@ class AstCreationPass(inputPath: String, cpg: Cpg, global: Global, packageTable:
   override def generateParts(): Array[String] = SourceFiles.determine(inputPath, RubySourceFileExtensions).toArray
 
   override def runOnPart(diffGraph: DiffGraphBuilder, fileName: String): Unit = {
-    diffGraph.absorb(new AstCreator(fileName, global, PackageContext(fileName, packageTable)).createAst())
+    diffGraph.absorb(
+      new AstCreator(fileName, global, PackageContext(fileName, packageTable), cpg.metaData.root.headOption).createAst()
+    )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstPackagePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstPackagePass.scala
@@ -1,11 +1,11 @@
 package io.joern.rubysrc2cpg.passes
 
+import better.files.File
 import io.joern.rubysrc2cpg.astcreation.AstCreator
 import io.joern.rubysrc2cpg.utils.{PackageContext, PackageTable}
 import io.joern.x2cpg.datastructures.Global
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
-import better.files.File
 
 import scala.util.Try
 
@@ -15,7 +15,14 @@ class AstPackagePass(cpg: Cpg, tempExtDir: String, global: Global, packageTable:
     getRubyDependenciesFile(inputPath) ++ getRubyDependenciesFile(tempExtDir)
 
   override def runOnPart(diffGraph: DiffGraphBuilder, filePath: String): Unit = {
-    Try(new AstCreator(filePath, global, PackageContext(resolveModuleNameFromPath(filePath), packageTable)).createAst())
+    Try(
+      new AstCreator(
+        filePath,
+        global,
+        PackageContext(resolveModuleNameFromPath(filePath), packageTable),
+        Option(tempExtDir)
+      ).createAst()
+    )
   }
 
   private def getRubyDependenciesFile(inputPath: String): Array[String] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstPackagePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstPackagePass.scala
@@ -15,12 +15,17 @@ class AstPackagePass(cpg: Cpg, tempExtDir: String, global: Global, packageTable:
     getRubyDependenciesFile(inputPath) ++ getRubyDependenciesFile(tempExtDir)
 
   override def runOnPart(diffGraph: DiffGraphBuilder, filePath: String): Unit = {
+    println(filePath)
+    println(tempExtDir)
+    println(inputPath)
+    import io.shiftleft.semanticcpg.language._
+    println(cpg.metaData.root.headOption)
     Try(
       new AstCreator(
         filePath,
         global,
         PackageContext(resolveModuleNameFromPath(filePath), packageTable),
-        Option(tempExtDir)
+        Option(inputPath)
       ).createAst()
     )
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstPackagePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstPackagePass.scala
@@ -15,11 +15,6 @@ class AstPackagePass(cpg: Cpg, tempExtDir: String, global: Global, packageTable:
     getRubyDependenciesFile(inputPath) ++ getRubyDependenciesFile(tempExtDir)
 
   override def runOnPart(diffGraph: DiffGraphBuilder, filePath: String): Unit = {
-    println(filePath)
-    println(tempExtDir)
-    println(inputPath)
-    import io.shiftleft.semanticcpg.language._
-    println(cpg.metaData.root.headOption)
     Try(
       new AstCreator(
         filePath,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
@@ -25,7 +25,7 @@ class PackageTable() {
         methodTableMap(module)
           .filter(_.methodName == methodName)
           .foreach(method => {
-            finalMethodName.addOne(s"$module.${method.parentClassPath}$methodName:${Defines.UnresolvedSignature}")
+            finalMethodName.addOne(s"$module::program:${method.parentClassPath}$methodName:${Defines.UnresolvedSignature}")
           })
       }
     })

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
@@ -25,7 +25,8 @@ class PackageTable() {
         methodTableMap(module)
           .filter(_.methodName == methodName)
           .foreach(method => {
-            finalMethodName.addOne(s"$module::program:${method.parentClassPath}$methodName:${Defines.UnresolvedSignature}")
+            finalMethodName
+              .addOne(s"$module::program:${method.parentClassPath}$methodName:${Defines.UnresolvedSignature}")
           })
       }
     })

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
@@ -1,9 +1,6 @@
 package io.joern.rubysrc2cpg.utils
 
-import io.joern.x2cpg.Defines
-
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 
 case class MethodTableModel(methodName: String, parentClassPath: String, classType: String)
 
@@ -18,22 +15,12 @@ class PackageTable() {
     methodTableMap.getOrElseUpdate(moduleName, mutable.HashSet.empty[MethodTableModel]) += packageMethod
   }
 
-  def getMethodFullNameUsingName(packageUsed: List[String], methodName: String): List[String] = {
-    val finalMethodName = ListBuffer[String]()
-    packageUsed.foreach(module => {
-      if (methodTableMap.contains(module)) {
+  def getMethodFullNameUsingName(packageUsed: List[String], methodName: String): List[String] =
+    packageUsed
+      .filter(methodTableMap.contains)
+      .flatMap(module =>
         methodTableMap(module)
           .filter(_.methodName == methodName)
-          .foreach(method => {
-            finalMethodName
-              .addOne(s"$module::program:${method.parentClassPath}$methodName:${Defines.UnresolvedSignature}")
-          })
-      }
-    })
-    if (finalMethodName.isEmpty) {
-      List.empty
-    } else {
-      finalMethodName.toList
-    }
-  }
+          .map(method => s"$module::program:${method.parentClassPath}$methodName")
+      )
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.dataflow
 
-import io.joern.rubysrc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.language._
+import io.joern.rubysrc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 
 class DataFlowTests extends DataFlowCodeToCpgSuite {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -530,6 +530,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
           |""".stripMargin)
 
       val List(methodNode) = cpg.method.name("\\[]").l
+      methodNode.fullName shouldBe "Test0.rb::program:MyClass:[]"
       methodNode.code shouldBe "def [](key)\n  @member_hash[key]\nend"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(5)
@@ -546,6 +547,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
           |""".stripMargin)
 
       val List(methodNode) = cpg.method.name("==").l
+      methodNode.fullName shouldBe "Test0.rb::program:MyClass:=="
       methodNode.code shouldBe "def ==(other)\n  @my_member==other\nend"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(5)
@@ -561,6 +563,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
           |""".stripMargin)
 
       val List(methodNode) = cpg.method.name("some_method").l
+      methodNode.fullName shouldBe "Test0.rb::program:MyClass:some_method"
       methodNode.code shouldBe "def some_method(param)\nend"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(4)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
@@ -13,7 +13,7 @@ class TypeDeclAstCreationPassTest extends RubyCode2CpgFixture {
           |""".stripMargin)
       val Some(myClass) = cpg.typeDecl.nameExact("MyClass").headOption
       myClass.name shouldBe "MyClass"
-      myClass.fullName shouldBe "Test0.rb::program.MyClass"
+      myClass.fullName shouldBe "Test0.rb::program:MyClass"
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
@@ -1,0 +1,21 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+class TypeDeclAstCreationPassTest extends RubyCode2CpgFixture {
+
+  "AST generation for simple classes declarations" should {
+
+    "generate a basic type declaration node for an empty class" in {
+      val cpg = code("""
+          |class MyClass
+          |end
+          |""".stripMargin)
+      val Some(myClass) = cpg.typeDecl.nameExact("MyClass").headOption
+      myClass.name shouldBe "MyClass"
+      myClass.fullName shouldBe "Test0.rb::program.MyClass"
+    }
+
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallGraphTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallGraphTests.scala
@@ -19,7 +19,7 @@ class CallGraphTests extends RubyCode2CpgFixture {
   "should identify call from `foo` to `bar`" in {
     val List(callToBar) = cpg.call("bar").l
     callToBar.name shouldBe "bar"
-    callToBar.methodFullName.matches(".*Test.*.rb:bar") shouldBe true
+    callToBar.methodFullName shouldBe "Test0.rb::program:bar"
     callToBar.lineNumber shouldBe Some(7)
     val List(bar: Method) = cpg.method("bar").internal.l
     bar.fullName shouldBe callToBar.methodFullName

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
@@ -1,6 +1,5 @@
 package io.joern.rubysrc2cpg.querying
 
-import better.files.File
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.BeforeAndAfterAll

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
@@ -40,12 +40,12 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
     "recognise methodFullName for call Node" in {
       if (!scala.util.Properties.isWin) {
         cpg.call.name("first_fun").head.methodFullName should equal(
-          "dummy_logger::program:Main_module:Main_outer_class:first_fun:<unresolvedSignature>"
+          "dummy_logger::program:Main_module:Main_outer_class:first_fun"
         )
         cpg.call
           .name("help_print")
           .head
-          .methodFullName shouldBe "dummy_logger::program:Help:help_print:<unresolvedSignature>"
+          .methodFullName shouldBe "dummy_logger::program:Help:help_print"
       }
     }
   }
@@ -73,11 +73,11 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
       )
 
     "recognise call node" in {
-      cpg.call.name("printValue").l.size shouldBe 1
+      cpg.call.name("printValue").size shouldBe 1
     }
 
     "recognise import node" in {
-      cpg.imports.code(".*util/help.rb*.").l.size shouldBe 1
+      cpg.imports.code(".*util/help.rb*.").size shouldBe 1
     }
 
     "recognise method full name for call node" in {
@@ -85,7 +85,7 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
         cpg.call
           .name("printValue")
           .head
-          .methodFullName shouldBe "util/help.rb::program:Outer:printValue:<unresolvedSignature>"
+          .methodFullName shouldBe "util/help.rb::program:Outer:printValue"
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
@@ -40,9 +40,13 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
     "recognise methodFullName for call Node" in {
       if (!scala.util.Properties.isWin) {
         cpg.call.name("first_fun").head.methodFullName should equal(
-          "dummy_logger.Main_module.Main_outer_class.first_fun:<unresolvedSignature>"
+          "dummy_logger::program:Main_module:Main_outer_class:first_fun:<unresolvedSignature>"
         )
-        cpg.call.name("help_print").head.methodFullName.matches(".*dummy_logger.Help.help_print:<unresolvedSignature>")
+        cpg.call
+          .name("help_print")
+          .head
+          .methodFullName
+          .matches(".*dummy_logger::program:Help:help_print:<unresolvedSignature>")
       }
     }
   }
@@ -83,7 +87,7 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
           .name("printValue")
           .head
           .methodFullName
-          .matches(".*util/help.rb.Outer.printValue:<unresolvedSignature>") shouldBe true
+          .matches(".*util/help.rb::program:Outer:printValue:<unresolvedSignature>") shouldBe true
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
@@ -45,8 +45,7 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
         cpg.call
           .name("help_print")
           .head
-          .methodFullName
-          .matches(".*dummy_logger::program:Help:help_print:<unresolvedSignature>")
+          .methodFullName shouldBe "dummy_logger::program:Help:help_print:<unresolvedSignature>"
       }
     }
   }
@@ -86,8 +85,7 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
         cpg.call
           .name("printValue")
           .head
-          .methodFullName
-          .matches(".*util/help.rb::program:Outer:printValue:<unresolvedSignature>") shouldBe true
+          .methodFullName shouldBe "util/help.rb::program:Outer:printValue:<unresolvedSignature>"
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.testfixtures
 import io.joern.dataflowengineoss.language._
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
+import io.joern.rubysrc2cpg.RubySrc2Cpg
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, TestCpg}
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
@@ -15,7 +16,7 @@ class DataFlowTestCpg(
 
   override protected def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
-
+    RubySrc2Cpg.postProcessingPasses(this)
     val context = new LayerCreatorContext(this)
     val options = new OssDataFlowOptions()
     new OssDataFlow(options).run(context)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -16,7 +16,6 @@ class DataFlowTestCpg(
 
   override protected def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
-    RubySrc2Cpg.postProcessingPasses(this)
     val context = new LayerCreatorContext(this)
     val options = new OssDataFlowOptions()
     new OssDataFlow(options).run(context)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -17,8 +17,13 @@ trait RubyFrontend extends LanguageFrontend {
     implicit val defaultConfig: Config = Config(enableDependencyDownload = withDependencyDownload)
     new RubySrc2Cpg()
       .createCpg(sourceCodeFile.getAbsolutePath)
-      .map { cpg => RubySrc2Cpg.postProcessingPasses(cpg).foreach(_.createAndApply()); cpg }
+      .map(applyPostProcessingPasses)
       .get
+  }
+
+  private def applyPostProcessingPasses(cpg: Cpg): Cpg = {
+    RubySrc2Cpg.postProcessingPasses(cpg).foreach(_.createAndApply())
+    cpg
   }
 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -15,7 +15,10 @@ trait RubyFrontend extends LanguageFrontend {
 
   override def execute(sourceCodeFile: File): Cpg = {
     implicit val defaultConfig: Config = Config(enableDependencyDownload = withDependencyDownload)
-    new RubySrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
+    new RubySrc2Cpg()
+      .createCpg(sourceCodeFile.getAbsolutePath)
+      .map { cpg => RubySrc2Cpg.postProcessingPasses(cpg).foreach(_.createAndApply()); cpg }
+      .get
   }
 }
 


### PR DESCRIPTION
* The class stack & scope are not being used properly, while this does not address the scope issue, this does start addressing the class stack issue
* Filename was used in the place of what a relative file name should be used, thus method full names were incorrect
* Method full names and calls also always assumed they were at the base of the file, and did not include the `:program` class (it was originally missing from the stack)
* Added the `NaiveCallLinker` to the post-processing pass to get some call linking going
* Creating very basic type declaration nodes for now, but this is to be revisited in another PR, as it cannot proceed until this work is merged
* Removed `<unresolvedSignature>` from dependency call resolver as there is no overloading in Ruby