### PR TITLE
rubysrc2cpg: Argument kinds not restricted by their index

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -180,11 +180,15 @@ argumentsWithoutParentheses
     ;
 
 arguments
-    :   blockArgument                                                                                                           # blockArgumentTypeArguments
-    |   splattingArgument (WS* COMMA wsOrNl expressions)? (WS* COMMA wsOrNl* associations)? (COMMA wsOrNl* blockArgument)?      # blockSplattingTypeArguments
-    |   expressions WS* COMMA wsOrNl* associations (WS* COMMA wsOrNl* splattingArgument)? (WS* COMMA wsOrNl* blockArgument)?    # blockSplattingExprAssocTypeArguments
-    |   (expressions | associations) (WS* COMMA wsOrNl* splattingArgument)? (WS* COMMA wsOrNl* blockArgument)?                  # blockExprAssocTypeArguments
-    |   command                                                                                                                 # commandTypeArguments
+    :   argument (WS* COMMA wsOrNl* argument)*
+    ;
+    
+argument
+    :   blockArgument                                                                                                           # blockArgumentArgument
+    |   splattingArgument                                                                                                       # splattingArgumentArgument
+    |   expression                                                                                                              # expressionArgument
+    |   association                                                                                                             # associationArgument
+    |   command                                                                                                                 # commandArgument
     ;
 
 blockArgument

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1466,20 +1466,6 @@ class AstCreator(
     astForExpressionContext(ctx.expression())
   }
 
-  def astForBlockArgumentTypeArgumentsContext(ctx: BlockArgumentTypeArgumentsContext): Seq[Ast] = {
-    astForBlockArgumentContext(ctx.blockArgument())
-  }
-
-  def astForBlockSplattingTypeArgumentsContext(ctx: BlockSplattingTypeArgumentsContext): Seq[Ast] = {
-    val splatAst = astForSplattingArgumentContext(ctx.splattingArgument())
-    if (ctx.blockArgument() != null) {
-      val blockArgAst = astForBlockArgumentContext(ctx.blockArgument())
-      blockArgAst ++ splatAst
-    } else {
-      splatAst
-    }
-  }
-
   def astForAssociationContext(ctx: AssociationContext): Seq[Ast] = {
     val expr1Asts = astForExpressionContext(ctx.expression().get(0))
     val expr2Asts = astForExpressionContext(ctx.expression().get(1))
@@ -1509,31 +1495,6 @@ class AstCreator(
         astForAssociationContext(assoc)
       })
       .toSeq
