### PR TITLE
rubysrc2cpg: Handled exceptions due to none of the cases matching

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -6,10 +6,13 @@ import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.NewJumpTarget
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
+import org.slf4j.LoggerFactory
+
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 trait AstForDeclarationsCreator { this: AstCreator =>
 
+  private val logger = LoggerFactory.getLogger(this.getClass)
   protected def astForArguments(ctx: ArgumentsContext): Seq[Ast] = {
     ctx.argument().asScala.flatMap(astForArgument).toSeq
   }
@@ -21,6 +24,9 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       case ctx: ExpressionArgumentContext        => astForExpressionContext(ctx.expression)
       case ctx: AssociationArgumentContext       => astForAssociationContext(ctx.association)
       case ctx: CommandArgumentContext           => astForCommand(ctx.command)
+      case _ =>
+        logger.error(s"astForArgument() $filename, ${ctx.getText} All contexts mismatched.")
+        Seq()
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -7,12 +7,15 @@ import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewFieldIdentifier, NewJumpTarget, NewLiteral, NewNode}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
-import io.joern.x2cpg.utils._
+import io.joern.x2cpg.utils.*
+import org.slf4j.LoggerFactory
+
 import scala.collection.immutable.Set
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 trait AstForExpressionsCreator { this: AstCreator =>
 
+  private val logger                         = LoggerFactory.getLogger(this.getClass)
   protected var lastModifier: Option[String] = None
 
   protected def astForPowerExpression(ctx: PowerExpressionContext): Ast =
@@ -108,6 +111,9 @@ trait AstForExpressionsCreator { this: AstCreator =>
     case ctx: RegularExpressionLiteralContext => Seq(astForRegularExpressionLiteral(ctx))
     case ctx: NonExpandedQuotedRegularExpressionLiteralContext =>
       Seq(astForNonExpandedQuotedRegularExpressionLiteral(ctx))
+    case _ =>
+      logger.error(s"astForLiteralPrimaryExpression() $filename, ${ctx.getText} All contexts mismatched.")
+      Seq()
   }
 
   protected def astForSymbol(ctx: SymbolContext): Seq[Ast] = {


### PR DESCRIPTION
Exceptions are being seen due to none of the cases matching. The required productions have been handled in code and so this will require more debugging. This change is to avoid a crash.