### PR TITLE
[rubysrc2cpg] Fix Returns on all Statements in Block-Helper

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -162,16 +162,12 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
           .flatMap(stCtx => {
             stmtCounter += 1
             if (isMethodBody) {
-              if (stmtCounter == stmtCount) {
-                processingLastMethodStatement = true
-              } else {
-                processingLastMethodStatement = false
-              }
+              processingLastMethodStatement = stmtCounter == stmtCount
             }
             val stAsts = astForStatement(stCtx)
-            if (stAsts.size > 0 && canConsiderAsLeaf && processingLastMethodStatement) {
+            if (stAsts.nonEmpty && canConsiderAsLeaf && processingLastMethodStatement) {
               blockChildHash.get(myBlockId) match {
-                case Some(value) =>
+                case Some(_) =>
                   // this is a non-leaf block
                   stAsts
                 case None =>
@@ -401,7 +397,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
         ).head
       case None =>
         val blockNode_    = blockNode(ctx, ctx.getText, Defines.Any)
-        val blockBodyAst  = astForCompoundStatement(compoundStmtCtx)
+        val blockBodyAst  = astForCompoundStatement(compoundStmtCtx, true)
         val blockParamAst = blockParamCtx.flatMap(astForBlockParameterContext)
         blockAst(blockNode_, blockBodyAst.toList ++ blockParamAst)
     }


### PR DESCRIPTION
It was observed that in code such as
```ruby
      define_method name do
        value = public_send("#{name}_value")
        unit = public_send("#{name}_unit")

        raise ArgumentError, "Invalid unit '#{INFINITY_UNIT}'" if !allow_infinite && unit == INFINITY_UNIT

        next Float::INFINITY if unit == INFINITY_UNIT

        next unless value.present? && unit.present?
        value.public_send(unit)
      end
 ```
Each statement was treated as a return statement. This breaks much of the CFG logic. Seems it was mostly a simple fix on how block helper compound statements were constructed.
 
#### Examples
[Original AST](https://dreampuf.github.io/GraphvizOnline/#digraph%20%22%22%20%7B%20%20%0A%2216%22%20%5Blabel%20%3D%20%3C(TYPE_DECL%2CApplicationRecord)%3E%20%5D%0A%2217%22%20%5Blabel%20%3D%20%3C(METHOD%2C%26lt%3Bclinit%26gt%3B)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2218%22%20%5Blabel%20%3D%20%3C(BLOCK%2C%26lt%3Bempty%26gt%3B%2C%26lt%3Bempty%26gt%3B)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2219%22%20%5Blabel%20%3D%20%3C(%26lt%3Boperator%26gt%3B.assignment%2C%3D)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2220%22%20%5Blabel%20%3D%20%3C(%26lt%3Boperator%26gt%3B.fieldAccess%2C%26lt%3Boperator%26gt%3B.fieldAccess)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2221%22%20%5Blabel%20%3D%20%3C(IDENTIFIER%2Cself%2C%3D)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2222%22%20%5Blabel%20%3D%20%3C(IDENTIFIER%2Cabstract_class%2C%3D)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2223%22%20%5Blabel%20%3D%20%3C(LITERAL%2Ctrue%2C%3D)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2224%22%20%5Blabel%20%3D%20%3C(%26lt%3Boperator%26gt%3B.assignment%2C%3D)%3CSUB%3E6%3C%2FSUB%3E%3E%20%5D%0A%2225%22%20%5Blabel%20%3D%20%3C(IDENTIFIER%2CINFINITY_UNIT%2C%3D)%3CSUB%3E6%3C%2FSUB%3E%3E%20%5D%0A%2226%22%20%5Blabel%20%3D%20%3C(LITERAL%2C%26quot%3Binfinite%26quot%3B%2C%3D)%3CSUB%3E6%3C%2FSUB%3E%3E%20%5D%0A%2227%22%20%5Blabel%20%3D%20%3C(METHOD_RETURN%2CANY)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2228%22%20%5Blabel%20%3D%20%3C(MEMBER%2CINFINITY_UNIT)%3CSUB%3E6%3C%2FSUB%3E%3E%20%5D%0A%2229%22%20%5Blabel%20%3D%20%3C(MODIFIER%2CVIRTUAL)%3E%20%5D%0A%2230%22%20%5Blabel%20%3D%20%3C(METHOD%2Cwith_duration)%3CSUB%3E8%3C%2FSUB%3E%3E%20%5D%0A%223%22%20%5Blabel%20%3D%20%3C(PARAM%2Cname)%3CSUB%3E8%3C%2FSUB%3E%3E%20%5D%0A%227%22%20%5Blabel%20%3D%20%3C(PARAM%2Callow_infinite)%3CSUB%3E8%3C%2FSUB%3E%3E%20%5D%0A%2231%22%20%5Blabel%20%3D%20%3C(BLOCK%2C%26lt%3Bempty%26gt%3B%2C%26lt%3Bempty%26gt%3B)%3E%20%5D%0A%2232%22%20%5Blabel%20%3D%20%3C(define_method%2Cdefine_method%20name%20do%5C012%20%20%20%20%20%20%20%20value%20%3D%20public_send(%26quot%3B%23%7Bname%7D_value%26quot%3B)%5C012%20%20%20%20%20%20%20%20unit%20%3D%20public_send(%26quot%3B%23%7Bname%7D_unit%26quot%3B)%5C012%5C012%20%20%20%20%20%20%20%20raise%20ArgumentError%2C%20%26quot%3BInvalid%20unit%20'%23%7BINFINITY_UNIT%7D'%26quot%3B%20if%20!allow_infinite%20%26amp%3B%26amp%3B%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20Float%3A%3AINFINITY%20if%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20unless%20value.present%3F%20%26amp%3B%26amp%3B%20unit.present%3F%5C012%20%20%20%20%20%20%20%20value.public_send(unit)%5C012%20%20%20%20%20%20end)%3CSUB%3E9%3C%2FSUB%3E%3E%20%5D%0A%222%22%20%5Blabel%20%3D%20%3C(IDENTIFIER%2Cname%2C%26lt%3Bempty%26gt%3B)%3CSUB%3E9%3C%2FSUB%3E%3E%20%5D%0A%2233%22%20%5Blabel%20%3D%20%3C(BLOCK%2Cdo%5C012%20%20%20%20%20%20%20%20value%20%3D%20public_send(%26quot%3B%23%7Bname%7D_value%26quot%3B)%5C012%20%20%20%20%20%20%20%20unit%20%3D%20public_send(%26quot%3B%23%7Bname%7D_unit%26quot%3B)%5C012%5C012%20%20%20%20%20%20%20%20raise%20ArgumentError%2C%20%26quot%3BInvalid%20unit%20'%23%7BINFINITY_UNIT%7D'%26quot%3B%20if%20!allow_infinite%20%26amp%3B%26amp%3B%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20Float%3A%3AINFINITY%20if%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20unless%20value.present%3F%20%26amp%3B%26amp%3B%20unit.present%3F%5C012%20%20%20%20%20%20%20%20value.public_send(unit)%5C012%20%20%20%20%20%20end%2Cdo%5C012%20%20%20%20%20%20%20%20value%20%3D%20public_send(%26quot%3B%23%7Bname%7D_value%26quot%3B)%5C012%20%20%20%20%20%20%20%20unit%20%3D%20public_send(%26quot%3B%23%7Bname%7D_unit%26quot%3B)%5C012%5C012%20%20%20%20%20%20%20%20raise%20ArgumentError%2C%20%26quot%3BInvalid%20unit%20'%23%7BINFINITY_UNIT%7D'%26quot%3B%20if%20!allow_infinite%20%26amp%3B%26amp%3B%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20Float%3A%3AINFINITY%20if%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20unless%20value.present%3F%20%26amp%3B%26amp%3B%20unit.present%3F%5C012%20%20%20%20%20%20%20%20value.public_send(unit)%5C012%20%20%20%20%20%20end)%3C)
[Fixed AST](https://dreampuf.github.io/GraphvizOnline/#digraph%20%22%22%20%7B%20%20%0A%2216%22%20%5Blabel%20%3D%20%3C(TYPE_DECL%2CApplicationRecord)%3E%20%5D%0A%2217%22%20%5Blabel%20%3D%20%3C(METHOD%2C%26lt%3Bclinit%26gt%3B)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2218%22%20%5Blabel%20%3D%20%3C(BLOCK%2C%26lt%3Bempty%26gt%3B%2C%26lt%3Bempty%26gt%3B)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2219%22%20%5Blabel%20%3D%20%3C(%26lt%3Boperator%26gt%3B.assignment%2C%3D)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2220%22%20%5Blabel%20%3D%20%3C(%26lt%3Boperator%26gt%3B.fieldAccess%2C%26lt%3Boperator%26gt%3B.fieldAccess)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2221%22%20%5Blabel%20%3D%20%3C(IDENTIFIER%2Cself%2C%3D)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2222%22%20%5Blabel%20%3D%20%3C(IDENTIFIER%2Cabstract_class%2C%3D)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2223%22%20%5Blabel%20%3D%20%3C(LITERAL%2Ctrue%2C%3D)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2224%22%20%5Blabel%20%3D%20%3C(%26lt%3Boperator%26gt%3B.assignment%2C%3D)%3CSUB%3E6%3C%2FSUB%3E%3E%20%5D%0A%2225%22%20%5Blabel%20%3D%20%3C(IDENTIFIER%2CINFINITY_UNIT%2C%3D)%3CSUB%3E6%3C%2FSUB%3E%3E%20%5D%0A%2226%22%20%5Blabel%20%3D%20%3C(LITERAL%2C%26quot%3Binfinite%26quot%3B%2C%3D)%3CSUB%3E6%3C%2FSUB%3E%3E%20%5D%0A%2227%22%20%5Blabel%20%3D%20%3C(METHOD_RETURN%2CANY)%3CSUB%3E4%3C%2FSUB%3E%3E%20%5D%0A%2228%22%20%5Blabel%20%3D%20%3C(MEMBER%2CINFINITY_UNIT)%3CSUB%3E6%3C%2FSUB%3E%3E%20%5D%0A%2229%22%20%5Blabel%20%3D%20%3C(MODIFIER%2CVIRTUAL)%3E%20%5D%0A%2230%22%20%5Blabel%20%3D%20%3C(METHOD%2Cwith_duration)%3CSUB%3E8%3C%2FSUB%3E%3E%20%5D%0A%223%22%20%5Blabel%20%3D%20%3C(PARAM%2Cname)%3CSUB%3E8%3C%2FSUB%3E%3E%20%5D%0A%227%22%20%5Blabel%20%3D%20%3C(PARAM%2Callow_infinite)%3CSUB%3E8%3C%2FSUB%3E%3E%20%5D%0A%2231%22%20%5Blabel%20%3D%20%3C(BLOCK%2C%26lt%3Bempty%26gt%3B%2C%26lt%3Bempty%26gt%3B)%3E%20%5D%0A%2232%22%20%5Blabel%20%3D%20%3C(define_method%2Cdefine_method%20name%20do%5C012%20%20%20%20%20%20%20%20value%20%3D%20public_send(%26quot%3B%23%7Bname%7D_value%26quot%3B)%5C012%20%20%20%20%20%20%20%20unit%20%3D%20public_send(%26quot%3B%23%7Bname%7D_unit%26quot%3B)%5C012%5C012%20%20%20%20%20%20%20%20raise%20ArgumentError%2C%20%26quot%3BInvalid%20unit%20'%23%7BINFINITY_UNIT%7D'%26quot%3B%20if%20!allow_infinite%20%26amp%3B%26amp%3B%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20Float%3A%3AINFINITY%20if%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20unless%20value.present%3F%20%26amp%3B%26amp%3B%20unit.present%3F%5C012%20%20%20%20%20%20%20%20value.public_send(unit)%5C012%20%20%20%20%20%20end)%3CSUB%3E9%3C%2FSUB%3E%3E%20%5D%0A%222%22%20%5Blabel%20%3D%20%3C(IDENTIFIER%2Cname%2C%26lt%3Bempty%26gt%3B)%3CSUB%3E9%3C%2FSUB%3E%3E%20%5D%0A%2233%22%20%5Blabel%20%3D%20%3C(BLOCK%2Cdo%5C012%20%20%20%20%20%20%20%20value%20%3D%20public_send(%26quot%3B%23%7Bname%7D_value%26quot%3B)%5C012%20%20%20%20%20%20%20%20unit%20%3D%20public_send(%26quot%3B%23%7Bname%7D_unit%26quot%3B)%5C012%5C012%20%20%20%20%20%20%20%20raise%20ArgumentError%2C%20%26quot%3BInvalid%20unit%20'%23%7BINFINITY_UNIT%7D'%26quot%3B%20if%20!allow_infinite%20%26amp%3B%26amp%3B%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20Float%3A%3AINFINITY%20if%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20unless%20value.present%3F%20%26amp%3B%26amp%3B%20unit.present%3F%5C012%20%20%20%20%20%20%20%20value.public_send(unit)%5C012%20%20%20%20%20%20end%2Cdo%5C012%20%20%20%20%20%20%20%20value%20%3D%20public_send(%26quot%3B%23%7Bname%7D_value%26quot%3B)%5C012%20%20%20%20%20%20%20%20unit%20%3D%20public_send(%26quot%3B%23%7Bname%7D_unit%26quot%3B)%5C012%5C012%20%20%20%20%20%20%20%20raise%20ArgumentError%2C%20%26quot%3BInvalid%20unit%20'%23%7BINFINITY_UNIT%7D'%26quot%3B%20if%20!allow_infinite%20%26amp%3B%26amp%3B%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20Float%3A%3AINFINITY%20if%20unit%20%3D%3D%20INFINITY_UNIT%5C012%5C012%20%20%20%20%20%20%20%20next%20unless%20value.present%3F%20%26amp%3B%26amp%3B%20unit.present%3F%5C012%20%20%20%20%20%20%20%20value.public_send(unit)%5C012%20%20%20%20%20%20end)%3C)