### PR TITLE
RubyParser: refactor separators

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -525,7 +525,7 @@ classOrModuleReference
 // --------------------------------------------------------
 
 moduleDefinition
-    :   MODULE NL* classOrModuleReference NL* bodyStatement NL* END
+    :   MODULE NL* classOrModuleReference bodyStatement END
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -16,10 +16,6 @@ compoundStatement
     :   (SEMI | NL)* statements? (SEMI | NL)*
     ;
 
-separators
-    :   (SEMI | NL)+
-    ;
-
 // --------------------------------------------------------
 // Statements
 // --------------------------------------------------------
@@ -84,7 +80,7 @@ primary
     |   RETURN argumentsWithParentheses                                                                                     # returnWithParenthesesPrimary
     |   jumpExpression                                                                                                      # jumpExpressionPrimary
     |   beginExpression                                                                                                     # beginExpressionPrimary
-    |   LPAREN NL* compoundStatement NL* RPAREN                                                                             # groupingExpressionPrimary
+    |   LPAREN compoundStatement RPAREN                                                                                     # groupingExpressionPrimary
     |   variableReference                                                                                                   # variableReferencePrimary
     |   COLON2 CONSTANT_IDENTIFIER                                                                                          # simpleScopedConstantReferencePrimary
     |   primary COLON2 CONSTANT_IDENTIFIER                                                                                  # chainedScopedConstantReferencePrimary
@@ -418,12 +414,12 @@ procParameter
 // --------------------------------------------------------
 
 ifExpression
-    :   IF NL* expressionOrCommand thenClause (NL* elsifClause)* (NL* elseClause)? NL* END
+    :   IF NL* expressionOrCommand thenClause elsifClause* elseClause? END
     ;
 
 thenClause
-    :   separators compoundStatement
-    |   separators? THEN compoundStatement
+    :   (SEMI | NL)+ compoundStatement
+    |   (SEMI | NL)? THEN compoundStatement
     ;
 
 elsifClause
@@ -431,15 +427,15 @@ elsifClause
     ;
 
 elseClause
-    :   ELSE NL* compoundStatement
+    :   ELSE compoundStatement
     ;
 
 unlessExpression
-    :   UNLESS NL* expressionOrCommand thenClause NL* elseClause? NL* END
+    :   UNLESS NL* expressionOrCommand thenClause elseClause? END
     ;
 
 caseExpression
-    :   CASE (NL* expressionOrCommand)? separators? whenClause+ elseClause? NL* END
+    :   CASE (NL* expressionOrCommand)? (SEMI | NL)* whenClause+ elseClause? END
     ;
 
 whenClause
@@ -456,11 +452,11 @@ whenArgument
 // --------------------------------------------------------
 
 whileExpression
-    :   WHILE NL* expressionOrCommand doClause NL* END
+    :   WHILE NL* expressionOrCommand doClause END
     ;
 
 doClause
-    :   separators compoundStatement
+    :   (SEMI | NL)+ compoundStatement
     |   DO compoundStatement
     ;
 
@@ -486,11 +482,11 @@ beginExpression
     ;
 
 bodyStatement
-    :   compoundStatement (NL* rescueClause)* (NL* elseClause)? (NL* ensureClause)?
+    :   compoundStatement rescueClause* elseClause? ensureClause?
     ;
 
 rescueClause
-    :   RESCUE exceptionClass? NL* exceptionVariableAssignment? NL* thenClause
+    :   RESCUE exceptionClass? NL* exceptionVariableAssignment? thenClause
     ;
 
 exceptionClass
@@ -503,7 +499,7 @@ exceptionVariableAssignment
     ;
 
 ensureClause
-    :   ENSURE NL* compoundStatement
+    :   ENSURE compoundStatement
     ;
 
 // --------------------------------------------------------
@@ -512,7 +508,7 @@ ensureClause
 
 classDefinition
     :   CLASS NL* classOrModuleReference (LT NL* expressionOrCommand)? bodyStatement END
-    |   CLASS NL* LT2 NL* expressionOrCommand separators bodyStatement END
+    |   CLASS NL* LT2 NL* expressionOrCommand (SEMI | NL)+ bodyStatement END
     ;
 
 classOrModuleReference

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -13,7 +13,7 @@ program
     ;
 
 compoundStatement
-    :   separators? statements? separators?
+    :   (SEMI | NL)* statements? (SEMI | NL)*
     ;
 
 separators
@@ -25,7 +25,7 @@ separators
 // --------------------------------------------------------
 
 statements
-    :   statement (separators statement)*
+    :   statement ((SEMI | NL)+ statement)*
     ;
 
 statement
@@ -232,11 +232,11 @@ block
     ;
 
 braceBlock
-    :   LCURLY NL* blockParameter? NL* bodyStatement NL* RCURLY
+    :   LCURLY NL* blockParameter? bodyStatement RCURLY
     ;
 
 doBlock
-    :   DO NL* blockParameter? separators NL* bodyStatement NL* END
+    :   DO NL* blockParameter? bodyStatement END
     ;
 
 blockParameter
@@ -325,7 +325,7 @@ association
 // --------------------------------------------------------
 
 methodDefinition
-    :   DEF NL* methodNamePart methodParameterPart separators? bodyStatement NL* END
+    :   DEF NL* methodNamePart methodParameterPart bodyStatement END
     |   DEF NL* methodIdentifier methodParameterPart EQ NL* expression
     ;
     
@@ -423,7 +423,7 @@ ifExpression
 
 thenClause
     :   separators compoundStatement
-    |   separators? THEN NL* compoundStatement
+    |   separators? THEN compoundStatement
     ;
 
 elsifClause
@@ -461,15 +461,15 @@ whileExpression
 
 doClause
     :   separators compoundStatement
