### PR TITLE
jssrc2cpg: updated astgen to 3.2.0

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.1.0"
+    astgen_version: "3.2.0"
 }


### PR DESCRIPTION
This brings in gzexe compression for smaller Linux executables (half the size).