### PR TITLE
rubysrc2cpg: Allow keyword?-named method invocations

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -314,7 +314,7 @@ methodIdentifier
     ;
 
 methodOnlyIdentifier
-    :   (LOCAL_VARIABLE_IDENTIFIER | CONSTANT_IDENTIFIER) (EMARK | QMARK)
+    :   (LOCAL_VARIABLE_IDENTIFIER | CONSTANT_IDENTIFIER | keyword) (EMARK | QMARK)
     ;
 
 methodParameterPart

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
@@ -1,0 +1,29 @@
+package io.joern.rubysrc2cpg.parser
+
+class InvocationWithoutParenthesesTests extends RubyParserAbstractTest {
+
+  "A method invocation without parentheses" should {
+
+    "be parsed as a primary expression" when {
+
+      "it contains a keyword?-named member" in {
+        val code = "task.nil?"
+
+        printAst(_.primary(), code) shouldBe
+          """ChainedInvocationPrimary
+            | VariableReferencePrimary
+            |  VariableIdentifierVariableReference
+            |   VariableIdentifier
+            |    task
+            | .
+            | MethodName
+            |  MethodIdentifier
+            |   MethodOnlyIdentifier
+            |    Keyword
+            |     nil
+            |    ?""".stripMargin
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
We already allowed keywords to be used as member names, e.g. `foo.class`. Now we allow the usage of `?` as suffix as well, e.g. `foo.class?`

Closes #3036