### PR TITLE
RubyParser: refactoring`return` statements

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -86,6 +86,7 @@ primary
     |   whileExpression                                                                                                     # whileExpressionPrimary
     |   untilExpression                                                                                                     # untilExpressionPrimary
     |   forExpression                                                                                                       # forExpressionPrimary
+    |   RETURN argumentsWithParentheses                                                                                     # returnWithParenthesesPrimary
     |   jumpExpression                                                                                                      # jumpExpressionPrimary
     |   beginExpression                                                                                                     # beginExpressionPrimary
     |   LPAREN wsOrNl* compoundStatement wsOrNl* RPAREN                                                                     # groupingExpressionPrimary
@@ -154,7 +155,7 @@ expressionOrCommands
 invocationWithoutParentheses
     :   chainedCommandWithDoBlock                                                                                               # chainedCommandDoBlockInvocationWithoutParentheses
     |   command                                                                                                                 # singleCommandOnlyInvocationWithoutParentheses
-    |   RETURN WS arguments                                                                                                     # returnArgsInvocationWithoutParentheses
+    |   RETURN (WS arguments)?                                                                                                  # returnArgsInvocationWithoutParentheses
     |   BREAK WS arguments                                                                                                      # breakArgsInvocationWithoutParentheses
     |   NEXT WS arguments                                                                                                       # nextArgsInvocationWithoutParentheses
     ;
@@ -504,8 +505,7 @@ yieldWithOptionalArgument
 // --------------------------------------------------------
 
 jumpExpression
-    :   RETURN argumentsWithParentheses?
-    |   BREAK
+    :   BREAK
     |   NEXT
     |   REDO
     |   RETRY

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -336,17 +336,20 @@ class AstCreator(
     case ctx: ProcDefinitionPrimaryContext   => astForProcDefinitionContext(ctx.procDefinition())
     case ctx: YieldWithOptionalArgumentPrimaryContext =>
       Seq(astForYieldCall(ctx, Option(ctx.yieldWithOptionalArgument().arguments())))
-    case ctx: IfExpressionPrimaryContext          => Seq(astForIfExpression(ctx.ifExpression()))
-    case ctx: UnlessExpressionPrimaryContext      => Seq(astForUnlessExpression(ctx.unlessExpression()))
-    case ctx: CaseExpressionPrimaryContext        => astForCaseExpressionPrimaryContext(ctx)
-    case ctx: WhileExpressionPrimaryContext       => Seq(astForWhileExpression(ctx.whileExpression()))
-    case ctx: UntilExpressionPrimaryContext       => Seq(astForUntilExpression(ctx.untilExpression()))
-    case ctx: ForExpressionPrimaryContext         => Seq(astForForExpression(ctx.forExpression()))
-    case ctx: ReturnWithParenthesesPrimaryContext => Seq(returnAst(returnNode(ctx, ctx.getText), astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses())))
-    case ctx: JumpExpressionPrimaryContext        => astForJumpExpressionPrimaryContext(ctx)
-    case ctx: BeginExpressionPrimaryContext       => astForBeginExpressionPrimaryContext(ctx)
-    case ctx: GroupingExpressionPrimaryContext    => astForCompoundStatement(ctx.compoundStatement(), false, false)
-    case ctx: VariableReferencePrimaryContext     => Seq(astForVariableReference(ctx.variableReference()))
+    case ctx: IfExpressionPrimaryContext     => Seq(astForIfExpression(ctx.ifExpression()))
+    case ctx: UnlessExpressionPrimaryContext => Seq(astForUnlessExpression(ctx.unlessExpression()))
+    case ctx: CaseExpressionPrimaryContext   => astForCaseExpressionPrimaryContext(ctx)
+    case ctx: WhileExpressionPrimaryContext  => Seq(astForWhileExpression(ctx.whileExpression()))
+    case ctx: UntilExpressionPrimaryContext  => Seq(astForUntilExpression(ctx.untilExpression()))
+    case ctx: ForExpressionPrimaryContext    => Seq(astForForExpression(ctx.forExpression()))
+    case ctx: ReturnWithParenthesesPrimaryContext =>
+      Seq(
+        returnAst(returnNode(ctx, ctx.getText), astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses()))
+      )
+    case ctx: JumpExpressionPrimaryContext     => astForJumpExpressionPrimaryContext(ctx)
+    case ctx: BeginExpressionPrimaryContext    => astForBeginExpressionPrimaryContext(ctx)
+    case ctx: GroupingExpressionPrimaryContext => astForCompoundStatement(ctx.compoundStatement(), false, false)
+    case ctx: VariableReferencePrimaryContext  => Seq(astForVariableReference(ctx.variableReference()))
     case ctx: SimpleScopedConstantReferencePrimaryContext =>
       astForSimpleScopedConstantReferencePrimaryContext(ctx)
     case ctx: ChainedScopedConstantReferencePrimaryContext =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ReturnTests.scala
