### PR TITLE
[rubysrc2cpg] Fix ATNConfig Memory Leak

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
@@ -1,16 +1,24 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.parser.{RubyLexer, RubyParser}
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream, ParserRuleContext, Token}
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
 
-class AntlrParser {
+import scala.util.Try
 
-  def parse(filename: String): RubyParser.ProgramContext = {
-    val charStream  = CharStreams.fromFileName(filename)
-    val lexer       = new RubyLexer(charStream)
-    val tokenStream = new CommonTokenStream(lexer)
-    val parser      = new RubyParser(tokenStream)
-    parser.program()
-  }
+/** A consumable wrapper for the RubyParser class used to parse the given file and clear resources held onto by ANTLR.
+  * @param filename
+  *   the file path to the file to be parsed.
+  */
+class AntlrParser(filename: String) extends AutoCloseable {
+
+  private val charStream  = CharStreams.fromFileName(filename)
+  private val lexer       = new RubyLexer(charStream)
+  private val tokenStream = new CommonTokenStream(lexer)
+  private val parser      = new RubyParser(tokenStream)
+
+  def parse(): Try[RubyParser.ProgramContext] = Try(parser.program())
+
+  override def close(): Unit =
+    parser.getInterpreter.clearDFA()
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.astcreation
+import io.joern.rubysrc2cpg.parser.RubyParser
 import io.joern.rubysrc2cpg.parser.RubyParser.*
-import io.joern.rubysrc2cpg.parser.{RubyLexer, RubyParser}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.utils.PackageContext
 import io.joern.x2cpg.Ast.storeInDiffGraph
@@ -9,17 +9,17 @@ import io.joern.x2cpg.datastructures.{Global, Scope}
 import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.antlr.v4.runtime.tree.TerminalNode
+import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.slf4j.LoggerFactory
-import overflowdb.{BatchedUpdate, NodeOrDetachedNode}
+import overflowdb.BatchedUpdate
 
 import java.io.File as JFile
 import scala.collection.immutable.Seq
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.*
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success, Using}
 
 class AstCreator(
   protected val filename: String,
@@ -107,10 +107,9 @@ class AstCreator(
   protected def getActualMethodName(name: String): String = {
     methodAliases.getOrElse(name, name)
   }
-  override def createAst(): BatchedUpdate.DiffGraphBuilder = {
-    Try {
-      new AntlrParser().parse(filename)
-    } match {
+
+  override def createAst(): BatchedUpdate.DiffGraphBuilder = Using.resource(new AntlrParser(filename)) { parser =>
+    parser.parse() match {
       case Success(programCtx) =>
         createAstForProgramCtx(programCtx)
       case Failure(exc) =>


### PR DESCRIPTION
* As mentioned in this thread https://github.com/antlr/grammars-v4/issues/2315, `ATNConfig` objects could eat up memory and the generation of this may be dependent on the kind of grammar
* This PR implements the suggested fix of calling `.clearDFA` after parsing which appears to, according to VisualVM, keep the number of live `ATNConfig` objects down

cc: @pandurangpatil 