### PR TITLE
RubyLexer: refactoring (non-)expanded delimiter handling

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -291,16 +291,18 @@ DOUBLE_QUOTED_STRING_START
 QUOTED_NON_EXPANDED_STRING_LITERAL_START
     :   '%q' {!Character.isAlphabetic(_input.LA(1))}?
     {
-        pushNonExpandedStringDelimiter(_input.LA(1));
+        pushNonExpandedDelimiter(_input.LA(1));
+        setNonExpandedDelimiterEndToken(QUOTED_NON_EXPANDED_STRING_LITERAL_END);
         _input.consume();
-        pushMode(NON_EXPANDED_DELIMITED_STRING_MODE);
     }
+        -> pushMode(NON_EXPANDED_DELIMITED_STRING_MODE)
     ;
     
 QUOTED_EXPANDED_STRING_LITERAL_START
     :   '%Q' {!Character.isAlphabetic(_input.LA(1))}?
     {
-        pushExpandedQuotedStringDelimiter(_input.LA(1));
+        pushExpandedDelimiter(_input.LA(1));
+        pushExpandedDelimiterEndToken(QUOTED_EXPANDED_STRING_LITERAL_END);
         _input.consume();
         pushMode(EXPANDED_DELIMITED_STRING_MODE);
     }
@@ -311,7 +313,8 @@ QUOTED_EXPANDED_STRING_LITERAL_START
     //  will still emit a QUOTED_EXPANDED_STRING_LITERAL_START.
     |   '%(' {!isNumericTokenType(previousTokenTypeOrEOF())}?
     {
-        pushExpandedQuotedStringDelimiter('(');
+        pushExpandedDelimiter('(');
+        pushExpandedDelimiterEndToken(QUOTED_EXPANDED_STRING_LITERAL_END);
         pushMode(EXPANDED_DELIMITED_STRING_MODE);
     }
     ;
@@ -319,18 +322,21 @@ QUOTED_EXPANDED_STRING_LITERAL_START
 QUOTED_NON_EXPANDED_REGULAR_EXPRESSION_START
     :   '%r' {!Character.isAlphabetic(_input.LA(1))}?
     {
-        pushNonExpandedRegexDelimiter(_input.LA(1));
+        pushNonExpandedDelimiter(_input.LA(1));
+        setNonExpandedDelimiterEndToken(QUOTED_NON_EXPANDED_REGULAR_EXPRESSION_END);
         _input.consume();
-        pushMode(NON_EXPANDED_DELIMITED_STRING_MODE);
-    };
+    }
+        -> pushMode(NON_EXPANDED_DELIMITED_STRING_MODE)
+    ;
     
 QUOTED_EXPANDED_EXTERNAL_COMMAND_LITERAL_START
     :   '%x' {!Character.isAlphabetic(_input.LA(1))}?
     {
-        pushExpandedQuotedExternalCommandDelimiter(_input.LA(1));
+        pushExpandedDelimiter(_input.LA(1));
+        pushExpandedDelimiterEndToken(QUOTED_EXPANDED_EXTERNAL_COMMAND_LITERAL_END);
         _input.consume();
-        pushMode(EXPANDED_DELIMITED_STRING_MODE);
     }
+        -> pushMode(EXPANDED_DELIMITED_STRING_MODE)
     ;
 
 // --------------------------------------------------------
@@ -340,19 +346,21 @@ QUOTED_EXPANDED_EXTERNAL_COMMAND_LITERAL_START
 QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_START
     :   '%w' {!Character.isAlphabetic(_input.LA(1))}?
     {
-        pushNonExpandedStringArrayDelimiter(_input.LA(1));
+        pushNonExpandedDelimiter(_input.LA(1));
+        setNonExpandedDelimiterEndToken(QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END);
         _input.consume();
-        pushMode(NON_EXPANDED_DELIMITED_ARRAY_MODE);
     }
