### PR TITLE
rubySrc2Cpg : Linking import node with respective call nodes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -5,6 +5,7 @@ import io.joern.rubysrc2cpg.parser.RubyParser.*
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
+import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewCall, NewControlStructure, NewImport, NewLiteral}
 import org.antlr.v4.runtime.ParserRuleContext
@@ -200,7 +201,8 @@ trait AstForStatementsCreator {
           pathValue
       }
       packageStack.append(result)
-      astForImportNode(node.code)
+      val importNode = createImportNodeAndLink(result, "", Some(callNode), diffGraph)
+      Seq(callAst(callNode, argsAst), Ast(importNode))
     } else {
       Seq(callAst(callNode, argsAst))
     }
@@ -216,17 +218,11 @@ trait AstForStatementsCreator {
       val currentDirectory = File(currentFile).parent
       val file             = File(currentDirectory, updatedPath)
       packageStack.append(file.pathAsString)
-      astForImportNode(node.code)
+      val importNode = createImportNodeAndLink(updatedPath, "", Some(callNode), diffGraph)
+      Seq(callAst(callNode, argsAst), Ast(importNode))
     } else {
       Seq(callAst(callNode, argsAst))
     }
-  }
-
-  protected def astForImportNode(code: String): Seq[Ast] = {
-    // fully implemented later
-    val importNode = NewImport()
-      .code(code)
-    Seq(Ast(importNode))
   }
 
   protected def astForBlock(ctx: BlockContext): Ast = ctx match

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ImportAstCreationTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ImportAstCreationTest.scala
@@ -1,0 +1,34 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+
+class ImportAstCreationTest extends RubyCode2CpgFixture {
+
+  "Ast creation for import node" should {
+    val cpg = code("""
+        |require "dummy_logger"
+        |require_relative "util/help.rb"
+        |load "mymodule.rb"
+        |""".stripMargin)
+    val imports = cpg.imports.l
+    val calls   = cpg.call("require|require_relative|load").l
+    "have a valid import node" in {
+      imports.importedEntity.l shouldBe List("dummy_logger", "util/help.rb", "mymodule.rb")
+      imports.importedAs.l shouldBe List("", "", "")
+    }
+
+    "have a valid call node" in {
+      calls.code.l shouldBe List(
+        "require \"dummy_logger\"",
+        "require_relative \"util/help.rb\"",
+        "load \"mymodule.rb\""
+      )
+    }
+
+    "have a valid linking" in {
+      calls.referencedImports.importedEntity.l shouldBe List("dummy_logger", "util/help.rb", "mymodule.rb")
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
@@ -36,10 +36,6 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture with BeforeAndAfterAll
       cpg.call.name("first_fun").l.size shouldBe 1
     }
 
-    "recognise import node" in {
-      cpg.imports.code(".*dummy_logger.*").l.size shouldBe 1
-    }
-
     "recognise methodFullName for call Node" in {
       if (!scala.util.Properties.isWin) {
         cpg.call.name("first_fun").head.methodFullName should equal(
@@ -78,10 +74,6 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture with BeforeAndAfterAll
 
     "recognise call node" in {
       cpg.call.name("printValue").size shouldBe 1
-    }
-
-    "recognise import node" in {
-      cpg.imports.code(".*util/help.rb*.").size shouldBe 1
     }
 
     "recognise method full name for call node" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RubyMethodFullNameTests.scala
@@ -32,7 +32,6 @@ class RubyMethodFullNameTests extends RubyCode2CpgFixture with BeforeAndAfterAll
         "Gemfile"
       )
       .withConfig(config)
-
     "recognise call node" in {
       cpg.call.name("first_fun").l.size shouldBe 1
     }


### PR DESCRIPTION
The PR contains the following
- Support for linking import nodes with call nodes
- Test Cases
- Currently have made this change directly in the AstCreation pass, should this be done in the Import pass separately?