### PR TITLE
RubyParser: fix missing WS for singleton class definitions

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -464,7 +464,7 @@ ensureClause
 
 classDefinition
     :   CLASS wsOrNl* classOrModuleReference WS* (LT wsOrNl* expressionOrCommand)? separators wsOrNl* bodyStatement wsOrNl* END
-    |   CLASS wsOrNl* LT2 expressionOrCommand separator bodyStatement wsOrNl* END
+    |   CLASS wsOrNl* LT2 wsOrNl* expressionOrCommand separators wsOrNl* bodyStatement wsOrNl* END
     ;
 
 classOrModuleReference

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
@@ -1,11 +1,11 @@
 package io.joern.rubysrc2cpg.parser
 
 class ClassDefinitionTests extends RubyParserAbstractTest {
-  
+
   "A one-line singleton class definition" should {
-    
+
     "be parsed as a primary expression" when {
-      
+
       "it contains no members" in {
         val code = "class << self ; end"
         printAst(_.primary(), code) shouldBe
@@ -31,11 +31,11 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
       }
     }
   }
-  
+
   "A multi-line singleton class definition" should {
-    
+
     "be parsed as a primary expression" when {
-      
+
       "it contains a single method definition" in {
         val code =
           """class << x

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
@@ -1,0 +1,108 @@
+package io.joern.rubysrc2cpg.parser
+
+class ClassDefinitionTests extends RubyParserAbstractTest {
+  
+  "A one-line singleton class definition" should {
+    
+    "be parsed as a primary expression" when {
+      
+      "it contains no members" in {
+        val code = "class << self ; end"
+        printAst(_.primary(), code) shouldBe
+          """ClassDefinitionPrimary
+            | ClassDefinition
+            |  class
+            |  WsOrNl
+            |  <<
+            |  WsOrNl
+            |  ExpressionExpressionOrCommand
+            |   PrimaryExpression
+            |    VariableReferencePrimary
+            |     PseudoVariableIdentifierVariableReference
+            |      SelfPseudoVariableIdentifier
+            |       self
+            |  Separators
+            |   Separator
+            |    ;
+            |  WsOrNl
+            |  BodyStatement
+            |   CompoundStatement
+            |  end""".stripMargin
+      }
+    }
+  }
+  
+  "A multi-line singleton class definition" should {
+    
+    "be parsed as a primary expression" when {
+      
+      "it contains a single method definition" in {
+        val code =
+          """class << x
+            | def show; puts self; end
+            |end""".stripMargin
+        printAst(_.primary(), code) shouldBe
+          """ClassDefinitionPrimary
+            | ClassDefinition
+            |  class
+            |  WsOrNl
+            |  <<
+            |  WsOrNl
+            |  ExpressionExpressionOrCommand
+            |   PrimaryExpression
+            |    VariableReferencePrimary
+            |     VariableIdentifierVariableReference
+            |      VariableIdentifier
+            |       x
+            |  Separators
+            |   Separator
+            |  WsOrNl
+            |  BodyStatement
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       PrimaryExpression
+            |        MethodDefinitionPrimary
+            |         MethodDefinition
+            |          def
+            |          WsOrNl
+            |          SimpleMethodNamePart
+            |           DefinedMethodName
+            |            MethodName
+            |             MethodIdentifier
+            |              show
+            |          MethodParameterPart
+            |           Separator
+            |            ;
+            |          WsOrNl
+            |          BodyStatement
+            |           CompoundStatement
+            |            Statements
+            |             ExpressionOrCommandStatement
+            |              InvocationExpressionOrCommand
+            |               SingleCommandOnlyInvocationWithoutParentheses
+            |                SimpleMethodCommand
+            |                 MethodIdentifier
+            |                  puts
+            |                 ArgumentsWithoutParentheses
+            |                  Arguments
+            |                   ExpressionArgument
+            |                    PrimaryExpression
+            |                     VariableReferencePrimary
+            |                      PseudoVariableIdentifierVariableReference
+            |                       SelfPseudoVariableIdentifier
+            |                        self
+            |            Separators
+            |             Separator
+            |              ;
+            |          WsOrNl
+            |          end
+            |    Separators
+            |     Separator
+            |  end""".stripMargin
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Also found in #3043. 