-    |   DO separators? compoundStatement
+    |   DO compoundStatement
     ;
 
 untilExpression
-    :   UNTIL NL* expressionOrCommand doClause NL* END
+    :   UNTIL NL* expressionOrCommand doClause END
     ;
 
 forExpression
-    :   FOR NL* forVariable IN NL* expressionOrCommand doClause NL* END
+    :   FOR NL* forVariable IN NL* expressionOrCommand doClause END
     ;
 
 forVariable
@@ -482,7 +482,7 @@ forVariable
 // --------------------------------------------------------
 
 beginExpression
-    :   BEGIN NL* bodyStatement NL* END
+    :   BEGIN bodyStatement END
     ;
 
 bodyStatement
@@ -511,8 +511,8 @@ ensureClause
 // --------------------------------------------------------
 
 classDefinition
-    :   CLASS NL* classOrModuleReference (LT NL* expressionOrCommand)? separators NL* bodyStatement NL* END
-    |   CLASS NL* LT2 NL* expressionOrCommand separators NL* bodyStatement NL* END
+    :   CLASS NL* classOrModuleReference (LT NL* expressionOrCommand)? bodyStatement END
+    |   CLASS NL* LT2 NL* expressionOrCommand separators bodyStatement END
     ;
 
 classOrModuleReference

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -9,11 +9,11 @@ options {
 // --------------------------------------------------------
 
 program
-    :   NL* compoundStatement EOF
+    :   compoundStatement EOF
     ;
 
 compoundStatement
-    :   statements? separators?
+    :   separators? statements? separators?
     ;
 
 separators
@@ -31,8 +31,8 @@ statements
 statement
     :   ALIAS NL* definedMethodNameOrSymbol NL* definedMethodNameOrSymbol                                           # aliasStatement
     |   UNDEF NL* definedMethodNameOrSymbol (COMMA NL* definedMethodNameOrSymbol)*                                  # undefStatement
-    |   BEGIN_ LCURLY NL* statements? NL* RCURLY                                                                    # beginStatement
-    |   END_ LCURLY NL* statements? NL* RCURLY                                                                      # endStatement
+    |   BEGIN_ LCURLY compoundStatement RCURLY                                                                      # beginStatement
+    |   END_ LCURLY compoundStatement RCURLY                                                                        # endStatement
     |   statement mod=(IF | UNLESS | WHILE | UNTIL | RESCUE) NL* statement                                          # modifierStatement
     |   expressionOrCommand                                                                                         # expressionOrCommandStatement
     ;
@@ -66,7 +66,6 @@ expression
     |   expression op=BAR2 NL* expression                                                                           # operatorOrExpression
     |   expression op=(DOT2 | DOT3) NL* expression?                                                                 # rangeExpression
     |   expression QMARK NL* expression NL* COLON NL* expression                                                    # conditionalOperatorExpression
-
     |   IS_DEFINED NL* expression                                                                                   # isDefinedExpression
     ;
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -25,11 +25,11 @@ statements
     ;
 
 statement
-    :   ALIAS NL* definedMethodNameOrSymbol NL* definedMethodNameOrSymbol                                           # aliasStatement
-    |   UNDEF NL* definedMethodNameOrSymbol (COMMA NL* definedMethodNameOrSymbol)*                                  # undefStatement
+    :   ALIAS NL? definedMethodNameOrSymbol NL? definedMethodNameOrSymbol                                           # aliasStatement
+    |   UNDEF NL? definedMethodNameOrSymbol (COMMA NL? definedMethodNameOrSymbol)*                                  # undefStatement
     |   BEGIN_ LCURLY compoundStatement RCURLY                                                                      # beginStatement
     |   END_ LCURLY compoundStatement RCURLY                                                                        # endStatement
-    |   statement mod=(IF | UNLESS | WHILE | UNTIL | RESCUE) NL* statement                                          # modifierStatement
+    |   statement mod=(IF | UNLESS | WHILE | UNTIL | RESCUE) NL? statement                                          # modifierStatement
     |   expressionOrCommand                                                                                         # expressionOrCommandStatement
     ;
 
@@ -39,30 +39,30 @@ statement
 
 expressionOrCommand
     :   expression                                                                                                  # expressionExpressionOrCommand
-    |   (EMARK NL*)? invocationWithoutParentheses                                                                   # invocationExpressionOrCommand
-    |   NOT NL* expressionOrCommand                                                                                 # notExpressionOrCommand
-    |   <assoc=right> expressionOrCommand op=(OR | AND) NL* expressionOrCommand                                     # orAndExpressionOrCommand
+    |   (EMARK NL?)? invocationWithoutParentheses                                                                   # invocationExpressionOrCommand
+    |   NOT NL? expressionOrCommand                                                                                 # notExpressionOrCommand
+    |   <assoc=right> expressionOrCommand op=(OR | AND) NL? expressionOrCommand                                     # orAndExpressionOrCommand
     ;
 
 expression
-    :   <assoc=right> singleLeftHandSide op=(EQ | ASSIGNMENT_OPERATOR) NL* multipleRightHandSide                    # singleAssignmentExpression
-    |   <assoc=right> multipleLeftHandSide EQ NL* multipleRightHandSide                                             # multipleAssignmentExpression
+    :   <assoc=right> singleLeftHandSide op=(EQ | ASSIGNMENT_OPERATOR) NL? multipleRightHandSide                    # singleAssignmentExpression
+    |   <assoc=right> multipleLeftHandSide EQ NL? multipleRightHandSide                                             # multipleAssignmentExpression
     |   primary                                                                                                     # primaryExpression
-    |   op=(TILDE | PLUS | EMARK) NL* expression                                                                    # unaryExpression
-    |   <assoc=right> expression STAR2 NL* expression                                                               # powerExpression
-    |   MINUS NL* expression                                                                                        # unaryMinusExpression
-    |   expression op=(STAR | SLASH | PERCENT) NL* expression                                                       # multiplicativeExpression
-    |   expression op=(PLUS | MINUS) NL* expression                                                                 # additiveExpression
-    |   expression op=(LT2 | GT2) NL* expression                                                                    # bitwiseShiftExpression
-    |   expression op=AMP NL* expression                                                                            # bitwiseAndExpression
-    |   expression op=(BAR | CARET) NL* expression                                                                  # bitwiseOrExpression
-    |   expression op=(GT | GTEQ | LT | LTEQ) NL* expression                                                        # relationalExpression
-    |   expression op=(LTEQGT | EQ2 | EQ3 | EMARKEQ | EQTILDE | EMARKTILDE) NL* expression?                         # equalityExpression
-    |   expression op=AMP2 NL* expression                                                                           # operatorAndExpression
-    |   expression op=BAR2 NL* expression                                                                           # operatorOrExpression
-    |   expression op=(DOT2 | DOT3) NL* expression?                                                                 # rangeExpression
-    |   expression QMARK NL* expression NL* COLON NL* expression                                                    # conditionalOperatorExpression
-    |   IS_DEFINED NL* expression                                                                                   # isDefinedExpression
+    |   op=(TILDE | PLUS | EMARK) NL? expression                                                                    # unaryExpression
+    |   <assoc=right> expression STAR2 NL? expression                                                               # powerExpression
+    |   MINUS NL? expression                                                                                        # unaryMinusExpression
+    |   expression op=(STAR | SLASH | PERCENT) NL? expression                                                       # multiplicativeExpression
+    |   expression op=(PLUS | MINUS) NL? expression                                                                 # additiveExpression
+    |   expression op=(LT2 | GT2) NL? expression                                                                    # bitwiseShiftExpression
+    |   expression op=AMP NL? expression                                                                            # bitwiseAndExpression
+    |   expression op=(BAR | CARET) NL? expression                                                                  # bitwiseOrExpression
+    |   expression op=(GT | GTEQ | LT | LTEQ) NL? expression                                                        # relationalExpression
+    |   expression op=(LTEQGT | EQ2 | EQ3 | EMARKEQ | EQTILDE | EMARKTILDE) NL? expression?                         # equalityExpression
+    |   expression op=AMP2 NL? expression                                                                           # operatorAndExpression
+    |   expression op=BAR2 NL? expression                                                                           # operatorOrExpression
+    |   expression op=(DOT2 | DOT3) NL? expression?                                                                 # rangeExpression
+    |   expression QMARK NL? expression NL? COLON NL? expression                                                    # conditionalOperatorExpression
+    |   IS_DEFINED NL? expression                                                                                   # isDefinedExpression
     ;
 
 primary
@@ -98,7 +98,7 @@ primary
     |   methodOnlyIdentifier                                                                                                # methodOnlyIdentifierPrimary
     |   methodIdentifier block                                                                                              # invocationWithBlockOnlyPrimary
     |   methodIdentifier argumentsWithParentheses block?                                                                    # invocationWithParenthesesPrimary
-    |   primary NL* (DOT | COLON2| AMPDOT) NL* methodName argumentsWithParentheses? block?                                  # chainedInvocationPrimary
+    |   primary NL? (DOT | COLON2| AMPDOT) NL? methodName argumentsWithParentheses? block?                                  # chainedInvocationPrimary
     |   primary COLON2 methodName block?                                                                                    # chainedInvocationWithoutArgumentsPrimary
     ;
 
@@ -114,7 +114,7 @@ singleLeftHandSide
     ;
 
 multipleLeftHandSide
-    :   (multipleLeftHandSideItem COMMA NL*)+ (multipleLeftHandSideItem | packingLeftHandSide)?                     # multipleLeftHandSideAndpackingLeftHandSideMultipleLeftHandSide
+    :   (multipleLeftHandSideItem COMMA NL?)+ (multipleLeftHandSideItem | packingLeftHandSide)?                     # multipleLeftHandSideAndpackingLeftHandSideMultipleLeftHandSide
     |   packingLeftHandSide                                                                                         # packingLeftHandSideOnlyMultipleLeftHandSide
     |   groupedLeftHandSide                                                                                         # groupedLeftHandSideOnlyMultipleLeftHandSide
     ;
@@ -133,12 +133,12 @@ groupedLeftHandSide
     ;
 
 multipleRightHandSide
-    :   expressionOrCommands (COMMA NL* splattingArgument)?
+    :   expressionOrCommands (COMMA NL? splattingArgument)?
     |   splattingArgument
     ;
 
 expressionOrCommands
-    :   expressionOrCommand (COMMA NL* expressionOrCommand)*
+    :   expressionOrCommand (COMMA NL? expressionOrCommand)*
     ;
 
 // --------------------------------------------------------
@@ -157,7 +157,7 @@ command
     :   SUPER argumentsWithoutParentheses                                                                                               # superCommand
     |   YIELD argumentsWithoutParentheses                                                                                               # yieldCommand
     |   methodIdentifier argumentsWithoutParentheses                                                                                    # simpleMethodCommand
-    |   primary (DOT | COLON2| AMPDOT) NL* methodName argumentsWithoutParentheses                                                       # memberAccessCommand
+    |   primary (DOT | COLON2| AMPDOT) NL? methodName argumentsWithoutParentheses                                                       # memberAccessCommand
     ;
 
 chainedCommandWithDoBlock
@@ -175,7 +175,7 @@ argumentsWithoutParentheses
     ;
 
 arguments
-    :   argument (COMMA NL* argument)*
+    :   argument (COMMA NL? argument)*
     ;
     
 argument
@@ -200,22 +200,22 @@ splattingArgument
     ;
 
 indexingArguments
-    :   expressions (COMMA NL*)?                                                                                                # expressionsOnlyIndexingArguments
-    |   expressions COMMA NL* splattingArgument                                                                                 # expressionsAndSplattingIndexingArguments
-    |   associations (COMMA NL*)?                                                                                               # associationsOnlyIndexingArguments
+    :   expressions (COMMA NL?)?                                                                                                # expressionsOnlyIndexingArguments
+    |   expressions COMMA NL? splattingArgument                                                                                 # expressionsAndSplattingIndexingArguments
+    |   associations (COMMA NL?)?                                                                                               # associationsOnlyIndexingArguments
     |   splattingArgument                                                                                                       # splattingOnlyIndexingArguments
     |   command                                                                                                                 # commandOnlyIndexingArguments
     ;
 
 argumentsWithParentheses
-    :   LPAREN NL* RPAREN                                                                                                       # blankArgsArgumentsWithParentheses
-    |   LPAREN NL* arguments (COMMA)? NL* RPAREN                                                                                # argsOnlyArgumentsWithParentheses
-    |   LPAREN NL* expressions COMMA NL* chainedCommandWithDoBlock NL* RPAREN                                                   # expressionsAndChainedCommandWithDoBlockArgumentsWithParentheses
-    |   LPAREN NL* chainedCommandWithDoBlock NL* RPAREN                                                                         # chainedCommandWithDoBlockOnlyArgumentsWithParentheses
+    :   LPAREN NL? RPAREN                                                                                                       # blankArgsArgumentsWithParentheses
+    |   LPAREN NL? arguments (COMMA)? NL? RPAREN                                                                                # argsOnlyArgumentsWithParentheses
+    |   LPAREN NL? expressions COMMA NL? chainedCommandWithDoBlock NL? RPAREN                                                   # expressionsAndChainedCommandWithDoBlockArgumentsWithParentheses
+    |   LPAREN NL? chainedCommandWithDoBlock NL? RPAREN                                                                         # chainedCommandWithDoBlockOnlyArgumentsWithParentheses
     ;
 
 expressions
-    :   expression (COMMA NL* expression)*
+    :   expression (COMMA NL? expression)*
     ;
 
 // --------------------------------------------------------
@@ -228,11 +228,11 @@ block
     ;
 
 braceBlock
-    :   LCURLY NL* blockParameter? bodyStatement RCURLY
+    :   LCURLY NL? blockParameter? bodyStatement RCURLY
     ;
 
 doBlock
-    :   DO NL* blockParameter? bodyStatement END
+    :   DO NL? blockParameter? bodyStatement END
     ;
 
 blockParameter
@@ -249,7 +249,7 @@ blockParameters
 // --------------------------------------------------------
 
 arrayConstructor
-    :   LBRACK NL* indexingArguments? NL* RBRACK                                                                    # bracketedArrayConstructor
+    :   LBRACK NL? indexingArguments? NL? RBRACK                                                                    # bracketedArrayConstructor
     |   QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_START
         nonExpandedArrayElements?
         QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END                                                                # nonExpandedWordArrayConstructor
@@ -296,11 +296,11 @@ nonExpandedArrayElement
 // --------------------------------------------------------
 
 hashConstructor
-    :   LCURLY NL* (hashConstructorElements COMMA?)? NL* RCURLY
+    :   LCURLY NL? (hashConstructorElements COMMA?)? NL? RCURLY
     ;
 
 hashConstructorElements
-    :   hashConstructorElement (COMMA NL* hashConstructorElement)*
+    :   hashConstructorElement (COMMA NL? hashConstructorElement)*
     ;
 
 hashConstructorElement
@@ -309,11 +309,11 @@ hashConstructorElement
     ;
 
 associations
-    :   association (COMMA NL* association)*
+    :   association (COMMA NL? association)*
     ;
 
 association
-    :   (expression | keyword) (EQGT|COLON) (NL* expression)?
+    :   (expression | keyword) (EQGT|COLON) (NL? expression)?
     ;
 
 // --------------------------------------------------------
@@ -321,8 +321,8 @@ association
 // --------------------------------------------------------
 
 methodDefinition
-    :   DEF NL* methodNamePart methodParameterPart bodyStatement END
-    |   DEF NL* methodIdentifier methodParameterPart EQ NL* expression
+    :   DEF NL? methodNamePart methodParameterPart bodyStatement END
+    |   DEF NL? methodIdentifier methodParameterPart EQ NL? expression
     ;
     
 
@@ -332,7 +332,7 @@ procDefinition
 
 methodNamePart
     :   definedMethodName                                                                                           # simpleMethodNamePart
-    |   singletonObject NL* (DOT | COLON2) NL* definedMethodName                                                    # singletonMethodNamePart
+    |   singletonObject NL? (DOT | COLON2) NL? definedMethodName                                                    # singletonMethodNamePart
     ;
 
 singletonObject
@@ -367,12 +367,12 @@ methodOnlyIdentifier
     ;
 
 methodParameterPart
-    :   LPAREN NL* parameters? NL* RPAREN
+    :   LPAREN NL? parameters? NL? RPAREN
     |   parameters?
     ;
 
 parameters
-    :   parameter (COMMA NL* parameter)*
+    :   parameter (COMMA NL? parameter)*
     ;
     
 parameter
@@ -389,7 +389,7 @@ mandatoryParameter
     ;
 
 optionalParameter
-    :   LOCAL_VARIABLE_IDENTIFIER EQ NL* expression
+    :   LOCAL_VARIABLE_IDENTIFIER EQ NL? expression
     ;
 
 arrayParameter
@@ -401,7 +401,7 @@ hashParameter
     ;
 
 keywordParameter
-    :   LOCAL_VARIABLE_IDENTIFIER COLON (NL* expression)?
+    :   LOCAL_VARIABLE_IDENTIFIER COLON (NL? expression)?
     ;
 
 procParameter
@@ -414,7 +414,7 @@ procParameter
 // --------------------------------------------------------
 
 ifExpression
-    :   IF NL* expressionOrCommand thenClause elsifClause* elseClause? END
+    :   IF NL? expressionOrCommand thenClause elsifClause* elseClause? END
     ;
 
 thenClause
@@ -423,7 +423,7 @@ thenClause
     ;
 
 elsifClause
-    :   ELSIF NL* expressionOrCommand thenClause
+    :   ELSIF NL? expressionOrCommand thenClause
     ;
 
 elseClause
@@ -431,15 +431,15 @@ elseClause
     ;
 
 unlessExpression
-    :   UNLESS NL* expressionOrCommand thenClause elseClause? END
+    :   UNLESS NL? expressionOrCommand thenClause elseClause? END
     ;
 
 caseExpression
-    :   CASE (NL* expressionOrCommand)? (SEMI | NL)* whenClause+ elseClause? END
+    :   CASE NL? expressionOrCommand? (SEMI | NL)* whenClause+ elseClause? END
     ;
 
 whenClause
-    :   WHEN NL* whenArgument thenClause
+    :   WHEN NL? whenArgument thenClause
     ;
 
 whenArgument
@@ -452,7 +452,7 @@ whenArgument
 // --------------------------------------------------------
 
 whileExpression
-    :   WHILE NL* expressionOrCommand doClause END
+    :   WHILE NL? expressionOrCommand doClause END
     ;
 
 doClause
@@ -461,11 +461,11 @@ doClause
     ;
 
 untilExpression
-    :   UNTIL NL* expressionOrCommand doClause END
+    :   UNTIL NL? expressionOrCommand doClause END
     ;
 
 forExpression
-    :   FOR NL* forVariable IN NL* expressionOrCommand doClause END
+    :   FOR NL? forVariable IN NL? expressionOrCommand doClause END
     ;
 
 forVariable
@@ -486,7 +486,7 @@ bodyStatement
     ;
 
 rescueClause
-    :   RESCUE exceptionClass? NL* exceptionVariableAssignment? thenClause
+    :   RESCUE exceptionClass? NL? exceptionVariableAssignment? thenClause
     ;
 
 exceptionClass
@@ -507,8 +507,8 @@ ensureClause
 // --------------------------------------------------------
 
 classDefinition
-    :   CLASS NL* classOrModuleReference (LT NL* expressionOrCommand)? bodyStatement END
-    |   CLASS NL* LT2 NL* expressionOrCommand (SEMI | NL)+ bodyStatement END
+    :   CLASS NL? classOrModuleReference (LT NL? expressionOrCommand)? bodyStatement END
+    |   CLASS NL? LT2 NL? expressionOrCommand (SEMI | NL)+ bodyStatement END
     ;
 
 classOrModuleReference
@@ -521,7 +521,7 @@ classOrModuleReference
 // --------------------------------------------------------
 
 moduleDefinition
-    :   MODULE NL* classOrModuleReference bodyStatement END
+    :   MODULE NL? classOrModuleReference bodyStatement END
     ;
 
 // --------------------------------------------------------

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -42,13 +42,13 @@ trait AstForStatementsCreator {
   }
 
   protected def astForBeginStatement(ctx: BeginStatementContext): Ast = {
-    val stmts     = astForStatements(ctx.statements())
+    val stmts     = Option(ctx.compoundStatement).map(astForCompoundStatement(_)).getOrElse(Seq())
     val blockNode = NewBlock().typeFullName(Defines.Any)
     blockAst(blockNode, stmts.toList)
   }
 
   protected def astForEndStatement(ctx: EndStatementContext): Ast = {
-    val stmts     = astForStatements(ctx.statements())
+    val stmts     = Option(ctx.compoundStatement).map(astForCompoundStatement(_)).getOrElse(Seq())
     val blockNode = NewBlock().typeFullName(Defines.Any)
     blockAst(blockNode, stmts.toList)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
@@ -49,7 +49,6 @@ class BeginExpressionTests extends RubyParserAbstractTest {
             |      VariableIdentifier
             |       e
             |    ThenClause
-            |     Separators
             |     CompoundStatement
             |  end""".stripMargin
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginExpressionTests.scala
@@ -35,7 +35,6 @@ class BeginExpressionTests extends RubyParserAbstractTest {
             |           NumericLiteral
             |            UnsignedNumericLiteral
             |             0
-            |    Separators
             |   RescueClause
             |    rescue
             |    ExceptionClass

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginStatementTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/BeginStatementTests.scala
@@ -1,0 +1,40 @@
+package io.joern.rubysrc2cpg.parser
+
+class BeginStatementTests extends RubyParserAbstractTest {
+
+  "BEGIN statement" should {
+
+    "be parsed as a statement" when {
+
+      "defined in a single line" in {
+        val code = "BEGIN { 1 }"
+        printAst(_.statement(), code) shouldEqual
+          """BeginStatement
+            | BEGIN
+            | {
+            | CompoundStatement
+            |  Statements
+            |   ExpressionOrCommandStatement
+            |    ExpressionExpressionOrCommand
+            |     PrimaryExpression
+            |      LiteralPrimary
+            |       NumericLiteralLiteral
+            |        NumericLiteral
+            |         UnsignedNumericLiteral
+            |          1
+            | }""".stripMargin
+      }
+
+      "empty (single-line)" in {
+        val code = "BEGIN {}"
+        printAst(_.statement(), code) shouldEqual
+          """BeginStatement
+            | BEGIN
+            | {
+            | CompoundStatement
+            | }""".stripMargin
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
@@ -24,7 +24,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       something
-            |  Separators
             |  WhenClause
             |   when
             |   WhenArgument
@@ -36,7 +35,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |         UnsignedNumericLiteral
             |          1
             |   ThenClause
-            |    Separators
             |    CompoundStatement
             |     Statements
             |      ExpressionOrCommandStatement
@@ -75,7 +73,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       something
-            |  Separators
             |  WhenClause
             |   when
             |   WhenArgument
@@ -87,7 +84,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |         UnsignedNumericLiteral
             |          1
             |   ThenClause
-            |    Separators
             |    CompoundStatement
             |  ElseClause
             |   else
@@ -112,7 +108,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       something
-            |  Separators
             |  WhenClause
             |   when
             |   WhenArgument
@@ -147,7 +142,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       x
-            |  Separators
             |  WhenClause
             |   when
             |   WhenArgument

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/CaseConditionTests.scala
@@ -54,7 +54,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |                NumericLiteral
             |                 UnsignedNumericLiteral
             |                  2
-            |     Separators
             |  end""".stripMargin
       }
 
@@ -171,7 +170,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |           NumericLiteral
             |            UnsignedNumericLiteral
             |             2
-            |     Separators
             |  WhenClause
             |   when
             |   WhenArgument
@@ -194,7 +192,6 @@ class CaseConditionTests extends RubyParserAbstractTest {
             |           NumericLiteral
             |            UnsignedNumericLiteral
             |             3
-            |     Separators
             |  end""".stripMargin
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
@@ -19,8 +19,7 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |     PseudoVariableIdentifierVariableReference
             |      SelfPseudoVariableIdentifier
             |       self
-            |  Separators
-            |   ;
+            |  ;
             |  BodyStatement
             |   CompoundStatement
             |  end""".stripMargin
@@ -70,7 +69,6 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |     VariableIdentifierVariableReference
             |      VariableIdentifier
             |       x
-            |  Separators
             |  BodyStatement
             |   CompoundStatement
             |    Statements

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ClassDefinitionTests.scala
@@ -25,6 +25,28 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |   CompoundStatement
             |  end""".stripMargin
       }
+
+      "it contains a single numeric literal in its body" in {
+        val code = "class X 1 end"
+        printAst(_.primary(), code) shouldBe
+          """ClassDefinitionPrimary
+            | ClassDefinition
+            |  class
+            |  ClassOrModuleReference
+            |   X
+            |  BodyStatement
+            |   CompoundStatement
+            |    Statements
+            |     ExpressionOrCommandStatement
+            |      ExpressionExpressionOrCommand
+            |       PrimaryExpression
+            |        LiteralPrimary
+            |         NumericLiteralLiteral
+            |          NumericLiteral
+            |           UnsignedNumericLiteral
+            |            1
+            |  end""".stripMargin
+      }
     }
   }
 
@@ -64,10 +86,9 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |             MethodIdentifier
             |              show
             |          MethodParameterPart
-            |          Separators
-            |           ;
             |          BodyStatement
             |           CompoundStatement
+            |            ;
             |            Statements
             |             ExpressionOrCommandStatement
             |              InvocationExpressionOrCommand
@@ -83,10 +104,8 @@ class ClassDefinitionTests extends RubyParserAbstractTest {
             |                      PseudoVariableIdentifierVariableReference
             |                       SelfPseudoVariableIdentifier
             |                        self
-            |            Separators
-            |             ;
+            |            ;
             |          end
-            |    Separators
             |  end""".stripMargin
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/EnsureClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/EnsureClauseTests.scala
@@ -21,7 +21,6 @@ class EnsureClauseTests extends RubyParserAbstractTest {
             |    MethodIdentifier
             |     refund
             | MethodParameterPart
-            | Separators
             | BodyStatement
             |  CompoundStatement
             |  EnsureClause
@@ -51,7 +50,6 @@ class EnsureClauseTests extends RubyParserAbstractTest {
             |                    VariableIdentifier
             |                     @charge
             |               )
-            |    Separators
             | end""".stripMargin
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesTests.scala
@@ -76,7 +76,6 @@ class InvocationWithoutParenthesesTests extends RubyParserAbstractTest {
             |            'should print 1'
             |     DoBlock
             |      do
-            |      Separators
             |      BodyStatement
             |       CompoundStatement
             |        Statements
@@ -95,7 +94,6 @@ class InvocationWithoutParenthesesTests extends RubyParserAbstractTest {
             |                   NumericLiteral
             |                    UnsignedNumericLiteral
             |                     1
-            |        Separators
             |      end""".stripMargin
 
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -550,6 +550,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |        SomeModule
             |       BodyStatement
             |        CompoundStatement
+            |         Separators
             |         Statements
             |          ExpressionOrCommandStatement
             |           ExpressionExpressionOrCommand

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -18,10 +18,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     MethodIdentifier
             |      foo
             |  MethodParameterPart
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -43,10 +42,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     MandatoryParameter
             |      x
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -75,10 +73,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |          UnsignedNumericLiteral
             |           1
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -105,10 +102,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      &
             |      y
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -131,10 +127,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      *
             |      arr
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -157,10 +152,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      **
             |      hash
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -188,10 +182,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      **
             |      hash
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -224,10 +217,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     MandatoryParameter
             |      y
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -256,10 +248,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |          UnsignedNumericLiteral
             |           1
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -282,10 +273,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      x
             |      :
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
 
@@ -313,10 +303,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      surname
             |      :
             |   )
-            |  Separators
-            |   ;
             |  BodyStatement
             |   CompoundStatement
+            |    ;
             |  end""".stripMargin
       }
     }
@@ -341,7 +330,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |     MethodIdentifier
             |      foo
             |  MethodParameterPart
-            |  Separators
             |  BodyStatement
             |   CompoundStatement
             |    Statements
@@ -361,7 +349,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |           NumericLiteral
             |            UnsignedNumericLiteral
             |             0
-            |    Separators
             |   RescueClause
             |    rescue
             |    ExceptionClass
@@ -493,11 +480,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |          MethodIdentifier
             |           foo1
             |       MethodParameterPart
-            |       Separators
             |       BodyStatement
             |        CompoundStatement
             |       end
-            |  Separators
             |  ExpressionOrCommandStatement
             |   ExpressionExpressionOrCommand
             |    PrimaryExpression
@@ -515,11 +500,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |          MandatoryParameter
             |           arg
             |        )
-            |       Separators
             |       BodyStatement
             |        CompoundStatement
-            |       end
-            | Separators""".stripMargin
+            |       end""".stripMargin
 
       }
 
@@ -550,7 +533,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |        SomeModule
             |       BodyStatement
             |        CompoundStatement
-            |         Separators
             |         Statements
             |          ExpressionOrCommandStatement
             |           ExpressionExpressionOrCommand
@@ -564,7 +546,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |                  MethodIdentifier
             |                   foo1
             |               MethodParameterPart
-            |               Separators
             |               BodyStatement
             |                CompoundStatement
             |                 Statements
@@ -581,9 +562,7 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |                       PseudoVariableIdentifierVariableReference
             |                        TruePseudoVariableIdentifier
             |                         true
-            |                 Separators
             |               end
-            |          Separators
             |          ExpressionOrCommandStatement
             |           ExpressionExpressionOrCommand
             |            PrimaryExpression
@@ -601,13 +580,10 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |                  MandatoryParameter
             |                   arg
             |                )
-            |               Separators
             |               BodyStatement
             |                CompoundStatement
             |               end
-            |         Separators
-            |       end
-            | Separators""".stripMargin
+            |       end""".stripMargin
       }
     }
   }
@@ -637,7 +613,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |      &
           |      block
           |   )
-          |  Separators
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -647,7 +622,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |        YieldWithOptionalArgumentPrimary
           |         YieldWithOptionalArgument
           |          yield
-          |    Separators
           |  end""".stripMargin
     }
 
@@ -674,7 +648,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |     ProcParameter
           |      &
           |   )
-          |  Separators
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -684,7 +657,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |        YieldWithOptionalArgumentPrimary
           |         YieldWithOptionalArgument
           |          yield
-          |    Separators
           |  end""".stripMargin
     }
   }
@@ -733,7 +705,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |     MethodIdentifier
           |      data
           |  MethodParameterPart
-          |  Separators
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -763,7 +734,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |             :
           |          ,
           |          }
-          |    Separators
           |  end""".stripMargin
     }
 
