### PR TITLE
rubysrc2cpg: handle string interpolation with single field only

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -15,6 +15,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewImport,
   NewLiteral,
   NewMethod,
+  NewNode,
   NewReturn
 }
 import org.slf4j.LoggerFactory
@@ -251,10 +252,10 @@ trait AstForStatementsCreator {
     val argsAsts = astForArguments(ctx.argumentsWithoutParentheses().arguments())
 
     /* get args without the method def in it */
-    val argAstsWithoutMethods = argsAsts.filterNot(_.nodes.head.isInstanceOf[NewMethod])
+    val argAstsWithoutMethods = argsAsts.filterNot(_.nodes.headOption.getOrElse(None).isInstanceOf[NewMethod])
 
     /* isolate methods from the original args and create identifier ASTs from it */
-    val methodDefAsts = argsAsts.filter(_.nodes.head.isInstanceOf[NewMethod])
+    val methodDefAsts = argsAsts.filter(_.nodes.headOption.getOrElse(None).isInstanceOf[NewMethod])
     val methodToIdentifierAsts = methodDefAsts.map { ast =>
       val id = NewIdentifier()
         .name(ast.nodes.head.asInstanceOf[NewMethod].name)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/FormatStringCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/FormatStringCpgTests.scala
@@ -7,16 +7,16 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 class FormatStringCpgTests extends RubyCode2CpgFixture {
   "#string interpolation" should {
-    val cpg = code("""pre#{x}post""".stripMargin)
-    "test formatString operator node" ignore {
-      val callNode = cpg.call.methodFullName(Operators.formatString).head
-      callNode.code shouldBe """pre#{x}post"""
+    val cpg = code("""puts "pre#{x}post"""".stripMargin)
+    "test formatValue operator node" in {
+      val callNode = cpg.call.methodFullName("<operator>.formatValue").head
+      callNode.code shouldBe "#{x}"
       callNode.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       callNode.lineNumber shouldBe Some(1)
     }
 
     "test formatString operator node arguments" ignore {
-      val callNode = cpg.call.methodFullName(Operators.formatString).head
+      val callNode = cpg.call.methodFullName("<operator>.formatValue").head
 
       val child1 = callNode.astChildren.order(1).isLiteral.head
       child1.code shouldBe "pre"
@@ -25,7 +25,7 @@ class FormatStringCpgTests extends RubyCode2CpgFixture {
       val child2 = callNode.astChildren.order(2).isCall.head
       child2.code shouldBe "#{x}"
       child2.argumentIndex shouldBe 2
-      child2.methodFullName shouldBe "<operator>.formattedValue"
+      child2.methodFullName shouldBe "<operator>.formatValue"
       child2.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
       val child3 = callNode.astChildren.order(3).isLiteral.head
@@ -34,7 +34,7 @@ class FormatStringCpgTests extends RubyCode2CpgFixture {
     }
 
     "test formattedValue operator child" ignore {
-      val callNode = cpg.call.methodFullName("<operator>.formattedValue").head
+      val callNode = cpg.call.methodFullName("<operator>.formatValue").head
 
       val child1 = callNode.astChildren.order(1).isIdentifier.head
       child1.code shouldBe "x"
@@ -42,10 +42,18 @@ class FormatStringCpgTests extends RubyCode2CpgFixture {
     }
   }
 
-  "test format string with multiple replacement fields" ignore {
-    val cpg      = code("""puts "The number #{a} is less than #{b}"""".stripMargin)
-    val callNode = cpg.call.methodFullName("<operator>.formatString").head
-    callNode.code shouldBe """puts "The number #{a} is less than #{b}"""""
+  "test format string with multiple replacement fields" in {
+    val cpg       = code("""puts "The number #{a} is less than #{b}"""".stripMargin)
+    val callNodeA = cpg.call.methodFullName("<operator>.formatValue").head
+    val callNodeB = cpg.call.methodFullName("<operator>.formatValue").last
+    callNodeA.code shouldBe "#{a}"
+    callNodeB.code shouldBe "#{b}"
+  }
+
+  "test format string with only single replacement field" in {
+    val cpg      = code("""puts "#{a}"""".stripMargin)
+    val callNode = cpg.call.methodFullName("<operator>.formatValue").head
+    callNode.code shouldBe "#{a}"
   }
 
 }


### PR DESCRIPTION
This essentially fixes the cases where there was only a single replacement field. Eg.

```
puts "#{a}"
```

In addition, fixed a few tests and enabled two more. One thing to note is that instead of `<operator>.formatString`, the frontend has used `<operator>.formatValue`. Should not have any issues downstream AFAIK