### PR TITLE
rubysrc2cpg: Allow optional parameters before mandatory ones

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -319,19 +319,19 @@ methodParameterPart
     ;
 
 parameters
-    :   mandatoryParameters (COMMA wsOrNl* optionalParameters)? (COMMA WS* arrayParameter)? (COMMA WS* hashParameter)? (COMMA WS* procParameter)?
-    |   optionalParameters (COMMA wsOrNl* arrayParameter)? (COMMA WS* hashParameter)? (COMMA wsOrNl* procParameter)?
-    |   arrayParameter (COMMA WS* hashParameter)? (COMMA wsOrNl* procParameter)?
-    |   hashParameter (COMMA wsOrNl* procParameter)?
+    :   parameter (WS* COMMA wsOrNl* parameter)*
+    ;
+    
+parameter
+    :   mandatoryParameter
+    |   optionalParameter
+    |   arrayParameter
+    |   hashParameter
     |   procParameter
     ;
 
-mandatoryParameters
-    :   LOCAL_VARIABLE_IDENTIFIER (COMMA wsOrNl* LOCAL_VARIABLE_IDENTIFIER)*
-    ;
-
-optionalParameters
-    :   optionalParameter (COMMA wsOrNl* optionalParameter)*
+mandatoryParameter
+    :   LOCAL_VARIABLE_IDENTIFIER
     ;
 
 optionalParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -977,38 +977,22 @@ class AstCreator(
       Seq(Ast())
   }
 
+  // TODO: Rewrite for simplicity and take into account more than parameter names.
   def astForMethodParameterPartContext(ctx: MethodParameterPartContext): Seq[Ast] = {
     if (ctx == null || ctx.parameters() == null) return Seq(Ast())
     // NOT differentiating between the productions here since either way we get paramaters
-    val mandatoryParameters = ctx.parameters().mandatoryParameters()
-    val optionalParameters  = ctx.parameters().optionalParameters()
-    val arrayParameter      = ctx.parameters().arrayParameter()
-    val procParameter       = ctx.parameters().procParameter()
+    val mandatoryParameters = ctx.parameters().parameter().asScala.filter(ctx => Option(ctx.mandatoryParameter()).isDefined).map(_.mandatoryParameter().LOCAL_VARIABLE_IDENTIFIER())
+    val optionalParameters  = ctx.parameters().parameter().asScala.filter(ctx => Option(ctx.optionalParameter()).isDefined).map(_.optionalParameter().LOCAL_VARIABLE_IDENTIFIER())
+    val arrayParameter      = ctx.parameters().parameter().asScala.filter(ctx => Option(ctx.arrayParameter()).isDefined).map(_.arrayParameter().LOCAL_VARIABLE_IDENTIFIER())
+    val procParameter       = ctx.parameters().parameter().asScala.filter(ctx => Option(ctx.procParameter()).isDefined).map(_.procParameter().LOCAL_VARIABLE_IDENTIFIER())
 
     val localVarList = ListBuffer[TerminalNode]()
-
-    if (mandatoryParameters != null) {
-      mandatoryParameters
-        .LOCAL_VARIABLE_IDENTIFIER()
-        .forEach(localVar => {
-          localVarList.addOne(localVar)
-        })
-    }
-
-    if (optionalParameters != null) {
-      val optionalParameterList = optionalParameters.optionalParameter()
-      optionalParameterList.forEach(param => {
-        localVarList.addOne(param.LOCAL_VARIABLE_IDENTIFIER())
-      })
-    }
-
-    if (arrayParameter != null) {
-      localVarList.addOne(arrayParameter.LOCAL_VARIABLE_IDENTIFIER())
-    }
-
-    if (procParameter != null) {
-      localVarList.addOne(procParameter.LOCAL_VARIABLE_IDENTIFIER())
-    }
+    
+    localVarList.addAll(mandatoryParameters)
+    localVarList.addAll(optionalParameters)
+    localVarList.addAll(arrayParameter)
+    localVarList.addAll(procParameter)
+    
 
     localVarList
       .map(localVar => {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -42,8 +42,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |  MethodParameterPart
             |   (
             |   Parameters
-            |    MandatoryParameters
-            |     x
+            |    Parameter
+            |     MandatoryParameter
+            |      x
             |   )
             |  BodyStatement
             |   CompoundStatement
@@ -68,7 +69,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
              |  MethodParameterPart
              |   (
              |   Parameters
-             |    OptionalParameters
+             |    Parameter
              |     OptionalParameter
              |      x
              |      =
@@ -102,12 +103,15 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |  MethodParameterPart
             |   (
             |   Parameters
-            |    MandatoryParameters
-            |     x
+            |    Parameter
+            |     MandatoryParameter
+            |      x
             |    ,
-            |    ProcParameter
-            |     &
-            |     y
+            |    WsOrNl
+            |    Parameter
+            |     ProcParameter
+            |      &
+            |      y
             |   )
             |  BodyStatement
             |   CompoundStatement
@@ -133,9 +137,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |  MethodParameterPart
           |   (
           |   Parameters
-          |    ArrayParameter
-          |     *
-          |     arr
+          |    Parameter
+          |     ArrayParameter
+          |      *
+          |      arr
           |   )
           |  BodyStatement
           |   CompoundStatement
@@ -161,9 +166,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |  MethodParameterPart
           |   (
           |   Parameters
-          |    HashParameter
-          |     **
-          |     hash
+          |    Parameter
+          |     HashParameter
+          |      **
+          |      hash
           |   )
           |  BodyStatement
           |   CompoundStatement
@@ -189,13 +195,16 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |  MethodParameterPart
           |   (
           |   Parameters
-          |    ArrayParameter
-          |     *
-          |     arr
+          |    Parameter
+          |     ArrayParameter
+          |      *
+          |      arr
           |    ,
-          |    HashParameter
-          |     **
-          |     hash
+          |    WsOrNl
+          |    Parameter
+          |     HashParameter
+          |      **
+          |      hash
           |   )
           |  BodyStatement
           |   CompoundStatement
@@ -204,6 +213,45 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |      ;
           |  WsOrNl
           |  end""".stripMargin
+      }
+      
+      "it contains an optional parameter before a mandatory one" in {
+        val code = "def foo(x=1,y); end"
+        printAst(_.primary(), code) shouldEqual
+          """MethodDefinitionPrimary
+            | MethodDefinition
+            |  def
+            |  WsOrNl
+            |  SimpleMethodNamePart
+            |   DefinedMethodName
+            |    MethodName
+            |     MethodIdentifier
+            |      foo
+            |  MethodParameterPart
+            |   (
+            |   Parameters
+            |    Parameter
+            |     OptionalParameter
+            |      x
+            |      =
+            |      PrimaryExpression
+            |       LiteralPrimary
+            |        NumericLiteralLiteral
+            |         NumericLiteral
+            |          UnsignedNumericLiteral
+            |           1
+            |    ,
+            |    Parameter
+            |     MandatoryParameter
+            |      y
+            |   )
+            |  BodyStatement
+            |   CompoundStatement
+            |    Separators
+            |     Separator
+            |      ;
+            |  WsOrNl
+            |  end""".stripMargin
       }
     }
   }


### PR DESCRIPTION
Found in #3022 