### PR TITLE
Don't re-throw javasrc astcreator errors to allow working files to be added to the ast

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -291,11 +291,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     } catch {
       case t: UnsolvedSymbolException =>
         logger.error(s"Unsolved symbol exception caught in $filename")
-        throw t
+        Ast()
       case t: Throwable =>
         logger.error(s"Parsing file $filename failed with $t")
         logger.error(s"Caused by ${t.getCause}")
-        throw t
+        Ast()
     }
   }
 


### PR DESCRIPTION
Currently any crashes would result in an empty cpg, even when the ast for some files could be created correctly. This PR changes this behaviour to allow scanning projects with some broken source files.