### PR TITLE
[rubysrc2cpg] Add support for Safe Navigation Operator to method call.

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -90,7 +90,7 @@ primary
     |   beginExpression                                                                                                     # beginExpressionPrimary
     |   LPAREN wsOrNl* compoundStatement wsOrNl* RPAREN                                                                     # groupingExpressionPrimary
     |   variableReference                                                                                                   # variableReferencePrimary
-            |   COLON2 CONSTANT_IDENTIFIER                                                                                  # simpleScopedConstantReferencePrimary
+    |   COLON2 CONSTANT_IDENTIFIER                                                                                          # simpleScopedConstantReferencePrimary
     |   primary COLON2 CONSTANT_IDENTIFIER                                                                                  # chainedScopedConstantReferencePrimary
     |   arrayConstructor                                                                                                    # arrayConstructorPrimary
     |   hashConstructor                                                                                                     # hashConstructorPrimary

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -104,7 +104,7 @@ primary
     |   methodOnlyIdentifier                                                                                        # methodOnlyIdentifierPrimary
     |   methodIdentifier WS? block                                                                                  # invocationWithBlockOnlyPrimary
     |   methodIdentifier argumentsWithParentheses WS* block?                                                        # invocationWithParenthesesPrimary
-    |   primary (DOT | COLON2) wsOrNl* methodName argumentsWithParentheses? WS? block?                              # chainedInvocationPrimary
+    |   primary (DOT | COLON2| AMPDOT) wsOrNl* methodName argumentsWithParentheses? WS? block?                              # chainedInvocationPrimary
     |   primary COLON2 methodName block?                                                                            # chainedInvocationWithoutArgumentsPrimary
     ;
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -75,37 +75,37 @@ expression
     ;
 
 primary
-    :   classDefinition                                                                                             # classDefinitionPrimary
-    |   moduleDefinition                                                                                            # moduleDefinitionPrimary
-    |   methodDefinition                                                                                            # methodDefinitionPrimary
-    |   procDefinition                                                                                              # procDefinitionPrimary
-    |   yieldWithOptionalArgument                                                                                   # yieldWithOptionalArgumentPrimary
-    |   ifExpression                                                                                                # ifExpressionPrimary
-    |   unlessExpression                                                                                            # unlessExpressionPrimary
-    |   caseExpression                                                                                              # caseExpressionPrimary
-    |   whileExpression                                                                                             # whileExpressionPrimary
-    |   untilExpression                                                                                             # untilExpressionPrimary
-    |   forExpression                                                                                               # forExpressionPrimary
-    |   jumpExpression                                                                                              # jumpExpressionPrimary
-    |   beginExpression                                                                                             # beginExpressionPrimary
-    |   LPAREN wsOrNl* compoundStatement wsOrNl* RPAREN                                                             # groupingExpressionPrimary
-    |   variableReference                                                                                           # variableReferencePrimary
-    |   COLON2 CONSTANT_IDENTIFIER                                                                                  # simpleScopedConstantReferencePrimary
-    |   primary COLON2 CONSTANT_IDENTIFIER                                                                          # chainedScopedConstantReferencePrimary
-    |   arrayConstructor                                                                                            # arrayConstructorPrimary
-    |   hashConstructor                                                                                             # hashConstructorPrimary
-    |   literal                                                                                                     # literalPrimary
-    |   stringExpression                                                                                            # stringExpressionPrimary
-    |   stringInterpolation                                                                                         # stringInterpolationPrimary
-    |   regexInterpolation                                                                                          # regexInterpolationPrimary
-    |   IS_DEFINED LPAREN expressionOrCommand RPAREN                                                                # isDefinedPrimary
-    |   SUPER argumentsWithParentheses? block?                                                                      # superExpressionPrimary
-    |   primary LBRACK WS* indexingArguments? WS* RBRACK                                                            # indexingExpressionPrimary
-    |   methodOnlyIdentifier                                                                                        # methodOnlyIdentifierPrimary
-    |   methodIdentifier WS? block                                                                                  # invocationWithBlockOnlyPrimary
-    |   methodIdentifier argumentsWithParentheses WS* block?                                                        # invocationWithParenthesesPrimary
+    :   classDefinition                                                                                                     # classDefinitionPrimary
+    |   moduleDefinition                                                                                                    # moduleDefinitionPrimary
+    |   methodDefinition                                                                                                    # methodDefinitionPrimary
+    |   procDefinition                                                                                                      # procDefinitionPrimary
+    |   yieldWithOptionalArgument                                                                                           # yieldWithOptionalArgumentPrimary
+    |   ifExpression                                                                                                        # ifExpressionPrimary
+    |   unlessExpression                                                                                                    # unlessExpressionPrimary
+    |   caseExpression                                                                                                      # caseExpressionPrimary
+    |   whileExpression                                                                                                     # whileExpressionPrimary
+    |   untilExpression                                                                                                     # untilExpressionPrimary
+    |   forExpression                                                                                                       # forExpressionPrimary
+    |   jumpExpression                                                                                                      # jumpExpressionPrimary
+    |   beginExpression                                                                                                     # beginExpressionPrimary
+    |   LPAREN wsOrNl* compoundStatement wsOrNl* RPAREN                                                                     # groupingExpressionPrimary
+    |   variableReference                                                                                                   # variableReferencePrimary
+            |   COLON2 CONSTANT_IDENTIFIER                                                                                  # simpleScopedConstantReferencePrimary
+    |   primary COLON2 CONSTANT_IDENTIFIER                                                                                  # chainedScopedConstantReferencePrimary
+    |   arrayConstructor                                                                                                    # arrayConstructorPrimary
+    |   hashConstructor                                                                                                     # hashConstructorPrimary
+    |   literal                                                                                                             # literalPrimary
+    |   stringExpression                                                                                                    # stringExpressionPrimary
+    |   stringInterpolation                                                                                                 # stringInterpolationPrimary
+    |   regexInterpolation                                                                                                  # regexInterpolationPrimary
+    |   IS_DEFINED LPAREN expressionOrCommand RPAREN                                                                        # isDefinedPrimary
+    |   SUPER argumentsWithParentheses? block?                                                                              # superExpressionPrimary
+    |   primary LBRACK WS* indexingArguments? WS* RBRACK                                                                    # indexingExpressionPrimary
+    |   methodOnlyIdentifier                                                                                                # methodOnlyIdentifierPrimary
+    |   methodIdentifier WS? block                                                                                          # invocationWithBlockOnlyPrimary
+    |   methodIdentifier argumentsWithParentheses WS* block?                                                                # invocationWithParenthesesPrimary
     |   primary (DOT | COLON2| AMPDOT) wsOrNl* methodName argumentsWithParentheses? WS? block?                              # chainedInvocationPrimary
