### PR TITLE
[pysrc2cpg] Change Type Inference Test Expectation

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -457,7 +457,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       )
     }
 
-    "correctly determine that, despite being unable to resolve the correct method full name, that it is an internal method" in {
+    "make no assumption that, despite the file being internal, that unless the entity is resolved, it is external" in {
       val Some(selfFindFound) = cpg.typeDecl(".*InstallationsDAO.*").ast.isCall.name("find_one").headOption: @unchecked
       selfFindFound.callee.isExternal.toSeq shouldBe Seq(true, true)
     }


### PR DESCRIPTION
As a follow-up on this PR https://github.com/joernio/joern/pull/3544 I investigated the claim of the unresolved method being intended as labelled `isExternal=false`.

I think it's likely a dangerous assumption to have in the first place with a path that has as many dummy access paths as the test had. I'm happy to keep the expectation to be `isExternal=true.`