-  }
-
-  def astForBlockSplattingExprAssocTypeArgumentsContext(ctx: BlockSplattingExprAssocTypeArgumentsContext): Seq[Ast] = {
-    val blockArgAsts     = astForBlockArgumentContext(ctx.blockArgument())
-    val splatAsts        = astForSplattingArgumentContext(ctx.splattingArgument())
-    val associationsAsts = astForAssociationsContext(ctx.associations())
-    val expAsts          = ctx.expressions().expression().asScala.flatMap(exp => astForExpressionContext(exp)).toSeq
-    blockArgAsts ++ splatAsts ++ associationsAsts ++ expAsts
-  }
-
-  def astForBlockExprAssocTypeArgumentsContext(ctx: BlockExprAssocTypeArgumentsContext): Seq[Ast] = {
-    val listAsts = ListBuffer[Ast]()
-
-    if (ctx.blockArgument() != null) {
-      listAsts.addAll(astForBlockArgumentContext(ctx.blockArgument()))
-    }
-
-    if (ctx.associations() != null) {
-      listAsts.addAll(astForAssociationsContext(ctx.associations()))
-    } else {
-      val exprAsts = ctx.expressions().expression().asScala.flatMap(exp => astForExpressionContext(exp))
-      listAsts.addAll(exprAsts)
-    }
-
-    listAsts.toSeq
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -1,23 +1,24 @@
 package io.joern.rubysrc2cpg.astcreation
 
-import io.joern.rubysrc2cpg.parser.RubyParser.{
-  ArgumentsContext,
-  BlockArgumentTypeArgumentsContext,
-  BlockExprAssocTypeArgumentsContext,
-  BlockSplattingExprAssocTypeArgumentsContext,
-  BlockSplattingTypeArgumentsContext,
-  CommandTypeArgumentsContext
-}
+import io.joern.rubysrc2cpg.parser.RubyParser.*
+import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
+import io.shiftleft.codepropertygraph.generated.nodes.NewJumpTarget
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
+import org.antlr.v4.runtime.ParserRuleContext
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 trait AstForDeclarationsCreator { this: AstCreator =>
 
-  // TODO: Return Ast instead of Seq[Ast]
-  protected def astForArguments(ctx: ArgumentsContext): Seq[Ast] = ctx match {
-    case ctx: BlockArgumentTypeArgumentsContext           => astForBlockArgumentTypeArgumentsContext(ctx)
-    case ctx: BlockSplattingTypeArgumentsContext          => astForBlockSplattingTypeArgumentsContext(ctx)
-    case ctx: BlockSplattingExprAssocTypeArgumentsContext => astForBlockSplattingExprAssocTypeArgumentsContext(ctx)
-    case ctx: BlockExprAssocTypeArgumentsContext          => astForBlockExprAssocTypeArgumentsContext(ctx)
-    case ctx: CommandTypeArgumentsContext                 => astForCommand(ctx.command)
+  protected def astForArguments(ctx: ArgumentsContext): Seq[Ast] = {
+    ctx.argument().asScala.flatMap(astForArgument).toSeq
+  }
+
+  protected def astForArgument(ctx: ArgumentContext): Seq[Ast] = ctx match {
+    case ctx: BlockArgumentArgumentContext     => astForBlockArgumentContext(ctx.blockArgument)
+    case ctx: SplattingArgumentArgumentContext => astForExpressionOrCommand(ctx.splattingArgument.expressionOrCommand)
+    case ctx: ExpressionArgumentContext        => astForExpressionContext(ctx.expression)
+    case ctx: AssociationArgumentContext       => astForAssociationContext(ctx.association)
+    case ctx: CommandArgumentContext           => astForCommand(ctx.command)
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
@@ -50,8 +50,8 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |          MethodIdentifier
             |           puts
             |          ArgumentsWithoutParentheses
-            |           BlockExprAssocTypeArguments
-            |            Expressions
+            |           Arguments
+            |            ExpressionArgument
             |             PrimaryExpression
             |              LiteralPrimary
             |               NumericLiteralLiteral

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -43,8 +43,8 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  foo
             | ArgsOnlyArgumentsWithParentheses
             |  (
-            |  BlockExprAssocTypeArguments
-            |   Expressions
+            |  Arguments
+            |   ExpressionArgument
             |    PrimaryExpression
             |     LiteralPrimary
             |      NumericLiteralLiteral
@@ -59,27 +59,27 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
 
         printAst(_.primary(), code) shouldEqual
           s"""InvocationWithParenthesesPrimary
-            | MethodIdentifier
-            |  foo
-            | ArgsOnlyArgumentsWithParentheses
-            |  (
-            |  BlockExprAssocTypeArguments
-            |   Associations
-            |    Association
-            |     PrimaryExpression
-            |      VariableReferencePrimary
-            |       VariableIdentifierVariableReference
-            |        VariableIdentifier
-            |         region
-            |     :
-            |     WsOrNl
-            |     PrimaryExpression
-            |      LiteralPrimary
-            |       NumericLiteralLiteral
-            |        NumericLiteral
-            |         UnsignedNumericLiteral
-            |          1
-            |  )""".stripMargin
+             | MethodIdentifier
+             |  foo
+             | ArgsOnlyArgumentsWithParentheses
+             |  (
+             |  Arguments
+             |   AssociationArgument
+             |    Association
+             |     PrimaryExpression
+             |      VariableReferencePrimary
+             |       VariableIdentifierVariableReference
+             |        VariableIdentifier
+             |         region
+             |     :
+             |     WsOrNl
+             |     PrimaryExpression
+             |      LiteralPrimary
+             |       NumericLiteralLiteral
+             |        NumericLiteral
+             |         UnsignedNumericLiteral
+             |          1
+             |  )""".stripMargin
       }
 
       "it contains a single symbol literal positional argument" in {
@@ -91,8 +91,8 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  foo
             | ArgsOnlyArgumentsWithParentheses
             |  (
-            |  BlockExprAssocTypeArguments
-            |   Expressions
+            |  Arguments
+            |   ExpressionArgument
             |    PrimaryExpression
             |     LiteralPrimary
             |      SymbolLiteral
@@ -110,8 +110,8 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  foo
             | ArgsOnlyArgumentsWithParentheses
             |  (
-            |  BlockExprAssocTypeArguments
-            |   Expressions
+            |  Arguments
+            |   ExpressionArgument
             |    PrimaryExpression
             |     LiteralPrimary
             |      SymbolLiteral
@@ -129,18 +129,19 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  foo
             | ArgsOnlyArgumentsWithParentheses
             |  (
-            |  BlockSplattingTypeArguments
-            |   SplattingArgument
-            |    *
-            |    ExpressionExpressionOrCommand
-            |     PrimaryExpression
-            |      VariableReferencePrimary
-            |       VariableIdentifierVariableReference
-            |        VariableIdentifier
-            |         x
+            |  Arguments
+            |   SplattingArgumentArgument
+            |    SplattingArgument
+            |     *
+            |     ExpressionExpressionOrCommand
+            |      PrimaryExpression
+            |       VariableReferencePrimary
+            |        VariableIdentifierVariableReference
+            |         VariableIdentifier
+            |          x
             |   ,
             |   WsOrNl
-            |   Associations
+            |   AssociationArgument
             |    Association
             |     PrimaryExpression
             |      VariableReferencePrimary

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -50,8 +50,8 @@ class RegexTests extends RubyParserAbstractTest {
             |   MethodIdentifier
             |    puts
             |   ArgumentsWithoutParentheses
-            |    BlockExprAssocTypeArguments
-            |     Expressions
+            |    Arguments
+            |     ExpressionArgument
             |      PrimaryExpression
             |       LiteralPrimary
             |        RegularExpressionLiteral
@@ -72,8 +72,8 @@ class RegexTests extends RubyParserAbstractTest {
             |    puts
             |   ArgsOnlyArgumentsWithParentheses
             |    (
-            |    BlockExprAssocTypeArguments
-            |     Expressions
+            |    Arguments
+            |     ExpressionArgument
             |      PrimaryExpression
             |       LiteralPrimary
             |        RegularExpressionLiteral
@@ -95,16 +95,17 @@ class RegexTests extends RubyParserAbstractTest {
             |    puts
             |   ArgsOnlyArgumentsWithParentheses
             |    (
-            |    BlockExprAssocTypeArguments
-            |     Expressions
+            |    Arguments
+            |     ExpressionArgument
             |      PrimaryExpression
             |       LiteralPrimary
             |        NumericLiteralLiteral
             |         NumericLiteral
             |          UnsignedNumericLiteral
             |           1
-            |      ,
-            |      WsOrNl
+            |     ,
+            |     WsOrNl
+            |     ExpressionArgument
             |      PrimaryExpression
             |       LiteralPrimary
             |        RegularExpressionLiteral
@@ -165,8 +166,8 @@ class RegexTests extends RubyParserAbstractTest {
             |   MethodIdentifier
             |    puts
             |   ArgumentsWithoutParentheses
-            |    BlockExprAssocTypeArguments
-            |     Expressions
+            |    Arguments
+            |     ExpressionArgument
             |      PrimaryExpression
             |       LiteralPrimary
             |        RegularExpressionLiteral
@@ -188,8 +189,8 @@ class RegexTests extends RubyParserAbstractTest {
             |    puts
             |   ArgsOnlyArgumentsWithParentheses
             |    (
-            |    BlockExprAssocTypeArguments
-            |     Expressions
+            |    Arguments
+            |     ExpressionArgument
             |      PrimaryExpression
             |       LiteralPrimary
             |        RegularExpressionLiteral
@@ -279,8 +280,8 @@ class RegexTests extends RubyParserAbstractTest {
             |   MethodIdentifier
             |    puts
             |   ArgumentsWithoutParentheses
-            |    BlockExprAssocTypeArguments
-            |     Expressions
+            |    Arguments
+            |     ExpressionArgument
             |      PrimaryExpression
             |       RegexInterpolationPrimary
             |        RegexInterpolation
@@ -316,8 +317,8 @@ class RegexTests extends RubyParserAbstractTest {
             |    puts
             |   ArgsOnlyArgumentsWithParentheses
             |    (
-            |    BlockExprAssocTypeArguments
-            |     Expressions
+            |    Arguments
+            |     ExpressionArgument
             |      PrimaryExpression
             |       RegexInterpolationPrimary
             |        RegexInterpolation


### PR DESCRIPTION
Previously, argument kinds (like keyword args, block args, etc.) were restricted to certain positions in the parameter list. This PR removes such restriction.

Finally closes #3022 