### PR TITLE
testDistro: run querydb last

### DIFF
--- a/testDistro.sh
+++ b/testDistro.sh
@@ -9,9 +9,9 @@ readonly REPO_ROOT=$SCRIPT_ABS_DIR
 echo "staging joern"
 pushd $REPO_ROOT
   sbt -Dsbt.log.noformat=true clean joerncli/stage querydb/createDistribution
-  tests/querydb-test.sh
   tests/frontends-tests.sh
   tests/scripts-test.sh
+  tests/querydb-test.sh
 popd
 
 echo "success. go analyse some code"


### PR DESCRIPTION
trying to fix the flakey testDistro execution: https://github.com/joernio/joern/issues/3087

It seems to be classpath related, and the querydb-test manually fiddles with the classpath. Not sure if it's that, but doesn't harm to do this in the very last step either way.