### PR TITLE
rubysrc2cpg: Refactor astForVariableIdentifier

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -484,8 +484,8 @@ jumpExpression
 // --------------------------------------------------------
 
 variableReference
-    :   variableIdentifier
-    |   pseudoVariableIdentifier
+    :   variableIdentifier                                                                                          # variableIdentifierVariableReference
+    |   pseudoVariableIdentifier                                                                                    # pseudoVariableIdentifierVariableReference
     ;
 
 variableIdentifier

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -197,9 +197,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     ctx: VariableIdentifierContext,
     definitelyIdentifier: Boolean = false
   ): Ast = {
-    val terminalNode = ctx.children.asScala.map(_.asInstanceOf[TerminalNode]).head
-    val token        = terminalNode.getSymbol
-    val variableName = token.getText
+    val variableName = ctx.getText
     /*
      * Preferences
      * 1. If definitelyIdentifier is SET, create a identifier node
@@ -212,8 +210,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
       val node = createIdentifierWithScope(ctx, variableName, variableName, Defines.Any, List[String]())
       Ast(node)
     } else if (methodNames.contains(variableName)) {
-      // TODO: astForCallNode always returns a single Ast even though its return type is Seq[Ast]
-      astForCallNode(terminalNode, ctx.getText).head
+      astForCallNode(ctx, ctx.getText)
     } else {
       val node = createIdentifierWithScope(ctx, variableName, variableName, Defines.Any, List[String]())
       Ast(node)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -6,7 +6,6 @@ import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.NewJumpTarget
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
-import org.antlr.v4.runtime.tree.TerminalNode
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -197,7 +196,6 @@ trait AstForExpressionsCreator { this: AstCreator =>
     ctx: VariableIdentifierContext,
     definitelyIdentifier: Boolean = false
   ): Ast = {
-    val variableName = ctx.getText
     /*
      * Preferences
      * 1. If definitelyIdentifier is SET, create a identifier node
@@ -206,13 +204,14 @@ trait AstForExpressionsCreator { this: AstCreator =>
      * 4. Otherwise default to identifier node creation since there is no reason (point 2) to create a call node
      */
 
+    val variableName = ctx.getText
     if (definitelyIdentifier || scope.lookupVariable(variableName).isDefined) {
-      val node = createIdentifierWithScope(ctx, variableName, variableName, Defines.Any, List[String]())
+      val node = createIdentifierWithScope(ctx, variableName, variableName, Defines.Any, List())
       Ast(node)
     } else if (methodNames.contains(variableName)) {
-      astForCallNode(ctx, ctx.getText)
+      astForCallNode(ctx, variableName)
     } else {
-      val node = createIdentifierWithScope(ctx, variableName, variableName, Defines.Any, List[String]())
+      val node = createIdentifierWithScope(ctx, variableName, variableName, Defines.Any, List())
       Ast(node)
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
@@ -22,7 +22,7 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
-            |     VariableReference
+            |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       something
             |  Separators
@@ -79,7 +79,7 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
-            |     VariableReference
+            |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       something
             |  Separators
@@ -122,7 +122,7 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
-            |     VariableReference
+            |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       something
             |  Separators
@@ -162,7 +162,7 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
-            |     VariableReference
+            |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       x
             |  Separators

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -68,7 +68,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |    Association
             |     PrimaryExpression
             |      VariableReferencePrimary
-            |       VariableReference
+            |       VariableIdentifierVariableReference
             |        VariableIdentifier
             |         region
             |     :

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
@@ -20,7 +20,7 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
-            |     VariableReference
+            |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       foo
             |  ThenClause
@@ -32,7 +32,7 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |      ExpressionExpressionOrCommand
             |       PrimaryExpression
             |        VariableReferencePrimary
-            |         VariableReference
+            |         VariableIdentifierVariableReference
             |          VariableIdentifier
             |           bar
             |    Separators
@@ -54,7 +54,7 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
-            |     VariableReference
+            |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       foo
             |  ThenClause
@@ -67,7 +67,7 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |      ExpressionExpressionOrCommand
             |       PrimaryExpression
             |        VariableReferencePrimary
-            |         VariableReference
+            |         VariableIdentifierVariableReference
             |          VariableIdentifier
             |           bar
             |    Separators
@@ -90,7 +90,7 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
-            |     VariableReference
+            |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       foo
             |  ThenClause
@@ -103,7 +103,7 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |      ExpressionExpressionOrCommand
             |       PrimaryExpression
             |        VariableReferencePrimary
-            |         VariableReference
+            |         VariableIdentifierVariableReference
             |          VariableIdentifier
             |           bar
             |    Separators


### PR DESCRIPTION
* Names `variableIdentifier` alternatives (so that we can safely pattern match on context types.)
* Moves and simplifies `astForVariableIdentifier`