### PR TITLE
[jssrc2cpg] Fixed dangling Cfg Nodes From Destruct Params

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -166,6 +166,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
             EvaluationStrategies.BY_VALUE,
             Option(tpe)
           )
+          Ast.storeInDiffGraph(typeDecl, diffGraph)
           scope.addVariable(paramName, param, MethodScope)
 
           additionalBlockStatements.addAll(nodeInfo.json("properties").arr.toList.map { element =>
@@ -206,7 +207,9 @@ trait AstForFunctionsCreator { this: AstCreator =>
             .map(x =>
               x.node match {
                 case TSTypeLiteral =>
-                  astForTypeAlias(x).root.collect { case t: NewTypeDecl => t.fullName }.getOrElse(typeFor(nodeInfo))
+                  val typeDecl = astForTypeAlias(x)
+                  Ast.storeInDiffGraph(typeDecl, diffGraph)
+                  typeDecl.root.collect { case t: NewTypeDecl => t.fullName }.getOrElse(typeFor(nodeInfo))
                 case _ => typeFor(nodeInfo)
               }
             )

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -53,14 +53,14 @@ trait AstForTypesCreator { this: AstCreator =>
       }
 
     // adding all class methods / functions and uninitialized, non-static members
-    (alias.node match {
+    val membersAndInitializers = (alias.node match {
       case TSTypeLiteral => classMembersForTypeAlias(alias)
       case ObjectPattern => Try(alias.json("properties").arr).toOption.toSeq.flatten
       case _             => classMembersForTypeAlias(createBabelNodeInfo(alias.json("typeAnnotation")))
     }).filter(member => isClassMethodOrUninitializedMemberOrObjectProperty(member) && !isStaticMember(member))
-      .foreach(m => astForClassMember(m, aliasTypeDeclNode))
+      .map(m => astForClassMember(m, aliasTypeDeclNode))
     typeDeclNodeAst.root.foreach(diffGraph.addEdge(methodAstParentStack.head, _, EdgeTypes.AST))
-    Ast(aliasTypeDeclNode)
+    Ast(aliasTypeDeclNode).withChildren(membersAndInitializers)
   }
 
   private def isConstructor(json: Value): Boolean = createBabelNodeInfo(json).node match {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTest.scala
@@ -2,6 +2,7 @@ package io.joern.jssrc2cpg.passes.ast
 
 import io.joern.jssrc2cpg.passes.{AbstractPassTest, Defines}
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode}
 import io.shiftleft.semanticcpg.language._
 
 class TsClassesAstCreationPassTest extends AbstractPassTest {
@@ -309,6 +310,8 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
       credentialsType.member.typeFullName.toSet shouldBe Set("__ecma.String")
       val Some(credentialsParam) = cpg.parameter.nameExact("credentials").headOption
       credentialsParam.typeFullName shouldBe "code.ts::program:Test:run:_anon_cdecl"
+      // should not produce dangling nodes that are meant to be inside procedures
+      cpg.all.collectAll[CfgNode].whereNot(_._astIn).size shouldBe 0
     }
 
     "AST generation for destructured type in a parameter" in TsAstFixture("""
@@ -322,6 +325,8 @@ class TsClassesAstCreationPassTest extends AbstractPassTest {
       credentialsType.member.typeFullName.toSet shouldBe Set(Defines.Any)
       val Some(credentialsParam) = cpg.parameter.nameExact("param1_0").headOption
       credentialsParam.typeFullName shouldBe "code.ts::program:apiCall:_anon_cdecl"
+      // should not produce dangling nodes that are meant to be inside procedures
+      cpg.all.collectAll[CfgNode].whereNot(_._astIn).size shouldBe 0
     }
 
   }


### PR DESCRIPTION
Related to [#2971](https://github.com/joernio/joern/pull/2971), prevents the case where the destructuring of parameter operations are not linked to the parent block node correctly.