-    |   primary COLON2 methodName block?                                                                            # chainedInvocationWithoutArgumentsPrimary
+    |   primary COLON2 methodName block?                                                                                    # chainedInvocationWithoutArgumentsPrimary
     ;
 
 // --------------------------------------------------------
@@ -160,10 +160,10 @@ invocationWithoutParentheses
     ;
 
 command
-    :   SUPER argumentsWithoutParentheses                                                                                       # superCommand
-    |   YIELD argumentsWithoutParentheses                                                                                       # yieldCommand
-    |   methodIdentifier argumentsWithoutParentheses                                                                            # simpleMethodCommand
-    |   primary WS* (DOT | COLON2) wsOrNl* methodName argumentsWithoutParentheses                                               # memberAccessCommand
+    :   SUPER argumentsWithoutParentheses                                                                                               # superCommand
+    |   YIELD argumentsWithoutParentheses                                                                                               # yieldCommand
+    |   methodIdentifier argumentsWithoutParentheses                                                                                    # simpleMethodCommand
+    |   primary WS* (DOT | COLON2| AMPDOT) wsOrNl* methodName argumentsWithoutParentheses                                               # memberAccessCommand
     ;
 
 chainedCommandWithDoBlock

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -578,8 +578,10 @@ class AstCreator(
 
     val terminalNode = if (ctx.COLON2() != null) {
       ctx.COLON2()
-    } else {
+    } else if (ctx.DOT() != null) {
       ctx.DOT()
+    } else {
+      ctx.AMPDOT()
     }
 
     val argsAst = if (ctx.argumentsWithParentheses() != null) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -14,11 +14,13 @@ trait AstForDeclarationsCreator { this: AstCreator =>
     ctx.argument().asScala.flatMap(astForArgument).toSeq
   }
 
-  protected def astForArgument(ctx: ArgumentContext): Seq[Ast] = ctx match {
-    case ctx: BlockArgumentArgumentContext     => astForExpressionContext(ctx.blockArgument.expression)
-    case ctx: SplattingArgumentArgumentContext => astForExpressionOrCommand(ctx.splattingArgument.expressionOrCommand)
-    case ctx: ExpressionArgumentContext        => astForExpressionContext(ctx.expression)
-    case ctx: AssociationArgumentContext       => astForAssociationContext(ctx.association)
-    case ctx: CommandArgumentContext           => astForCommand(ctx.command)
+  protected def astForArgument(ctx: ArgumentContext): Seq[Ast] = {
+    ctx match {
+      case ctx: BlockArgumentArgumentContext     => astForExpressionContext(ctx.blockArgument.expression)
+      case ctx: SplattingArgumentArgumentContext => astForExpressionOrCommand(ctx.splattingArgument.expressionOrCommand)
+      case ctx: ExpressionArgumentContext        => astForExpressionContext(ctx.expression)
+      case ctx: AssociationArgumentContext       => astForAssociationContext(ctx.association)
+      case ctx: CommandArgumentContext           => astForCommand(ctx.command)
+    }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2355,4 +2355,45 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
       sink.reachableByFlows(source).size shouldBe 3
     }
   }
+
+  "flow through a method call with safe navigation operator with parantheses" should {
+    val cpg = code("""
+        |class Foo
+        | def bar(x)
+        |   return x
+        | end
+        |end
+        |x=1
+        |foo = Foo.new
+        |y = foo&.bar(x)
+        |puts y
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).size shouldBe 3
+    }
+  }
+
+  // TODO: Flow size should be 3 as above, but is 1 instead.
+  "flow through a method call with safe navigation operator without parantheses" ignore {
+    val cpg = code("""
+        |class Foo
+        | def bar(x)
+        |   return x
+        | end
+        |end
+        |x=1
+        |foo = Foo.new
+        |y = foo&.bar x
+        |puts y
+        |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).size shouldBe 3
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -235,6 +235,57 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  )""".stripMargin
       }
 
+      "it contains a safe navigation operator with no parameters" in {
+        val code = "foo&.bar()"
+        printAst(_.primary(), code) shouldEqual
+          """ChainedInvocationPrimary
+            | VariableReferencePrimary
+            |  VariableIdentifierVariableReference
+            |   VariableIdentifier
+            |    foo
+            | &.
+            | MethodName
+            |  MethodIdentifier
+            |   bar
+            | BlankArgsArgumentsWithParentheses
+            |  (
+            |  )""".stripMargin
+      }
+
+      "it contains a safe navigation operator with non-zero parameters" in {
+        val code = "foo&.bar(1, 2)"
+        printAst(_.primary(), code) shouldEqual
+          """ChainedInvocationPrimary
+            | VariableReferencePrimary
+            |  VariableIdentifierVariableReference
+            |   VariableIdentifier
+            |    foo
+            | &.
+            | MethodName
+            |  MethodIdentifier
+            |   bar
+            | ArgsOnlyArgumentsWithParentheses
+            |  (
+            |  Arguments
+            |   ExpressionArgument
+            |    PrimaryExpression
+            |     LiteralPrimary
+            |      NumericLiteralLiteral
+            |       NumericLiteral
+            |        UnsignedNumericLiteral
+            |         1
+            |   ,
+            |   WsOrNl
+            |   ExpressionArgument
+            |    PrimaryExpression
+            |     LiteralPrimary
+            |      NumericLiteralLiteral
+            |       NumericLiteral
+            |        UnsignedNumericLiteral
+            |         2
+            |  )""".stripMargin
+      }
+
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
@@ -102,6 +102,52 @@ class InvocationWithoutParenthesesTests extends RubyParserAbstractTest {
             |      end""".stripMargin
 
       }
