### PR TITLE
Throw an exception when source paths don't exist or no source files are found

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -4,13 +4,10 @@ import better.files.File.VisitOptions
 import better.files._
 import org.slf4j.LoggerFactory
 
+import java.io.FileNotFoundException
 import java.nio.file.Paths
 
 object SourceFiles {
-
-  case object InvalidInputPathsException extends Exception("Invalid source input paths")
-
-  case object NoSourceFilesFoundException extends Exception("No source files found at input paths")
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -85,9 +82,7 @@ object SourceFiles {
       .filter(hasSourceFileExtension)
       .map(_.pathAsString)
 
-    val sourceFiles = (matchingFiles ++ matchingFilesFromDirs).toList.sorted
-    assertNonEmpty(inputPaths, sourceFiles)
-    sourceFiles
+    (matchingFiles ++ matchingFilesFromDirs).toList.sorted
   }
 
   /** Attempting to analyse source paths that do not exist is a hard error. Terminate execution early to avoid
@@ -102,18 +97,7 @@ object SourceFiles {
 
       logErrorWithPaths("Source input paths exist, but are not readable", nonReadable.map(_.canonicalPath))
 
-      throw InvalidInputPathsException
-    }
-  }
-
-  /** Finding no source files is an unexpected result that is most likely due to user error. Terminate execution early
-    * to avoid unexpected and hard-to-debug issues in the results.
-    */
-  def assertNonEmpty(inputPaths: Set[String], sourceFiles: List[String]): Unit = {
-    if (sourceFiles.isEmpty) {
-      logErrorWithPaths("No source files found at input paths", inputPaths)
-
-      throw NoSourceFilesFoundException
+      throw FileNotFoundException("Invalid source paths provided")
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/SourceFilesTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/SourceFilesTests.scala
@@ -1,6 +1,7 @@
 package io.joern.x2cpg
 
 import better.files._
+import io.joern.x2cpg.utils.IgnoreInWindows
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -43,7 +44,7 @@ class SourceFilesTests extends AnyWordSpec with Matchers with Inside {
       result.failed.get shouldBe a[FileNotFoundException]
     }
 
-    "the input file exists, but is not readable" in {
+    "the input file exists, but is not readable" taggedAs IgnoreInWindows in {
       File.usingTemporaryFile() { tmpFile =>
         tmpFile.setPermissions(PosixFilePermissions.fromString("-wx-w--w-").asScala.toSet)
         tmpFile.exists shouldBe true

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/SourceFilesTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/SourceFilesTests.scala
@@ -1,7 +1,6 @@
 package io.joern.x2cpg
 
 import better.files._
-import io.joern.x2cpg.SourceFiles._
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -10,6 +9,7 @@ import org.scalatest.Inside
 import java.nio.file.attribute.PosixFilePermissions
 import scala.jdk.CollectionConverters._
 import scala.util.Try
+import java.io.FileNotFoundException
 
 class SourceFilesTests extends AnyWordSpec with Matchers with Inside {
 
@@ -40,7 +40,7 @@ class SourceFilesTests extends AnyWordSpec with Matchers with Inside {
     "the input file does not exist" in {
       val result = Try(SourceFiles.determine("path/to/nothing/", cSourceFileExtensions))
       result.isFailure shouldBe true
-      result.failed.get shouldBe InvalidInputPathsException
+      result.failed.get shouldBe a[FileNotFoundException]
     }
 
     "the input file exists, but is not readable" in {
@@ -51,7 +51,7 @@ class SourceFilesTests extends AnyWordSpec with Matchers with Inside {
 
         val result = Try(SourceFiles.determine(tmpFile.canonicalPath, cSourceFileExtensions))
         result.isFailure shouldBe true
-        result.failed.get shouldBe InvalidInputPathsException
+        result.failed.get shouldBe a[FileNotFoundException]
       }
     }
   }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/SourceFilesTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/SourceFilesTests.scala
@@ -54,15 +54,5 @@ class SourceFilesTests extends AnyWordSpec with Matchers with Inside {
         result.failed.get shouldBe InvalidInputPathsException
       }
     }
-
-    "no source files are found" in {
-      File.usingTemporaryDirectory() { tmpDirectory =>
-        (tmpDirectory / "non-source-file").createFileIfNotExists()
-
-        val result = Try(SourceFiles.determine(tmpDirectory.canonicalPath, cSourceFileExtensions))
-        result.isFailure shouldBe true
-        result.failed.get shouldBe NoSourceFilesFoundException
-      }
-    }
   }
 }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/IgnoreInWindows.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/IgnoreInWindows.scala
@@ -1,0 +1,10 @@
+package io.joern.x2cpg.utils
+
+import org.scalatest.{Ignore, Tag}
+
+object IgnoreInWindows
+    extends Tag(if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+      classOf[Ignore].getName
+    } else {
+      ""
+    })


### PR DESCRIPTION
__Motivation:__ We've run into issues in the past where invalid source directories were given, but `*2cpg` failed silently. These silent failures are difficult to debug (especially with customer submissions) and are most likely due to user error. This PR adds 2 failure modes when finding source files:
* __The input path doesn't exist or isn't readable:__ this is most likely due to a typo in the input path. This should definitely be an exception that terminates execution since this does not match user intent.
* ~__No source files could be found at the given input paths:__ This could be an acceptable error (for example when finding config files), but in general will not be. The current implementation always throws an exception (which can then be handled by the caller if an empty source list is acceptable), but adding an option to allow an empty sources list (with the default still being to not allow them) is potentially a better option.~