### PR TITLE
RubyLexer: disambiguate `x:y`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -431,8 +431,8 @@ fragment LINE_TERMINATOR
 
 SYMBOL_LITERAL
     :   ':' SYMBOL_NAME
-    |   ':+@'
-    |   ':-@'
+    // This check exists to prevent issuing a SYMBOL_LITERAL in whitespace-free associations, e.g. `foo(x:y)`.
+    {previousTokenTypeOrEOF() != LOCAL_VARIABLE_IDENTIFIER}?
     ;
 
 fragment SYMBOL_NAME
@@ -445,6 +445,11 @@ fragment SYMBOL_NAME
     |   ASSIGNMENT_LIKE_METHOD_IDENTIFIER
     |   OPERATOR_METHOD_NAME
     |   KEYWORD
+    // NOTE: Even though we have PLUSAT and MINUSAT in OPERATOR_METHOD_NAME, the former
+    // are not emitted unless there's a DEF token before them, cf. their predicate.
+    // Thus, we need to add them explicitly here in order to recognize standalone SYMBOL_LITERAL tokens as well.
+    |   '+@'
+    |   '-@'
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
@@ -32,7 +32,7 @@ abstract class RubyLexerBase(input: CharStream)
   def previousNonWsTokenTypeOrEOF(): Int = {
     previousNonWsToken.map(_.getType).getOrElse(EOF)
   }
-  
+
   def previousTokenTypeOrEOF(): Int = {
     previousToken.map(_.getType).getOrElse(EOF)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
@@ -32,5 +32,9 @@ abstract class RubyLexerBase(input: CharStream)
   def previousNonWsTokenTypeOrEOF(): Int = {
     previousNonWsToken.map(_.getType).getOrElse(EOF)
   }
+  
+  def previousTokenTypeOrEOF(): Int = {
+    previousToken.map(_.getType).getOrElse(EOF)
+  }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -82,6 +82,32 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
              |  )""".stripMargin
       }
 
+      "it contains an identifier keyword argument" in {
+        val code = "foo(region:region)"
+
+        printAst(_.primary(), code) shouldEqual
+          s"""InvocationWithParenthesesPrimary
+             | MethodIdentifier
+             |  foo
+             | ArgsOnlyArgumentsWithParentheses
+             |  (
+             |  Arguments
+             |   AssociationArgument
+             |    Association
+             |     PrimaryExpression
+             |      VariableReferencePrimary
+             |       VariableIdentifierVariableReference
+             |        VariableIdentifier
+             |         region
+             |     :
+             |     PrimaryExpression
+             |      VariableReferencePrimary
+             |       VariableIdentifierVariableReference
+             |        VariableIdentifier
+             |         region
+             |  )""".stripMargin
+      }
+
       "it contains a single symbol literal positional argument" in {
         val code = "foo(:region)"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -531,10 +531,18 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
-  
+
   "identifier used in a keyword argument" should "not be mistaken for a symbol literal" in {
     // This test exists to check if RubyLexer properly decided between COLON and SYMBOL_LITERAL
     val code = "foo(x:y)"
-    tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, LPAREN, LOCAL_VARIABLE_IDENTIFIER, COLON, LOCAL_VARIABLE_IDENTIFIER, RPAREN, EOF)
+    tokenize(code) shouldBe Seq(
+      LOCAL_VARIABLE_IDENTIFIER,
+      LPAREN,
+      LOCAL_VARIABLE_IDENTIFIER,
+      COLON,
+      LOCAL_VARIABLE_IDENTIFIER,
+      RPAREN,
+      EOF
+    )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -531,4 +531,10 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
+  
+  "identifier used in a keyword argument" should "not be mistaken for a symbol literal" in {
+    // This test exists to check if RubyLexer properly decided between COLON and SYMBOL_LITERAL
+    val code = "foo(x:y)"
+    tokenize(code) shouldBe Seq(LOCAL_VARIABLE_IDENTIFIER, LPAREN, LOCAL_VARIABLE_IDENTIFIER, COLON, LOCAL_VARIABLE_IDENTIFIER, RPAREN, EOF)
+  }
 }


### PR DESCRIPTION
In an expression like `foo(x:y)`, the lexer would recognize `x:y` as 2 tokens:  `LOCAL_VARIABLE_IDENTIFIER`, `SYMBOL_LITERAL`, when it should recognize 3: `LOCAL_VARIABLE_IDENTIFIER`, `COLON`, `LOCAL_VARIABLE_IDENTIFIER`.

Found in #3037