### PR TITLE
rubysrc2cpg: clear parser errors in unit-tests

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2264,7 +2264,6 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
         |y = Proc.new {
         |x=1
         |x
-        |end
         |}
         |puts y
         |""".stripMargin)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -779,8 +779,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
 
     "have correct structure for a hash created using a method" in {
       val code =
-        """
-          |def data
+        """def data
           |    {
           |     first_link:,
           |     action_link_group:,
@@ -842,8 +841,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
 
     "have correct structure when a method parameter is defined using whitespace" in {
       val code =
-        """
-          |class SampleClass
+        """class SampleClass
           |  def sample_method( first_param:, second_param:)
           |  end
           |end
@@ -901,8 +899,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
 
     "have correct structure when method parameters are defined using new line" in {
       val code =
-        """
-          |class SomeClass
+        """class SomeClass
           |  def initialize(
           |              name, age)
           |  end
@@ -960,8 +957,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
 
     "have correct structure when method parameters are defined using wsOrNL" in {
       val code =
-        """
-          |class SomeClass
+        """class SomeClass
           |  def initialize(
           |              name, age
           |              )
@@ -1022,8 +1018,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
 
     "have correct structure when keyword parameters are defined using wsOrNL" in {
       val code =
-        """
-          |class SomeClass
+        """class SomeClass
           |  def initialize(
           |              name: nil, age
           |              )

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/AssignCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/AssignCpgTests.scala
@@ -138,7 +138,7 @@ class AssignCpgTests extends RubyCode2CpgFixture {
   }
 
   "multi target assign" should {
-    val cpg = code("""x = y = "abcd" """.stripMargin)
+    val cpg = code("""x = y = "abcd"""".stripMargin)
 
     def getSurroundingBlock: nodes.Block = {
       cpg.all.collect { case block: nodes.Block if block.code != "" => block }.head


### PR DESCRIPTION
* When using `printAst`, we are testing a specific parser rule (often `primary`), and thus extra whitespaces could cause parsing errors (purposely unaccounted by that rule). I removed those unaccounted whitespaces in those occasions.
* Also fixed a test that contained invalid syntax.