### PR TITLE
Ruby: Missing dataflow for method defined under inner class

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2538,7 +2538,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).size shouldBe 2
   }
-  
+
   "flow through endless method" in {
     val cpg = code("""
         |def multiply(a,b) = a*b
@@ -2573,5 +2573,5 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
         |""".stripMargin)
     val source = cpg.identifier.name("x").l
   }
-    
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2520,6 +2520,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
   }
 
   "dataflow in method defined under class << self block" ignore {
+//    Marked it ignored as flow from identifier "firstName" to call "puts" is missing
     val cpg = code("""
        class MyClass
         |

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2518,4 +2518,23 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).size shouldBe 2
   }
+
+  "dataflow in method defined under class << self block" ignore {
+    val cpg = code("""
+       class MyClass
+        |
+        |  class << self
+        |    def printPII
+        |      firstName="somename"
+        |      puts "log PII #{firstName}"
+        |    end
+        |  end
+        |end
+        |
+        |MyClass.printPII""".stripMargin)
+
+    val source = cpg.identifier.name("firstName").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1119,4 +1119,26 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     callNode.lineNumber shouldBe Some(2)
     callNode.columnNumber shouldBe Some(9)
   }
+
+  "method defined inside a class using <<" in {
+    val cpg = code(
+      """
+        class MyClass
+        |
+        |  class << self
+        |    def print
+        |      puts "log #{self}"
+        |    end
+        |  end
+        |  class << self
+        |  end
+        |end
+        |
+        |MyClass.printPII""".stripMargin)
+
+    val List(callNode) = cpg.call.name("print").l
+    callNode.lineNumber shouldBe Some(12)
+    callNode.columnNumber shouldBe Some(7)
+    callNode.name shouldBe "print"
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1119,10 +1119,9 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     callNode.lineNumber shouldBe Some(2)
     callNode.columnNumber shouldBe Some(9)
   }
-  
+
   "method defined inside a class using << operator" in {
-    val cpg = code(
-      """
+    val cpg = code("""
         class MyClass
         |
         |  class << self
@@ -1140,7 +1139,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     callNode.lineNumber shouldBe Some(13)
     callNode.columnNumber shouldBe Some(7)
     callNode.name shouldBe "print"
-   }
+  }
 
   "have correct structure for body statements inside a do block" in {
     val cpg = code("""

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1120,7 +1120,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     callNode.columnNumber shouldBe Some(9)
   }
 
-  "method defined inside a class using <<" in {
+  "method defined inside a class using << operator" in {
     val cpg = code(
       """
         class MyClass
@@ -1134,10 +1134,10 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
         |  end
         |end
         |
-        |MyClass.printPII""".stripMargin)
+        |MyClass.print""".stripMargin)
 
     val List(callNode) = cpg.call.name("print").l
-    callNode.lineNumber shouldBe Some(12)
+    callNode.lineNumber shouldBe Some(13)
     callNode.columnNumber shouldBe Some(7)
     callNode.name shouldBe "print"
   }


### PR DESCRIPTION
Added a breaking test case, marked it as ignore: A method is defined under a inner class inheriting self, flow under that method is missing.