### PR TITLE
RubyParser: allow parenthesised arguments in a return jump

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -493,7 +493,7 @@ yieldWithOptionalArgument
 // --------------------------------------------------------
 
 jumpExpression
-    :   RETURN
+    :   RETURN argumentsWithParentheses?
     |   BREAK
     |   NEXT
     |   REDO

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.parser
 
 class UnlessConditionTests extends RubyParserAbstractTest {
 
-  "An unless statement" should {
+  "An unless expression" should {
     "be parsed as a primary expression" when {
 
       "it uses a newline instead of the keyword then" in {
@@ -109,6 +109,44 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |    Separators
             |     Separator
             |  end""".stripMargin
+      }
+    }
+  }
+  
+  "An unless (modifier) statement" should {
+    
+    "be parsed as a statement" when {
+      
+      "it explicitly returns an identifier out of a method" in {
+        val code = "return(value) unless item"
+          
+        printAst(_.statement(), code) shouldEqual
+          """ModifierStatement
+            | ExpressionOrCommandStatement
+            |  ExpressionExpressionOrCommand
+            |   PrimaryExpression
+            |    JumpExpressionPrimary
+            |     JumpExpression
+            |      return
+            |      ArgsOnlyArgumentsWithParentheses
+            |       (
+            |       Arguments
+            |        ExpressionArgument
+            |         PrimaryExpression
+            |          VariableReferencePrimary
+            |           VariableIdentifierVariableReference
+            |            VariableIdentifier
+            |             value
+            |       )
+            | unless
+            | WsOrNl
+            | ExpressionOrCommandStatement
+            |  ExpressionExpressionOrCommand
+            |   PrimaryExpression
+            |    VariableReferencePrimary
+            |     VariableIdentifierVariableReference
+            |      VariableIdentifier
+            |       item""".stripMargin
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
@@ -112,14 +112,14 @@ class UnlessConditionTests extends RubyParserAbstractTest {
       }
     }
   }
-  
+
   "An unless (modifier) statement" should {
-    
+
     "be parsed as a statement" when {
-      
+
       "it explicitly returns an identifier out of a method" in {
         val code = "return(value) unless item"
-          
+
         printAst(_.statement(), code) shouldEqual
           """ModifierStatement
             | ExpressionOrCommandStatement


### PR DESCRIPTION
Closes #3185