### PR TITLE
rubysrc2cpg: Support for whitespace-separated general string expressions

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -94,6 +94,7 @@ primary
     |   arrayConstructor                                                                                            # arrayConstructorPrimary
     |   hashConstructor                                                                                             # hashConstructorPrimary
     |   literal                                                                                                     # literalPrimary
+    |   stringExpression                                                                                            # stringExpressionPrimary
     |   stringInterpolation                                                                                         # stringInterpolationPrimary
     |   regexInterpolation                                                                                          # regexInterpolationPrimary
     |   IS_DEFINED LPAREN expressionOrCommand RPAREN                                                                # isDefinedPrimary
@@ -533,24 +534,28 @@ scopedConstantReference
 literal
     :   numericLiteral                                                                                              # numericLiteralLiteral
     |   symbol                                                                                                      # symbolLiteral
-    |   stringLiteral                                                                                               # stringLiteralLiteral
     |   REGULAR_EXPRESSION_START REGULAR_EXPRESSION_BODY? REGULAR_EXPRESSION_END                                    # regularExpressionLiteral
     ;
     
-stringLiteral
-    :   SINGLE_QUOTED_STRING_LITERAL                                                                                # singleQuotedStringLiteral
-    |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END                # doubleQuotedStringLiteral
-    |   stringLiteral (WS stringLiteral)+                                                                           # concatenatedStringLiteral
-    ;
-
 symbol
     :   SYMBOL_LITERAL
     |   COLON SINGLE_QUOTED_STRING_LITERAL
     ;
 
 // --------------------------------------------------------
-// String interpolation
+// Strings
 // --------------------------------------------------------
+
+stringExpression
+    :   simpleString                                                                                                # simpleStringExpression
+    |   stringInterpolation                                                                                         # interpolatedStringExpression
+    |   stringExpression (WS stringExpression)+                                                                     # concatenatedStringExpression
+    ;
+
+simpleString
+    :   SINGLE_QUOTED_STRING_LITERAL                                                                                # singleQuotedStringLiteral
+    |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END                # doubleQuotedStringLiteral
+    ;
 
 stringInterpolation
     :   DOUBLE_QUOTED_STRING_START

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -150,7 +150,7 @@ class AstCreator(
     val activeRecordAssociation = "<operator>.activeRecordAssociation"
     val undef                   = "<operator>.undef"
     val superKeyword            = "<operator>.super"
-    val concatStringLiteral     = "<operator>.stringConcatenation"
+    val stringConcatenation     = "<operator>.stringConcatenation"
   }
   private def getOperatorName(token: Token): String = token.getType match {
     case ASSIGNMENT_OPERATOR => Operators.assignment
@@ -279,7 +279,7 @@ class AstCreator(
     }
   }
 
