### PR TITLE
rubysrc2cpg: Fix missing double splatting argument/parameter

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -197,6 +197,7 @@ blockArgument
 
 splattingArgument
     :   STAR WS* expressionOrCommand
+    |   STAR2 WS* expressionOrCommand
     ;
 
 indexingArguments
@@ -338,6 +339,7 @@ optionalParameter
 
 arrayParameter
     :   STAR LOCAL_VARIABLE_IDENTIFIER?
+    |   STAR2 LOCAL_VARIABLE_IDENTIFIER?
     ;
 
 procParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -322,6 +322,7 @@ parameters
     :   mandatoryParameters (COMMA wsOrNl* optionalParameters)? (COMMA WS* arrayParameter)? (COMMA WS* hashParameter)? (COMMA WS* procParameter)?
     |   optionalParameters (COMMA wsOrNl* arrayParameter)? (COMMA WS* hashParameter)? (COMMA wsOrNl* procParameter)?
     |   arrayParameter (COMMA wsOrNl* procParameter)?
+    |   hashParameter (COMMA wsOrNl* procParameter)?
     |   procParameter
     ;
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -319,8 +319,8 @@ methodParameterPart
     ;
 
 parameters
-    :   mandatoryParameters (COMMA wsOrNl* optionalParameters)? (COMMA WS* arrayParameter)? (COMMA WS* procParameter)?
-    |   optionalParameters (COMMA wsOrNl* arrayParameter)? (COMMA wsOrNl* procParameter)?
+    :   mandatoryParameters (COMMA wsOrNl* optionalParameters)? (COMMA WS* arrayParameter)? (COMMA WS* hashParameter)? (COMMA WS* procParameter)?
+    |   optionalParameters (COMMA wsOrNl* arrayParameter)? (COMMA WS* hashParameter)? (COMMA wsOrNl* procParameter)?
     |   arrayParameter (COMMA wsOrNl* procParameter)?
     |   procParameter
     ;
@@ -339,7 +339,10 @@ optionalParameter
 
 arrayParameter
     :   STAR LOCAL_VARIABLE_IDENTIFIER?
-    |   STAR2 LOCAL_VARIABLE_IDENTIFIER?
+    ;
+
+hashParameter
+    :   STAR2 LOCAL_VARIABLE_IDENTIFIER?
     ;
 
 procParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -321,7 +321,7 @@ methodParameterPart
 parameters
     :   mandatoryParameters (COMMA wsOrNl* optionalParameters)? (COMMA WS* arrayParameter)? (COMMA WS* hashParameter)? (COMMA WS* procParameter)?
     |   optionalParameters (COMMA wsOrNl* arrayParameter)? (COMMA WS* hashParameter)? (COMMA wsOrNl* procParameter)?
-    |   arrayParameter (COMMA wsOrNl* procParameter)?
+    |   arrayParameter (COMMA WS* hashParameter)? (COMMA wsOrNl* procParameter)?
     |   hashParameter (COMMA wsOrNl* procParameter)?
     |   procParameter
     ;

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -173,6 +173,38 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |  WsOrNl
           |  end""".stripMargin
       }
+
+      "it contains both a named array and hash splatting argument" in {
+        val code = "def foo(*arr, **hash); end"
+        printAst(_.primary(), code) shouldEqual
+          """MethodDefinitionPrimary
+          | MethodDefinition
+          |  def
+          |  WsOrNl
+          |  SimpleMethodNamePart
+          |   DefinedMethodName
+          |    MethodName
+          |     MethodIdentifier
+          |      foo
+          |  MethodParameterPart
+          |   (
+          |   Parameters
+          |    ArrayParameter
+          |     *
+          |     arr
+          |    ,
+          |    HashParameter
+          |     **
+          |     hash
+          |   )
+          |  BodyStatement
+          |   CompoundStatement
+          |    Separators
+          |     Separator
+          |      ;
+          |  WsOrNl
+          |  end""".stripMargin
+      }
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -117,6 +117,62 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |  WsOrNl
             |  end""".stripMargin
       }
+
+      "it contains a named (array) splatting argument" in {
+        val code = "def foo(*arr); end"
+        printAst(_.primary(), code) shouldEqual
+          """MethodDefinitionPrimary
+          | MethodDefinition
+          |  def
+          |  WsOrNl
+          |  SimpleMethodNamePart
+          |   DefinedMethodName
+          |    MethodName
+          |     MethodIdentifier
+          |      foo
+          |  MethodParameterPart
+          |   (
+          |   Parameters
+          |    ArrayParameter
+          |     *
+          |     arr
+          |   )
+          |  BodyStatement
+          |   CompoundStatement
+          |    Separators
+          |     Separator
+          |      ;
+          |  WsOrNl
+          |  end""".stripMargin
+      }
+
+      "it contains a named (hash) splatting argument" in {
+        val code = "def foo(**hash); end"
+        printAst(_.primary(), code) shouldEqual
+          """MethodDefinitionPrimary
+          | MethodDefinition
+          |  def
+          |  WsOrNl
+          |  SimpleMethodNamePart
+          |   DefinedMethodName
+          |    MethodName
+          |     MethodIdentifier
+          |      foo
+          |  MethodParameterPart
+          |   (
+          |   Parameters
+          |    HashParameter
+          |     **
+          |     hash
+          |   )
+          |  BodyStatement
+          |   CompoundStatement
+          |    Separators
+          |     Separator
+          |      ;
+          |  WsOrNl
+          |  end""".stripMargin
+      }
     }
   }
 }


### PR DESCRIPTION
Found in #3022 