### PR TITLE
rubysrc2cpg: Support for `%r`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -106,6 +106,8 @@ trait AstForExpressionsCreator { this: AstCreator =>
     case ctx: NumericLiteralLiteralContext    => Seq(astForNumericLiteral(ctx.numericLiteral()))
     case ctx: SymbolLiteralContext            => astForSymbol(ctx.symbol())
     case ctx: RegularExpressionLiteralContext => Seq(astForRegularExpressionLiteral(ctx))
+    case ctx: NonExpandedQuotedRegularExpressionLiteralContext =>
+      Seq(astForNonExpandedQuotedRegularExpressionLiteral(ctx))
   }
 
   protected def astForSymbol(ctx: SymbolContext): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -52,6 +52,11 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   protected def astForRegularExpressionLiteral(ctx: RubyParser.RegularExpressionLiteralContext): Ast =
     Ast(literalNode(ctx, ctx.getText, Defines.Regexp))
 
+  protected def astForNonExpandedQuotedRegularExpressionLiteral(
+    ctx: RubyParser.NonExpandedQuotedRegularExpressionLiteralContext
+  ): Ast =
+    Ast(literalNode(ctx, ctx.getText, Defines.Regexp))
+
   private def isFloatLiteral(ctx: RubyParser.UnsignedNumericLiteralContext): Boolean =
     Option(ctx.FLOAT_LITERAL_WITH_EXPONENT).isDefined || Option(ctx.FLOAT_LITERAL_WITHOUT_EXPONENT).isDefined
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -272,6 +272,15 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       literal.columnNumber shouldBe Some(0)
     }
 
+    "have correct structure for a single-line quoted (%r) regular expression literal" in {
+      val cpg               = code("%r{eu|us}")
+      val List(literalNode) = cpg.literal.l
+      literalNode.typeFullName shouldBe Defines.Regexp
+      literalNode.code shouldBe "%r{eu|us}"
+      literalNode.lineNumber shouldBe Some(1)
+      literalNode.columnNumber shouldBe Some(0)
+    }
+
     "have correct structure for an empty regular expression literal used as the second argument to a call" in {
       val cpg           = code("puts(x, //)")
       val List(literal) = cpg.literal.l


### PR DESCRIPTION
`%r...` literals are handled the same way as `/.../`.