### PR TITLE
[rubysrc2cpg] Array Entries With Newlines

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -80,14 +80,12 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   private def astForNonExpandedWordArrayConstructor(ctx: NonExpandedWordArrayConstructorContext): Seq[Ast] = {
     Option(ctx.nonExpandedWordArrayElements)
-      .map(
-        _.nonExpandedWordArrayElement.asScala.filterNot(_.getText.isBlank).map(astForNonExpandedWordArrayElement).toSeq
-      )
+      .map(_.nonExpandedWordArrayElement.asScala.map(astForNonExpandedWordArrayElement).toSeq)
       .getOrElse(Seq(astForEmptyArrayInitializer(ctx)))
   }
 
   private def astForNonExpandedWordArrayElement(ctx: NonExpandedWordArrayElementContext): Ast = {
-    Ast(literalNode(ctx, ctx.getText.strip(), Defines.String, List(Defines.String)))
+    Ast(literalNode(ctx, ctx.getText, Defines.String, List(Defines.String)))
   }
 
   private def astForNonExpandedSymbolArrayConstructor(ctx: NonExpandedSymbolArrayConstructorContext): Seq[Ast] = {
@@ -97,6 +95,6 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   }
 
   private def astForNonExpandedSymbolArrayElement(ctx: NonExpandedSymbolArrayElementContext): Ast = {
-    Ast(literalNode(ctx, ctx.getText.strip(), Defines.Symbol))
+    Ast(literalNode(ctx, ctx.getText, Defines.Symbol))
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -80,12 +80,14 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   private def astForNonExpandedWordArrayConstructor(ctx: NonExpandedWordArrayConstructorContext): Seq[Ast] = {
     Option(ctx.nonExpandedWordArrayElements)
-      .map(_.nonExpandedWordArrayElement.asScala.map(astForNonExpandedWordArrayElement).toSeq)
+      .map(
+        _.nonExpandedWordArrayElement.asScala.filterNot(_.getText.isBlank).map(astForNonExpandedWordArrayElement).toSeq
+      )
       .getOrElse(Seq(astForEmptyArrayInitializer(ctx)))
   }
 
   private def astForNonExpandedWordArrayElement(ctx: NonExpandedWordArrayElementContext): Ast = {
-    Ast(literalNode(ctx, ctx.getText, Defines.String, List(Defines.String)))
+    Ast(literalNode(ctx, ctx.getText.strip(), Defines.String, List(Defines.String)))
   }
 
   private def astForNonExpandedSymbolArrayConstructor(ctx: NonExpandedSymbolArrayConstructorContext): Seq[Ast] = {
@@ -95,6 +97,6 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   }
 
   private def astForNonExpandedSymbolArrayElement(ctx: NonExpandedSymbolArrayElementContext): Ast = {
-    Ast(literalNode(ctx, ctx.getText, Defines.Symbol))
+    Ast(literalNode(ctx, ctx.getText.strip(), Defines.Symbol))
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1278,6 +1278,33 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       .l shouldBe List("d")
   }
 
+  "have correct structure for %w array with %w() with entries separated by whitespace" in {
+    val cpg = code("""
+        |a = %w(
+        | bob
+        | cod
+        | dod
+        |)
+        |""".stripMargin)
+
+    val List(assignmentCallNode) = cpg.call.name(Operators.assignment).l
+    assignmentCallNode.size shouldBe 1
+    val List(arrayCallNode) = cpg.call.name(Operators.arrayInitializer).l
+    arrayCallNode.size shouldBe 1
+    arrayCallNode.argument
+      .where(_.argumentIndex(1))
+      .code
+      .l shouldBe List("bob")
+    arrayCallNode.argument
+      .where(_.argumentIndex(2))
+      .code
+      .l shouldBe List("cod")
+    arrayCallNode.argument
+      .where(_.argumentIndex(3))
+      .code
+      .l shouldBe List("dod")
+  }
+
   "have correct structure for %w array with %w- -" in {
     val cpg = code("""
         |a = %w-b c-


### PR DESCRIPTION
This PR fixes new lines being interpreted as array initializer arguments and strips any trailing newlines from the string literal.