### PR TITLE
Enable withConfig for rubysrc2cpg

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
@@ -3,8 +3,11 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.BeforeAndAfterAll
+import io.joern.rubysrc2cpg.Config
 
-class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAfterAll {
+class RubyMethodFullNameTests extends RubyCode2CpgFixture with BeforeAndAfterAll {
+
+  private val config = Config().withEnableDependencyDownload(true)
 
   "Code for method full name when method present in module" should {
     val cpg = code(
@@ -28,6 +31,7 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
           |""".stripMargin,
         "Gemfile"
       )
+      .withConfig(config)
 
     "recognise call node" in {
       cpg.call.name("first_fun").l.size shouldBe 1
@@ -71,6 +75,7 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture(true) with BeforeAndAf
           |""".stripMargin,
         Seq("util", "help.rb").mkString(java.io.File.separator)
       )
+      .withConfig(config)
 
     "recognise call node" in {
       cpg.call.name("printValue").size shouldBe 1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -8,11 +8,7 @@ import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, TestCpg}
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
-class DataFlowTestCpg(
-  override protected
-  val withDependencyDownload: Boolean
-) extends TestCpg
-    with RubyFrontend {
+class DataFlowTestCpg extends TestCpg with RubyFrontend {
 
   override protected def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
@@ -23,7 +19,7 @@ class DataFlowTestCpg(
 }
 
 class DataFlowCodeToCpgSuite(withDependencyDownload: Boolean = false)
-    extends Code2CpgFixture(() => new DataFlowTestCpg(withDependencyDownload)) {
+    extends Code2CpgFixture(() => new DataFlowTestCpg()) {
 
   protected implicit val context: EngineContext = EngineContext()
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -9,12 +9,13 @@ import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
 import java.io.File
 
 trait RubyFrontend extends LanguageFrontend {
-  protected val withDependencyDownload: Boolean
-
   override val fileSuffix: String = ".rb"
 
   override def execute(sourceCodeFile: File): Cpg = {
-    implicit val defaultConfig: Config = Config(enableDependencyDownload = withDependencyDownload)
+    implicit val defaultConfig: Config = 
+      getConfig()
+      .map(_.asInstanceOf[Config])
+      .getOrElse(Config())
     new RubySrc2Cpg()
       .createCpg(sourceCodeFile.getAbsolutePath)
       .map(applyPostProcessingPasses)
@@ -27,12 +28,9 @@ trait RubyFrontend extends LanguageFrontend {
   }
 }
 
-class DefaultTestCpgWithRuby(override protected val withDependencyDownload: Boolean)
-    extends DefaultTestCpg
-    with RubyFrontend
+class DefaultTestCpgWithRuby extends DefaultTestCpg with RubyFrontend
 
-class RubyCode2CpgFixture(withDependencyDownload: Boolean = false)
-    extends Code2CpgFixture(() => new DefaultTestCpgWithRuby(withDependencyDownload)) {
+class RubyCode2CpgFixture extends Code2CpgFixture(() => new DefaultTestCpgWithRuby()) {
   implicit val resolver: ICallResolver           = NoResolve
   implicit lazy val engineContext: EngineContext = EngineContext()
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -12,10 +12,10 @@ trait RubyFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".rb"
 
   override def execute(sourceCodeFile: File): Cpg = {
-    implicit val defaultConfig: Config = 
+    implicit val defaultConfig: Config =
       getConfig()
-      .map(_.asInstanceOf[Config])
-      .getOrElse(Config())
+        .map(_.asInstanceOf[Config])
+        .getOrElse(Config())
     new RubySrc2Cpg()
       .createCpg(sourceCodeFile.getAbsolutePath)
       .map(applyPostProcessingPasses)


### PR DESCRIPTION
https://github.com/joernio/joern/pull/2982 added a `withConfig` method to testCpgs to set the config on a per-testcase basis without having to wire class parameters through the various fixtures. This PR enables this for rubysrc2cpg.