### PR TITLE
rubysrc2cpg: Option based null check to avoid crash in indexing arguments

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -762,7 +762,7 @@ class AstCreator(
 
   def astForIndexingExpressionPrimaryContext(ctx: IndexingExpressionPrimaryContext): Seq[Ast] = {
     val lhsExpressionAst = astForPrimaryContext(ctx.primary())
-    val rhsExpressionAst = Option(ctx.indexingArguments()) match
+    val rhsExpressionAst = Option(ctx.indexingArguments).map(astForIndexingArgumentsContext).getOrElse(Seq())
       case Some(ctxIndexingArguments) => astForIndexingArgumentsContext(ctxIndexingArguments)
       case None                       => Seq()
     val callNode = NewCall()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -526,9 +526,7 @@ class AstCreator(
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
       Seq(callAst(arrayInitCallNode))
     } else {
-      Option(ctx.arrayConstructor().indexingArguments()) match
-        case Some(ctxIndexingArguments) => astForIndexingArgumentsContext(ctxIndexingArguments)
-        case None                       => Seq()
+      Option(ctx.arrayConstructor().indexingArguments).map(astForIndexingArgumentsContext).getOrElse(Seq())
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -763,8 +763,6 @@ class AstCreator(
   def astForIndexingExpressionPrimaryContext(ctx: IndexingExpressionPrimaryContext): Seq[Ast] = {
     val lhsExpressionAst = astForPrimaryContext(ctx.primary())
     val rhsExpressionAst = Option(ctx.indexingArguments).map(astForIndexingArgumentsContext).getOrElse(Seq())
-      case Some(ctxIndexingArguments) => astForIndexingArgumentsContext(ctxIndexingArguments)
-      case None                       => Seq()
     val callNode = NewCall()
       .name(Operators.indexAccess)
       .code(ctx.getText)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -474,51 +474,45 @@ class AstCreator(
     }
   }
 
-  def astForIndexingArgumentsContext(ctx: IndexingArgumentsContext): Seq[Ast] = Option(ctx) match {
-    case Some(ctx) =>
-      ctx match {
-        case ctx: RubyParser.CommandOnlyIndexingArgumentsContext =>
-          astForCommand(ctx.command())
-        case ctx: RubyParser.ExpressionsOnlyIndexingArgumentsContext =>
-          ctx
-            .expressions()
-            .expression()
-            .asScala
-            .flatMap(exp => {
-              astForExpressionContext(exp)
-            })
-            .toSeq
-        case ctx: RubyParser.ExpressionsAndSplattingIndexingArgumentsContext =>
-          val expAsts = ctx
-            .expressions()
-            .expression()
-            .asScala
-            .flatMap(exp => {
-              astForExpressionContext(exp)
-            })
-            .toSeq
-          val splatAsts = astForExpressionOrCommand(ctx.splattingArgument().expressionOrCommand())
-          val callNode = NewCall()
-            .name(ctx.COMMA().getText)
-            .methodFullName(Operators.arrayInitializer)
-            .signature(Operators.arrayInitializer)
-            .typeFullName(Defines.Any)
-            .dispatchType(DispatchTypes.STATIC_DISPATCH)
-            .code(ctx.getText)
-            .lineNumber(ctx.COMMA().getSymbol.getLine)
-            .columnNumber(ctx.COMMA().getSymbol.getCharPositionInLine)
-          Seq(callAst(callNode, expAsts ++ splatAsts))
-        case ctx: AssociationsOnlyIndexingArgumentsContext =>
-          astForAssociationsContext(ctx.associations())
-        case ctx: RubyParser.SplattingOnlyIndexingArgumentsContext =>
-          astForExpressionOrCommand(ctx.splattingArgument().expressionOrCommand())
-        case _ =>
-          logger.error(s"astForIndexingArgumentsContext() $filename, ${ctx.getText} All contexts mismatched.")
-          Seq(Ast())
-      }
-    case None =>
-      logger.error(s"astForIndexingArgumentsContext() $filename All contexts mismatched.")
-      Seq()
+  def astForIndexingArgumentsContext(ctx: IndexingArgumentsContext): Seq[Ast] = ctx match {
+    case ctx: RubyParser.CommandOnlyIndexingArgumentsContext =>
+      astForCommand(ctx.command())
+    case ctx: RubyParser.ExpressionsOnlyIndexingArgumentsContext =>
+      ctx
+        .expressions()
+        .expression()
+        .asScala
+        .flatMap(exp => {
+          astForExpressionContext(exp)
+        })
+        .toSeq
+    case ctx: RubyParser.ExpressionsAndSplattingIndexingArgumentsContext =>
+      val expAsts = ctx
+        .expressions()
+        .expression()
+        .asScala
+        .flatMap(exp => {
+          astForExpressionContext(exp)
+        })
+        .toSeq
+      val splatAsts = astForExpressionOrCommand(ctx.splattingArgument().expressionOrCommand())
+      val callNode = NewCall()
+        .name(ctx.COMMA().getText)
+        .methodFullName(Operators.arrayInitializer)
+        .signature(Operators.arrayInitializer)
+        .typeFullName(Defines.Any)
+        .dispatchType(DispatchTypes.STATIC_DISPATCH)
+        .code(ctx.getText)
+        .lineNumber(ctx.COMMA().getSymbol.getLine)
+        .columnNumber(ctx.COMMA().getSymbol.getCharPositionInLine)
+      Seq(callAst(callNode, expAsts ++ splatAsts))
+    case ctx: AssociationsOnlyIndexingArgumentsContext =>
+      astForAssociationsContext(ctx.associations())
+    case ctx: RubyParser.SplattingOnlyIndexingArgumentsContext =>
+      astForExpressionOrCommand(ctx.splattingArgument().expressionOrCommand())
+    case _ =>
+      logger.error(s"astForIndexingArgumentsContext() $filename, ${ctx.getText} All contexts mismatched.")
+      Seq(Ast())
   }
 
   def astForArrayConstructorPrimaryContext(ctx: ArrayConstructorPrimaryContext): Seq[Ast] = {
@@ -532,7 +526,9 @@ class AstCreator(
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
       Seq(callAst(arrayInitCallNode))
     } else {
-      astForIndexingArgumentsContext(ctx.arrayConstructor().indexingArguments())
+      Option(ctx.arrayConstructor().indexingArguments()) match
+        case Some(ctxIndexingArguments) => astForIndexingArgumentsContext(ctxIndexingArguments)
+        case None                       => Seq()
     }
   }
 
@@ -766,7 +762,9 @@ class AstCreator(
 
   def astForIndexingExpressionPrimaryContext(ctx: IndexingExpressionPrimaryContext): Seq[Ast] = {
     val lhsExpressionAst = astForPrimaryContext(ctx.primary())
-    val rhsExpressionAst = astForIndexingArgumentsContext(ctx.indexingArguments())
+    val rhsExpressionAst = Option(ctx.indexingArguments()) match
+      case Some(ctxIndexingArguments) => astForIndexingArgumentsContext(ctxIndexingArguments)
+      case None                       => Seq()
     val callNode = NewCall()
       .name(Operators.indexAccess)
       .code(ctx.getText)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1147,4 +1147,14 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     c.lineNumber shouldBe Some(3)
     c.columnNumber shouldBe Some(2)
   }
+
+  "have correct structure for blank indexing arguments" in {
+    val cpg = code("""
+        |bar = Set[]
+        |""".stripMargin)
+
+    val List(callNode) = cpg.call.name("<operator>.indexAccess").l
+    callNode.lineNumber shouldBe Some(2)
+    callNode.columnNumber shouldBe Some(9)
+  }
 }


### PR DESCRIPTION
1. Fix for crash in indexing arguments handling by putting a Option/null check
2. Test for the same
3. Removed defensive code that was put in to handle this issue
@xavierpinho 