### PR TITLE
rubysrc2cpg: Support for `rescue` stmts in `def` blocks

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -234,11 +234,11 @@ block
     ;
 
 braceBlock
-    :   LCURLY wsOrNl* blockParameter? wsOrNl* compoundStatement wsOrNl* RCURLY
+    :   LCURLY wsOrNl* blockParameter? wsOrNl* bodyStatement wsOrNl* RCURLY
     ;
 
 doBlock
-    :   DO wsOrNl* blockParameter? separators wsOrNl* compoundStatement wsOrNl* END
+    :   DO wsOrNl* blockParameter? separators wsOrNl* bodyStatement wsOrNl* END
     ;
 
 blockParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -345,17 +345,17 @@ trait AstForStatementsCreator {
   }
 
   protected def astForDoBlock(ctx: DoBlockContext): Ast = {
-    astForBlockHelper(ctx, Option(ctx.blockParameter), ctx.compoundStatement)
+    astForBlockHelper(ctx, Option(ctx.blockParameter), ctx.bodyStatement().compoundStatement())
   }
 
   protected def astForBraceBlock(ctx: BraceBlockContext): Ast = {
-    astForBlockHelper(ctx, Option(ctx.blockParameter), ctx.compoundStatement)
+    astForBlockHelper(ctx, Option(ctx.blockParameter), ctx.bodyStatement().compoundStatement())
   }
 
   // TODO: This class shouldn't be required and will eventually be phased out.
   protected implicit class BlockContextExt(val ctx: BlockContext) {
     def compoundStatement: CompoundStatementContext = {
-      fold(_.compoundStatement(), _.compoundStatement)
+      fold(_.bodyStatement.compoundStatement, _.bodyStatement.compoundStatement)
     }
 
     def blockParameter: Option[BlockParameterContext] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
@@ -79,25 +79,26 @@ class InvocationWithoutParenthesesTests extends RubyParserAbstractTest {
             |      Separators
             |       Separator
             |      WsOrNl
-            |      CompoundStatement
-            |       Statements
-            |        ExpressionOrCommandStatement
-            |         InvocationExpressionOrCommand
-            |          SingleCommandOnlyInvocationWithoutParentheses
-            |           SimpleMethodCommand
-            |            MethodIdentifier
-            |             puts
-            |            ArgumentsWithoutParentheses
-            |             Arguments
-            |              ExpressionArgument
-            |               PrimaryExpression
-            |                LiteralPrimary
-            |                 NumericLiteralLiteral
-            |                  NumericLiteral
-            |                   UnsignedNumericLiteral
-            |                    1
-            |       Separators
-            |        Separator
+            |      BodyStatement
+            |       CompoundStatement
+            |        Statements
+            |         ExpressionOrCommandStatement
+            |          InvocationExpressionOrCommand
+            |           SingleCommandOnlyInvocationWithoutParentheses
+            |            SimpleMethodCommand
+            |             MethodIdentifier
+            |              puts
+            |             ArgumentsWithoutParentheses
+            |              Arguments
+            |               ExpressionArgument
+            |                PrimaryExpression
+            |                 LiteralPrimary
+            |                  NumericLiteralLiteral
+            |                   NumericLiteral
+            |                    UnsignedNumericLiteral
+            |                     1
+            |        Separators
+            |         Separator
             |      end""".stripMargin
 
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -357,4 +357,75 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
       }
     }
   }
+  
+  "A multi-line method definition" should {
+    
+    "be parsed as a primary expression" when {
+      
+      "it contains a `rescue` clause" in {
+        val code = """def foo
+                      |  1/0
+                      |  rescue ZeroDivisionError => e
+                      |end""".stripMargin
+        printAst(_.primary(), code) shouldBe
+          """MethodDefinitionPrimary
+            | MethodDefinition
+            |  def
+            |  WsOrNl
+            |  SimpleMethodNamePart
+            |   DefinedMethodName
+            |    MethodName
+            |     MethodIdentifier
+            |      foo
+            |  MethodParameterPart
+            |   Separator
+            |  WsOrNl
+            |  BodyStatement
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       MultiplicativeExpression
+            |        PrimaryExpression
+            |         LiteralPrimary
+            |          NumericLiteralLiteral
+            |           NumericLiteral
+            |            UnsignedNumericLiteral
+            |             1
+            |        /
+            |        PrimaryExpression
+            |         LiteralPrimary
+            |          NumericLiteralLiteral
+            |           NumericLiteral
+            |            UnsignedNumericLiteral
+            |             0
+            |    Separators
+            |     Separator
+            |   WsOrNl
+            |   RescueClause
+            |    rescue
+            |    ExceptionClass
+            |     PrimaryExpression
+            |      VariableReferencePrimary
+            |       VariableIdentifierVariableReference
+            |        VariableIdentifier
+            |         ZeroDivisionError
+            |    WsOrNl
+            |    ExceptionVariableAssignment
+            |     =>
+            |     VariableIdentifierOnlySingleLeftHandSide
+            |      VariableIdentifier
+            |       e
+            |    ThenClause
+            |     Separator
+            |     CompoundStatement
+            |  end""".stripMargin
+        
+        
+      }
+    }
+    
+    
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -357,11 +357,11 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
       }
     }
   }
-  
+
   "A multi-line method definition" should {
-    
+
     "be parsed as a primary expression" when {
-      
+
       "it contains a `rescue` clause" in {
         val code = """def foo
                       |  1/0
@@ -420,12 +420,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     Separator
             |     CompoundStatement
             |  end""".stripMargin
-        
-        
+
       }
     }
-    
-    
+
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
@@ -15,7 +15,8 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  BraceBlockBlock
             |   BraceBlock
             |    {
-            |    CompoundStatement
+            |    BodyStatement
+            |     CompoundStatement
             |    }""".stripMargin
       }
 
@@ -33,7 +34,8 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |     Separator
             |      ;
             |    WsOrNl
-            |    CompoundStatement
+            |    BodyStatement
+            |     CompoundStatement
             |    end""".stripMargin
       }
 
@@ -52,7 +54,8 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  BraceBlockBlock
             |   BraceBlock
             |    {
-            |    CompoundStatement
+            |    BodyStatement
+            |     CompoundStatement
             |    }""".stripMargin
       }
 
