### PR TITLE
rubysrc2cpg: Correct operator usage for arrays

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -845,10 +845,20 @@ class AstCreator(
   def astForIndexingExpressionPrimaryContext(ctx: IndexingExpressionPrimaryContext): Seq[Ast] = {
     val lhsExpressionAst = astForPrimaryContext(ctx.primary())
     val rhsExpressionAst = Option(ctx.indexingArguments).map(astForIndexingArgumentsContext).getOrElse(Seq())
+
+    val operator = lhsExpressionAst.flatMap(_.nodes.filter(_.isInstanceOf[NewIdentifier])).headOption match
+      case Some(node) =>
+        if (node.asInstanceOf[NewIdentifier].name == "Array") {
+          Operators.arrayInitializer
+        } else {
+          Operators.indexAccess
+        }
+      case None => Operators.indexAccess
+
     val callNode = NewCall()
-      .name(Operators.indexAccess)
+      .name(operator)
       .code(ctx.getText)
-      .methodFullName(Operators.indexAccess)
+      .methodFullName(operator)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -2591,7 +2591,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     sink.reachableByFlows(source).size shouldBe 1
   }
 
-  "flow through array constructor using []" ignore {
+  "flow through array constructor using []" in {
     val cpg = code("""
         |x=1
         |y=x
@@ -2599,12 +2599,12 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
         |puts "#{z}"
         |""".stripMargin)
 
-    val source = cpg.literal.code("x").l
+    val source = cpg.identifier.name("x").l
     val sink   = cpg.call.name("puts").l
-    sink.reachableByFlows(source).size shouldBe 1
+    sink.reachableByFlows(source).size shouldBe 2
   }
 
-  "flow through array constructor using [] and command in []" ignore {
+  "flow through array constructor using [] and command in []" in {
     val cpg = code("""
         |def foo(arg)
         |return arg
@@ -2616,8 +2616,8 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
         |puts "#{z}"
         |""".stripMargin)
 
-    val source = cpg.literal.code("x").l
+    val source = cpg.identifier.name("x").l
     val sink   = cpg.call.name("puts").l
-    sink.reachableByFlows(source).size shouldBe 1
+    sink.reachableByFlows(source).size shouldBe 2
   }
 }


### PR DESCRIPTION
1. Used the correct operator for array initialization and index access
2. Corrected test cases
@xavierpinho 