+
+      "it contains a safe navigation operator with no parameters" in {
+        val code = "foo&.bar"
+        printAst(_.primary(), code) shouldEqual
+          """ChainedInvocationPrimary
+            | VariableReferencePrimary
+            |  VariableIdentifierVariableReference
+            |   VariableIdentifier
+            |    foo
+            | &.
+            | MethodName
+            |  MethodIdentifier
+            |   bar""".stripMargin
+      }
+
+      "it contains a safe navigation operator with non-zero parameters" in {
+        val code = "foo&.bar 1,2"
+        printAst(_.command(), code) shouldEqual
+          """MemberAccessCommand
+            | VariableReferencePrimary
+            |  VariableIdentifierVariableReference
+            |   VariableIdentifier
+            |    foo
+            | &.
+            | MethodName
+            |  MethodIdentifier
+            |   bar
+            | ArgumentsWithoutParentheses
+            |  Arguments
+            |   ExpressionArgument
+            |    PrimaryExpression
+            |     LiteralPrimary
+            |      NumericLiteralLiteral
+            |       NumericLiteral
+            |        UnsignedNumericLiteral
+            |         1
+            |   ,
+            |   ExpressionArgument
+            |    PrimaryExpression
+            |     LiteralPrimary
+            |      NumericLiteralLiteral
+            |       NumericLiteral
+            |        UnsignedNumericLiteral
+            |         2""".stripMargin
+      }
+
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -943,5 +943,33 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       cpg.parameter.size shouldBe 6
       cpg.call.size shouldBe 6
     }
+
+    "have correct structure when method called with safe navigation without parameters" in {
+      val cpg             = code("foo&.bar")
+      val List(parameter) = cpg.parameter.l
+      parameter.name shouldBe "this"
+      cpg.parameter.size shouldBe 1
+      cpg.call.size shouldBe 1
+    }
+
+    "have correct structure when method called with safe navigation with parameters with parantheses" in {
+      val cpg = code("foo&.bar(1)")
+
+      val List(callNode)  = cpg.call.l
+      val List(actualArg) = callNode.argument.argumentIndex(1).l
+      actualArg.code shouldBe "1"
+      cpg.argument.size shouldBe 2
+      cpg.call.size shouldBe 1
+    }
+
+    "have correct structure when method called with safe navigation with parameters without parantheses" in {
+      val cpg = code("foo&.bar 1,2")
+
+      val List(callNode)  = cpg.call.l
+      val List(actualArg) = callNode.argument.argumentIndex(2).l
+      actualArg.code shouldBe "1"
+      cpg.argument.size shouldBe 3
+      cpg.call.size shouldBe 1
+    }
   }
 }


### PR DESCRIPTION
Added support for usage of safe navigation operator on method calls. Now the parser does not throw an error when we use AMPDOT operator for a chained invocation.

Example usecase:
```
class Foo
   def bar
     puts "bar"
   end
end
foo = Foo.new
foo&.bar
```

Issue solved: #3143 #3168 