### PR TITLE
[rubysrc2cpg] `this` style field accesses handled

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -194,7 +194,7 @@ class AstCreator(
           null
         }
       }
-      val varSymbol = localVar.getSymbol()
+      val varSymbol = localVar.getSymbol
       val node =
         createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
       val yAst = Ast(node)
@@ -207,11 +207,11 @@ class AstCreator(
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
         .lineNumber(localVar.getSymbol.getLine)
-        .columnNumber(localVar.getSymbol.getCharPositionInLine())
+        .columnNumber(localVar.getSymbol.getCharPositionInLine)
       Seq(callAst(callNode, xAsts ++ Seq(yAst)))
     case ctx: ScopedConstantAccessSingleLeftHandSideContext =>
       val localVar  = ctx.CONSTANT_IDENTIFIER()
-      val varSymbol = localVar.getSymbol()
+      val varSymbol = localVar.getSymbol
       val node = createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
       Seq(Ast(node))
     case _ =>
@@ -244,17 +244,7 @@ class AstCreator(
     val rightAst = astForMultipleRightHandSideContext(ctx.multipleRightHandSide())
     val leftAst  = astForSingleLeftHandSideContext(ctx.singleLeftHandSide())
 
-    val operatorName      = getOperatorName(ctx.op)
-    val isSelfFieldAccess = ctx.singleLeftHandSide().getText.startsWith("@")
-
-    // Very basic field detection
-    // TODO: Create a <operator.fieldAccess>
-    if (isSelfFieldAccess) {
-      fieldReferences.updateWith(classStack.top) {
-        case Some(xs) => Option(xs ++ Set(ctx.singleLeftHandSide()))
-        case None     => Option(Set(ctx.singleLeftHandSide()))
-      }
-    }
+    val operatorName = getOperatorName(ctx.op)
 
     if (leftAst.size == 1 && rightAst.size > 1) {
       /*
@@ -267,8 +257,8 @@ class AstCreator(
         .methodFullName(operatorName)
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
-        .lineNumber(ctx.op.getLine())
-        .columnNumber(ctx.op.getCharPositionInLine())
+        .lineNumber(ctx.op.getLine)
+        .columnNumber(ctx.op.getCharPositionInLine)
 
       val packedRHS = getPackedRHS(rightAst)
       Seq(callAst(callNode, leftAst ++ packedRHS))
@@ -280,8 +270,8 @@ class AstCreator(
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
-        .lineNumber(ctx.op.getLine())
-        .columnNumber(ctx.op.getCharPositionInLine())
+        .lineNumber(ctx.op.getLine)
+        .columnNumber(ctx.op.getCharPositionInLine)
       Seq(callAst(callNode, leftAst ++ rightAst))
     }
   }
@@ -1096,7 +1086,13 @@ class AstCreator(
           .name(code.replaceAll("@", ""))
           .code(code)
           .typeFullName(Defines.Any)
-      }).toList.distinctBy(_.name).map(Ast.apply)
+      }).toList.distinctBy(_.name).map { m =>
+        val modifierType = m.name match
+          case x if x.startsWith("@@") => ModifierTypes.STATIC
+          case _                       => ModifierTypes.VIRTUAL
+        val modifierAst = Ast(NewModifier().modifierType(modifierType))
+        Ast(m).withChild(modifierAst)
+      }
     Seq(blockAst(blockNode(classCtx), blockStmts.toList)) ++ uniqueMemberReferences ++ methodStmts
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
@@ -65,12 +65,14 @@ class TypeDeclAstCreationPassTest extends RubyCode2CpgFixture {
       song.name shouldBe "Song"
       song.fullName shouldBe "Test0.rb::program:Song"
 
-      val List(plays, artist, duration, name) = song.member.l
+      val List(artist, duration, name, plays) = song.member.l
 
       plays.name shouldBe "plays"
       name.name shouldBe "name"
       artist.name shouldBe "artist"
       duration.name shouldBe "duration"
+
+      cpg.fieldAccess.fieldIdentifier.canonicalName.l shouldBe List("plays", "name", "artist", "duration")
     }
 
     "generate members for various class members when using the `attr_reader` and `attr_writer` idioms" ignore {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FunctionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FunctionTests.scala
@@ -31,10 +31,10 @@ class FunctionTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "recognise all identifier nodes" in {
-      cpg.identifier.name("name").l.size shouldBe 1
-      cpg.identifier.name("age").l.size shouldBe 1
-      cpg.identifier.name("@name").l.size shouldBe 2
-      cpg.identifier.name("@age").l.size shouldBe 4
+      cpg.identifier.name("name").size shouldBe 1
+      cpg.identifier.name("age").size shouldBe 1
+      cpg.fieldAccess.fieldIdentifier.canonicalName("name").size shouldBe 2
+      cpg.fieldAccess.fieldIdentifier.canonicalName("age").size shouldBe 4
       cpg.identifier.size shouldBe 11
     }
 
@@ -80,11 +80,11 @@ class FunctionTests extends RubyCode2CpgFixture {
       cpg.call.name(Operators.assignment).size shouldBe 3
       cpg.call.name("to_s").size shouldBe 2
       cpg.call.name("new").size shouldBe 1
-      cpg.call.size shouldBe 8
+      cpg.call.size shouldBe 11
     }
 
     "recognize all identifier nodes" in {
-      cpg.identifier.name("@my_hash").size shouldBe 3
+      cpg.fieldAccess.fieldIdentifier.canonicalName("my_hash").size shouldBe 3
       cpg.identifier.name("key").size shouldBe 2
       cpg.identifier.name("value").size shouldBe 1
       cpg.identifier.name("my_object").size shouldBe 1


### PR DESCRIPTION
* Some code cleanups
* Detected when `@`-style field accesses were called and generated the necessary `Operators.fieldAccess` structure
* For members: Added static modifier when `@@` notation detected and the virtual modifier otherwise

Partially resolves #3068, more to be done for instance object field accesses.