### PR TITLE
Upgrade javaparser

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -3,14 +3,14 @@ name := "javasrc2cpg"
 dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->test")
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "codepropertygraph" % Versions.cpg,
-  "io.joern" % "javaparser-symbol-solver-core" % "3.24.3-SL3", // custom build of our fork, sources at https://github.com/mpollmeier/javaparser
-  "org.gradle"              % "gradle-tooling-api"         % Versions.gradleTooling,
-  "org.scalatest"          %% "scalatest"                  % Versions.scalatest % Test,
-  "org.projectlombok"       % "lombok"                     % "1.18.28",
-  "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
-  "org.scala-lang.modules" %% "scala-parser-combinators"   % "2.2.0",
-  "net.lingala.zip4j"       % "zip4j"                      % "2.11.5"
+  "io.shiftleft"           %% "codepropertygraph"             % Versions.cpg,
+  "com.github.javaparser"   % "javaparser-symbol-solver-core" % "3.25.4",
+  "org.gradle"              % "gradle-tooling-api"            % Versions.gradleTooling,
+  "org.scalatest"          %% "scalatest"                     % Versions.scalatest % Test,
+  "org.projectlombok"       % "lombok"                        % "1.18.28",
+  "org.scala-lang.modules" %% "scala-parallel-collections"    % "1.0.4",
+  "org.scala-lang.modules" %% "scala-parser-combinators"      % "2.2.0",
+  "net.lingala.zip4j"       % "zip4j"                         % "2.11.5"
 )
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
@@ -3,7 +3,8 @@ package io.joern.javasrc2cpg.typesolvers
 import com.github.javaparser.ast.body.TypeDeclaration
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade
-import com.github.javaparser.symbolsolver.model.resolution.{SymbolReference, TypeSolver}
+import com.github.javaparser.resolution.model.SymbolReference
+import com.github.javaparser.resolution.TypeSolver
 import io.joern.javasrc2cpg.util.SourceParser
 import org.slf4j.LoggerFactory
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
@@ -3,7 +3,8 @@ package io.joern.javasrc2cpg.typesolvers
 import com.github.javaparser.resolution.UnsolvedSymbolException
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
 import com.github.javaparser.symbolsolver.cache.GuavaCache
-import com.github.javaparser.symbolsolver.model.resolution.{SymbolReference, TypeSolver}
+import com.github.javaparser.resolution.TypeSolver
+import com.github.javaparser.resolution.model.SymbolReference
 import com.google.common.cache.CacheBuilder
 import org.slf4j.LoggerFactory
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -9,8 +9,8 @@ import com.github.javaparser.resolution.declarations.{
 }
 import com.github.javaparser.resolution.types._
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
-import com.github.javaparser.symbolsolver.logic.InferenceVariableType
-import com.github.javaparser.symbolsolver.model.typesystem.{LazyType, NullType}
+import com.github.javaparser.resolution.logic.InferenceVariableType
+import com.github.javaparser.resolution.model.typesystem.{LazyType, NullType}
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.{TypeConstants, TypeNameConstants}
 import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JdkJarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JdkJarTypeSolver.scala
@@ -1,7 +1,6 @@
 package io.joern.javasrc2cpg.typesolvers
 
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
-import com.github.javaparser.symbolsolver.model.resolution.{SymbolReference, TypeSolver}
 import com.github.javaparser.resolution.UnsolvedSymbolException
 import io.joern.javasrc2cpg.typesolvers.JdkJarTypeSolver._
 import javassist.ClassPool
@@ -22,6 +21,8 @@ import com.github.javaparser.symbolsolver.javassistmodel.JavassistFactory
 import javassist.NotFoundException
 import javassist.ClassPath
 import io.shiftleft.semanticcpg.language.singleToEvalTypeAccessorsParameterOut
+import com.github.javaparser.resolution.TypeSolver
+import com.github.javaparser.resolution.model.SymbolReference
 
 class JdkJarTypeSolver private (jdkPath: String) extends TypeSolver {
 


### PR DESCRIPTION
The patch introduced in our fork was released upstream (actually quite long ago), so switching to the latest version is useful before starting to debug javaparser stack overflows that may have already been fixed.