### PR TITLE
[rubysrc2cpg] Decouple parser and ASTCreator

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -22,7 +22,7 @@ private object Frontend {
       programName("rubysrc2cpg"),
       opt[Unit]("enableDependencyDownload")
         .hidden()
-        .action((_, c) => c.withEnableDependencyDownload(false))
+        .action((_, c) => c.withEnableDependencyDownload(true))
         .text("enable dependency download for Unix System only")
     )
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
@@ -1,0 +1,16 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.rubysrc2cpg.parser.{RubyLexer, RubyParser}
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream, ParserRuleContext, Token}
+
+class AntlrParser {
+
+  def parse(filename: String): RubyParser.ProgramContext = {
+    val charStream  = CharStreams.fromFileName(filename)
+    val lexer       = new RubyLexer(charStream)
+    val tokenStream = new CommonTokenStream(lexer)
+    val parser      = new RubyParser(tokenStream)
+    parser.program()
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -113,6 +113,7 @@ class AstCreator(
         createAstForProgramCtx(programCtx)
       case Failure(exc) =>
         logger.warn(s"Could not parse file: $filename, skipping")
+        logger.warn(exc.getMessage)
         diffGraph
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -9,7 +9,7 @@ import io.joern.x2cpg.datastructures.{Global, Scope}
 import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import org.antlr.v4.runtime.ParserRuleContext
+import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.antlr.v4.runtime.tree.TerminalNode
 import org.slf4j.LoggerFactory
 import overflowdb.{BatchedUpdate, NodeOrDetachedNode}


### PR DESCRIPTION
* Fix a bug in command line parsing (when flag was enabled by user, flag was disabled in the config)
* Catch parser errors inside `createAst` and skip the corresponding file rather than failing

I'm still tuning the logging a bit so that we get actionable information.