### PR TITLE
rubysrc2cpg: Add missing splatting argument

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -183,7 +183,7 @@ arguments
     :   blockArgument                                                                                                           # blockArgumentTypeArguments
     |   splattingArgument (COMMA wsOrNl* blockArgument)?                                                                        # blockSplattingTypeArguments
     |   expressions WS* COMMA wsOrNl* associations (WS* COMMA wsOrNl* splattingArgument)? (WS* COMMA wsOrNl* blockArgument)?    # blockSplattingExprAssocTypeArguments
-    |   (expressions | associations) (WS* COMMA wsOrNl* blockArgument)?                                                         # blockExprAssocTypeArguments
+    |   (expressions | associations) (WS* COMMA wsOrNl* splattingArgument)? (WS* COMMA wsOrNl* blockArgument)?                  # blockExprAssocTypeArguments
     |   command                                                                                                                 # commandTypeArguments
     ;
 
@@ -196,7 +196,7 @@ blockArgument
 // --------------------------------------------------------
 
 splattingArgument
-    :   STAR expressionOrCommand
+    :   STAR WS* expressionOrCommand
     ;
 
 indexingArguments


### PR DESCRIPTION
Found in #3022 