### PR TITLE
Early AST Validation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.3.0"
 
-val cpgVersion = "1.4.1"
+val cpgVersion = "1.4.9+2-4ee586a9"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.3.0"
 
-val cpgVersion = "1.4.9+2-4ee586a9"
+val cpgVersion = "1.4.12"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -20,7 +20,7 @@ class C2Cpg extends X2CpgFrontend[Config] {
       new MetaDataPass(cpg, Languages.NEWC, config.inputPath).createAndApply()
       new AstCreationPass(cpg, config, report).createAndApply()
       TypeNodePass.withRegisteredTypes(CGlobal.typesSeen(), cpg).createAndApply()
-      new TypeDeclNodePass(cpg).createAndApply()
+      new TypeDeclNodePass(cpg)(config.schemaValidation).createAndApply()
       report.print()
     }
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -1,16 +1,15 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.c2cpg.Config
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.NodeTypes
-import overflowdb.BatchedUpdate.DiffGraphBuilder
-import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
-import io.joern.x2cpg.{Ast, AstCreatorBase}
 import io.joern.x2cpg.datastructures.Scope
-import io.joern.x2cpg.datastructures.Stack._
-import io.joern.x2cpg.{AstNodeBuilder => X2CpgAstNodeBuilder}
+import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.eclipse.cdt.core.dom.ast.{IASTNode, IASTTranslationUnit}
 import org.slf4j.{Logger, LoggerFactory}
+import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
@@ -22,7 +21,8 @@ class AstCreator(
   val config: Config,
   val cdtAst: IASTTranslationUnit,
   val file2OffsetTable: ConcurrentHashMap[String, Array[Int]]
-) extends AstCreatorBase(filename)
+)(implicit withSchemaValidation: ValidationMode)
+    extends AstCreatorBase(filename)
     with AstForTypesCreator
     with AstForFunctionsCreator
     with AstForPrimitivesCreator

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -3,8 +3,7 @@ package io.joern.c2cpg.astcreation
 import io.joern.c2cpg.datastructures.CGlobal
 import io.shiftleft.codepropertygraph.generated.nodes.{ExpressionNew, NewNode}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.{Ast, SourceFiles, ValidationMode}
 import io.joern.x2cpg.utils.NodeBuilders.newDependencyNode
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.utils.IOUtils
@@ -40,7 +39,7 @@ object AstCreatorHelper {
   }
 }
 
-trait AstCreatorHelper { this: AstCreator =>
+trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   import AstCreatorHelper._
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -2,13 +2,13 @@ package io.joern.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewIdentifier, NewMethodRef}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.joern.x2cpg.Ast
-import org.eclipse.cdt.core.dom.ast._
-import org.eclipse.cdt.core.dom.ast.cpp._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import org.eclipse.cdt.core.dom.ast.*
+import org.eclipse.cdt.core.dom.ast.cpp.*
 import org.eclipse.cdt.core.dom.ast.gnu.IGNUASTCompoundStatementExpression
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTQualifiedName
 
