### PR TITLE
rubysrc2cpg: Add `*.tokens` to .gitignore

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/.gitignore
+++ b/joern-cli/frontends/rubysrc2cpg/.gitignore
@@ -1,2 +1,3 @@
 # Created by IntelliJ's ANTLR plugin
 gen/
+*.tokens


### PR DESCRIPTION
Preventing `RubyLexer.tokens` from showing up.