### PR TITLE
[rubysrc2cpg] multiline `%i` support

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2661,4 +2661,16 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     sink.reachableByFlows(source).size shouldBe 2
   }
 
+  "flow through %i array" in {
+    val cpg = code("""
+        |a = %i[b
+        |    c]
+        |puts a
+        |""".stripMargin)
+
+    val source = cpg.literal.code("b").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 1
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1392,4 +1392,26 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     cpg.identifier.name("b").size shouldBe 1
   }
 
+  "have correct structure for multiline %i" in {
+    val cpg = code("""
+        |w = %i(x y
+        |     z)
+        |""".stripMargin)
+
+    val List(arrayInit)                                      = cpg.call.name(Operators.arrayInitializer).l
+    val List(xNode: Literal, yNode: Literal, zNode: Literal) = arrayInit.argument.l
+
+    xNode.code shouldBe "x"
+    xNode.argumentIndex shouldBe 1
+    xNode.typeFullName shouldBe Defines.Symbol
+
+    yNode.code shouldBe "y"
+    yNode.argumentIndex shouldBe 2
+    yNode.typeFullName shouldBe Defines.Symbol
+
+    zNode.code shouldBe "z"
+    zNode.argumentIndex shouldBe 3
+    zNode.typeFullName shouldBe Defines.Symbol
+  }
+
 }


### PR DESCRIPTION
Added unit and dataflow test for multiline `%i` 