### PR TITLE
RubyParser: Allow splatting arguments before expressions or associations

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -181,7 +181,7 @@ argumentsWithoutParentheses
 
 arguments
     :   blockArgument                                                                                                           # blockArgumentTypeArguments
-    |   splattingArgument (COMMA wsOrNl* blockArgument)?                                                                        # blockSplattingTypeArguments
+    |   splattingArgument (WS* COMMA wsOrNl expressions)? (WS* COMMA wsOrNl* associations)? (COMMA wsOrNl* blockArgument)?      # blockSplattingTypeArguments
     |   expressions WS* COMMA wsOrNl* associations (WS* COMMA wsOrNl* splattingArgument)? (WS* COMMA wsOrNl* blockArgument)?    # blockSplattingExprAssocTypeArguments
     |   (expressions | associations) (WS* COMMA wsOrNl* splattingArgument)? (WS* COMMA wsOrNl* blockArgument)?                  # blockExprAssocTypeArguments
     |   command                                                                                                                 # commandTypeArguments

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -120,6 +120,43 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  ,
             |  )""".stripMargin
       }
+
+      "it contains a splatting expression before a keyword argument" in {
+        val code = "foo(*x, y: 1)"
+        printAst(_.primary(), code) shouldEqual
+          """InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgsOnlyArgumentsWithParentheses
+            |  (
+            |  BlockSplattingTypeArguments
+            |   SplattingArgument
+            |    *
+            |    ExpressionExpressionOrCommand
+            |     PrimaryExpression
+            |      VariableReferencePrimary
+            |       VariableIdentifierVariableReference
+            |        VariableIdentifier
+            |         x
+            |   ,
+            |   WsOrNl
+            |   Associations
+            |    Association
+            |     PrimaryExpression
+            |      VariableReferencePrimary
+            |       VariableIdentifierVariableReference
+            |        VariableIdentifier
+            |         y
+            |     :
+            |     WsOrNl
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       NumericLiteralLiteral
+            |        NumericLiteral
+            |         UnsignedNumericLiteral
+            |          1
+            |  )""".stripMargin
+      }
     }
   }
 }


### PR DESCRIPTION
Found in #3022