### PR TITLE
RubyParser: support for whitespace-separated string literals

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -540,7 +540,7 @@ literal
 stringLiteral
     :   SINGLE_QUOTED_STRING_LITERAL                                                                                # singleQuotedStringLiteral
     |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END                # doubleQuotedStringLiteral
-    |   stringLiteral (WS stringLiteral)+                                                                           # concatenationStringLiteral
+    |   stringLiteral (WS stringLiteral)+                                                                           # concatenatedStringLiteral
     ;
 
 symbol

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -533,9 +533,14 @@ scopedConstantReference
 literal
     :   numericLiteral                                                                                              # numericLiteralLiteral
     |   symbol                                                                                                      # symbolLiteral
-    |   SINGLE_QUOTED_STRING_LITERAL                                                                                # singleQuotedStringLiteral
-    |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END                # doubleQuotedStringLiteral
+    |   stringLiteral                                                                                               # stringLiteralLiteral
     |   REGULAR_EXPRESSION_START REGULAR_EXPRESSION_BODY? REGULAR_EXPRESSION_END                                    # regularExpressionLiteral
+    ;
+    
+stringLiteral
+    :   SINGLE_QUOTED_STRING_LITERAL                                                                                # singleQuotedStringLiteral
+    |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END                # doubleQuotedStringLiteral
+    |   stringLiteral (WS stringLiteral)+                                                                           # concatenationStringLiteral
     ;
 
 symbol

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -148,6 +148,7 @@ class AstCreator(
     val activeRecordAssociation = "<operator>.activeRecordAssociation"
     val undef                   = "<operator>.undef"
     val superKeyword            = "<operator>.super"
+    val concatStringLiteral     = "<operator>.stringConcatenation"
   }
   private def getOperatorName(token: Token): String = token.getType match {
     case ASSIGNMENT_OPERATOR => Operators.assignment

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -102,21 +102,27 @@ trait AstForExpressionsCreator { this: AstCreator =>
   }
 
   protected def astForLiteralPrimaryExpression(ctx: LiteralPrimaryContext): Ast = ctx.literal() match {
-    case ctx: NumericLiteralLiteralContext     => astForNumericLiteral(ctx.numericLiteral())
-    case ctx: SymbolLiteralContext             => astForSymbolLiteral(ctx.symbol())
-    case ctx: StringLiteralLiteralContext      => astForStringLiteral(ctx.stringLiteral)
-    case ctx: RegularExpressionLiteralContext  => astForRegularExpressionLiteral(ctx)
+    case ctx: NumericLiteralLiteralContext    => astForNumericLiteral(ctx.numericLiteral())
+    case ctx: SymbolLiteralContext            => astForSymbolLiteral(ctx.symbol())
+    case ctx: StringLiteralLiteralContext     => astForStringLiteral(ctx.stringLiteral)
+    case ctx: RegularExpressionLiteralContext => astForRegularExpressionLiteral(ctx)
   }
-  
+
   protected def astForStringLiteral(ctx: StringLiteralContext): Ast = ctx match {
     case ctx: SingleQuotedStringLiteralContext  => astForSingleQuotedStringLiteral(ctx)
     case ctx: DoubleQuotedStringLiteralContext  => astForDoubleQuotedStringLiteral(ctx)
     case ctx: ConcatenationStringLiteralContext => astForConcatenatedStringLiterals(ctx)
   }
-  
+
   protected def astForConcatenatedStringLiterals(ctx: ConcatenationStringLiteralContext): Ast = {
     val literalAsts = ctx.stringLiteral().asScala.map(astForStringLiteral)
-    val callNode_ = callNode(ctx, ctx.getText, RubyOperators.concatStringLiteral, RubyOperators.concatStringLiteral, DispatchTypes.STATIC_DISPATCH)
+    val callNode_ = callNode(
+      ctx,
+      ctx.getText,
+      RubyOperators.concatStringLiteral,
+      RubyOperators.concatStringLiteral,
+      DispatchTypes.STATIC_DISPATCH
+    )
     callAst(callNode_, literalAsts.toSeq)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -104,9 +104,20 @@ trait AstForExpressionsCreator { this: AstCreator =>
   protected def astForLiteralPrimaryExpression(ctx: LiteralPrimaryContext): Ast = ctx.literal() match {
     case ctx: NumericLiteralLiteralContext     => astForNumericLiteral(ctx.numericLiteral())
     case ctx: SymbolLiteralContext             => astForSymbolLiteral(ctx.symbol())
-    case ctx: SingleQuotedStringLiteralContext => astForSingleQuotedStringLiteral(ctx)
-    case ctx: DoubleQuotedStringLiteralContext => astForDoubleQuotedStringLiteral(ctx)
+    case ctx: StringLiteralLiteralContext      => astForStringLiteral(ctx.stringLiteral)
     case ctx: RegularExpressionLiteralContext  => astForRegularExpressionLiteral(ctx)
+  }
+  
+  protected def astForStringLiteral(ctx: StringLiteralContext): Ast = ctx match {
+    case ctx: SingleQuotedStringLiteralContext  => astForSingleQuotedStringLiteral(ctx)
+    case ctx: DoubleQuotedStringLiteralContext  => astForDoubleQuotedStringLiteral(ctx)
+    case ctx: ConcatenationStringLiteralContext => astForConcatenatedStringLiterals(ctx)
+  }
+  
+  protected def astForConcatenatedStringLiterals(ctx: ConcatenationStringLiteralContext): Ast = {
+    val literalAsts = ctx.stringLiteral().asScala.map(astForStringLiteral)
+    val callNode_ = callNode(ctx, ctx.getText, RubyOperators.concatStringLiteral, RubyOperators.concatStringLiteral, DispatchTypes.STATIC_DISPATCH)
+    callAst(callNode_, literalAsts.toSeq)
   }
 
   protected def astForTernaryConditionalOperator(ctx: ConditionalOperatorExpressionContext): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -109,12 +109,12 @@ trait AstForExpressionsCreator { this: AstCreator =>
   }
 
   protected def astForStringLiteral(ctx: StringLiteralContext): Ast = ctx match {
-    case ctx: SingleQuotedStringLiteralContext  => astForSingleQuotedStringLiteral(ctx)
-    case ctx: DoubleQuotedStringLiteralContext  => astForDoubleQuotedStringLiteral(ctx)
-    case ctx: ConcatenationStringLiteralContext => astForConcatenatedStringLiterals(ctx)
+    case ctx: SingleQuotedStringLiteralContext => astForSingleQuotedStringLiteral(ctx)
+    case ctx: DoubleQuotedStringLiteralContext => astForDoubleQuotedStringLiteral(ctx)
+    case ctx: ConcatenatedStringLiteralContext => astForConcatenatedStringLiterals(ctx)
   }
 
-  protected def astForConcatenatedStringLiterals(ctx: ConcatenationStringLiteralContext): Ast = {
+  protected def astForConcatenatedStringLiterals(ctx: ConcatenatedStringLiteralContext): Ast = {
     val literalAsts = ctx.stringLiteral().asScala.map(astForStringLiteral)
     val callNode_ = callNode(
       ctx,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -350,4 +350,11 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
+  
+  "Multi-line string literal concatenation" should "be recognized as two string literals separated by whitespace" in {
+    val code =
+      """'abc' \
+        |'cde'""".stripMargin
+    tokenize(code) shouldBe Seq(SINGLE_QUOTED_STRING_LITERAL, WS, SINGLE_QUOTED_STRING_LITERAL, EOF)
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -350,7 +350,7 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
-  
+
   "Multi-line string literal concatenation" should "be recognized as two string literals separated by whitespace" in {
     val code =
       """'abc' \

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -10,8 +10,9 @@ class StringTests extends RubyParserAbstractTest {
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
           """LiteralPrimary
-            | SingleQuotedStringLiteral
-            |  ''""".stripMargin
+            | StringLiteralLiteral
+            |  SingleQuotedStringLiteral
+            |   ''""".stripMargin
       }
     }
   }
@@ -24,9 +25,10 @@ class StringTests extends RubyParserAbstractTest {
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
           """LiteralPrimary
-            | DoubleQuotedStringLiteral
-            |  "
-            |  """".stripMargin
+            | StringLiteralLiteral
+            |  DoubleQuotedStringLiteral
+            |   "
+            |   """".stripMargin
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -15,6 +15,36 @@ class StringTests extends RubyParserAbstractTest {
             |   ''""".stripMargin
       }
     }
+
+    "separated by whitespace" should {
+      val code = "'x' 'y'"
+
+      "be parsed as a literal expression" in {
+        printAst(_.literal(), code) shouldEqual
+          """StringLiteralLiteral
+            | ConcatenationStringLiteral
+            |  SingleQuotedStringLiteral
+            |   'x'
+            |  SingleQuotedStringLiteral
+            |   'y'""".stripMargin
+      }
+    }
+
+    "separated by '\\\n' " should {
+      val code = """'x' \
+          | 'y'""".stripMargin
+
+      "be parsed as a literal expression" in {
+        printAst(_.literal(), code) shouldEqual
+          """StringLiteralLiteral
+            | ConcatenationStringLiteral
+            |  SingleQuotedStringLiteral
+            |   'x'
+            |   \
+            |  SingleQuotedStringLiteral
+            |   'y'""".stripMargin
+      }
+    }
   }
 
   "A double-quoted string literal" when {
@@ -29,6 +59,45 @@ class StringTests extends RubyParserAbstractTest {
             |  DoubleQuotedStringLiteral
             |   "
             |   """".stripMargin
+      }
+
+      "separated by whitespace" should {
+        val code = "\"x\" \"y\""
+
+        "be parsed as a literal expression" in {
+          printAst(_.literal(), code) shouldEqual
+            """StringLiteralLiteral
+              | ConcatenationStringLiteral
+              |  DoubleQuotedStringLiteral
+              |   "
+              |   x
+              |   "
+              |  DoubleQuotedStringLiteral
+              |   "
+              |   y
+              |   """".stripMargin
+        }
+      }
+
+      "separated by '\\\n' " should {
+        val code =
+          """"x" \
+            | "y" """.stripMargin
+
+        "be parsed as a literal expression" in {
+          printAst(_.literal(), code) shouldEqual
+            """StringLiteralLiteral
+              | ConcatenationStringLiteral
+              |  DoubleQuotedStringLiteral
+              |   "
+              |   x
+              |   "
+              |   \
+              |  DoubleQuotedStringLiteral
+              |   "
+              |   y
+              |   """".stripMargin
+        }
       }
     }
 
@@ -55,6 +124,28 @@ class StringTests extends RubyParserAbstractTest {
             |            1
             |   }
             |  """".stripMargin
+      }
+    }
+
+    "separated by '\\\n' and containing a numeric literal interpolation" should {
+      val code = """"#{10} is a" \
+                   |"number"""".stripMargin
+
+      "be parsed as a literal expression" in {
+        printAst(_.literal(), code) shouldEqual
+          """StringLiteralLiteral
+          | DoubleQuotedStringLiteral
+          |  "
+          |  #{
+          |  10
+          |  }
+          |   is a
+          |  "
+          |   \
+          |  "
+          |  number
+          |  """".stripMargin
+
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -145,7 +145,6 @@ class StringTests extends RubyParserAbstractTest {
           |  "
           |  number
           |  """".stripMargin
-
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -22,7 +22,7 @@ class StringTests extends RubyParserAbstractTest {
       "be parsed as a literal expression" in {
         printAst(_.literal(), code) shouldEqual
           """StringLiteralLiteral
-            | ConcatenationStringLiteral
+            | ConcatenatedStringLiteral
             |  SingleQuotedStringLiteral
             |   'x'
             |  SingleQuotedStringLiteral
@@ -30,14 +30,14 @@ class StringTests extends RubyParserAbstractTest {
       }
     }
 
-    "separated by '\\\n' " should {
+    "separated by '\\\\n' " should {
       val code = """'x' \
           | 'y'""".stripMargin
 
       "be parsed as a literal expression" in {
         printAst(_.literal(), code) shouldEqual
           """StringLiteralLiteral
-            | ConcatenationStringLiteral
+            | ConcatenatedStringLiteral
             |  SingleQuotedStringLiteral
             |   'x'
             |   \
@@ -67,7 +67,7 @@ class StringTests extends RubyParserAbstractTest {
         "be parsed as a literal expression" in {
           printAst(_.literal(), code) shouldEqual
             """StringLiteralLiteral
-              | ConcatenationStringLiteral
+              | ConcatenatedStringLiteral
               |  DoubleQuotedStringLiteral
               |   "
               |   x
@@ -79,7 +79,7 @@ class StringTests extends RubyParserAbstractTest {
         }
       }
 
-      "separated by '\\\n' " should {
+      "separated by '\\\\n'" should {
         val code =
           """"x" \
             | "y" """.stripMargin
@@ -87,7 +87,7 @@ class StringTests extends RubyParserAbstractTest {
         "be parsed as a literal expression" in {
           printAst(_.literal(), code) shouldEqual
             """StringLiteralLiteral
-              | ConcatenationStringLiteral
+              | ConcatenatedStringLiteral
               |  DoubleQuotedStringLiteral
               |   "
               |   x
@@ -124,27 +124,6 @@ class StringTests extends RubyParserAbstractTest {
             |            1
             |   }
             |  """".stripMargin
-      }
-    }
-
-    "separated by '\\\n' and containing a numeric literal interpolation" should {
-      val code = """"#{10} is a" \
-                   |"number"""".stripMargin
-
-      "be parsed as a literal expression" in {
-        printAst(_.literal(), code) shouldEqual
-          """StringLiteralLiteral
-          | DoubleQuotedStringLiteral
-          |  "
-          |  #{
-          |  10
-          |  }
-          |   is a
-          |  "
-          |   \
-          |  "
-          |  number
-          |  """".stripMargin
       }
     }
 


### PR DESCRIPTION
Supports samples such as

```ruby
"foo" \
"bar"
```

by representing them as a call to `<operator>.stringConcatenation` with the given string literals for arguments.

Towards closing #3081 .