### PR TITLE
rubysrc2cpg: ignore call node as param

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1583,19 +1583,22 @@ class AstCreator(
     val publicModifier = NewModifier().modifierType(ModifierTypes.PUBLIC)
     val paramSeq = astMethodParam.headOption match {
       case Some(value) =>
-        value.nodes
-          .map(node => {
-            // this is guaranteed to be picked up as an identifier since this is a parameter
-            val identifierNode = node.asInstanceOf[NewIdentifier]
+        value.nodes.map {
+          /* In majority of cases, node will be an identifier */
+          case identifierNode: NewIdentifier =>
             val param = NewMethodParameterIn()
               .name(identifierNode.name)
               .code(identifierNode.code)
               .lineNumber(identifierNode.lineNumber)
               .columnNumber(identifierNode.columnNumber)
             Ast(param)
-
-          })
-          .toSeq
+          case callNode: NewCall =>
+            /* TODO: Occasionally, we might encounter a _ call in cases like "do |_, x|" where we should handle this?
+             * But for now, we just return an empty AST. Keeping this match explicitly here so we come back */
+            Ast()
+          case _ =>
+            Ast()
+        }.toSeq
       case None => Seq()
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -24,6 +24,24 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     }
   }
 
+  "CPG for code iterating over hash discarding key using _" should {
+    val cpg = code("""
+        |x.each do |_, y|
+        |  puts y
+        |end
+        |""".stripMargin)
+
+    "have a valid each call and method" in {
+      cpg.call("each").size shouldBe 1
+      cpg.call("each").argument.where(_.isIdentifier).code.l shouldBe List("x")
+    }
+
+    "have valid identifiers" in {
+      cpg.identifier.name("x").size shouldBe 1
+      cpg.identifier.name("y").size shouldBe 1
+    }
+  }
+
   "CPG for code with doBlock iterating over a constant array and multiple params" should {
     val cpg = code("""
           |[1, 2, "three"].each do |n, m|


### PR DESCRIPTION
In some cases like following ones, we encounter a call node instead of an identifier when we model a block as a method. Trying to set it as a param of the method causes issues. This is specifically present when `_` is used to discard iterations over a hash:

### Synthetic example
```
x.each do |_, y|
  puts y
end
```

### Real-life HTTP param filtering example
```
params.permit(:a, :b).reject { |_, v| v.blank? }
```

To fix this, we just ignore calls nodes when encountered as a param in a block (modeled as method). Should not have any major repercussions AFAIU. I've left a TODO explicitly just in case.  


