### PR TITLE
RubyParser: fix multi-line `%i` parsing

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -765,6 +765,7 @@ fragment QUOTED_NON_EXPANDED_NON_ESCAPED_SYMBOL_ARRAY_CHARACTER
 
 fragment QUOTED_NON_EXPANDED_SYMBOL_ARRAY_DELIMITER
     :   [\u0009]
+    |   [\u000a]
     |   [\u000b]
     |   [\u000c]
     |   [\u000d]

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -261,12 +261,14 @@ arrayConstructor
         nonExpandedWordArrayElements?
         QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END                                                                # nonExpandedWordArrayConstructor
     |   QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_START
+        QUOTED_NON_EXPANDED_SYMBOL_ARRAY_SEPARATOR*
         nonExpandedSymbolArrayElements?
+        QUOTED_NON_EXPANDED_SYMBOL_ARRAY_SEPARATOR*
         QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_END                                                                # nonExpandedSymbolArrayConstructor
     ;
     
 nonExpandedSymbolArrayElements
-    :   nonExpandedSymbolArrayElement (QUOTED_NON_EXPANDED_SYMBOL_ARRAY_SEPARATOR nonExpandedSymbolArrayElement)*
+    :   nonExpandedSymbolArrayElement (QUOTED_NON_EXPANDED_SYMBOL_ARRAY_SEPARATOR+ nonExpandedSymbolArrayElement)*
     ;
 
 nonExpandedSymbolArrayElement

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -6,10 +6,13 @@ import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.NewJumpTarget
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
+import org.slf4j.LoggerFactory
+
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 trait AstForDeclarationsCreator { this: AstCreator =>
 
+  private val logger = LoggerFactory.getLogger(this.getClass)
   protected def astForArguments(ctx: ArgumentsContext): Seq[Ast] = {
     ctx.argument().asScala.flatMap(astForArgument).toSeq
   }
@@ -21,6 +24,9 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       case ctx: ExpressionArgumentContext        => astForExpressionContext(ctx.expression)
       case ctx: AssociationArgumentContext       => astForAssociationContext(ctx.association)
       case ctx: CommandArgumentContext           => astForCommand(ctx.command)
+      case _ =>
+        logger.error(s"astForArgument() $filename, ${ctx.getText} All contexts mismatched.")
+        Seq()
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -7,12 +7,15 @@ import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewFieldIdentifier, NewJumpTarget, NewLiteral, NewNode}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
-import io.joern.x2cpg.utils._
+import io.joern.x2cpg.utils.*
+import org.slf4j.LoggerFactory
+
 import scala.collection.immutable.Set
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 trait AstForExpressionsCreator { this: AstCreator =>
 
+  private val logger                         = LoggerFactory.getLogger(this.getClass)
   protected var lastModifier: Option[String] = None
 
   protected def astForPowerExpression(ctx: PowerExpressionContext): Ast =
@@ -108,6 +111,9 @@ trait AstForExpressionsCreator { this: AstCreator =>
     case ctx: RegularExpressionLiteralContext => Seq(astForRegularExpressionLiteral(ctx))
     case ctx: NonExpandedQuotedRegularExpressionLiteralContext =>
       Seq(astForNonExpandedQuotedRegularExpressionLiteral(ctx))
+    case _ =>
+      logger.error(s"astForLiteralPrimaryExpression() $filename, ${ctx.getText} All contexts mismatched.")
+      Seq()
   }
 
   protected def astForSymbol(ctx: SymbolContext): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ArrayTests.scala
@@ -167,6 +167,26 @@ class ArrayTests extends RubyParserAbstractTest {
             |  ]""".stripMargin
 
       }
+
+      "it uses the %i( ) delimiters in a multi-line fashion" in {
+        val code =
+          """%i(
+            |x y
+            |z
+            |)""".stripMargin
+        printAst(_.primary(), code) shouldEqual
+          """ArrayConstructorPrimary
+            | NonExpandedSymbolArrayConstructor
+            |  %i(
+            |  NonExpandedSymbolArrayElements
+            |   NonExpandedSymbolArrayElement
+            |    x
+            |   NonExpandedSymbolArrayElement
+            |    y
+            |   NonExpandedSymbolArrayElement
+            |    z
+            |  )""".stripMargin
+      }
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -683,6 +683,24 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     )
   }
 
+  "multi-line two-word `%i` symbol array literals" should "be recognized as such" in {
+    val code =
+      """%i(
+        |x
+        |y
+        |)""".stripMargin
+    tokenize(code) shouldBe Seq(
+      QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_START,
+      QUOTED_NON_EXPANDED_SYMBOL_ARRAY_SEPARATOR,
+      QUOTED_NON_EXPANDED_SYMBOL_ARRAY_CHARACTER,
+      QUOTED_NON_EXPANDED_SYMBOL_ARRAY_SEPARATOR,
+      QUOTED_NON_EXPANDED_SYMBOL_ARRAY_CHARACTER,
+      QUOTED_NON_EXPANDED_SYMBOL_ARRAY_SEPARATOR,
+      QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_END,
+      EOF
+    )
+  }
+
   "identifier used in a keyword argument" should "not be mistaken for a symbol literal" in {
     // This test exists to check if RubyLexer properly decided between COLON and SYMBOL_LITERAL
     val code = "foo(x:y)"


### PR DESCRIPTION
`\n` was not included in the set of separators for `%i` elements and as a result multi-line symbol arrays wouldn't be properly split.