### PR TITLE
RubyParser: allow wsOrNl before `.` in a chained invocation

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -104,7 +104,7 @@ primary
     |   methodOnlyIdentifier                                                                                                # methodOnlyIdentifierPrimary
     |   methodIdentifier WS? block                                                                                          # invocationWithBlockOnlyPrimary
     |   methodIdentifier argumentsWithParentheses WS* block?                                                                # invocationWithParenthesesPrimary
-    |   primary (DOT | COLON2| AMPDOT) wsOrNl* methodName argumentsWithParentheses? WS? block?                              # chainedInvocationPrimary
+    |   primary wsOrNl* (DOT | COLON2| AMPDOT) wsOrNl* methodName argumentsWithParentheses? WS? block?                      # chainedInvocationPrimary
     |   primary COLON2 methodName block?                                                                                    # chainedInvocationWithoutArgumentsPrimary
     ;
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -285,7 +285,38 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |         2
             |  )""".stripMargin
       }
-
+      
+      "it spans two lines, with the second line starting with `.`" in {
+        val code = "foo\n   .bar"
+        printAst(_.primary(), code) shouldEqual
+          """ChainedInvocationPrimary
+            | VariableReferencePrimary
+            |  VariableIdentifierVariableReference
+            |   VariableIdentifier
+            |    foo
+            | WsOrNl
+            | WsOrNl
+            | .
+            | MethodName
+            |  MethodIdentifier
+            |   bar""".stripMargin
+      }
+      
+      "it spans two lines, with the first line ending with `.`" in {
+        val code = "foo.\n   bar"
+        printAst(_.primary(), code) shouldEqual
+          """ChainedInvocationPrimary
+            | VariableReferencePrimary
+            |  VariableIdentifierVariableReference
+            |   VariableIdentifier
+            |    foo
+            | .
+            | WsOrNl
+            | WsOrNl
+            | MethodName
+            |  MethodIdentifier
+            |   bar""".stripMargin
+      }
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -285,7 +285,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |         2
             |  )""".stripMargin
       }
-      
+
       "it spans two lines, with the second line starting with `.`" in {
         val code = "foo\n   .bar"
         printAst(_.primary(), code) shouldEqual
@@ -301,7 +301,7 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  MethodIdentifier
             |   bar""".stripMargin
       }
-      
+
       "it spans two lines, with the first line ending with `.`" in {
         val code = "foo.\n   bar"
         printAst(_.primary(), code) shouldEqual


### PR DESCRIPTION
Closes #3144