### PR TITLE
rubysrc2cpg: refactoring `%w` literals

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -256,12 +256,20 @@ blockParameters
 // --------------------------------------------------------
 
 arrayConstructor
-    :   LBRACK wsOrNl* indexingArguments? wsOrNl* RBRACK
+    :   LBRACK wsOrNl* indexingArguments? wsOrNl* RBRACK                                                            # bracketedArrayConstructor
     |   QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_START
-        (QUOTED_NON_EXPANDED_STRING_ARRAY_CHARACTER
-        |QUOTED_NON_EXPANDED_STRING_ARRAY_SEPARATOR)*
-        QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END
+        nonExpandedWordArrayElements?
+        QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END                                                                # nonExpandedWordArrayConstructor
     ;
+
+nonExpandedWordArrayElements
+    :   nonExpandedWordArrayElement (QUOTED_NON_EXPANDED_STRING_ARRAY_SEPARATOR nonExpandedWordArrayElement)*
+    ;
+
+nonExpandedWordArrayElement
+    :   QUOTED_NON_EXPANDED_STRING_ARRAY_CHARACTER+   
+    ;
+
 
 // --------------------------------------------------------
 // Hashes

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -441,7 +441,7 @@ class AstCreator(
       astForSimpleScopedConstantReferencePrimaryContext(ctx)
     case ctx: ChainedScopedConstantReferencePrimaryContext =>
       astForChainedScopedConstantReferencePrimaryContext(ctx)
-    case ctx: ArrayConstructorPrimaryContext => astForArrayConstructorPrimaryContext(ctx)
+    case ctx: ArrayConstructorPrimaryContext => astForArrayLiteral(ctx.arrayConstructor())
     case ctx: HashConstructorPrimaryContext  => astForHashConstructorPrimaryContext(ctx)
     case ctx: LiteralPrimaryContext          => astForLiteralPrimaryExpression(ctx)
     case ctx: StringExpressionPrimaryContext => astForStringExpression(ctx.stringExpression)
@@ -586,48 +586,6 @@ class AstCreator(
     case _ =>
       logger.error(s"astForIndexingArgumentsContext() $filename, ${ctx.getText} All contexts mismatched.")
       Seq(Ast())
-  }
-
-  def astForArrayConstructorPrimaryContext(ctx: ArrayConstructorPrimaryContext): Seq[Ast] = {
-    if (ctx.getText == "[]") {
-      /* we might have an empty array, so create an empty as there would be no indexing args */
-      val arrayInitCallNode = NewCall()
-        .name(Operators.arrayInitializer)
-        .methodFullName(Operators.arrayInitializer)
-        .signature(Operators.arrayInitializer)
-        .typeFullName(Defines.Any)
-        .dispatchType(DispatchTypes.STATIC_DISPATCH)
-      Seq(callAst(arrayInitCallNode))
-    } else if (ctx.arrayConstructor().QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_START() != null) {
-      if (ctx.arrayConstructor().QUOTED_NON_EXPANDED_STRING_ARRAY_CHARACTER().size() == 0) {
-        /* Handle empty array*/
-        val arrayInitCallNode = NewCall()
-          .name(Operators.arrayInitializer)
-          .methodFullName(Operators.arrayInitializer)
-          .signature(Operators.arrayInitializer)
-          .typeFullName(Defines.Any)
-          .dispatchType(DispatchTypes.STATIC_DISPATCH)
-        Seq(callAst(arrayInitCallNode))
-      } else {
-        ctx
-          .arrayConstructor()
-          .QUOTED_NON_EXPANDED_STRING_ARRAY_CHARACTER()
-          .asScala
-          .map { str =>
-            {
-              Ast(
-                NewLiteral()
-                  .code(str.getText)
-                  .typeFullName(Defines.String)
-                  .dynamicTypeHintFullName(List(Defines.String))
-              )
-            }
-          }
-          .toSeq
-      }
-    } else {
-      Option(ctx.arrayConstructor().indexingArguments).map(astForIndexingArgumentsContext).getOrElse(Seq())
-    }
   }
 
   def astForBeginExpressionPrimaryContext(ctx: BeginExpressionPrimaryContext): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -1,9 +1,15 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.parser.RubyParser
+import io.joern.rubysrc2cpg.parser.RubyParser.*
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.x2cpg.Ast
+import io.shiftleft.codepropertygraph.generated.nodes.NewCall
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import org.antlr.v4.runtime.ParserRuleContext
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 trait AstForPrimitivesCreator { this: AstCreator =>
 
@@ -49,4 +55,30 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   private def isFloatLiteral(ctx: RubyParser.UnsignedNumericLiteralContext): Boolean =
     Option(ctx.FLOAT_LITERAL_WITH_EXPONENT).isDefined || Option(ctx.FLOAT_LITERAL_WITHOUT_EXPONENT).isDefined
 
+  // TODO: Return Ast instead of Seq[Ast]
+  protected def astForArrayLiteral(ctx: ArrayConstructorContext): Seq[Ast] = ctx match
+    case ctx: BracketedArrayConstructorContext       => astForBracketedArrayConstructor(ctx)
+    case ctx: NonExpandedWordArrayConstructorContext => astForNonExpandedWordArrayConstructor(ctx)
+
+  private def astForBracketedArrayConstructor(ctx: BracketedArrayConstructorContext): Seq[Ast] = {
+    Option(ctx.indexingArguments)
+      .map(astForIndexingArgumentsContext)
+      .getOrElse(Seq(astForEmptyArrayInitializer(ctx)))
+  }
+
+  private def astForEmptyArrayInitializer(ctx: ParserRuleContext): Ast = {
+    Ast(
+      callNode(ctx, ctx.getText, Operators.arrayInitializer, Operators.arrayInitializer, DispatchTypes.STATIC_DISPATCH)
+    )
+  }
+
+  private def astForNonExpandedWordArrayConstructor(ctx: NonExpandedWordArrayConstructorContext): Seq[Ast] = {
+    Option(ctx.nonExpandedWordArrayElements)
+      .map(_.nonExpandedWordArrayElement.asScala.map(astForNonExpandedWordArrayElement).toSeq)
+      .getOrElse(Seq(astForEmptyArrayInitializer(ctx)))
+  }
+
+  private def astForNonExpandedWordArrayElement(ctx: NonExpandedWordArrayElementContext): Ast = {
+    Ast(literalNode(ctx, ctx.getText, Defines.String, List(Defines.String)))
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ArrayTests.scala
@@ -10,7 +10,7 @@ class ArrayTests extends RubyParserAbstractTest {
         val code = "[]"
         printAst(_.primary(), code) shouldEqual
           """ArrayConstructorPrimary
-            | ArrayConstructor
+            | BracketedArrayConstructor
             |  [
             |  ]""".stripMargin
       }
@@ -19,7 +19,7 @@ class ArrayTests extends RubyParserAbstractTest {
         val code = "%w[]"
         printAst(_.primary(), code) shouldEqual
           """ArrayConstructorPrimary
-            | ArrayConstructor
+            | NonExpandedWordArrayConstructor
             |  %w[
             |  ]""".stripMargin
 
@@ -35,11 +35,15 @@ class ArrayTests extends RubyParserAbstractTest {
         val code = "%w[x y z]"
         printAst(_.primary(), code) shouldEqual
           """ArrayConstructorPrimary
-            | ArrayConstructor
+            | NonExpandedWordArrayConstructor
             |  %w[
-            |  x
-            |  y
-            |  z
+            |  NonExpandedWordArrayElements
+            |   NonExpandedWordArrayElement
+            |    x
+            |   NonExpandedWordArrayElement
+            |    y
+            |   NonExpandedWordArrayElement
+            |    z
             |  ]""".stripMargin
       }
 
@@ -47,11 +51,15 @@ class ArrayTests extends RubyParserAbstractTest {
         val code = "%w(x y z)"
         printAst(_.primary(), code) shouldEqual
           """ArrayConstructorPrimary
-            | ArrayConstructor
+            | NonExpandedWordArrayConstructor
             |  %w(
-            |  x
-            |  y
-            |  z
+            |  NonExpandedWordArrayElements
+            |   NonExpandedWordArrayElement
+            |    x
+            |   NonExpandedWordArrayElement
+            |    y
+            |   NonExpandedWordArrayElement
+            |    z
             |  )""".stripMargin
       }
 
@@ -59,11 +67,15 @@ class ArrayTests extends RubyParserAbstractTest {
         val code = "%w{x y z}"
         printAst(_.primary(), code) shouldEqual
           """ArrayConstructorPrimary
-            | ArrayConstructor
+            | NonExpandedWordArrayConstructor
             |  %w{
-            |  x
-            |  y
-            |  z
+            |  NonExpandedWordArrayElements
+            |   NonExpandedWordArrayElement
+            |    x
+            |   NonExpandedWordArrayElement
+            |    y
+            |   NonExpandedWordArrayElement
+            |    z
             |  }""".stripMargin
       }
 
@@ -71,11 +83,15 @@ class ArrayTests extends RubyParserAbstractTest {
         val code = "%w-x y z-"
         printAst(_.primary(), code) shouldEqual
           """ArrayConstructorPrimary
-            | ArrayConstructor
+            | NonExpandedWordArrayConstructor
             |  %w-
-            |  x
-            |  y
-            |  z
+            |  NonExpandedWordArrayElements
+            |   NonExpandedWordArrayElement
+            |    x
+            |   NonExpandedWordArrayElement
+            |    y
+            |   NonExpandedWordArrayElement
+            |    z
             |  -""".stripMargin
       }
     }


### PR DESCRIPTION
* Words inside a `%w[xx yy]` are now considered `nonExpandedWordArrayElement` (`xx` and `yy`, respectively.)
* Simplified the `astForArrayConstructorPrimaryContext`, although it should still be further simplified.