### PR TITLE
kotlin2cpg: handle obj exprs at pkg top-level

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -1840,12 +1840,13 @@ trait KtPsiToAst {
       Option(parentFn)
         .collect { case namedFn: KtNamedFunction => namedFn }
         .map(AnonymousObjectContext(_))
+        .getOrElse(AnonymousObjectContext(expr.getContainingKtFile))
 
     val idxOpt  = PsiUtils.objectIdxMaybe(expr.getObjectDeclaration, parentFn)
     val idx     = idxOpt.getOrElse(Random.nextInt())
     val tmpName = s"tmp_obj_$idx"
 
-    val typeDeclAsts     = astsForClassOrObject(expr.getObjectDeclaration, ctx)
+    val typeDeclAsts     = astsForClassOrObject(expr.getObjectDeclaration, Some(ctx))
     val typeDeclAst      = typeDeclAsts.head
     val typeDeclFullName = typeDeclAst.root.get.asInstanceOf[NewTypeDecl].fullName
 
@@ -1952,13 +1953,14 @@ trait KtPsiToAst {
       Seq(localAst, assignmentCallAst, initAst)
     } else if (hasRHSObjectLiteral) {
       val typedExpr = expr.getDelegateExpressionOrInitializer.asInstanceOf[KtObjectLiteralExpression]
+      val parentFn  = KtPsiUtil.getTopmostParentOfTypes(expr, classOf[KtNamedFunction])
       val ctx =
-        Option(expr.getParent)
-          .map(_.getParent)
+        Option(parentFn)
           .collect { case namedFn: KtNamedFunction => namedFn }
           .map(AnonymousObjectContext(_))
+          .getOrElse(AnonymousObjectContext(expr.getContainingKtFile))
 
-      val typeDeclAsts     = astsForClassOrObject(typedExpr.getObjectDeclaration, ctx)
+      val typeDeclAsts     = astsForClassOrObject(typedExpr.getObjectDeclaration, Some(ctx))
       val typeDeclAst      = typeDeclAsts.head
       val typeDeclFullName = typeDeclAst.root.get.asInstanceOf[NewTypeDecl].fullName
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
@@ -258,8 +258,9 @@ class DefaultTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeIn
   }
 
   def anonymousObjectIdx(obj: KtElement): Option[Int] = {
-    val parentFn = KtPsiUtil.getTopmostParentOfTypes(obj, classOf[KtNamedFunction])
-    PsiUtils.objectIdxMaybe(obj, parentFn)
+    val parentFn      = KtPsiUtil.getTopmostParentOfTypes(obj, classOf[KtNamedFunction])
+    val containingObj = Option(parentFn).getOrElse(obj.getContainingKtFile)
+    PsiUtils.objectIdxMaybe(obj, containingObj)
   }
 
   def fullName(

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.psi.{
   KtClassLiteralExpression,
   KtClassOrObject,
   KtDestructuringDeclarationEntry,
+  KtElement,
   KtExpression,
   KtFile,
   KtLambdaArgument,
@@ -24,7 +25,7 @@ import org.jetbrains.kotlin.psi.{
   KtTypeReference
 }
 
-case class AnonymousObjectContext(declaration: KtNamedFunction)
+case class AnonymousObjectContext(declaration: KtElement)
 
 trait TypeInfoProvider {
   def isExtensionFn(fn: KtNamedFunction): Boolean

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
@@ -198,4 +198,22 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
       i.code shouldBe "tmp_obj_1"
     }
   }
+
+  "CPG for code with object literal defined at the top-level of the package" should {
+    val cpg = code("""
+        |package mypkg
+        |interface SomeInterface {
+        |    fun doSomething()
+        |}
+        |val AN_OBJ = object : SomeInterface {
+        |    override fun doSomething() {
+        |        println("something")
+        |    }
+        |}
+        | """.stripMargin)
+
+    "contain a correctly lowered representation" in {
+      cpg.typeDecl.fullNameExact("mypkg.AN_OBJ$object$1").l should not be List()
+    }
+  }
 }


### PR DESCRIPTION
versus obj exprs defined inside function scope