### PR TITLE
[rubysec2cpg] Additional skipFileRegex parameter in importCode 

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CCpgGenerator.scala
@@ -13,7 +13,7 @@ case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGene
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin", skipFileRegex: String): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CSharpCpgGenerator.scala
@@ -11,7 +11,7 @@ case class CSharpCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip", skipFileRegex: String): Try[String] = {
     var arguments = Seq("-i", inputPath, "-o", outputPath) ++ config.cmdLineParams
     var command   = rootPath.resolve("csharp2cpg.sh").toString
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -23,7 +23,7 @@ abstract class CpgGenerator() {
     *
     * This method appends command line options in config.frontend.cmdLineParams to the shell command.
     */
-  def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String]
+  def generate(inputPath: String, outputPath: String = "cpg.bin.zip", skipFileRegex: String): Try[String]
 
   protected def runShellCommand(program: String, arguments: Seq[String]): Try[Unit] =
     Try {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -54,9 +54,9 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
 
   def languageIsKnown(language: String): Boolean = CpgGeneratorFactory.KNOWN_LANGUAGES.contains(language)
 
-  def runGenerator(generator: CpgGenerator, inputPath: String, outputPath: String): Try[Path] = {
+  def runGenerator(generator: CpgGenerator, inputPath: String, outputPath: String, skipFileRegex: String): Try[Path] = {
     val outputFileOpt: Try[File] =
-      generator.generate(inputPath, outputPath).map(File(_))
+      generator.generate(inputPath, outputPath, skipFileRegex).map(File(_))
     outputFileOpt.map { outFile =>
       val parentPath = outFile.parent.path.toAbsolutePath
       if (isZipFile(outFile)) {

--- a/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GhidraCpgGenerator.scala
@@ -12,7 +12,7 @@ case class GhidraCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin", skipFileRegex: String): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/GoCpgGenerator.scala
@@ -13,7 +13,7 @@ case class GoCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String): Try[String] = {
+  override def generate(inputPath: String, outputPath: String, skipFileRegex: String): Try[String] = {
     if (go2CpgAvailable()) go2CpgGenerate(inputPath, outputPath) else goSrc2CpgGenerate(inputPath, outputPath)
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaCpgGenerator.scala
@@ -12,7 +12,7 @@ case class JavaCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip", skipFileRegex: String): Try[String] = {
 
     if (commercialAvailable) {
       generateCommercial(inputPath, outputPath)

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -16,7 +16,7 @@ case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends C
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin", skipFileRegex: String): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     javaConfig = X2Cpg.parseCommandLine(arguments.toArray, Main.getCmdLineParser, Config())
     runShellCommand(command.toString, arguments).map(_ => outputPath)

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsCpgGenerator.scala
@@ -10,7 +10,7 @@ case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip", skipFileRegex: String): Try[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -14,7 +14,7 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip", skipFileRegex: String): Try[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
     jsConfig = X2Cpg.parseCommandLine(arguments.toArray, Frontend.cmdLineParser, Config())
     runShellCommand(command.toString, arguments).map(_ => outputPath)

--- a/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/KotlinCpgGenerator.scala
@@ -12,7 +12,7 @@ case class KotlinCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin", skipFileRegex: String): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
@@ -11,7 +11,7 @@ case class LlvmCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip", skipFileRegex: String): Try[String] = {
     val command   = rootPath.resolve("llvm2cpg.sh").toString
     val arguments = Seq("--output", outputPath) ++ config.cmdLineParams ++ List(inputPath)
     runShellCommand(command, arguments).map(_ => outputPath)

--- a/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PhpCpgGenerator.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 case class PhpCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("php2cpg.bat") else rootPath.resolve("php2cpg")
 
-  override def generate(inputPath: String, outputPath: String): Try[String] = {
+  override def generate(inputPath: String, outputPath: String, skipFileRegex: String): Try[String] = {
     val arguments = List(inputPath) ++ Seq("-o", outputPath) ++ config.cmdLineParams
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }

--- a/console/src/main/scala/io/joern/console/cpgcreation/PyCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PyCpgGenerator.scala
@@ -13,7 +13,7 @@ case class PyCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip", skipFileRegex: String): Try[String] = {
     val arguments = Seq("i", inputPath, "-o", outputPath) ++ config.cmdLineParams ++ Seq("-i", inputPath)
 
     runShellCommand(command.toString, arguments).map(_ => outputPath)

--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -17,7 +17,7 @@ case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
-  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+  override def generate(inputPath: String, outputPath: String = "cpg.bin.zip", skipFileRegex: String): Try[String] = {
     val arguments = Seq(inputPath, "-o", outputPath) ++ config.cmdLineParams
     pyConfig = X2Cpg.parseCommandLine(arguments.toArray, NewMain.getCmdLineParser, Py2CpgOnFileSystemConfig())
     runShellCommand(command.toString, arguments).map(_ => outputPath)

--- a/console/src/main/scala/io/joern/console/cpgcreation/RubyCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/RubyCpgGenerator.scala
@@ -10,8 +10,8 @@ import scala.util.Try
 case class RubyCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("rubysrc2cpg.bat") else rootPath.resolve("rubysrc2cpg")
 
-  override def generate(inputPath: String, outputPath: String): Try[String] = {
-    val arguments = List(inputPath) ++ Seq("-o", outputPath) ++ config.cmdLineParams
+  override def generate(inputPath: String, outputPath: String, skipFileRegex: String): Try[String] = {
+    val arguments = List(inputPath) ++ Seq("-o", outputPath) ++ Seq("-s", skipFileRegex) ++config.cmdLineParams
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -4,7 +4,7 @@ import io.joern.rubysrc2cpg.Frontend._
 import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
-final case class Config(enableDependencyDownload: Boolean = false) extends X2CpgConfig[Config] {
+final case class Config(enableDependencyDownload: Boolean = false, skipFileRegex: String = "") extends X2CpgConfig[Config] {
 
   def withEnableDependencyDownload(value: Boolean): Config = {
     copy(enableDependencyDownload = value).withInheritedFields(this)
@@ -23,7 +23,11 @@ private object Frontend {
       opt[Unit]("enableDependencyDownload")
         .hidden()
         .action((_, c) => c.withEnableDependencyDownload(false))
-        .text("enable dependency download for Unix System only")
+        .text("enable dependency download for Unix System only"),
+      opt[String]("skipFileRegex")
+        .abbr("s")
+        .text("skip regex matched files")
+        .action((regex, c) => c.withIgnoredFilesRegex(regex))
     )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -46,7 +46,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
         }
       }
 
-      val astCreationPass = new AstCreationPass(config.inputPath, cpg, global, RubySrc2Cpg.packageTableInfo)
+      val astCreationPass = new AstCreationPass(config, cpg, global, RubySrc2Cpg.packageTableInfo)
       astCreationPass.createAndApply()
       TypeNodePass.withRegisteredTypes(astCreationPass.allUsedTypes(), cpg).createAndApply()
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
@@ -1,4 +1,5 @@
 package io.joern.rubysrc2cpg.passes
+import io.joern.rubysrc2cpg.Config
 import io.joern.rubysrc2cpg.astcreation.AstCreator
 import io.joern.rubysrc2cpg.utils.{PackageContext, PackageTable}
 import io.joern.x2cpg.SourceFiles
@@ -11,7 +12,7 @@ import overflowdb.BatchedUpdate
 
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
-class AstCreationPass(inputPath: String, cpg: Cpg, global: Global, packageTable: PackageTable)
+class AstCreationPass(config: Config, cpg: Cpg, global: Global, packageTable: PackageTable)
     extends ConcurrentWriterCpgPass[String](cpg) {
 
   private val logger                        = LoggerFactory.getLogger(this.getClass)
@@ -20,7 +21,7 @@ class AstCreationPass(inputPath: String, cpg: Cpg, global: Global, packageTable:
   def allUsedTypes(): List[String] =
     global.usedTypes.keys().asScala.toList
 
-  override def generateParts(): Array[String] = SourceFiles.determine(inputPath, RubySourceFileExtensions).toArray
+  override def generateParts(): Array[String] = SourceFiles.determine(config.inputPath, RubySourceFileExtensions, config).toArray
 
   override def runOnPart(diffGraph: DiffGraphBuilder, fileName: String): Unit = {
     try {

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
@@ -146,7 +146,7 @@ object JoernParse {
       }.flatMap { newGenerator =>
         generator = newGenerator
         generator
-          .generate(config.inputPath, outputPath = config.outputCpgFile)
+          .generate(config.inputPath, outputPath = config.outputCpgFile, skipFileRegex = "")
           .recover { case exception =>
             throw new RuntimeException(
               s"Could not generate CPG with language = $language and input = ${config.inputPath}",

--- a/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
@@ -26,7 +26,7 @@ trait AbstractJoernCliTest {
       case Languages.C | Languages.CSHARP         => CCpgGenerator(new FrontendConfig(), relativePath("c2cpg"))
       case Languages.JSSRC | Languages.JAVASCRIPT => JsSrcCpgGenerator(new FrontendConfig(), relativePath("jssrc2cpg"))
     }
-    cpgGenerator.generate(inputPath = file.pathAsString, outputPath = cpgOutFileName) match {
+    cpgGenerator.generate(inputPath = file.pathAsString, outputPath = cpgOutFileName, skipFileRegex = "") match {
       case Failure(exception) => throw new AssertionError("error while invoking cpgGenerator", exception)
       case _                  =>
     }


### PR DESCRIPTION
Now we can directly skip the file while using joern-cli. We will incorporate it for other frontends incrementally over the period of time.

Example: 
```
 importCode(inputPath = "path", skipFileRegex = "regex")
```

@fabsx00 @xavierpinho can you pls review this? 