-  def astForStringInterpolationPrimaryContext(ctx: StringInterpolationPrimaryContext): Seq[Ast] = {
+  def astForStringInterpolationContext(ctx: InterpolatedStringExpressionContext): Seq[Ast] = {
     val varAsts = ctx
       .stringInterpolation()
       .interpolatedStringSequence()
@@ -329,7 +329,7 @@ class AstCreator(
     case ctx: ArrayConstructorPrimaryContext          => astForArrayConstructorPrimaryContext(ctx)
     case ctx: HashConstructorPrimaryContext           => astForHashConstructorPrimaryContext(ctx)
     case ctx: LiteralPrimaryContext                   => Seq(astForLiteralPrimaryExpression(ctx))
-    case ctx: StringInterpolationPrimaryContext       => astForStringInterpolationPrimaryContext(ctx)
+    case ctx: StringExpressionPrimaryContext          => astForStringExpression(ctx.stringExpression)
     case ctx: IsDefinedPrimaryContext                 => Seq(astForIsDefinedPrimaryExpression(ctx))
     case ctx: SuperExpressionPrimaryContext           => Seq(astForSuperExpression(ctx))
     case ctx: IndexingExpressionPrimaryContext        => astForIndexingExpressionPrimaryContext(ctx)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -49,6 +49,31 @@ class StringTests extends RubyParserAbstractTest {
             |    'y'""".stripMargin
       }
     }
+
+    "separated by '\\\\n' twice" should {
+      val code =
+        """'x' \
+          | 'y' \
+          | 'z'""".stripMargin
+
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """StringExpressionPrimary
+            | ConcatenatedStringExpression
+            |  SimpleStringExpression
+            |   SingleQuotedStringLiteral
+            |    'x'
+            |   \
+            |  ConcatenatedStringExpression
+            |   SimpleStringExpression
+            |    SingleQuotedStringLiteral
+            |     'y'
+            |    \
+            |   SimpleStringExpression
+            |    SingleQuotedStringLiteral
+            |     'z'""".stripMargin
+      }
+    }
   }
 
   "A double-quoted string literal" when {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -9,8 +9,8 @@ class StringTests extends RubyParserAbstractTest {
 
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
-          """LiteralPrimary
-            | StringLiteralLiteral
+          """StringExpressionPrimary
+            | SimpleStringExpression
             |  SingleQuotedStringLiteral
             |   ''""".stripMargin
       }
@@ -19,14 +19,16 @@ class StringTests extends RubyParserAbstractTest {
     "separated by whitespace" should {
       val code = "'x' 'y'"
 
-      "be parsed as a literal expression" in {
-        printAst(_.literal(), code) shouldEqual
-          """StringLiteralLiteral
-            | ConcatenatedStringLiteral
-            |  SingleQuotedStringLiteral
-            |   'x'
-            |  SingleQuotedStringLiteral
-            |   'y'""".stripMargin
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """StringExpressionPrimary
+            | ConcatenatedStringExpression
+            |  SimpleStringExpression
+            |   SingleQuotedStringLiteral
+            |    'x'
+            |  SimpleStringExpression
+            |   SingleQuotedStringLiteral
+            |    'y'""".stripMargin
       }
     }
 
@@ -34,15 +36,17 @@ class StringTests extends RubyParserAbstractTest {
       val code = """'x' \
           | 'y'""".stripMargin
 
-      "be parsed as a literal expression" in {
-        printAst(_.literal(), code) shouldEqual
-          """StringLiteralLiteral
-            | ConcatenatedStringLiteral
-            |  SingleQuotedStringLiteral
-            |   'x'
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """StringExpressionPrimary
+            | ConcatenatedStringExpression
+            |  SimpleStringExpression
+            |   SingleQuotedStringLiteral
+            |    'x'
             |   \
-            |  SingleQuotedStringLiteral
-            |   'y'""".stripMargin
+            |  SimpleStringExpression
+            |   SingleQuotedStringLiteral
+            |    'y'""".stripMargin
       }
     }
   }
@@ -54,8 +58,8 @@ class StringTests extends RubyParserAbstractTest {
 
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
-          """LiteralPrimary
-            | StringLiteralLiteral
+          """StringExpressionPrimary
+            | SimpleStringExpression
             |  DoubleQuotedStringLiteral
             |   "
             |   """".stripMargin
@@ -64,18 +68,20 @@ class StringTests extends RubyParserAbstractTest {
       "separated by whitespace" should {
         val code = "\"x\" \"y\""
 
-        "be parsed as a literal expression" in {
-          printAst(_.literal(), code) shouldEqual
-            """StringLiteralLiteral
-              | ConcatenatedStringLiteral
-              |  DoubleQuotedStringLiteral
-              |   "
-              |   x
-              |   "
-              |  DoubleQuotedStringLiteral
-              |   "
-              |   y
-              |   """".stripMargin
+        "be parsed as a primary expression" in {
+          printAst(_.primary(), code) shouldEqual
+            """StringExpressionPrimary
+              | ConcatenatedStringExpression
+              |  SimpleStringExpression
+              |   DoubleQuotedStringLiteral
+              |    "
+              |    x
+              |    "
+              |  SimpleStringExpression
+              |   DoubleQuotedStringLiteral
+              |    "
+              |    y
+              |    """".stripMargin
         }
       }
 
@@ -84,19 +90,21 @@ class StringTests extends RubyParserAbstractTest {
           """"x" \
             | "y" """.stripMargin
 
-        "be parsed as a literal expression" in {
-          printAst(_.literal(), code) shouldEqual
-            """StringLiteralLiteral
-              | ConcatenatedStringLiteral
-              |  DoubleQuotedStringLiteral
-              |   "
-              |   x
-              |   "
+        "be parsed as a primary expression" in {
+          printAst(_.primary(), code) shouldEqual
+            """StringExpressionPrimary
+              | ConcatenatedStringExpression
+              |  SimpleStringExpression
+              |   DoubleQuotedStringLiteral
+              |    "
+              |    x
+              |    "
               |   \
-              |  DoubleQuotedStringLiteral
-              |   "
-              |   y
-              |   """".stripMargin
+              |  SimpleStringExpression
+              |   DoubleQuotedStringLiteral
+              |    "
+              |    y
+              |    """".stripMargin
         }
       }
     }
@@ -106,24 +114,25 @@ class StringTests extends RubyParserAbstractTest {
 
       "be parsed as primary expression" in {
         printAst(_.primary(), code) shouldEqual
-          """StringInterpolationPrimary
-            | StringInterpolation
-            |  "
-            |  text=
-            |  InterpolatedStringSequence
-            |   #{
-            |   CompoundStatement
-            |    Statements
-            |     ExpressionOrCommandStatement
-            |      ExpressionExpressionOrCommand
-            |       PrimaryExpression
-            |        LiteralPrimary
-            |         NumericLiteralLiteral
-            |          NumericLiteral
-            |           UnsignedNumericLiteral
-            |            1
-            |   }
-            |  """".stripMargin
+          """StringExpressionPrimary
+            | InterpolatedStringExpression
+            |  StringInterpolation
+            |   "
+            |   text=
+            |   InterpolatedStringSequence
+            |    #{
+            |    CompoundStatement
+            |     Statements
+            |      ExpressionOrCommandStatement
+            |       ExpressionExpressionOrCommand
+            |        PrimaryExpression
+            |         LiteralPrimary
+            |          NumericLiteralLiteral
+            |           NumericLiteral
+            |            UnsignedNumericLiteral
+            |             1
+            |    }
+            |   """".stripMargin
       }
     }
 
@@ -132,36 +141,93 @@ class StringTests extends RubyParserAbstractTest {
 
       "be parsed as primary expression" in {
         printAst(_.primary(), code) shouldEqual
-          """StringInterpolationPrimary
-            | StringInterpolation
-            |  "
-            |  InterpolatedStringSequence
-            |   #{
-            |   CompoundStatement
-            |    Statements
-            |     ExpressionOrCommandStatement
-            |      ExpressionExpressionOrCommand
-            |       PrimaryExpression
-            |        LiteralPrimary
-            |         NumericLiteralLiteral
-            |          NumericLiteral
-            |           UnsignedNumericLiteral
-            |            1
-            |   }
-            |  InterpolatedStringSequence
-            |   #{
-            |   CompoundStatement
-            |    Statements
-            |     ExpressionOrCommandStatement
-            |      ExpressionExpressionOrCommand
-            |       PrimaryExpression
-            |        LiteralPrimary
-            |         NumericLiteralLiteral
-            |          NumericLiteral
-            |           UnsignedNumericLiteral
-            |            2
-            |   }
-            |  """".stripMargin
+          """StringExpressionPrimary
+            | InterpolatedStringExpression
+            |  StringInterpolation
+            |   "
+            |   InterpolatedStringSequence
+            |    #{
+            |    CompoundStatement
+            |     Statements
+            |      ExpressionOrCommandStatement
+            |       ExpressionExpressionOrCommand
+            |        PrimaryExpression
+            |         LiteralPrimary
+            |          NumericLiteralLiteral
+            |           NumericLiteral
+            |            UnsignedNumericLiteral
+            |             1
+            |    }
+            |   InterpolatedStringSequence
+            |    #{
+            |    CompoundStatement
+            |     Statements
+            |      ExpressionOrCommandStatement
+            |       ExpressionExpressionOrCommand
+            |        PrimaryExpression
+            |         LiteralPrimary
+            |          NumericLiteralLiteral
+            |           NumericLiteral
+            |            UnsignedNumericLiteral
+            |             2
+            |    }
+            |   """".stripMargin
+      }
+    }
+
+    "separated by '\\\\n'" should {
+      val code = """"x" \
+          | "y" """.stripMargin
+
+      "be parsed as a primary expression" in {
+        printAst(_.primary(), code) shouldEqual
+          """StringExpressionPrimary
+              | ConcatenatedStringExpression
+              |  SimpleStringExpression
+              |   DoubleQuotedStringLiteral
+              |    "
+              |    x
+              |    "
+              |   \
+              |  SimpleStringExpression
+              |   DoubleQuotedStringLiteral
+              |    "
+              |    y
+              |    """".stripMargin
+      }
+
+      "separated by '\\\\n' and containing a numeric interpolation" should {
+        val code = """"#{10}" \
+                     | "is a number."""".stripMargin
+
+        "be parsed as a primary expression" in {
+          printAst(_.primary(), code) shouldEqual
+            """StringExpressionPrimary
+              | ConcatenatedStringExpression
+              |  InterpolatedStringExpression
+              |   StringInterpolation
+              |    "
+              |    InterpolatedStringSequence
+              |     #{
+              |     CompoundStatement
+              |      Statements
+              |       ExpressionOrCommandStatement
+              |        ExpressionExpressionOrCommand
+              |         PrimaryExpression
+              |          LiteralPrimary
+              |           NumericLiteralLiteral
+              |            NumericLiteral
+              |             UnsignedNumericLiteral
+              |              10
+              |     }
+              |    "
+              |   \
+              |  SimpleStringExpression
+              |   DoubleQuotedStringLiteral
+              |    "
+              |    is a number.
+              |    """".stripMargin
+        }
       }
     }
   }


### PR DESCRIPTION
* Unified string literals and string interpolations under the same rule ("string expressions"), since the ability to concatenate strings applied to both literals and interpolations.

Closes #3081 