### PR TITLE
[rubysrc2cpg] Parser Hardening on Timeouts

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -28,7 +28,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
     withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
       new MetaDataPass(cpg, Languages.RUBYSRC, config.inputPath).createAndApply()
       new ConfigFileCreationPass(cpg).createAndApply()
-      Using.resource(new ResourceManagedParser(config.antlrCacheMemLimit)) { parser =>
+      Using.resource(new ResourceManagedParser(config.antlrCacheMemLimit, config.parserTimeoutMs)) { parser =>
         if (config.enableDependencyDownload && !scala.util.Properties.isWin) {
           val tempDir = File.newTemporaryDirectory()
           try {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
@@ -53,4 +53,20 @@ class UnknownConstructPass extends RubyCode2CpgFixture {
     }
   }
 
+  "an attempted fix" should {
+    val cpg = code("""
+        |class DerivedClass < BaseClass
+        | KEYS = %i(
+        |  id1
+        |  id2
+        |  id3
+        | ).freeze
+        |end
+        |""".stripMargin)
+
+    "not cause an infinite loop once the last line is blanked out, at the cost of the structure" in {
+      cpg.typeDecl("DerivedClass").size shouldBe 0
+    }
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
@@ -1,6 +1,8 @@
 package io.joern.rubysrc2cpg.passes
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.joern.x2cpg.utils.Environment
+import io.joern.x2cpg.utils.Environment.OperatingSystemType
 import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.shiftleft.semanticcpg.language.*
 
@@ -64,8 +66,9 @@ class UnknownConstructPass extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    "not cause an infinite loop once the last line is blanked out, at the cost of the structure" in {
-      cpg.typeDecl("DerivedClass").size shouldBe 0
+    "not cause an infinite loop once the last line is blanked out, at the cost of the structure (in Unix)" in {
+      cpg.typeDecl("DerivedClass").size shouldBe
+        (if (Environment.operatingSystem == OperatingSystemType.Windows) 1 else 0)
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/TimeUtils.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/TimeUtils.scala
@@ -1,7 +1,11 @@
 package io.joern.x2cpg.utils
 
 import java.util.Locale
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.*
+import scala.language.postfixOps
+import scala.util.Try
 
 object TimeUtils {
 
@@ -16,6 +20,10 @@ object TimeUtils {
 
   /** Selects most appropriate TimeUnit for given duration and formats it accordingly */
   def pretty(duration: Long): String = pretty(Duration.fromNanos(duration))
+
+  def runWithTimeout[T](timeoutMs: Long)(f: => T): Try[T] = {
+    Try(Await.result(Future(f), timeoutMs milliseconds))
+  }
 
   private def pretty(duration: Duration): String =
     duration match {


### PR DESCRIPTION
Another issue encountered by the Ruby parser is that some inputs cause ANTLR to parse indefinitely (see https://github.com/joernio/joern/issues/3424). To reduce the impact of this issue until it is fixed, a configurable timeout as been introduced.

This PR also fixes an issue in the [cowboy PR](https://github.com/joernio/joern/pull/3421) that causes the line removal to occur infinitely if removing lines does not fix the parsing issues by the final line.