### PR TITLE
simplify versions: use the same circeVersion as globally (0.14.5)

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/build.sbt
+++ b/joern-cli/frontends/gosrc2cpg/build.sbt
@@ -8,8 +8,6 @@ name := "gosrc2cpg"
 scalaVersion       := "2.13.8"
 crossScalaVersions := Seq("2.13.8", "3.3.0")
 
-val circeVersion = "0.14.1"
-
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
@@ -19,9 +17,9 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind"  % "2.15.2",
   "com.typesafe"               % "config"            % "1.4.2",
   "com.michaelpollmeier"       % "versionsort"       % "1.0.11",
-  "io.circe"                  %% "circe-core"        % circeVersion,
-  "io.circe"                  %% "circe-generic"     % circeVersion,
-  "io.circe"                  %% "circe-parser"      % circeVersion,
+  "io.circe"                  %% "circe-core"        % Versions.circe,
+  "io.circe"                  %% "circe-generic"     % Versions.circe,
+  "io.circe"                  %% "circe-parser"      % Versions.circe,
 )
 
 scalacOptions ++= Seq(


### PR DESCRIPTION
fixup for https://github.com/joernio/joern/pull/2960