### PR TITLE
rubysrc2cpg: Allow keyword-named association keys

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -270,7 +270,7 @@ associations
     ;
 
 association
-    :   expression WS* (EQGT|COLON) wsOrNl* expression
+    :   (expression | keyword) WS* (EQGT|COLON) wsOrNl* expression
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -158,6 +158,29 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |          1
             |  )""".stripMargin
       }
+
+      "it contains a keyword-named keyword argument" in {
+        val code = "foo(if: true)"
+        printAst(_.primary(), code) shouldEqual
+          """InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgsOnlyArgumentsWithParentheses
+            |  (
+            |  Arguments
+            |   AssociationArgument
+            |    Association
+            |     Keyword
+            |      if
+            |     :
+            |     WsOrNl
+            |     PrimaryExpression
+            |      VariableReferencePrimary
+            |       PseudoVariableIdentifierVariableReference
+            |        TruePseudoVariableIdentifier
+            |         true
+            |  )""".stripMargin
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #3041 .
Closes #3046 as well.