### PR TITLE
[rubysrc2cpg] Cowboy Parser Hardening

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
@@ -23,7 +23,7 @@ class AntlrParser(filename: String) {
   var parser: RubyParser  = generateParser()
 
   private def generateParser(): RubyParser = {
-    val inputString = sourceLines.mkString("\n")
+    val inputString = sourceLines.mkString(System.lineSeparator)
     val charStream  = CharStreams.fromString(inputString)
     val lexer       = new RubyLexer(charStream)
     val tokenStream = new CommonTokenStream(lexer)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
@@ -23,7 +23,7 @@ class AntlrParser(filename: String) {
   var parser: RubyParser  = generateParser()
 
   private def generateParser(): RubyParser = {
-    val inputString = sourceLines.mkString(System.lineSeparator)
+    val inputString = sourceLines.mkString("\n")
     val charStream  = CharStreams.fromString(inputString)
     val lexer       = new RubyLexer(charStream)
     val tokenStream = new CommonTokenStream(lexer)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
@@ -1,25 +1,55 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.parser.{RubyLexer, RubyParser}
+import io.shiftleft.utils.IOUtils
+import org.antlr.v4.runtime.*
 import org.antlr.v4.runtime.atn.ATN
 import org.antlr.v4.runtime.dfa.DFA
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
 import org.slf4j.LoggerFactory
 
+import java.nio.file.Paths
+import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 
-/** A consumable wrapper for the RubyParser class used to parse the given file and be disposed thereafter.
+/** A consumable wrapper for the RubyParser class used to parse the given file and be disposed thereafter. This includes
+  * a "hacky" recovery of the parser when unsupported constructs are encountered by simply not parsing those lines.
   * @param filename
   *   the file path to the file to be parsed.
   */
 class AntlrParser(filename: String) {
 
-  private val charStream  = CharStreams.fromFileName(filename)
-  private val lexer       = new RubyLexer(charStream)
-  private val tokenStream = new CommonTokenStream(lexer)
-  val parser: RubyParser  = new RubyParser(tokenStream)
+  private val logger         = LoggerFactory.getLogger(getClass)
+  private val erroneousLines = ArrayBuffer[Int]()
+  var parser: RubyParser     = generateParser()
 
-  def parse(): Try[RubyParser.ProgramContext] = Try(parser.program())
+  private def generateParser(): RubyParser = {
+    val inputString = IOUtils
+      .readLinesInFile(Paths.get(filename))
+      .zipWithIndex
+      .filterNot { case (_, i) => erroneousLines.contains(i + 1) }
+      .map(_._1)
+      .mkString(System.lineSeparator)
+    val charStream  = CharStreams.fromString(inputString)
+    val lexer       = new RubyLexer(charStream)
+    val tokenStream = new CommonTokenStream(lexer)
+    val parser      = new RubyParser(tokenStream)
+    parser.removeErrorListeners()
+    parser.addErrorListener(ErroneousLineListener.INSTANCE)
+    parser
+  }
+
+  def parse(): Try[RubyParser.ProgramContext] = {
+    var result    = Try(parser.program())
+    var lastError = ErroneousLineListener.INSTANCE.getLastErrorAndReset
+    while (lastError != -1) {
+      logger.warn(s"Erroneous line reported at $lastError, removing and re-parsing")
+      erroneousLines.addOne(lastError)
+      parser = generateParser()
+      result = Try(parser.program())
+      lastError = ErroneousLineListener.INSTANCE.getLastErrorAndReset
+    }
+    result
+  }
 
 }
 
@@ -65,4 +95,37 @@ class ResourceManagedParser(clearLimit: Double) extends AutoCloseable {
   }
 
   override def close(): Unit = clearDFA()
+}
+
+private class ErroneousLineListener extends BaseErrorListener {
+
+  private val logger         = LoggerFactory.getLogger(getClass)
+  private var lastError: Int = -1
+
+  def getLastErrorAndReset: Int = {
+    val tmp = lastError
+    lastError = -1
+    tmp
+  }
+
+  override def syntaxError(
+    recognizer: Recognizer[_, _],
+    offendingSymbol: Any,
+    line: Int,
+    charPositionInLine: Int,
+    msg: String,
+    e: RecognitionException
+  ): Unit = {
+    val tokenString = offendingSymbol match
+      case x: CommonToken => x.getText
+      case x              => x.getClass
+
+    lastError = line
+    logger.warn(s"$msg. Offending symbol '$tokenString' at $line:$charPositionInLine.")
+  }
+
+}
+
+object ErroneousLineListener {
+  val INSTANCE: ErroneousLineListener = new ErroneousLineListener()
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
@@ -1,0 +1,56 @@
+package io.joern.rubysrc2cpg.passes
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.Method
+import io.shiftleft.semanticcpg.language.*
+
+class UnknownConstructPass extends RubyCode2CpgFixture {
+
+  "invalid assignment" should {
+    val cpg = code("""
+        |a = 1
+        |b = [[]
+        |c = 2
+        |""".stripMargin)
+
+    "be ignored" in {
+      val List(a, c) = cpg.assignment.l
+      a.target.code shouldBe "a"
+      a.source.code shouldBe "1"
+
+      c.target.code shouldBe "c"
+      c.source.code shouldBe "2"
+    }
+  }
+
+  "invalid method body" should {
+    val cpg = code("""
+        |x = 1
+        |def random(a)
+        | b = 3 + 2)
+        | y = 2
+        |end
+        |z = 2
+        |""".stripMargin)
+
+    "preserve code around it and show the rest of the method body" in {
+      val List(x, y, z, random) = cpg.assignment.l
+      x.target.code shouldBe "x"
+      x.source.code shouldBe "1"
+
+      y.target.code shouldBe "y"
+      y.source.code shouldBe "2"
+
+      z.target.code shouldBe "z"
+      z.source.code shouldBe "2"
+
+      random.target.code shouldBe "random"
+      random.source.code shouldBe "def random(...)"
+
+      val List(m: Method) = cpg.method.nameExact("random").l
+      val List(_y)        = m.assignment.l
+      y.id() shouldBe _y.id()
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -9,6 +9,8 @@ import io.joern.rubysrc2cpg.astcreation.AstCreator
 
 class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
+  private val sep = System.lineSeparator
+
   "AST generation for simple fragments" should {
 
     "have correct structure for a single command call" in {
@@ -521,7 +523,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a indexing expression" in {
-      val cpg            = code("def some_method(index)\n some_map[index]\nend")
+      val cpg            = code(s"def some_method(index)$sep some_map[index]${sep}end")
       val List(callNode) = cpg.call.name(Operators.indexAccess).l
       callNode.code shouldBe "some_map[index]"
       callNode.lineNumber shouldBe Some(2)
@@ -539,7 +541,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
       val List(methodNode) = cpg.method.name("\\[]").l
       methodNode.fullName shouldBe "Test0.rb::program.MyClass.[]"
-      methodNode.code shouldBe "def [](key)\n  @member_hash[key]\nend"
+      methodNode.code shouldBe s"def [](key)$sep  @member_hash[key]${sep}end"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(5)
       methodNode.columnNumber shouldBe Some(4)
@@ -556,7 +558,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
       val List(methodNode) = cpg.method.name("==").l
       methodNode.fullName shouldBe "Test0.rb::program.MyClass.=="
-      methodNode.code shouldBe "def ==(other)\n  @my_member==other\nend"
+      methodNode.code shouldBe s"def ==(other)$sep  @my_member==other${sep}end"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(5)
       methodNode.columnNumber shouldBe Some(4)
@@ -572,7 +574,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
       val List(methodNode) = cpg.method.name("some_method").l
       methodNode.fullName shouldBe "Test0.rb::program.MyClass.some_method"
-      methodNode.code shouldBe "def some_method(param)\nend"
+      methodNode.code shouldBe s"def some_method(param)${sep}end"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(4)
       methodNode.columnNumber shouldBe Some(4)
@@ -634,15 +636,15 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for negation before block (invocationExpressionOrCommand)" in {
-      val cpg = code("!foo arg do\nputs arg\nend")
+      val cpg = code(s"!foo arg do${sep}puts arg${sep}end")
 
       val List(callNode1) = cpg.call.name(Operators.not).l
-      callNode1.code shouldBe "!foo arg do\nputs arg\nend"
+      callNode1.code shouldBe s"!foo arg do${sep}puts arg${sep}end"
       callNode1.lineNumber shouldBe Some(1)
       callNode1.columnNumber shouldBe Some(0)
 
       val List(callNode2) = cpg.call.name("foo").l
-      callNode2.code shouldBe "foo arg do\nputs arg\nend"
+      callNode2.code shouldBe s"foo arg do${sep}puts arg${sep}end"
       callNode2.lineNumber shouldBe Some(1)
       callNode2.columnNumber shouldBe Some(1)
 
@@ -698,7 +700,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for chainedInvocationWithoutArgumentsPrimary" in {
-      val cpg = code("object::foo do\nputs \"right here\"\nend")
+      val cpg = code(s"object::foo do${sep}puts \"right here\"${sep}end")
 
       val List(callNode1) = cpg.call.name("foo").l
       callNode1.code shouldBe "puts \"right here\""
@@ -801,7 +803,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for class definition with body having only identifiers" in {
-      val cpg = code("class MyClass\nidentifier1\nidentifier2\nend")
+      val cpg = code(s"class MyClass${sep}identifier1${sep}identifier2${sep}end")
 
       val List(identifierNode1) = cpg.identifier.name("identifier1").l
       identifierNode1.code shouldBe "identifier1"
@@ -953,11 +955,11 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure when method call present in next line, with the second line starting with `.`" in {
-      val cpg = code("foo\n   .bar(1)")
+      val cpg = code(s"foo${sep}   .bar(1)")
 
       val List(callNode) = cpg.call.l
       cpg.call.size shouldBe 1
-      callNode.code shouldBe ("foo\n   .bar(1)")
+      callNode.code shouldBe (s"foo${sep}   .bar(1)")
       callNode.name shouldBe "bar"
       callNode.lineNumber shouldBe Some(2)
       val List(actualArg) = callNode.argument.argumentIndex(1).l
@@ -965,11 +967,11 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure when method call present in next line, with the first line ending with `.`" in {
-      val cpg = code("foo.\n   bar(1)")
+      val cpg = code(s"foo.${sep}   bar(1)")
 
       val List(callNode) = cpg.call.l
       cpg.call.size shouldBe 1
-      callNode.code shouldBe ("foo.\n   bar(1)")
+      callNode.code shouldBe (s"foo.${sep}   bar(1)")
       callNode.name shouldBe "bar"
       callNode.lineNumber shouldBe Some(1)
       val List(actualArg) = callNode.argument.argumentIndex(1).l
@@ -1095,7 +1097,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     val List(controlNode) = cpg.controlStructure.l
     controlNode.controlStructureType shouldBe ControlStructureTypes.IF
-    controlNode.code shouldBe "a ?\n b\n: c"
+    controlNode.code shouldBe s"a ?${sep} b${sep}: c"
     controlNode.lineNumber shouldBe Some(1)
     controlNode.columnNumber shouldBe Some(4)
 


### PR DESCRIPTION
When an unexpected symbol is encountered, The Ruby grammar and parser seem to be prone to bombing out to `ProgramContext` and the default error strategy continues until `<EOF>`.

This is not great for a variety of reasons, but this is understandable as Ruby is a wild west language in terms of understanding which context we're currently in, so I propose an equally wild west solution - inspired by a questionable Discord conversation between @xavierpinho and I:

* Add an error listener and keep track of the line on which an error occurred.
* If the parser wrapper detects that an error occurred, remove that line and reparse. Continue until completion.

A more elegant, two-phase parsing strategy has been suggested by @fabsx00, but for the best interest of having a robust parser as soon as possible this should do for now...