### PR TITLE
Speed up javasrc type inference pass

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
@@ -12,73 +12,83 @@ import io.shiftleft.semanticcpg.language._
 import org.slf4j.LoggerFactory
 
 import scala.jdk.OptionConverters.RichOptional
+import io.joern.x2cpg.Defines.UnresolvedNamespace
 
-class TypeInferencePass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
+class TypeInferencePass(cpg: Cpg) extends ConcurrentWriterCpgPass[(String, List[Call])](cpg) {
 
-  private val logger         = LoggerFactory.getLogger(this.getClass)
-  private val cache          = new GuavaCache(CacheBuilder.newBuilder().build[String, Option[Method]]())
-  private val namePartsCache = new GuavaCache(CacheBuilder.newBuilder().build[String, NameParts]())
+  private val logger = LoggerFactory.getLogger(this.getClass)
+  private val cache  = new GuavaCache(CacheBuilder.newBuilder().build[String, Option[Method]]())
+  private val resolvedMethodIndex = cpg.method.internal
+    .filterNot(_.fullName.startsWith(Defines.UnresolvedNamespace))
+    .filterNot(_.signature.startsWith(Defines.UnresolvedSignature))
+    .groupBy(_.name)
 
-  private case class NameParts(typeDecl: Option[String], signature: Option[String])
+  private case class NameParts(typeDecl: Option[String], signature: String)
 
   private val NamePartsPattern = raw"(.*\.)*.*:(.+\(.*\))".r
 
-  override def generateParts(): Array[Call] = {
-    cpg.call.methodFullName(s".*(${Defines.UnresolvedNamespace}|${Defines.UnresolvedSignature}).*").toArray
+  override def generateParts(): Array[(String, List[Call])] = {
+    cpg.call
+      .filter(_.signature.startsWith(Defines.UnresolvedSignature))
+      .groupBy(_.methodFullName)
+      .filterNot { case (name, _) => name.startsWith(UnresolvedNamespace) }
+      .toArray
   }
 
   private def isMatchingMethod(method: Method, call: Call, callNameParts: NameParts): Boolean = {
     // An erroneous `this` argument is added for unresolved calls to static methods.
     val argSizeMod = if (method.modifier.modifierType.iterator.contains(ModifierTypes.STATIC)) 1 else 0
-    if (
-      method.parameter.size != (call.argument.size - argSizeMod) || callNameParts.typeDecl.contains(
-        Defines.UnresolvedNamespace
-      )
-    ) {
+    if (method.parameter.size != (call.argument.size - argSizeMod)) {
       false
     } else {
-      val methodNameParts = getNameParts(method.fullName)
+      val methodNameParts = getNameParts(method.name, method.fullName)
       callNameParts.typeDecl == methodNameParts.typeDecl
     }
-
   }
 
-  private def getNameParts(fullName: String): NameParts = {
-    namePartsCache.get(fullName).toScala.getOrElse {
-      val nameParts = fullName match {
-        case NamePartsPattern(maybeTd, maybeSig) =>
-          val typeDecl  = Option(maybeTd).map(_.init)
-          val signature = Option(maybeSig)
-          NameParts(typeDecl, signature)
+  private def getNameParts(name: String, fullName: String): NameParts = {
+    val Array(qualifiedName, signature) = fullName.split(":", 2) match {
+      case Array(qualifiedName, signature) => Array(qualifiedName, signature)
 
-        case _ =>
-          logger.warn(s"Could not extract name parts from $fullName")
-          NameParts(None, None)
-      }
-      namePartsCache.put(fullName, nameParts)
-      nameParts
+      case _ => throw new RuntimeException(s"Invalid name string $fullName")
     }
+
+    val typeDeclName = qualifiedName.stripSuffix(name) match {
+      case "" => None
+
+      case typeDeclName => Some(typeDeclName)
+    }
+
+    NameParts(typeDeclName, signature)
   }
 
   private def getReplacementMethod(call: Call): Option[Method] = {
     cache.get(call.methodFullName).toScala.getOrElse {
-      val callNameParts    = getNameParts(call.methodFullName)
-      val candidateMethods = cpg.method.internal.nameExact(call.name)
-
-      val uniqueMatchingMethod = candidateMethods.find(isMatchingMethod(_, call, callNameParts)).flatMap { method =>
-        val otherMatchingMethod = candidateMethods.find(isMatchingMethod(_, call, callNameParts))
-        // Only return a resulting method if exactly one matching method is found.
-        Option.when(otherMatchingMethod.isEmpty)(method)
+      val callNameParts = getNameParts(call.name, call.methodFullName)
+      resolvedMethodIndex.get(call.name).flatMap { candidateMethods =>
+        val uniqueMatchingMethod = candidateMethods.find(isMatchingMethod(_, call, callNameParts)).flatMap { method =>
+          val otherMatchingMethod = candidateMethods.find(isMatchingMethod(_, call, callNameParts))
+          // Only return a resulting method if exactly one matching method is found.
+          Option.when(otherMatchingMethod.isEmpty)(method)
+        }
+        cache.put(call.methodFullName, uniqueMatchingMethod)
+        uniqueMatchingMethod
       }
-      cache.put(call.methodFullName, uniqueMatchingMethod)
-      uniqueMatchingMethod
     }
   }
-  override def runOnPart(diffGraph: DiffGraphBuilder, call: Call): Unit = {
-    getReplacementMethod(call).foreach { method =>
-      diffGraph.setNodeProperty(call, PropertyNames.MethodFullName, method.fullName)
-      diffGraph.setNodeProperty(call, PropertyNames.Signature, method.signature)
-      diffGraph.setNodeProperty(call, PropertyNames.TypeFullName, method.methodReturn.typeFullName)
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, part: (String, List[Call])): Unit = {
+    part match {
+      case (_, Nil)      => // This should never happen
+      case (name, calls) =>
+        // Since call full names match, the replacement method for each will be the same
+        getReplacementMethod(calls.head) foreach { replacementMethod =>
+          calls.foreach { call =>
+            diffGraph.setNodeProperty(call, PropertyNames.MethodFullName, replacementMethod.fullName)
+            diffGraph.setNodeProperty(call, PropertyNames.Signature, replacementMethod.signature)
+            diffGraph.setNodeProperty(call, PropertyNames.TypeFullName, replacementMethod.methodReturn.typeFullName)
+          }
+        }
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
@@ -46,7 +46,9 @@ class TypeInferencePass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
     parameterSizesMatch && argTypesMatch && typeDeclMatches
   }
 
-  def doArgumentTypesMatch(method: Method, call: Call, skipCallThis: Boolean): Boolean = {
+  /** Check if argument types match by comparing exact full names. TODO: Take inheritance hierarchies into account
+    */
+  private def doArgumentTypesMatch(method: Method, call: Call, skipCallThis: Boolean): Boolean = {
     val callArgs = if (skipCallThis) call.argument.toList.tail else call.argument.toList
 
     val hasDifferingArg = method.parameter.zip(callArgs).exists { case (parameter, argument) =>


### PR DESCRIPTION
The focus of this PR is just performance, so it speeds up the pass without modifying the logic (which could do with a revision as well). With that being said, the new version takes the pass runtime from ~160s to <10s when creating a CPG for elasticsearch on my machine.