### PR TITLE
RubyLexer: support for \uXXXX chars

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -615,7 +615,7 @@ fragment SIMPLE_ESCAPE_SEQUENCE
     ;
 
 fragment DOUBLE_ESCAPED_CHARACTER
-    :   [ntrfvaebs]
+    :   [ntrfvaebsu]
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -193,6 +193,11 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
+  
+  "Double-quoted string literals containing `\\u` character sequences" should "be recognized as such" in {
+    val code = """"AB\u0003\u0004\u0014\u0000\u0000\u0000\b\u0000\u0000\u0000!\u0000file""""
+    tokenize(code) shouldBe Seq(DOUBLE_QUOTED_STRING_START, DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE, DOUBLE_QUOTED_STRING_END, EOF)
+  }
 
   "Interpolated double-quoted string literal" should "be recognized as such" in {
     val code = "\"x is #{1+1}\""

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -193,10 +193,15 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
       EOF
     )
   }
-  
+
   "Double-quoted string literals containing `\\u` character sequences" should "be recognized as such" in {
     val code = """"AB\u0003\u0004\u0014\u0000\u0000\u0000\b\u0000\u0000\u0000!\u0000file""""
-    tokenize(code) shouldBe Seq(DOUBLE_QUOTED_STRING_START, DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE, DOUBLE_QUOTED_STRING_END, EOF)
+    tokenize(code) shouldBe Seq(
+      DOUBLE_QUOTED_STRING_START,
+      DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE,
+      DOUBLE_QUOTED_STRING_END,
+      EOF
+    )
   }
 
   "Interpolated double-quoted string literal" should "be recognized as such" in {


### PR DESCRIPTION
Closes #3202 