### PR TITLE
rubysrc2cpg: method param ref edges

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1277,7 +1277,7 @@ class AstCreator(
           .asInstanceOf[Seq[NewMethodParameterIn]]
       )
       .foreach(paramNode => {
-        val linkIdentifiers = identifiers.filter(_.name.equals(paramNode.name))
+        val linkIdentifiers = identifiers.filter(_.name == paramNode.name)
         identifiers.foreach { identifier =>
           diffGraph.addEdge(identifier, paramNode, EdgeTypes.REF)
         }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -1756,7 +1756,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
       sink.reachableByFlows(src).size shouldBe 1
     }
 
-    "be found for sink in nested block" ignore {
+    "be found for sink in nested block" in {
       val src  = cpg.identifier("x").lineNumber(3).l
       val sink = cpg.call.name("puts").argument(1).lineNumber(7).l
       sink.reachableByFlows(src).size shouldBe 1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/IdentifierLocalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/IdentifierLocalTests.scala
@@ -36,29 +36,27 @@ class IdentifierLocalTests extends RubyCode2CpgFixture {
   "be correct for local x in method1" ignore {
     val List(method) = cpg.method.nameExact("method1").l
     method.block.ast.isIdentifier.l.size shouldBe 2
-    val List(indentifierX, _) = method.block.ast.isIdentifier.l
-    indentifierX.name shouldBe "x"
+    val List(identifierX, _) = method.block.ast.isIdentifier.l
+    identifierX.name shouldBe "x"
 
-    val localX = indentifierX._localViaRefOut.get
+    val localX = identifierX._localViaRefOut.get
     localX.name shouldBe "x"
   }
 
-  // TODO: Need to be fixed
-  "be correct for parameter x in method2" ignore {
+  "be correct for parameter x in method2" in {
     val List(method)       = cpg.method.nameExact("method2").l
-    val List(indentifierX) = method.block.ast.isIdentifier.l
-    indentifierX.name shouldBe "x"
+    val List(identifierX) = method.block.ast.isIdentifier.l
+    identifierX.name shouldBe "x"
 
-    indentifierX.refsTo.l.size shouldBe 1
-    val List(paramx) = indentifierX.refsTo.l
+    identifierX.refsTo.l.size shouldBe 1
+    val List(paramx) = identifierX.refsTo.l
     paramx.name shouldBe "x"
 
-    val parameterX = indentifierX._methodParameterInViaRefOut.get
+    val parameterX = identifierX._methodParameterInViaRefOut.get
     parameterX.name shouldBe "x"
   }
 
-  // TODO: Need to be fixed.
-  "Reach parameter from last identifer" ignore {
+  "Reach parameter from last identifier" in {
     val List(method)           = cpg.method.nameExact("method3").l
     val List(outerIdentifierX) = method.ast.isIdentifier.lineNumber(22).l
     val parameterX             = outerIdentifierX._methodParameterInViaRefOut.get
@@ -74,7 +72,7 @@ class IdentifierLocalTests extends RubyCode2CpgFixture {
   }
 
   // TODO: Need to be fixed.
-  "nested block identifer to local taversal" ignore {
+  "nested block identifier to local traversal" ignore {
     val List(method) = cpg.method.nameExact("method3").l
     method.block.astChildren.isBlock.l.size shouldBe 1
     val List(nestedBlock) = method.block.astChildren.isBlock.l

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/IdentifierLocalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/IdentifierLocalTests.scala
@@ -44,7 +44,7 @@ class IdentifierLocalTests extends RubyCode2CpgFixture {
   }
 
   "be correct for parameter x in method2" in {
-    val List(method)       = cpg.method.nameExact("method2").l
+    val List(method)      = cpg.method.nameExact("method2").l
     val List(identifierX) = method.block.ast.isIdentifier.l
     identifierX.name shouldBe "x"
 


### PR DESCRIPTION
Adds ref edges from method param nodes to relevant identifiers in method block. Fixes 3 failing tests.