### PR TITLE
RubyParser: fix `%q` and `%Q` contexts

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -98,6 +98,7 @@ primary
     |   literal                                                                                                             # literalPrimary
     |   stringExpression                                                                                                    # stringExpressionPrimary
     |   stringInterpolation                                                                                                 # stringInterpolationPrimary
+    |   quotedStringExpression                                                                                              # quotedStringExpressionPrimary
     |   regexInterpolation                                                                                                  # regexInterpolationPrimary
     |   IS_DEFINED LPAREN expressionOrCommand RPAREN                                                                        # isDefinedPrimary
     |   SUPER argumentsWithParentheses? block?                                                                              # superExpressionPrimary
@@ -584,22 +585,21 @@ symbol
 stringExpression
     :   simpleString                                                                                                # simpleStringExpression
     |   stringInterpolation                                                                                         # interpolatedStringExpression
-    |   quotedExpandedStringExpression                                                                              # quotedExpandedStringExpressionStringExpression
     |   stringExpression (WS stringExpression)+                                                                     # concatenatedStringExpression
     ;
 
-quotedExpandedStringExpression
-    :   QUOTED_EXPANDED_STRING_LITERAL_START
+quotedStringExpression
+    :   QUOTED_NON_EXPANDED_STRING_LITERAL_START 
+        NON_EXPANDED_LITERAL_CHARACTER* 
+        QUOTED_NON_EXPANDED_STRING_LITERAL_END                                                                      # nonExpandedQuotedStringLiteral
+    |   QUOTED_EXPANDED_STRING_LITERAL_START
         (EXPANDED_LITERAL_CHARACTER | delimitedStringInterpolation)*
-        QUOTED_EXPANDED_STRING_LITERAL_END
+        QUOTED_EXPANDED_STRING_LITERAL_END                                                                          # expandedQuotedStringLiteral
     ;
 
 simpleString
     :   SINGLE_QUOTED_STRING_LITERAL                                                                                # singleQuotedStringLiteral
     |   DOUBLE_QUOTED_STRING_START DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE? DOUBLE_QUOTED_STRING_END                # doubleQuotedStringLiteral
-    |   QUOTED_NON_EXPANDED_STRING_LITERAL_START 
-        NON_EXPANDED_LITERAL_CHARACTER* 
-        QUOTED_NON_EXPANDED_STRING_LITERAL_END                                                                      # nonExpandedQuotedStringLiteral
     ;
 
 delimitedStringInterpolation

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -83,168 +83,153 @@ class StringTests extends RubyParserAbstractTest {
       "it is empty and uses the `(`-`)` delimiters" in {
         val code = "%q()"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q(
-            |   )""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q(
+            |  )""".stripMargin
       }
 
       "it is empty and uses the `[`-`]` delimiters" in {
         val code = "%q[]"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q[
-            |   ]""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q[
+            |  ]""".stripMargin
       }
 
       "it is empty and uses the `{`-`}` delimiters" in {
         val code = "%q{}"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q{
-            |   }""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q{
+            |  }""".stripMargin
       }
 
       "it is empty and uses the `<`-`>` delimiters" in {
         val code = "%q<>"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q<
-            |   >""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q<
+            |  >""".stripMargin
       }
 
       "it is empty and uses the `#` delimiters" in {
         val code = "%q##"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q#
-            |   #""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q#
+            |  #""".stripMargin
       }
 
       "it contains a single non-escaped character and uses the `(`-`)` delimiters" in {
         val code = "%q(x)"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q(
-            |   x
-            |   )""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q(
+            |  x
+            |  )""".stripMargin
       }
 
       "it contains a single non-escaped character and uses the `[`-`]` delimiters" in {
         val code = "%q[x]"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q[
-            |   x
-            |   ]""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q[
+            |  x
+            |  ]""".stripMargin
       }
 
       "it contains a single non-escaped character and uses the `#` delimiters" in {
         val code = "%q#x#"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q#
-            |   x
-            |   #""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q#
+            |  x
+            |  #""".stripMargin
       }
 
       "it contains a single escaped character and uses the `(`-`)` delimiters" in {
         val code = "%q(\\()"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q(
-            |   \(
-            |   )""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q(
+            |  \(
+            |  )""".stripMargin
       }
 
       "it contains a single escaped character and uses the `[`-`]` delimiters" in {
         val code = "%q[\\]]"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q[
-            |   \]
-            |   ]""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q[
+            |  \]
+            |  ]""".stripMargin
       }
 
       "it contains a single escaped character and uses the `#` delimiters" in {
         val code = "%q#\\##"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q#
-            |   \#
-            |   #""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q#
+            |  \#
+            |  #""".stripMargin
       }
 
       "it contains a word and uses the `(`-`)` delimiters" in {
         val code = "%q(foo)"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q(
-            |   f
-            |   o
-            |   o
-            |   )""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q(
+            |  f
+            |  o
+            |  o
+            |  )""".stripMargin
       }
 
       "it contains an empty nested string using the `(`-`)` delimiters" in {
         val code = "%q( () )"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q(
-            |   (
-            |   )
-            |   )""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q(
+            |  (
+            |  )
+            |  )""".stripMargin
       }
 
       "it contains an escaped single-character nested string using the `(`-`)` delimiters" in {
         val code = "%q( (\\)) )"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q(
-            |   (
-            |   \)
-            |   )
-            |   )""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q(
+            |  (
+            |  \)
+            |  )
+            |  )""".stripMargin
       }
 
       "it contains an escaped single-character nested string using the `<`-`>` delimiters" in {
         val code = "%q< <\\>> >"
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | SimpleStringExpression
-            |  NonExpandedQuotedStringLiteral
-            |   %q<
-            |   <
-            |   \>
-            |   >
-            |   >""".stripMargin
+          """QuotedStringExpressionPrimary
+            | NonExpandedQuotedStringLiteral
+            |  %q<
+            |  <
+            |  \>
+            |  >
+            |  >""".stripMargin
       }
     }
   }
