### PR TITLE
RubyParser: omit `WS` tokens from the token stream

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -217,14 +217,14 @@ indexingArguments
     ;
 
 argumentsWithParentheses
-    :   LPAREN wsOrNl* RPAREN                                                                                                   # blankArgsArgumentsWithParentheses
-    |   LPAREN wsOrNl* arguments (WS* COMMA)? wsOrNl* RPAREN                                                                    # argsOnlyArgumentsWithParentheses
-    |   LPAREN wsOrNl* expressions WS* COMMA wsOrNl* chainedCommandWithDoBlock wsOrNl* RPAREN                                   # expressionsAndChainedCommandWithDoBlockArgumentsWithParentheses
-    |   LPAREN wsOrNl* chainedCommandWithDoBlock wsOrNl* RPAREN                                                                 # chainedCommandWithDoBlockOnlyArgumentsWithParentheses
+    :   LPAREN NL* RPAREN                                                                                                       # blankArgsArgumentsWithParentheses
+    |   LPAREN NL* arguments (COMMA)? NL* RPAREN                                                                                # argsOnlyArgumentsWithParentheses
+    |   LPAREN NL* expressions COMMA NL* chainedCommandWithDoBlock NL* RPAREN                                                   # expressionsAndChainedCommandWithDoBlockArgumentsWithParentheses
+    |   LPAREN NL* chainedCommandWithDoBlock NL* RPAREN                                                                         # chainedCommandWithDoBlockOnlyArgumentsWithParentheses
     ;
 
 expressions
-    :   expression (WS* COMMA wsOrNl* expression)*
+    :   expression (COMMA NL* expression)*
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -209,8 +209,8 @@ splattingArgument
     ;
 
 indexingArguments
-    :   command                                                                                                                 # commandOnlyIndexingArguments
-    |   expressions (WS* COMMA wsOrNl*)?                                                                                        # expressionsOnlyIndexingArguments
+    :   //command                                                                                                                 # commandOnlyIndexingArguments
+        expressions (WS* COMMA wsOrNl*)?                                                                                        # expressionsOnlyIndexingArguments
     |   expressions WS* COMMA wsOrNl* splattingArgument                                                                         # expressionsAndSplattingIndexingArguments
     |   associations (WS* COMMA wsOrNl*)?                                                                                       # associationsOnlyIndexingArguments
     |   splattingArgument                                                                                                       # splattingOnlyIndexingArguments

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -36,7 +36,7 @@ statements
 statement
     :   ALIAS wsOrNl* definedMethodNameOrSymbol wsOrNl* definedMethodNameOrSymbol                                   # aliasStatement
     |   UNDEF wsOrNl* definedMethodNameOrSymbol (wsOrNl* COMMA wsOrNl* definedMethodNameOrSymbol)*                  # undefStatement
-    |   statement WS* mod=(IF | UNLESS | WHILE | UNTIL | RESCUE) wsOrNl* statement                                  # modifierStatement
+    |   statement mod=(IF | UNLESS | WHILE | UNTIL | RESCUE) NL* statement                                          # modifierStatement
     |   BEGIN_ wsOrNl* LCURLY wsOrNl* statements? wsOrNl* RCURLY                                                    # beginStatement
     |   END_ wsOrNl* LCURLY wsOrNl* statements? wsOrNl* RCURLY                                                      # endStatement
     |   expressionOrCommand                                                                                         # expressionOrCommandStatement

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -69,7 +69,7 @@ expression
     |   expression WS* op=BAR2 wsOrNl* expression                                                                   # operatorOrExpression
     |   expression WS* op=(DOT2 | DOT3) wsOrNl* expression?                                                         # rangeExpression
     |   expression QMARK NL* expression NL* COLON NL* expression                                                    # conditionalOperatorExpression
-    |   <assoc=right> singleLeftHandSide WS* op=(EQ | ASSIGNMENT_OPERATOR) wsOrNl* multipleRightHandSide            # singleAssignmentExpression
+    |   <assoc=right> singleLeftHandSide op=(EQ | ASSIGNMENT_OPERATOR) NL* multipleRightHandSide                    # singleAssignmentExpression
     |   <assoc=right> multipleLeftHandSide WS* EQ wsOrNl* multipleRightHandSide                                     # multipleAssignmentExpression
     |   IS_DEFINED wsOrNl* expression                                                                               # isDefinedExpression
     ;

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -440,7 +440,7 @@ elseClause
     ;
 
 unlessExpression
-    :   UNLESS wsOrNl* expressionOrCommand WS* thenClause wsOrNl* elseClause? wsOrNl* END
+    :   UNLESS NL* expressionOrCommand thenClause NL* elseClause? NL* END
     ;
 
 caseExpression

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -516,8 +516,8 @@ ensureClause
 // --------------------------------------------------------
 
 classDefinition
-    :   CLASS wsOrNl* classOrModuleReference WS* (LT wsOrNl* expressionOrCommand)? separators wsOrNl* bodyStatement wsOrNl* END
-    |   CLASS wsOrNl* LT2 wsOrNl* expressionOrCommand separators wsOrNl* bodyStatement wsOrNl* END
+    :   CLASS NL* classOrModuleReference (LT NL* expressionOrCommand)? separators NL* bodyStatement NL* END
+    |   CLASS NL* LT2 NL* expressionOrCommand separators NL* bodyStatement NL* END
     ;
 
 classOrModuleReference

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -157,9 +157,9 @@ expressionOrCommands
 invocationWithoutParentheses
     :   chainedCommandWithDoBlock                                                                                               # chainedCommandDoBlockInvocationWithoutParentheses
     |   command                                                                                                                 # singleCommandOnlyInvocationWithoutParentheses
-    |   RETURN (WS arguments)?                                                                                                  # returnArgsInvocationWithoutParentheses
-    |   BREAK WS arguments                                                                                                      # breakArgsInvocationWithoutParentheses
-    |   NEXT WS arguments                                                                                                       # nextArgsInvocationWithoutParentheses
+    |   RETURN arguments?                                                                                                       # returnArgsInvocationWithoutParentheses
+    |   BREAK arguments                                                                                                         # breakArgsInvocationWithoutParentheses
+    |   NEXT arguments                                                                                                          # nextArgsInvocationWithoutParentheses
     ;
 
 command

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -180,7 +180,7 @@ commandWithDoBlock
     ;
 
 argumentsWithoutParentheses
-    :   WS+ arguments
+    :   arguments
     ;
 
 arguments

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -305,24 +305,24 @@ nonExpandedArrayElement
 // --------------------------------------------------------
 
 hashConstructor
-    :   LCURLY wsOrNl* (hashConstructorElements WS* COMMA?)? wsOrNl* RCURLY
+    :   LCURLY NL* (hashConstructorElements COMMA?)? NL* RCURLY
     ;
 
 hashConstructorElements
-    :   hashConstructorElement (WS* COMMA wsOrNl* hashConstructorElement)*
+    :   hashConstructorElement (COMMA NL* hashConstructorElement)*
     ;
 
 hashConstructorElement
     :   association
-    |   STAR2 WS* expression
+    |   STAR2 expression
     ;
 
 associations
-    :   association (WS* COMMA wsOrNl* association)*
+    :   association (COMMA NL* association)*
     ;
 
 association
-    :   (expression | keyword) WS* (EQGT|COLON) (wsOrNl* expression)?
+    :   (expression | keyword) (EQGT|COLON) (NL* expression)?
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -209,11 +209,11 @@ splattingArgument
     ;
 
 indexingArguments
-    :   //command                                                                                                                 # commandOnlyIndexingArguments
-        expressions (WS* COMMA wsOrNl*)?                                                                                        # expressionsOnlyIndexingArguments
+    :   expressions (WS* COMMA wsOrNl*)?                                                                                        # expressionsOnlyIndexingArguments
     |   expressions WS* COMMA wsOrNl* splattingArgument                                                                         # expressionsAndSplattingIndexingArguments
     |   associations (WS* COMMA wsOrNl*)?                                                                                       # associationsOnlyIndexingArguments
     |   splattingArgument                                                                                                       # splattingOnlyIndexingArguments
+    |   command                                                                                                                 # commandOnlyIndexingArguments
     ;
 
 argumentsWithParentheses

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -237,15 +237,15 @@ block
     ;
 
 braceBlock
-    :   LCURLY wsOrNl* blockParameter? wsOrNl* bodyStatement wsOrNl* RCURLY
+    :   LCURLY NL* blockParameter? NL* bodyStatement NL* RCURLY
     ;
 
 doBlock
-    :   DO wsOrNl* blockParameter? separators wsOrNl* bodyStatement wsOrNl* END
+    :   DO NL* blockParameter? separators NL* bodyStatement NL* END
     ;
 
 blockParameter
-    :   BAR WS* blockParameters? WS* BAR
+    :   BAR blockParameters? BAR
     ;
 
 blockParameters

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -487,7 +487,7 @@ forVariable
 // --------------------------------------------------------
 
 beginExpression
-    :   BEGIN wsOrNl* bodyStatement wsOrNl* END
+    :   BEGIN NL* bodyStatement NL* END
     ;
 
 bodyStatement

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -68,7 +68,7 @@ expression
     |   expression WS* op=AMP2 wsOrNl* expression                                                                   # operatorAndExpression
     |   expression WS* op=BAR2 wsOrNl* expression                                                                   # operatorOrExpression
     |   expression WS* op=(DOT2 | DOT3) wsOrNl* expression?                                                         # rangeExpression
