### PR TITLE
Have ANY argument types match every argument type in javasrc type inference pass

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory
 import scala.jdk.OptionConverters.RichOptional
 import io.joern.x2cpg.Defines.UnresolvedNamespace
 import io.shiftleft.codepropertygraph.generated.nodes.Call.PropertyNames
+import coursier.core.Type
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 
 class TypeInferencePass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
 
@@ -46,13 +48,21 @@ class TypeInferencePass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
     parameterSizesMatch && argTypesMatch && typeDeclMatches
   }
 
-  /** Check if argument types match by comparing exact full names. TODO: Take inheritance hierarchies into account
+  /** Check if argument types match by comparing exact full names. An argument type of `ANY` always matches.
+    *
+    * TODO: Take inheritance hierarchies into account
     */
   private def doArgumentTypesMatch(method: Method, call: Call, skipCallThis: Boolean): Boolean = {
     val callArgs = if (skipCallThis) call.argument.toList.tail else call.argument.toList
 
     val hasDifferingArg = method.parameter.zip(callArgs).exists { case (parameter, argument) =>
-      !Option(argument.property(PropertyNames.TypeFullName).toString()).contains(parameter.typeFullName)
+      val maybeArgumentType = Option(argument.property(PropertyNames.TypeFullName))
+        .map(_.toString())
+        .getOrElse(TypeConstants.Any)
+
+      val argMatches = maybeArgumentType == TypeConstants.Any || maybeArgumentType == parameter.typeFullName
+
+      !argMatches
     }
 
     !hasDifferingArg

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory
 import scala.jdk.OptionConverters.RichOptional
 import io.joern.x2cpg.Defines.UnresolvedNamespace
 import io.shiftleft.codepropertygraph.generated.nodes.Call.PropertyNames
-import coursier.core.Type
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 
 class TypeInferencePass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {


### PR DESCRIPTION
Fixes https://github.com/joernio/joern/issues/3527

The argument <-> parameter matching added during the speed-up pr was too strict and didn't handle `ANY` types correctly. With this PR, `ANY` argument types will match every type for the purposes of finding matching methods.

The behaviour still won't be exactly the same as the pre-speedup version since that version didn't take argument types into account at all, but this version will be closer and fixes https://github.com/joernio/joern/issues/3527