### PR TITLE
[rubysrc2cpg] Fixed Returning Method instead of MethodRef

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -698,6 +698,7 @@ class AstCreator(
         .code(blockMethodNode.code)
         .lineNumber(blockMethodNode.lineNumber)
         .columnNumber(blockMethodNode.columnNumber)
+        .dispatchType(DispatchTypes.STATIC_DISPATCH)
 
       val methodRefNode = NewMethodRef()
         .methodFullName(blockMethodNode.fullName)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -103,9 +103,10 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     if (lastStmtIsAlreadyReturn) {
       lastStmtAst
     } else {
-      val retNode = NewReturn()
-        .code(code)
-      returnAst(retNode, Seq[Ast](lastStmtAst))
+      val retNode = NewReturn().code(code)
+      lastStmtAst.root match
+        case Some(method: NewMethod) => returnAst(retNode, Seq(Ast(methodToMethodRef(method))))
+        case _                       => returnAst(retNode, Seq[Ast](lastStmtAst))
     }
   }
 
@@ -318,11 +319,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     primaryAst.headOption match {
       case Some(value) =>
         if (value.root.map(_.isInstanceOf[NewMethod]).getOrElse(false)) {
-          val methodNode = value.root.head.asInstanceOf[NewMethod]
-          val methodRefNode = NewMethodRef()
-            .code("def " + methodNode.name + "(...)")
-            .methodFullName(methodNode.fullName)
-            .typeFullName(methodNode.fullName)
+          val methodNode    = value.root.head.asInstanceOf[NewMethod]
+          val methodRefNode = methodToMethodRef(methodNode)
           blockMethods.addOne(primaryAst.head)
           Seq(callAst(callNode, Seq(Ast(methodRefNode)) ++ argsAst))
         } else {
@@ -330,6 +328,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
         }
       case None => Seq(callAst(callNode, argsAst, primaryAst.headOption))
     }
+  }
+
+  private def methodToMethodRef(methodNode: NewMethod): NewMethodRef = {
+    NewMethodRef()
+      .code("def " + methodNode.name + "(...)")
+      .methodFullName(methodNode.fullName)
+      .typeFullName(methodNode.fullName)
   }
 
   protected def astForCommand(ctx: CommandContext): Seq[Ast] = ctx match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -280,7 +280,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
       "public_class_method",
       "private_class_method",
       "private",
-      "protected"
+      "protected",
+      "module_function"
     )
 
     val callNodes = methodIdentifierAsts.head.nodes.collect { case x: NewCall => x }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ReturnTests.scala
@@ -1,0 +1,22 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.MethodRef
+import io.shiftleft.semanticcpg.language.*
+
+class ReturnTests extends RubyCode2CpgFixture {
+
+  "a method, where the last statement is a method" should {
+    val cpg = code("""
+        |Row = Struct.new(:cancel_date) do
+        |    def end_date = cancel_date
+        |end
+        |""".stripMargin)
+
+    "return a method ref" in {
+      val List(mRef: MethodRef) = cpg.method("new2").ast.isReturn.astChildren.l: @unchecked
+      mRef.methodFullName shouldBe "Test0.rb::program.end_date"
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -4,7 +4,7 @@ import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOpti
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.rubysrc2cpg.utils.PackageTable
 import io.joern.rubysrc2cpg.{Config, RubySrc2Cpg}
-import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.{ValidationMode, X2Cpg}
 import io.joern.x2cpg.testfixtures.{CfgTestCpg, Code2CpgFixture, DefaultTestCpg, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
@@ -19,7 +19,7 @@ trait RubyFrontend extends LanguageFrontend {
     implicit val defaultConfig: Config =
       getConfig()
         .map(_.asInstanceOf[Config])
-        .getOrElse(Config())
+        .getOrElse(Config().withSchemaValidation(ValidationMode.Enabled))
     new RubySrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
   }
 


### PR DESCRIPTION
* Did a check at the implicit return where if the last statement is a method, create a method ref and return that instead
* Added a dispatch type for the call node that calls a block procedure
* Tests are in `ReturnTests`
* Added `"module_function"` to `prefixMethods`