@@ -256,11 +241,10 @@ class StringTests extends RubyParserAbstractTest {
 
       "be parsed as a primary expression" in {
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | QuotedExpandedStringExpressionStringExpression
-            |  QuotedExpandedStringExpression
-            |   %Q(
-            |   )""".stripMargin
+          """QuotedStringExpressionPrimary
+            | ExpandedQuotedStringLiteral
+            |  %Q(
+            |  )""".stripMargin
       }
     }
 
@@ -269,29 +253,28 @@ class StringTests extends RubyParserAbstractTest {
 
       "be parsed as primary expression" in {
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | QuotedExpandedStringExpressionStringExpression
-            |  QuotedExpandedStringExpression
-            |   %Q{
-            |   t
-            |   e
-            |   x
-            |   t
-            |   =
-            |   DelimitedStringInterpolation
-            |    #{
-            |    CompoundStatement
-            |     Statements
-            |      ExpressionOrCommandStatement
-            |       ExpressionExpressionOrCommand
-            |        PrimaryExpression
-            |         LiteralPrimary
-            |          NumericLiteralLiteral
-            |           NumericLiteral
-            |            UnsignedNumericLiteral
-            |             1
-            |    }
-            |   }""".stripMargin
+          """QuotedStringExpressionPrimary
+            | ExpandedQuotedStringLiteral
+            |  %Q{
+            |  t
+            |  e
+            |  x
+            |  t
+            |  =
+            |  DelimitedStringInterpolation
+            |   #{
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            1
+            |   }
+            |  }""".stripMargin
       }
     }
 
@@ -300,37 +283,36 @@ class StringTests extends RubyParserAbstractTest {
 
       "be parsed as primary expression" in {
         printAst(_.primary(), code) shouldEqual
-          """StringExpressionPrimary
-            | QuotedExpandedStringExpressionStringExpression
-            |  QuotedExpandedStringExpression
-            |   %Q[
-            |   DelimitedStringInterpolation
-            |    #{
-            |    CompoundStatement
-            |     Statements
-            |      ExpressionOrCommandStatement
-            |       ExpressionExpressionOrCommand
-            |        PrimaryExpression
-            |         LiteralPrimary
-            |          NumericLiteralLiteral
-            |           NumericLiteral
-            |            UnsignedNumericLiteral
-            |             1
-            |    }
-            |   DelimitedStringInterpolation
-            |    #{
-            |    CompoundStatement
-            |     Statements
-            |      ExpressionOrCommandStatement
-            |       ExpressionExpressionOrCommand
-            |        PrimaryExpression
-            |         LiteralPrimary
-            |          NumericLiteralLiteral
-            |           NumericLiteral
-            |            UnsignedNumericLiteral
-            |             2
-            |    }
-            |   ]""".stripMargin
+          """QuotedStringExpressionPrimary
+            | ExpandedQuotedStringLiteral
+            |  %Q[
+            |  DelimitedStringInterpolation
+            |   #{
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            1
+            |   }
+            |  DelimitedStringInterpolation
+            |   #{
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            2
+            |   }
+            |  ]""".stripMargin
       }
     }
 


### PR DESCRIPTION
In Ruby (like in C) we can implicitly concatenate string literals by writing them consecutively, e.g

```ruby
"x" "y" # => "xy"
```

However, this rule does not apply to quoted strings (`%q` or `%Q`). So this patch corrects #3477 , in which that would be admissible.