-trait AstForExpressionsCreator { this: AstCreator =>
+trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   private def astForBinaryExpression(bin: IASTBinaryExpression): Ast = {
     val op = bin.getOperator match {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -1,21 +1,21 @@
 package io.joern.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.joern.x2cpg.Ast
-import org.eclipse.cdt.core.dom.ast._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.joern.x2cpg.{Ast, ValidationMode}
+import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTLambdaExpression
 import org.eclipse.cdt.core.dom.ast.gnu.c.ICASTKnRFunctionDeclarator
 import org.eclipse.cdt.internal.core.dom.parser.c.{CASTFunctionDeclarator, CASTParameterDeclaration}
 import org.eclipse.cdt.internal.core.dom.parser.cpp.{CPPASTFunctionDeclarator, CPPASTParameterDeclaration}
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.datastructures.Stack.*
 import org.apache.commons.lang.StringUtils
 
 import scala.annotation.tailrec
 import scala.collection.mutable
 
-trait AstForFunctionsCreator { this: AstCreator =>
+trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   private val seenFunctionSignatures = mutable.HashSet.empty[String]
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -1,12 +1,12 @@
 package io.joern.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.joern.x2cpg.Ast
-import org.eclipse.cdt.core.dom.ast._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTQualifiedName
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
-trait AstForPrimitivesCreator { this: AstCreator =>
+trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForComment(comment: IASTComment): Ast =
     Ast(newCommentNode(comment, nodeSignature(comment), fileName(comment)))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,17 +1,17 @@
 package io.joern.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.ExpressionNew
-import org.eclipse.cdt.core.dom.ast._
-import org.eclipse.cdt.core.dom.ast.cpp._
+import org.eclipse.cdt.core.dom.ast.*
+import org.eclipse.cdt.core.dom.ast.cpp.*
 import org.eclipse.cdt.core.dom.ast.gnu.IGNUASTGotoStatement
 import org.eclipse.cdt.internal.core.dom.parser.c.CASTIfStatement
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTIfStatement
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTNamespaceAlias
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
-trait AstForStatementsCreator { this: AstCreator =>
+trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   import io.joern.c2cpg.astcreation.AstCreatorHelper.OptionSafeAst
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -1,15 +1,15 @@
 package io.joern.c2cpg.astcreation
 
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.joern.x2cpg.Ast
-import org.eclipse.cdt.core.dom.ast._
-import org.eclipse.cdt.core.dom.ast.cpp._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import org.eclipse.cdt.core.dom.ast.*
+import org.eclipse.cdt.core.dom.ast.cpp.*
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTAliasDeclaration
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.datastructures.Stack.*
 
-trait AstForTypesCreator { this: AstCreator =>
+trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   private def parentIsClassDef(node: IASTNode): Boolean = Option(node.getParent) match {
     case Some(_: IASTCompositeTypeSpecifier) => true

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -9,7 +9,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewFieldIdentifier,
   NewNode
 }
-import io.joern.x2cpg.{Ast, AstEdge}
+import io.joern.x2cpg.{Ast, AstEdge, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
 import org.apache.commons.lang.StringUtils
 import org.eclipse.cdt.core.dom.ast.{IASTMacroExpansionLocation, IASTNode, IASTPreprocessorMacroDefinition}
@@ -20,7 +20,7 @@ import org.eclipse.cdt.internal.core.parser.scanner.MacroArgumentExtractor
 import scala.annotation.nowarn
 import scala.collection.mutable
 
-trait MacroHandler { this: AstCreator =>
+trait MacroHandler(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   private val nodeOffsetMacroPairs: mutable.Stack[(Int, IASTPreprocessorMacroDefinition)] = {
     mutable.Stack.from(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -44,7 +44,8 @@ class AstCreationPass(cpg: Cpg, config: Config, report: Report = new Report())
       parseResult match {
         case Some(translationUnit) =>
           report.addReportInfo(relPath, fileLOC, parsed = true)
-          val localDiff = new AstCreator(relPath, config, translationUnit, file2OffsetTable).createAst()
+          val localDiff =
+            new AstCreator(relPath, config, translationUnit, file2OffsetTable)(config.schemaValidation).createAst()
           diffGraph.absorb(localDiff)
           true
         case None =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/TypeDeclNodePass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/TypeDeclNodePass.scala
@@ -2,16 +2,16 @@ package io.joern.c2cpg.passes
 
 import io.joern.c2cpg.astcreation.Defines
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.joern.x2cpg.passes.frontend.MetaDataPass
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 
-class TypeDeclNodePass(cpg: Cpg) extends CpgPass(cpg) {
+class TypeDeclNodePass(cpg: Cpg)(implicit withSchemaValidation: ValidationMode) extends CpgPass(cpg) {
 
   private val filename: String   = "<includes>"
   private val globalName: String = NamespaceTraversal.globalNamespaceName

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -2,11 +2,11 @@ package io.joern.gosrc2cpg.astcreation
 
 import io.joern.gosrc2cpg.model.GoMod
 import io.joern.gosrc2cpg.parser.GoAstJsonParser.ParserResult
-import io.joern.gosrc2cpg.parser.ParserAst._
+import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg.datastructures.Scope
-import io.joern.x2cpg.datastructures.Stack._
-import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder => X2CpgAstNodeBuilder}
+import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{NewFile, NewNamespaceBlock, NewNode}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
@@ -14,8 +14,9 @@ import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 import ujson.Value
 
-class AstCreator(val relPathFileName: String, val parserResult: ParserResult)
-    extends AstCreatorBase(relPathFileName)
+class AstCreator(val relPathFileName: String, val parserResult: ParserResult)(implicit
+  withSchemaValidation: ValidationMode
+) extends AstCreatorBase(relPathFileName)
     with AstCreatorHelper
     with AstForGenDeclarationCreator
     with AstForExpressionCreator

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
@@ -1,13 +1,13 @@
 package io.joern.gosrc2cpg.astcreation
 
-import io.joern.gosrc2cpg.parser.ParserAst._
+import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.gosrc2cpg.utils.Operator
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewCall
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 
-trait AstForExpressionCreator { this: AstCreator =>
+trait AstForExpressionCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
   def astsForExpression(expr: ParserNodeInfo): Seq[Ast] = {
     expr.node match {
       case BinaryExpr => astForBinaryExpr(expr)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -2,16 +2,16 @@ package io.joern.gosrc2cpg.astcreation
 
 import io.joern.gosrc2cpg.parser.ParserAst.{BlockStmt, Ellipsis, Ident, SelectorExpr}
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.datastructures.Stack.*
 import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterIn
 import ujson.Value
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-trait AstForFunctionsCreator { this: AstCreator =>
+trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
   def astForFuncDecl(funcDecl: ParserNodeInfo): Seq[Ast] = {
 
     val filename = relPathFileName

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
@@ -1,14 +1,14 @@
 package io.joern.gosrc2cpg.astcreation
 
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
-import io.joern.x2cpg.Ast
-import io.joern.gosrc2cpg.parser.ParserAst._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import ujson.Value
 
 import scala.util.Try
 
-trait AstForGenDeclarationCreator { this: AstCreator =>
+trait AstForGenDeclarationCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
   def astForGenDecl(genDecl: ParserNodeInfo): Seq[Ast] = {
     genDecl.json(ParserKeys.Tok).str match {
       case "import" => astForImport(genDecl)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -2,11 +2,11 @@ package io.joern.gosrc2cpg.astcreation
 
 import io.joern.gosrc2cpg.parser.ParserAst.{BasePrimitive, BasicLit, Ident}
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 
 import scala.util.Try
 
-trait AstForPrimitivesCreator { this: AstCreator =>
+trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForPrimitive(primitive: ParserNodeInfo): Ast = {
     primitive.node match {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -3,7 +3,7 @@ package io.joern.gosrc2cpg.astcreation
 import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.gosrc2cpg.utils.Operator
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.ExpressionNew
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import ujson.Value
@@ -11,7 +11,7 @@ import ujson.Value
 import scala.annotation.tailrec
 import scala.util.Try
 
-trait AstForStatementsCreator { this: AstCreator =>
+trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
   def astForBlockStatement(blockStmt: ParserNodeInfo, order: Int = -1): Ast = {
     val newBlockNode = blockNode(blockStmt, Defines.empty, Defines.voidTypeName).order(order).argumentIndex(order)
     scope.pushNewScope(newBlockNode)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/AstCreationPass.scala
@@ -25,7 +25,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
       val relPathFileName = SourceFiles.toRelativePath(parseResult.fullPath, config.inputPath)
       report.addReportInfo(parseResult.filename, fileLOC, parsed = true)
       Try {
-        val localDiff = new AstCreator(relPathFileName, parseResult).createAst()
+        val localDiff = new AstCreator(relPathFileName, parseResult)(config.schemaValidation).createAst()
         diffGraph.absorb(localDiff)
       } match {
         case Failure(exception) =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -1,8 +1,7 @@
 package io.joern.javasrc2cpg.passes
 
 import better.files.File
-import com.github.javaparser.JavaParser
-import com.github.javaparser.ParserConfiguration
+import com.github.javaparser.{JavaParser, ParserConfiguration}
 import com.github.javaparser.ParserConfiguration.LanguageLevel
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.Node.Parsedness
@@ -12,14 +11,13 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.{
   JarTypeSolver,
   ReflectionTypeSolver
 }
-import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.javasrc2cpg.JavaSrc2Cpg.JavaSrcEnvVar
-import io.joern.javasrc2cpg.passes.AstCreationPass._
+import io.joern.javasrc2cpg.passes.AstCreationPass.*
 import io.joern.javasrc2cpg.typesolvers.{EagerSourceTypeSolver, JdkJarTypeSolver, SimpleCombinedTypeSolver}
-import io.joern.javasrc2cpg.util.Delombok
 import io.joern.javasrc2cpg.util.Delombok.DelombokMode
-import io.joern.javasrc2cpg.util.Delombok.DelombokMode._
-import io.joern.javasrc2cpg.util.SourceParser
+import io.joern.javasrc2cpg.util.Delombok.DelombokMode.*
+import io.joern.javasrc2cpg.util.{Delombok, SourceParser}
+import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
@@ -29,13 +27,11 @@ import io.shiftleft.passes.ConcurrentWriterCpgPass
 import org.slf4j.LoggerFactory
 
 import java.net.URLClassLoader
-import java.nio.file.Path
-import java.nio.file.Paths
-import scala.collection.parallel.CollectionConverters._
-import scala.jdk.CollectionConverters._
+import java.nio.file.{Path, Paths}
+import scala.collection.parallel.CollectionConverters.*
+import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.Success
-import scala.util.Try
+import scala.util.{Success, Try}
 
 class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[String]] = None)
     extends ConcurrentWriterCpgPass[String](cpg) {
@@ -54,7 +50,9 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
     sourceParser.parseAnalysisFile(relativeFilename) match {
       case Some(compilationUnit) =>
         symbolSolver.inject(compilationUnit)
-        diffGraph.absorb(new AstCreator(relativeFilename, compilationUnit, global, symbolSolver).createAst())
+        diffGraph.absorb(
+          new AstCreator(relativeFilename, compilationUnit, global, symbolSolver)(config.schemaValidation).createAst()
+        )
 
       case None => logger.warn(s"Skipping AST creation for $filename")
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -88,6 +88,7 @@ import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParame
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType, ResolvedTypeVariable}
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.{ObjectMethodSignatures, TypeConstants}
 import io.joern.javasrc2cpg.util.BindingTable.createBindingTable
 import io.joern.x2cpg.utils.NodeBuilders.{
   newAnnotationLiteralNode,
@@ -148,20 +149,20 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewTypeDecl,
   NewTypeRef
 }
-import io.joern.x2cpg.{Ast, AstCreatorBase, Defines}
+import io.joern.x2cpg.{Ast, AstCreatorBase, Defines, ValidationMode}
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.passes.frontend.TypeNodePass
-import io.joern.x2cpg.utils.AstPropertiesUtil._
+import io.joern.x2cpg.utils.AstPropertiesUtil.*
 import io.joern.x2cpg.utils.NodeBuilders
 import io.joern.x2cpg.AstNodeBuilder
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode.PropertyDefaults
-import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn.{PropertyDefaults => ParameterDefaults}
+import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn.PropertyDefaults as ParameterDefaults
 import io.shiftleft.passes.IntervalKeyPool
 import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 import scala.language.{existentials, implicitConversions}
 import scala.util.{Failure, Success, Try}
@@ -195,8 +196,9 @@ object AstWithStaticInit {
 
 /** Translate a Java Parser AST into a CPG AST
   */
-class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Global, symbolSolver: JavaSymbolSolver)
-    extends AstCreatorBase(filename)
+class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Global, symbolSolver: JavaSymbolSolver)(
+  implicit withSchemaValidation: ValidationMode
+) extends AstCreatorBase(filename)
     with AstNodeBuilder[Node, AstCreator] {
 
   private val logger = LoggerFactory.getLogger(this.getClass)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Scope.scala
@@ -3,9 +3,9 @@ package io.joern.javasrc2cpg.util
 import io.joern.javasrc2cpg.passes.ExpectedType
 import io.joern.javasrc2cpg.util.Scope.ScopeTypes.{MethodScope, NamespaceScope, ScopeType, TypeDeclScope}
 import io.joern.javasrc2cpg.util.Scope.WildcardImportName
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.datastructures.{ScopeElement, Scope => X2CpgScope}
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.datastructures.{ScopeElement, Scope as X2CpgScope}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
@@ -18,7 +18,7 @@ case class NodeTypeInfo(
   isStatic: Boolean = false
 )
 
-class Scope extends X2CpgScope[String, NodeTypeInfo, ScopeType] {
+class Scope(implicit withSchemaValidation: ValidationMode) extends X2CpgScope[String, NodeTypeInfo, ScopeType] {
 
   private val logger                                        = LoggerFactory.getLogger(this.getClass)
   private var typeDeclStack: List[NewTypeDecl]              = Nil
@@ -171,5 +171,5 @@ object Scope {
     case object NamespaceScope                       extends ScopeType
   }
 
-  def apply(): Scope = new Scope()
+  def apply()(implicit withSchemaValidation: ValidationMode): Scope = new Scope()
 }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -88,8 +88,6 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
   }
 
   /** Apply the soot passes
-    * @param cpg
-    * @param config
     * @param tmpDir
     *   A temporary directory that will be used as the classpath for extracted class files
     */
@@ -102,14 +100,14 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
       case Some(".apk" | ".dex") if input.isRegularFile =>
         sootLoadApk(input, config.android)
         { () =>
-          val astCreator = SootAstCreationPass(cpg)
+          val astCreator = SootAstCreationPass(cpg, config)
           astCreator.createAndApply()
           astCreator.global
         }
       case _ =>
         val classFiles = sootLoad(input, tmpDir, config.recurse)
         { () =>
-          val astCreator = AstCreationPass(classFiles, cpg)
+          val astCreator = AstCreationPass(classFiles, cpg, config)
           astCreator.createAndApply()
           astCreator.global
         }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -1,7 +1,6 @@
 package io.joern.jimple2cpg.passes
 
-import better.files.File
-import io.joern.jimple2cpg.Jimple2Cpg
+import io.joern.jimple2cpg.Config
 import io.joern.jimple2cpg.util.ProgramHandlingUtil.ClassFile
 import io.joern.x2cpg.datastructures.Global
 import io.shiftleft.codepropertygraph.Cpg
@@ -15,7 +14,8 @@ import soot.Scene
   * @param cpg
   *   The CPG to add to
   */
-class AstCreationPass(classFiles: List[ClassFile], cpg: Cpg) extends ConcurrentWriterCpgPass[ClassFile](cpg) {
+class AstCreationPass(classFiles: List[ClassFile], cpg: Cpg, config: Config)
+    extends ConcurrentWriterCpgPass[ClassFile](cpg) {
 
   val global: Global = new Global()
   private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
@@ -26,7 +26,7 @@ class AstCreationPass(classFiles: List[ClassFile], cpg: Cpg) extends ConcurrentW
     try {
       val sootClass = Scene.v().loadClassAndSupport(classFile.fullyQualifiedClassName.get)
       sootClass.setApplicationClass()
-      val localDiff = AstCreator(classFile.file.canonicalPath, sootClass, global).createAst()
+      val localDiff = AstCreator(classFile.file.canonicalPath, sootClass, global)(config.schemaValidation).createAst()
       builder.absorb(localDiff)
     } catch {
       case e: Exception =>

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -3,15 +3,15 @@ package io.joern.jimple2cpg.passes
 import io.joern.x2cpg.Ast.storeInDiffGraph
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.utils.NodeBuilders
-import io.joern.x2cpg.{Ast, AstCreatorBase}
-import io.shiftleft.codepropertygraph.generated._
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.*
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate.DiffGraphBuilder
-import soot.jimple._
+import soot.jimple.*
 import soot.jimple.internal.JimpleLocal
-import soot.tagkit._
-import soot.{Local => _, _}
+import soot.tagkit.*
+import soot.{Local as _, *}
 
 import scala.collection.immutable.HashSet
 import scala.collection.mutable
@@ -19,9 +19,10 @@ import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.{Failure, Success, Try}
 
-class AstCreator(filename: String, cls: SootClass, global: Global) extends AstCreatorBase(filename) {
+class AstCreator(filename: String, cls: SootClass, global: Global)(implicit withSchemaValidation: ValidationMode)
+    extends AstCreatorBase(filename) {
 
-  import AstCreator._
+  import AstCreator.*
 
   private val logger         = LoggerFactory.getLogger(classOf[AstCreationPass])
   private val unitToAsts     = mutable.HashMap[soot.Unit, Seq[Ast]]()

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/SootAstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/SootAstCreationPass.scala
@@ -1,6 +1,6 @@
 package io.joern.jimple2cpg.passes
 
-import io.joern.jimple2cpg.Jimple2Cpg
+import io.joern.jimple2cpg.{Config, Jimple2Cpg}
 import io.joern.x2cpg.datastructures.Global
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
@@ -11,7 +11,7 @@ import soot.SourceLocator
 
 /** Creates the AST layer from the given class file and stores all types in the given global parameter.
   */
-class SootAstCreationPass(cpg: Cpg) extends ConcurrentWriterCpgPass[SootClass](cpg) {
+class SootAstCreationPass(cpg: Cpg, config: Config) extends ConcurrentWriterCpgPass[SootClass](cpg) {
 
   val global: Global = new Global()
   private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
@@ -22,7 +22,7 @@ class SootAstCreationPass(cpg: Cpg) extends ConcurrentWriterCpgPass[SootClass](c
     val jimpleFile = SourceLocator.v().getSourceForClass(part.getName())
     try {
       // sootClass.setApplicationClass()
-      val localDiff = new AstCreator(jimpleFile, part, global).createAst()
+      val localDiff = new AstCreator(jimpleFile, part, global)(config.schemaValidation).createAst()
       builder.absorb(localDiff)
     } catch {
       case e: Exception =>

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -26,7 +26,7 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
         val astGenResult = new AstGenRunner(config).execute(tmpDir)
         val hash         = HashUtil.sha256(astGenResult.parsedFiles.map { case (_, file) => File(file).path })
 
-        val astCreationPass = new AstCreationPass(cpg, astGenResult, config, report)
+        val astCreationPass = new AstCreationPass(cpg, astGenResult, config, report)(config.schemaValidation)
         astCreationPass.createAndApply()
 
         new TypeNodePass(astCreationPass.allUsedTypes(), cpg).createAndApply()

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -2,13 +2,13 @@ package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.datastructures.{MethodScope, Scope}
-import io.joern.jssrc2cpg.parser.BabelAst._
+import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelJsonParser.ParseResult
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
-import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder => X2CpgAstNodeBuilder}
+import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
 import io.shiftleft.codepropertygraph.generated.nodes.NewFile
@@ -27,7 +27,8 @@ class AstCreator(
   val config: Config,
   val parserResult: ParseResult,
   val usedTypes: ConcurrentHashMap[(String, String), Boolean]
-) extends AstCreatorBase(parserResult.filename)
+)(implicit withSchemaValidation: ValidationMode)
+    extends AstCreatorBase(parserResult.filename)
     with AstForExpressionsCreator
     with AstForPrimitivesCreator
     with AstForTypesCreator

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,10 +1,10 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.jssrc2cpg.datastructures._
-import io.joern.jssrc2cpg.parser.BabelAst._
+import io.joern.jssrc2cpg.datastructures.*
+import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.utils.NodeBuilders.{newClosureBindingNode, newLocalNode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies}
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters.EnumerationHasAsScala
 import scala.util.Success
 import scala.util.Try
 
-trait AstCreatorHelper { this: AstCreator =>
+trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   // maximum length of code fields in number of characters
   private val MaxCodeLength: Int = 1000

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -1,11 +1,11 @@
 package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.datastructures.{BlockScope, MethodScope, ScopeType}
-import io.joern.jssrc2cpg.parser.BabelAst._
+import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.{newDependencyNode, newLocalNode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewImport}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes}
@@ -13,7 +13,7 @@ import ujson.Value
 
 import scala.util.Try
 
-trait AstForDeclarationsCreator { this: AstCreator =>
+trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   private val DefaultsKey    = "default"
   private val ExportKeyword  = "exports"

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -1,17 +1,17 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.jssrc2cpg.parser.BabelAst._
+import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.{Defines, EcmaBuiltins, GlobalBuiltins}
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.newLocalNode
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
 
 import scala.util.Try
 
-trait AstForExpressionsCreator { this: AstCreator =>
+trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForExpressionStatement(exprStmt: BabelNodeInfo): Ast =
     astForNodeWithFunctionReference(exprStmt.json("expression"))

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -3,7 +3,7 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.datastructures.{BlockScope, MethodScope}
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newLocalNode}
 import io.shiftleft.codepropertygraph.generated.nodes.{Identifier as _, *}
@@ -13,7 +13,7 @@ import ujson.Value
 import scala.collection.mutable
 import scala.util.Try
 
-trait AstForFunctionsCreator { this: AstCreator =>
+trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   case class MethodAst(ast: Ast, methodNode: NewMethod, methodAst: Ast)
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -2,10 +2,10 @@ package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 
-trait AstForPrimitivesCreator { this: AstCreator =>
+trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForIdentifier(ident: BabelNodeInfo, typeFullName: Option[String] = None): Ast = {
     val name      = ident.json("name").str

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,10 +1,10 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.jssrc2cpg.parser.BabelAst._
+import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.utils.NodeBuilders.newLocalNode
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
@@ -15,7 +15,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.NewJumpTarget
 import ujson.Obj
 import ujson.Value
 
-trait AstForStatementsCreator { this: AstCreator =>
+trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   /** Sort all block statements with the following result:
     *   - all function declarations go first

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
@@ -1,11 +1,11 @@
 package io.joern.jssrc2cpg.astcreation
 
-import io.joern.jssrc2cpg.parser.BabelAst._
+import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import ujson.Obj
 
-trait AstForTemplateDomCreator { this: AstCreator =>
+trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForJsxElement(jsxElem: BabelNodeInfo): Ast = {
     val domNode = createTemplateDomNode(jsxElem.node.toString, jsxElem.code, jsxElem.lineNumber, jsxElem.columnNumber)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -1,19 +1,19 @@
 package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.datastructures.BlockScope
-import io.joern.jssrc2cpg.parser.BabelAst._
+import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.datastructures.Stack._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newLocalNode}
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, ModifierTypes, Operators}
 import ujson.Value
 
 import scala.util.Try
 
-trait AstForTypesCreator { this: AstCreator =>
+trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForTypeAlias(alias: BabelNodeInfo): Ast = {
     val (aliasName, aliasFullName) = calcTypeNameAndFullName(alias)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -3,13 +3,13 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
 
-trait AstNodeBuilder { this: AstCreator =>
+trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
   protected def createMethodReturnNode(func: BabelNodeInfo): NewMethodReturn = {
     newMethodReturnNode(typeFor(func), line = func.lineNumber, column = func.columnNumber)
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -1,25 +1,24 @@
 package io.joern.jssrc2cpg.passes
 
-import io.joern.jssrc2cpg.astcreation.AstCreator
 import io.joern.jssrc2cpg.Config
+import io.joern.jssrc2cpg.astcreation.AstCreator
 import io.joern.jssrc2cpg.parser.BabelJsonParser
 import io.joern.jssrc2cpg.utils.AstGenRunner.AstGenRunnerResult
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.shiftleft.utils.IOUtils
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
-class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: Config, report: Report = new Report())
-    extends ConcurrentWriterCpgPass[(String, String)](cpg) {
+class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: Config, report: Report = new Report())(
+  implicit withSchemaValidation: ValidationMode
+) extends ConcurrentWriterCpgPass[(String, String)](cpg) {
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTest.scala
@@ -4,8 +4,9 @@ import better.files.File
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.passes.AstCreationPass
 import io.joern.jssrc2cpg.utils.AstGenRunner
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
@@ -14,6 +15,8 @@ import org.scalatest.BeforeAndAfterAll
 import java.util.regex.Pattern
 
 class ExcludeTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks with BeforeAndAfterAll {
+
+  private implicit val schemaValidationMode: ValidationMode = ValidationMode.Enabled
 
   private val testFiles: List[String] = List(
     ".sub/e.js",

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/MinifiedFileDetectionTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/MinifiedFileDetectionTest.scala
@@ -5,12 +5,14 @@ import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.passes.AstCreationPass
 import io.joern.jssrc2cpg.utils.AstGenRunner
+import io.joern.x2cpg.ValidationMode
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 class MinifiedFileDetectionTest extends AnyWordSpec with Matchers {
+
+  private implicit val schemaValidationMode: ValidationMode = ValidationMode.Enabled
 
   "Detecting minified files" should {
     "skip minified files by name correctly" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ProjectParseTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ProjectParseTest.scala
@@ -5,12 +5,15 @@ import io.joern.jssrc2cpg.testfixtures.JsSrc2CpgSuite
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.passes.AstCreationPass
 import io.joern.jssrc2cpg.utils.AstGenRunner
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.scalatest.BeforeAndAfterAll
 
 class ProjectParseTest extends JsSrc2CpgSuite with BeforeAndAfterAll {
+
+  private implicit val schemaValidationMode: ValidationMode = ValidationMode.Enabled
 
   private val projectWithSubfolders: File = {
     val dir = File.newTemporaryDirectory("jssrc2cpgTestsSubfolders")

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/TranspiledFileDetectionTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/TranspiledFileDetectionTest.scala
@@ -4,12 +4,15 @@ import better.files.File
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.passes.AstCreationPass
 import io.joern.jssrc2cpg.utils.AstGenRunner
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class TranspiledFileDetectionTest extends AnyWordSpec with Matchers {
+
+  private implicit val schemaValidationMode: ValidationMode = ValidationMode.Enabled
 
   "Detecting transpiled files" should {
     "skip transpiled files correctly (with source map comment)" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/AbstractPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/AbstractPassTest.scala
@@ -3,6 +3,7 @@ package io.joern.jssrc2cpg.passes
 import better.files.File
 import io.joern.jssrc2cpg.utils.AstGenRunner
 import io.joern.jssrc2cpg.Config
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.shiftleft.codepropertygraph.Cpg
 import org.scalatest.matchers.should.Matchers
@@ -12,6 +13,8 @@ import org.scalatest.Inside
 abstract class AbstractPassTest extends AnyWordSpec with Matchers with Inside {
 
   protected abstract class Fixture
+
+  private implicit val schemaValidationMode: ValidationMode = ValidationMode.Enabled
 
   protected object AstFixture extends Fixture {
     def apply(code: String, filename: String = "code.js", tsTypes: Boolean = false)(f: Cpg => Unit): Unit = {

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -132,7 +132,7 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] with UsesService {
       val typeInfoProvider = new DefaultTypeInfoProvider(environment)
 
       new MetaDataPass(cpg, Languages.KOTLIN, config.inputPath).createAndApply()
-      val astCreator = new AstCreationPass(sources, typeInfoProvider, cpg)
+      val astCreator = new AstCreationPass(sources, typeInfoProvider, cpg)(config.schemaValidation)
       astCreator.createAndApply()
       val kotlinAstCreatorTypes = astCreator.global.usedTypes.keys().asScala.toList
       TypeNodePass.withRegisteredTypes(kotlinAstCreatorTypes, cpg).createAndApply()

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -6,10 +6,9 @@ import io.joern.kotlin2cpg.types.{TypeConstants, TypeInfoProvider, TypeRenderer}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.passes.IntervalKeyPool
-import io.joern.x2cpg.{Ast, AstCreatorBase}
+import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, ValidationMode}
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.AstNodeBuilder
 import io.joern.kotlin2cpg.datastructures.Scope
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.*
@@ -23,8 +22,9 @@ import scala.collection.mutable
 case class BindingInfo(node: NewBinding, edgeMeta: Seq[(NewNode, NewNode, String)])
 case class ClosureBindingDef(node: NewClosureBinding, captureEdgeTo: NewMethodRef, refEdgeTo: NewNode)
 
-class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvider, global: Global)
-    extends AstCreatorBase(fileWithMeta.filename)
+class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvider, global: Global)(implicit
+  withSchemaValidation: ValidationMode
+) extends AstCreatorBase(fileWithMeta.filename)
     with KtPsiToAst
     with AstNodeBuilder[PsiElement, AstCreator] {
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/KtPsiToAst.scala
@@ -10,7 +10,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.shiftleft.semanticcpg.language.*
-import io.joern.x2cpg.{Ast, Defines}
+import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders
 import io.joern.x2cpg.utils.NodeBuilders.{
@@ -31,7 +31,7 @@ import scala.annotation.unused
 import scala.jdk.CollectionConverters.*
 import scala.util.Random
 
-trait KtPsiToAst {
+trait KtPsiToAst(implicit withSchemaValidation: ValidationMode) {
   this: AstCreator =>
 
   def astForFile(fileWithMeta: KtFileWithMeta)(implicit typeInfoProvider: TypeInfoProvider): Ast = {

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
@@ -1,16 +1,17 @@
 package io.joern.kotlin2cpg.passes
 
 import io.joern.kotlin2cpg.KtFileWithMeta
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.joern.kotlin2cpg.ast.AstCreator
 import io.joern.kotlin2cpg.types.TypeInfoProvider
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.datastructures.Global
-
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.passes.ConcurrentWriterCpgPass
 import org.slf4j.LoggerFactory
 
-class AstCreationPass(filesWithMeta: Iterable[KtFileWithMeta], typeInfoProvider: TypeInfoProvider, cpg: Cpg)
-    extends ConcurrentWriterCpgPass[KtFileWithMeta](cpg) {
+class AstCreationPass(filesWithMeta: Iterable[KtFileWithMeta], typeInfoProvider: TypeInfoProvider, cpg: Cpg)(implicit
+  withSchemaValidation: ValidationMode
+) extends ConcurrentWriterCpgPass[KtFileWithMeta](cpg) {
   val global: Global = new Global()
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -48,7 +48,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
     if (errorMessages.isEmpty) {
       withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
         new MetaDataPass(cpg, Languages.PHP, config.inputPath).createAndApply()
-        new AstCreationPass(config, cpg, parser.get).createAndApply()
+        new AstCreationPass(config, cpg, parser.get)(config.schemaValidation).createAndApply()
         new AstParentInfoPass(cpg).createAndApply()
         new AnyTypePass(cpg).createAndApply()
         TypeNodePass.withTypesFromCpg(cpg).createAndApply()

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -3,11 +3,11 @@ package io.joern.php2cpg.astcreation
 import io.joern.php2cpg.astcreation.AstCreator.{NameConstants, TypeConstants, operatorSymbols}
 import io.joern.php2cpg.datastructures.{ArrayIndexTracker, Scope}
 import io.joern.php2cpg.parser.Domain.PhpModifiers.containsAccessModifier
-import io.joern.php2cpg.parser.Domain._
+import io.joern.php2cpg.parser.Domain.*
 import io.joern.x2cpg.Ast.storeInDiffGraph
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.utils.AstPropertiesUtil.RootProperties
-import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder}
+import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, ValidationMode}
 import io.joern.x2cpg.Defines.{StaticInitMethodName, UnresolvedNamespace, UnresolvedSignature}
 import io.joern.x2cpg.utils.NodeBuilders.{
   newFieldIdentifierNode,
@@ -16,17 +16,17 @@ import io.joern.x2cpg.utils.NodeBuilders.{
   newModifierNode,
   newOperatorCallNode
 }
-import io.shiftleft.codepropertygraph.generated._
+import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.Call.PropertyDefaults
-import io.shiftleft.codepropertygraph.generated.nodes.Local.{PropertyDefaults => LocalDefaults}
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.Local.PropertyDefaults as LocalDefaults
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 
-class AstCreator(filename: String, phpAst: PhpFile)
+class AstCreator(filename: String, phpAst: PhpFile)(implicit withSchemaValidation: ValidationMode)
     extends AstCreatorBase(filename)
     with AstNodeBuilder[PhpNode, AstCreator] {
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -4,15 +4,16 @@ import better.files.File
 import io.joern.php2cpg.Config
 import io.joern.php2cpg.astcreation.AstCreator
 import io.joern.php2cpg.parser.PhpParser
-import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.datastructures.Global
+import io.joern.x2cpg.{SourceFiles, ValidationMode}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
 import org.slf4j.LoggerFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
-class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser) extends ConcurrentWriterCpgPass[String](cpg) {
+class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser)(implicit withSchemaValidation: ValidationMode)
+    extends ConcurrentWriterCpgPass[String](cpg) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -28,7 +29,7 @@ class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser) extends Concu
     }
     parser.parseFile(filename, config.phpIni) match {
       case Some(parseResult) =>
-        diffGraph.absorb(new AstCreator(relativeFilename, parseResult).createAst())
+        diffGraph.absorb(new AstCreator(relativeFilename, parseResult)(config.schemaValidation).createAst())
 
       case None =>
         logger.warn(s"Could not parse file $filename. Results will be missing!")

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2Cpg.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2Cpg.scala
@@ -1,5 +1,6 @@
 package io.joern.pysrc2cpg
 
+import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import overflowdb.BatchedUpdate
@@ -20,12 +21,15 @@ object Py2Cpg {
   *   The project root.
   * @param requirementsTxt
   *   The configured name of the requirements txt file.
+  * @param schemaValidationMode
+  *   The boolean switch for enabling or disabling early schema checking during AST creation.
   */
 class Py2Cpg(
   inputProviders: Iterable[Py2Cpg.InputProvider],
   outputCpg: Cpg,
   inputPath: String,
-  requirementsTxt: String = "requirements.txt"
+  requirementsTxt: String = "requirements.txt",
+  schemaValidationMode: ValidationMode
 ) {
   private val diffGraph   = new DiffGraphBuilder()
   private val nodeBuilder = new NodeBuilder(diffGraph)
@@ -39,7 +43,7 @@ class Py2Cpg(
     val anyTypeDecl = nodeBuilder.typeDeclNode(Constants.ANY, Constants.ANY, "N/A", Nil, LineAndColumn(1, 1, 1, 1))
     edgeBuilder.astEdge(anyTypeDecl, globalNamespaceBlock, 0)
     BatchedUpdate.applyDiff(outputCpg.graph, diffGraph)
-    new CodeToCpg(outputCpg, inputProviders).createAndApply()
+    new CodeToCpg(outputCpg, inputProviders, schemaValidationMode).createAndApply()
     new ConfigFileCreationPass(outputCpg, requirementsTxt).createAndApply()
     new DependenciesFromRequirementsTxtPass(outputCpg).createAndApply()
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
@@ -58,7 +58,7 @@ class Py2CpgOnFileSystem extends X2CpgFrontend[Py2CpgOnFileSystemConfig] {
           Py2Cpg.InputPair(content, inputFile.toString, Paths.get(config.inputPath).relativize(inputFile).toString)
         }
       }
-      val py2Cpg = new Py2Cpg(inputProviders, cpg, config.inputPath, config.requirementsTxt)
+      val py2Cpg = new Py2Cpg(inputProviders, cpg, config.inputPath, config.requirementsTxt, config.schemaValidation)
       py2Cpg.buildCpg()
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -1,9 +1,10 @@
 package io.joern.pysrc2cpg
 
 import io.joern.pysrc2cpg.PythonAstVisitor.{builtinPrefix, metaClassSuffix}
-import io.joern.pysrc2cpg.memop._
+import io.joern.pysrc2cpg.memop.*
 import io.joern.pythonparser.ast
-import io.shiftleft.codepropertygraph.generated._
+import io.joern.x2cpg.ValidationMode
+import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, NewTypeDecl}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
@@ -26,7 +27,8 @@ class PythonAstVisitor(
   relFileName: String,
   protected val nodeToCode: NodeToCode,
   version: PythonVersion
-) extends PythonAstVisitorHelpers {
+)(implicit withSchemaValidation: ValidationMode)
+    extends PythonAstVisitorHelpers {
 
   private val diffGraph     = new DiffGraphBuilder()
   protected val nodeBuilder = new NodeBuilder(diffGraph)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/Py2CpgTestContext.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/Py2CpgTestContext.scala
@@ -1,5 +1,6 @@
 package io.joern.pysrc2cpg
 
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.defaultOverlayCreators
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
@@ -33,8 +34,14 @@ class Py2CpgTestContext {
 
   def buildCpg: Cpg = {
     if (buildResult.isEmpty) {
-      val cpg    = new Cpg()
-      val py2Cpg = new Py2Cpg(codeAndFile.map(inputPair => () => inputPair), cpg, absTestFilePath)
+      val cpg = new Cpg()
+      val py2Cpg =
+        new Py2Cpg(
+          codeAndFile.map(inputPair => () => inputPair),
+          cpg,
+          absTestFilePath,
+          schemaValidationMode = ValidationMode.Enabled
+        )
       py2Cpg.buildCpg()
 
       val context = new LayerCreatorContext(cpg)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -33,8 +33,9 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
           val tempDir = File.newTemporaryDirectory()
           try {
             downloadDependency(config.inputPath, tempDir.toString())
-            new AstPackagePass(cpg, tempDir.toString(), global, parser, RubySrc2Cpg.packageTableInfo, config.inputPath)
-              .createAndApply()
+            new AstPackagePass(cpg, tempDir.toString(), global, parser, RubySrc2Cpg.packageTableInfo, config.inputPath)(
+              config.schemaValidation
+            ).createAndApply()
           } finally {
             tempDir.delete()
           }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -28,7 +28,7 @@ class AstCreator(
   parser: ResourceManagedParser,
   packageContext: PackageContext,
   projectRoot: Option[String] = None
-)(implicit withSchemaValidation: ValidationMode = ValidationMode.Disabled)
+)(implicit withSchemaValidation: ValidationMode)
     extends AstCreatorBase(filename)
     with AstNodeBuilder[ParserRuleContext, AstCreator]
     with AstForPrimitivesCreator

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -19,7 +19,7 @@ import scala.collection.immutable.Seq
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.*
-import scala.util.{Failure, Success, Using}
+import scala.util.{Failure, Success}
 
 class AstCreator(
   protected val filename: String,
@@ -27,7 +27,8 @@ class AstCreator(
   parser: ResourceManagedParser,
   packageContext: PackageContext,
   projectRoot: Option[String] = None
-) extends AstCreatorBase(filename)
+)(implicit withSchemaValidation: Boolean = false)
+    extends AstCreatorBase(filename)
     with AstNodeBuilder[ParserRuleContext, AstCreator]
     with AstForPrimitivesCreator
     with AstForStatementsCreator

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -7,6 +7,7 @@ import io.joern.x2cpg.Ast.storeInDiffGraph
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
 import io.joern.x2cpg.datastructures.{Global, Scope}
 import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, Defines as XDefines}
+import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.antlr.v4.runtime.tree.TerminalNode
@@ -27,7 +28,7 @@ class AstCreator(
   parser: ResourceManagedParser,
   packageContext: PackageContext,
   projectRoot: Option[String] = None
-)(implicit withSchemaValidation: Boolean = false)
+)(implicit withSchemaValidation: ValidationMode = ValidationMode.Disabled)
     extends AstCreatorBase(filename)
     with AstNodeBuilder[ParserRuleContext, AstCreator]
     with AstForPrimitivesCreator

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.astcreation
 
-import io.joern.x2cpg.{Ast, Defines}
+import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.{
@@ -10,8 +10,9 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewMethodParameterIn,
   NewNode
 }
+
 import scala.collection.mutable
-trait AstCreatorHelper { this: AstCreator =>
+trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   import GlobalTypes._
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.parser.RubyParser.*
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewFieldIdentifier, NewJumpTarget, NewLiteral, NewNode}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.immutable.Set
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-trait AstForExpressionsCreator { this: AstCreator =>
+trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   private val logger                         = LoggerFactory.getLogger(this.getClass)
   protected var lastModifier: Option[String] = None

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -4,14 +4,14 @@ import io.joern.rubysrc2cpg.parser.RubyParser
 import io.joern.rubysrc2cpg.parser.RubyParser.*
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewCall
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-trait AstForPrimitivesCreator { this: AstCreator =>
+trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForNilLiteral(ctx: RubyParser.NilPseudoVariableIdentifierContext): Ast =
     Ast(literalNode(ctx, ctx.getText, Defines.NilClass))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.astcreation
 import better.files.File
 import io.joern.rubysrc2cpg.parser.RubyParser.*
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
 import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
@@ -24,7 +24,7 @@ import org.antlr.v4.runtime.ParserRuleContext
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-trait AstForStatementsCreator {
+trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   this: AstCreator =>
 
   private val logger = LoggerFactory.getLogger(this.getClass)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -13,14 +13,14 @@ import io.joern.rubysrc2cpg.parser.RubyParser.{
 }
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes}
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.antlr.v4.runtime.ParserRuleContext
 import io.joern.x2cpg.utils.*
 
 import scala.collection.mutable
 
-trait AstForTypesCreator { this: AstCreator =>
+trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   // Maps field references of known types
   protected val fieldReferences = mutable.HashMap.empty[String, Set[ParserRuleContext]]

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
@@ -32,8 +32,9 @@ class AstCreationPass(
   override def runOnPart(diffGraph: DiffGraphBuilder, fileName: String): Unit = {
     try {
       diffGraph.absorb(
-        new AstCreator(fileName, global, parser, PackageContext(fileName, packageTable), cpg.metaData.root.headOption)
-          .createAst()
+        new AstCreator(fileName, global, parser, PackageContext(fileName, packageTable), cpg.metaData.root.headOption)(
+          config.schemaValidation
+        ).createAst()
       )
     } catch {
       case ex: Exception =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstPackagePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstPackagePass.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.passes
 import better.files.File
 import io.joern.rubysrc2cpg.astcreation.{AstCreator, ResourceManagedParser}
 import io.joern.rubysrc2cpg.utils.{PackageContext, PackageTable}
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.datastructures.Global
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass
@@ -16,7 +17,8 @@ class AstPackagePass(
   parser: ResourceManagedParser,
   packageTable: PackageTable,
   inputPath: String
-) extends ConcurrentWriterCpgPass[String](cpg) {
+)(implicit withSchemaValidation: ValidationMode)
+    extends ConcurrentWriterCpgPass[String](cpg) {
 
   override def generateParts(): Array[String] =
     getRubyDependenciesFile(inputPath) ++ getRubyDependenciesFile(tempExtDir)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -2,28 +2,22 @@ package io.joern.x2cpg
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode.PropertyDefaults
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  AstNodeNew,
-  ExpressionNew,
-  NewBlock,
-  NewCall,
-  NewControlStructure,
-  NewFieldIdentifier,
-  NewIdentifier,
-  NewLiteral,
-  NewMethodRef,
-  NewNode,
-  NewReturn,
-  NewTypeRef,
-  NewUnknown
-}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import overflowdb.BatchedUpdate.DiffGraphBuilder
+import overflowdb.SchemaViolationException
 
 case class AstEdge(src: NewNode, dst: NewNode)
 
 object Ast {
+
+  private var withSchemaValidation = false
+
   def apply(node: NewNode): Ast = Ast(Vector.empty :+ node)
   def apply(): Ast              = new Ast(Vector.empty)
+
+  def setSchemaValidation(value: Boolean): Unit = {
+    withSchemaValidation = value
+  }
 
   /** Copy nodes/edges of given `AST` into the given `diffGraph`.
     */
@@ -54,6 +48,12 @@ object Ast {
     ast.bindsEdges.foreach { edge =>
       diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.BINDS)
     }
+  }
+
+  def neighbourValidation(src: NewNode, dst: NewNode, edge: String): Unit = if (
+    withSchemaValidation && !(src.isValidOutNeighbour(edge, dst) && dst.isValidInNeighbour(edge, src))
+  ) {
+    throw new SchemaViolationException(s"(${src.label()}) -[$edge]-> (${dst.label()}) violates the schema.")
   }
 
   /** For all `order` fields that are unset, derive the `order` field automatically by determining the position of the
@@ -100,6 +100,7 @@ case class Ast(
       nodes ++ other.nodes,
       edges = edges ++ other.edges ++ root.toList.flatMap(r =>
         other.root.toList.map { rc =>
+          Ast.neighbourValidation(r, rc, EdgeTypes.AST)
           AstEdge(r, rc)
         }
       ),
@@ -139,30 +140,37 @@ case class Ast(
   }
 
   def withConditionEdge(src: NewNode, dst: NewNode): Ast = {
+    Ast.neighbourValidation(src, dst, EdgeTypes.CONDITION)
     this.copy(conditionEdges = conditionEdges ++ List(AstEdge(src, dst)))
   }
 
   def withRefEdge(src: NewNode, dst: NewNode): Ast = {
+    Ast.neighbourValidation(src, dst, EdgeTypes.REF)
     this.copy(refEdges = refEdges ++ List(AstEdge(src, dst)))
   }
 
   def withBindsEdge(src: NewNode, dst: NewNode): Ast = {
+    Ast.neighbourValidation(src, dst, EdgeTypes.BINDS)
     this.copy(bindsEdges = bindsEdges ++ List(AstEdge(src, dst)))
   }
 
   def withReceiverEdge(src: NewNode, dst: NewNode): Ast = {
+    Ast.neighbourValidation(src, dst, EdgeTypes.RECEIVER)
     this.copy(receiverEdges = receiverEdges ++ List(AstEdge(src, dst)))
   }
 
   def withArgEdge(src: NewNode, dst: NewNode): Ast = {
+    Ast.neighbourValidation(src, dst, EdgeTypes.ARGUMENT)
     this.copy(argEdges = argEdges ++ List(AstEdge(src, dst)))
   }
 
   def withArgEdges(src: NewNode, dsts: Seq[NewNode]): Ast = {
+    dsts.foreach(dst => Ast.neighbourValidation(src, dst, EdgeTypes.ARGUMENT))
     this.copy(argEdges = argEdges ++ dsts.map(AstEdge(src, _)))
   }
 
   def withArgEdges(src: NewNode, dsts: Seq[NewNode], argIndexStart: Int): Ast = {
+    dsts.foreach(dst => Ast.neighbourValidation(src, dst, EdgeTypes.CONDITION))
     var index = argIndexStart
     this.copy(argEdges = argEdges ++ dsts.map { dst =>
       addArgumentIndex(dst, index)
@@ -185,18 +193,22 @@ case class Ast(
   }
 
   def withConditionEdges(src: NewNode, dsts: List[NewNode]): Ast = {
+    dsts.foreach(dst => Ast.neighbourValidation(src, dst, EdgeTypes.CONDITION))
     this.copy(conditionEdges = conditionEdges ++ dsts.map(AstEdge(src, _)))
   }
 
   def withRefEdges(src: NewNode, dsts: List[NewNode]): Ast = {
+    dsts.foreach(dst => Ast.neighbourValidation(src, dst, EdgeTypes.REF))
     this.copy(refEdges = refEdges ++ dsts.map(AstEdge(src, _)))
   }
 
   def withBindsEdges(src: NewNode, dsts: List[NewNode]): Ast = {
+    dsts.foreach(dst => Ast.neighbourValidation(src, dst, EdgeTypes.BINDS))
     this.copy(bindsEdges = bindsEdges ++ dsts.map(AstEdge(src, _)))
   }
 
   def withReceiverEdges(src: NewNode, dsts: List[NewNode]): Ast = {
+    dsts.foreach(dst => Ast.neighbourValidation(src, dst, EdgeTypes.RECEIVER))
     this.copy(receiverEdges = receiverEdges ++ dsts.map(AstEdge(src, _)))
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -11,6 +11,10 @@ import scala.util.{Failure, Success, Try}
 
 case class AstEdge(src: NewNode, dst: NewNode)
 
+enum ValidationMode {
+  case Enabled, Disabled
+}
+
 object Ast {
 
   private val logger = LoggerFactory.getLogger(getClass)
@@ -49,8 +53,11 @@ object Ast {
     }
   }
 
-  def neighbourValidation(src: NewNode, dst: NewNode, edge: String)(implicit withSchemaValidation: Boolean): Unit = if (
-    withSchemaValidation && !(src.isValidOutNeighbor(edge, dst) && dst.isValidInNeighbor(edge, src))
+  def neighbourValidation(src: NewNode, dst: NewNode, edge: String)(implicit
+    withSchemaValidation: ValidationMode
+  ): Unit = if (
+    withSchemaValidation == ValidationMode.Enabled &&
+    !(src.isValidOutNeighbor(edge, dst) && dst.isValidInNeighbor(edge, src))
   ) {
     logger.warn(
       "Malformed AST detected!",
@@ -89,7 +96,7 @@ case class Ast(
   bindsEdges: collection.Seq[AstEdge] = Vector.empty,
   receiverEdges: collection.Seq[AstEdge] = Vector.empty,
   argEdges: collection.Seq[AstEdge] = Vector.empty
-)(implicit withSchemaValidation: Boolean = false) {
+)(implicit withSchemaValidation: ValidationMode = ValidationMode.Disabled) {
 
   def root: Option[NewNode] = nodes.headOption
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -7,7 +7,9 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Modifier
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
-abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: Boolean = false) {
+abstract class AstCreatorBase(filename: String)(implicit
+  withSchemaValidation: ValidationMode = ValidationMode.Disabled
+) {
   val diffGraph: DiffGraphBuilder = new DiffGraphBuilder
 
   def createAst(): DiffGraphBuilder

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -7,9 +7,7 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Modifier
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
-abstract class AstCreatorBase(filename: String)(implicit
-  withSchemaValidation: ValidationMode = ValidationMode.Disabled
-) {
+abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: ValidationMode) {
   val diffGraph: DiffGraphBuilder = new DiffGraphBuilder
 
   def createAst(): DiffGraphBuilder

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -7,7 +7,7 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Modifier
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
-abstract class AstCreatorBase(filename: String) {
+abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: Boolean = false) {
   val diffGraph: DiffGraphBuilder = new DiffGraphBuilder
 
   def createAst(): DiffGraphBuilder

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -10,10 +10,9 @@ import overflowdb.Config
 import scopt.OParser
 
 import java.io.PrintWriter
-import java.nio.file.Files
-import java.nio.file.Paths
-import scala.util.{Failure, Success, Try}
+import java.nio.file.{Files, Paths}
 import scala.util.matching.Regex
+import scala.util.{Failure, Success, Try}
 
 object X2CpgConfig {
   def defaultOutputPath: String = "cpg.bin"
@@ -194,7 +193,7 @@ object X2Cpg {
     */
   private def commandLineParser[R <: X2CpgConfig[R]](frontendSpecific: OParser[_, R]): OParser[_, R] = {
     val builder = OParser.builder[R]
-    import builder._
+    import builder.*
     OParser.sequence(
       arg[String]("input-dir")
         .text("source directory")
@@ -218,6 +217,11 @@ object X2Cpg {
           c
         }
         .text("a regex specifying files to exclude during CPG generation (paths relative to <input-dir> are matched)"),
+      opt[Unit]("enable-early-schema-checking")
+        .action { (_, c) =>
+          Ast.setSchemaValidation(true); c
+        }
+        .text("enables early schema validation during AST creation (disabled by default)"),
       help("help").text("display this help message"),
       frontendSpecific
     )

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -1,6 +1,7 @@
 package io.joern.x2cpg
 
 import better.files.File
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, withErrorsToConsole}
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
 import io.shiftleft.codepropertygraph.Cpg
@@ -57,9 +58,9 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
     else { Paths.get(inputPath, ignore).toAbsolutePath.normalize().toString }
   }
 
-  var schemaValidation: Boolean = true
+  var schemaValidation: ValidationMode = ValidationMode.Disabled
 
-  def withSchemaValidation(value: Boolean): R = {
+  def withSchemaValidation(value: ValidationMode): R = {
     this.schemaValidation = value
     this.asInstanceOf[R]
   }
@@ -225,7 +226,7 @@ object X2Cpg {
         }
         .text("a regex specifying files to exclude during CPG generation (paths relative to <input-dir> are matched)"),
       opt[Unit]("enable-early-schema-checking")
-        .action((_, c) => c.withSchemaValidation(true))
+        .action((_, c) => c.withSchemaValidation(ValidationMode.Enabled))
         .text("enables early schema validation during AST creation (disabled by default)"),
       help("help").text("display this help message"),
       frontendSpecific

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -57,6 +57,13 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
     else { Paths.get(inputPath, ignore).toAbsolutePath.normalize().toString }
   }
 
+  var schemaValidation: Boolean = true
+
+  def withSchemaValidation(value: Boolean): R = {
+    this.schemaValidation = value
+    this.asInstanceOf[R]
+  }
+
   def withInheritedFields(config: R): R = {
     this.inputPath = config.inputPath
     this.outputPath = config.outputPath
@@ -218,9 +225,7 @@ object X2Cpg {
         }
         .text("a regex specifying files to exclude during CPG generation (paths relative to <input-dir> are matched)"),
       opt[Unit]("enable-early-schema-checking")
-        .action { (_, c) =>
-          Ast.setSchemaValidation(true); c
-        }
+        .action((_, c) => c.withSchemaValidation(true))
         .text("enables early schema validation during AST creation (disabled by default)"),
       help("help").text("display this help message"),
       frontendSpecific


### PR DESCRIPTION
As a way to enable faster feedback and better debugging for frontend development, the `Ast` class has been extended with an optional schema validation flag that will throw an exception at the exact point where a schema violation occurs. This config has been added to `X2Cpg` as a CLI option and propagated throughout the frontends as an implicit enum.

Notes:
* We could instead log a warning with an un-thrown exception
* I have noticed that the schema inheritance has permitted a lot of potentially unwanted flexibility, e.g. `AstNode` permits `CALL -(AST)-> NAMESPACE_BLOCK` which seems weird.