### PR TITLE
[gosrc2cpg] - pending items for method node

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 gosrc2cpg {
-    goastgen_version: "0.6.1"
+    goastgen_version: "0.9.0"
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -32,6 +32,13 @@ trait AstCreatorHelper { this: AstCreator =>
         val node  = nodeType(json)
         val pni   = ParserNodeInfo(node, json, c, ln, cn, lnEnd, cnEnd)
         parserNodeCache.addOne(json(ParserKeys.NodeId).num.toLong, pni)
+        node match
+          case CallExpr =>
+            json(ParserKeys.Fun)(ParserKeys.Obj).objOpt.map(obj => {
+              createParserNodeInfo(obj(ParserKeys.Decl))
+            })
+          case _ =>
+        // Do nothing
         pni
       case Success(nodeReferenceId) => parserNodeCache(nodeReferenceId)
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -23,7 +23,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   ): Ast = {
 
     val parentNode: NewTypeDecl = methodAstParentStack.collectFirst { case t: NewTypeDecl => t }.getOrElse {
-      // TODO: Need to add respective Unit test to test this possibility, as looks to me as dead code. Replicated it from 'c2cpg' by referring AstForFunctionsCreator.
+      // TODO: Need to add respective Unit test to test this possibility, as looks to me as dead code.
+      //  Replicated it from 'c2cpg' by referring AstForFunctionsCreator.
       val astParentType     = methodAstParentStack.head.label
       val astParentFullName = methodAstParentStack.head.properties(PropertyNames.FULL_NAME).toString
       val typeDeclNode_ =

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -89,6 +89,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
               typeFullName
             )
             index += 1
+            scope.addToScope(paramName, (parameterNode, typeFullName))
             Ast(parameterNode)
           })
       )

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
@@ -98,4 +98,5 @@ object ParserKeys {
   val Elt             = "Elt"
   val Sel             = "Sel"
   val Elts            = "Elts"
+  val Fun             = "Fun"
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -1400,6 +1400,7 @@ class MethodTests extends GoCodeToCpgSuite {
       argv.name shouldBe "argv"
     }
   }
+
   // TODO: Add unit test for tuple return
   // TODO: Add unit tests with Generics
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -37,6 +37,51 @@ class MethodTests extends GoCodeToCpgSuite {
     }
   }
 
