### PR TITLE
RubyParser: refactor `compoundStatement` and `BEGIN`/`END`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -9,11 +9,11 @@ options {
 // --------------------------------------------------------
 
 program
-    :   NL* compoundStatement EOF
+    :   compoundStatement EOF
     ;
 
 compoundStatement
-    :   statements? separators?
+    :   separators? statements? separators?
     ;
 
 separators
@@ -31,8 +31,8 @@ statements
 statement
     :   ALIAS NL* definedMethodNameOrSymbol NL* definedMethodNameOrSymbol                                           # aliasStatement
     |   UNDEF NL* definedMethodNameOrSymbol (COMMA NL* definedMethodNameOrSymbol)*                                  # undefStatement
-    |   BEGIN_ LCURLY NL* statements? NL* RCURLY                                                                    # beginStatement
-    |   END_ LCURLY NL* statements? NL* RCURLY                                                                      # endStatement
+    |   BEGIN_ LCURLY compoundStatement RCURLY                                                                      # beginStatement
+    |   END_ LCURLY compoundStatement RCURLY                                                                        # endStatement
     |   statement mod=(IF | UNLESS | WHILE | UNTIL | RESCUE) NL* statement                                          # modifierStatement
     |   expressionOrCommand                                                                                         # expressionOrCommandStatement
     ;
@@ -66,7 +66,6 @@ expression
     |   expression op=BAR2 NL* expression                                                                           # operatorOrExpression
     |   expression op=(DOT2 | DOT3) NL* expression?                                                                 # rangeExpression
     |   expression QMARK NL* expression NL* COLON NL* expression                                                    # conditionalOperatorExpression
-
     |   IS_DEFINED NL* expression                                                                                   # isDefinedExpression
     ;
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -42,13 +42,13 @@ trait AstForStatementsCreator {
   }
 
   protected def astForBeginStatement(ctx: BeginStatementContext): Ast = {
-    val stmts     = astForStatements(ctx.statements())
+    val stmts     = Option(ctx.compoundStatement).map(astForCompoundStatement(_)).getOrElse(Seq())
     val blockNode = NewBlock().typeFullName(Defines.Any)
     blockAst(blockNode, stmts.toList)
   }
 
   protected def astForEndStatement(ctx: EndStatementContext): Ast = {
-    val stmts     = astForStatements(ctx.statements())
+    val stmts     = Option(ctx.compoundStatement).map(astForCompoundStatement(_)).getOrElse(Seq())
     val blockNode = NewBlock().typeFullName(Defines.Any)
     blockAst(blockNode, stmts.toList)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginStatementTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginStatementTests.scala
@@ -1,0 +1,40 @@
+package io.joern.rubysrc2cpg.parser
+
+class BeginStatementTests extends RubyParserAbstractTest {
+
+  "BEGIN statement" should {
+
+    "be parsed as a statement" when {
+
+      "defined in a single line" in {
+        val code = "BEGIN { 1 }"
+        printAst(_.statement(), code) shouldEqual
+          """BeginStatement
+            | BEGIN
+            | {
+            | CompoundStatement
+            |  Statements
+            |   ExpressionOrCommandStatement
+            |    ExpressionExpressionOrCommand
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       NumericLiteralLiteral
+            |        NumericLiteral
+            |         UnsignedNumericLiteral
+            |          1
+            | }""".stripMargin
+      }
+
+      "empty (single-line)" in {
+        val code = "BEGIN {}"
+        printAst(_.statement(), code) shouldEqual
+          """BeginStatement
+            | BEGIN
+            | {
+            | CompoundStatement
+            | }""".stripMargin
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Simplification to `compoundStatement`, leading to a simplification to `BEGIN`/`END` statements as well.