+        -> pushMode(NON_EXPANDED_DELIMITED_ARRAY_MODE)
     ;
     
 QUOTED_EXPANDED_STRING_ARRAY_LITERAL_START
     :   '%W' {!Character.isAlphabetic(_input.LA(1))}?
     {
-        pushExpandedStringArrayDelimiter(_input.LA(1));
+        pushExpandedDelimiter(_input.LA(1));
+        pushExpandedDelimiterEndToken(QUOTED_EXPANDED_STRING_ARRAY_LITERAL_END);
         _input.consume();
-        pushMode(EXPANDED_DELIMITED_ARRAY_MODE);
     }
+        -> pushMode(EXPANDED_DELIMITED_ARRAY_MODE)
     ;
 
 // --------------------------------------------------------
@@ -362,19 +370,21 @@ QUOTED_EXPANDED_STRING_ARRAY_LITERAL_START
 QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_START
     :   '%i' {!Character.isAlphabetic(_input.LA(1))}?
     {
-        pushNonExpandedSymbolArrayDelimiter(_input.LA(1));
+        pushNonExpandedDelimiter(_input.LA(1));
+        setNonExpandedDelimiterEndToken(QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_END);
         _input.consume();
-        pushMode(NON_EXPANDED_DELIMITED_ARRAY_MODE);
     }
+        -> pushMode(NON_EXPANDED_DELIMITED_ARRAY_MODE)
     ;
 
 QUOTED_EXPANDED_SYMBOL_ARRAY_LITERAL_START
     :   '%I' {!Character.isAlphabetic(_input.LA(1))}?
     {
-        pushExpandedSymbolArrayDelimiter(_input.LA(1));
+        pushExpandedDelimiter(_input.LA(1));
+        pushExpandedDelimiterEndToken(QUOTED_EXPANDED_SYMBOL_ARRAY_LITERAL_END);
         _input.consume();
-        pushMode(EXPANDED_DELIMITED_ARRAY_MODE);
     }
