### PR TITLE
ruby: method defined under class using << operator

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1119,4 +1119,26 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     callNode.lineNumber shouldBe Some(2)
     callNode.columnNumber shouldBe Some(9)
   }
+
+  "method defined inside a class using <<" in {
+    val cpg = code(
+      """
+        class MyClass
+        |
+        |  class << self
+        |    def print
+        |      puts "log #{self}"
+        |    end
+        |  end
+        |  class << self
+        |  end
+        |end
+        |
+        |MyClass.printPII""".stripMargin)
+
+    val List(callNode) = cpg.call.name("print").l
+    callNode.lineNumber shouldBe Some(12)
+    callNode.columnNumber shouldBe Some(7)
+    callNode.name shouldBe "print"
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1119,10 +1119,9 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     callNode.lineNumber shouldBe Some(2)
     callNode.columnNumber shouldBe Some(9)
   }
-  
+
   "method defined inside a class using << operator" in {
-    val cpg = code(
-      """
+    val cpg = code("""
         class MyClass
         |
         |  class << self
@@ -1140,7 +1139,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     callNode.lineNumber shouldBe Some(13)
     callNode.columnNumber shouldBe Some(7)
     callNode.name shouldBe "print"
-   }
+  }
 
   "have correct structure for body statements inside a do block" in {
     val cpg = code("""

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1120,7 +1120,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     callNode.columnNumber shouldBe Some(9)
   }
 
-  "method defined inside a class using <<" in {
+  "method defined inside a class using << operator" in {
     val cpg = code(
       """
         class MyClass
@@ -1134,10 +1134,10 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
         |  end
         |end
         |
-        |MyClass.printPII""".stripMargin)
+        |MyClass.print""".stripMargin)
 
     val List(callNode) = cpg.call.name("print").l
-    callNode.lineNumber shouldBe Some(12)
+    callNode.lineNumber shouldBe Some(13)
     callNode.columnNumber shouldBe Some(7)
     callNode.name shouldBe "print"
   }


### PR DESCRIPTION
Test case is related to: https://github.com/joernio/joern/pull/3131
Cases covered:
1. Extending a class using `<<` operator
2. Defining a empty class inheriting using`self`.