+  "Method called from another method first in the code" should {
+    val cpg = code("""
+        |package main
+        |func foo() {
+        |  bar()
+        |}
+        |func bar() {
+        |}
+        |""".stripMargin)
+
+    "Be correct with method node properties" in {
+      val List(x) = cpg.method.name("foo").l
+      x.name shouldBe "foo"
+      x.fullName shouldBe "main.foo"
+      x.code should startWith("func foo() {")
+      x.signature shouldBe "main.foo ()"
+      x.isExternal shouldBe false
+      x.astParentType shouldBe NodeTypes.TYPE_DECL
+      x.astParentFullName shouldBe "Test0.go:main.<global>"
+      x.order shouldBe 1
+      x.filename shouldBe "Test0.go"
+      x.lineNumber shouldBe Option(3)
+      x.lineNumberEnd shouldBe Option(5)
+
+      val List(y) = cpg.method.name("bar").l
+      y.name shouldBe "bar"
+      y.fullName shouldBe "main.bar"
+      y.code should startWith("func bar() {")
+      y.signature shouldBe "main.bar ()"
+      y.isExternal shouldBe false
+      y.astParentType shouldBe NodeTypes.TYPE_DECL
+      y.astParentFullName shouldBe "Test0.go:main.<global>"
+      y.order shouldBe 2
+      y.filename shouldBe "Test0.go"
+      y.lineNumber shouldBe Option(6)
+      y.lineNumberEnd shouldBe Option(7)
+    }
+
+    "check binding Node" in {
+      val List(x) = cpg.method.name("foo").bindingTypeDecl.l
+      x.name shouldBe "main.<global>"
+      x.fullName shouldBe "Test0.go:main.<global>"
+    }
+  }
+
   "Method arguments with primitive types" should {
     val cpg = code("""
                      |package main

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -317,6 +317,59 @@ class MethodTests extends GoCodeToCpgSuite {
     }
   }
 
+  "Method arguments with primitive pointer to pointer" should {
+    val cpg = code("""
+        |package main
+        |func foo(argc int, argv **string) {
+        |}
+        |""".stripMargin)
+
+    "Be correct with method node properties" ignore {
+      val List(x) = cpg.method.name("foo").l
+      x.name shouldBe "foo"
+      x.fullName shouldBe "main.foo"
+      x.code should startWith("func foo(argc int, argv **string)")
+      // TODO: pointer to pointer use cae need to be hanled
+      x.signature shouldBe "main.foo (int, **string)"
+      x.isExternal shouldBe false
+      x.astParentType shouldBe NodeTypes.TYPE_DECL
+      x.astParentFullName shouldBe "Test0.go:main.<global>"
+      x.order shouldBe 1
+      x.filename shouldBe "Test0.go"
+      x.lineNumber shouldBe Option(3)
+      x.lineNumberEnd shouldBe Option(4)
+    }
+
+    "be correct for parameter nodes" ignore {
+      cpg.parameter.name.l shouldBe List("argc", "argv")
+      val List(argc) = cpg.parameter.name("argc").l
+      argc.code shouldBe "argc int"
+      argc.order shouldBe 1
+      argc.typeFullName shouldBe "int"
+      argc.isVariadic shouldBe false
+      argc.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
+
+      val List(argv) = cpg.parameter.name("argv").l
+      argv.code shouldBe "argv **string"
+      argv.order shouldBe 2
+      // TODO: pointer to pointer use cae need to be hanled
+      argv.typeFullName shouldBe "**string"
+      argv.isVariadic shouldBe false
+      argv.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
+    }
+
+    "traversing from parameter to method" in {
+      cpg.parameter.name("argc").method.name.l shouldBe List("foo")
+      cpg.parameter.name("argv").method.name.l shouldBe List("foo")
+    }
+
+    "traversing from method to parameter" in {
+      val List(argc, argv) = cpg.method.name("foo").parameter.l
+      argc.name shouldBe "argc"
+      argv.name shouldBe "argv"
+    }
+  }
+
   "Method arguments with array of primitive pointer" should {
     val cpg = code("""
         |package main
@@ -1239,7 +1292,69 @@ class MethodTests extends GoCodeToCpgSuite {
       argd.name shouldBe "argd"
     }
   }
-  // TODO: Add pointer to pointer use case.
+
+  "struct type argument from third party dependency imported as . " should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package main
+        |import . "privado.ai/test/fpkg"
+        |func foo(argc int, argv Sample) {
+        |}
+        |""".stripMargin,
+      "main.go"
+    )
+
+    "Be correct with method node properties" ignore {
+      val List(x) = cpg.method.name("foo").l
+      x.name shouldBe "foo"
+      x.fullName shouldBe "main.foo"
+      x.code should startWith("func foo(argc int, argv Sample)")
+      // TODO: wrong methodfull name being genearted when the packaged is imported with '.'
+      x.signature shouldBe "main.foo (int, privado.ai/test/fpkg.Sample)"
+      x.isExternal shouldBe false
+      x.astParentType shouldBe NodeTypes.TYPE_DECL
+      x.astParentFullName shouldBe "main.go:main.<global>"
+      x.order shouldBe 2
+      x.filename shouldBe "main.go"
+      x.lineNumber shouldBe Option(4)
+      x.lineNumberEnd shouldBe Option(5)
+    }
+
+    "be correct for parameter nodes" ignore {
+      cpg.parameter.name.l shouldBe List("argc", "argv")
+      val List(argc) = cpg.parameter.name("argc").l
+      argc.code shouldBe "argc int"
+      argc.order shouldBe 1
+      argc.typeFullName shouldBe "int"
+      argc.isVariadic shouldBe false
+      argc.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
+
+      val List(argv) = cpg.parameter.name("argv").l
+      argv.code shouldBe "argv Sample"
+      argv.order shouldBe 2
+      // TODO: wrong methodfull name being genearted when the packaged is imported with '.'
+      argv.typeFullName shouldBe "privado.ai/test/fpkg.Sample"
+      argv.isVariadic shouldBe false
+      argv.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
+    }
+
+    "traversing from parameter to method" in {
+      cpg.parameter.name("argc").method.name.l shouldBe List("foo")
+      cpg.parameter.name("argv").method.name.l shouldBe List("foo")
+    }
+
+    "traversing from method to parameter" in {
+      val List(argc, argv) = cpg.method.name("foo").parameter.l
+      argc.name shouldBe "argc"
+      argv.name shouldBe "argv"
+    }
+  }
   // TODO: Add unit test for tuple return
   // TODO: Add unit tests with Generics
 }


### PR DESCRIPTION
1. Added unit test in ignore state for use case a. Pointer to pointer parameter type handling is not done b. struct paramter imported from external package with `.` alias.
2. Addition of parameter node to `scope`. 
3. Handling for use case function is being called before it has been declared in the same file. `goastgen` will create a `FuncDecl` inside `CallExp` being created for the method call and refer this `node_id` from the place `FuncDecl` is declared. Have added respective unit tests for the same.
4. Upgraded `goastgen` to new `0.8.0` to pickup parallel process changes done in it.
5. Handled some past review comments by David 