### PR TITLE
rubysrc2cg: Proc parameter fixes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -725,11 +725,18 @@ class AstCreator(
         .filter(node => node.isInstanceOf[NewCall])
         .head
         .asInstanceOf[NewCall]
-      callNode
-        .code(ctx.getText)
-        .lineNumber(terminalNode.getSymbol().getLine())
-        .columnNumber(terminalNode.getSymbol().getCharPositionInLine())
-      Seq(callAst(callNode, argsAst, baseAst.headOption))
+
+      if (callNode.name == "call" && ctx.primary().isInstanceOf[ProcDefinitionPrimaryContext]) {
+        // this is a proc.call
+        val baseCallNode = baseAst.head.nodes.head.asInstanceOf[NewCall]
+        Seq(callAst(baseCallNode, argsAst))
+      } else {
+        callNode
+          .code(ctx.getText)
+          .lineNumber(terminalNode.getSymbol().getLine())
+          .columnNumber(terminalNode.getSymbol().getCharPositionInLine())
+        Seq(callAst(callNode, argsAst, baseAst.headOption))
+      }
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2331,12 +2331,11 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     }
   }
 
-  "flow through a proc definition using Proc.new" should {
+  "flow through a proc definition using Proc.new and flow originating within the proc" should {
     val cpg = code("""
-        |x=1
         |y = Proc.new {
-        |if x == 1
-        | x
+        |x=1
+        |x
         |end
         |}
         |puts y
@@ -2349,14 +2348,13 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     }
   }
 
-  "flow through a proc definition with non-empty block and zero parameters" should {
+  "flow through a proc definition with non-empty block and zero parameters" ignore {
     val cpg = code("""
-        |x=1
+        |x=10
+        |y = x
         |-> {
-        |if x==1
-        | puts x
-        |end
-        |}
+        |puts y
+        |}.call
         |""".stripMargin)
 
     "find flows to the sink" in {
@@ -2368,18 +2366,16 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
 
   "flow through a proc definition with non-empty block and non-zero parameters" should {
     val cpg = code("""
-        |x=1
-        |-> (x,y) {
-        |if x==1
-        | puts x
-        |end
-        |}
+        |x=10
+        |-> (arg){
+        |puts arg
+        |}.call(x)
         |""".stripMargin)
 
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).size shouldBe 4
+      sink.reachableByFlows(source).size shouldBe 2
     }
   }
 


### PR DESCRIPTION
1. Fix to be able to send parameters to a proc function. 
2. Data flow tests cases for `proc` were incorrectly written. The flow being tested was within the `proc`. Corrected it. Disabled a test case that is not working.

@xavierpinho 