### PR TITLE
[rubysrc2cpg] Unit tests replicated from c2cpg and pysrc2cpg

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
@@ -46,7 +46,7 @@ class FileTests extends GoCodeToCpgSuite {
       .typeDecl
       .name
       .l
-      .sorted shouldBe List("main.<global>", "Sample")
+      .sorted shouldBe List("main.<global>", "int", "Sample")
   }
 
   "should allow traversing to namespaces" in {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
@@ -1,0 +1,60 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+class FileTests extends GoCodeToCpgSuite {
+  private val cpg = code("""
+      |package main
+      |func foo() {}
+      |func bar() {}
+      |type Sample struct {
+      |	name int
+      |}
+      |""".stripMargin)
+
+  // TODO: Fix this unit test
+  "should contain two file nodes in total, both with order=0" ignore {
+    cpg.file.order.l shouldBe List(0, 0)
+    cpg.file.name(FileTraversal.UNKNOWN).size shouldBe 1
+    cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 1
+  }
+
+  "should contain exactly one placeholder file node with `name=\"<unknown>\"/order=0`" in {
+    cpg.file(FileTraversal.UNKNOWN).order.l shouldBe List(0)
+    cpg.file(FileTraversal.UNKNOWN).hash.l shouldBe List()
+  }
+
+  "should allow traversing from file to its namespace blocks" in {
+    cpg.file.nameNot(FileTraversal.UNKNOWN).namespaceBlock.name.toSetMutable shouldBe Set("main")
+  }
+
+  "should allow traversing from file to its methods via namespace block" in {
+    cpg.file.nameNot(FileTraversal.UNKNOWN).method.name.toSetMutable shouldBe Set(
+      "main." + NamespaceTraversal.globalNamespaceName,
+      "foo",
+      "bar"
+    )
+  }
+
+  // TODO: TypeDecl fix the unit test
+  "should allow traversing from file to its type declarations via namespace block" ignore {
+    cpg.file
+      .nameNot(FileTraversal.UNKNOWN)
+      .typeDecl
+      .name
+      .l
+      .sorted shouldBe List("main.<global>", "Sample")
+  }
+
+  "should allow traversing to namespaces" in {
+    val List(ns1, ns2) = cpg.file.namespaceBlock.l
+    ns1.filename shouldBe "<unknown>"
+    ns1.fullName shouldBe "<global>"
+    ns2.filename shouldBe "Test0.go"
+    ns2.fullName shouldBe "Test0.go:main"
+    cpg.file.namespace.l.size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/FileTests.scala
@@ -1,0 +1,62 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+class FileTests extends RubyCode2CpgFixture {
+  val cpg = code("""
+      |def foo()
+      |end
+      |def bar()
+      |end
+      |class MyClass
+      |end
+      |""".stripMargin)
+
+  // TODO: Fix this unit test
+  "should contain two file nodes in total, both with order=0" ignore {
+    cpg.file.order.l shouldBe List(0, 0)
+    cpg.file.name(FileTraversal.UNKNOWN).size shouldBe 1
+    cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 1
+  }
+
+  "should contain exactly one placeholder file node with `name=\"<unknown>\"/order=0`" in {
+    cpg.file(FileTraversal.UNKNOWN).order.l shouldBe List(0)
+    cpg.file(FileTraversal.UNKNOWN).hash.l shouldBe List()
+  }
+
+  "should allow traversing from file to its namespace blocks" in {
+    cpg.file.nameNot(FileTraversal.UNKNOWN).namespaceBlock.name.toSetMutable shouldBe Set(
+      NamespaceTraversal.globalNamespaceName
+    )
+  }
+
+  "should allow traversing from file to its methods via namespace block" in {
+    cpg.file.nameNot(FileTraversal.UNKNOWN).method.name.toSetMutable shouldBe Set(":program", "foo", "bar")
+  }
+
+  // TODO: TypeDecl fix this unit test
+  "should allow traversing from file to its type declarations via namespace block" ignore {
+    cpg.file
+      .nameNot(FileTraversal.UNKNOWN)
+      .typeDecl
+      .nameNot(NamespaceTraversal.globalNamespaceName)
+      .name
+      .l
+      .sorted shouldBe List("MyClass")
+  }
+
+  // TODO: Need to fix this test.
+  "should allow traversing to namespaces" ignore {
+    val List(ns1, ns2) = cpg.file.namespaceBlock.l
+    // At present it returning full file system path. It should return relative path
+    ns1.filename shouldBe "Test0.rb"
+    // At present it returning full file system path. It should return relative path
+    ns1.fullName shouldBe "Test0.rb:<global>"
+    ns2.filename shouldBe "<unknown>"
+    ns2.fullName shouldBe "<global>"
+    cpg.file.namespace.name(NamespaceTraversal.globalNamespaceName).l.size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MetaDataTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MetaDataTests.scala
@@ -1,0 +1,28 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
+import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.language._
+class MetaDataTests extends RubyCode2CpgFixture {
+  val cpg = code("""puts 123""")
+
+  "should contain exactly one node with all mandatory fields set" in {
+    val List(x) = cpg.metaData.l
+    x.language shouldBe Languages.RUBYSRC
+    x.version shouldBe "0.1"
+    x.overlays shouldBe List(
+      Base.overlayName,
+      ControlFlow.overlayName,
+      TypeRelations.overlayName,
+      CallGraph.overlayName
+    )
+    x.hash shouldBe None
+  }
+
+  "should not have any incoming or outgoing edges" in {
+    cpg.metaData.size shouldBe 1
+    cpg.metaData.in.l shouldBe List()
+    cpg.metaData.out.l shouldBe List()
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -23,8 +23,7 @@ class MethodOneTests extends RubyCode2CpgFixture {
         x.code should startWith("def foo(a, b)")
         x.isExternal shouldBe false
         x.order shouldBe 1
-        // TODO: At present it is returning absolute path
-//        x.filename shouldBe "Test0.rb"
+        x.filename endsWith "Test0.rb"
         x.lineNumber shouldBe Option(2)
         x.lineNumberEnd shouldBe Option(4)
       }
@@ -84,7 +83,7 @@ class MethodOneTests extends RubyCode2CpgFixture {
       parameter1.index shouldBe 1
       parameter1.typeFullName shouldBe "ANY"
 
-      val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
+      val parameter2 = cpg.method.fullName("Test0.rb::program:foo").parameter.order(2).head
       parameter2.name shouldBe "b"
       parameter2.index shouldBe 2
       parameter2.typeFullName shouldBe "ANY"
@@ -119,7 +118,7 @@ class MethodOneTests extends RubyCode2CpgFixture {
         |  if names == "Alice"
         |    return 1
         |  else
-        |    return 1
+        |    return 2
         |end
         |""".stripMargin)
 
@@ -135,7 +134,7 @@ class MethodOneTests extends RubyCode2CpgFixture {
       inside(astReturns) { case List(ret1, ret2) =>
         ret1.code shouldBe "return 1"
         ret1.lineNumber shouldBe Option(4)
-        ret2.code shouldBe "return 2;"
+        ret2.code shouldBe "return 2"
         ret2.lineNumber shouldBe Option(6)
       }
       astReturns shouldBe cfgReturns

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -1,0 +1,89 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+class MethodOneTests extends RubyCode2CpgFixture {
+
+  "Method test with regular keyword def and end " should {
+    val cpg = code("""
+        |def foo(a, b)
+        |  return ""
+        |end
+        |""".stripMargin)
+
+    "should contain exactly one method node with correct fields" in {
+      inside(cpg.method.name("foo").l) { case List(x) =>
+        x.name shouldBe "foo"
+        x.isExternal shouldBe false
+        x.fullName shouldBe "Test0.rb::program:foo"
+        x.code should startWith("def foo(a, b)")
+        x.isExternal shouldBe false
+        x.order shouldBe 1
+        // TODO: At present it is returning absolute path
+//        x.filename shouldBe "Test0.rb"
+        x.lineNumber shouldBe Option(2)
+        x.lineNumberEnd shouldBe Option(4)
+      }
+    }
+
+    "should return correct number of lines" in {
+      cpg.method.name("foo").numberOfLines.l shouldBe List(3)
+    }
+
+    // TODO: This test cases needs to be fixed.
+    "should allow traversing to parameters" ignore {
+      cpg.method.name("foo").parameter.name.toSetMutable shouldBe Set("a", "b")
+    }
+
+    "should allow traversing to methodReturn" in {
+      cpg.method.name("foo").methodReturn.typeFullName.head shouldBe "ANY"
+    }
+
+    "should allow traversing to file" in {
+      cpg.method.name("foo").file.name.l should not be empty
+    }
+
+    // TODO: Need to be fixed
+    "test function method ref" ignore {
+      cpg.methodRef("foo").referencedMethod.fullName.l should not be empty
+      cpg.methodRef("foo").referencedMethod.fullName.head shouldBe
+        "Test0.rb::program:foo"
+    }
+
+    // TODO: Need to be fixed.
+    "test existence of local variable in module function" ignore {
+      cpg.method.fullName("Test0.rb::program").local.name.l should contain("foo")
+    }
+
+    // TODO: need to be fixed.
+    "test corresponding type, typeDecl and binding" ignore {
+      cpg.method.fullName("Test0.rb::program:foo").referencingBinding.bindingTypeDecl.l should not be empty
+      val bindingTypeDecl =
+        cpg.method.fullName("Test0.rb::program:foo").referencingBinding.bindingTypeDecl.head
+
+      bindingTypeDecl.name shouldBe "foo"
+      bindingTypeDecl.fullName shouldBe "Test0.rb::program:foo"
+      bindingTypeDecl.referencingType.name.head shouldBe "foo"
+      bindingTypeDecl.referencingType.fullName.head shouldBe "Test0.rb::program:foo"
+    }
+
+    // TODO: Need to be fixed
+    "test method parameter nodes" ignore {
+      cpg.method.name("foo").parameter.name.l.size shouldBe 2
+      val parameter1 = cpg.method.fullName("Test0.rb::program:foo").parameter.order(1).head
+      parameter1.name shouldBe "a"
+      parameter1.index shouldBe 1
+      parameter1.typeFullName shouldBe "ANY"
+
+      val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
+      parameter2.name shouldBe "b"
+      parameter2.index shouldBe 2
+      parameter2.typeFullName shouldBe "ANY"
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodTwoTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodTwoTests.scala
@@ -23,8 +23,7 @@ class MethodTwoTests extends RubyCode2CpgFixture {
         x.code should startWith("def foo(a, b)")
         x.isExternal shouldBe false
         x.order shouldBe 1
-        // TODO: At present it is returning absolute path
-        //        x.filename shouldBe "Test0.rb"
+        x.filename endsWith "Test0.rb"
         x.lineNumber shouldBe Option(2)
         x.lineNumberEnd shouldBe Option(4)
       }
@@ -89,7 +88,7 @@ class MethodTwoTests extends RubyCode2CpgFixture {
       parameter1.index shouldBe 1
       parameter1.typeFullName shouldBe "ANY"
 
-      val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
+      val parameter2 = cpg.method.fullName("Test0.rb::program:foo").parameter.order(2).head
       parameter2.name shouldBe "b"
       parameter2.index shouldBe 2
       parameter2.typeFullName shouldBe "ANY"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodTwoTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodTwoTests.scala
@@ -42,7 +42,13 @@ class MethodTwoTests extends RubyCode2CpgFixture {
 
     // TODO: This test cases needs to be fixed.
     "should allow traversing to methodReturn" ignore {
+      cpg.method.name("foo").methodReturn.l.size shouldBe 1
       cpg.method.name("foo").methodReturn.typeFullName.head shouldBe "ANY"
+    }
+
+    // TODO: This test cases needs to be fixed.
+    "should allow traversing to method" ignore {
+      cpg.methodReturn.method.name.l shouldBe List("foo", ":program")
     }
 
     // TODO: This test cases needs to be fixed.
@@ -87,6 +93,12 @@ class MethodTwoTests extends RubyCode2CpgFixture {
       parameter2.name shouldBe "b"
       parameter2.index shouldBe 2
       parameter2.typeFullName shouldBe "ANY"
+    }
+
+    // TODO: Need to be fixed
+    "should allow traversing from parameter to method" ignore {
+      cpg.parameter.name("a").method.name.l shouldBe List("foo")
+      cpg.parameter.name("b").method.name.l shouldBe List("foo")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodTwoTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodTwoTests.scala
@@ -1,0 +1,92 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes}
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+class MethodTwoTests extends RubyCode2CpgFixture {
+
+  "Method test with define_method" should {
+    val cpg = code("""
+        |define_method(:foo) do |a, b|
+        |  return ""
+        |end
+        |""".stripMargin)
+
+    // TODO: This test cases needs to be fixed.
+    "should contain exactly one method node with correct fields" ignore {
+      inside(cpg.method.name("foo").l) { case List(x) =>
+        x.name shouldBe "foo"
+        x.isExternal shouldBe false
+        x.fullName shouldBe "Test0.rb::program:foo"
+        x.code should startWith("def foo(a, b)")
+        x.isExternal shouldBe false
+        x.order shouldBe 1
+        // TODO: At present it is returning absolute path
+        //        x.filename shouldBe "Test0.rb"
+        x.lineNumber shouldBe Option(2)
+        x.lineNumberEnd shouldBe Option(4)
+      }
+    }
+
+    // TODO: This test cases needs to be fixed.
+    "should return correct number of lines" ignore {
+      cpg.method.name("foo").numberOfLines.l shouldBe List(3)
+    }
+
+    // TODO: This test cases needs to be fixed.
+    "should allow traversing to parameters" ignore {
+      cpg.method.name("foo").parameter.name.toSetMutable shouldBe Set("a", "b")
+    }
+
+    // TODO: This test cases needs to be fixed.
+    "should allow traversing to methodReturn" ignore {
+      cpg.method.name("foo").methodReturn.typeFullName.head shouldBe "ANY"
+    }
+
+    // TODO: This test cases needs to be fixed.
+    "should allow traversing to file" ignore {
+      cpg.method.name("foo").file.name.l should not be empty
+    }
+
+    // TODO: Need to be fixed
+    "test function method ref" ignore {
+      cpg.methodRef("foo").referencedMethod.fullName.l should not be empty
+      cpg.methodRef("foo").referencedMethod.fullName.head shouldBe
+        "Test0.rb::program:foo"
+    }
+
+    // TODO: Need to be fixed.
+    "test existence of local variable in module function" ignore {
+      cpg.method.fullName("Test0.rb::program").local.name.l should contain("foo")
+    }
+
+    // TODO: need to be fixed.
+    "test corresponding type, typeDecl and binding" ignore {
+      cpg.method.fullName("Test0.rb::program:foo").referencingBinding.bindingTypeDecl.l should not be empty
+      val bindingTypeDecl =
+        cpg.method.fullName("Test0.rb::program:foo").referencingBinding.bindingTypeDecl.head
+
+      bindingTypeDecl.name shouldBe "foo"
+      bindingTypeDecl.fullName shouldBe "Test0.rb::program:foo"
+      bindingTypeDecl.referencingType.name.head shouldBe "foo"
+      bindingTypeDecl.referencingType.fullName.head shouldBe "Test0.rb::program:foo"
+    }
+
+    // TODO: Need to be fixed
+    "test method parameter nodes" ignore {
+
+      cpg.method.name("foo").parameter.name.l.size shouldBe 2
+      val parameter1 = cpg.method.fullName("Test0.rb::program:foo").parameter.order(1).head
+      parameter1.name shouldBe "a"
+      parameter1.index shouldBe 1
+      parameter1.typeFullName shouldBe "ANY"
+
+      val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
+      parameter2.name shouldBe "b"
+      parameter2.index shouldBe 2
+      parameter2.typeFullName shouldBe "ANY"
+    }
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/NamespaceBlockTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/NamespaceBlockTest.scala
@@ -1,0 +1,51 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+class NamespaceBlockTest extends RubyCode2CpgFixture {
+  val cpg = code("""puts 123
+      |def foo()
+      |end
+      |class MyClass
+      |end
+      |""".stripMargin)
+
+  "should contain a correct global namespace block for the `<unknown>` file" in {
+    val List(x) = cpg.namespaceBlock.filename(FileTraversal.UNKNOWN).l
+    x.name shouldBe NamespaceTraversal.globalNamespaceName
+    x.fullName shouldBe NamespaceTraversal.globalNamespaceName
+    x.order shouldBe 1
+  }
+
+  "should contain correct namespace block for known file" in {
+    val List(x) = cpg.namespaceBlock.filenameNot(FileTraversal.UNKNOWN).l
+    x.name shouldBe NamespaceTraversal.globalNamespaceName
+    x.filename should not be empty
+    x.fullName shouldBe s"${x.filename}:${NamespaceTraversal.globalNamespaceName}"
+    x.order shouldBe 1
+  }
+
+  "should allow traversing from namespace block to method" in {
+    cpg.namespaceBlock.filenameNot(FileTraversal.UNKNOWN).ast.isMethod.name.l shouldBe List(":program", "foo")
+  }
+
+  "should allow traversing from namespace block to type declaration" in {
+    cpg.namespaceBlock
+      .filenameNot(FileTraversal.UNKNOWN)
+      .ast
+      .isTypeDecl
+      .nameNot(NamespaceTraversal.globalNamespaceName)
+      .name
+      .l
+      .sorted shouldBe List("MyClass")
+  }
+
+  "should allow traversing from namespace block to namespace" in {
+    cpg.namespaceBlock.filenameNot(FileTraversal.UNKNOWN).namespace.name.l shouldBe List(
+      NamespaceTraversal.globalNamespaceName
+    )
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/NamespaceBlockTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/NamespaceBlockTest.scala
@@ -39,8 +39,7 @@ class NamespaceBlockTest extends RubyCode2CpgFixture {
       .isTypeDecl
       .nameNot(NamespaceTraversal.globalNamespaceName)
       .name
-      .l
-      .sorted shouldBe List("MyClass")
+      .l shouldBe List("MyClass")
   }
 
   "should allow traversing from namespace block to namespace" in {


### PR DESCRIPTION
ruby and go AST unit tests
1. File node related unit tests - Added similar unit tests for `gosrc2cpg`
2. Metadata unit tests
3. Namespace unit tests
4. Method unit tests covering 
    - Two types of method definitions a. def ... end b. define_method ... end
    - Method parameters and its traversal
    - Method return nodes and its traversal
