### PR TITLE
rubysrc2cpg: Try catch for rescue and fixes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -92,6 +92,28 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
+  "Implicit return in if-else block" ignore {
+    val cpg = code("""
+        |def foo(arg)
+        |if arg > 1
+        |        arg + 1
+        |else
+        |        arg + 10
+        |end
+        |end
+        |
+        |x = 1
+        |y = foo x
+        |puts y
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("x").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
   "Return via call w/o initialization" should {
     val cpg = code("""
         |def add(p)
@@ -1115,7 +1137,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow for begin/rescue with sink in function without begin" ignore {
+  "Data flow for begin/rescue with sink in function without begin" should {
     val cpg = code("""
         |def foo(arg)
         |  puts "in begin"
@@ -1140,7 +1162,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow for begin/rescue with sink in function without begin and sink in rescue with exception" ignore {
+  "Data flow for begin/rescue with sink in function without begin and sink in rescue with exception" should {
     val cpg = code("""
         |def foo(arg)
         |  puts "in begin"
@@ -1163,7 +1185,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
-  "Data flow for begin/rescue with sink in function without begin and sink in catch-call rescue" ignore {
+  "Data flow for begin/rescue with sink in function without begin and sink in catch-call rescue" should {
     val cpg = code("""
         |def foo(arg)
         |  puts "in begin"


### PR DESCRIPTION
1. Used try-catch control structure for rescue like other frontends. Used the wrapper in it
2. Changes to handle implicit returns only if there is no rescue block. This is to handle the complications of implicit/explicit returns separately in a different PR
3. Disabled test case for implicit return handling with if-else
4. Enabled test cases passing due to this change. They were failing due to implicit returns being used in try-catch