### PR TITLE
rubysrc2cpg: Support for proc literals

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -136,6 +136,7 @@ DOT2: '..';
 DOT3: '...';
 QMARK: '?';
 EQGT: '=>';
+MINUSGT: '->';
 
 fragment PUNCTUATOR
     :   LBRACK

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -78,6 +78,7 @@ primary
     :   classDefinition                                                                                             # classDefinitionPrimary
     |   moduleDefinition                                                                                            # moduleDefinitionPrimary
     |   methodDefinition                                                                                            # methodDefinitionPrimary
+    |   procDefinition                                                                                              # procDefinitionPrimary
     |   yieldWithOptionalArgument                                                                                   # yieldWithOptionalArgumentPrimary
     |   ifExpression                                                                                                # ifExpressionPrimary
     |   unlessExpression                                                                                            # unlessExpressionPrimary
@@ -280,6 +281,10 @@ association
 
 methodDefinition
     :   DEF wsOrNl* methodNamePart WS* methodParameterPart wsOrNl* bodyStatement wsOrNl* END
+    ;
+
+procDefinition
+    :   MINUSGT WS? (LPAREN parameters? RPAREN)? WS? block
     ;
 
 methodNamePart

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
@@ -1,0 +1,201 @@
+package io.joern.rubysrc2cpg.parser
+
+class ProcDefinitionTests extends RubyParserAbstractTest {
+  
+  "A one-line proc definition" should {
+    
+    "be parsed as a primary expression" when {
+      
+      "it contains no parameters and no statements in a brace block" in {
+        val code = "-> {}"
+        printAst(_.primary(), code) shouldBe
+          """ProcDefinitionPrimary
+            | ProcDefinition
+            |  ->
+            |  BraceBlockBlock
+            |   BraceBlock
+            |    {
+            |    CompoundStatement
+            |    }""".stripMargin
+      }
+      
+      "it contains no parameters and no statements in a do block" in {
+        val code = "-> do ; end"
+        printAst(_.primary(), code) shouldBe
+          """ProcDefinitionPrimary
+            | ProcDefinition
+            |  ->
+            |  DoBlockBlock
+            |   DoBlock
+            |    do
+            |    WsOrNl
+            |    Separators
+            |     Separator
+            |      ;
+            |    WsOrNl
+            |    CompoundStatement
+            |    end""".stripMargin
+      }
+      
+      "it contains a mandatory parameter and no statements in a brace block" in {
+        val code = "-> (x) {}"
+        printAst(_.primary(), code) shouldBe
+          """ProcDefinitionPrimary
+            | ProcDefinition
+            |  ->
+            |  (
+            |  Parameters
+            |   Parameter
+            |    MandatoryParameter
+            |     x
+            |  )
+            |  BraceBlockBlock
+            |   BraceBlock
+            |    {
+            |    CompoundStatement
+            |    }""".stripMargin
+      }
+      
+      "it contains a mandatory parameter and no statements in a do block" in {
+        val code = "-> (x) do ; end"
+        printAst(_.primary(), code) shouldBe
+          """ProcDefinitionPrimary
+            | ProcDefinition
+            |  ->
+            |  (
+            |  Parameters
+            |   Parameter
+            |    MandatoryParameter
+            |     x
+            |  )
+            |  DoBlockBlock
+            |   DoBlock
+            |    do
+            |    WsOrNl
+            |    Separators
+            |     Separator
+            |      ;
+            |    WsOrNl
+            |    CompoundStatement
+            |    end""".stripMargin
+      }
+      
+      "it contains an optional numeric parameter and no statements in a brace block" in {
+        val code = "->(x = 1) {}"
+        printAst(_.primary(), code) shouldBe
+          """ProcDefinitionPrimary
+            | ProcDefinition
+            |  ->
+            |  (
+            |  Parameters
+            |   Parameter
+            |    OptionalParameter
+            |     x
+            |     =
+            |     WsOrNl
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       NumericLiteralLiteral
+            |        NumericLiteral
+            |         UnsignedNumericLiteral
+            |          1
+            |  )
+            |  BraceBlockBlock
+            |   BraceBlock
+            |    {
+            |    CompoundStatement
+            |    }""".stripMargin
+      }
+      
+      "it contains a keyword parameter and no statements in a do block" in {
+        val code = "-> (foo: 1) do ; end"
+        printAst(_.primary(), code) shouldBe
+          """ProcDefinitionPrimary
+            | ProcDefinition
+            |  ->
+            |  (
+            |  Parameters
+            |   Parameter
+            |    KeywordParameter
+            |     foo
+            |     :
+            |     WsOrNl
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       NumericLiteralLiteral
+            |        NumericLiteral
+            |         UnsignedNumericLiteral
+            |          1
+            |  )
+            |  DoBlockBlock
+            |   DoBlock
+            |    do
+            |    WsOrNl
+            |    Separators
+            |     Separator
+            |      ;
+            |    WsOrNl
+            |    CompoundStatement
+            |    end""".stripMargin
+      }
+      
+      "it contains two mandatory parameters and two puts statements in a brace block" in {
+        val code = "->(x, y) {puts x; puts y}"
+        printAst(_.primary(), code) shouldBe
+          """ProcDefinitionPrimary
+            | ProcDefinition
+            |  ->
+            |  (
+            |  Parameters
+            |   Parameter
+            |    MandatoryParameter
+            |     x
+            |   ,
+            |   WsOrNl
+            |   Parameter
+            |    MandatoryParameter
+            |     y
+            |  )
+            |  BraceBlockBlock
+            |   BraceBlock
+            |    {
+            |    CompoundStatement
+            |     Statements
+            |      ExpressionOrCommandStatement
+            |       InvocationExpressionOrCommand
+            |        SingleCommandOnlyInvocationWithoutParentheses
+            |         SimpleMethodCommand
+            |          MethodIdentifier
+            |           puts
+            |          ArgumentsWithoutParentheses
+            |           Arguments
+            |            ExpressionArgument
+            |             PrimaryExpression
+            |              VariableReferencePrimary
+            |               VariableIdentifierVariableReference
+            |                VariableIdentifier
+            |                 x
+            |      Separators
+            |       Separator
+            |        ;
+            |      ExpressionOrCommandStatement
+            |       InvocationExpressionOrCommand
+            |        SingleCommandOnlyInvocationWithoutParentheses
+            |         SimpleMethodCommand
+            |          MethodIdentifier
+            |           puts
+            |          ArgumentsWithoutParentheses
+            |           Arguments
+            |            ExpressionArgument
+            |             PrimaryExpression
+            |              VariableReferencePrimary
+            |               VariableIdentifierVariableReference
+            |                VariableIdentifier
+            |                 y
+            |    }""".stripMargin
+      }
+      
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
@@ -1,11 +1,11 @@
 package io.joern.rubysrc2cpg.parser
 
 class ProcDefinitionTests extends RubyParserAbstractTest {
-  
+
   "A one-line proc definition" should {
-    
+
     "be parsed as a primary expression" when {
-      
+
       "it contains no parameters and no statements in a brace block" in {
         val code = "-> {}"
         printAst(_.primary(), code) shouldBe
@@ -18,7 +18,7 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    CompoundStatement
             |    }""".stripMargin
       }
-      
+
       "it contains no parameters and no statements in a do block" in {
         val code = "-> do ; end"
         printAst(_.primary(), code) shouldBe
@@ -36,7 +36,7 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    CompoundStatement
             |    end""".stripMargin
       }
-      
+
       "it contains a mandatory parameter and no statements in a brace block" in {
         val code = "-> (x) {}"
         printAst(_.primary(), code) shouldBe
@@ -55,7 +55,7 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    CompoundStatement
             |    }""".stripMargin
       }
-      
+
       "it contains a mandatory parameter and no statements in a do block" in {
         val code = "-> (x) do ; end"
         printAst(_.primary(), code) shouldBe
@@ -79,7 +79,7 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    CompoundStatement
             |    end""".stripMargin
       }
-      
+
       "it contains an optional numeric parameter and no statements in a brace block" in {
         val code = "->(x = 1) {}"
         printAst(_.primary(), code) shouldBe
@@ -106,7 +106,7 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    CompoundStatement
             |    }""".stripMargin
       }
-      
+
       "it contains a keyword parameter and no statements in a do block" in {
         val code = "-> (foo: 1) do ; end"
         printAst(_.primary(), code) shouldBe
@@ -138,7 +138,7 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    CompoundStatement
             |    end""".stripMargin
       }
-      
+
       "it contains two mandatory parameters and two puts statements in a brace block" in {
         val code = "->(x, y) {puts x; puts y}"
         printAst(_.primary(), code) shouldBe
@@ -194,7 +194,7 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |                 y
             |    }""".stripMargin
       }
-      
+
     }
   }
 


### PR DESCRIPTION
Closes #3043 