@@ -1,11 +1,11 @@
 package io.joern.rubysrc2cpg.parser
 
 class ReturnTests extends RubyParserAbstractTest {
-  
+
   "A standalone return statement" should {
-    
+
     "be parsed as statement" when {
-      
+
       "it contains no arguments" in {
         val code = "return"
         printAst(_.statement(), code) shouldEqual
@@ -13,9 +13,9 @@ class ReturnTests extends RubyParserAbstractTest {
             | InvocationExpressionOrCommand
             |  ReturnArgsInvocationWithoutParentheses
             |   return""".stripMargin
-        
+
       }
-      
+
       "it contains a scoped chain invocation" in {
         val code = "return ::X.y()"
         printAst(_.statement(), code) shouldEqual
@@ -38,7 +38,7 @@ class ReturnTests extends RubyParserAbstractTest {
             |        (
             |        )""".stripMargin
       }
-      
+
       "it contains arguments in parentheses" in {
         val code = "return(0)"
         printAst(_.statement(), code) shouldEqual
@@ -59,7 +59,7 @@ class ReturnTests extends RubyParserAbstractTest {
             |            0
             |     )""".stripMargin
       }
-    } 
+    }
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ReturnTests.scala
@@ -1,0 +1,65 @@
+package io.joern.rubysrc2cpg.parser
+
+class ReturnTests extends RubyParserAbstractTest {
+  
+  "A standalone return statement" should {
+    
+    "be parsed as statement" when {
+      
+      "it contains no arguments" in {
+        val code = "return"
+        printAst(_.statement(), code) shouldEqual
+          """ExpressionOrCommandStatement
+            | InvocationExpressionOrCommand
+            |  ReturnArgsInvocationWithoutParentheses
+            |   return""".stripMargin
+        
+      }
+      
+      "it contains a scoped chain invocation" in {
+        val code = "return ::X.y()"
+        printAst(_.statement(), code) shouldEqual
+          """ExpressionOrCommandStatement
+            | InvocationExpressionOrCommand
+            |  ReturnArgsInvocationWithoutParentheses
+            |   return
+            |   Arguments
+            |    ExpressionArgument
+            |     PrimaryExpression
+            |      ChainedInvocationPrimary
+            |       SimpleScopedConstantReferencePrimary
+            |        ::
+            |        X
+            |       .
+            |       MethodName
+            |        MethodIdentifier
+            |         y
+            |       BlankArgsArgumentsWithParentheses
+            |        (
+            |        )""".stripMargin
+      }
+      
+      "it contains arguments in parentheses" in {
+        val code = "return(0)"
+        printAst(_.statement(), code) shouldEqual
+          """ExpressionOrCommandStatement
+            | ExpressionExpressionOrCommand
+            |  PrimaryExpression
+            |   ReturnWithParenthesesPrimary
+            |    return
+            |    ArgsOnlyArgumentsWithParentheses
+            |     (
+            |     Arguments
+            |      ExpressionArgument
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            0
+            |     )""".stripMargin
+      }
+    } 
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
@@ -125,19 +125,18 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             | ExpressionOrCommandStatement
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
-            |    JumpExpressionPrimary
-            |     JumpExpression
-            |      return
-            |      ArgsOnlyArgumentsWithParentheses
-            |       (
-            |       Arguments
-            |        ExpressionArgument
-            |         PrimaryExpression
-            |          VariableReferencePrimary
-            |           VariableIdentifierVariableReference
-            |            VariableIdentifier
-            |             value
-            |       )
+            |    ReturnWithParenthesesPrimary
+            |     return
+            |     ArgsOnlyArgumentsWithParentheses
+            |      (
+            |      Arguments
+            |       ExpressionArgument
+            |        PrimaryExpression
+            |         VariableReferencePrimary
+            |          VariableIdentifierVariableReference
+            |           VariableIdentifier
+            |            value
+            |      )
             | unless
             | WsOrNl
             | ExpressionOrCommandStatement


### PR DESCRIPTION
Previously `return` commands could be parsed as primary expressions, which would be incorrect. E.g. `return ::X.y`. Here, `::X.y` is meant to be the argument to `return`, and not the member of a `return`.

Thanks @rahul-privado for pointing this out.