### PR TITLE
rubysrc2cpg: Add .gitignore

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/.gitignore
+++ b/joern-cli/frontends/rubysrc2cpg/.gitignore
@@ -1,0 +1,2 @@
+# Created by IntelliJ's ANTLR plugin
+gen/


### PR DESCRIPTION
To hide IntelliJ's ANTLR plugin generated files