### PR TITLE
[rubysrc2cpg] Reverting Workarounds Related to Parsing

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -5,11 +5,8 @@ import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
 import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
-final case class Config(
-  enableDependencyDownload: Boolean = false,
-  antlrCacheMemLimit: Double = 0.6d,
-  parserTimeoutMs: Long = 5000
-) extends X2CpgConfig[Config]
+final case class Config(enableDependencyDownload: Boolean = false, antlrCacheMemLimit: Double = 0.6d)
+    extends X2CpgConfig[Config]
     with TypeRecoveryParserConfig[Config] {
 
   def withEnableDependencyDownload(value: Boolean): Config = {
@@ -18,10 +15,6 @@ final case class Config(
 
   def withAntlrCacheMemoryLimit(value: Double): Config = {
     copy(antlrCacheMemLimit = value).withInheritedFields(this)
-  }
-
-  def withParserTimeoutMs(value: Long): Config = {
-    copy(parserTimeoutMs = value).withInheritedFields(this)
   }
 }
 
@@ -50,16 +43,6 @@ private object Frontend {
             success
         }
         .text("sets the heap usage threshold at which the ANTLR DFA cache is cleared during parsing (default 0.6)"),
-      opt[Long]("parserTimeoutMs")
-        .hidden()
-        .action((x, c) => c.withParserTimeoutMs(x))
-        .validate(x =>
-          if (x < 50)
-            failure(s"$x is far too low of a parser timeout limit")
-          else
-            success
-        )
-        .text("sets the timeout (in milliseconds) for how long ANTLR is allowed to parse a file for (default 5000ms)"),
       XTypeRecovery.parserOptions
     )
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -28,7 +28,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
     withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
       new MetaDataPass(cpg, Languages.RUBYSRC, config.inputPath).createAndApply()
       new ConfigFileCreationPass(cpg).createAndApply()
-      Using.resource(new ResourceManagedParser(config.antlrCacheMemLimit, config.parserTimeoutMs)) { parser =>
+      Using.resource(new ResourceManagedParser(config.antlrCacheMemLimit)) { parser =>
         if (config.enableDependencyDownload && !scala.util.Properties.isWin) {
           val tempDir = File.newTemporaryDirectory()
           try {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language.*
 
 class UnknownConstructPass extends RubyCode2CpgFixture {
 
-  "invalid assignment" should {
+  "invalid assignment" ignore {
     val cpg = code("""
         |a = 1
         |b = [[]
@@ -25,7 +25,7 @@ class UnknownConstructPass extends RubyCode2CpgFixture {
     }
   }
 
-  "invalid method body" should {
+  "invalid method body" ignore {
     val cpg = code("""
         |x = 1
         |def random(a)
@@ -55,7 +55,7 @@ class UnknownConstructPass extends RubyCode2CpgFixture {
     }
   }
 
-  "unrecognized token in the RHS of an assignment" should {
+  "unrecognized token in the RHS of an assignment" ignore {
     val cpg = code("""
         |x = \!
         |y = 1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/UnknownConstructPass.scala
@@ -69,7 +69,7 @@ class UnknownConstructPass extends RubyCode2CpgFixture {
     }
   }
 
-  "an attempted fix" should {
+  "an attempted fix" ignore {
     val cpg = code("""
         |class DerivedClass < BaseClass
         | KEYS = %w(

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -9,8 +9,6 @@ import io.joern.rubysrc2cpg.astcreation.AstCreator
 
 class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
-  private val sep = System.lineSeparator
-
   "AST generation for simple fragments" should {
 
     "have correct structure for a single command call" in {
@@ -532,7 +530,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for a indexing expression" in {
-      val cpg            = code(s"def some_method(index)$sep some_map[index]${sep}end")
+      val cpg            = code("def some_method(index)\n some_map[index]\nend")
       val List(callNode) = cpg.call.name(Operators.indexAccess).l
       callNode.code shouldBe "some_map[index]"
       callNode.lineNumber shouldBe Some(2)
@@ -550,7 +548,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
       val List(methodNode) = cpg.method.name("\\[]").l
       methodNode.fullName shouldBe "Test0.rb::program.MyClass.[]"
-      methodNode.code shouldBe s"def [](key)$sep  @member_hash[key]${sep}end"
+      methodNode.code shouldBe "def [](key)\n  @member_hash[key]\nend"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(5)
       methodNode.columnNumber shouldBe Some(4)
@@ -567,7 +565,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
       val List(methodNode) = cpg.method.name("==").l
       methodNode.fullName shouldBe "Test0.rb::program.MyClass.=="
-      methodNode.code shouldBe s"def ==(other)$sep  @my_member==other${sep}end"
+      methodNode.code shouldBe "def ==(other)\n  @my_member==other\nend"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(5)
       methodNode.columnNumber shouldBe Some(4)
@@ -583,7 +581,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
       val List(methodNode) = cpg.method.name("some_method").l
       methodNode.fullName shouldBe "Test0.rb::program.MyClass.some_method"
-      methodNode.code shouldBe s"def some_method(param)${sep}end"
+      methodNode.code shouldBe "def some_method(param)\nend"
       methodNode.lineNumber shouldBe Some(3)
       methodNode.lineNumberEnd shouldBe Some(4)
       methodNode.columnNumber shouldBe Some(4)
@@ -645,15 +643,15 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for negation before block (invocationExpressionOrCommand)" in {
-      val cpg = code(s"!foo arg do${sep}puts arg${sep}end")
+      val cpg = code("!foo arg do\nputs arg\nend")
 
       val List(callNode1) = cpg.call.name(Operators.not).l
-      callNode1.code shouldBe s"!foo arg do${sep}puts arg${sep}end"
+      callNode1.code shouldBe "!foo arg do\nputs arg\nend"
       callNode1.lineNumber shouldBe Some(1)
       callNode1.columnNumber shouldBe Some(0)
 
       val List(callNode2) = cpg.call.name("foo").l
-      callNode2.code shouldBe s"foo arg do${sep}puts arg${sep}end"
+      callNode2.code shouldBe "foo arg do\nputs arg\nend"
       callNode2.lineNumber shouldBe Some(1)
       callNode2.columnNumber shouldBe Some(1)
 
@@ -709,7 +707,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for chainedInvocationWithoutArgumentsPrimary" in {
-      val cpg = code(s"object::foo do${sep}puts \"right here\"${sep}end")
+      val cpg = code("object::foo do\nputs \"right here\"\nend")
 
       val List(callNode1) = cpg.call.name("foo").l
       callNode1.code shouldBe "puts \"right here\""
@@ -812,7 +810,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure for class definition with body having only identifiers" in {
-      val cpg = code(s"class MyClass${sep}identifier1${sep}identifier2${sep}end")
+      val cpg = code("class MyClass\nidentifier1\nidentifier2\nend")
 
       val List(identifierNode1) = cpg.identifier.name("identifier1").l
       identifierNode1.code shouldBe "identifier1"
@@ -964,11 +962,11 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure when method call present in next line, with the second line starting with `.`" in {
-      val cpg = code(s"foo${sep}   .bar(1)")
+      val cpg = code("foo\n   .bar(1)")
 
       val List(callNode) = cpg.call.l
       cpg.call.size shouldBe 1
-      callNode.code shouldBe (s"foo${sep}   .bar(1)")
+      callNode.code shouldBe ("foo\n   .bar(1)")
       callNode.name shouldBe "bar"
       callNode.lineNumber shouldBe Some(2)
       val List(actualArg) = callNode.argument.argumentIndex(1).l
@@ -976,11 +974,11 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     }
 
     "have correct structure when method call present in next line, with the first line ending with `.`" in {
-      val cpg = code(s"foo.${sep}   bar(1)")
+      val cpg = code("foo.\n   bar(1)")
 
       val List(callNode) = cpg.call.l
       cpg.call.size shouldBe 1
-      callNode.code shouldBe (s"foo.${sep}   bar(1)")
+      callNode.code shouldBe ("foo.\n   bar(1)")
       callNode.name shouldBe "bar"
       callNode.lineNumber shouldBe Some(1)
       val List(actualArg) = callNode.argument.argumentIndex(1).l
@@ -1106,7 +1104,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     val List(controlNode) = cpg.controlStructure.l
     controlNode.controlStructureType shouldBe ControlStructureTypes.IF
-    controlNode.code shouldBe s"a ?${sep} b${sep}: c"
+    controlNode.code shouldBe "a ?\n b\n: c"
     controlNode.lineNumber shouldBe Some(1)
     controlNode.columnNumber shouldBe Some(4)
 


### PR DESCRIPTION
Reverting the changes, @DavidBakerEffendi recently made to handle the situation where the parser was getting into a loop for the specific use cases of the file. For now we were able to proceed by removing this file.

1. It has introduced inconsistent behaviour in the scan results.
2. It has also increased the source code parsing time.
3. When I tried with the latest master by reverting these changes and with this change. I observed CPG of bigger size, along with more files being processed, and more sources and sinks being tagged. 