@@ -76,7 +79,8 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |     Separator
             |      ;
             |    WsOrNl
-            |    CompoundStatement
+            |    BodyStatement
+            |     CompoundStatement
             |    end""".stripMargin
       }
 
@@ -103,7 +107,8 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  BraceBlockBlock
             |   BraceBlock
             |    {
-            |    CompoundStatement
+            |    BodyStatement
+            |     CompoundStatement
             |    }""".stripMargin
       }
 
@@ -135,7 +140,8 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |     Separator
             |      ;
             |    WsOrNl
-            |    CompoundStatement
+            |    BodyStatement
+            |     CompoundStatement
             |    end""".stripMargin
       }
 
@@ -159,39 +165,40 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  BraceBlockBlock
             |   BraceBlock
             |    {
-            |    CompoundStatement
-            |     Statements
-            |      ExpressionOrCommandStatement
-            |       InvocationExpressionOrCommand
-            |        SingleCommandOnlyInvocationWithoutParentheses
-            |         SimpleMethodCommand
-            |          MethodIdentifier
-            |           puts
-            |          ArgumentsWithoutParentheses
-            |           Arguments
-            |            ExpressionArgument
-            |             PrimaryExpression
-            |              VariableReferencePrimary
-            |               VariableIdentifierVariableReference
-            |                VariableIdentifier
-            |                 x
-            |      Separators
-            |       Separator
-            |        ;
-            |      ExpressionOrCommandStatement
-            |       InvocationExpressionOrCommand
-            |        SingleCommandOnlyInvocationWithoutParentheses
-            |         SimpleMethodCommand
-            |          MethodIdentifier
-            |           puts
-            |          ArgumentsWithoutParentheses
-            |           Arguments
-            |            ExpressionArgument
-            |             PrimaryExpression
-            |              VariableReferencePrimary
-            |               VariableIdentifierVariableReference
-            |                VariableIdentifier
-            |                 y
+            |    BodyStatement
+            |     CompoundStatement
+            |      Statements
+            |       ExpressionOrCommandStatement
+            |        InvocationExpressionOrCommand
+            |         SingleCommandOnlyInvocationWithoutParentheses
+            |          SimpleMethodCommand
+            |           MethodIdentifier
+            |            puts
+            |           ArgumentsWithoutParentheses
+            |            Arguments
+            |             ExpressionArgument
+            |              PrimaryExpression
+            |               VariableReferencePrimary
+            |                VariableIdentifierVariableReference
+            |                 VariableIdentifier
+            |                  x
+            |       Separators
+            |        Separator
+            |         ;
+            |       ExpressionOrCommandStatement
+            |        InvocationExpressionOrCommand
+            |         SingleCommandOnlyInvocationWithoutParentheses
+            |          SimpleMethodCommand
+            |           MethodIdentifier
+            |            puts
+            |           ArgumentsWithoutParentheses
+            |            Arguments
+            |             ExpressionArgument
+            |              PrimaryExpression
+            |               VariableReferencePrimary
+            |                VariableIdentifierVariableReference
+            |                 VariableIdentifier
+            |                  y
             |    }""".stripMargin
       }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
