### PR TITLE
[rubysrc2cpg] Added ast and dataflow tests for `:x=>`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2531,4 +2531,20 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).size shouldBe 2
   }
+
+  "flow through symbol literal defined using \\:" ignore {
+    val cpg = code("""
+        |def foo(arg)
+        |hash = {:y => arg}
+        |puts hash
+        |end
+        |
+        |x = 3
+        |foo(x)
+        |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1185,4 +1185,16 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     methodNode.lineNumber shouldBe Some(2)
     methodNode.columnNumber shouldBe Some(4)
   }
+
+  "have correct structure for symbol literal defined using \\:" in {
+    val cpg = code("""
+        |foo = {:bar=>zoo}
+        |""".stripMargin)
+
+    val List(keyValueAssocOperator) = cpg.call(".*keyValueAssociation.*").l
+    keyValueAssocOperator.code shouldBe ":bar=>zoo"
+    keyValueAssocOperator.astChildren.l.head.code shouldBe ":bar"
+    keyValueAssocOperator.astChildren.l(1).code shouldBe "zoo"
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1187,7 +1187,6 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     methodNode.columnNumber shouldBe Some(4)
   }
 
-
   "have correct structure for symbol literal defined using \\:" in {
     val cpg = code("""
         |foo = {:bar=>zoo}
@@ -1198,7 +1197,6 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     keyValueAssocOperator.astChildren.l.head.code shouldBe ":bar"
     keyValueAssocOperator.astChildren.l(1).code shouldBe "zoo"
   }
-
 
   "have correct structure for regex match global variables" in {
     val cpg = code("""


### PR DESCRIPTION
@xavierpinho, tagging for review. 