### PR TITLE
[jimple2cpg] Do not unpack "jars in jars" by default

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -10,7 +10,8 @@ final case class Config(
   android: Option[String] = None,
   dynamicDirs: Seq[String] = Seq.empty,
   dynamicPkgs: Seq[String] = Seq.empty,
-  fullResolver: Boolean = false
+  fullResolver: Boolean = false,
+  recurse: Boolean = false
 ) extends X2CpgConfig[Config] {
   def withAndroid(android: String): Config = {
     copy(android = Some(android)).withInheritedFields(this)
@@ -24,6 +25,11 @@ final case class Config(
   def withFullResolver(value: Boolean): Config = {
     copy(fullResolver = value).withInheritedFields(this)
   }
+
+  def withRecurse(value: Boolean): Config = {
+    copy(recurse = value)
+  }
+
 }
 
 private object Frontend {
@@ -41,6 +47,9 @@ private object Frontend {
       opt[Unit]("full-resolver")
         .text("enables full transitive resolution of all references found in all classes that are resolved")
         .action((_, config) => config.withFullResolver(true)),
+      opt[Unit]("recurse")
+        .text("recursively unpack jars")
+        .action((_, config) => config.withRecurse(true)),
       opt[Seq[String]]("dynamic-dirs")
         .valueName("<dir1>,<dir2>,...")
         .text(

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -90,7 +90,7 @@ object ProgramHandlingUtil {
         case f if f.isDirectory() =>
           val files = f.listRecursively.filterNot(_.isDirectory).toList
           Right(files)
-        case f if isArchive(Entry(f)) && recurse =>
+        case f if isArchive(Entry(f)) && (recurse || f == src) =>
           val xTmp = File.newTemporaryDirectory("extract-archive-", parent = Some(tmpDir))
           val unzipDirs = Try(f.unzipTo(xTmp, e => shouldExtract(Entry(e)))) match {
             case Success(dir) => List(dir)

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
@@ -14,7 +14,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import java.nio.file.{Files, Path, Paths}
 import scala.util.{Failure, Success, Try}
 
-class JarUnpacking extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   var validCpgs: Map[String, Cpg] = _
   var slippyCpg: Cpg              = _
@@ -30,7 +30,7 @@ class JarUnpacking extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   private def getUnpackingCpg(path: String): Cpg =
     Try(getClass.getResource(s"/unpacking/${path}").toURI) match {
       case Success(x) =>
-        implicit val defaultConfig: Config = Config()
+        implicit val config: Config = Config().withRecurse(true)
         new Jimple2Cpg().createCpg(Paths.get(x).toString).get
       case Failure(x: Throwable) =>
         fail("Unable to obtain test resources.", x)


### PR DESCRIPTION
I noticed that the recent fixes to the jar unpacking had one downside: jars inside jars were unpacked by default. In practice, this would lead to long CPG generation times. With this PR, there is now a `recurse`-flag to control whether recursive unpacking happens or not. This flag is set to `false` by default, that is, recursive unpacking is disabled by default.
