### PR TITLE
[rubysrc2cpg] Fixes existing ignored test cases for RubyTypeRecovery

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1296,7 +1296,10 @@ class AstCreator(
 
   def astForModuleDefinitionPrimaryContext(ctx: ModuleDefinitionPrimaryContext): Seq[Ast] = {
     val referenceAsts = astForClassOrModuleReferenceContext(ctx.moduleDefinition().classOrModuleReference())
-    val bodyStmtAsts  = astForBodyStatementContext(ctx.moduleDefinition().bodyStatement())
+    if (classStack.nonEmpty) {
+      packageContext.packageTable.addModule(filename, classStack.top)
+    }
+    val bodyStmtAsts = astForBodyStatementContext(ctx.moduleDefinition().bodyStatement())
     if (classStack.size > 0) {
       classStack.pop()
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.parser.RubyParser
 import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.x2cpg.Ast
 
 trait AstForPrimitivesCreator { this: AstCreator =>
@@ -19,16 +20,17 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Object))
 
   protected def astForFilePseudoIdentifier(ctx: RubyParser.FilePseudoVariableIdentifierContext): Ast =
-    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.String))
+    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, getBuiltInType(Defines.String)))
 
   protected def astForLinePseudoIdentifier(ctx: RubyParser.LinePseudoVariableIdentifierContext): Ast =
-    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Integer))
+    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, getBuiltInType(Defines.Integer)))
 
   protected def astForEncodingPseudoIdentifier(ctx: RubyParser.EncodingPseudoVariableIdentifierContext): Ast =
     Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Encoding))
 
   protected def astForNumericLiteral(ctx: RubyParser.NumericLiteralContext): Ast = {
-    val numericTypeName = if (isFloatLiteral(ctx.unsignedNumericLiteral)) Defines.Float else Defines.Integer
+    val numericTypeName =
+      if (isFloatLiteral(ctx.unsignedNumericLiteral)) getBuiltInType(Defines.Float) else getBuiltInType(Defines.Integer)
     Ast(literalNode(ctx, ctx.getText, numericTypeName))
   }
 
@@ -36,10 +38,10 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     Ast(literalNode(ctx, ctx.getText, Defines.Symbol))
 
   protected def astForSingleQuotedStringLiteral(ctx: RubyParser.SingleQuotedStringLiteralContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, Defines.String))
+    Ast(literalNode(ctx, ctx.getText, getBuiltInType(Defines.String)))
 
   protected def astForDoubleQuotedStringLiteral(ctx: RubyParser.DoubleQuotedStringLiteralContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, Defines.String))
+    Ast(literalNode(ctx, ctx.getText, getBuiltInType(Defines.String)))
 
   protected def astForRegularExpressionLiteral(ctx: RubyParser.RegularExpressionLiteralContext): Ast =
     Ast(literalNode(ctx, ctx.getText, Defines.Regexp))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -1,5 +1,7 @@
 package io.joern.rubysrc2cpg.passes
 
