### PR TITLE
rubysrc2cpg: Safety check for blank compound statements

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -122,13 +122,17 @@ class AstCreator(
 
     classStack.push(fullName)
 
-    val statementCtx = programCtx.compoundStatement().statements()
     scope.pushNewScope(())
-    val statementAsts = if (statementCtx != null) {
-      astForStatements(statementCtx, false, false) ++ blockMethods
-    } else {
-      List[Ast](Ast())
-    }
+    val statementAsts =
+      if (
+        programCtx.compoundStatement() != null &&
+        programCtx.compoundStatement().statements() != null
+      ) {
+        astForStatements(programCtx.compoundStatement().statements(), false, false) ++ blockMethods
+      } else {
+        logger.error(s"File $filename has no compound statement. Needs to be examined")
+        List[Ast](Ast())
+      }
     scope.popScope()
 
     val thisParam = parameterInNode(programCtx, "this", "this", 0, false, EvaluationStrategies.BY_VALUE).typeFullName(


### PR DESCRIPTION
Safety check to get around crash due to https://github.com/joernio/joern/issues/3040 while importing some Ruby repositories

@xavierpinho 