### PR TITLE
rubysrc2cpg: fix method param not populating

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1103,9 +1103,9 @@ class AstCreator(
 
   def astForMethodDefinitionContext(ctx: MethodDefinitionContext): Seq[Ast] = {
     scope.pushNewScope(())
-    val astMethodParam = astForMethodParameterPartContext(ctx.methodParameterPart())
-    val astMethodName  = astForMethodNamePartContext(ctx.methodNamePart())
-    val callNode       = astMethodName.head.nodes.filter(node => node.isInstanceOf[NewCall]).head.asInstanceOf[NewCall]
+    val astMethodParamSeq = astForMethodParameterPartContext(ctx.methodParameterPart())
+    val astMethodName     = astForMethodNamePartContext(ctx.methodNamePart())
+    val callNode = astMethodName.head.nodes.filter(node => node.isInstanceOf[NewCall]).head.asInstanceOf[NewCall]
     // there can be only one call node
     val astBody = astForBodyStatementContext(ctx.bodyStatement(), addReturnNode = true)
     scope.popScope()
@@ -1171,18 +1171,12 @@ class AstCreator(
      * TODO find out how they should be used. Need to do this iff it adds any value
      */
 
-    val paramSeq = astMethodParam.head.nodes
-      .map(node => {
-        Ast(node)
-      })
-      .toSeq
-
     methodNames.add(methodNode.name)
     val blockNode = NewBlock().typeFullName(Defines.Any)
     Seq(
       methodAst(
         methodNode,
-        paramSeq,
+        astMethodParamSeq,
         blockAst(blockNode, astBody.toList),
         methodRetNode,
         Seq[NewModifier](publicModifier)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1018,6 +1018,7 @@ class AstCreator(
           .name(varSymbol.getText)
           .code(varSymbol.getText)
           .lineNumber(varSymbol.getLine)
+          .typeFullName(Defines.Any)
           .columnNumber(varSymbol.getCharPositionInLine)
         Ast(param)
       })

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -74,8 +74,7 @@ class MethodOneTests extends RubyCode2CpgFixture {
       bindingTypeDecl.referencingType.fullName.head shouldBe "Test0.rb::program:foo"
     }
 
-    // TODO: Need to be fixed
-    "test method parameter nodes" ignore {
+    "test method parameter nodes" in {
       cpg.method.name("foo").parameter.name.l.size shouldBe 2
       val parameter1 = cpg.method.fullName("Test0.rb::program:foo").parameter.order(1).head
       parameter1.name shouldBe "a"
@@ -88,10 +87,8 @@ class MethodOneTests extends RubyCode2CpgFixture {
       parameter2.typeFullName shouldBe "ANY"
     }
 
-    // TODO: Need to be fixed
-    "should allow traversing from parameter to method" ignore {
+    "should allow traversing from parameter to method" in {
       cpg.parameter.name("a").method.name.l shouldBe List("foo")
-      // TODO: its not working with "b"
       cpg.parameter.name("b").method.name.l shouldBe List("foo")
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -34,7 +34,7 @@ class MethodOneTests extends RubyCode2CpgFixture {
     }
 
     // TODO: This test cases needs to be fixed.
-    "should allow traversing to parameters" ignore {
+    "should allow traversing to parameters" in {
       cpg.method.name("foo").parameter.name.toSetMutable shouldBe Set("a", "b")
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -50,11 +50,6 @@ class MethodOneTests extends RubyCode2CpgFixture {
       cpg.method.name("foo").file.name.l should not be empty
     }
 
-    // TODO: Need to be fixed.
-    "test existence of local variable in module function" ignore {
-      cpg.method.fullName("Test0.rb::program").local.name.l should contain("foo")
-    }
-
     // TODO: need to be fixed.
     "test corresponding type, typeDecl and binding" ignore {
       cpg.method.fullName("Test0.rb::program:foo").referencingBinding.bindingTypeDecl.l should not be empty

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -50,13 +50,6 @@ class MethodOneTests extends RubyCode2CpgFixture {
       cpg.method.name("foo").file.name.l should not be empty
     }
 
-    // TODO: Need to be fixed
-    "test function method ref" ignore {
-      cpg.methodRef("foo").referencedMethod.fullName.l should not be empty
-      cpg.methodRef("foo").referencedMethod.fullName.head shouldBe
-        "Test0.rb::program:foo"
-    }
-
     // TODO: Need to be fixed.
     "test existence of local variable in module function" ignore {
       cpg.method.fullName("Test0.rb::program").local.name.l should contain("foo")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -33,7 +33,6 @@ class MethodOneTests extends RubyCode2CpgFixture {
       cpg.method.name("foo").numberOfLines.l shouldBe List(3)
     }
 
-    // TODO: This test cases needs to be fixed.
     "should allow traversing to parameters" in {
       cpg.method.name("foo").parameter.name.toSetMutable shouldBe Set("a", "b")
     }


### PR DESCRIPTION
Fixes issue where only one method param was getting added for `def foo(a, b)`. Ignored test switched on