### PR TITLE
rubysrc2cpg: Crash fix in super call w/o arguments

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1500,31 +1500,25 @@ class AstCreator(
     cmdAsts ++ mNameAsts ++ apAsts
   }
 
-  def astForArgumentsWithParenthesesContext(ctx: ArgumentsWithParenthesesContext): Seq[Ast] = Option(ctx) match {
-    case Some(ctx) =>
-      ctx match {
-        case ctx: BlankArgsArgumentsWithParenthesesContext => Seq(Ast())
-        case ctx: ArgsOnlyArgumentsWithParenthesesContext  => astForArguments(ctx.arguments())
-        case ctx: ExpressionsAndChainedCommandWithDoBlockArgumentsWithParenthesesContext =>
-          val expAsts = ctx
-            .expressions()
-            .expression
-            .asScala
-            .flatMap(exp => {
-              astForExpressionContext(exp)
-            })
-            .toSeq
-          val ccDoBlock = astForChainedCommandWithDoBlockContext(ctx.chainedCommandWithDoBlock())
-          expAsts ++ ccDoBlock
-        case ctx: ChainedCommandWithDoBlockOnlyArgumentsWithParenthesesContext =>
-          astForChainedCommandWithDoBlockContext(ctx.chainedCommandWithDoBlock())
-        case _ =>
-          logger.error(s"astForArgumentsWithParenthesesContext() $filename, ${ctx.getText} All contexts mismatched.")
-          Seq(Ast())
-      }
-    case None =>
-      logger.error(s"astForArgumentsWithParenthesesContext() $filename All contexts mismatched.")
-      Seq()
+  def astForArgumentsWithParenthesesContext(ctx: ArgumentsWithParenthesesContext): Seq[Ast] = ctx match {
+    case ctx: BlankArgsArgumentsWithParenthesesContext => Seq(Ast())
+    case ctx: ArgsOnlyArgumentsWithParenthesesContext  => astForArguments(ctx.arguments())
+    case ctx: ExpressionsAndChainedCommandWithDoBlockArgumentsWithParenthesesContext =>
+      val expAsts = ctx
+        .expressions()
+        .expression
+        .asScala
+        .flatMap(exp => {
+          astForExpressionContext(exp)
+        })
+        .toSeq
+      val ccDoBlock = astForChainedCommandWithDoBlockContext(ctx.chainedCommandWithDoBlock())
+      expAsts ++ ccDoBlock
+    case ctx: ChainedCommandWithDoBlockOnlyArgumentsWithParenthesesContext =>
+      astForChainedCommandWithDoBlockContext(ctx.chainedCommandWithDoBlock())
+    case _ =>
+      logger.error(s"astForArgumentsWithParenthesesContext() $filename, ${ctx.getText} All contexts mismatched.")
+      Seq(Ast())
   }
 
   def astForBlockParametersContext(ctx: BlockParametersContext): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -174,8 +174,12 @@ trait AstForExpressionsCreator { this: AstCreator =>
   def astForRangeExpressionContext(ctx: RangeExpressionContext): Seq[Ast] =
     Seq(astForBinaryOperatorExpression(ctx, Operators.range, ctx.expression().asScala))
 
-  protected def astForSuperExpression(ctx: SuperExpressionPrimaryContext): Ast =
-    astForSuperCall(ctx, astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses))
+  protected def astForSuperExpression(ctx: SuperExpressionPrimaryContext): Ast = {
+    val argsAst = Option(ctx.argumentsWithParentheses()) match
+      case Some(ctxArgs) => astForArgumentsWithParenthesesContext(ctxArgs)
+      case None          => Seq()
+    astForSuperCall(ctx, argsAst)
+  }
 
   // TODO: Handle the optional block.
   // NOTE: `super` is quite complicated semantically speaking. We'll need

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
@@ -308,4 +308,24 @@ class MiscTests extends RubyCode2CpgFixture {
       cpg.namespace.name("SomeModule").size shouldBe 1
     }
   }
+
+  "CPG for code with super without arguments" should {
+    val cpg = code("""
+        |class Parent
+        |  def foo(arg)
+        |  end
+        |end
+        |
+        |class Child < Parent
+        |  def foo(arg)
+        |    super
+        |  end
+        |end
+        |""".stripMargin)
+
+    "recognise all call nodes" in {
+      cpg.call.name("<operator>.super").size shouldBe 1
+      cpg.method.name("foo").size shouldBe 2
+    }
+  }
 }


### PR DESCRIPTION
1. Fix for crash in super call by putting a Option/null check
2. Test for the same
3. Removed defensive code that was put in to handle this issue

@xavierpinho 