### PR TITLE
Revert "jssrc2cpg: Handle Destructured Params (#2883)"

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -154,9 +154,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
           param
         case ObjectPattern =>
           val paramName = generateUnusedVariableName(usedVariableNames, s"param$index")
-          // Handle de-structured parameters declared as `{ username: string; password: string; }`
-          val typeDecl = astForTypeAlias(nodeInfo)
-          val tpe      = typeDecl.root.collect { case t: NewTypeDecl => t.fullName }.getOrElse(typeFor(nodeInfo))
+          val tpe       = typeFor(nodeInfo)
           val param = parameterInNode(
             nodeInfo,
             paramName,

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -7,8 +7,8 @@ import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.Stack._
 import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newLocalNode}
-import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, ModifierTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes._
 import ujson.Value
 
 import scala.util.Try
@@ -53,11 +53,10 @@ trait AstForTypesCreator { this: AstCreator =>
       }
 
     // adding all class methods / functions and uninitialized, non-static members
-    (alias.node match {
-      case TSTypeLiteral => classMembersForTypeAlias(alias)
-      case ObjectPattern => Try(alias.json("properties").arr).toOption.toSeq.flatten
-      case _             => classMembersForTypeAlias(createBabelNodeInfo(alias.json("typeAnnotation")))
-    }).filter(member => isClassMethodOrUninitializedMemberOrObjectProperty(member) && !isStaticMember(member))
+    classMembersForTypeAlias(alias.node match {
+      case TSTypeLiteral => alias
+      case _             => createBabelNodeInfo(alias.json("typeAnnotation"))
+    }).filter(member => isClassMethodOrUninitializedMember(member) && !isStaticMember(member))
       .foreach(m => astForClassMember(m, aliasTypeDeclNode))
     typeDeclNodeAst.root.foreach(diffGraph.addEdge(methodAstParentStack.head, _, EdgeTypes.AST))
     Ast(aliasTypeDeclNode)
@@ -186,7 +185,7 @@ trait AstForTypesCreator { this: AstCreator =>
         val memberNodeInfo = createBabelNodeInfo(nodeInfo.json("expression")("left")("property"))
         val name           = memberNodeInfo.code
         memberNode(nodeInfo, name, nodeInfo.code, typeFullName)
-      case TSPropertySignature | ObjectProperty =>
+      case TSPropertySignature =>
         val memberNodeInfo = createBabelNodeInfo(nodeInfo.json("key"))
         val name           = memberNodeInfo.json("name").str
         memberNode(nodeInfo, name, nodeInfo.code, typeFullName)
@@ -291,14 +290,6 @@ trait AstForTypesCreator { this: AstCreator =>
     val nodeInfo = createBabelNodeInfo(json).node
     !isStaticInitBlock(json) &&
     (nodeInfo == ClassMethod || nodeInfo == ClassPrivateMethod || !isInitializedMember(json))
-  }
-
-  private def isClassMethodOrUninitializedMemberOrObjectProperty(json: Value): Boolean = {
-    val nodeInfo = createBabelNodeInfo(json).node
-    !isStaticInitBlock(json) &&
-    (nodeInfo == ObjectProperty || nodeInfo == ClassMethod || nodeInfo == ClassPrivateMethod || !isInitializedMember(
-      json
-    ))
   }
 
   protected def astForClass(clazz: BabelNodeInfo, shouldCreateAssignmentCall: Boolean = false): Ast = {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTest.scala
@@ -789,6 +789,17 @@ class MixedAstCreationPassTest extends AbstractPassTest {
       tmpReturnIdentifier.name shouldBe "_tmp_0"
     }
 
+    "have correct edges (destructing parameter)" in AstFixture("""
+        |class Foo {
+        |  bar(param1, { param2_a, param2_b }) {}
+        |}
+        """.stripMargin) { cpg =>
+      val List(param2_a) = cpg.identifier.nameExact("param2_a").l
+      param2_a.astIn should not be empty
+      val List(param2_b) = cpg.identifier.nameExact("param2_b").l
+      param2_b.astIn should not be empty
+    }
+
     "have correct ref edge (destructing parameter)" in AstFixture("""
         |const WindowOpen = ({ value }) => {
         |  return (

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
@@ -311,19 +311,6 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
       credentialsParam.typeFullName shouldBe "code.ts::program:Test:run:_anon_cdecl"
     }
 
-    "AST generation for destructured type in a parameter" in TsAstFixture("""
-        |function apiCall({ username, password }) {
-        |    log(`${username}: ${password}`);
-        |}
-        |""".stripMargin) { cpg =>
-      val Some(credentialsType) = cpg.typeDecl.nameExact("_anon_cdecl").headOption
-      credentialsType.fullName shouldBe "code.ts::program:apiCall:_anon_cdecl"
-      credentialsType.member.name.l shouldBe List("username", "password")
-      credentialsType.member.typeFullName.toSet shouldBe Set(Defines.Any)
-      val Some(credentialsParam) = cpg.parameter.nameExact("param1_0").headOption
-      credentialsParam.typeFullName shouldBe "code.ts::program:apiCall:_anon_cdecl"
-    }
-
   }
 
 }


### PR DESCRIPTION
This reverts commit b5336999a69a25cccc69531629af660e263d9999.

@DavidBakerEffendi Had to revert this as it creates identifier nodes not being included into the AST. That crashes many passes later on. Check e.g., tarpit-nodejs