### PR TITLE
RubyLexer: allow regex literal after `unless`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerRegexHandling.scala
@@ -24,6 +24,8 @@ trait RubyLexerRegexHandling { this: RubyLexerBase =>
     COLON,
     // When '/' occurs after 'when'.
     WHEN,
+    // When '/' occurs after 'unless'.
+    UNLESS,
     // When '/' occurs after an operator.
     EMARK,
     EMARKEQ,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -163,6 +163,48 @@ class RegexTests extends RubyParserAbstractTest {
               |      Separator
               |  end""".stripMargin
       }
+
+      "used in a `unless` clause" should {
+        val code =
+          """unless /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i.match?(value)
+            |end""".stripMargin
+
+        "be parsed as such" in {
+          printAst(_.primary(), code) shouldEqual
+            """UnlessExpressionPrimary
+              | UnlessExpression
+              |  unless
+              |  WsOrNl
+              |  ExpressionExpressionOrCommand
+              |   PrimaryExpression
+              |    ChainedInvocationPrimary
+              |     LiteralPrimary
+              |      RegularExpressionLiteral
+              |       /
+              |       \A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z
+              |       /i
+              |     .
+              |     MethodName
+              |      MethodIdentifier
+              |       MethodOnlyIdentifier
+              |        match
+              |        ?
+              |     ArgsOnlyArgumentsWithParentheses
+              |      (
+              |      Arguments
+              |       ExpressionArgument
+              |        PrimaryExpression
+              |         VariableReferencePrimary
+              |          VariableIdentifierVariableReference
+              |           VariableIdentifier
+              |            value
+              |      )
+              |  ThenClause
+              |   Separator
+              |   CompoundStatement
+              |  end""".stripMargin
+        }
+      }
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -327,6 +327,18 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
+  
+  "Non-empty regex literal after `unless`" should "be recognized as such" in {
+    val code = "unless /^ch_/"
+    tokenize(code) shouldBe Seq(
+      UNLESS,
+      WS,
+      REGULAR_EXPRESSION_START,
+      REGULAR_EXPRESSION_BODY,
+      REGULAR_EXPRESSION_END,
+      EOF
+    )
+  }
 
   "Regex literals without metacharacters" should "be recognized as such" in {
     val eg = Seq("/regexp/", "/a regexp/")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -327,7 +327,7 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
-  
+
   "Non-empty regex literal after `unless`" should "be recognized as such" in {
     val code = "unless /^ch_/"
     tokenize(code) shouldBe Seq(


### PR DESCRIPTION
Closes #3199