### PR TITLE
Fix php param to identifier dataflow issue

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -297,7 +297,7 @@ private class UsageAnalyzer(
     inElement match {
       case call: Call if containerSet.contains(call.name) =>
         call.argument.headOption.exists { base =>
-          nodeToString(use).contains(base.code)
+          nodeToString(use) == nodeToString(base)
         }
       case _ => false
     }
@@ -311,11 +311,11 @@ private class UsageAnalyzer(
         inElement match {
           case param: MethodParameterIn =>
             call.argument.headOption.exists { base =>
-              base.code == param.name
+              nodeToString(base).contains(param.name)
             }
           case identifier: Identifier =>
             call.argument.headOption.exists { base =>
-              base.code == identifier.name
+              nodeToString(base).contains(identifier.name)
             }
           case _ => false
         }
@@ -364,6 +364,7 @@ private class UsageAnalyzer(
 
   private def nodeToString(node: StoredNode): Option[String] = {
     node match {
+      case ident: Identifier     => Some(ident.name)
       case exp: Expression       => Some(exp.code)
       case p: MethodParameterIn  => Some(p.name)
       case p: MethodParameterOut => Some(p.name)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
@@ -1,0 +1,17 @@
+package io.joern.php2cpg.dataflow
+
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.shiftleft.semanticcpg.language._
+import io.joern.dataflowengineoss.language._
+
+class IntraMethodDataflowTests extends PhpCode2CpgFixture(runOssDataflow = true) {
+  "flows from parameters to corresponding identifiers should be found" in {
+    val cpg = code("""<?php
+        |function runShell($cmd) {
+        |  system($cmd);
+        |}
+        |""".stripMargin)
+
+    cpg.identifier.name("cmd").reachableBy(cpg.parameter.name("cmd")).size shouldBe 1
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/joernio/joern/issues/2099 

This is an alternative to https://github.com/joernio/joern/pull/3183 which doesn't rely on the parameter `code` field for the comparison since there's no guarantee that the `code` field will contain only `$parameterName`. For example, parameters with default values will likely show those in the code field as well (this is TODO for php2cpg, but may already exist in other frontends). Instead, this PR uses `nodeToString` to consistently compare node types.