### PR TITLE
Support for constants of Module and class

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -242,7 +242,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
      */
 
     val variableName      = ctx.getText
-    val isSelfFieldAccess = variableName.startsWith("@")
+    val isSelfFieldAccess = variableName.startsWith("@") || variableName.forall(x => x.isUpper || !x.isLetter)
     if (isSelfFieldAccess) {
       // Very basic field detection
       fieldReferences.updateWith(classStack.top) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -6,7 +6,7 @@ import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.{NewFieldIdentifier, NewJumpTarget, NewLiteral, NewNode}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
-
+import io.joern.x2cpg.utils._
 import scala.collection.immutable.Set
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -242,7 +242,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
      */
 
     val variableName      = ctx.getText
-    val isSelfFieldAccess = variableName.startsWith("@") || variableName.forall(x => x.isUpper || !x.isLetter)
+    val isSelfFieldAccess = variableName.startsWith("@") || variableName.isAllUpperCase
     if (isSelfFieldAccess) {
       // Very basic field detection
       fieldReferences.updateWith(classStack.top) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -115,12 +115,13 @@ trait AstForTypesCreator { this: AstCreator =>
 
   def membersFromStatementAsts(ast: Ast): Seq[Ast] =
     ast.nodes
-      .collect { case i: NewIdentifier if i.name.startsWith("@") => i }
+      .collect { case i: NewIdentifier if i.name.startsWith("@") || i.name.forall(x => x.isUpper || !x.isLetter) => i }
       .map { i =>
         val code = ast.root.collect { case c: NewCall => c.code }.getOrElse(i.name)
         val modifierType = i.name match
-          case x if x.startsWith("@@") => ModifierTypes.STATIC
-          case _                       => ModifierTypes.VIRTUAL
+          case x if x.startsWith("@@")                      => ModifierTypes.STATIC
+          case x if x.forall(y => y.isUpper || !y.isLetter) => ModifierTypes.FINAL
+          case _                                            => ModifierTypes.VIRTUAL
         val modifierAst = Ast(NewModifier().modifierType(modifierType))
         Ast(
           NewMember()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -11,7 +11,7 @@ import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.antlr.v4.runtime.ParserRuleContext
-
+import io.joern.x2cpg.utils._
 import scala.collection.mutable
 
 trait AstForTypesCreator { this: AstCreator =>
@@ -115,13 +115,13 @@ trait AstForTypesCreator { this: AstCreator =>
 
   def membersFromStatementAsts(ast: Ast): Seq[Ast] =
     ast.nodes
-      .collect { case i: NewIdentifier if i.name.startsWith("@") || i.name.forall(x => x.isUpper || !x.isLetter) => i }
+      .collect { case i: NewIdentifier if i.name.startsWith("@") || i.name.isAllUpperCase => i }
       .map { i =>
         val code = ast.root.collect { case c: NewCall => c.code }.getOrElse(i.name)
         val modifierType = i.name match
-          case x if x.startsWith("@@")                      => ModifierTypes.STATIC
-          case x if x.forall(y => y.isUpper || !y.isLetter) => ModifierTypes.FINAL
-          case _                                            => ModifierTypes.VIRTUAL
+          case x if x.startsWith("@@") => ModifierTypes.STATIC
+          case x if x.isAllUpperCase   => ModifierTypes.FINAL
+          case _                       => ModifierTypes.VIRTUAL
         val modifierAst = Ast(NewModifier().modifierType(modifierType))
         Ast(
           NewMember()

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -72,7 +72,7 @@ class RubyTypeRecoveryTests
     }
 
     "resolve module constant type" in {
-      cpg.typeDecl("MyNamespace").l.size shouldBe 1
+      cpg.typeDecl("MyNamespace").size shouldBe 1
       val List(typeDecl) = cpg.typeDecl("MyNamespace").l
       val List(myconst)  = typeDecl.member.l
       myconst.typeFullName shouldBe "__builtin.Integer"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -72,9 +72,10 @@ class RubyTypeRecoveryTests
     }
 
     "resolve module constant type" in {
-      cpg.identifier("MY_CONSTANT").l.size shouldBe 1
-      val List(x) = cpg.identifier("MY_CONSTANT").l
-      x.typeFullName shouldBe "__builtin.Integer"
+      cpg.typeDecl("MyNamespace").l.size shouldBe 1
+      val List(typeDecl) = cpg.typeDecl("MyNamespace").l
+      val List(myconst)  = typeDecl.member.l
+      myconst.typeFullName shouldBe "__builtin.Integer"
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ModuleTests.scala
@@ -117,7 +117,7 @@ class ModuleTests extends RubyCode2CpgFixture {
     }
   }
 
-  "Module internal structure checks with Constant defined in moudle" should {
+  "Module internal structure checks with Constant defined in module" should {
     val cpg = code("""
         |module MyNamespace
         |  MY_CONSTANT = 0

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ModuleTests.scala
@@ -115,25 +115,18 @@ class ModuleTests extends RubyCode2CpgFixture {
       plays.name shouldBe "plays"
       cpg.fieldAccess.fieldIdentifier.canonicalName.l shouldBe List("plays")
     }
-
-    "Module Constant strucutre in place" ignore {
-      cpg.identifier("MY_CONSTANT").l.size shouldBe 1
-      val List(x)      = cpg.typeDecl("MyClass").l
-      val List(member) = x.member.l
-      member.name shouldBe "MY_CONSTANT"
-    }
   }
 
-  "Module internal structure checks with Constant defined in moudle" ignore {
+  "Module internal structure checks with Constant defined in moudle" should {
     val cpg = code("""
         |module MyNamespace
-        |  MY_CONSTANT = 100
+        |  MY_CONSTANT = 0
         |end
         |""".stripMargin)
     "member variables structure in place" in {
-      val List(classInit) = cpg.method(XDefines.StaticInitMethodName).l
-      classInit.fullName shouldBe s"Test0.rb::program.MyNamespace.${XDefines.StaticInitMethodName}"
-      val List(myconstant) = classInit.call.nameExact(Operators.fieldAccess).fieldAccess.l
+      val List(moduleInit) = cpg.method(XDefines.StaticInitMethodName).l
+      moduleInit.fullName shouldBe s"Test0.rb::program.MyNamespace.${XDefines.StaticInitMethodName}"
+      val List(myconstant) = moduleInit.call.nameExact(Operators.fieldAccess).fieldAccess.l
       myconstant.fieldIdentifier.canonicalName.headOption shouldBe Option("MY_CONSTANT")
 
       val List(myclassTd)  = cpg.typeDecl("MyNamespace").l
@@ -143,4 +136,74 @@ class ModuleTests extends RubyCode2CpgFixture {
     }
   }
 
+  "Hierarchical module checks with constants" ignore {
+    val cpg = code("""
+        |module MyNamespace
+        |  MY_CONSTANT = 0
+        |  @@plays = 0
+        |  module ChildModule
+        |    @@name = 0
+        |    MY_CONSTANT = 0
+        |  end
+        |end
+        |""".stripMargin)
+
+    "member variables structure in place" in {
+      val List(modInit1, modInit2) = cpg.method(XDefines.StaticInitMethodName).l
+      modInit1.fullName shouldBe s"Test0.rb::program.MyNamespace.${XDefines.StaticInitMethodName}"
+      val List(myconstantfa, playsfa) = modInit1.call.nameExact(Operators.fieldAccess).fieldAccess.l
+      myconstantfa.fieldIdentifier.canonicalName.headOption shouldBe Option("MY_CONSTANT")
+      playsfa.fieldIdentifier.canonicalName.headOption shouldBe Option("plays")
+
+      modInit2.fullName shouldBe s"Test0.rb::program.MyNamespace.ChildModule.${XDefines.StaticInitMethodName}"
+      val List(namefa, myconstant2fa) = modInit2.call.nameExact(Operators.fieldAccess).fieldAccess.l
+      myconstant2fa.fieldIdentifier.canonicalName.headOption shouldBe Option("MY_CONSTANT")
+      namefa.fieldIdentifier.canonicalName.headOption shouldBe Option("name")
+
+      val List(myclassTd2)          = cpg.typeDecl("ChildModule").l
+      val List(namem, myConstant2m) = myclassTd2.member.l
+      myConstant2m.name shouldBe "MY_CONSTANT"
+      namem.name shouldBe "name"
+      cpg.fieldAccess.fieldIdentifier.canonicalName.l shouldBe List("name", "MY_CONSTANT")
+
+      val List(myclassTd)           = cpg.typeDecl("MyNamespace").l
+      val List(myconstantm, playsm) = myclassTd.member.l
+      myconstantm.name shouldBe "MY_CONSTANT"
+      playsm.name shouldBe "plays"
+      cpg.fieldAccess.fieldIdentifier.canonicalName.l shouldBe List("MY_CONSTANT", "plays")
+
+    }
+  }
+
+  "Class inside module checks with constants" ignore {
+    val cpg = code("""
+        |module MyNamespace
+        |  MY_CONSTANT = 0
+        |  class ChildCls
+        |    MY_CONSTANT = 0
+        |  end
+        |end
+        |""".stripMargin)
+
+    "member variables structure in place" in {
+      val List(modInit1, modInit2) = cpg.method(XDefines.StaticInitMethodName).l
+      modInit1.fullName shouldBe s"Test0.rb::program.MyNamespace.${XDefines.StaticInitMethodName}"
+      val List(myconstant) = modInit1.call.nameExact(Operators.fieldAccess).fieldAccess.l
+      myconstant.fieldIdentifier.canonicalName.headOption shouldBe Option("MY_CONSTANT")
+
+      modInit2.fullName shouldBe s"Test0.rb::program.MyNamespace.ChildCls.${XDefines.StaticInitMethodName}"
+      val List(myconstant2) = modInit2.call.nameExact(Operators.fieldAccess).fieldAccess.l
+      myconstant2.fieldIdentifier.canonicalName.headOption shouldBe Option("MY_CONSTANT")
+
+      val List(myclassTd)  = cpg.typeDecl("MyNamespace").l
+      val List(myConstant) = myclassTd.member.l
+      myConstant.name shouldBe "MY_CONSTANT"
+      cpg.fieldAccess.fieldIdentifier.canonicalName.l shouldBe List("MY_CONSTANT")
+
+      val List(myclassTd2)  = cpg.typeDecl("ChildCls").l
+      val List(myConstant2) = myclassTd2.member.l
+      myConstant2.name shouldBe "MY_CONSTANT"
+      cpg.fieldAccess.fieldIdentifier.canonicalName.l shouldBe List("MY_CONSTANT")
+    }
+  }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/StringUtils.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/StringUtils.scala
@@ -1,0 +1,7 @@
+package io.joern.x2cpg.utils
+
+implicit class StringUtils(str: String) {
+  def isAllUpperCase: Boolean = {
+    str.forall(c => c.isUpper || !c.isLetter)
+  }
+}


### PR DESCRIPTION
1. Handled mapping of module and class constants as members of the TypeDecl.
2. Added additional unit tests to verify the changes.
3. Added a few more unit tests which verify if hierarchical modules or classes are defined with members. Does it generates the expected AST nodes. As of now, these tests are failing hence marking them ignored will handle that in the next PR.