### PR TITLE
RubyLexer: extra regex unit-test

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -258,6 +258,20 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     )
   }
 
+  "Non-empty regex literal on the RHS of an assignment" should "be recognized as such" in {
+    val code = """NAME_REGEX = /\A[^0-9!\``@#\$%\^&*+_=]+\z/"""
+    tokenize(code) shouldBe Seq(
+      CONSTANT_IDENTIFIER,
+      WS,
+      EQ,
+      WS,
+      REGULAR_EXPRESSION_START,
+      REGULAR_EXPRESSION_BODY,
+      REGULAR_EXPRESSION_END,
+      EOF
+    )
+  }
+
   "Regex literals without metacharacters" should "be recognized as such" in {
     val eg = Seq("/regexp/", "/a regexp/")
     all(eg.map(tokenize)) shouldBe Seq(REGULAR_EXPRESSION_START, REGULAR_EXPRESSION_BODY, REGULAR_EXPRESSION_END, EOF)
@@ -505,5 +519,4 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
-
 }


### PR DESCRIPTION
Used, in a private discussion, to show that this is properly parsed. Might as well add it since there's no similar unit-test for this.