### PR TITLE
rubysrc2cpg: Checked statement list size to avoid crash

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -170,7 +170,7 @@ trait AstForStatementsCreator {
               }
             }
             val stAsts = astForStatement(stCtx)
-            if (canConsiderAsLeaf && processingLastMethodStatement) {
+            if (stAsts.size > 0 && canConsiderAsLeaf && processingLastMethodStatement) {
               blockChildHash.get(myBlockId) match {
                 case Some(value) =>
                   // this is a non-leaf block

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
@@ -292,4 +292,20 @@ class MiscTests extends RubyCode2CpgFixture {
       cpg.method.name("foo=").size shouldBe 1
     }
   }
+
+  // expectation is that this should not cause a crash
+  "CPG for code with method having a singleton class" should {
+    val cpg = code("""
+        |module SomeModule
+        |    def self.someMethod(arg)
+        |      class << arg
+        |      end
+        |    end
+        |end
+        |""".stripMargin)
+
+    "recognise all namespace nodes" in {
+      cpg.namespace.name("SomeModule").size shouldBe 1
+    }
+  }
 }


### PR DESCRIPTION
The `class << x` has no implementation and returns no statement ASTs. This caused a crash in the statement `Seq(lastStmtAsReturn(stCtx.getText, stAsts.head))` since `stAsts` was a empty list.

Put a check for the list size to avoid a crash. Wrote a test for the same. 
A proper implementation of `class << x` will avoid this issue. However, that will be in a separate PR. This one only avoids the crash.

@xavierpinho 