+import io.joern.rubysrc2cpg.astcreation.GlobalTypes
+
 object Defines {
   val Any: String    = "ANY"
   val Object: String = "Object"
@@ -25,4 +27,6 @@ object Defines {
   val ModifierRedo: String  = "redo"
   val ModifierRetry: String = "retry"
   var ModifierNext: String  = "next"
+
+  def getBuiltInType(typeInString: String) = s"${GlobalTypes.builtinPrefix}.$typeInString"
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryPass.scala
@@ -71,8 +71,8 @@ private class RecoverForRubyFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, 
     val memberTypes = methodFullNames.flatMap { fullName =>
       val memberName = fullName.split("\\.").lastOption
       if (memberName.isDefined) {
-        val typeDeclName = fullName.stripSuffix(memberName.get).stripSuffix(".")
-        cpg.typeDecl.nameExact(typeDeclName).member.nameExact(memberName.get).typeFullName.l
+        val typeDeclFullName = fullName.stripSuffix(s".${memberName.get}")
+        cpg.typeDecl.fullName(typeDeclFullName).member.nameExact(memberName.get).typeFullName.l
       } else
         List.empty
     }.toSet

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
@@ -8,11 +8,16 @@ case class PackageContext(moduleName: String, packageTable: PackageTable)
 
 class PackageTable() {
 
-  val methodTableMap = mutable.HashMap[String, mutable.HashSet[MethodTableModel]]()
+  val methodTableMap   = mutable.HashMap[String, mutable.HashSet[MethodTableModel]]()
+  val gemModuleMapping = mutable.HashMap[String, mutable.HashSet[String]]()
 
   def addPackageMethod(moduleName: String, methodName: String, parentClassPath: String, classType: String): Unit = {
     val packageMethod = MethodTableModel(methodName, parentClassPath, classType)
     methodTableMap.getOrElseUpdate(moduleName, mutable.HashSet.empty[MethodTableModel]) += packageMethod
+  }
+
+  def addModule(gemName: String, moduleName: String) = {
+    gemModuleMapping.getOrElseUpdate(gemName, mutable.HashSet.empty[String]) += moduleName
   }
 
   def getMethodFullNameUsingName(packageUsed: List[String], methodName: String): List[String] =
@@ -27,11 +32,21 @@ class PackageTable() {
   def getPackageInfo(moduleName: String): List[MethodTableModel] = {
     methodTableMap.get(moduleName) match
       case Some(value) => value.toList
-      case None        => List[MethodTableModel]()
+      case None        => List.empty[MethodTableModel]
+  }
+
+  def getModulesByGem(gemName: String) = {
+    gemModuleMapping.get(gemName) match
+      case Some(value) => value.toList
+      case None        => List.empty[String]
   }
 
   def set(table: PackageTable): Unit = {
     methodTableMap.addAll(table.methodTableMap)
+    gemModuleMapping.addAll(table.gemModuleMapping)
   }
-  def clear(): Unit = methodTableMap.clear
+  def clear(): Unit = {
+    methodTableMap.clear
+    gemModuleMapping.clear
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -1751,7 +1751,6 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
       val source = cpg.literal.code("1").l
       val sink   = cpg.call.name("puts").argument(1).lineNumber(3).l
       sink.reachableByFlows(source).size shouldBe 1
-
       val src = cpg.identifier("x").lineNumber(3).l
       sink.reachableByFlows(src).size shouldBe 1
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -9,6 +9,7 @@ class RubyTypeRecoveryTests extends RubyCode2CpgFixture {
   private val config = Config().withEnableDependencyDownload(true)
 
   "Type information for nodes with external dependency" should {
+    // TODO:
     "be present in (Case 1)" ignore {
       val cpg = code(
         """
@@ -32,6 +33,54 @@ class RubyTypeRecoveryTests extends RubyCode2CpgFixture {
       cpg.identifier("sg").typeFullName.l shouldBe List("sendgrid-ruby::program:SendGrid.API")
       cpg.call("client").methodFullName.l shouldBe List("sendgrid-ruby::program:SendGrid.API.client")
       // cpg.call("post").methodFullName.l shouldBe List("sendgrid-ruby::program:SendGrid.API.client<returnValue>.mail<returnValue>.anonymous<returnValue>.post")
+    }
+  }
+
+  // TODO:
+  "literals declared from built-in types" ignore {
+    val cpg = code(
+      """
+        |x = 123
+        |
+        |def newfunc
+        | x = "foo"
+        |end
+        |""".stripMargin,
+      "main.rb"
+    )
+    "resolve 'x' identifier types despite shadowing" in {
+      val List(xOuterScope, xInnerScope) = cpg.identifier("x").take(2).l
+      xOuterScope.dynamicTypeHintFullName shouldBe Seq("__builtin.Integer", "__builtin.String")
+      xInnerScope.dynamicTypeHintFullName shouldBe Seq("__builtin.Integer", "__builtin.String")
+    }
+  }
+
+  "recovering paths for built-in calls" should {
+    lazy val cpg = code(
+      """
+        |print("Hello world")
+        |puts "Hello"
+        |
+        |def sleep(input)
+        |end
+        |
+        |sleep(2)
+        |""".stripMargin,
+      "main.rb"
+    ).cpg
+
+    "resolve 'print' and 'puts' calls" in {
+      val Some(printCall) = cpg.call("print").headOption: @unchecked
+      printCall.methodFullName shouldBe "__builtin.print"
+      val Some(maxCall) = cpg.call("puts").headOption: @unchecked
+      maxCall.methodFullName shouldBe "__builtin.puts"
+    }
+
+    "conservatively present either option when an imported function uses the same name as a builtin" ignore {
+      val Some(absCall) = cpg.call("sleep").headOption: @unchecked
+      absCall.methodFullName shouldBe "main.rb::program.sleep"
+      // NOTE: I am not sure if this is a valid expectation. If it is not then we can get rid of this one.
+      absCall.dynamicTypeHintFullName shouldBe Seq("main.rb::program.sleep", "__builtin.sleep")
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -2,42 +2,56 @@ package io.joern.rubysrc2cpg.passes
 
 import io.joern.rubysrc2cpg.Config
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.joern.rubysrc2cpg.utils.PackageTable
+import io.joern.x2cpg.passes.frontend.ImportsPass.{
+  ResolvedMethod,
+  ResolvedTypeDecl,
+  TagToResolvedImportExt,
+  UnknownImport
+}
 import io.shiftleft.semanticcpg.language.*
 
-class RubyTypeRecoveryTests extends RubyCode2CpgFixture {
+object RubyTypeRecoveryTests {
+  def getPackageTable: PackageTable = {
+    val packageTable = PackageTable()
+    packageTable.addPackageMethod("sendgrid-ruby", "client", "SendGrid.API", "API")
+    packageTable.addPackageMethod("dbi", "connect", "DBI", "DBI")
+    packageTable.addPackageMethod("dbi", "select_one", "DBI", "DBI")
+    packageTable.addPackageMethod("logger", "error", "Logger", "Logger")
+    packageTable
+  }
 
-  private val config = Config().withEnableDependencyDownload(true)
+}
+class RubyTypeRecoveryTests
+    extends RubyCode2CpgFixture(withPostProcessing = true, packageTable = Some(RubyTypeRecoveryTests.getPackageTable)) {
 
   "Type information for nodes with external dependency" should {
-    // TODO:
-    "be present in (Case 1)" ignore {
-      val cpg = code(
-        """
-          |require "sendgrid-ruby"
-          |
-          |def func
-          |   sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-          |   response = sg.client.mail._('send').post(request_body: data)
-          |end
-          |""".stripMargin,
-        "main.rb"
-      ).moreCode(
-        """
-          |source 'https://rubygems.org'
-          |gem 'sendgrid-ruby'
-          |
-          |""".stripMargin,
-        "Gemfile"
-      ).withConfig(config)
 
-      cpg.identifier("sg").typeFullName.l shouldBe List("sendgrid-ruby::program:SendGrid.API")
-      cpg.call("client").methodFullName.l shouldBe List("sendgrid-ruby::program:SendGrid.API.client")
-      // cpg.call("post").methodFullName.l shouldBe List("sendgrid-ruby::program:SendGrid.API.client<returnValue>.mail<returnValue>.anonymous<returnValue>.post")
+    val cpg = code(
+      """
+        |require "sendgrid-ruby"
+        |
+        |def func
+        |   sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+        |   response = sg.client.mail._('send').post(request_body: data)
+        |end
+        |""".stripMargin,
+      "main.rb"
+    )
+
+    "be present in (Case 1)" in {
+      cpg.identifier("sg").lineNumber(5).typeFullName.l shouldBe List("sendgrid-ruby::program.SendGrid.API")
+      cpg.call("client").methodFullName.l shouldBe List("sendgrid-ruby::program.SendGrid.API.client")
+    }
+
+    "be present in (Case 2)" ignore {
+      cpg.call("post").methodFullName.l shouldBe List(
+        "sendgrid-ruby::program.SendGrid.API.client<returnValue>.mail<returnValue>.anonymous<returnValue>.post"
+      )
     }
   }
 
-  // TODO:
-  "literals declared from built-in types" ignore {
+  "literals declared from built-in types" should {
     val cpg = code(
       """
         |x = 123
@@ -76,12 +90,115 @@ class RubyTypeRecoveryTests extends RubyCode2CpgFixture {
       maxCall.methodFullName shouldBe "__builtin.puts"
     }
 
-    "conservatively present either option when an imported function uses the same name as a builtin" ignore {
+    "function uses the same name as a builtin" in {
       val Some(absCall) = cpg.call("sleep").headOption: @unchecked
       absCall.methodFullName shouldBe "main.rb::program.sleep"
-      // NOTE: I am not sure if this is a valid expectation. If it is not then we can get rid of this one.
-      absCall.dynamicTypeHintFullName shouldBe Seq("main.rb::program.sleep", "__builtin.sleep")
+      absCall.dynamicTypeHintFullName shouldBe Seq("main.rb::program.sleep")
     }
   }
 
+  "recovering module members across modules" should {
+    lazy val cpg = code(
+      """
+        |require "dbi"
+        |
+        |module FooModule
+        | x = 1
+        | y = "test"
+        | db = DBI.connect("DBI:Mysql:TESTDB:localhost", "testuser", "test123")
+        |end
+        |
+        |""".stripMargin,
+      "foo.rb"
+    ).moreCode(
+      """
+        |require_relative "./foo.rb"
+        |
+        |z = FooModule::x
+        |z = FooModule::y
+        |
+        |d = FooModule::db
+        |
+        |row = d.select_one("SELECT VERSION()")
+        |
+        |""".stripMargin,
+      "bar.rb"
+    ).cpg
+
+    "resolve correct imports via tag nodes" in {
+      val List(foo1: ResolvedMethod, foo2: ResolvedTypeDecl) =
+        cpg.file(".*foo.rb").ast.isCall.where(_.referencedImports).tag.toResolvedImport.toList: @unchecked
+      foo1.fullName shouldBe "dbi::program.DBI.new"
+      foo2.fullName shouldBe "dbi::program.DBI"
+      val List(bar: ResolvedTypeDecl) =
+        cpg.file(".*bar.rb").ast.isCall.where(_.referencedImports).tag.toResolvedImport.toList: @unchecked
+      bar.fullName shouldBe "foo.rb::program.FooModule"
+    }
+
+    "resolve 'x' and 'y' locally under foo.rb" in {
+      val Some(x) = cpg.identifier("x").where(_.file.name(".*foo.*")).headOption: @unchecked
+      x.typeFullName shouldBe "__builtin.Integer"
+      val Some(y) = cpg.identifier("y").where(_.file.name(".*foo.*")).headOption: @unchecked
+      y.typeFullName shouldBe "__builtin.String"
+    }
+
+    "resolve 'FooModule.x' and 'FooModule.y' field access primitive types correctly" ignore {
+      val List(z1, z2) = cpg.file
+        .name(".*bar.*")
+        .ast
+        .isIdentifier
+        .name("z")
+        .l
+      z1.typeFullName shouldBe "ANY"
+      z1.dynamicTypeHintFullName shouldBe Seq("__builtin.Integer", "__builtin.String")
+      z2.typeFullName shouldBe "ANY"
+      z2.dynamicTypeHintFullName shouldBe Seq("__builtin.Integer", "__builtin.String")
+    }
+
+    "resolve 'FooModule.d' field access object types correctly" ignore {
+      val Some(d) = cpg.file
+        .name(".*bar.*")
+        .ast
+        .isIdentifier
+        .name("d")
+        .headOption: @unchecked
+      d.typeFullName shouldBe "dbi::program.DBI.connect.<returnValue>"
+      d.dynamicTypeHintFullName shouldBe Seq()
+    }
+
+    "resolve a 'select_one' call indirectly from 'FooModule.d' field access correctly" ignore {
+      val List(d) = cpg.file
+        .name(".*bar.*")
+        .ast
+        .isCall
+        .name("select_one")
+        .l
+      d.methodFullName shouldBe "dbi::program.DBI.connect.<returnValue>.select_one"
+      d.dynamicTypeHintFullName shouldBe Seq()
+      d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
+    }
+
+  }
+
+  "assignment from a call to a method inside an imported module" should {
+    lazy val cpg = code("""
+        |require 'logger'
+        |
+        |log = Logger.new(STDOUT)
+        |log.error("foo")
+        |
+        |""".stripMargin).cpg
+
+    "resolve correct imports via tag nodes" in {
+      val List(logging: ResolvedMethod, _) = cpg.call.where(_.referencedImports).tag.toResolvedImport.toList: @unchecked
+      logging.fullName shouldBe "logger::program.Logger.new"
+    }
+
+    "provide a dummy type" in {
+      val Some(log) = cpg.identifier("log").headOption: @unchecked
+      log.typeFullName shouldBe "logger::program.Logger"
+      val List(errorCall) = cpg.call("error").l
+      errorCall.methodFullName shouldBe "logger::program.Logger.error"
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -27,7 +27,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for an unsigned, decimal integer literal" in {
       val cpg           = code("123")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "123"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -36,7 +36,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a +integer, decimal literal" in {
       val cpg           = code("+1")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "+1"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -45,7 +45,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a -integer, decimal literal" in {
       val cpg           = code("-1")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "-1"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -54,7 +54,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for an unsigned, decimal float literal" in {
       val cpg           = code("3.14")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Float
+      literal.typeFullName shouldBe "__builtin.Float"
       literal.code shouldBe "3.14"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -63,7 +63,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a +float, decimal literal" in {
       val cpg           = code("+3.14")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Float
+      literal.typeFullName shouldBe "__builtin.Float"
       literal.code shouldBe "+3.14"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -72,7 +72,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a -float, decimal literal" in {
       val cpg           = code("-3.14")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Float
+      literal.typeFullName shouldBe "__builtin.Float"
       literal.code shouldBe "-3.14"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -81,7 +81,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for an unsigned, decimal float literal with unsigned exponent" in {
       val cpg           = code("3e10")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Float
+      literal.typeFullName shouldBe "__builtin.Float"
       literal.code shouldBe "3e10"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -90,7 +90,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for an unsigned, decimal float literal with -exponent" in {
       val cpg           = code("12e-10")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Float
+      literal.typeFullName shouldBe "__builtin.Float"
       literal.code shouldBe "12e-10"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -99,7 +99,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for an unsigned, binary integer literal" in {
       val cpg           = code("0b01")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "0b01"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -108,7 +108,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a -integer, binary literal" in {
       val cpg           = code("-0b01")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "-0b01"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -117,7 +117,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a +integer, binary literal" in {
       val cpg           = code("+0b01")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "+0b01"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -126,7 +126,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for an unsigned, hexadecimal integer literal" in {
       val cpg           = code("0xabc")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "0xabc"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -135,7 +135,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a -integer, hexadecimal literal" in {
       val cpg           = code("-0xa")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "-0xa"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -144,7 +144,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a +integer, hexadecimal literal" in {
       val cpg           = code("+0xa")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.Integer
+      literal.typeFullName shouldBe "__builtin.Integer"
       literal.code shouldBe "+0xa"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -189,7 +189,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for `__FILE__` identifier" in {
       val cpg        = code("puts __FILE__")
       val List(file) = cpg.identifier.l
-      file.typeFullName shouldBe Defines.String
+      file.typeFullName shouldBe "__builtin.String"
       file.code shouldBe "__FILE__"
       file.lineNumber shouldBe Some(1)
       file.columnNumber shouldBe Some(5)
@@ -198,7 +198,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for `__LINE__` identifier" in {
       val cpg        = code("puts __LINE__")
       val List(line) = cpg.identifier.l
-      line.typeFullName shouldBe Defines.Integer
+      line.typeFullName shouldBe "__builtin.Integer"
       line.code shouldBe "__LINE__"
       line.lineNumber shouldBe Some(1)
       line.columnNumber shouldBe Some(5)
@@ -216,7 +216,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a single-line double-quoted string literal" in {
       val cpg           = code("\"hello\"")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.String
+      literal.typeFullName shouldBe "__builtin.String"
       literal.code shouldBe "\"hello\""
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)
@@ -225,7 +225,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a single-line single-quoted string literal" in {
       val cpg           = code("'hello'")
       val List(literal) = cpg.literal.l
-      literal.typeFullName shouldBe Defines.String
+      literal.typeFullName shouldBe "__builtin.String"
       literal.code shouldBe "'hello'"
       literal.lineNumber shouldBe Some(1)
       literal.columnNumber shouldBe Some(0)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -34,7 +34,6 @@ class DefaultTestCpgWithRuby(withPostProcessing: Boolean, withDataFlow: Boolean,
     if (withPostProcessing) {
       packageTable match {
         case Some(table) =>
-          RubySrc2Cpg.packageTableInfo.clear()
           RubySrc2Cpg.packageTableInfo.set(table)
         case None =>
       }


### PR DESCRIPTION
The PR contains the following
- Streamlined built-in primitives generation for ruby. Ex - The type for Integer will be `__builtin.Integer`
- Support for resolving Module variables across file in Type Recovery
- Have Ignored 3 test cases in TypeRecovery which will be fixed once the Ast Generation for Modules is in place
- Added a data structure in packageTable to store Encountered Modules. (May not need this in future)
cc - @DavidBakerEffendi 