@@ -1,0 +1,200 @@
+package io.joern.rubysrc2cpg.parser
+
+class RescueClauseTests extends RubyParserAbstractTest {
+  
+  "A rescue statement" should {
+    
+    "be parsed as a standalone statement" when {
+      
+      "in the immediate scope of a `begin` block" in {
+        val code =
+          """begin
+            |1/0
+            |rescue ZeroDivisionError => e
+            |end""".stripMargin
+        
+        printAst(_.beginExpression(), code) shouldEqual
+          """BeginExpression
+            | begin
+            | WsOrNl
+            | BodyStatement
+            |  CompoundStatement
+            |   Statements
+            |    ExpressionOrCommandStatement
+            |     ExpressionExpressionOrCommand
+            |      MultiplicativeExpression
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            1
+            |       /
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            0
+            |   Separators
+            |    Separator
+            |  RescueClause
+            |   rescue
+            |   ExceptionClass
+            |    PrimaryExpression
+            |     VariableReferencePrimary
+            |      VariableIdentifierVariableReference
+            |       VariableIdentifier
+            |        ZeroDivisionError
+            |   WsOrNl
+            |   ExceptionVariableAssignment
+            |    =>
+            |    VariableIdentifierOnlySingleLeftHandSide
+            |     VariableIdentifier
+            |      e
+            |   ThenClause
+            |    Separator
+            |    CompoundStatement
+            | end""".stripMargin
+      }
+      
+      "in the immediate scope of a `def` block" in {
+        val code =
+          """def foo;
+            |1/0
+            |rescue ZeroDivisionError => e
+            |end""".stripMargin
+        
+        printAst(_.methodDefinition(), code) shouldEqual
+          """MethodDefinition
+            | def
+            | WsOrNl
+            | SimpleMethodNamePart
+            |  DefinedMethodName
+            |   MethodName
+            |    MethodIdentifier
+            |     foo
+            | MethodParameterPart
+            |  Separator
+            |   ;
+            | WsOrNl
+            | BodyStatement
+            |  CompoundStatement
+            |   Statements
+            |    ExpressionOrCommandStatement
+            |     ExpressionExpressionOrCommand
+            |      MultiplicativeExpression
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            1
+            |       /
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            0
+            |   Separators
+            |    Separator
+            |  RescueClause
+            |   rescue
+            |   ExceptionClass
+            |    PrimaryExpression
+            |     VariableReferencePrimary
+            |      VariableIdentifierVariableReference
+            |       VariableIdentifier
+            |        ZeroDivisionError
+            |   WsOrNl
+            |   ExceptionVariableAssignment
+            |    =>
+            |    VariableIdentifierOnlySingleLeftHandSide
+            |     VariableIdentifier
+            |      e
+            |   ThenClause
+            |    Separator
+            |    CompoundStatement
+            | end""".stripMargin
+      }
+      
+      "in the immediate scope of a `do` block" in {
+        val code =
+          """foo x do |y|
+            |y/0
+            |rescue ZeroDivisionError => e
+            |end""".stripMargin
+          
+        printAst(_.statement(), code) shouldEqual
+          """ExpressionOrCommandStatement
+            | InvocationExpressionOrCommand
+            |  ChainedCommandDoBlockInvocationWithoutParentheses
+            |   ChainedCommandWithDoBlock
+            |    ArgsAndDoBlockAndMethodIdCommandWithDoBlock
+            |     MethodIdentifier
+            |      foo
+            |     ArgumentsWithoutParentheses
+            |      Arguments
+            |       ExpressionArgument
+            |        PrimaryExpression
+            |         VariableReferencePrimary
+            |          VariableIdentifierVariableReference
+            |           VariableIdentifier
+            |            x
+            |     DoBlock
+            |      do
+            |      WsOrNl
+            |      BlockParameter
+            |       |
+            |       BlockParameters
+            |        VariableIdentifierOnlySingleLeftHandSide
+            |         VariableIdentifier
+            |          y
+            |       |
+            |      Separators
+            |       Separator
+            |      BodyStatement
+            |       CompoundStatement
+            |        Statements
+            |         ExpressionOrCommandStatement
+            |          ExpressionExpressionOrCommand
+            |           MultiplicativeExpression
+            |            PrimaryExpression
+            |             VariableReferencePrimary
+            |              VariableIdentifierVariableReference
+            |               VariableIdentifier
+            |                y
+            |            /
+            |            PrimaryExpression
+            |             LiteralPrimary
+            |              NumericLiteralLiteral
+            |               NumericLiteral
+            |                UnsignedNumericLiteral
+            |                 0
+            |        Separators
+            |         Separator
+            |       RescueClause
+            |        rescue
+            |        ExceptionClass
+            |         PrimaryExpression
+            |          VariableReferencePrimary
+            |           VariableIdentifierVariableReference
+            |            VariableIdentifier
+            |             ZeroDivisionError
+            |        WsOrNl
+            |        ExceptionVariableAssignment
+            |         =>
+            |         VariableIdentifierOnlySingleLeftHandSide
+            |          VariableIdentifier
+            |           e
+            |        ThenClause
+            |         Separator
+            |         CompoundStatement
+            |      end""".stripMargin
+      }
+    }
+    
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
@@ -1,18 +1,18 @@
 package io.joern.rubysrc2cpg.parser
 
 class RescueClauseTests extends RubyParserAbstractTest {
-  
+
   "A rescue statement" should {
-    
+
     "be parsed as a standalone statement" when {
-      
+
       "in the immediate scope of a `begin` block" in {
         val code =
           """begin
             |1/0
             |rescue ZeroDivisionError => e
             |end""".stripMargin
-        
+
         printAst(_.beginExpression(), code) shouldEqual
           """BeginExpression
             | begin
@@ -57,14 +57,14 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |    CompoundStatement
             | end""".stripMargin
       }
-      
+
       "in the immediate scope of a `def` block" in {
         val code =
           """def foo;
             |1/0
             |rescue ZeroDivisionError => e
             |end""".stripMargin
-        
+
         printAst(_.methodDefinition(), code) shouldEqual
           """MethodDefinition
             | def
@@ -118,14 +118,14 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |    CompoundStatement
             | end""".stripMargin
       }
-      
+
       "in the immediate scope of a `do` block" in {
         val code =
           """foo x do |y|
             |y/0
             |rescue ZeroDivisionError => e
             |end""".stripMargin
-          
+
         printAst(_.statement(), code) shouldEqual
           """ExpressionOrCommandStatement
             | InvocationExpressionOrCommand
@@ -194,7 +194,7 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |      end""".stripMargin
       }
     }
-    
+
   }
 
 }


### PR DESCRIPTION
Standalone `rescue` statements were initially only allowed inside `begin..end` expressions. Turns out (e.g. [StackOverflow](https://stackoverflow.com/questions/1542672/how-does-one-use-rescue-in-ruby-without-the-begin-and-end-block)), `def`, `do` and `{` also act as if they were "begin" expressions wrt `rescue` statements.

Closes #3160