### PR TITLE
RubyParser: support for mandatory keyword parameters

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -357,7 +357,7 @@ hashParameter
     ;
 
 keywordParameter
-    :   LOCAL_VARIABLE_IDENTIFIER WS* COLON wsOrNl* expression
+    :   LOCAL_VARIABLE_IDENTIFIER WS* COLON (wsOrNl* expression)?
     ;
 
 procParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -289,6 +289,72 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |  WsOrNl
             |  end""".stripMargin
       }
+
+      "it contains a mandatory keyword parameter" in {
+        val code = "def foo(x:) ; end"
+        printAst(_.primary(), code) shouldBe
+          """MethodDefinitionPrimary
+            | MethodDefinition
+            |  def
+            |  WsOrNl
+            |  SimpleMethodNamePart
+            |   DefinedMethodName
+            |    MethodName
+            |     MethodIdentifier
+            |      foo
+            |  MethodParameterPart
+            |   (
+            |   Parameters
+            |    Parameter
+            |     KeywordParameter
+            |      x
+            |      :
+            |   )
+            |  WsOrNl
+            |  BodyStatement
+            |   CompoundStatement
+            |    Separators
+            |     Separator
+            |      ;
+            |  WsOrNl
+            |  end""".stripMargin
+      }
+
+      "it contains two mandatory keyword parameters" in {
+        val code = "def foo(name:, surname:) ; end"
+        printAst(_.primary(), code) shouldBe
+          """MethodDefinitionPrimary
+            | MethodDefinition
+            |  def
+            |  WsOrNl
+            |  SimpleMethodNamePart
+            |   DefinedMethodName
+            |    MethodName
+            |     MethodIdentifier
+            |      foo
+            |  MethodParameterPart
+            |   (
+            |   Parameters
+            |    Parameter
+            |     KeywordParameter
+            |      name
+            |      :
+            |    ,
+            |    WsOrNl
+            |    Parameter
+            |     KeywordParameter
+            |      surname
+            |      :
+            |   )
+            |  WsOrNl
+            |  BodyStatement
+            |   CompoundStatement
+            |    Separators
+            |     Separator
+            |      ;
+            |  WsOrNl
+            |  end""".stripMargin
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #3157 