### PR TITLE
RubyLexer: disambiguate `x+@y`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -193,8 +193,10 @@ SLASH: '/'
 ;
 PERCENT: '%';
 TILDE: '~';
-PLUSAT: '+@';
-MINUSAT: '-@';
+// These tokens should only occur after a DEF token, as they are solely used to (re)define unary + and - operators.
+// This way we won't emit the wrong token in e.g. `x+@y` (which means + between x and @y)
+PLUSAT: '+@'  {previousNonWsTokenTypeOrEOF() == DEF}?;
+MINUSAT: '-@' {previousNonWsTokenTypeOrEOF() == DEF}?;
 
 ASSIGNMENT_OPERATOR
     :   ASSIGNMENT_OPERATOR_NAME '='
@@ -429,6 +431,8 @@ fragment LINE_TERMINATOR
 
 SYMBOL_LITERAL
     :   ':' SYMBOL_NAME
+    |   ':+@'
+    |   ':-@'
     ;
 
 fragment SYMBOL_NAME

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.parser
 
-import io.joern.rubysrc2cpg.parser.RubyLexer._
+import io.joern.rubysrc2cpg.parser.RubyLexer.*
+import org.antlr.v4.runtime.Recognizer.EOF
 import org.antlr.v4.runtime.{CharStream, Lexer, Token}
 
 /** Aggregates auxiliary features to RubyLexer in a single place. */
@@ -26,6 +27,10 @@ abstract class RubyLexerBase(input: CharStream)
     }
     previousToken = Some(token)
     token
+  }
+  
+  def previousNonWsTokenTypeOrEOF(): Int = {
+    previousNonWsToken.map(_.getType).getOrElse(EOF)
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
@@ -28,7 +28,7 @@ abstract class RubyLexerBase(input: CharStream)
     previousToken = Some(token)
     token
   }
-  
+
   def previousNonWsTokenTypeOrEOF(): Int = {
     previousNonWsToken.map(_.getType).getOrElse(EOF)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -352,13 +352,13 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     val code = "x / y"
     tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, WS, SLASH, WS, LOCAL_VARIABLE_IDENTIFIER, EOF)
   }
-  
+
   "Addition between class fields" should "not be confused with +@ token" in {
     // This test exists to check if RubyLexer properly decided between PLUS and PLUSAT
     val code = "x+@y"
-    tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER,PLUS, INSTANCE_VARIABLE_IDENTIFIER, EOF) 
+    tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, PLUS, INSTANCE_VARIABLE_IDENTIFIER, EOF)
   }
-  
+
   "Subtraction between class fields" should "not be confused with -@ token" in {
     // This test exists to check if RubyLexer properly decided between MINUS and MINUSAT
     val code = "x-@y"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -352,6 +352,18 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     val code = "x / y"
     tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, WS, SLASH, WS, LOCAL_VARIABLE_IDENTIFIER, EOF)
   }
+  
+  "Addition between class fields" should "not be confused with +@ token" in {
+    // This test exists to check if RubyLexer properly decided between PLUS and PLUSAT
+    val code = "x+@y"
+    tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER,PLUS, INSTANCE_VARIABLE_IDENTIFIER, EOF) 
+  }
+  
+  "Subtraction between class fields" should "not be confused with -@ token" in {
+    // This test exists to check if RubyLexer properly decided between MINUS and MINUSAT
+    val code = "x-@y"
+    tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, MINUS, INSTANCE_VARIABLE_IDENTIFIER, EOF)
+  }
 
   "Invocation of command with regex literal" should "not be confused with binary division" in {
     val code = "puts /x/"


### PR DESCRIPTION
Expressions like `x+@y`, which mean addition between `x` and `@y`, were not being properly lexed since `+@` is a token by itself. However, the usage of `+@` is restricted to (re-)definitions of the unary `+` (and `-`) operator. To disambiguate, we shall only emit `+@` tokens when the previous non-whitespace token is `def`, thus complying with the restriction.

Found in #3037. 