### PR TITLE
RubyParser: Support for keyword parameters

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -327,6 +327,7 @@ parameter
     |   optionalParameter
     |   arrayParameter
     |   hashParameter
+    |   keywordParameter
     |   procParameter
     ;
 
@@ -344,6 +345,10 @@ arrayParameter
 
 hashParameter
     :   STAR2 LOCAL_VARIABLE_IDENTIFIER?
+    ;
+
+keywordParameter
+    :   LOCAL_VARIABLE_IDENTIFIER WS* COLON wsOrNl* expression
     ;
 
 procParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -253,6 +253,42 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |  WsOrNl
             |  end""".stripMargin
       }
+
+      "it contains a keyword parameter" in {
+        val code = "def foo(x: 1); end"
+        printAst(_.primary(), code) shouldEqual
+          """MethodDefinitionPrimary
+            | MethodDefinition
+            |  def
+            |  WsOrNl
+            |  SimpleMethodNamePart
+            |   DefinedMethodName
+            |    MethodName
+            |     MethodIdentifier
+            |      foo
+            |  MethodParameterPart
+            |   (
+            |   Parameters
+            |    Parameter
+            |     KeywordParameter
+            |      x
+            |      :
+            |      WsOrNl
+            |      PrimaryExpression
+            |       LiteralPrimary
+            |        NumericLiteralLiteral
+            |         NumericLiteral
+            |          UnsignedNumericLiteral
+            |           1
+            |   )
+            |  BodyStatement
+            |   CompoundStatement
+            |    Separators
+            |     Separator
+            |      ;
+            |  WsOrNl
+            |  end""".stripMargin
+      }
     }
   }
 }


### PR DESCRIPTION
Found in #3022 