### PR TITLE
RubySrc2Cpg : Change in packageTable schema

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportResolverPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportResolverPass.scala
@@ -73,10 +73,13 @@ class ImportResolverPass(cpg: Cpg, packageTableInfo: PackageTable) extends XImpo
           .flatMap(module => Seq(ResolvedTypeDecl(module.fullName)))
           .toSet
 
+        // Expose methods which are directly present in a file, without any module, TypeDecl
         val resolvedMethods = cpg.method
           .where(_.file.name(s"${Pattern.quote(expResolvedPath)}\\.?.*"))
-          .whereNot(_.nameExact(":program"))
-          .whereNot(_.nameExact("<clinit>"))
+          .where(_.nameExact(":program"))
+          .astChildren
+          .astChildren
+          .isMethod
           .flatMap(method => Seq(ResolvedMethod(method.fullName, method.name)))
           .toSet
         resolvedTypeDecls ++ resolvedModules ++ resolvedMethods

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryPass.scala
@@ -92,7 +92,14 @@ private class RecoverForRubyFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, 
       visitIdentifierAssignedToCall(i, c)
     } else if (
       c.argument.headOption
-        .exists(_.isCall) && c.argument.head.asInstanceOf[Call].name.equals("<operator>.scopeResolution")
+        .exists(_.isCall) && c.argument.head
+        .asInstanceOf[Call]
+        .name
+        .equals("<operator>.scopeResolution") && c.argument.head
+        .asInstanceOf[Call]
+        .argument
+        .lastOption
+        .exists(symbolTable.contains)
     ) {
       setCallMethodFullNameFromBaseScopeResolution(c)
       // Repeat this method now that the call has a type

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/PackageTable.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.utils
 
 import java.io.File as JFile
-import java.util.regex.Matcher
+import java.util.regex.Pattern
 import scala.collection.mutable
 
 case class MethodTableModel(methodName: String, parentClassPath: String, classType: String)
@@ -21,7 +21,7 @@ class PackageTable {
   }
 
   def addModule(gemOrFileName: String, moduleName: String, modulePath: String): Unit = {
-    val fName = gemOrFileName.split(Matcher.quoteReplacement(JFile.separator)).lastOption.getOrElse(gemOrFileName)
+    val fName = gemOrFileName.split(Pattern.quote(JFile.separator)).lastOption.getOrElse(gemOrFileName)
     moduleMapping.getOrElseUpdate(gemOrFileName, mutable.HashSet.empty[ModuleModel]) += ModuleModel(
       moduleName,
       s"$fName::program.$modulePath"
@@ -29,7 +29,7 @@ class PackageTable {
   }
 
   def addTypeDecl(gemOrFileName: String, typeDeclName: String, typeDeclPath: String): Unit = {
-    val fName = gemOrFileName.split(Matcher.quoteReplacement(JFile.separator)).lastOption.getOrElse(gemOrFileName)
+    val fName = gemOrFileName.split(Pattern.quote(JFile.separator)).lastOption.getOrElse(gemOrFileName)
     typeDeclMapping.getOrElseUpdate(gemOrFileName, mutable.HashSet.empty[TypeDeclModel]) += TypeDeclModel(
       typeDeclName,
       s"$fName::program.$typeDeclPath"


### PR DESCRIPTION
The PR contains the following
- Change in the package table schema to hold module and TypeDecl
- Updated ImportResolverPass to be more robust
- Added test case and handling to get types from scopeResolution access

cc - @fabsx00 @DavidBakerEffendi 