### PR TITLE
rubysrc2cpg: Removed null pointer dereference

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -504,7 +504,7 @@ class AstCreator(
           Seq(Ast())
       }
     case None =>
-      logger.error(s"astForIndexingArgumentsContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForIndexingArgumentsContext() $filename All contexts mismatched.")
       Seq()
   }
 
@@ -1492,7 +1492,7 @@ class AstCreator(
           Seq(Ast())
       }
     case None =>
-      logger.error(s"astForArgumentsWithParenthesesContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForArgumentsWithParenthesesContext() $filename All contexts mismatched.")
       Seq()
   }
 


### PR DESCRIPTION
The null `ctx` was being references in the log message causing a crash. Removed it. This makes some more repository scans to proceed further.
@xavierpinho @tuxology 