### PR TITLE
rubysrc2cpg: handle private_class_method

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -220,7 +220,8 @@ class AstCreator(
         Seq(Ast()),
         blockAst(
           blockNode,
-          statementAsts.toList ++ builtInMethodAst ++ methodRefAssignmentAsts ++ typeRefAssignmentAst
+          statementAsts.toList ++ builtInMethodAst ++ methodRefAssignmentAsts ++ typeRefAssignmentAst ++ methodDefInArgument
+            .map(ast => ast)
         ),
         methodRetNode
       )

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -52,7 +52,7 @@ class AstCreator(
 
   protected val methodAliases       = mutable.HashMap[String, String]()
   protected val methodNameToMethod  = mutable.HashMap[String, nodes.NewMethod]()
-  protected val methodDefInArgument = mutable.HashSet[Ast]()
+  protected val methodDefInArgument = mutable.ListBuffer[Ast]()
 
   protected val typeDeclNameToTypeDecl = mutable.HashMap[String, nodes.NewTypeDecl]()
 
@@ -213,6 +213,8 @@ class AstCreator(
       typeRefAssignmentAst
     }
 
+    val methodDefInArgumentAsts = methodDefInArgument.toList
+
     val blockNode = NewBlock().typeFullName(Defines.Any)
     val programAst =
       methodAst(
@@ -220,8 +222,7 @@ class AstCreator(
         Seq(Ast()),
         blockAst(
           blockNode,
-          statementAsts.toList ++ builtInMethodAst ++ methodRefAssignmentAsts ++ typeRefAssignmentAst ++ methodDefInArgument
-            .map(ast => ast)
+          statementAsts.toList ++ builtInMethodAst ++ methodRefAssignmentAsts ++ typeRefAssignmentAst ++ methodDefInArgumentAsts
         ),
         methodRetNode
       )

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -277,7 +277,7 @@ trait AstForStatementsCreator {
         resolveRequireOrLoadPath(argsAsts, callNode)
       } else if (callNode.name == "require_relative") {
         resolveRelativePath(filename, argsAsts, callNode)
-      } else if (callNode.name == "attr_accessor") {
+      } else if (callNode.name == "attr_accessor" || callNode.name == "private_class_method") {
         /* we remove the method definition AST from argument and add its corresponding identifier form */
         Seq(callAst(callNode, argAstsWithoutMethods ++ methodToIdentifierAsts))
       } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -267,7 +267,7 @@ trait AstForStatementsCreator {
 
     /* TODO: we add the isolated method defs later on to the parent instead */
     methodDefAsts.foreach { ast =>
-      methodDefInArgument.add(ast)
+      methodDefInArgument.addOne(ast)
     }
 
     val callNodes = methodIdentifierAsts.head.nodes.collect { case x: NewCall => x }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -146,8 +146,21 @@ class MethodOneTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "contain empty array" in {
-      // one from the METHOD_REF node and one on line `def self.c`
       cpg.identifier("c").astParent.isCallTo("attr_accessor").size shouldBe 1
+    }
+  }
+
+  "Function for private_class_method" should {
+    val cpg = code("""
+        |private_class_method def foo(a)
+        |  b
+        |end
+        |""".stripMargin)
+
+    "have function identifier as argument and function definition" in {
+      // one from the METHOD_REF node and one on line `def self.c`
+      cpg.identifier("foo").astParent.isCallTo("private_class_method").size shouldBe 1
+      cpg.method.nameExact("foo").size shouldBe 1
     }
   }
 }


### PR DESCRIPTION
In Ruby we can define a private class method in a way where the argument to the `private_class_method` function can itself be a function definition

```
private_class_method def foo(a) 
  1
end
```

Here, we model the argument of `private_class_method` function itself as an identifier and add the foo method definition to the main `:program` block (is that ideal?)

This is the resulting AST for above case 👇 
![image](https://github.com/joernio/joern/assets/3373857/392bfd4c-d715-46ad-83c8-504a58e28be3)
