### PR TITLE
RubyLexer: improve regex starting predicate

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
@@ -20,6 +20,8 @@ trait RubyLexerRegexHandling { this: RubyLexerBase =>
     NL,
     // When '/' occurs after a ','.
     COMMA,
+    // When '/' occurs after a ':'.
+    COLON,
     // When '/' occurs after an operator.
     EMARK,
     EMARKEQ,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -108,6 +108,33 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
              |  )""".stripMargin
       }
 
+      "it contains a non-empty regex literal keyword argument" in {
+        val code = "foo(id: /.*/)"
+        printAst(_.primary(), code) shouldEqual
+          """InvocationWithParenthesesPrimary
+            | MethodIdentifier
+            |  foo
+            | ArgsOnlyArgumentsWithParentheses
+            |  (
+            |  Arguments
+            |   AssociationArgument
+            |    Association
+            |     PrimaryExpression
+            |      VariableReferencePrimary
+            |       VariableIdentifierVariableReference
+            |        VariableIdentifier
+            |         id
+            |     :
+            |     WsOrNl
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       RegularExpressionLiteral
+            |        /
+            |        .*
+            |        /
+            |  )""".stripMargin
+      }
+
       "it contains a single symbol literal positional argument" in {
         val code = "foo(:region)"
 
@@ -207,6 +234,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |         true
             |  )""".stripMargin
       }
+      
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -234,7 +234,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |         true
             |  )""".stripMargin
       }
-      
+
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -257,6 +257,36 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
+  
+  "Empty regex literal on the RHS of an association" should "be recognized as such" in {
+    val code = "{x: //}"
+    tokenize(code) shouldBe Seq(
+      LCURLY,
+      LOCAL_VARIABLE_IDENTIFIER,
+      COLON,
+      WS,
+      REGULAR_EXPRESSION_START,
+      REGULAR_EXPRESSION_END,
+      RCURLY,
+      EOF
+    )
+  }
+  
+  "Non-empty regex literal on the RHS of a keyword argument" should "be recognized as such" in {
+    val code = "foo(x: /.*/)"
+    tokenize(code) shouldBe Seq(
+      LOCAL_VARIABLE_IDENTIFIER,
+      LPAREN,
+      LOCAL_VARIABLE_IDENTIFIER,
+      COLON,
+      WS,
+      REGULAR_EXPRESSION_START,
+      REGULAR_EXPRESSION_BODY,
+      REGULAR_EXPRESSION_END,
+      RPAREN,
+      EOF
+    )
+  }
 
   "Non-empty regex literal on the RHS of an assignment" should "be recognized as such" in {
     val code = """NAME_REGEX = /\A[^0-9!\``@#\$%\^&*+_=]+\z/"""

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -257,7 +257,7 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
-  
+
   "Empty regex literal on the RHS of an association" should "be recognized as such" in {
     val code = "{x: //}"
     tokenize(code) shouldBe Seq(
@@ -271,7 +271,7 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
-  
+
   "Non-empty regex literal on the RHS of a keyword argument" should "be recognized as such" in {
     val code = "foo(x: /.*/)"
     tokenize(code) shouldBe Seq(


### PR DESCRIPTION
The lexer predicate that decides if a `SLASH` token should start a regex literal was not taking into account colons (`:`), which is necessary to properly lex associations whose value are regex literals - e.g. `{x: /.*/}`.

Closes #3139