### PR TITLE
RubyParser: add simple assignment unit-test

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentTests.scala
@@ -1,0 +1,32 @@
+package io.joern.rubysrc2cpg.parser
+
+class AssignmentTests extends RubyParserAbstractTest {
+  
+  "single assignment" should {
+    
+    "be parsed as a statement" when {
+      
+      "it contains no whitespace before `=`" in {
+        val code = "x=1"
+        printAst(_.statement(), code) shouldEqual
+          """ExpressionOrCommandStatement
+            | ExpressionExpressionOrCommand
+            |  SingleAssignmentExpression
+            |   VariableIdentifierOnlySingleLeftHandSide
+            |    VariableIdentifier
+            |     x
+            |   =
+            |   MultipleRightHandSide
+            |    ExpressionOrCommands
+            |     ExpressionExpressionOrCommand
+            |      PrimaryExpression
+            |       LiteralPrimary
+            |        NumericLiteralLiteral
+            |         NumericLiteral
+            |          UnsignedNumericLiteral
+            |           1""".stripMargin
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentTests.scala
@@ -1,11 +1,11 @@
 package io.joern.rubysrc2cpg.parser
 
 class AssignmentTests extends RubyParserAbstractTest {
-  
+
   "single assignment" should {
-    
+
     "be parsed as a statement" when {
-      
+
       "it contains no whitespace before `=`" in {
         val code = "x=1"
         printAst(_.statement(), code) shouldEqual


### PR DESCRIPTION
Closing #3407 as this shows that the assignment is properly recognized.

@rahul-privado Don't rely on the ANTLR plugin since it doesn't handle predicates.