@@ -781,7 +751,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |  class
           |  ClassOrModuleReference
           |   SampleClass
-          |  Separators
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -809,11 +778,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |              second_param
           |              :
           |           )
-          |          Separators
           |          BodyStatement
           |           CompoundStatement
           |          end
-          |    Separators
           |  end""".stripMargin
     }
 
@@ -832,7 +799,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |  class
           |  ClassOrModuleReference
           |   SomeClass
-          |  Separators
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -858,11 +824,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |             MandatoryParameter
           |              age
           |           )
-          |          Separators
           |          BodyStatement
           |           CompoundStatement
           |          end
-          |    Separators
           |  end""".stripMargin
     }
 
@@ -882,7 +846,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |  class
           |  ClassOrModuleReference
           |   SomeClass
-          |  Separators
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -908,11 +871,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |             MandatoryParameter
           |              age
           |           )
-          |          Separators
           |          BodyStatement
           |           CompoundStatement
           |          end
-          |    Separators
           |  end""".stripMargin
     }
 
@@ -932,7 +893,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |  class
           |  ClassOrModuleReference
           |   SomeClass
-          |  Separators
           |  BodyStatement
           |   CompoundStatement
           |    Statements
@@ -964,11 +924,9 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
           |             MandatoryParameter
           |              age
           |           )
-          |          Separators
           |          BodyStatement
           |           CompoundStatement
           |          end
-          |    Separators
           |  end""".stripMargin
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionTests.scala
@@ -363,7 +363,6 @@ class MethodDefinitionTests extends RubyParserAbstractTest {
             |      VariableIdentifier
             |       e
             |    ThenClause
-            |     Separators
             |     CompoundStatement
             |  end""".stripMargin
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ModuleTests.scala
@@ -15,8 +15,7 @@ class ModuleTests extends RubyParserAbstractTest {
             |  Bar
             | BodyStatement
             |  CompoundStatement
-            |   Separators
-            |    ;
+            |   ;
             | end""".stripMargin
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ModuleTests.scala
@@ -1,0 +1,25 @@
+package io.joern.rubysrc2cpg.parser
+
+class ModuleTests extends RubyParserAbstractTest {
+
+  "Empty module definition" should {
+
+    "be parsed as a definition" when {
+
+      "defined in a single line" in {
+        val code = """module Bar; end"""
+        printAst(_.moduleDefinition(), code) shouldEqual
+          """ModuleDefinition
+            | module
+            | ClassOrModuleReference
+            |  Bar
+            | BodyStatement
+            |  CompoundStatement
+            |   Separators
+            |    ;
+            | end""".stripMargin
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionTests.scala
@@ -29,10 +29,9 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  DoBlockBlock
             |   DoBlock
             |    do
-            |    Separators
-            |     ;
             |    BodyStatement
             |     CompoundStatement
+            |      ;
             |    end""".stripMargin
       }
 
@@ -45,7 +44,17 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  DoBlockBlock
             |   DoBlock
             |    do
-            |    1
+            |    BodyStatement
+            |     CompoundStatement
+            |      Statements
+            |       ExpressionOrCommandStatement
+            |        ExpressionExpressionOrCommand
+            |         PrimaryExpression
+            |          LiteralPrimary
+            |           NumericLiteralLiteral
+            |            NumericLiteral
+            |             UnsignedNumericLiteral
+            |              1
             |    end""".stripMargin
       }
 
@@ -84,10 +93,9 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  DoBlockBlock
             |   DoBlock
             |    do
-            |    Separators
-            |     ;
             |    BodyStatement
             |     CompoundStatement
+            |      ;
             |    end""".stripMargin
       }
 
@@ -140,10 +148,9 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |  DoBlockBlock
             |   DoBlock
             |    do
-            |    Separators
-            |     ;
             |    BodyStatement
             |     CompoundStatement
+            |      ;
             |    end""".stripMargin
       }
 
@@ -183,8 +190,7 @@ class ProcDefinitionTests extends RubyParserAbstractTest {
             |                VariableIdentifierVariableReference
             |                 VariableIdentifier
             |                  x
-            |       Separators
-            |        ;
+            |       ;
             |       ExpressionOrCommandStatement
             |        InvocationExpressionOrCommand
             |         SingleCommandOnlyInvocationWithoutParentheses

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -153,7 +153,6 @@ class RegexTests extends RubyParserAbstractTest {
               |          VariableIdentifierVariableReference
               |           VariableIdentifier
               |            bar
-              |     Separators
               |  end""".stripMargin
       }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RegexTests.scala
@@ -131,7 +131,6 @@ class RegexTests extends RubyParserAbstractTest {
               |     VariableIdentifierVariableReference
               |      VariableIdentifier
               |       foo
-              |  Separators
               |  WhenClause
               |   when
               |   WhenArgument
@@ -143,7 +142,6 @@ class RegexTests extends RubyParserAbstractTest {
               |        ^ch_
               |        /
               |   ThenClause
-              |    Separators
               |    CompoundStatement
               |     Statements
               |      ExpressionOrCommandStatement
@@ -191,7 +189,6 @@ class RegexTests extends RubyParserAbstractTest {
               |            value
               |      )
               |  ThenClause
-              |   Separators
               |   CompoundStatement
               |  end""".stripMargin
         }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
@@ -35,7 +35,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |          NumericLiteral
             |           UnsignedNumericLiteral
             |            0
-            |   Separators
             |  RescueClause
             |   rescue
             |   ExceptionClass
@@ -71,10 +70,9 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |    MethodIdentifier
             |     foo
             | MethodParameterPart
-            | Separators
-            |  ;
             | BodyStatement
             |  CompoundStatement
+            |   ;
             |   Statements
             |    ExpressionOrCommandStatement
             |     ExpressionExpressionOrCommand
@@ -92,7 +90,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |          NumericLiteral
             |           UnsignedNumericLiteral
             |            0
-            |   Separators
             |  RescueClause
             |   rescue
             |   ExceptionClass
@@ -144,7 +141,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |         VariableIdentifier
             |          y
             |       |
-            |      Separators
             |      BodyStatement
             |       CompoundStatement
             |        Statements
@@ -163,7 +159,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |               NumericLiteral
             |                UnsignedNumericLiteral
             |                 0
-            |        Separators
             |       RescueClause
             |        rescue
             |        ExceptionClass

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RescueClauseTests.scala
@@ -49,7 +49,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |     VariableIdentifier
             |      e
             |   ThenClause
-            |    Separators
             |    CompoundStatement
             | end""".stripMargin
       }
@@ -104,7 +103,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |     VariableIdentifier
             |      e
             |   ThenClause
-            |    Separators
             |    CompoundStatement
             | end""".stripMargin
       }
@@ -173,7 +171,6 @@ class RescueClauseTests extends RubyParserAbstractTest {
             |          VariableIdentifier
             |           e
             |        ThenClause
-            |         Separators
             |         CompoundStatement
             |      end""".stripMargin
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
@@ -23,7 +23,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |      VariableIdentifier
             |       foo
             |  ThenClause
-            |   Separators
             |   CompoundStatement
             |    Statements
             |     ExpressionOrCommandStatement
@@ -53,8 +52,7 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |      VariableIdentifier
             |       foo
             |  ThenClause
-            |   Separators
-            |    ;
+            |   ;
             |   CompoundStatement
             |    Statements
             |     ExpressionOrCommandStatement

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/UnlessConditionTests.scala
@@ -33,7 +33,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |         VariableIdentifierVariableReference
             |          VariableIdentifier
             |           bar
-            |    Separators
             |  end""".stripMargin
       }
 
@@ -65,7 +64,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |         VariableIdentifierVariableReference
             |          VariableIdentifier
             |           bar
-            |    Separators
             |  end""".stripMargin
       }
 
@@ -97,7 +95,6 @@ class UnlessConditionTests extends RubyParserAbstractTest {
             |         VariableIdentifierVariableReference
             |          VariableIdentifier
             |           bar
-            |    Separators
             |  end""".stripMargin
       }
     }


### PR DESCRIPTION
* `separators` has been in-place replaced by its definition, since we don't care for them in the resulting AST.
* Fixed a couple of previously-mandatory `NL` that shouldn't be.
* `compoundStatement` now includes leading/trailing separators, so that rules that rely on it don't have to include them all the time as well.
* Replaced usages of `NL*` by `NL?` since the lexer already merges contiguous `NL` together.