### PR TITLE
GoSrc2Cpg : AST generation for switch case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Joern - The Bug Hunter's Workbench
-=== 
+===
 
 [![release](https://github.com/joernio/joern/actions/workflows/release.yml/badge.svg)](https://github.com/joernio/joern/actions/workflows/release.yml)
 [![Joern SBT](https://index.scala-lang.org/joernio/joern/latest.svg)](https://index.scala-lang.org/joernio/joern)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Joern - The Bug Hunter's Workbench
-===
+=== 
 
 [![release](https://github.com/joernio/joern/actions/workflows/release.yml/badge.svg)](https://github.com/joernio/joern/actions/workflows/release.yml)
 [![Joern SBT](https://index.scala-lang.org/joernio/joern/latest.svg)](https://index.scala-lang.org/joernio/joern)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,6 +1,6 @@
 package io.joern.gosrc2cpg.astcreation
 
-import io.joern.gosrc2cpg.parser.ParserAst.{ParserNode, fromString}
+import io.joern.gosrc2cpg.parser.ParserAst.{Ident, ParserNode, fromString}
 import ujson.Value
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import org.apache.commons.lang.StringUtils
@@ -66,5 +66,11 @@ trait AstCreatorHelper { this: AstCreator =>
       }
       .toMap
   }
-
+  protected def getTypeForJsonNode(jsonNode: Value): String = {
+    val nodeInfo = createParserNodeInfo(jsonNode)
+    nodeInfo.node match {
+      case Ident => jsonNode.obj(ParserKeys.Name).str
+      case _     => Defines.anyTypeName
+    }
+  }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
@@ -4,6 +4,7 @@ import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg.Ast
 import io.joern.gosrc2cpg.parser.ParserAst._
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import ujson.Value
 
 import scala.util.Try
 
@@ -50,7 +51,7 @@ trait AstForGenDeclarationCreator { this: AstCreator =>
               val localParserNode = createParserNodeInfo(parserNode)
 
               val name = parserNode(ParserKeys.Name).str
-              val typ  = valueSpec.json(ParserKeys.Type).obj(ParserKeys.Name).str
+              val typ  = getTypeForJsonNode(valueSpec.json(ParserKeys.Type))
               val node = localNode(localParserNode, name, localParserNode.code, typ)
               scope.addToScope(name, (node, typ))
               Ast(node)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -6,6 +6,7 @@ import io.joern.gosrc2cpg.utils.Operator
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 
+import scala.annotation.tailrec
 import scala.util.Try
 
 trait AstForStatementsCreator { this: AstCreator =>
@@ -23,14 +24,20 @@ trait AstForStatementsCreator { this: AstCreator =>
     blockAst(newBlockNode, childAsts.toList)
   }
 
+  @tailrec
   private def astsForStatement(statement: ParserNodeInfo, argIndex: Int = -1): Seq[Ast] = {
     statement.node match {
-      case AssignStmt => astForAssignStatement(statement)
-      case BlockStmt  => Seq(astForBlockStatement(statement, argIndex))
-      case DeclStmt   => astForDeclStatement(statement)
-      case IfStmt     => Seq(astForIfStatement(statement))
-      case IncDecStmt => Seq(astForIncDecStatement(statement))
-      case _          => Seq()
+      case AssignStmt     => astForAssignStatement(statement)
+      case BlockStmt      => Seq(astForBlockStatement(statement, argIndex))
+      case CaseClause     => astForCaseClause(statement)
+      case DeclStmt       => astForDeclStatement(statement)
+      case ExprStmt       => astsForStatement(createParserNodeInfo(statement.json(ParserKeys.X)))
+      case IfStmt         => Seq(astForIfStatement(statement))
+      case IncDecStmt     => Seq(astForIncDecStatement(statement))
+      case SwitchStmt     => Seq(astForSwitchStatement(statement))
+      case TypeAssertExpr => astForNode(statement.json(ParserKeys.X))
+      case TypeSwitchStmt => Seq(astForTypeSwitchStatement(statement))
+      case _              => astForNode(statement.json)
     }
   }
 
@@ -100,7 +107,7 @@ trait AstForStatementsCreator { this: AstCreator =>
   private def astForConditionExpression(condStmt: ParserNodeInfo): Ast = {
     condStmt.node match {
       case ParenExpr => astForNode(condStmt.json(ParserKeys.X)).head
-      case _         => Ast()
+      case _         => astsForStatement(condStmt).head
     }
   }
 
@@ -133,4 +140,45 @@ trait AstForStatementsCreator { this: AstCreator =>
     controlStructureAst(ifNode, Some(conditionAst), Seq(thenAst, elseAst))
   }
 
+  private def astForSwitchStatement(switchStmt: ParserNodeInfo): Ast = {
+
+    val conditionParserNode = Try(createParserNodeInfo(switchStmt.json(ParserKeys.Tag)))
+    val (code, conditionAst) = conditionParserNode.toOption match {
+      case Some(node) => (node.code, Some(astForConditionExpression(node)))
+      case _          => ("", None)
+    }
+    val switchNode = controlStructureNode(switchStmt, ControlStructureTypes.SWITCH, s"switch $code")
+    val stmtAsts   = astsForStatement(createParserNodeInfo(switchStmt.json(ParserKeys.Body)))
+    controlStructureAst(switchNode, conditionAst, stmtAsts)
+  }
+
+  private def astForTypeSwitchStatement(typeSwitchStmt: ParserNodeInfo): Ast = {
+
+    val conditionParserNode = Try(createParserNodeInfo(typeSwitchStmt.json(ParserKeys.Assign)))
+    val (code, conditionAst) = conditionParserNode.toOption match {
+      case Some(node) => (node.code, Some(astForConditionExpression(node)))
+      case _          => ("", None)
+    }
+    val switchNode = controlStructureNode(typeSwitchStmt, ControlStructureTypes.SWITCH, s"switch $code")
+    val stmtAsts   = astsForStatement(createParserNodeInfo(typeSwitchStmt.json(ParserKeys.Body)))
+    controlStructureAst(switchNode, conditionAst, stmtAsts)
+  }
+
+  private def astForCaseClause(caseStmt: ParserNodeInfo): Seq[Ast] = {
+    val caseClauseAst = caseStmt.json(ParserKeys.List).arrOpt match {
+      case Some(caseConditionList) =>
+        caseConditionList.flatMap { caseConditionNode =>
+          val caseConditionParserNode = createParserNodeInfo(caseConditionNode)
+          val jumpTarget              = jumpTargetNode(caseStmt, "case", s"case ${caseConditionParserNode.code}")
+          val labelAsts               = astForNode(caseConditionNode).toList
+          Ast(jumpTarget) :: labelAsts
+        }
+      case _ =>
+        val target = jumpTargetNode(caseStmt, "default", "default")
+        Seq(Ast(target))
+    }
+
+    val caseBodyAst = caseStmt.json(ParserKeys.Body).arr.map(createParserNodeInfo).flatMap(astsForStatement(_)).toList
+    caseClauseAst ++: caseBodyAst
+  }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -107,7 +107,7 @@ trait AstForStatementsCreator { this: AstCreator =>
   private def astForConditionExpression(condStmt: ParserNodeInfo): Ast = {
     condStmt.node match {
       case ParenExpr => astForNode(condStmt.json(ParserKeys.X)).head
-      case _         => astsForStatement(condStmt).head
+      case _         => astsForStatement(condStmt).headOption.getOrElse(Ast())
     }
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
@@ -29,13 +29,19 @@ object ParserAst {
   object UnaryExpr  extends BaseExprStmt
   object StarExpr   extends BaseExprStmt
 
-  object IncDecStmt extends ParserNode
-  object IfStmt     extends ParserNode
-  object ParenExpr  extends BaseExprStmt
+  object IncDecStmt     extends ParserNode
+  object IfStmt         extends ParserNode
+  object ParenExpr      extends BaseExprStmt
+  object SwitchStmt     extends ParserNode
+  object CaseClause     extends ParserNode
+  object TypeSwitchStmt extends ParserNode
+  object TypeAssertExpr extends BaseExprStmt
+  object InterfaceType  extends ParserNode
 }
 
 object ParserKeys {
 
+  val Assign        = "Assign"
   val Body          = "Body"
   val Cond          = "Cond"
   val Decl          = "Decl"
@@ -56,6 +62,7 @@ object ParserKeys {
   val Path          = "Path"
   val Rhs           = "Rhs"
   val Specs         = "Specs"
+  val Tag           = "Tag"
   val Tok           = "Tok"
   val Type          = "Type"
   val Value         = "Value"

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/dataflow/DataflowTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/dataflow/DataflowTests.scala
@@ -130,7 +130,7 @@ class DataflowTests extends GoCodeToCpgSuite(withOssDataflow = true) {
   }
 
   "Source to sink dataflow through switch case" should {
-    "be reachable" in {
+    "be reachable for expression condition" in {
       val cpg = code("""
         |package main
         |func method() {
@@ -143,16 +143,10 @@ class DataflowTests extends GoCodeToCpgSuite(withOssDataflow = true) {
         |   }
         |}
     """.stripMargin)
-      "(case in)" in {
-        val source = cpg.identifier("grade").lineNumber(5)
-        val sink   = cpg.identifier("myGrade").lineNumber(7)
-        sink.reachableByFlows(source).size shouldBe 1
-      }
-      "(case 2)" in {
-        val source = cpg.identifier("grade").lineNumber(7)
-        val sink   = cpg.identifier("myGrade").lineNumber(7)
-        sink.reachableByFlows(source).size shouldBe 1
-      }
+      val source = cpg.identifier("grade").lineNumber(5)
+      val sink   = cpg.identifier("myGrade").lineNumber(7)
+      sink.reachableByFlows(source).size shouldBe 1
+
     }
 
     "be reachable for empty condition" ignore {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/dataflow/DataflowTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/dataflow/DataflowTests.scala
@@ -129,4 +129,51 @@ class DataflowTests extends GoCodeToCpgSuite(withOssDataflow = true) {
     }
   }
 
+  "Source to sink dataflow through switch case" should {
+    "be reachable" in {
+      val cpg = code("""
+        |package main
+        |func method() {
+        |  var marks int = 90
+        |  var grade string = "B"
+        |  switch marks {
+        |      case 90: myGrade := grade
+        |      case 50,60,70: grade = "C"
+        |      default: grade = "D"
+        |   }
+        |}
+    """.stripMargin)
+      "(case in)" in {
+        val source = cpg.identifier("grade").lineNumber(5)
+        val sink   = cpg.identifier("myGrade").lineNumber(7)
+        sink.reachableByFlows(source).size shouldBe 1
+      }
+      "(case 2)" in {
+        val source = cpg.identifier("grade").lineNumber(7)
+        val sink   = cpg.identifier("myGrade").lineNumber(7)
+        sink.reachableByFlows(source).size shouldBe 1
+      }
+    }
+
+    "be reachable for empty condition" ignore {
+      // TODO (BUG)dataflow doesn't work for empty condition in switch case
+      val cpg = code("""
+          |package main
+          |func method() {
+          |  var marks int = 90
+          |  var grade string = "B"
+          |  switch {
+          |      case grade == "A" :
+          |         mymarks := grade
+          |      case grade == "B":
+          |         marks = 80
+          |   }
+          |}
+      """.stripMargin)
+      val source = cpg.identifier("grade").lineNumber(5).l
+      val sink   = cpg.identifier("mymarks").lineNumber(8).l
+      sink.reachableByFlows(source).size shouldBe 1
+    }
+  }
+
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -1697,7 +1697,7 @@ trait KtPsiToAst {
     val name =
       if (entry.getElseKeyword == null) Constants.defaultCaseNode
       else s"${Constants.caseNodePrefix}$argIdx"
-    val jumpNode = jumpTargetNode(entry.getText, name, Constants.caseNodeParserTypeName, line(entry), column(entry))
+    val jumpNode = jumpTargetNode(entry, name, entry.getText, Some(Constants.caseNodeParserTypeName))
       .argumentIndex(argIdx)
     val exprNode = astsForExpression(entry.getExpression, Some(argIdx + 1)).headOption.getOrElse(Ast())
     Seq(Ast(jumpNode), exprNode)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/Nodes.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/Nodes.scala
@@ -5,21 +5,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewJumpTarget, N
 
 object Nodes {
 
-  def jumpTargetNode(
-    code: String,
-    name: String,
-    parserTypeName: String,
-    line: Option[Integer] = None,
-    column: Option[Integer] = None
-  ): NewJumpTarget = {
-    NewJumpTarget()
-      .code(code)
-      .name(name)
-      .parserTypeName(parserTypeName)
-      .lineNumber(line)
-      .columnNumber(column)
-  }
-
   def modifierNode(_type: String): NewModifier = {
     NewModifier()
       .modifierType(_type)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -8,6 +8,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewFieldIdentifier,
   NewIdentifier,
   NewImport,
+  NewJumpTarget,
   NewLiteral,
   NewLocal,
   NewMember,
@@ -297,5 +298,19 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
 
   protected def methodReturnNode(node: Node, typeFullName: String): NewMethodReturn = {
     newMethodReturnNode(typeFullName, None, line(node), column(node))
+  }
+
+  protected def jumpTargetNode(
+    node: Node,
+    name: String,
+    code: String,
+    parserTypeName: Option[String] = None
+  ): NewJumpTarget = {
+    NewJumpTarget()
+      .parserTypeName(parserTypeName.getOrElse(node.getClass.getSimpleName))
+      .name(name)
+      .code(code)
+      .lineNumber(line(node))
+      .columnNumber(column(node))
   }
 }


### PR DESCRIPTION
The PR covers the following
- Ast creation for switch case
- Corresponding Ast and dataflow tests
- Moved JumpTargetNode from kotlin2cpg to x2cpg as it was redundant
- Ignored 1 test case in Ast creation where due to the presence of a `local` node in the condition of switch it throws an error
- Ignored 1 test case in Dataflow where due to an empty condition in the switch, dataflow doesn't propagate