### PR TITLE
rubysrc2cpg: added test case for failing dataflow

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2555,4 +2555,26 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).size shouldBe 2
   }
+
+  "dataflow in method defined under class << self block" ignore {
+    //    Marked it ignored as flow from identifier "firstName" to call "puts" is missing
+    val cpg = code(
+      """
+       class MyClass
+        |
+        |  class << self
+        |    def printPII
+        |      firstName="somename"
+        |      puts "log PII #{firstName}"
+        |    end
+        |  end
+        |end
+        |
+        |MyClass.printPII""".stripMargin)
+
+    val source = cpg.identifier.name("firstName").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2558,8 +2558,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
 
   "dataflow in method defined under class << self block" ignore {
     //    Marked it ignored as flow from identifier "firstName" to call "puts" is missing
-    val cpg = code(
-      """
+    val cpg = code("""
        class MyClass
         |
         |  class << self
@@ -2573,7 +2572,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
         |MyClass.printPII""".stripMargin)
 
     val source = cpg.identifier.name("firstName").l
-    val sink = cpg.call.name("puts").l
+    val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).size shouldBe 2
   }
 


### PR DESCRIPTION
Scenario: firstName(source) is a identifier defined under inner class and puts(sink) is statement just after the same. Expected dataflow should be exist in between two but its failing so marked it as ignore.