### PR TITLE
c2cpg: handle method bodies for lambdas

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -16,7 +16,11 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   import io.joern.c2cpg.astcreation.AstCreatorHelper.OptionSafeAst
 
   protected def astForBlockStatement(blockStmt: IASTCompoundStatement, order: Int = -1): Ast = {
-    val node = blockNode(blockStmt, Defines.empty, registerType(Defines.voidTypeName)).order(order).argumentIndex(order)
+    val code      = nodeSignature(blockStmt)
+    val blockCode = if (code == "{}" || code.isEmpty) Defines.empty else code
+    val node = blockNode(blockStmt, blockCode, registerType(Defines.voidTypeName))
+      .order(order)
+      .argumentIndex(order)
     scope.pushNewScope(node)
     var currOrder = 1
     val childAsts = blockStmt.getStatements.flatMap { stmt =>

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -98,13 +98,9 @@ class AstCreationPassTests extends AbstractPassTest {
     "be correct for simple lambda expressions" in AstFixture(
       """
         |auto x = [] (int a, int b) -> int
-        |{
-        |    return a + b;
-        |};
+        | { return a + b; };
         |auto y = [] (string a, string b) -> string
-        |{
-        |    return a + b;
-        |};
+        | { return a + b; };
         |""".stripMargin,
       "test.cpp"
     ) { cpg =>
@@ -129,12 +125,14 @@ class AstCreationPassTests extends AbstractPassTest {
         l1.name shouldBe lambda1FullName
         l1.code should startWith("[] (int a, int b) -> int")
         l1.signature shouldBe "int anonymous_lambda_0 (int,int)"
+        l1.body.code shouldBe "{ return a + b; }"
       }
 
       inside(cpg.method.fullNameExact(lambda2FullName).l) { case List(l2) =>
         l2.name shouldBe lambda2FullName
         l2.code should startWith("[] (string a, string b) -> string")
         l2.signature shouldBe "string anonymous_lambda_1 (string,string)"
+        l2.body.code shouldBe "{ return a + b; }"
       }
 
       inside(cpg.typeDecl(NamespaceTraversal.globalNamespaceName).head.bindsOut.l) {


### PR DESCRIPTION
We only generated stubs for CPP lambdas. This PR fixes that.

Fixes: https://github.com/joernio/joern/issues/3522