### PR TITLE
RubyLexer: disambiguate `:x=>`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -431,8 +431,10 @@ fragment LINE_TERMINATOR
 
 SYMBOL_LITERAL
     :   ':' SYMBOL_NAME
-    // This check exists to prevent issuing a SYMBOL_LITERAL in whitespace-free associations, e.g. `foo(x:y)`.
-    {previousTokenTypeOrEOF() != LOCAL_VARIABLE_IDENTIFIER}?
+    // This check exists to prevent issuing a SYMBOL_LITERAL in whitespace-free associations, e.g. 
+    //      in `foo(x:y)`, so that `:y` is not a SYMBOL_LITERAL
+    // or   in `{:x=>1}`, so that `:x=` is not a SYMBOL_LITERAL
+    {previousTokenTypeOrEOF() != LOCAL_VARIABLE_IDENTIFIER && _input.LA(1) != '>'}?
     ;
 
 fragment SYMBOL_NAME

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -589,6 +589,19 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
+  
+  "operator-named symbol used in a whitespace-free `=>` association" should "not be include `=` as part of its name" in {
+    // This test exists to check if RubyLexer properly recognizes EQGT
+    val code = "{:x=>1}"
+    tokenize(code) shouldBe Seq(
+      LCURLY,
+      SYMBOL_LITERAL,
+      EQGT,
+      DECIMAL_INTEGER_LITERAL,
+      RCURLY,
+      EOF
+    )
+  }
 
   "class variable used in a keyword argument" should "not be mistaken for a symbol literal" in {
     // This test exists to check if RubyLexer properly decided between COLON and SYMBOL_LITERAL

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -589,18 +589,11 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
-  
+
   "operator-named symbol used in a whitespace-free `=>` association" should "not be include `=` as part of its name" in {
     // This test exists to check if RubyLexer properly recognizes EQGT
     val code = "{:x=>1}"
-    tokenize(code) shouldBe Seq(
-      LCURLY,
-      SYMBOL_LITERAL,
-      EQGT,
-      DECIMAL_INTEGER_LITERAL,
-      RCURLY,
-      EOF
-    )
+    tokenize(code) shouldBe Seq(LCURLY, SYMBOL_LITERAL, EQGT, DECIMAL_INTEGER_LITERAL, RCURLY, EOF)
   }
 
   "class variable used in a keyword argument" should "not be mistaken for a symbol literal" in {


### PR DESCRIPTION
Closes #3176