### PR TITLE
rubysrc2cpg: remove base classname from name

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -31,7 +31,7 @@ trait AstForTypesCreator { this: AstCreator =>
       None
     }
 
-    val className = ctx.className(baseClassName)
+    var className = ctx.className(baseClassName)
     if (className != Defines.Any) {
       classStack.push(className)
       val fullName = classStack.reverse.mkString(pathSep)
@@ -40,6 +40,11 @@ trait AstForTypesCreator { this: AstCreator =>
 
       if (classStack.nonEmpty) {
         classStack.pop()
+      }
+
+      /* If we have basename, we will have X.Y as classname. We only need Y for "name" though */
+      if (baseClassName != null) {
+        className = Option(className.split("\\.").last).getOrElse(className)
       }
 
       val typeDeclNode = NewTypeDecl()

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
@@ -31,6 +31,19 @@ class TypeDeclAstCreationPassTest extends RubyCode2CpgFixture {
       myClass.fullName shouldBe "Test0.rb::program.MyClass"
     }
 
+    // TODO: Need to be fixed.
+    "populate class name correctly for a derived class" in {
+      val cpg = code("""
+          |module ApplicationCable
+          |  class Channel < ActionCable::Channel::Base
+          |  end
+          |end
+          |""".stripMargin)
+      val List(myClass) = cpg.typeDecl.nameExact("Channel").l
+      myClass.name shouldBe "Channel"
+      myClass.fullName shouldBe "Test0.rb::program.ApplicationCable.ActionCable.Channel"
+    }
+
     "generate methods under type declarations" in {
       val cpg = code("""
           |class Vehicle


### PR DESCRIPTION
We don't need baseclass name in `name`. We have that in `fullName` already. 