### PR TITLE
rubysrc2cpg: Fix for member access command

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -957,7 +957,9 @@ class AstCreator(
       )
     } else {
       val blockAst = Seq(astForBlock(ctx.block()))
-      blockAst ++ methodIdAst
+      // this is expected to be a call node
+      val callNode = methodIdAst.head.nodes.head.asInstanceOf[NewCall]
+      Seq(callAst(callNode, blockAst))
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -302,7 +302,7 @@ trait AstForStatementsCreator {
       .typeFullName(Defines.Any)
       .lineNumber(methodCallNode.lineNumber)
       .columnNumber(methodCallNode.columnNumber)
-    Seq(callAst(callNode, primaryAst ++ argsAst))
+    Seq(callAst(callNode, argsAst, primaryAst.headOption))
   }
 
   protected def astForCommand(ctx: CommandContext): Seq[Ast] = ctx match {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2382,8 +2382,8 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
   "flow through a method call with safe navigation operator with parantheses" should {
     val cpg = code("""
         |class Foo
-        | def bar(x)
-        |   return x
+        | def bar(arg)
+        |   return arg
         | end
         |end
         |x=1
@@ -2395,16 +2395,15 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).size shouldBe 3
+      sink.reachableByFlows(source).size shouldBe 2
     }
   }
 
-  // TODO: Flow size should be 3 as above, but is 1 instead.
-  "flow through a method call with safe navigation operator without parantheses" ignore {
+  "flow through a method call with safe navigation operator without parantheses" should {
     val cpg = code("""
         |class Foo
-        | def bar(x)
-        |   return x
+        | def bar(arg)
+        |   return arg
         | end
         |end
         |x=1
@@ -2416,7 +2415,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).size shouldBe 3
+      sink.reachableByFlows(source).size shouldBe 2
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2549,7 +2549,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     sink.reachableByFlows(source).size shouldBe 2
   }
 
-  "flow through symbol literal defined using \\:" ignore {
+  "flow through symbol literal defined using \\:" should {
     val cpg = code("""
         |def foo(arg)
         |hash = {:y => arg}
@@ -2559,9 +2559,12 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
         |x = 3
         |foo(x)
         |""".stripMargin)
-    val source = cpg.identifier.name("x").l
-    val sink   = cpg.call.name("puts").l
-    sink.reachableByFlows(source).size shouldBe 2
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).size shouldBe 2
+    }
   }
 
   "flow through %w array" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -943,9 +943,11 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure when method called with safe navigation with parameters without parantheses" in {
       val cpg = code("foo&.bar 1,2")
 
-      val List(callNode)  = cpg.call.l
-      val List(actualArg) = callNode.argument.argumentIndex(2).l
-      actualArg.code shouldBe "1"
+      val List(callNode)   = cpg.call.l
+      val List(actualArg1) = callNode.argument.argumentIndex(1).l
+      actualArg1.code shouldBe "1"
+      val List(actualArg2) = callNode.argument.argumentIndex(2).l
+      actualArg2.code shouldBe "2"
       cpg.argument.size shouldBe 3
       cpg.call.size shouldBe 1
     }


### PR DESCRIPTION
1. Fix for member access command code
2. `astForInvocationWithBlockOnlyPrimaryContext()` had incorrect code in in which the primary and block ASTs were just being appended resulting in the loss of a call node in the primary AST causing a UT fail. Corrected it.
3. Test case correction. The variable `x` which is source was in the path. This causes confusion in the test. Also enabled a test case that works after this change.
4. Corrected test case `flow through symbol literal defined using`. It was not working because it was incorrectly structured

@xavierpinho 