### PR TITLE
rubysrc2cpg: add more special prefix functions

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -270,7 +270,7 @@ trait AstForStatementsCreator {
       methodDefInArgument.addOne(ast)
     }
 
-    val prefixMethods = List(
+    val prefixMethods = Set(
       "attr_reader",
       "attr_writer",
       "attr_accessor",

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -270,6 +270,17 @@ trait AstForStatementsCreator {
       methodDefInArgument.addOne(ast)
     }
 
+    val prefixMethods = List(
+      "attr_reader",
+      "attr_writer",
+      "attr_accessor",
+      "remove_method",
+      "public_class_method",
+      "private_class_method",
+      "private",
+      "protected"
+    )
+
     val callNodes = methodIdentifierAsts.head.nodes.collect { case x: NewCall => x }
     if (callNodes.size == 1) {
       val callNode = callNodes.head
@@ -277,7 +288,7 @@ trait AstForStatementsCreator {
         resolveRequireOrLoadPath(argsAsts, callNode)
       } else if (callNode.name == "require_relative") {
         resolveRelativePath(filename, argsAsts, callNode)
-      } else if (callNode.name == "attr_accessor" || callNode.name == "private_class_method") {
+      } else if (prefixMethods.contains(callNode.name)) {
         /* we remove the method definition AST from argument and add its corresponding identifier form */
         Seq(callAst(callNode, argAstsWithoutMethods ++ methodToIdentifierAsts))
       } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2627,4 +2627,31 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     sink.reachableByFlows(source).size shouldBe 2
   }
 
+  "flow through special prefix methods" in {
+    /* We only check private_class_method here. The mechanism is similar to others:
+     *     attr_reader
+     *     attr_writer
+     *     attr_accessor
+     *     remove_method
+     *     public_class_method
+     *     private
+     *     protected
+     */
+    val cpg = code("""
+        |class Foo
+        | z = 1
+        | private_class_method def self.bar(x)
+        |   x
+        | end
+        |
+        | y = self.bar(z)
+        | puts y
+        |end
+        |""".stripMargin)
+
+    val source = cpg.identifier.name("z").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -162,5 +162,25 @@ class MethodOneTests extends RubyCode2CpgFixture {
       cpg.identifier("foo").astParent.isCallTo("private_class_method").size shouldBe 1
       cpg.method.nameExact("foo").size shouldBe 1
     }
+
+    "Function for multiple function prefixes" should {
+      val cpg = code("""
+          |class Foo
+          |  private attr_reader :bar
+          |
+          |  def bar
+          |    x
+          |  end
+          |end
+          |""".stripMargin)
+
+      "have function identifier as argument and function definition" ignore {
+        /* FIXME: We are capturing the prefixes but order in ast is private -> attr_reader -> LITERAL(bar)
+         *   We should duplicate the bar node and set parent as both methods */
+        cpg.identifier("bar").astParent.isCallTo("private").size shouldBe 1
+        cpg.identifier("bar").astParent.isCallTo("attr_reader").size shouldBe 1
+        cpg.method.nameExact("bar").size shouldBe 1
+      }
+    }
   }
 }


### PR DESCRIPTION
Following up on #3401 adding more "special" method prefixes. In addition one more test that needs fixing a bit where multiple prefixes are used. Will be handled in subsequent PR