### PR TITLE
[gosrc2cpg] Variable referencing tests for `golang`

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/VariableReferencingTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/VariableReferencingTests.scala
@@ -1,0 +1,70 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+
+class VariableReferencingTests extends GoCodeToCpgSuite {
+  "AST Creation for local nodes" should {
+    val cpg = code("""package main
+        |func main() {
+        | x := 1
+        | y := x
+        |}
+        |""".stripMargin)
+
+    "test local variable exists" in {
+      val localNode = cpg.method("main").local.name("x").head
+      localNode.closureBindingId shouldBe None
+    }
+
+    "test identifier association to local nodes" in {
+      val localNode = cpg.method("main").local.name("x").head
+      localNode.referencingIdentifiers.l.size shouldBe 2
+      localNode.referencingIdentifiers.lineNumber(3).code.head shouldBe "x"
+      localNode.referencingIdentifiers.lineNumber(4).code.head shouldBe "x"
+    }
+
+    "test local variable line and column numbers" in {
+      val localNodeX = cpg.method("main").local.name("x").head
+      localNodeX.lineNumber shouldBe Some(3)
+      localNodeX.columnNumber shouldBe Some(2)
+
+      val localNodeY = cpg.method("main").local.name("y").head
+      localNodeX.lineNumber shouldBe Some(3)
+      localNodeX.columnNumber shouldBe Some(2)
+    }
+  }
+
+  "global variable reference" should {
+    val cpg = code("""package main
+        |var x = 1
+        |func main(){
+        |y:=x
+        |}
+        |""".stripMargin)
+
+    "test local variable exists" in {
+      val List(localNode) = cpg.method("main.<global>").local.nameExact("x").l
+      localNode.code shouldBe "x"
+      localNode.closureBindingId shouldBe None
+    }
+
+    "test identifier association to local" in {
+      val List(localNode) = cpg.method("main.<global>").local.nameExact("x").l
+      localNode.referencingIdentifiers.lineNumber(2).code.head shouldBe "x"
+      localNode.referencingIdentifiers.lineNumber(4).code.head shouldBe "x"
+    }
+
+    "test global variable line and column numbers" in {
+      val List(localNode) = cpg.method("main.<global>").local.nameExact("x").l
+      localNode.lineNumber shouldBe Some(2)
+      localNode.columnNumber shouldBe Some(5)
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR contains unit tests for variable referencing tests in `gosrc2cpg`.

Changes that need to be added in the variable referencing tests after respective AST is handled -
1. Parameter variable referencing
2. Class variable referencing
3. Nested methods variable referencing
4. Closure bindings for all local nodes.

@DavidBakerEffendi, please review. 
cc: @pandurangpatil 