### PR TITLE
rubysrc2cpg: Support for `%i`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -57,8 +57,9 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   // TODO: Return Ast instead of Seq[Ast]
   protected def astForArrayLiteral(ctx: ArrayConstructorContext): Seq[Ast] = ctx match
-    case ctx: BracketedArrayConstructorContext       => astForBracketedArrayConstructor(ctx)
-    case ctx: NonExpandedWordArrayConstructorContext => astForNonExpandedWordArrayConstructor(ctx)
+    case ctx: BracketedArrayConstructorContext         => astForBracketedArrayConstructor(ctx)
+    case ctx: NonExpandedWordArrayConstructorContext   => astForNonExpandedWordArrayConstructor(ctx)
+    case ctx: NonExpandedSymbolArrayConstructorContext => astForNonExpandedSymbolArrayConstructor(ctx)
 
   private def astForBracketedArrayConstructor(ctx: BracketedArrayConstructorContext): Seq[Ast] = {
     Option(ctx.indexingArguments)
@@ -80,5 +81,15 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   private def astForNonExpandedWordArrayElement(ctx: NonExpandedWordArrayElementContext): Ast = {
     Ast(literalNode(ctx, ctx.getText, Defines.String, List(Defines.String)))
+  }
+
+  private def astForNonExpandedSymbolArrayConstructor(ctx: NonExpandedSymbolArrayConstructorContext): Seq[Ast] = {
+    Option(ctx.nonExpandedSymbolArrayElements)
+      .map(_.nonExpandedSymbolArrayElement.asScala.map(astForNonExpandedSymbolArrayElement).toSeq)
+      .getOrElse(Seq(astForEmptyArrayInitializer(ctx)))
+  }
+
+  private def astForNonExpandedSymbolArrayElement(ctx: NonExpandedSymbolArrayElementContext): Ast = {
+    Ast(literalNode(ctx, ctx.getText, Defines.Symbol))
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1290,6 +1290,21 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       .l shouldBe List("c")
   }
 
+  "have correct structure for %i() array with two elements" in {
+    val cpg = code("x = %i(yy zz)")
+
+    val List(arrayInit)                        = cpg.call.name(Operators.arrayInitializer).l
+    val List(yyNode: Literal, zzNode: Literal) = arrayInit.argument.l
+
+    yyNode.code shouldBe "yy"
+    yyNode.argumentIndex shouldBe 1
+    yyNode.typeFullName shouldBe Defines.Symbol
+
+    zzNode.code shouldBe "zz"
+    zzNode.argumentIndex shouldBe 2
+    zzNode.typeFullName shouldBe Defines.Symbol
+  }
+
   "have correct structure parenthesised arguments in a return jump" in {
     val cpg = code("""return(value) unless item""".stripMargin)
 


### PR DESCRIPTION
Each element in a `%i(..)` array gets handled the same as a `:..` (symbol).