### PR TITLE
rubysrc2cpg: start refactoring astForBlock

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1528,7 +1528,7 @@ class AstCreator(
         val blockNode = NewBlock().typeFullName(Defines.Any)
         val retAst = ctxParam match
           case Some(ctxParam) => blockAst(blockNode, astForBlockParameterContext(ctxParam).toList ++ stmtAsts)
-          case None => blockAst(blockNode, stmtAsts)
+          case None           => blockAst(blockNode, stmtAsts)
         Seq(retAst)
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -226,20 +226,19 @@ trait AstForStatementsCreator { this: AstCreator =>
       .code(code)
     Seq(Ast(importNode))
   }
-  
 
   protected implicit class BlockContextExt(val ctx: BlockContext) {
     def compoundStatement: CompoundStatementContext = {
       fold(_.compoundStatement(), _.compoundStatement())
     }
-    
+
     def blockParameter: Option[BlockParameterContext] = {
       fold(ctx => Option(ctx.blockParameter()), ctx => Option(ctx.blockParameter()))
     }
-    
+
     private def fold[A](f: DoBlockContext => A, g: BraceBlockContext => A): A = {
       Option(ctx.doBlock()).fold(g(ctx.braceBlock()))(f)
     }
   }
-    
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -226,4 +226,20 @@ trait AstForStatementsCreator { this: AstCreator =>
       .code(code)
     Seq(Ast(importNode))
   }
+  
+
+  protected implicit class BlockContextExt(val ctx: BlockContext) {
+    def compoundStatement: CompoundStatementContext = {
+      fold(_.compoundStatement(), _.compoundStatement())
+    }
+    
+    def blockParameter: Option[BlockParameterContext] = {
+      fold(ctx => Option(ctx.blockParameter()), ctx => Option(ctx.blockParameter()))
+    }
+    
+    private def fold[A](f: DoBlockContext => A, g: BraceBlockContext => A): A = {
+      Option(ctx.doBlock()).fold(g(ctx.braceBlock()))(f)
+    }
+  }
+    
 }


### PR DESCRIPTION
* `astForBlockContext` takes an optional method name that complicates matters just for 1 possible scenario. Also, there's duplicate code for handling do/brace blocks. I'm arranging this logic in smaller pieces. Since the full refactoring would make for a convoluted diff, I'm splitting this in 2-3 PRs.