### PR TITLE
[rubysrc2cpg] Handle Conditional `next` as Conditional Return

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/dotgenerator/DotAstGeneratorTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/dotgenerator/DotAstGeneratorTests.scala
@@ -32,7 +32,7 @@ class DotAstGeneratorTests extends CCodeToCpgSuite {
       inside(cpg.method.name("my_func").dotAst.l) { case List(x) =>
         x should (
           startWith("digraph \"my_func\"") and
-            include("""[label = <(CONTROL_STRUCTURE,if (y &gt; 42),if (y &gt; 42))<SUB>5</SUB>> ]""") and
+            include("""[label = <(CONTROL_STRUCTURE,IF,if (y &gt; 42))<SUB>5</SUB>> ]""") and
             endWith("}\n")
         )
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -6,8 +6,7 @@ import io.joern.rubysrc2cpg.utils.PackageContext
 import io.joern.x2cpg.Ast.storeInDiffGraph
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
 import io.joern.x2cpg.datastructures.{Global, Scope}
-import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, Defines as XDefines}
-import io.joern.x2cpg.ValidationMode
+import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, ValidationMode, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.antlr.v4.runtime.tree.TerminalNode
@@ -927,8 +926,9 @@ class AstCreator(
           )
       }
     case ctx: NextArgsInvocationWithoutParenthesesContext =>
-      // failing test case. Exception:  Only jump labels and integer literals are currently supported for continue statements.
-      // this overlaps with the problem if returning a value from a block
+      /*
+       * While this is a `CONTINUE` for now, if we detect that this is the LHS of an `IF` then this becomes a `RETURN`
+       */
       val node = NewControlStructure()
         .controlStructureType(ControlStructureTypes.CONTINUE)
         .lineNumber(ctx.NEXT().getSymbol.getLine)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -3,24 +3,13 @@ package io.joern.rubysrc2cpg.astcreation
 import better.files.File
 import io.joern.rubysrc2cpg.parser.RubyParser.*
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
 import io.joern.x2cpg.Imports.createImportNodeAndLink
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  NewBlock,
-  NewCall,
-  NewControlStructure,
-  NewIdentifier,
-  NewImport,
-  NewLiteral,
-  NewMethod,
-  NewMethodRef,
-  NewNode,
-  NewReturn
-}
-import org.slf4j.LoggerFactory
 import org.antlr.v4.runtime.ParserRuleContext
+import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -65,7 +54,14 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     val lhs    = astForStatement(ctx.statement(0))
     val rhs    = astForStatement(ctx.statement(1)).headOption
     val ifNode = controlStructureNode(ctx, ControlStructureTypes.IF, ctx.getText)
-    controlStructureAst(ifNode, rhs, lhs)
+    lhs.headOption.flatMap(_.root) match
+      // If the LHS is a `next` command, then this if statement is its condition and it becomes a `return`
+      case Some(x: NewControlStructure) if x.code == Defines.ModifierNext =>
+        val children = lhs.head.nodes.filterNot(_ == x).map(Ast.apply)
+        val retNode  = NewReturn().code(Defines.ModifierNext).lineNumber(x.lineNumber).columnNumber(x.columnNumber)
+        val retAst   = Ast(retNode).withChildren(children)
+        controlStructureAst(ifNode, rhs, Seq(retAst))
+      case _ => controlStructureAst(ifNode, rhs, lhs)
   }
 
   protected def astForUnlessModifierStatement(ctx: ModifierStatementContext): Ast = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -7,8 +7,6 @@ import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 import overflowdb.SchemaViolationException
 
-import scala.util.{Failure, Success, Try}
-
 case class AstEdge(src: NewNode, dst: NewNode)
 
 enum ValidationMode {
@@ -220,10 +218,13 @@ case class Ast(
   }
 
   /** Returns a deep copy of the sub tree rooted in `node`. If `order` is set, then the `order` and `argumentIndex`
-    * fields of the new root node are set to `order`.
+    * fields of the new root node are set to `order`. If `replacementNode` is set, then this replaces `node` in the new
+    * copy.
     */
-  def subTreeCopy(node: AstNodeNew, argIndex: Int = -1): Ast = {
-    val newNode = node.copy
+  def subTreeCopy(node: AstNodeNew, argIndex: Int = -1, replacementNode: Option[AstNodeNew] = None): Ast = {
+    val newNode = replacementNode match
+      case Some(n) => n
+      case None    => node.copy
     if (argIndex != -1) {
       // newNode.order = argIndex
       newNode match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.PropertyNames
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.utils.MemberAccess
 
 import java.util.Optional
@@ -64,6 +64,7 @@ object DotSerializer {
     val maybeLineNo: Optional[AnyRef] = vertex.propertyOption(PropertyNames.LINE_NUMBER)
     escape(vertex match {
       case call: Call                            => (call.name, call.code).toString
+      case contrl: ControlStructure              => (contrl.label, contrl.controlStructureType, contrl.code).toString()
       case expr: Expression                      => (expr.label, expr.code, toCfgNode(expr).code).toString
       case method: Method                        => (method.label, method.name).toString
       case ret: MethodReturn                     => (ret.label, ret.typeFullName).toString


### PR DESCRIPTION
* Added control structure type to dot visualizer
* Check if an if-statement `lhs` is a `next` command with return values, if this is the case, convert it to a conditional return instead
* Extended `Ast.subTreeCopy` to be able to replace the root node with a given node. This is used to replace the `ControlStructure(next)` with a `Return`

Fixes invalid AST due to `CONTINUE` having a non-integer child literal. Note this always assumes a return when this pattern is detected, though this is likely a reasonable assumption.