### PR TITLE
Add withConfig support for c2cpg, jssrc2cpg, and php2cpg

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/CCodeToCpgSuite.scala
@@ -12,9 +12,13 @@ trait C2CpgFrontend extends LanguageFrontend {
     val cpgOutFile = File.newTemporaryFile("c2cpg.bin")
     cpgOutFile.deleteOnExit()
     val c2cpg = new C2Cpg()
-    val config = Config(includeComments = true)
+
+    val config = getConfig()
+      .map(_.asInstanceOf[Config])
+      .getOrElse(Config(includeComments = true))
       .withInputPath(sourceCodePath.getAbsolutePath)
       .withOutputPath(cpgOutFile.pathAsString)
+
     c2cpg.createCpg(config).get
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
@@ -12,8 +12,11 @@ trait JsSrc2CpgFrontend extends LanguageFrontend {
     val cpgOutFile = File.newTemporaryFile(suffix = "cpg.bin")
     cpgOutFile.deleteOnExit()
     val jssrc2cpg = new JsSrc2Cpg()
-    val config =
-      Config(tsTypes = false).withInputPath(sourceCodePath.getAbsolutePath).withOutputPath(cpgOutFile.pathAsString)
+    val config = getConfig()
+      .map(_.asInstanceOf[Config])
+      .getOrElse(Config(tsTypes = false))
+      .withInputPath(sourceCodePath.getAbsolutePath())
+      .withOutputPath(cpgOutFile.pathAsString)
     jssrc2cpg.createCpg(config).get
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/testfixtures/PhpCode2CpgFixture.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/testfixtures/PhpCode2CpgFixture.scala
@@ -12,7 +12,7 @@ trait PhpFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".php"
 
   override def execute(sourceCodeFile: File): Cpg = {
-    implicit val defaultConfig: Config = Config()
+    implicit val defaultConfig: Config = getConfig().map(_.asInstanceOf[Config]).getOrElse(Config())
     new Php2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
   }
 }


### PR DESCRIPTION
https://github.com/joernio/joern/pull/2982 added a `withConfig` method to testCpgs to set the config on a per-testcase basis without having to wire class parameters through the various fixtures. This PR enables this for c2cpg, jssrc2cpg, and php2cpg.