### PR TITLE
rubysrc2cpg: handle empty arrays

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -508,7 +508,12 @@ class AstCreator(
   }
 
   def astForArrayConstructorPrimaryContext(ctx: ArrayConstructorPrimaryContext): Seq[Ast] = {
-    astForIndexingArgumentsContext(ctx.arrayConstructor().indexingArguments())
+    if (ctx.getText == "[]") {
+      /* we might have empty array, so create empty literal with [] */
+      Seq(Ast(literalNode(ctx, ctx.getText, Defines.NilClass)))
+    } else {
+      astForIndexingArgumentsContext(ctx.arrayConstructor().indexingArguments())
+    }
   }
 
   def astForBeginExpressionPrimaryContext(ctx: BeginExpressionPrimaryContext): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -509,8 +509,14 @@ class AstCreator(
 
   def astForArrayConstructorPrimaryContext(ctx: ArrayConstructorPrimaryContext): Seq[Ast] = {
     if (ctx.getText == "[]") {
-      /* we might have empty array, so create empty literal with [] */
-      Seq(Ast(literalNode(ctx, ctx.getText, Defines.NilClass)))
+      /* we might have an empty array, so create an empty as there would be no indexing args */
+      val arrayInitCallNode = NewCall()
+        .name(Operators.arrayInitializer)
+        .methodFullName(Operators.arrayInitializer)
+        .signature(Operators.arrayInitializer)
+        .typeFullName(Defines.Any)
+        .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      Seq(callAst(arrayInitCallNode))
     } else {
       astForIndexingArgumentsContext(ctx.arrayConstructor().indexingArguments())
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/AssignCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/AssignCpgTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.passes.ast
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes, DispatchTypes, Operators, nodes}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, NodeTypes, Operators, nodes}
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
@@ -171,6 +171,15 @@ class AssignCpgTests extends RubyCode2CpgFixture {
       tmpAssignNode.code shouldBe "tmp0 = list"
       tmpAssignNode.methodFullName shouldBe Operators.assignment
       tmpAssignNode.lineNumber shouldBe Some(1)
+    }
+  }
+
+  "empty array assignment" should {
+    val cpg = code("""x.y = []""".stripMargin)
+
+    "have an empty assignment" in {
+      val List(assignment) = cpg.call.name(Operators.assignment).l
+      assignment.argument.where(_.argumentIndex(2)).code.l shouldBe List("[]")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/AssignCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/AssignCpgTests.scala
@@ -179,7 +179,8 @@ class AssignCpgTests extends RubyCode2CpgFixture {
 
     "have an empty assignment" in {
       val List(assignment) = cpg.call.name(Operators.assignment).l
-      assignment.argument.where(_.argumentIndex(2)).code.l shouldBe List("[]")
+      assignment.argument.where(_.argumentIndex(2)).isCall.name.l shouldBe List(Operators.arrayInitializer)
+      assignment.argument.where(_.argumentIndex(2)).isCall.argument.l shouldBe List()
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -1,8 +1,7 @@
 package io.joern.rubysrc2cpg.passes.ast
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
-import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
@@ -119,6 +118,19 @@ class MethodOneTests extends RubyCode2CpgFixture {
         ret2.code shouldBe "return 2"
         ret2.lineNumber shouldBe Option(6)
       }
+    }
+  }
+
+  "Function with empty array in block" should {
+    val cpg = code("""
+        |def foo
+        |  []
+        |end
+        |""".stripMargin)
+
+    "contain empty array" in {
+      cpg.method.name("foo").size shouldBe 1
+      cpg.method.name("foo").block.containsCallTo(Operators.arrayInitializer).size shouldBe 1
     }
   }
 }


### PR DESCRIPTION
Handles cases like `x.y = [ ]` where a new empty literal of `NilClass` type is introduced when there is empty array in RHS