### PR TITLE
Fix javasrc unresolved lambda parameter types

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2675,7 +2675,7 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
       .zipWithIndex
       .map { case ((param, maybeType), idx) =>
         val name         = param.getNameAsString
-        val typeFullName = maybeType.getOrElse(s"${Defines.UnresolvedNamespace}")
+        val typeFullName = maybeType.getOrElse(TypeConstants.Any)
         val code         = s"$typeFullName $name"
         val evalStrat =
           if (param.getType.isPrimitiveType) EvaluationStrategies.BY_VALUE else EvaluationStrategies.BY_SHARING

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -17,6 +17,20 @@ import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.jIteratortoTraversal
 
 class LambdaTests extends JavaSrcCode2CpgFixture {
+  "unresolved lambda parameters should have an ANY type" in {
+    val cpg = code("""
+        |public class Test {
+        |  public void method() {
+        |    unresolvedCall().foreach(lambdaParam -> {
+        |       foo(lambdaParam);
+        |    });
+        |  }
+        |}
+        |""".stripMargin)
+
+    cpg.call.name("foo").argument.collectAll[Identifier].name("lambdaParam").typeFullName.toList shouldBe List("ANY")
+  }
+
   "nested lambdas" should {
     val cpg = code("""
         |import java.util.ArrayList;


### PR DESCRIPTION
`<unresolvedNamespace>` should only be used in method full names. When a local/param type can't be resolved, it should be `ANY` instead.

This also fixes https://github.com/joernio/joern/issues/3552