### PR TITLE
RubyLexer: allow regex after `when`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
@@ -22,6 +22,8 @@ trait RubyLexerRegexHandling { this: RubyLexerBase =>
     COMMA,
     // When '/' occurs after a ':'.
     COLON,
+    // When '/' occurs after 'when'.
+    WHEN,
     // When '/' occurs after an operator.
     EMARK,
     EMARKEQ,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -114,6 +114,56 @@ class RegexTests extends RubyParserAbstractTest {
             |    )""".stripMargin
       }
     }
+
+    "used in a `when` clause" should {
+      val code =
+        """case foo
+            |      when /^ch_/
+            |        bar
+            |end""".stripMargin
+
+      "be parsed as such" in {
+        printAst(_.primary(), code) shouldEqual
+          """CaseExpressionPrimary
+              | CaseExpression
+              |  case
+              |  WsOrNl
+              |  ExpressionExpressionOrCommand
+              |   PrimaryExpression
+              |    VariableReferencePrimary
+              |     VariableIdentifierVariableReference
+              |      VariableIdentifier
+              |       foo
+              |  Separators
+              |   Separator
+              |  WhenClause
+              |   when
+              |   WsOrNl
+              |   WhenArgument
+              |    Expressions
+              |     PrimaryExpression
+              |      LiteralPrimary
+              |       RegularExpressionLiteral
+              |        /
+              |        ^ch_
+              |        /
+              |   ThenClause
+              |    Separator
+              |    WsOrNl
+              |    CompoundStatement
+              |     Statements
+              |      ExpressionOrCommandStatement
+              |       ExpressionExpressionOrCommand
+              |        PrimaryExpression
+              |         VariableReferencePrimary
+              |          VariableIdentifierVariableReference
+              |           VariableIdentifier
+              |            bar
+              |     Separators
+              |      Separator
+              |  end""".stripMargin
+      }
+    }
   }
 
   "A non-interpolated regex literal" when {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -316,6 +316,18 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     )
   }
 
+  "Non-empty regex literal after `when`" should "be recognized as such" in {
+    val code = "when /^ch_/"
+    tokenize(code) shouldBe Seq(
+      WHEN,
+      WS,
+      REGULAR_EXPRESSION_START,
+      REGULAR_EXPRESSION_BODY,
+      REGULAR_EXPRESSION_END,
+      EOF
+    )
+  }
+
   "Regex literals without metacharacters" should "be recognized as such" in {
     val eg = Seq("/regexp/", "/a regexp/")
     all(eg.map(tokenize)) shouldBe Seq(REGULAR_EXPRESSION_START, REGULAR_EXPRESSION_BODY, REGULAR_EXPRESSION_END, EOF)


### PR DESCRIPTION
Closes #3173 