### PR TITLE
RubyParser: support for `%w` literals

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -257,6 +257,10 @@ blockParameters
 
 arrayConstructor
     :   LBRACK wsOrNl* indexingArguments? wsOrNl* RBRACK
+    |   QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_START
+        (QUOTED_NON_EXPANDED_STRING_ARRAY_CHARACTER
+        |QUOTED_NON_EXPANDED_STRING_ARRAY_SEPARATOR)*
+        QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ArrayTests.scala
@@ -1,0 +1,84 @@
+package io.joern.rubysrc2cpg.parser
+
+class ArrayTests extends RubyParserAbstractTest {
+  
+  "An empty array literal" should {
+    
+    "be parsed as a primary expression" when {
+      
+      "it uses the traditional [, ] delimiters" in {
+        val code = "[]"
+        printAst(_.primary(), code) shouldEqual
+          """ArrayConstructorPrimary
+            | ArrayConstructor
+            |  [
+            |  ]""".stripMargin
+      }
+      
+      "it uses the %w[ ] delimiters" in {
+        val code = "%w[]"
+        printAst(_.primary(), code) shouldEqual
+          """ArrayConstructorPrimary
+            | ArrayConstructor
+            |  %w[
+            |  ]""".stripMargin
+        
+      }
+    }
+  }
+  
+  "A non-empty array literal" should {
+    
+    "be parsed as a primary expression" when {
+      
+      "it uses the %w[ ] delimiters" in {
+        val code = "%w[x y z]"
+        printAst(_.primary(), code) shouldEqual
+          """ArrayConstructorPrimary
+            | ArrayConstructor
+            |  %w[
+            |  x
+            |  y
+            |  z
+            |  ]""".stripMargin
+      }
+      
+      "it uses the %w( ) delimiters" in {
+        val code = "%w(x y z)"
+        printAst(_.primary(), code) shouldEqual
+          """ArrayConstructorPrimary
+            | ArrayConstructor
+            |  %w(
+            |  x
+            |  y
+            |  z
+            |  )""".stripMargin
+      }
+      
+      "it uses the %w{ } delimiters" in {
+        val code = "%w{x y z}"
+        printAst(_.primary(), code) shouldEqual
+          """ArrayConstructorPrimary
+            | ArrayConstructor
+            |  %w{
+            |  x
+            |  y
+            |  z
+            |  }""".stripMargin
+      }
+      
+      "it uses the %w- - delimiters" in {
+        val code = "%w-x y z-"
+        printAst(_.primary(), code) shouldEqual
+          """ArrayConstructorPrimary
+            | ArrayConstructor
+            |  %w-
+            |  x
+            |  y
+            |  z
+            |  -""".stripMargin
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ArrayTests.scala
@@ -1,11 +1,11 @@
 package io.joern.rubysrc2cpg.parser
 
 class ArrayTests extends RubyParserAbstractTest {
-  
+
   "An empty array literal" should {
-    
+
     "be parsed as a primary expression" when {
-      
+
       "it uses the traditional [, ] delimiters" in {
         val code = "[]"
         printAst(_.primary(), code) shouldEqual
@@ -14,7 +14,7 @@ class ArrayTests extends RubyParserAbstractTest {
             |  [
             |  ]""".stripMargin
       }
-      
+
       "it uses the %w[ ] delimiters" in {
         val code = "%w[]"
         printAst(_.primary(), code) shouldEqual
@@ -22,15 +22,15 @@ class ArrayTests extends RubyParserAbstractTest {
             | ArrayConstructor
             |  %w[
             |  ]""".stripMargin
-        
+
       }
     }
   }
-  
+
   "A non-empty array literal" should {
-    
+
     "be parsed as a primary expression" when {
-      
+
       "it uses the %w[ ] delimiters" in {
         val code = "%w[x y z]"
         printAst(_.primary(), code) shouldEqual
@@ -42,7 +42,7 @@ class ArrayTests extends RubyParserAbstractTest {
             |  z
             |  ]""".stripMargin
       }
-      
+
       "it uses the %w( ) delimiters" in {
         val code = "%w(x y z)"
         printAst(_.primary(), code) shouldEqual
@@ -54,7 +54,7 @@ class ArrayTests extends RubyParserAbstractTest {
             |  z
             |  )""".stripMargin
       }
-      
+
       "it uses the %w{ } delimiters" in {
         val code = "%w{x y z}"
         printAst(_.primary(), code) shouldEqual
@@ -66,7 +66,7 @@ class ArrayTests extends RubyParserAbstractTest {
             |  z
             |  }""".stripMargin
       }
-      
+
       "it uses the %w- - delimiters" in {
         val code = "%w-x y z-"
         printAst(_.primary(), code) shouldEqual


### PR DESCRIPTION
I'm in the process of providing an alternative implementation for this construct (one that doesn't emit a token for each character). But until then, we can use this approach to keep parsing some code bases.