### PR TITLE
rubysrc2cpg: fix dataflows through constructor with blocks

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -693,7 +693,7 @@ class AstCreator(
         .name(blockName)
         .methodFullName(blockMethodNode.fullName)
         .typeFullName(Defines.Any)
-        .code(blockMethodNode.code)
+        .code(ctx.getText)
         .lineNumber(blockMethodNode.lineNumber)
         .columnNumber(blockMethodNode.columnNumber)
 
@@ -703,8 +703,7 @@ class AstCreator(
         .code(blockMethodNode.code)
         .lineNumber(blockMethodNode.lineNumber)
         .columnNumber(blockMethodNode.columnNumber)
-
-      Seq(callAst(callNode, Seq(Ast(methodRefNode)), primaryAst.headOption))
+      Seq(callAst(callNode, Seq(Ast(methodRefNode)), argsAst.headOption, primaryAst.headOption))
     } else {
       val callNode = methodNameAst.head.nodes
         .filter(node => node.isInstanceOf[NewCall])


### PR DESCRIPTION
Fixes issues where we were not able to get flows from the literal to `.new` arguments: 

```class Foo
  API_HOST = 'https://graph.facebook.com'

  private

  def bar(payload)
    Faraday.new(API_HOST) do |x|
     x
    end
  end
end
```
