### PR TITLE
RubyParser: fix missing wsOrNl before `ensure` clauses

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -437,7 +437,7 @@ beginExpression
     ;
 
 bodyStatement
-    :   compoundStatement (wsOrNl* rescueClause)* (wsOrNl* elseClause)? ensureClause?
+    :   compoundStatement (wsOrNl* rescueClause)* (wsOrNl* elseClause)? (wsOrNl* ensureClause)?
     ;
 
 rescueClause

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/EnsureClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/EnsureClauseTests.scala
@@ -1,11 +1,11 @@
 package io.joern.rubysrc2cpg.parser
 
 class EnsureClauseTests extends RubyParserAbstractTest {
-  
+
   "An ensure statement" should {
-    
+
     "be parsed as a standalone statement" when {
-      
+
       "in the immediate scope of a `def` block" in {
         val code =
           """def refund

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/EnsureClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/EnsureClauseTests.scala
@@ -1,0 +1,65 @@
+package io.joern.rubysrc2cpg.parser
+
+class EnsureClauseTests extends RubyParserAbstractTest {
+  
+  "An ensure statement" should {
+    
+    "be parsed as a standalone statement" when {
+      
+      "in the immediate scope of a `def` block" in {
+        val code =
+          """def refund
+            |  ensure
+            |    redirect_to paddle_charge_path(@charge)
+            |end""".stripMargin
+        printAst(_.methodDefinition(), code) shouldEqual
+          """MethodDefinition
+            | def
+            | WsOrNl
+            | SimpleMethodNamePart
+            |  DefinedMethodName
+            |   MethodName
+            |    MethodIdentifier
+            |     refund
+            | MethodParameterPart
+            |  Separator
+            | WsOrNl
+            | BodyStatement
+            |  CompoundStatement
+            |  EnsureClause
+            |   ensure
+            |   WsOrNl
+            |   WsOrNl
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      InvocationExpressionOrCommand
+            |       SingleCommandOnlyInvocationWithoutParentheses
+            |        SimpleMethodCommand
+            |         MethodIdentifier
+            |          redirect_to
+            |         ArgumentsWithoutParentheses
+            |          Arguments
+            |           ExpressionArgument
+            |            PrimaryExpression
+            |             InvocationWithParenthesesPrimary
+            |              MethodIdentifier
+            |               paddle_charge_path
+            |              ArgsOnlyArgumentsWithParentheses
+            |               (
+            |               Arguments
+            |                ExpressionArgument
+            |                 PrimaryExpression
+            |                  VariableReferencePrimary
+            |                   VariableIdentifierVariableReference
+            |                    VariableIdentifier
+            |                     @charge
+            |               )
+            |    Separators
+            |     Separator
+            | end""".stripMargin
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Closes #3172 