+        -> pushMode(EXPANDED_DELIMITED_ARRAY_MODE)
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/ExpandedDelimiterHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/ExpandedDelimiterHandling.scala
@@ -7,11 +7,11 @@ trait ExpandedDelimiterHandling { this: RubyLexerBase =>
   private val delimiters    = mutable.Stack[Int]()
   private val endTokenTypes = mutable.Stack[Int]()
 
-  private def pushExpandedStringDelimiter(char: Int): Unit = {
+  def pushExpandedDelimiter(char: Int): Unit = {
     delimiters.push(char)
   }
 
-  private def popExpandedStringDelimiter(): Unit = {
+  def popExpandedDelimiter(): Unit = {
     delimiters.pop()
   }
 
@@ -31,46 +31,26 @@ trait ExpandedDelimiterHandling { this: RubyLexerBase =>
     delimiters.top
   }
 
-  private def pushExpandedDelimiterEndToken(endTokenType: Int): Unit = {
+  def pushExpandedDelimiterEndToken(endTokenType: Int): Unit = {
     endTokenTypes.push(endTokenType)
   }
 
-  private def popExpandedDelimiterEndToken(): Int = {
+  def popExpandedDelimiterEndToken(): Int = {
     endTokenTypes.pop()
   }
 
   private def currentClosingDelimiter(): Int = closingDelimiterFor(currentOpeningDelimiter())
 
-  def pushExpandedQuotedStringDelimiter(char: Int): Unit = {
-    pushExpandedStringDelimiter(char)
-    pushExpandedDelimiterEndToken(RubyLexer.QUOTED_EXPANDED_STRING_LITERAL_END)
-  }
-
-  def pushExpandedQuotedExternalCommandDelimiter(char: Int): Unit = {
-    pushExpandedQuotedStringDelimiter(char)
-    pushExpandedDelimiterEndToken(RubyLexer.QUOTED_EXPANDED_EXTERNAL_COMMAND_LITERAL_END)
-  }
-
-  def pushExpandedStringArrayDelimiter(char: Int): Unit = {
-    pushExpandedStringDelimiter(char)
-    pushExpandedDelimiterEndToken(RubyLexer.QUOTED_EXPANDED_STRING_ARRAY_LITERAL_END)
-  }
-
-  def pushExpandedSymbolArrayDelimiter(char: Int): Unit = {
-    pushExpandedStringDelimiter(char)
-    pushExpandedDelimiterEndToken(RubyLexer.QUOTED_EXPANDED_SYMBOL_ARRAY_LITERAL_END)
-  }
-
   def consumeExpandedCharAndMaybePopMode(char: Int): Unit = {
     if (isExpandedClosingDelimiter(char)) {
-      popExpandedStringDelimiter()
+      popExpandedDelimiter()
 
       if (isExpandedDelimitersStackEmpty) {
         setType(popExpandedDelimiterEndToken())
         popMode()
       }
     } else if (isExpandedOpeningDelimiter(char)) {
-      pushExpandedQuotedStringDelimiter(char)
+      pushExpandedDelimiter(char)
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/NonExpandedDelimiterHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/NonExpandedDelimiterHandling.scala
@@ -1,12 +1,5 @@
 package io.joern.rubysrc2cpg.parser
 
-import io.joern.rubysrc2cpg.parser.RubyLexer.{
-  QUOTED_NON_EXPANDED_STRING_LITERAL_END,
-  QUOTED_NON_EXPANDED_REGULAR_EXPRESSION_END,
-  QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END,
-  QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_END
-}
-
 import scala.collection.mutable
 
 trait NonExpandedDelimiterHandling { this: RubyLexerBase =>
@@ -14,11 +7,11 @@ trait NonExpandedDelimiterHandling { this: RubyLexerBase =>
   private val delimiters   = mutable.Stack[Int]()
   private var endTokenType = 0
 
-  private def pushNonExpandedDelimiter(char: Int): Unit = {
+  def pushNonExpandedDelimiter(char: Int): Unit = {
     delimiters.push(char)
   }
 
-  private def popNonExpandedDelimiter(): Unit = {
+  def popNonExpandedDelimiter(): Unit = {
     delimiters.pop()
   }
 
@@ -45,26 +38,6 @@ trait NonExpandedDelimiterHandling { this: RubyLexerBase =>
   private def getNonExpandedDelimitedStringEndToken: Int = endTokenType
 
   private def currentClosingDelimiter(): Int = closingDelimiterFor(currentOpeningDelimiter())
-
-  def pushNonExpandedStringDelimiter(char: Int): Unit = {
-    pushNonExpandedDelimiter(char)
-    setNonExpandedDelimiterEndToken(QUOTED_NON_EXPANDED_STRING_LITERAL_END)
-  }
-
-  def pushNonExpandedRegexDelimiter(char: Int): Unit = {
-    pushNonExpandedDelimiter(char)
-    setNonExpandedDelimiterEndToken(QUOTED_NON_EXPANDED_REGULAR_EXPRESSION_END)
-  }
-
-  def pushNonExpandedStringArrayDelimiter(char: Int): Unit = {
-    pushNonExpandedDelimiter(char)
-    setNonExpandedDelimiterEndToken(QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END)
-  }
-
-  def pushNonExpandedSymbolArrayDelimiter(char: Int): Unit = {
-    pushNonExpandedDelimiter(char)
-    setNonExpandedDelimiterEndToken(QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_END)
-  }
 
   def consumeNonExpandedCharAndMaybePopMode(char: Int): Unit = {
     if (isNonExpandedClosingDelimiter(char)) {


### PR DESCRIPTION
* The end goal is to have a unified handling of either expanded vs non-expanded delimiters.
* Fixed a bug (due to an autocomplete typo) in which the handling of `%x` was inserting an extra delimiter to the stack thereof.
* Slight quality of life improvement: having `-> pushMode(..)` (i.e. outside of semantic actions) allows the ANTLR plugin to jump directly to that mode.