### PR TITLE
rubysrc2cpg: Implicit return handling in blocks

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -71,6 +71,11 @@ class AstCreator(
   protected val relativeFilename: String =
     projectRoot.map(filename.stripPrefix).map(_.stripPrefix(JFile.separator)).getOrElse(filename)
 
+  protected var processingLastMethodStatement = false
+  protected var blockIdCounter                = 1
+  protected var currentBlockId                = 0
+  protected val blockChildHash                = mutable.HashMap[Int, Int]()
+
   protected def createIdentifierWithScope(
     ctx: ParserRuleContext,
     name: String,
@@ -110,7 +115,7 @@ class AstCreator(
     val statementCtx = programCtx.compoundStatement().statements()
     scope.pushNewScope(())
     val statementAsts = if (statementCtx != null) {
-      astForStatements(statementCtx) ++ blockMethods
+      astForStatements(statementCtx, false, false) ++ blockMethods
     } else {
       List[Ast](Ast())
     }
@@ -285,7 +290,7 @@ class AstCreator(
       .interpolatedStringSequence()
       .asScala
       .flatMap(inter => {
-        astForStatements(inter.compoundStatement().statements())
+        astForStatements(inter.compoundStatement().statements(), false, false)
       })
       .toSeq
 
@@ -320,7 +325,7 @@ class AstCreator(
     case ctx: ForExpressionPrimaryContext      => Seq(astForForExpression(ctx.forExpression()))
     case ctx: JumpExpressionPrimaryContext     => astForJumpExpressionPrimaryContext(ctx)
     case ctx: BeginExpressionPrimaryContext    => astForBeginExpressionPrimaryContext(ctx)
-    case ctx: GroupingExpressionPrimaryContext => astForCompoundStatement(ctx.compoundStatement())
+    case ctx: GroupingExpressionPrimaryContext => astForCompoundStatement(ctx.compoundStatement(), false, false)
     case ctx: VariableReferencePrimaryContext  => Seq(astForVariableReference(ctx.variableReference()))
     case ctx: SimpleScopedConstantReferencePrimaryContext =>
       astForSimpleScopedConstantReferencePrimaryContext(ctx)
@@ -1059,7 +1064,7 @@ class AstCreator(
     */
   def astForClassBody(ctx: BodyStatementContext): Seq[Ast] = {
     val rootStatements =
-      Option(ctx).map(_.compoundStatement()).map(_.statements()).map(astForStatements).getOrElse(Seq())
+      Option(ctx).map(_.compoundStatement()).map(_.statements()).map(st => { astForStatements(st) }).getOrElse(Seq())
     retrieveAndGenerateClassChildren(ctx, rootStatements)
   }
 
@@ -1121,44 +1126,16 @@ class AstCreator(
     classInitMethodAst ++ uniqueMemberReferences ++ methodStmts
   }
 
-  private def convertLastStmtToReturn(compoundStatementAsts: Seq[Ast], ctxStmt: StatementsContext): Seq[Ast] = {
-    val lastStmtIsAlreadyReturn = compoundStatementAsts.last.root match {
-      case Some(value) => value.isInstanceOf[NewReturn]
-      case None        => false
-    }
-
-    val lastStmtIsLiteralIdentifier = compoundStatementAsts.last.root match {
-      case Some(value) => value.isInstanceOf[NewIdentifier] || value.isInstanceOf[NewLiteral]
-      case None        => false
-    }
-
-    if (
-      !lastStmtIsAlreadyReturn &&
-      ctxStmt != null
-    ) {
-      val len  = ctxStmt.statement().size()
-      var code = ctxStmt.statement().get(len - 1).getText
-      if (!lastStmtIsLiteralIdentifier) {
-        code = ""
-      }
-      val retNode = NewReturn()
-        .code(code)
-      val returnReplaced = returnAst(retNode, Seq[Ast](compoundStatementAsts.last))
-      compoundStatementAsts.updated(compoundStatementAsts.size - 1, returnReplaced)
-    } else {
-      compoundStatementAsts
-    }
-  }
-  def astForBodyStatementContext(ctx: BodyStatementContext, addReturnNode: Boolean = false): Seq[Ast] = {
-    val compoundStatementAsts = astForCompoundStatement(ctx.compoundStatement(), !addReturnNode)
-
+  def astForBodyStatementContext(ctx: BodyStatementContext, isMethodBody: Boolean = false): Seq[Ast] = {
     if (ctx.rescueClause().size > 0) {
+      val compoundStatementAsts = astForCompoundStatement(ctx.compoundStatement())
       val elseClauseAsts = Option(ctx.elseClause()) match
         case Some(ctx) => astForCompoundStatement(ctx.compoundStatement(), false)
         case None      => Seq()
 
       /*
        * TODO Conversion of last statement to return AST is needed here
+       * This can be done after the data flow engine issue with return from a try block is fixed
        */
       val tryBodyAsts = compoundStatementAsts ++ elseClauseAsts
       val tryBodyAst  = blockAst(blockNode(ctx), tryBodyAsts.toList)
@@ -1180,15 +1157,8 @@ class AstCreator(
         .columnNumber(column(ctx))
 
       Seq(tryCatchAst(tryNode, tryBodyAst, catchAsts, finallyAst))
-    } else if (addReturnNode && compoundStatementAsts.nonEmpty) {
-      /*
-       * Convert the last statement to a return AST if it is not already a return AST.
-       * If it is a return AST leave it untouched.
-       * TODO Handling for last statement being if-else is needed here
-       */
-      convertLastStmtToReturn(compoundStatementAsts, ctx.compoundStatement().statements())
     } else {
-      compoundStatementAsts
+      astForCompoundStatement(ctx.compoundStatement(), isMethodBody)
     }
   }
 
@@ -1198,7 +1168,7 @@ class AstCreator(
     val astMethodName     = astForMethodNamePartContext(ctx.methodNamePart())
     val callNode = astMethodName.head.nodes.filter(node => node.isInstanceOf[NewCall]).head.asInstanceOf[NewCall]
     // there can be only one call node
-    val astBody = astForBodyStatementContext(ctx.bodyStatement(), addReturnNode = true)
+    val astBody = astForBodyStatementContext(ctx.bodyStatement(), true)
     scope.popScope()
 
     /*
@@ -1490,10 +1460,8 @@ class AstCreator(
 
     val astMethodParam = ctxParam.map(astForBlockParameterContext).getOrElse(Seq())
     scope.pushNewScope(())
-    val astBodyWOReturn = astForStatements(ctxStmt)
+    val astBody = astForStatements(ctxStmt, true)
     scope.popScope()
-
-    val astBody = convertLastStmtToReturn(astBodyWOReturn, ctxStmt)
 
     val methodFullName = classStack.reverse :+ blockMethodName mkString pathSep
     val methodNode = NewMethod()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1064,7 +1064,7 @@ class AstCreator(
     */
   def astForClassBody(ctx: BodyStatementContext): Seq[Ast] = {
     val rootStatements =
-      Option(ctx).map(_.compoundStatement()).map(_.statements()).map(st => { astForStatements(st) }).getOrElse(Seq())
+      Option(ctx).map(_.compoundStatement()).map(_.statements()).map(astForStatements(_)).getOrElse(Seq())
     retrieveAndGenerateClassChildren(ctx, rootStatements)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -71,10 +71,20 @@ class AstCreator(
   protected val relativeFilename: String =
     projectRoot.map(filename.stripPrefix).map(_.stripPrefix(JFile.separator)).getOrElse(filename)
 
+  // The below are for adding implicit return nodes to methods
+
+  // This is true if the last statement of a method is being processed. The last statement could be a if-else as well
   protected var processingLastMethodStatement = false
-  protected var blockIdCounter                = 1
-  protected var currentBlockId                = 0
-  protected val blockChildHash                = mutable.HashMap[Int, Int]()
+  // a monotonically increasing block id unique within this file
+  protected var blockIdCounter = 1
+  // block id of the block currently being processed
+  protected var currentBlockId = 0
+  /*
+   * This is a hash of parent block id ---> child block id. If there are multiple children, any one child can be present.
+   * The value of this entry for a block is read AFTER its last statement has been processed. Absence of the the block
+   * in this hash implies this is a leaf block.
+   */
+  protected val blockChildHash = mutable.HashMap[Int, Int]()
 
   protected def createIdentifierWithScope(
     ctx: ParserRuleContext,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -7,7 +7,15 @@ import io.joern.x2cpg.Ast
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
 import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewCall, NewControlStructure, NewImport, NewLiteral}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  NewBlock,
+  NewCall,
+  NewControlStructure,
+  NewIdentifier,
+  NewImport,
+  NewLiteral,
+  NewReturn
+}
 import org.slf4j.LoggerFactory
 import org.antlr.v4.runtime.ParserRuleContext
 
@@ -83,19 +91,98 @@ trait AstForStatementsCreator {
     controlStructureAst(throwNode, rhs.headOption, lhs)
   }
 
-  protected def astForCompoundStatement(ctx: CompoundStatementContext, packInBlock: Boolean = true): Seq[Ast] = {
-    val stmtAsts = Option(ctx).map(_.statements()).map(astForStatements).getOrElse(Seq())
-    if (packInBlock) {
-      Seq(blockAst(blockNode(ctx), stmtAsts.toList))
+  private def lastStmtAsReturn(code: String, lastStmtAst: Ast): Ast = {
+    val lastStmtIsAlreadyReturn = lastStmtAst.root match {
+      case Some(value) => value.isInstanceOf[NewReturn]
+      case None        => false
+    }
+
+    if (lastStmtIsAlreadyReturn) {
+      lastStmtAst
     } else {
-      stmtAsts
+      val retNode = NewReturn()
+        .code(code)
+      returnAst(retNode, Seq[Ast](lastStmtAst))
     }
   }
 
-  protected def astForStatements(ctx: StatementsContext): Seq[Ast] = {
+  protected def astForCompoundStatement(
+    ctx: CompoundStatementContext,
+    isMethodBody: Boolean = false,
+    canConsiderAsLeaf: Boolean = true
+  ): Seq[Ast] = {
+    val stmtAsts = Option(ctx)
+      .map(_.statements())
+      .map(st => { astForStatements(st, isMethodBody, canConsiderAsLeaf) })
+      .getOrElse(Seq())
+    if (isMethodBody) {
+      stmtAsts
+    } else {
+      Seq(blockAst(blockNode(ctx), stmtAsts.toList))
+
+    }
+  }
+
+  /*
+   * We will convert the last statement of the last leaf block in the hierarchy of blocks to a return
+   * isMethodBody => The statement set is the top level block in the method. i.e. the root block
+   * canConsiderAsLeaf => The statement set can be considered a leaf block. This is set to false by the caller when it is a statement
+   * set as a part of an expression. Eg. argument in string interpolation. We do not want to construct return nodes out of
+   * string interpolation arguments
+   * blockChildHash => Hash of a block id to any child. Absence of a block in this after all its statements have been processed implies
+   * that the block is a leaf
+   * blockIdCounter => A simple counter used to assign an id to each block.
+   */
+  protected def astForStatements(
+    ctx: StatementsContext,
+    isMethodBody: Boolean = false,
+    canConsiderAsLeaf: Boolean = true
+  ): Seq[Ast] = {
     Option(ctx) match {
       case Some(ctx) =>
-        Option(ctx).map(_.statement()).map(_.asScala).getOrElse(Seq()).flatMap(astForStatement).toSeq
+        val stmtCount   = ctx.statement().size()
+        var stmtCounter = 0
+        val myBlockId   = blockIdCounter
+        blockIdCounter += 1
+        val parentBlockId = currentBlockId
+        if (canConsiderAsLeaf) {
+          blockChildHash.update(parentBlockId, myBlockId)
+        }
+        currentBlockId = myBlockId
+
+        val stmtAsts = Option(ctx)
+          .map(_.statement())
+          .map(_.asScala)
+          .getOrElse(Seq())
+          .flatMap(stCtx => {
+            stmtCounter += 1
+            if (isMethodBody) {
+              if (stmtCounter == stmtCount) {
+                processingLastMethodStatement = true
+              } else {
+                processingLastMethodStatement = false
+              }
+            }
+            val stAsts = astForStatement(stCtx)
+            if (canConsiderAsLeaf && processingLastMethodStatement) {
+              blockChildHash.get(myBlockId) match {
+                case Some(value) =>
+                  // this is a non-leaf block
+                  stAsts
+                case None =>
+                  // this is a leaf block
+                  if (isMethodBody && stmtCounter == stmtCount) {
+                    processingLastMethodStatement = false
+                  }
+                  Seq(lastStmtAsReturn(stCtx.getText, stAsts.head))
+              }
+            } else {
+              stAsts
+            }
+          })
+          .toSeq
+        currentBlockId = parentBlockId
+        stmtAsts
       case None =>
         Seq()
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -124,14 +124,20 @@ trait AstForStatementsCreator {
   }
 
   /*
-   * We will convert the last statement of the last leaf block in the hierarchy of blocks to a return
+   * Each statement set can be considered a block. The blocks of a method can be considered to form a hierarchy.
+   * We can consider the blocks structure as a n-way tree. Leaf blocks are blocks that have no more sub blocks i.e children in the
+   * hierarchy. The last statement of the block of the method which is the top level/root block i.e. method body should be
+   * converted into a implicit return. However, if the last statement is a if-else it has sub-blocks/child blocks and the last statement of each leaf block in it
+   * will have to be converted to a implicit return, unless it is already a implicit return.
+   * Some sub-blocks are exempt from their last statements being converted to returns. Examples are blocks that are arguments to functions like string interpolation.
+   *
    * isMethodBody => The statement set is the top level block in the method. i.e. the root block
    * canConsiderAsLeaf => The statement set can be considered a leaf block. This is set to false by the caller when it is a statement
    * set as a part of an expression. Eg. argument in string interpolation. We do not want to construct return nodes out of
-   * string interpolation arguments
+   * string interpolation arguments. These are exempt blocks for implicit returns.
    * blockChildHash => Hash of a block id to any child. Absence of a block in this after all its statements have been processed implies
    * that the block is a leaf
-   * blockIdCounter => A simple counter used to assign an id to each block.
+   * blockIdCounter => A simple counter used to assign an unique id to each block.
    */
   protected def astForStatements(
     ctx: StatementsContext,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -92,8 +92,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     }
   }
 
-  // TODO:
-  "Implicit return in if-else block" ignore {
+  "Implicit return in if-else block" should {
     val cpg = code("""
         |def foo(arg)
         |if arg > 1
@@ -106,6 +105,33 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
         |x = 1
         |y = foo x
         |puts y
+        |""".stripMargin)
+
+    "be found" in {
+      val src  = cpg.identifier.name("x").l
+      val sink = cpg.call.name("puts").l
+      sink.reachableByFlows(src).l.size shouldBe 2
+    }
+  }
+
+  "Implicit return in if-else block and underlying function call" should {
+    val cpg = code("""
+        |def add(arg)
+        |arg + 100
+        |end
+        |
+        |def foo(arg)
+        |if arg > 1
+        |        add(arg)
+        |else
+        |        add(arg)
+        |end
+        |end
+        |
+        |x = 1
+        |y = foo x
+        |puts y
+        |
         |""".stripMargin)
 
     "be found" in {
@@ -2055,8 +2081,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     }
   }
 
-  // TODO:
-  "Data flow through ensureClause" ignore {
+  "Data flow through ensureClause" should {
     val cpg = code("""
         |begin
         |    x = File.open("myFile.txt", "r")
@@ -2074,12 +2099,11 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).size shouldBe 3
+      sink.reachableByFlows(source).size shouldBe 2 // flow through the rescue is not a flow
     }
   }
 
-  // TODO:
-  "Data flow through begin-else" ignore {
+  "Data flow through begin-else" should {
     val cpg = code("""
         |begin
         |    x = File.open("myFile.txt", "r")
@@ -2107,8 +2131,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     }
   }
 
-  // TODO:
-  "Data flow through block argument context" ignore {
+  "Data flow through block argument context" should {
     val cpg = code("""
         |x=10
         |y=0
@@ -2130,12 +2153,11 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).size shouldBe 3
+      sink.reachableByFlows(source).size shouldBe 2
     }
   }
 
-  // TODO:
-  "Data flow through block splatting type arguments context" ignore {
+  "Data flow through block splatting type arguments context" should {
     val cpg = code("""
         |x=10
         |y=0
@@ -2157,12 +2179,11 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).size shouldBe 3
+      sink.reachableByFlows(source).size shouldBe 2
     }
   }
 
-  // TODO:
-  "Flow through tainted object" ignore {
+  "Flow through tainted object" should {
     val cpg = code("""
         |def put_req(api_endpoint, params)
         |    puts "Hitting " + api_endpoint + " with params: " + params
@@ -2181,7 +2202,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     "find flows to the sink" in {
       val source = cpg.identifier.name("accountId").l
       val sink   = cpg.call.name("put_req").l
-      sink.reachableByFlows(source).size shouldBe 3
+      sink.reachableByFlows(source).size shouldBe 1
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -108,17 +108,16 @@ class MethodOneTests extends RubyCode2CpgFixture {
 
     "be correct for multiple returns" in {
       cpg.method("foo").methodReturn.l.size shouldBe 1
-      cpg.method("foo").ast.isReturn.l.size shouldBe 3 // there is 1 implicit return node also
+      cpg.method("foo").ast.isReturn.l.size shouldBe 2
       inside(cpg.method("foo").methodReturn.l) { case List(fooReturn) =>
         fooReturn.typeFullName shouldBe "ANY"
       }
       val astReturns = cpg.method("foo").ast.isReturn.l
-      inside(astReturns) { case List(ret1, ret2, ret3) =>
-        ret1.code shouldBe ""
-        ret2.code shouldBe "return 1"
-        ret2.lineNumber shouldBe Option(4)
-        ret3.code shouldBe "return 2"
-        ret3.lineNumber shouldBe Option(6)
+      inside(astReturns) { case List(ret1, ret2) =>
+        ret1.code shouldBe "return 1"
+        ret1.lineNumber shouldBe Option(4)
+        ret2.code shouldBe "return 2"
+        ret2.lineNumber shouldBe Option(6)
       }
     }
   }


### PR DESCRIPTION
1. Got implicit returns working when the last method statement is not just an expression but contains blocks like if-else
2. Could not do this for the last statement of begin blocks since there is an existing issue with the data flow engine. The below Java code does not return flows due to that issue. Raised it with @fabsx00 separately.
3. Enabled and corrected some other test cases that are working.

Java code that does not produce data flows.
```
public class Main {
  public static int foo(String args) {
    try {
      System.out.println("in begin");
      return 0 ;
    } catch (Exception e) {
      System.out.println("Something went wrong." + args);
    }
  }
  public static void main(String[ ] args) {
       String x = "1";
       foo(x);
  }
}
```

If we set `source -> x` and `sink -> println()` we do not get data flows in the below code. However, if we remove `return 0`, we do get data flows.