### PR TITLE
kotlin2cpg: add null-check in tree visitor

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/psi/PsiUtils.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/psi/PsiUtils.scala
@@ -21,8 +21,10 @@ object PsiUtils {
   def objectIdxMaybe(psiElem: PsiElement, containing: PsiElement) = {
     class ForEachTreeVisitor(block: (KtElement) => Unit) extends KtTreeVisitorVoid {
       override def visitKtElement(element: KtElement): Unit = {
-        super.visitKtElement(element)
-        block(element)
+        if (element != null) {
+          super.visitKtElement(element)
+          block(element)
+        }
       }
     }
 


### PR DESCRIPTION
without the check, the visitor may crash when encountering certain constructs