-    |   expression WS* QMARK wsOrNl* expression wsOrNl* COLON wsOrNl* expression                                    # conditionalOperatorExpression
+    |   expression QMARK NL* expression NL* COLON NL* expression                                                    # conditionalOperatorExpression
     |   <assoc=right> singleLeftHandSide WS* op=(EQ | ASSIGNMENT_OPERATOR) wsOrNl* multipleRightHandSide            # singleAssignmentExpression
     |   <assoc=right> multipleLeftHandSide WS* EQ wsOrNl* multipleRightHandSide                                     # multipleAssignmentExpression
     |   IS_DEFINED wsOrNl* expression                                                                               # isDefinedExpression

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -606,7 +606,7 @@ symbol
 stringExpression
     :   simpleString                                                                                                # simpleStringExpression
     |   stringInterpolation                                                                                         # interpolatedStringExpression
-    |   stringExpression (WS stringExpression)+                                                                     # concatenatedStringExpression
+    |   stringExpression stringExpression+                                                                          # concatenatedStringExpression
     ;
 
 quotedStringExpression

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -444,7 +444,7 @@ unlessExpression
     ;
 
 caseExpression
-    :   CASE (wsOrNl* expressionOrCommand)? separators? (WS* whenClause WS*)+ elseClause? wsOrNl* END
+    :   CASE (NL* expressionOrCommand)? separators? whenClause+ elseClause? NL* END
     ;
 
 whenClause

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -560,6 +560,8 @@ class AstCreator(
   }
 
   def astForIndexingArgumentsContext(ctx: IndexingArgumentsContext): Seq[Ast] = ctx match {
+    case ctx: RubyParser.CommandOnlyIndexingArgumentsContext =>
+      astForCommand(ctx.command())
     case ctx: RubyParser.ExpressionsOnlyIndexingArgumentsContext =>
       ctx
         .expressions()
@@ -1664,7 +1666,7 @@ class AstCreator(
 
     val methodFullName = classStack.reverse :+ blockMethodName mkString pathSep
     val methodNode = NewMethod()
-      .code(ctxStmt.getText)
+      .code(text(ctxStmt))
       .name(blockMethodName)
       .fullName(methodFullName)
       .filename(filename)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -270,9 +270,9 @@ class AstCreator(
   protected def lineEnd(ctx: ParserRuleContext): Option[Integer]   = Option(ctx.getStop.getLine)
   protected def columnEnd(ctx: ParserRuleContext): Option[Integer] = Option(ctx.getStop.getCharPositionInLine)
   protected def text(ctx: ParserRuleContext): String = {
-    val a = ctx.getStart.getStartIndex
-    val b = ctx.getStop.getStopIndex
-    val intv = new Interval(a, b)
+    val a     = ctx.getStart.getStartIndex
+    val b     = ctx.getStop.getStopIndex
+    val intv  = new Interval(a, b)
     val input = ctx.getStart.getInputStream
     input.getText(intv)
   }
@@ -440,9 +440,7 @@ class AstCreator(
     case ctx: UntilExpressionPrimaryContext  => Seq(astForUntilExpression(ctx.untilExpression()))
     case ctx: ForExpressionPrimaryContext    => Seq(astForForExpression(ctx.forExpression()))
     case ctx: ReturnWithParenthesesPrimaryContext =>
-      Seq(
-        returnAst(returnNode(ctx, text(ctx)), astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses()))
-      )
+      Seq(returnAst(returnNode(ctx, text(ctx)), astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses())))
     case ctx: JumpExpressionPrimaryContext     => astForJumpExpressionPrimaryContext(ctx)
     case ctx: BeginExpressionPrimaryContext    => astForBeginExpressionPrimaryContext(ctx)
     case ctx: GroupingExpressionPrimaryContext => astForCompoundStatement(ctx.compoundStatement(), false, false)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -9,6 +9,7 @@ import io.joern.x2cpg.datastructures.{Global, Scope}
 import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.tree.TerminalNode
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.slf4j.LoggerFactory
@@ -268,6 +269,14 @@ class AstCreator(
   protected def column(ctx: ParserRuleContext): Option[Integer]    = Option(ctx.getStart.getCharPositionInLine)
   protected def lineEnd(ctx: ParserRuleContext): Option[Integer]   = Option(ctx.getStop.getLine)
   protected def columnEnd(ctx: ParserRuleContext): Option[Integer] = Option(ctx.getStop.getCharPositionInLine)
+  protected def text(ctx: ParserRuleContext): String = {
+    val a = ctx.getStart.getStartIndex
+    val b = ctx.getStop.getStopIndex
+    val intv = new Interval(a, b)
+    val input = ctx.getStart.getInputStream
+    
+    input.getText(intv)
+  }
 
   def astForSingleLeftHandSideContext(ctx: SingleLeftHandSideContext): Seq[Ast] = ctx match {
     case ctx: VariableIdentifierOnlySingleLeftHandSideContext =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -560,8 +560,6 @@ class AstCreator(
   }
 
   def astForIndexingArgumentsContext(ctx: IndexingArgumentsContext): Seq[Ast] = ctx match {
-    case ctx: RubyParser.CommandOnlyIndexingArgumentsContext =>
-      astForCommand(ctx.command())
     case ctx: RubyParser.ExpressionsOnlyIndexingArgumentsContext =>
       ctx
         .expressions()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -274,7 +274,6 @@ class AstCreator(
     val b = ctx.getStop.getStopIndex
     val intv = new Interval(a, b)
     val input = ctx.getStart.getInputStream
-    
     input.getText(intv)
   }
 
@@ -286,7 +285,7 @@ class AstCreator(
       val argsAsts    = astForArguments(ctx.arguments())
       val callNode = NewCall()
         .name(Operators.indexAccess)
-        .code(ctx.getText)
+        .code(text(ctx))
         .methodFullName(Operators.indexAccess)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -327,7 +326,7 @@ class AstCreator(
       val node = createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
       Seq(Ast(node))
     case _ =>
-      logger.error(s"astForSingleLeftHandSideContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForSingleLeftHandSideContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
 
   }
@@ -365,7 +364,7 @@ class AstCreator(
        */
       val callNode = NewCall()
         .name(operatorName)
-        .code(ctx.getText)
+        .code(text(ctx))
         .methodFullName(operatorName)
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
         .typeFullName(Defines.Any)
@@ -442,7 +441,7 @@ class AstCreator(
     case ctx: ForExpressionPrimaryContext    => Seq(astForForExpression(ctx.forExpression()))
     case ctx: ReturnWithParenthesesPrimaryContext =>
       Seq(
-        returnAst(returnNode(ctx, ctx.getText), astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses()))
+        returnAst(returnNode(ctx, text(ctx)), astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses()))
       )
     case ctx: JumpExpressionPrimaryContext     => astForJumpExpressionPrimaryContext(ctx)
     case ctx: BeginExpressionPrimaryContext    => astForBeginExpressionPrimaryContext(ctx)
@@ -470,7 +469,7 @@ class AstCreator(
     case ctx: ChainedInvocationWithoutArgumentsPrimaryContext =>
       astForChainedInvocationWithoutArgumentsPrimaryContext(ctx)
     case _ =>
-      logger.error(s"astForPrimaryContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForPrimaryContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
@@ -494,7 +493,7 @@ class AstCreator(
     case ctx: MultipleAssignmentExpressionContext  => astForMultipleAssignmentExpressionContext(ctx)
     case ctx: IsDefinedExpressionContext           => Seq(astForIsDefinedExpression(ctx))
     case _ =>
-      logger.error(s"astForExpressionContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForExpressionContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
@@ -514,7 +513,7 @@ class AstCreator(
 
     val methodFullName = classStack.reverse :+ procMethodName mkString pathSep
     val methodNode = NewMethod()
-      .code(ctx.getText)
+      .code(text(ctx))
       .name(procMethodName)
       .fullName(methodFullName)
       .filename(filename)
@@ -546,7 +545,7 @@ class AstCreator(
       .methodFullName(methodFullName)
       .typeFullName(Defines.Any)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
-      .code(ctx.getText)
+      .code(text(ctx))
     Seq(callAst(callNode, callArgs))
   }
 
@@ -588,7 +587,7 @@ class AstCreator(
         .signature(Operators.arrayInitializer)
         .typeFullName(Defines.Any)
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
-        .code(ctx.getText)
+        .code(text(ctx))
         .lineNumber(ctx.COMMA().getSymbol.getLine)
         .columnNumber(ctx.COMMA().getSymbol.getCharPositionInLine)
       Seq(callAst(callNode, expAsts ++ splatAsts))
@@ -597,7 +596,7 @@ class AstCreator(
     case ctx: RubyParser.SplattingOnlyIndexingArgumentsContext =>
       astForExpressionOrCommand(ctx.splattingArgument().expressionOrCommand())
     case _ =>
-      logger.error(s"astForIndexingArgumentsContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForIndexingArgumentsContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
@@ -728,7 +727,7 @@ class AstCreator(
         Seq(callAst(baseCallNode, argsAst))
       } else {
         callNode
-          .code(ctx.getText)
+          .code(text(ctx))
           .lineNumber(terminalNode.getSymbol().getLine())
           .columnNumber(terminalNode.getSymbol().getCharPositionInLine())
 
@@ -765,7 +764,7 @@ class AstCreator(
     }
     val callNode = methodNameAst.head.nodes.filter(node => node.isInstanceOf[NewCall]).head.asInstanceOf[NewCall]
     callNode
-      .code(ctx.getText)
+      .code(text(ctx))
       .lineNumber(ctx.COLON2().getSymbol().getLine())
       .columnNumber(ctx.COLON2().getSymbol().getCharPositionInLine())
     Seq(callAst(callNode, baseAst ++ blocksAst))
@@ -783,7 +782,7 @@ class AstCreator(
     val operatorName = getOperatorName(ctx.COLON2().getSymbol)
     val callNode = NewCall()
       .name(operatorName)
-      .code(ctx.getText)
+      .code(text(ctx))
       .methodFullName(operatorName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -830,7 +829,7 @@ class AstCreator(
     case ctx: GroupedLeftHandSideOnlyMultipleLeftHandSideContext =>
       astForGroupedLeftHandSideContext(ctx.groupedLeftHandSide())
     case _ =>
-      logger.error(s"astForMultipleLeftHandSideContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForMultipleLeftHandSideContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
@@ -868,7 +867,7 @@ class AstCreator(
 
     val callNode = NewCall()
       .name(operator)
-      .code(ctx.getText)
+      .code(text(ctx))
       .methodFullName(operator)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -885,7 +884,7 @@ class AstCreator(
       val operatorName     = getOperatorName(ctx.EMARK().getSymbol)
       val callNode = NewCall()
         .name(operatorName)
-        .code(ctx.getText)
+        .code(text(ctx))
         .methodFullName(operatorName)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -904,7 +903,7 @@ class AstCreator(
       astForChainedCommandWithDoBlockContext(ctx.chainedCommandWithDoBlock())
     case ctx: ReturnArgsInvocationWithoutParenthesesContext =>
       val retNode = NewReturn()
-        .code(ctx.getText)
+        .code(text(ctx))
         .lineNumber(ctx.RETURN().getSymbol().getLine)
         .columnNumber(ctx.RETURN().getSymbol().getCharPositionInLine)
       val argAst = Option(ctx.arguments).map(astForArguments).getOrElse(Seq())
@@ -918,7 +917,7 @@ class AstCreator(
            * Model this as a return since this is effectively a  return
            */
           val retNode = NewReturn()
-            .code(ctx.getText)
+            .code(text(ctx))
             .lineNumber(ctx.BREAK().getSymbol().getLine)
             .columnNumber(ctx.BREAK().getSymbol().getCharPositionInLine)
           val argAst = astForArguments(args)
@@ -928,7 +927,7 @@ class AstCreator(
             .controlStructureType(ControlStructureTypes.BREAK)
             .lineNumber(ctx.BREAK().getSymbol.getLine)
             .columnNumber(ctx.BREAK().getSymbol.getCharPositionInLine)
-            .code(ctx.getText)
+            .code(text(ctx))
           Seq(
             Ast(node)
               .withChildren(astForArguments(ctx.arguments()))
@@ -947,12 +946,12 @@ class AstCreator(
           .withChildren(astForArguments(ctx.arguments()))
       )
     case _ =>
-      logger.error(s"astForInvocationWithoutParenthesesContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForInvocationWithoutParenthesesContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
   def astForInvocationWithBlockOnlyPrimaryContext(ctx: InvocationWithBlockOnlyPrimaryContext): Seq[Ast] = {
-    val methodIdAst = astForMethodIdentifierContext(ctx.methodIdentifier(), ctx.getText)
+    val methodIdAst = astForMethodIdentifierContext(ctx.methodIdentifier(), text(ctx))
     val blockName = methodIdAst.head.nodes.head
       .asInstanceOf[NewCall]
       .name
@@ -986,7 +985,7 @@ class AstCreator(
   }
 
   def astForInvocationWithParenthesesPrimaryContext(ctx: InvocationWithParenthesesPrimaryContext): Seq[Ast] = {
-    val methodIdAst = astForMethodIdentifierContext(ctx.methodIdentifier(), ctx.getText)
+    val methodIdAst = astForMethodIdentifierContext(ctx.methodIdentifier(), text(ctx))
     val parenAst    = astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses())
     val callNode    = methodIdAst.head.nodes.filter(_.isInstanceOf[NewCall]).head.asInstanceOf[NewCall]
     callNode.name(getActualMethodName(callNode.name))
@@ -1016,7 +1015,7 @@ class AstCreator(
         .controlStructureType(ControlStructureTypes.BREAK)
         .lineNumber(ctx.jumpExpression().BREAK().getSymbol.getLine)
         .columnNumber(ctx.jumpExpression().BREAK().getSymbol.getCharPositionInLine)
-        .code(ctx.getText)
+        .code(text(ctx))
       Seq(Ast(node))
     } else if (ctx.jumpExpression().NEXT() != null) {
       val node = NewControlStructure()
@@ -1055,7 +1054,7 @@ class AstCreator(
       } else {
         ""
       }
-    val name = s"${getActualMethodName(ctx.getText)}$nameSuffix"
+    val name = s"${getActualMethodName(text(ctx))}$nameSuffix"
     // Add the call name to the global builtIn callNames set
     if (isBuiltin(name))
       builtInCallNames.add(name)
@@ -1065,9 +1064,9 @@ class AstCreator(
 
   def astForMethodOnlyIdentifier(ctx: MethodOnlyIdentifierContext): Seq[Ast] = {
     if (ctx.LOCAL_VARIABLE_IDENTIFIER() != null) {
-      Seq(astForCallNode(ctx, ctx.getText))
+      Seq(astForCallNode(ctx, text(ctx)))
     } else if (ctx.CONSTANT_IDENTIFIER() != null) {
-      Seq(astForCallNode(ctx, ctx.getText))
+      Seq(astForCallNode(ctx, text(ctx)))
     } else if (ctx.keyword() != null) {
       Seq(astForCallNode(ctx, ctx.keyword().getText))
     } else {
@@ -1098,12 +1097,12 @@ class AstCreator(
     val terminalNode = ctx.children.asScala.head
       .asInstanceOf[TerminalNode]
 
-    val name           = ctx.getText
+    val name           = text(ctx)
     val methodFullName = classStack.reverse :+ name mkString pathSep
 
     val callNode = NewCall()
       .name(name)
-      .code(ctx.getText)
+      .code(text(ctx))
       .methodFullName(methodFullName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1115,7 +1114,7 @@ class AstCreator(
 
   def astForMethodNameContext(ctx: MethodNameContext): Seq[Ast] = {
     if (ctx.methodIdentifier() != null) {
-      astForMethodIdentifierContext(ctx.methodIdentifier(), ctx.getText)
+      astForMethodIdentifierContext(ctx.methodIdentifier(), text(ctx))
     } else if (ctx.operatorMethodName() != null) {
       astForOperatorMethodNameContext(ctx.operatorMethodName())
     } else if (ctx.keyword() != null) {
@@ -1127,7 +1126,7 @@ class AstCreator(
         .asInstanceOf[TerminalNode]
       val callNode = NewCall()
         .name(terminalNode.getText)
-        .code(ctx.getText)
+        .code(text(ctx))
         .methodFullName(terminalNode.getText)
         .signature("")
         .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1142,7 +1141,7 @@ class AstCreator(
   def astForAssignmentLikeMethodIdentifierContext(ctx: AssignmentLikeMethodIdentifierContext): Seq[Ast] = {
     Seq(
       callAst(
-        callNode(ctx, ctx.getText, ctx.getText, ctx.getText, DispatchTypes.STATIC_DISPATCH, Some(""), Some(Defines.Any))
+        callNode(ctx, text(ctx), text(ctx), text(ctx), DispatchTypes.STATIC_DISPATCH, Some(""), Some(Defines.Any))
       )
     )
   }
@@ -1175,7 +1174,7 @@ class AstCreator(
     case ctx: SimpleMethodNamePartContext    => astForSimpleMethodNamePartContext(ctx)
     case ctx: SingletonMethodNamePartContext => astForSingletonMethodNamePartContext(ctx)
     case _ =>
-      logger.error(s"astForMethodNamePartContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForMethodNamePartContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
@@ -1358,7 +1357,7 @@ class AstCreator(
       case Some(ctxMethodNamePart) =>
         astForMethodNamePartContext(ctxMethodNamePart)
       case None =>
-        astForMethodIdentifierContext(ctx.methodIdentifier(), ctx.getText)
+        astForMethodIdentifierContext(ctx.methodIdentifier(), text(ctx))
     val callNode = astMethodName.head.nodes.filter(node => node.isInstanceOf[NewCall]).head.asInstanceOf[NewCall]
 
     // Create thisParameter if this is an instance method
@@ -1397,7 +1396,7 @@ class AstCreator(
 
     val methodFullName = classStack.reverse :+ callNode.name mkString pathSep
     val methodNode = NewMethod()
-      .code(ctx.getText)
+      .code(text(ctx))
       .name(callNode.name)
       .fullName(methodFullName)
       .columnNumber(callNode.columnNumber)
@@ -1562,7 +1561,7 @@ class AstCreator(
     val operatorName = getOperatorName(ctx.COLON2().getSymbol)
     val callNode = NewCall()
       .name(operatorName)
-      .code(ctx.getText)
+      .code(text(ctx))
       .methodFullName(operatorName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -1582,7 +1581,7 @@ class AstCreator(
     case ctx: RubyParser.ArgsAndDoBlockAndMethodIdCommandWithDoBlockContext =>
       val argsAsts     = astForArguments(ctx.argumentsWithoutParentheses().arguments())
       val doBlockAsts  = Seq(astForDoBlock(ctx.doBlock()))
-      val methodIdAsts = astForMethodIdentifierContext(ctx.methodIdentifier(), ctx.getText)
+      val methodIdAsts = astForMethodIdentifierContext(ctx.methodIdentifier(), text(ctx))
       methodIdAsts ++ argsAsts ++ doBlockAsts
     case ctx: RubyParser.PrimaryMethodArgsDoBlockCommandWithDoBlockContext =>
       val argsAsts       = astForArguments(ctx.argumentsWithoutParentheses().arguments())
@@ -1591,7 +1590,7 @@ class AstCreator(
       val primaryAsts    = astForPrimaryContext(ctx.primary())
       primaryAsts ++ methodNameAsts ++ argsAsts ++ doBlockAsts
     case _ =>
-      logger.error(s"astForCommandWithDoBlockContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForCommandWithDoBlockContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
@@ -1625,7 +1624,7 @@ class AstCreator(
     case ctx: ChainedCommandWithDoBlockOnlyArgumentsWithParenthesesContext =>
       astForChainedCommandWithDoBlockContext(ctx.chainedCommandWithDoBlock())
     case _ =>
-      logger.error(s"astForArgumentsWithParenthesesContext() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForArgumentsWithParenthesesContext() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
@@ -1735,7 +1734,7 @@ class AstCreator(
 
     val callNode = NewCall()
       .name(operatorText)
-      .code(ctx.getText)
+      .code(text(ctx))
       .methodFullName(operatorText)
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -91,7 +91,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
     arguments: Iterable[ExpressionContext]
   ): Ast = {
     val argsAst = arguments.flatMap(astForExpressionContext)
-    val call    = callNode(ctx, ctx.getText, name, name, DispatchTypes.STATIC_DISPATCH)
+    val call    = callNode(ctx, text(ctx), name, name, DispatchTypes.STATIC_DISPATCH)
     callAst(call, argsAst.toList)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -101,7 +101,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
   // TODO: Maybe merge (in RubyParser.g4) isDefinedExpression with isDefinedPrimaryExpression?
   protected def astForIsDefinedPrimaryExpression(ctx: IsDefinedPrimaryContext): Ast = {
     val argsAst = astForExpressionOrCommand(ctx.expressionOrCommand())
-    val call = callNode(ctx, text(ctx), RubyOperators.defined, RubyOperators.defined, DispatchTypes.STATIC_DISPATCH)
+    val call    = callNode(ctx, text(ctx), RubyOperators.defined, RubyOperators.defined, DispatchTypes.STATIC_DISPATCH)
     callAst(call, argsAst.toList)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -14,43 +14,43 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 trait AstForPrimitivesCreator { this: AstCreator =>
 
   protected def astForNilLiteral(ctx: RubyParser.NilPseudoVariableIdentifierContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, Defines.NilClass))
+    Ast(literalNode(ctx, text(ctx), Defines.NilClass))
 
   protected def astForTrueLiteral(ctx: RubyParser.TruePseudoVariableIdentifierContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, Defines.TrueClass))
+    Ast(literalNode(ctx, text(ctx), Defines.TrueClass))
 
   protected def astForFalseLiteral(ctx: RubyParser.FalsePseudoVariableIdentifierContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, Defines.FalseClass))
+    Ast(literalNode(ctx, text(ctx), Defines.FalseClass))
 
   protected def astForSelfPseudoIdentifier(ctx: RubyParser.SelfPseudoVariableIdentifierContext): Ast =
-    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Object))
+    Ast(createIdentifierWithScope(ctx, text(ctx), text(ctx), Defines.Object))
 
   protected def astForFilePseudoIdentifier(ctx: RubyParser.FilePseudoVariableIdentifierContext): Ast =
-    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, getBuiltInType(Defines.String)))
+    Ast(createIdentifierWithScope(ctx, text(ctx), text(ctx), getBuiltInType(Defines.String)))
 
   protected def astForLinePseudoIdentifier(ctx: RubyParser.LinePseudoVariableIdentifierContext): Ast =
-    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, getBuiltInType(Defines.Integer)))
+    Ast(createIdentifierWithScope(ctx, text(ctx), text(ctx), getBuiltInType(Defines.Integer)))
 
   protected def astForEncodingPseudoIdentifier(ctx: RubyParser.EncodingPseudoVariableIdentifierContext): Ast =
-    Ast(createIdentifierWithScope(ctx, ctx.getText, ctx.getText, Defines.Encoding))
+    Ast(createIdentifierWithScope(ctx, text(ctx), text(ctx), Defines.Encoding))
 
   protected def astForNumericLiteral(ctx: RubyParser.NumericLiteralContext): Ast = {
     val numericTypeName =
       if (isFloatLiteral(ctx.unsignedNumericLiteral)) getBuiltInType(Defines.Float) else getBuiltInType(Defines.Integer)
-    Ast(literalNode(ctx, ctx.getText, numericTypeName))
+    Ast(literalNode(ctx, text(ctx), numericTypeName))
   }
 
   protected def astForSymbolLiteral(ctx: RubyParser.SymbolContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, Defines.Symbol))
+    Ast(literalNode(ctx, text(ctx), Defines.Symbol))
 
   protected def astForSingleQuotedStringLiteral(ctx: RubyParser.SingleQuotedStringLiteralContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, getBuiltInType(Defines.String)))
+    Ast(literalNode(ctx, text(ctx), getBuiltInType(Defines.String)))
 
   protected def astForDoubleQuotedStringLiteral(ctx: RubyParser.DoubleQuotedStringLiteralContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, getBuiltInType(Defines.String)))
+    Ast(literalNode(ctx, text(ctx), getBuiltInType(Defines.String)))
 
   protected def astForRegularExpressionLiteral(ctx: RubyParser.RegularExpressionLiteralContext): Ast =
-    Ast(literalNode(ctx, ctx.getText, Defines.Regexp))
+    Ast(literalNode(ctx, text(ctx), Defines.Regexp))
 
   private def isFloatLiteral(ctx: RubyParser.UnsignedNumericLiteralContext): Boolean =
     Option(ctx.FLOAT_LITERAL_WITH_EXPONENT).isDefined || Option(ctx.FLOAT_LITERAL_WITHOUT_EXPONENT).isDefined
@@ -69,7 +69,7 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   private def astForEmptyArrayInitializer(ctx: ParserRuleContext): Ast = {
     Ast(
-      callNode(ctx, ctx.getText, Operators.arrayInitializer, Operators.arrayInitializer, DispatchTypes.STATIC_DISPATCH)
+      callNode(ctx, text(ctx), Operators.arrayInitializer, Operators.arrayInitializer, DispatchTypes.STATIC_DISPATCH)
     )
   }
 
@@ -80,7 +80,7 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   }
 
   private def astForNonExpandedWordArrayElement(ctx: NonExpandedArrayElementContext): Ast = {
-    Ast(literalNode(ctx, ctx.getText, Defines.String, List(Defines.String)))
+    Ast(literalNode(ctx, text(ctx), Defines.String, List(Defines.String)))
   }
 
   private def astForNonExpandedSymbolArrayConstructor(ctx: NonExpandedSymbolArrayConstructorContext): Seq[Ast] = {
@@ -97,6 +97,6 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   }
 
   private def astForNonExpandedSymbolArrayElement(ctx: NonExpandedArrayElementContext): Ast = {
-    Ast(literalNode(ctx, ctx.getText, Defines.Symbol))
+    Ast(literalNode(ctx, text(ctx), Defines.Symbol))
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -68,9 +68,7 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   }
 
   private def astForEmptyArrayInitializer(ctx: ParserRuleContext): Ast = {
-    Ast(
-      callNode(ctx, text(ctx), Operators.arrayInitializer, Operators.arrayInitializer, DispatchTypes.STATIC_DISPATCH)
-    )
+    Ast(callNode(ctx, text(ctx), Operators.arrayInitializer, Operators.arrayInitializer, DispatchTypes.STATIC_DISPATCH))
   }
 
   private def astForNonExpandedWordArrayConstructor(ctx: NonExpandedWordArrayConstructorContext): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -37,7 +37,7 @@ trait AstForStatementsCreator {
 
   protected def astForUndefStatement(ctx: UndefStatementContext): Ast = {
     val undefNames = ctx.definedMethodNameOrSymbol().asScala.flatMap(astForDefinedMethodNameOrSymbolContext).toSeq
-    val call       = callNode(ctx, ctx.getText, RubyOperators.undef, RubyOperators.undef, DispatchTypes.STATIC_DISPATCH)
+    val call       = callNode(ctx, text(ctx), RubyOperators.undef, RubyOperators.undef, DispatchTypes.STATIC_DISPATCH)
     callAst(call, undefNames)
   }
 
@@ -64,33 +64,33 @@ trait AstForStatementsCreator {
   protected def astForIfModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs    = astForStatement(ctx.statement(0))
     val rhs    = astForStatement(ctx.statement(1)).headOption
-    val ifNode = controlStructureNode(ctx, ControlStructureTypes.IF, ctx.getText)
+    val ifNode = controlStructureNode(ctx, ControlStructureTypes.IF, text(ctx))
     controlStructureAst(ifNode, rhs, lhs)
   }
 
   protected def astForUnlessModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs    = astForStatement(ctx.statement(0))
     val rhs    = astForStatement(ctx.statement(1))
-    val ifNode = controlStructureNode(ctx, ControlStructureTypes.IF, ctx.getText)
+    val ifNode = controlStructureNode(ctx, ControlStructureTypes.IF, text(ctx))
     controlStructureAst(ifNode, lhs.headOption, rhs)
   }
 
   protected def astForWhileModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs = astForStatement(ctx.statement(0))
     val rhs = astForStatement(ctx.statement(1))
-    whileAst(rhs.headOption, lhs, Some(ctx.getText))
+    whileAst(rhs.headOption, lhs, Some(text(ctx)))
   }
 
   protected def astForUntilModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs = astForStatement(ctx.statement(0))
     val rhs = astForStatement(ctx.statement(1))
-    whileAst(rhs.headOption, lhs, Some(ctx.getText))
+    whileAst(rhs.headOption, lhs, Some(text(ctx)))
   }
 
   protected def astForRescueModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs       = astForStatement(ctx.statement(0))
     val rhs       = astForStatement(ctx.statement(1))
-    val throwNode = controlStructureNode(ctx, ControlStructureTypes.THROW, ctx.getText)
+    val throwNode = controlStructureNode(ctx, ControlStructureTypes.THROW, text(ctx))
     controlStructureAst(throwNode, rhs.headOption, lhs)
   }
 
@@ -183,7 +183,7 @@ trait AstForStatementsCreator {
                   if (isMethodBody && stmtCounter == stmtCount) {
                     processingLastMethodStatement = false
                   }
-                  Seq(lastStmtAsReturn(stCtx.getText, stAsts.head))
+                  Seq(lastStmtAsReturn(text(stCtx), stAsts.head))
               }
             } else {
               stAsts
@@ -214,13 +214,13 @@ trait AstForStatementsCreator {
     case ctx: OrAndExpressionOrCommandContext      => Seq(astForOrAndExpressionOrCommand(ctx))
     case ctx: ExpressionExpressionOrCommandContext => astForExpressionContext(ctx.expression())
     case _ =>
-      logger.error(s"astForExpressionOrCommand() $filename, ${ctx.getText} All contexts mismatched.")
+      logger.error(s"astForExpressionOrCommand() $filename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
   protected def astForNotKeywordExpressionOrCommand(ctx: NotExpressionOrCommandContext): Ast = {
     val exprOrCommandAst = astForExpressionOrCommand(ctx.expressionOrCommand())
-    val call             = callNode(ctx, ctx.getText, Operators.not, Operators.not, DispatchTypes.STATIC_DISPATCH)
+    val call             = callNode(ctx, text(ctx), Operators.not, Operators.not, DispatchTypes.STATIC_DISPATCH)
     callAst(call, exprOrCommandAst)
   }
 
@@ -231,13 +231,13 @@ trait AstForStatementsCreator {
 
   protected def astForOrExpressionOrCommand(ctx: OrAndExpressionOrCommandContext): Ast = {
     val argsAst = ctx.expressionOrCommand().asScala.flatMap(astForExpressionOrCommand)
-    val call    = callNode(ctx, ctx.getText, Operators.or, Operators.or, DispatchTypes.STATIC_DISPATCH)
+    val call    = callNode(ctx, text(ctx), Operators.or, Operators.or, DispatchTypes.STATIC_DISPATCH)
     callAst(call, argsAst.toList)
   }
 
   protected def astForAndExpressionOrCommand(ctx: OrAndExpressionOrCommandContext): Ast = {
     val argsAst = ctx.expressionOrCommand().asScala.flatMap(astForExpressionOrCommand)
-    val call    = callNode(ctx, ctx.getText, Operators.and, Operators.and, DispatchTypes.STATIC_DISPATCH)
+    val call    = callNode(ctx, text(ctx), Operators.and, Operators.and, DispatchTypes.STATIC_DISPATCH)
     callAst(call, argsAst.toList)
   }
 
@@ -248,7 +248,7 @@ trait AstForStatementsCreator {
     astForYieldCall(ctx, Option(ctx.argumentsWithoutParentheses().arguments()))
 
   protected def astForSimpleMethodCommand(ctx: SimpleMethodCommandContext): Seq[Ast] = {
-    val methodIdentifierAsts = astForMethodIdentifierContext(ctx.methodIdentifier(), ctx.getText)
+    val methodIdentifierAsts = astForMethodIdentifierContext(ctx.methodIdentifier(), text(ctx))
     methodNameAsIdentifierStack.push(methodIdentifierAsts.head)
     val argsAsts = astForArguments(ctx.argumentsWithoutParentheses().arguments())
 
@@ -307,7 +307,7 @@ trait AstForStatementsCreator {
       .asInstanceOf[NewCall]
     val callNode = NewCall()
       .name(getActualMethodName(methodCallNode.name))
-      .code(ctx.getText)
+      .code(text(ctx))
       .methodFullName(DynamicCallUnknownFullName)
       .signature("")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
@@ -399,7 +399,7 @@ trait AstForStatementsCreator {
           columnEnd(compoundStmtCtx).head
         ).head
       case None =>
-        val blockNode_    = blockNode(ctx, ctx.getText, Defines.Any)
+        val blockNode_    = blockNode(ctx, text(ctx), Defines.Any)
         val blockBodyAst  = astForCompoundStatement(compoundStmtCtx)
         val blockParamAst = blockParamCtx.flatMap(astForBlockParameterContext)
         blockAst(blockNode_, blockBodyAst.toList ++ blockParamAst)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -64,7 +64,7 @@ trait AstForTypesCreator { this: AstCreator =>
     val astExprOfCommand = astForExpressionOrCommand(ctx.classDefinition().expressionOrCommand())
     val astBodyStatement = astForBodyStatementContext(ctx.classDefinition().bodyStatement())
     val blockNode = NewBlock()
-      .code(ctx.getText)
+      .code(text(ctx))
     val bodyBlockAst = blockAst(blockNode, astBodyStatement.toList)
     astExprOfCommand ++ Seq(bodyBlockAst)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerPostProcessor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerPostProcessor.scala
@@ -17,7 +17,8 @@ object RubyLexerPostProcessor {
 
     tokens = tokens.mergeConsecutive(NON_EXPANDED_LITERAL_CHARACTER, NON_EXPANDED_LITERAL_CHARACTER_SEQUENCE)
     tokens = tokens.mergeConsecutive(EXPANDED_LITERAL_CHARACTER, EXPANDED_LITERAL_CHARACTER_SEQUENCE)
-
+    tokens = tokens.filterNot(_.is(WS))
+    
     new ListTokenSource(tokens.asJava)
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerPostProcessor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerPostProcessor.scala
@@ -18,7 +18,7 @@ object RubyLexerPostProcessor {
     tokens = tokens.mergeConsecutive(NON_EXPANDED_LITERAL_CHARACTER, NON_EXPANDED_LITERAL_CHARACTER_SEQUENCE)
     tokens = tokens.mergeConsecutive(EXPANDED_LITERAL_CHARACTER, EXPANDED_LITERAL_CHARACTER_SEQUENCE)
     tokens = tokens.filterNot(_.is(WS))
-    
+
     new ListTokenSource(tokens.asJava)
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentTests.scala
@@ -28,5 +28,55 @@ class AssignmentTests extends RubyParserAbstractTest {
       }
     }
   }
+  
+  "multiple assignment" should {
+
+    "be parsed as a statement" when {
+      "two identifiers are assigned an array containing two calls" in {
+        val code = "p, q = [foo(), bar()]"
+        printAst(_.statement(), code) shouldEqual
+          """ExpressionOrCommandStatement
+            | ExpressionExpressionOrCommand
+            |  MultipleAssignmentExpression
+            |   MultipleLeftHandSideAndpackingLeftHandSideMultipleLeftHandSide
+            |    MultipleLeftHandSideItem
+            |     VariableIdentifierOnlySingleLeftHandSide
+            |      VariableIdentifier
+            |       p
+            |    ,
+            |    MultipleLeftHandSideItem
+            |     VariableIdentifierOnlySingleLeftHandSide
+            |      VariableIdentifier
+            |       q
+            |   =
+            |   MultipleRightHandSide
+            |    ExpressionOrCommands
+            |     ExpressionExpressionOrCommand
+            |      PrimaryExpression
+            |       ArrayConstructorPrimary
+            |        BracketedArrayConstructor
+            |         [
+            |         ExpressionsOnlyIndexingArguments
+            |          Expressions
+            |           PrimaryExpression
+            |            InvocationWithParenthesesPrimary
+            |             MethodIdentifier
+            |              foo
+            |             BlankArgsArgumentsWithParentheses
+            |              (
+            |              )
+            |           ,
+            |           PrimaryExpression
+            |            InvocationWithParenthesesPrimary
+            |             MethodIdentifier
+            |              bar
+            |             BlankArgsArgumentsWithParentheses
+            |              (
+            |              )
+            |         ]""".stripMargin
+      }
+    }
+  }
+  
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentTests.scala
@@ -28,7 +28,7 @@ class AssignmentTests extends RubyParserAbstractTest {
       }
     }
   }
-  
+
   "multiple assignment" should {
 
     "be parsed as a statement" when {
@@ -77,6 +77,5 @@ class AssignmentTests extends RubyParserAbstractTest {
       }
     }
   }
-  
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
@@ -16,7 +16,6 @@ class BeginExpressionTests extends RubyParserAbstractTest {
           """BeginExpressionPrimary
             | BeginExpression
             |  begin
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |    Statements
@@ -46,7 +45,6 @@ class BeginExpressionTests extends RubyParserAbstractTest {
             |       VariableIdentifierVariableReference
             |        VariableIdentifier
             |         ZeroDivisionError
-            |    WsOrNl
             |    ExceptionVariableAssignment
             |     =>
             |     VariableIdentifierOnlySingleLeftHandSide

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
@@ -75,7 +75,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
           """CaseExpressionPrimary
             | CaseExpression
             |  case
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -86,7 +85,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |   Separator
             |  WhenClause
             |   when
-            |   WsOrNl
             |   WhenArgument
             |    Expressions
             |     PrimaryExpression
@@ -97,11 +95,9 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |          1
             |   ThenClause
             |    Separator
-            |    WsOrNl
             |    CompoundStatement
             |  ElseClause
             |   else
-            |   WsOrNl
             |   WsOrNl
             |   CompoundStatement
             |  end""".stripMargin
@@ -118,7 +114,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
           """CaseExpressionPrimary
             | CaseExpression
             |  case
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -129,7 +124,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |   Separator
             |  WhenClause
             |   when
-            |   WsOrNl
             |   WhenArgument
             |    Expressions
             |     PrimaryExpression
@@ -140,7 +134,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |          1
             |   ThenClause
             |    then
-            |    WsOrNl
             |    WsOrNl
             |    CompoundStatement
             |  end""".stripMargin
@@ -158,7 +151,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
           """CaseExpressionPrimary
             | CaseExpression
             |  case
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -169,7 +161,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |   Separator
             |  WhenClause
             |   when
-            |   WsOrNl
             |   WhenArgument
             |    Expressions
             |     PrimaryExpression
@@ -180,7 +171,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |          1
             |   ThenClause
             |    then
-            |    WsOrNl
             |    CompoundStatement
             |     Statements
             |      ExpressionOrCommandStatement
@@ -195,7 +185,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |      Separator
             |  WhenClause
             |   when
-            |   WsOrNl
             |   WhenArgument
             |    Expressions
             |     PrimaryExpression
@@ -206,7 +195,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |          2
             |   ThenClause
             |    then
-            |    WsOrNl
             |    CompoundStatement
             |     Statements
             |      ExpressionOrCommandStatement

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
@@ -18,7 +18,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
           """CaseExpressionPrimary
             | CaseExpression
             |  case
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -29,7 +28,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |   Separator
             |  WhenClause
             |   when
-            |   WsOrNl
             |   WhenArgument
             |    Expressions
             |     PrimaryExpression
@@ -40,7 +38,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |          1
             |   ThenClause
             |    Separator
-            |    WsOrNl
             |    CompoundStatement
             |     Statements
             |      ExpressionOrCommandStatement

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
@@ -42,9 +42,7 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
           """ClassDefinitionPrimary
             | ClassDefinition
             |  class
-            |  WsOrNl
             |  <<
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -53,7 +51,6 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |       x
             |  Separators
             |   Separator
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |    Statements
@@ -63,7 +60,6 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |        MethodDefinitionPrimary
             |         MethodDefinition
             |          def
-            |          WsOrNl
             |          SimpleMethodNamePart
             |           DefinedMethodName
             |            MethodName
@@ -72,7 +68,6 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |          MethodParameterPart
             |          Separator
             |           ;
-            |          WsOrNl
             |          BodyStatement
             |           CompoundStatement
             |            Statements
@@ -93,7 +88,6 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |            Separators
             |             Separator
             |              ;
-            |          WsOrNl
             |          end
             |    Separators
             |     Separator

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
@@ -12,9 +12,7 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
           """ClassDefinitionPrimary
             | ClassDefinition
             |  class
-            |  WsOrNl
             |  <<
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -24,7 +22,6 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |  Separators
             |   Separator
             |    ;
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/EnsureClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/EnsureClauseTests.scala
@@ -15,7 +15,6 @@ class EnsureClauseTests extends RubyParserAbstractTest {
         printAst(_.methodDefinition(), code) shouldEqual
           """MethodDefinition
             | def
-            | WsOrNl
             | SimpleMethodNamePart
             |  DefinedMethodName
             |   MethodName
@@ -23,12 +22,10 @@ class EnsureClauseTests extends RubyParserAbstractTest {
             |     refund
             | MethodParameterPart
             | Separator
-            | WsOrNl
             | BodyStatement
             |  CompoundStatement
             |  EnsureClause
             |   ensure
-            |   WsOrNl
             |   WsOrNl
             |   CompoundStatement
             |    Statements

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/HashLiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/HashLiteralTests.scala
@@ -12,7 +12,6 @@ class HashLiteralTests extends RubyParserAbstractTest {
           """HashConstructorPrimary
             | HashConstructor
             |  {
-            |  WsOrNl
             |  }""".stripMargin
       }
 
@@ -22,7 +21,6 @@ class HashLiteralTests extends RubyParserAbstractTest {
           """HashConstructorPrimary
             | HashConstructor
             |  {
-            |  WsOrNl
             |  HashConstructorElements
             |   HashConstructorElement
             |    **
@@ -49,7 +47,6 @@ class HashLiteralTests extends RubyParserAbstractTest {
             |       VariableIdentifier
             |        x
             |   ,
-            |   WsOrNl
             |   HashConstructorElement
             |    **
             |    PrimaryExpression
@@ -76,7 +73,6 @@ class HashLiteralTests extends RubyParserAbstractTest {
             |       VariableIdentifier
             |        x
             |   ,
-            |   WsOrNl
             |   HashConstructorElement
             |    Association
             |     PrimaryExpression
@@ -85,7 +81,6 @@ class HashLiteralTests extends RubyParserAbstractTest {
             |        VariableIdentifier
             |         y
             |     =>
-            |     WsOrNl
             |     PrimaryExpression
             |      LiteralPrimary
             |       NumericLiteralLiteral
@@ -93,7 +88,6 @@ class HashLiteralTests extends RubyParserAbstractTest {
             |         UnsignedNumericLiteral
             |          1
             |   ,
-            |   WsOrNl
             |   HashConstructorElement
             |    **
             |    PrimaryExpression

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -288,7 +288,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |   VariableIdentifier
             |    foo
             | WsOrNl
-            | WsOrNl
             | .
             | MethodName
             |  MethodIdentifier
@@ -304,7 +303,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |   VariableIdentifier
             |    foo
             | .
-            | WsOrNl
             | WsOrNl
             | MethodName
             |  MethodIdentifier

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesesTests.scala
@@ -30,7 +30,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |  foo
             | BlankArgsArgumentsWithParentheses
             |  (
-            |  WsOrNl
             |  )""".stripMargin
       }
 
@@ -72,7 +71,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
              |        VariableIdentifier
              |         region
              |     :
-             |     WsOrNl
              |     PrimaryExpression
              |      LiteralPrimary
              |       NumericLiteralLiteral
@@ -125,7 +123,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |        VariableIdentifier
             |         id
             |     :
-            |     WsOrNl
             |     PrimaryExpression
             |      LiteralPrimary
             |       RegularExpressionLiteral
@@ -193,7 +190,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |         VariableIdentifier
             |          x
             |   ,
-            |   WsOrNl
             |   AssociationArgument
             |    Association
             |     PrimaryExpression
@@ -202,7 +198,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |        VariableIdentifier
             |         y
             |     :
-            |     WsOrNl
             |     PrimaryExpression
             |      LiteralPrimary
             |       NumericLiteralLiteral
@@ -226,7 +221,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |     Keyword
             |      if
             |     :
-            |     WsOrNl
             |     PrimaryExpression
             |      VariableReferencePrimary
             |       PseudoVariableIdentifierVariableReference
@@ -275,7 +269,6 @@ class InvocationWithParenthesesTests extends RubyParserAbstractTest {
             |        UnsignedNumericLiteral
             |         1
             |   ,
-            |   WsOrNl
             |   ExpressionArgument
             |    PrimaryExpression
             |     LiteralPrimary

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
@@ -78,7 +78,6 @@ class InvocationWithoutParenthesesTests extends RubyParserAbstractTest {
             |      do
             |      Separators
             |       Separator
-            |      WsOrNl
             |      BodyStatement
             |       CompoundStatement
             |        Statements

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -12,7 +12,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -21,7 +20,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |  MethodParameterPart
             |  Separator
             |   ;
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin
@@ -33,7 +31,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -59,7 +56,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -92,7 +88,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -105,7 +100,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     MandatoryParameter
             |      x
             |    ,
-            |    WsOrNl
             |    Parameter
             |     ProcParameter
             |      &
@@ -113,7 +107,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |   )
             |  Separator
             |   ;
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin
@@ -125,7 +118,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -141,7 +133,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |   )
             |  Separator
             |   ;
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin
@@ -153,7 +144,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -169,7 +159,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |   )
             |  Separator
             |   ;
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin
@@ -181,7 +170,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -195,7 +183,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      *
             |      arr
             |    ,
-            |    WsOrNl
             |    Parameter
             |     HashParameter
             |      **
@@ -203,7 +190,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |   )
             |  Separator
             |   ;
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin
@@ -215,7 +201,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -241,7 +226,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |   )
             |  Separator
             |   ;
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin
@@ -253,7 +237,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -266,7 +249,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     KeywordParameter
             |      x
             |      :
-            |      WsOrNl
             |      PrimaryExpression
             |       LiteralPrimary
             |        NumericLiteralLiteral
@@ -276,7 +258,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |   )
             |  Separator
             |   ;
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin
@@ -288,7 +269,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -302,13 +282,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      x
             |      :
             |   )
-            |  WsOrNl
+            |  Separator
+            |   ;
             |  BodyStatement
             |   CompoundStatement
-            |    Separators
-            |     Separator
-            |      ;
-            |  WsOrNl
             |  end""".stripMargin
       }
 
@@ -318,7 +295,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -332,19 +308,15 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      name
             |      :
             |    ,
-            |    WsOrNl
             |    Parameter
             |     KeywordParameter
             |      surname
             |      :
             |   )
-            |  WsOrNl
+            |  Separator
+            |   ;
             |  BodyStatement
             |   CompoundStatement
-            |    Separators
-            |     Separator
-            |      ;
-            |  WsOrNl
             |  end""".stripMargin
       }
     }
@@ -363,7 +335,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  SimpleMethodNamePart
             |   DefinedMethodName
             |    MethodName
@@ -371,7 +342,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      foo
             |  MethodParameterPart
             |  Separator
-            |  WsOrNl
             |  BodyStatement
             |   CompoundStatement
             |    Statements
@@ -393,7 +363,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |             0
             |    Separators
             |     Separator
-            |   WsOrNl
             |   RescueClause
             |    rescue
             |    ExceptionClass
@@ -402,7 +371,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |       VariableIdentifierVariableReference
             |        VariableIdentifier
             |         ZeroDivisionError
-            |    WsOrNl
             |    ExceptionVariableAssignment
             |     =>
             |     VariableIdentifierOnlySingleLeftHandSide
@@ -428,12 +396,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  MethodIdentifier
             |   foo
             |  MethodParameterPart
             |  =
-            |  WsOrNl
             |  PrimaryExpression
             |   VariableReferencePrimary
             |    VariableIdentifierVariableReference
@@ -447,12 +413,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  MethodIdentifier
             |   foo
             |  MethodParameterPart
             |  =
-            |  WsOrNl
             |  WsOrNl
             |  PrimaryExpression
             |   VariableReferencePrimary
@@ -467,12 +431,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  MethodIdentifier
             |   foo
             |  MethodParameterPart
             |  =
-            |  WsOrNl
             |  PrimaryExpression
             |   StringExpressionPrimary
             |    SimpleStringExpression
@@ -488,7 +450,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           """MethodDefinitionPrimary
             | MethodDefinition
             |  def
-            |  WsOrNl
             |  MethodIdentifier
             |   id
             |  MethodParameterPart
@@ -499,7 +460,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      x
             |   )
             |  =
-            |  WsOrNl
             |  PrimaryExpression
             |   VariableReferencePrimary
             |    VariableIdentifierVariableReference
@@ -529,7 +489,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     MethodDefinitionPrimary
             |      MethodDefinition
             |       def
-            |       WsOrNl
             |       SimpleMethodNamePart
             |        DefinedMethodName
             |         MethodName
@@ -548,7 +507,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     MethodDefinitionPrimary
             |      MethodDefinition
             |       def
-            |       WsOrNl
             |       SimpleMethodNamePart
             |        DefinedMethodName
             |         AssignmentLikeMethodIdentifier
@@ -592,7 +550,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     ModuleDefinitionPrimary
             |      ModuleDefinition
             |       module
-            |       WsOrNl
             |       ClassOrModuleReference
             |        SomeModule
             |       WsOrNl
@@ -605,7 +562,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |             MethodDefinitionPrimary
             |              MethodDefinition
             |               def
-            |               WsOrNl
             |               SimpleMethodNamePart
             |                DefinedMethodName
             |                 MethodName
@@ -613,7 +569,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |                   foo1
             |               MethodParameterPart
             |               Separator
-            |               WsOrNl
             |               BodyStatement
             |                CompoundStatement
             |                 Statements
@@ -623,7 +578,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |                     ReturnArgsInvocationWithoutParentheses
             |                      return
             |                   unless
-            |                   WsOrNl
             |                   ExpressionOrCommandStatement
             |                    ExpressionExpressionOrCommand
             |                     PrimaryExpression
@@ -642,7 +596,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |             MethodDefinitionPrimary
             |              MethodDefinition
             |               def
-            |               WsOrNl
             |               SimpleMethodNamePart
             |                DefinedMethodName
             |                 AssignmentLikeMethodIdentifier
@@ -679,7 +632,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
         """MethodDefinitionPrimary
           | MethodDefinition
           |  def
-          |  WsOrNl
           |  SimpleMethodNamePart
           |   DefinedMethodName
           |    MethodName
@@ -694,7 +646,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |      block
           |   )
           |  Separator
-          |  WsOrNl
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -720,7 +671,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
         """MethodDefinitionPrimary
           | MethodDefinition
           |  def
-          |  WsOrNl
           |  SimpleMethodNamePart
           |   DefinedMethodName
           |    MethodName
@@ -734,7 +684,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |      &
           |   )
           |  Separator
-          |  WsOrNl
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -757,7 +706,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
         """MethodDefinitionPrimary
           | MethodDefinition
           |  def
-          |  WsOrNl
           |  SimpleMethodNamePart
           |   DefinedMethodName
           |    MethodName
@@ -771,7 +719,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |      bar
           |      :
           |   )
-          |  WsOrNl
           |  BodyStatement
           |   CompoundStatement
           |  end""".stripMargin
@@ -790,7 +737,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
         """MethodDefinitionPrimary
           | MethodDefinition
           |  def
-          |  WsOrNl
           |  SimpleMethodNamePart
           |   DefinedMethodName
           |    MethodName
@@ -798,7 +744,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |      data
           |  MethodParameterPart
           |  Separator
-          |  WsOrNl
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -808,8 +753,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |        HashConstructorPrimary
           |         HashConstructor
           |          {
-          |          WsOrNl
-          |          WsOrNl
           |          HashConstructorElements
           |           HashConstructorElement
           |            Association
@@ -820,8 +763,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |                 first_link
           |             :
           |           ,
-          |           WsOrNl
-          |           WsOrNl
           |           HashConstructorElement
           |            Association
           |             PrimaryExpression
@@ -831,8 +772,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |                 action_link_group
           |             :
           |          ,
-          |          WsOrNl
-          |          WsOrNl
           |          }
           |    Separators
           |     Separator
@@ -851,12 +790,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
         """ClassDefinitionPrimary
           | ClassDefinition
           |  class
-          |  WsOrNl
           |  ClassOrModuleReference
           |   SampleClass
           |  Separators
           |   Separator
-          |  WsOrNl
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -866,7 +803,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |        MethodDefinitionPrimary
           |         MethodDefinition
           |          def
-          |          WsOrNl
           |          SimpleMethodNamePart
           |           DefinedMethodName
           |            MethodName
@@ -874,21 +810,18 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |              sample_method
           |          MethodParameterPart
           |           (
-          |           WsOrNl
           |           Parameters
           |            Parameter
           |             KeywordParameter
           |              first_param
           |              :
           |            ,
-          |            WsOrNl
           |            Parameter
           |             KeywordParameter
           |              second_param
           |              :
           |           )
           |          Separator
-          |          WsOrNl
           |          BodyStatement
           |           CompoundStatement
           |          end
@@ -910,12 +843,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
         """ClassDefinitionPrimary
           | ClassDefinition
           |  class
-          |  WsOrNl
           |  ClassOrModuleReference
           |   SomeClass
           |  Separators
           |   Separator
-          |  WsOrNl
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -925,7 +856,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |        MethodDefinitionPrimary
           |         MethodDefinition
           |          def
-          |          WsOrNl
           |          SimpleMethodNamePart
           |           DefinedMethodName
           |            MethodName
@@ -934,19 +864,16 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |          MethodParameterPart
           |           (
           |           WsOrNl
-          |           WsOrNl
           |           Parameters
           |            Parameter
           |             MandatoryParameter
           |              name
           |            ,
-          |            WsOrNl
           |            Parameter
           |             MandatoryParameter
           |              age
           |           )
           |          Separator
-          |          WsOrNl
           |          BodyStatement
           |           CompoundStatement
           |          end
@@ -969,12 +896,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
         """ClassDefinitionPrimary
           | ClassDefinition
           |  class
-          |  WsOrNl
           |  ClassOrModuleReference
           |   SomeClass
           |  Separators
           |   Separator
-          |  WsOrNl
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -984,7 +909,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |        MethodDefinitionPrimary
           |         MethodDefinition
           |          def
-          |          WsOrNl
           |          SimpleMethodNamePart
           |           DefinedMethodName
           |            MethodName
@@ -993,21 +917,17 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |          MethodParameterPart
           |           (
           |           WsOrNl
-          |           WsOrNl
           |           Parameters
           |            Parameter
           |             MandatoryParameter
           |              name
           |            ,
-          |            WsOrNl
           |            Parameter
           |             MandatoryParameter
           |              age
           |           WsOrNl
-          |           WsOrNl
           |           )
           |          Separator
-          |          WsOrNl
           |          BodyStatement
           |           CompoundStatement
           |          end
@@ -1030,12 +950,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
         """ClassDefinitionPrimary
           | ClassDefinition
           |  class
-          |  WsOrNl
           |  ClassOrModuleReference
           |   SomeClass
           |  Separators
           |   Separator
-          |  WsOrNl
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -1045,7 +963,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |        MethodDefinitionPrimary
           |         MethodDefinition
           |          def
-          |          WsOrNl
           |          SimpleMethodNamePart
           |           DefinedMethodName
           |            MethodName
@@ -1054,28 +971,23 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |          MethodParameterPart
           |           (
           |           WsOrNl
-          |           WsOrNl
           |           Parameters
           |            Parameter
           |             KeywordParameter
           |              name
           |              :
-          |              WsOrNl
           |              PrimaryExpression
           |               VariableReferencePrimary
           |                PseudoVariableIdentifierVariableReference
           |                 NilPseudoVariableIdentifier
           |                  nil
           |            ,
-          |            WsOrNl
           |            Parameter
           |             MandatoryParameter
           |              age
           |           WsOrNl
-          |           WsOrNl
           |           )
           |          Separator
-          |          WsOrNl
           |          BodyStatement
           |           CompoundStatement
           |          end

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
@@ -29,11 +29,9 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  DoBlockBlock
             |   DoBlock
             |    do
-            |    WsOrNl
             |    Separators
             |     Separator
             |      ;
-            |    WsOrNl
             |    BodyStatement
             |     CompoundStatement
             |    end""".stripMargin
@@ -74,11 +72,9 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  DoBlockBlock
             |   DoBlock
             |    do
-            |    WsOrNl
             |    Separators
             |     Separator
             |      ;
-            |    WsOrNl
             |    BodyStatement
             |     CompoundStatement
             |    end""".stripMargin
@@ -96,7 +92,6 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    OptionalParameter
             |     x
             |     =
-            |     WsOrNl
             |     PrimaryExpression
             |      LiteralPrimary
             |       NumericLiteralLiteral
@@ -124,7 +119,6 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    KeywordParameter
             |     foo
             |     :
-            |     WsOrNl
             |     PrimaryExpression
             |      LiteralPrimary
             |       NumericLiteralLiteral
@@ -135,11 +129,9 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  DoBlockBlock
             |   DoBlock
             |    do
-            |    WsOrNl
             |    Separators
             |     Separator
             |      ;
-            |    WsOrNl
             |    BodyStatement
             |     CompoundStatement
             |    end""".stripMargin
@@ -157,7 +149,6 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |    MandatoryParameter
             |     x
             |   ,
-            |   WsOrNl
             |   Parameter
             |    MandatoryParameter
             |     y

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -103,7 +103,6 @@ class RegexTests extends RubyParserAbstractTest {
             |          UnsignedNumericLiteral
             |           1
             |     ,
-            |     WsOrNl
             |     ExpressionArgument
             |      PrimaryExpression
             |       LiteralPrimary
@@ -126,7 +125,6 @@ class RegexTests extends RubyParserAbstractTest {
           """CaseExpressionPrimary
               | CaseExpression
               |  case
-              |  WsOrNl
               |  ExpressionExpressionOrCommand
               |   PrimaryExpression
               |    VariableReferencePrimary
@@ -137,7 +135,6 @@ class RegexTests extends RubyParserAbstractTest {
               |   Separator
               |  WhenClause
               |   when
-              |   WsOrNl
               |   WhenArgument
               |    Expressions
               |     PrimaryExpression
@@ -148,7 +145,6 @@ class RegexTests extends RubyParserAbstractTest {
               |        /
               |   ThenClause
               |    Separator
-              |    WsOrNl
               |    CompoundStatement
               |     Statements
               |      ExpressionOrCommandStatement
@@ -173,7 +169,6 @@ class RegexTests extends RubyParserAbstractTest {
             """UnlessExpressionPrimary
               | UnlessExpression
               |  unless
-              |  WsOrNl
               |  ExpressionExpressionOrCommand
               |   PrimaryExpression
               |    ChainedInvocationPrimary

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -27,7 +27,6 @@ class RegexTests extends RubyParserAbstractTest {
             |   VariableIdentifier
             |    x
             |  =
-            |  WsOrNl
             |  MultipleRightHandSide
             |   ExpressionOrCommands
             |    ExpressionExpressionOrCommand
@@ -234,7 +233,6 @@ class RegexTests extends RubyParserAbstractTest {
             |   VariableIdentifier
             |    x
             |  =
-            |  WsOrNl
             |  MultipleRightHandSide
             |   ExpressionOrCommands
             |    ExpressionExpressionOrCommand
@@ -376,7 +374,6 @@ class RegexTests extends RubyParserAbstractTest {
             |   VariableIdentifier
             |    x
             |  =
-            |  WsOrNl
             |  MultipleRightHandSide
             |   ExpressionOrCommands
             |    ExpressionExpressionOrCommand

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
@@ -16,7 +16,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
         printAst(_.beginExpression(), code) shouldEqual
           """BeginExpression
             | begin
-            | WsOrNl
             | BodyStatement
             |  CompoundStatement
             |   Statements
@@ -46,7 +45,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |      VariableIdentifierVariableReference
             |       VariableIdentifier
             |        ZeroDivisionError
-            |   WsOrNl
             |   ExceptionVariableAssignment
             |    =>
             |    VariableIdentifierOnlySingleLeftHandSide
@@ -68,7 +66,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
         printAst(_.methodDefinition(), code) shouldEqual
           """MethodDefinition
             | def
-            | WsOrNl
             | SimpleMethodNamePart
             |  DefinedMethodName
             |   MethodName
@@ -107,7 +104,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |      VariableIdentifierVariableReference
             |       VariableIdentifier
             |        ZeroDivisionError
-            |   WsOrNl
             |   ExceptionVariableAssignment
             |    =>
             |    VariableIdentifierOnlySingleLeftHandSide
@@ -144,7 +140,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |            x
             |     DoBlock
             |      do
-            |      WsOrNl
             |      BlockParameter
             |       |
             |       BlockParameters
@@ -182,7 +177,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |           VariableIdentifierVariableReference
             |            VariableIdentifier
             |             ZeroDivisionError
-            |        WsOrNl
             |        ExceptionVariableAssignment
             |         =>
             |         VariableIdentifierOnlySingleLeftHandSide

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RubyLexerTests.scala
@@ -491,6 +491,13 @@ class RubyLexerTests extends AnyFlatSpec with Matchers {
     tokenize(code) shouldBe Seq(SINGLE_QUOTED_STRING_LITERAL, WS, SINGLE_QUOTED_STRING_LITERAL, EOF)
   }
 
+  "Multi-line string literal concatenation" should "be optimized as two consecutive string literals" in {
+    val code =
+      """'abc' \
+        |'cde'""".stripMargin
+    tokenizeOpt(code) shouldBe Seq(SINGLE_QUOTED_STRING_LITERAL, SINGLE_QUOTED_STRING_LITERAL, EOF)
+  }
+
   "empty `%q` string literals" should "be recognized as such" in {
     val eg = Seq("%q()", "%q[]", "%q{}", "%q<>", "%q##", "%q!!", "%q--", "%q@@", "%q++", "%q**", "%q//", "%q&&")
     all(eg.map(tokenize)) shouldBe Seq(

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -453,7 +453,6 @@ class StringTests extends RubyParserAbstractTest {
               |    "
               |    x
               |    "
-              |   \
               |  SimpleStringExpression
               |   DoubleQuotedStringLiteral
               |    "
@@ -542,7 +541,6 @@ class StringTests extends RubyParserAbstractTest {
               |    "
               |    x
               |    "
-              |   \
               |  SimpleStringExpression
               |   DoubleQuotedStringLiteral
               |    "
@@ -575,7 +573,6 @@ class StringTests extends RubyParserAbstractTest {
               |              10
               |     }
               |    "
-              |   \
               |  SimpleStringExpression
               |   DoubleQuotedStringLiteral
               |    "

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringTests.scala
@@ -43,7 +43,6 @@ class StringTests extends RubyParserAbstractTest {
             |  SimpleStringExpression
             |   SingleQuotedStringLiteral
             |    'x'
-            |   \
             |  SimpleStringExpression
             |   SingleQuotedStringLiteral
             |    'y'""".stripMargin
@@ -63,12 +62,10 @@ class StringTests extends RubyParserAbstractTest {
             |  SimpleStringExpression
             |   SingleQuotedStringLiteral
             |    'x'
-            |   \
             |  ConcatenatedStringExpression
             |   SimpleStringExpression
             |    SingleQuotedStringLiteral
             |     'y'
-            |    \
             |   SimpleStringExpression
             |    SingleQuotedStringLiteral
             |     'z'""".stripMargin

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/TernaryConditionalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/TernaryConditionalTests.scala
@@ -16,15 +16,12 @@ class TernaryConditionalTests extends RubyParserAbstractTest {
             |    VariableIdentifier
             |     x
             | ?
-            | WsOrNl
             | PrimaryExpression
             |  VariableReferencePrimary
             |   VariableIdentifierVariableReference
             |    VariableIdentifier
             |     y
-            | WsOrNl
             | :
-            | WsOrNl
             | PrimaryExpression
             |  VariableReferencePrimary
             |   VariableIdentifierVariableReference
@@ -47,16 +44,12 @@ class TernaryConditionalTests extends RubyParserAbstractTest {
             |    VariableIdentifier
             |     x
             | ?
-            | WsOrNl
-            | WsOrNl
             | PrimaryExpression
             |  VariableReferencePrimary
             |   VariableIdentifierVariableReference
             |    VariableIdentifier
             |     y
-            | WsOrNl
             | :
-            | WsOrNl
             | PrimaryExpression
             |  VariableReferencePrimary
             |   VariableIdentifierVariableReference

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
@@ -132,7 +132,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |            value
             |      )
             | unless
-            | WsOrNl
             | ExpressionOrCommandStatement
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
@@ -16,7 +16,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
           """UnlessExpressionPrimary
             | UnlessExpression
             |  unless
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -25,7 +24,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |       foo
             |  ThenClause
             |   Separator
-            |   WsOrNl
             |   CompoundStatement
             |    Statements
             |     ExpressionOrCommandStatement
@@ -50,7 +48,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
           """UnlessExpressionPrimary
             | UnlessExpression
             |  unless
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -60,7 +57,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |  ThenClause
             |   Separator
             |    ;
-            |   WsOrNl
             |   CompoundStatement
             |    Statements
             |     ExpressionOrCommandStatement
@@ -86,7 +82,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
           """UnlessExpressionPrimary
             | UnlessExpression
             |  unless
-            |  WsOrNl
             |  ExpressionExpressionOrCommand
             |   PrimaryExpression
             |    VariableReferencePrimary
@@ -95,7 +90,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |       foo
             |  ThenClause
             |   then
-            |   WsOrNl
             |   WsOrNl
             |   CompoundStatement
             |    Statements

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -480,7 +480,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode.argument
         .where(_.argumentIndex(2))
         .code
-        .l shouldBe List("foo()", "bar() ")
+        .l shouldBe List("foo()", "bar()")
       callNode.lineNumber.l shouldBe List(1, 1)
     }
 


### PR DESCRIPTION
Removes `WS` tokens from the token stream (in RubyLexerPostProcessor) and provides the least amount of changes to the grammar and unit-tests that keep them passing.