### PR TITLE
rubysrc2cpg: handle method def in method arg

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -49,8 +49,9 @@ class AstCreator(
    */
   protected val methodNameAsIdentifierStack = mutable.Stack[Ast]()
 
-  protected val methodAliases      = mutable.HashMap[String, String]()
-  protected val methodNameToMethod = mutable.HashMap[String, nodes.NewMethod]()
+  protected val methodAliases       = mutable.HashMap[String, String]()
+  protected val methodNameToMethod  = mutable.HashMap[String, nodes.NewMethod]()
+  protected val methodDefInArgument = mutable.HashSet[Ast]()
 
   protected val methodNamesWithYield = mutable.HashSet[String]()
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -14,6 +14,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewIdentifier,
   NewImport,
   NewLiteral,
+  NewMethod,
   NewReturn
 }
 import org.slf4j.LoggerFactory
@@ -249,6 +250,25 @@ trait AstForStatementsCreator {
     methodNameAsIdentifierStack.push(methodIdentifierAsts.head)
     val argsAsts = astForArguments(ctx.argumentsWithoutParentheses().arguments())
 
+    /* get args without the method def in it */
+    val argAstsWithoutMethods = argsAsts.filterNot(_.nodes.head.isInstanceOf[NewMethod])
+
+    /* isolate methods from the original args and create identifier ASTs from it */
+    val methodDefAsts = argsAsts.filter(_.nodes.head.isInstanceOf[NewMethod])
+    val methodToIdentifierAsts = methodDefAsts.map { ast =>
+      val id = NewIdentifier()
+        .name(ast.nodes.head.asInstanceOf[NewMethod].name)
+        .code(ast.nodes.head.asInstanceOf[NewMethod].name)
+        .typeFullName(Defines.Any)
+        .lineNumber(ast.nodes.head.asInstanceOf[NewMethod].lineNumber)
+      Ast(id)
+    }
+
+    /* TODO: we add the isolated method defs later on to the parent instead */
+    methodDefAsts.foreach { ast =>
+      methodDefInArgument.add(ast)
+    }
+
     val callNodes = methodIdentifierAsts.head.nodes.collect { case x: NewCall => x }
     if (callNodes.size == 1) {
       val callNode = callNodes.head
@@ -256,6 +276,9 @@ trait AstForStatementsCreator {
         resolveRequireOrLoadPath(argsAsts, callNode)
       } else if (callNode.name == "require_relative") {
         resolveRelativePath(filename, argsAsts, callNode)
+      } else if (callNode.name == "attr_accessor") {
+        /* we remove the method definition AST from argument and add its corresponding identifier form */
+        Seq(callAst(callNode, argAstsWithoutMethods ++ methodToIdentifierAsts))
       } else {
         Seq(callAst(callNode, argsAsts))
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -133,4 +133,21 @@ class MethodOneTests extends RubyCode2CpgFixture {
       cpg.method.name("foo").block.containsCallTo(Operators.arrayInitializer).size shouldBe 1
     }
   }
+
+  "Function as a list element in accessor" should {
+    val cpg = code("""
+        |class Bar
+        |  attr_accessor :a,
+        |    :b,
+        |  def self.c
+        |    1
+        |  end
+        |end
+        |""".stripMargin)
+
+    "contain empty array" in {
+      // one from the METHOD_REF node and one on line `def self.c`
+      cpg.identifier("c").astParent.isCallTo("attr_accessor").size shouldBe 1
+    }
+  }
 }


### PR DESCRIPTION
Fixes #3330 

For now, this removes the definition node completely. Here is the rearranged AST so far for a similar accessor case:

![image](https://github.com/joernio/joern/assets/3373857/361ed83d-2bec-4f14-acea-21f8101fae00)


### TODOs
 - [ ] ~Need to figure out if we need to put the isolated method definition node from the arguments of the `attr_accessor` method somewhere in the class or the METHOD_REF node that gets generated would suffice~

Upon investigation, it seems we can ignore the method node for now since the accessor is storing only identifiers. We will add them later if we want, so added boilerplate code