### PR TITLE
rubysrc2cpg: Missing ws in `rescueClause`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -421,7 +421,7 @@ bodyStatement
     ;
 
 rescueClause
-    :   RESCUE WS* exceptionClass? wsOrNl* exceptionVariableAssignment? thenClause
+    :   RESCUE WS* exceptionClass? wsOrNl* exceptionVariableAssignment? wsOrNl* thenClause
     ;
 
 exceptionClass

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
@@ -1,0 +1,63 @@
+package io.joern.rubysrc2cpg.parser
+
+class BeginExpressionTests extends RubyParserAbstractTest {
+  
+  "A begin expression" should {
+    
+    "be parsed as a primary expression" when {
+      
+      "it contains a `rescue` clause with both exception class and exception variable" in {
+        val code = """begin
+            |1/0
+            |rescue ZeroDivisionError => e
+            |end""".stripMargin
+          
+        printAst(_.primary(), code) shouldBe
+          """BeginExpressionPrimary
+            | BeginExpression
+            |  begin
+            |  WsOrNl
+            |  BodyStatement
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       MultiplicativeExpression
+            |        PrimaryExpression
+            |         LiteralPrimary
+            |          NumericLiteralLiteral
+            |           NumericLiteral
+            |            UnsignedNumericLiteral
+            |             1
+            |        /
+            |        PrimaryExpression
+            |         LiteralPrimary
+            |          NumericLiteralLiteral
+            |           NumericLiteral
+            |            UnsignedNumericLiteral
+            |             0
+            |    Separators
+            |     Separator
+            |   RescueClause
+            |    rescue
+            |    ExceptionClass
+            |     PrimaryExpression
+            |      VariableReferencePrimary
+            |       VariableIdentifierVariableReference
+            |        VariableIdentifier
+            |         ZeroDivisionError
+            |    WsOrNl
+            |    ExceptionVariableAssignment
+            |     =>
+            |     VariableIdentifierOnlySingleLeftHandSide
+            |      VariableIdentifier
+            |       e
+            |    ThenClause
+            |     Separator
+            |     CompoundStatement
+            |  end""".stripMargin
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
@@ -1,17 +1,17 @@
 package io.joern.rubysrc2cpg.parser
 
 class BeginExpressionTests extends RubyParserAbstractTest {
-  
+
   "A begin expression" should {
-    
+
     "be parsed as a primary expression" when {
-      
+
       "it contains a `rescue` clause with both exception class and exception variable" in {
         val code = """begin
             |1/0
             |rescue ZeroDivisionError => e
             |end""".stripMargin
-          
+
         printAst(_.primary(), code) shouldBe
           """BeginExpressionPrimary
             | BeginExpression


### PR DESCRIPTION
Fixes #3020 