### PR TITLE
kotlin2cpg: remove CLOSURE_BINDING id randomness

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -130,6 +130,10 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     }
   }
 
+  protected def stringForUUID(node: KtExpression, name: String, typeFullName: String): String = {
+    node.getText + node.getContainingKtFile.getName + node.getContainingKtFile.getPackageFqName.toString + name + typeFullName
+  }
+
   protected def ktTokenToOperator(forPostfixExpr: Boolean): PartialFunction[KtToken, String] = {
     val postfixKtTokenToOperator: PartialFunction[KtToken, String] = {
       case KtTokens.EXCLEXCL   => Operators.notNullAssert

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -1,16 +1,16 @@
 package io.joern.kotlin2cpg.ast
 
-import io.joern.kotlin2cpg.ast.Nodes._
+import io.joern.kotlin2cpg.ast.Nodes.*
 import io.joern.kotlin2cpg.Constants
 import io.joern.kotlin2cpg.KtFileWithMeta
-import io.joern.kotlin2cpg.psi.PsiUtils._
+import io.joern.kotlin2cpg.psi.PsiUtils.*
 import io.joern.kotlin2cpg.types.{AnonymousObjectContext, CallKinds, TypeConstants, TypeInfoProvider}
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.joern.x2cpg.{Ast, Defines}
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders
 import io.joern.x2cpg.utils.NodeBuilders.{
   newBindingNode,
@@ -22,12 +22,12 @@ import io.joern.x2cpg.utils.NodeBuilders.{
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.DescriptorVisibility
 
-import java.util.UUID.randomUUID
-import org.jetbrains.kotlin.psi._
+import java.util.UUID.{nameUUIDFromBytes}
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.lexer.{KtToken, KtTokens}
 
 import scala.annotation.unused
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 trait KtPsiToAst {
   this: AstCreator =>
@@ -625,8 +625,9 @@ trait KtPsiToAst {
         case node: NewMember            => NodeContext(node, node.name, node.typeFullName)
       }
       .map { capturedNodeContext =>
-        // TODO: remove the randomness here, two CPGs created from the same codebase should be the same
-        val closureBindingId = randomUUID().toString
+        val uuidBytes =
+          fn.getContainingKtFile.getName + fn.getContainingKtFile.getPackageFqName.toString + capturedNodeContext.name + capturedNodeContext.typeFullName
+        val closureBindingId = nameUUIDFromBytes(uuidBytes.getBytes).toString
         val closureBindingNode =
           newClosureBindingNode(closureBindingId, capturedNodeContext.name, EvaluationStrategies.BY_REFERENCE)
         (closureBindingNode, capturedNodeContext)
@@ -708,8 +709,9 @@ trait KtPsiToAst {
         case node: NewMember            => NodeContext(node, node.name, node.typeFullName)
       }
       .map { capturedNodeContext =>
-        // TODO: remove the randomness here, two CPGs created from the same codebase should be the same
-        val closureBindingId = randomUUID().toString
+        val uuidBytes =
+          expr.getContainingKtFile.getName + expr.getContainingKtFile.getPackageFqName.toString + capturedNodeContext.name + capturedNodeContext.typeFullName
+        val closureBindingId = nameUUIDFromBytes(uuidBytes.getBytes).toString
         val closureBindingNode =
           newClosureBindingNode(closureBindingId, capturedNodeContext.name, EvaluationStrategies.BY_REFERENCE)
         (closureBindingNode, capturedNodeContext)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -625,8 +625,7 @@ trait KtPsiToAst {
         case node: NewMember            => NodeContext(node, node.name, node.typeFullName)
       }
       .map { capturedNodeContext =>
-        val uuidBytes =
-          fn.getContainingKtFile.getName + fn.getContainingKtFile.getPackageFqName.toString + capturedNodeContext.name + capturedNodeContext.typeFullName
+        val uuidBytes        = stringForUUID(fn, capturedNodeContext.name, capturedNodeContext.typeFullName)
         val closureBindingId = nameUUIDFromBytes(uuidBytes.getBytes).toString
         val closureBindingNode =
           newClosureBindingNode(closureBindingId, capturedNodeContext.name, EvaluationStrategies.BY_REFERENCE)
@@ -709,8 +708,7 @@ trait KtPsiToAst {
         case node: NewMember            => NodeContext(node, node.name, node.typeFullName)
       }
       .map { capturedNodeContext =>
-        val uuidBytes =
-          expr.getContainingKtFile.getName + expr.getContainingKtFile.getPackageFqName.toString + capturedNodeContext.name + capturedNodeContext.typeFullName
+        val uuidBytes        = stringForUUID(expr, capturedNodeContext.name, capturedNodeContext.typeFullName)
         val closureBindingId = nameUUIDFromBytes(uuidBytes.getBytes).toString
         val closureBindingNode =
           newClosureBindingNode(closureBindingId, capturedNodeContext.name, EvaluationStrategies.BY_REFERENCE)


### PR DESCRIPTION
generally we want CPGs generated from the same input to be identical