### PR TITLE
[gosrc2cpg] - Simple return node handling

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -97,7 +97,7 @@ class AstCreator(val relPathFileName: String, val parserResult: ParserResult)(im
   }
 
   protected def astForEmptyArrayInitializer(primitive: ParserNodeInfo): Ast = {
-    val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(primitive.json)
+    val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(primitive)
     Ast(
       callNode(
         primitive,

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -176,22 +176,21 @@ trait AstCreatorHelper { this: AstCreator =>
     }
   }
 
-  protected def processTypeInfo(jsonNode: Value): (String, String, Boolean, String) = {
-    val nodeInfo = createParserNodeInfo(jsonNode)
+  protected def processTypeInfo(nodeInfo: ParserNodeInfo): (String, String, Boolean, String) = {
     nodeInfo.node match {
       case ArrayType =>
         val (fullName, typeNameForcode, evaluationStrategy) = internalStarExpHandler(
-          createParserNodeInfo(jsonNode.obj(ParserKeys.Elt))
+          createParserNodeInfo(nodeInfo.json(ParserKeys.Elt))
         )
         (s"[]$fullName", s"[]$typeNameForcode", false, evaluationStrategy)
       case CompositeLit =>
         val (fullName, typeNameForcode, evaluationStrategy) = internalStarExpHandler(
-          createParserNodeInfo(jsonNode.obj(ParserKeys.Type)(ParserKeys.Elt))
+          createParserNodeInfo(nodeInfo.json(ParserKeys.Type)(ParserKeys.Elt))
         )
         (s"[]$fullName", s"[]$typeNameForcode", false, evaluationStrategy)
       case Ellipsis =>
         val (fullName, typeNameForcode, evaluationStrategy) = internalStarExpHandler(
-          createParserNodeInfo(jsonNode.obj(ParserKeys.Elt))
+          createParserNodeInfo(nodeInfo.json(ParserKeys.Elt))
         )
         (s"[]$fullName", s"...$typeNameForcode", true, evaluationStrategy)
       case _ =>

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -3,7 +3,6 @@ package io.joern.gosrc2cpg.astcreation
 import io.joern.gosrc2cpg.parser.ParserAst.{BlockStmt, Ellipsis, Ident, SelectorExpr}
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.utils.StringUtils
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.PropertyNames
@@ -12,6 +11,7 @@ import ujson.Value
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.util.{Failure, Success, Try}
 
 trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
   private def createFunctionTypeAndTypeDecl(
@@ -44,21 +44,24 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val name     = funcDecl.json(ParserKeys.Name).obj(ParserKeys.Name).str
     val fullname = s"${fullyQualifiedPackage}.${name}"
     // TODO: handle multiple return type or tuple (int, int)
-    val returnType     = getReturnType(funcDecl.json(ParserKeys.Type)).headOption.getOrElse("")
+    val (returnTypeStr, methodReturn) =
+      getReturnType(funcDecl.json(ParserKeys.Type)).headOption
+        .getOrElse(("", methodReturnNode(funcDecl, Defines.voidTypeName)))
     val templateParams = ""
     val params         = funcDecl.json(ParserKeys.Type)(ParserKeys.Params)(ParserKeys.List)
     val signature =
-      s"$fullname$templateParams (${parameterSignature(params)})$returnType"
+      s"$fullname$templateParams(${parameterSignature(params)})$returnTypeStr"
 
     val methodNode_ = methodNode(funcDecl, name, funcDecl.code, fullname, Some(signature), filename)
     methodAstParentStack.push(methodNode_)
     scope.pushNewScope(methodNode_)
-    val astForMethod = methodAst(
-      methodNode_,
-      astForMethodParameter(params),
-      astForMethodBody(funcDecl.json(ParserKeys.Body)),
-      newMethodReturnNode(returnType, None, line(funcDecl), column(funcDecl))
-    )
+    val astForMethod =
+      methodAst(
+        methodNode_,
+        astForMethodParameter(params),
+        astForMethodBody(funcDecl.json(ParserKeys.Body)),
+        methodReturn
+      )
     scope.popScope()
     methodAstParentStack.pop()
     val typeDeclAst = createFunctionTypeAndTypeDecl(funcDecl, methodNode_, name, fullname, signature)
@@ -71,7 +74,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       .getOrElse(List())
       .flatMap(x =>
         val typeInfo = createParserNodeInfo(x(ParserKeys.Type))
-        val (typeFullName, typeFullNameForcode, isVariadic, evaluationStrategy) = processTypeInfo(typeInfo.json)
+        val (typeFullName, typeFullNameForcode, isVariadic, evaluationStrategy) = processTypeInfo(typeInfo)
         x(ParserKeys.Names).arrOpt
           .getOrElse(List())
           .map(y => {
@@ -102,7 +105,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       .getOrElse(ArrayBuffer())
       .map(x =>
         val typeInfo                                           = createParserNodeInfo(x(ParserKeys.Type))
-        val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeInfo.json)
+        val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeInfo)
         x(ParserKeys.Names).arrOpt
           .getOrElse(List())
           .map(_ => {
@@ -114,10 +117,18 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       .mkString(", ")
   }
 
-  private def getReturnType(methodTypes: Value): Seq[String] = {
-    if (methodTypes.obj.contains(ParserKeys.Results))
-      methodTypes(ParserKeys.Results)(ParserKeys.List).arr.map(x => x(ParserKeys.Type)(ParserKeys.Name))
-    Seq()
+  private def getReturnType(methodTypes: Value): Seq[(String, NewMethodReturn)] = {
+    Try(methodTypes(ParserKeys.Results)) match
+      case Success(returnType) =>
+        returnType(ParserKeys.List).arrOpt
+          .getOrElse(List())
+          .map(x => {
+            val typeInfo                                           = createParserNodeInfo(x(ParserKeys.Type))
+            val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeInfo)
+            (typeFullName, methodReturnNode(typeInfo, typeFullName))
+          })
+          .toSeq
+      case Failure(exception) => Seq.empty
   }
 
   def astForMethodBody(body: Value): Ast = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -122,11 +122,11 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       case Success(returnType) =>
         returnType(ParserKeys.List).arrOpt
           .getOrElse(List())
-          .map(x => {
+          .map(x =>
             val typeInfo                                           = createParserNodeInfo(x(ParserKeys.Type))
             val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeInfo)
             (typeFullName, methodReturnNode(typeInfo, typeFullName))
-          })
+          )
           .toSeq
       case Failure(exception) => Seq.empty
   }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
@@ -81,7 +81,7 @@ trait AstForGenDeclarationCreator(implicit withSchemaValidation: ValidationMode)
       val localParserNode = createParserNodeInfo(parserNode)
 
       val name                                               = parserNode(ParserKeys.Name).str
-      val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeJson)
+      val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeInfoNode)
       val node = localNode(localParserNode, name, localParserNode.code, typeFullName)
       scope.addToScope(name, (node, typeFullName))
       Ast(node)

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -150,7 +150,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo() (fpkg.Sample,error){")
-      // TODO: Touple handling needs to be done properly to return both the types.
+      // TODO: Tuple handling needs to be done properly to return both the types.
       x.signature shouldBe "main.foo()(joern.io/sample/fpkg.Sample,error)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
@@ -164,7 +164,7 @@ class MethodTests extends GoCodeToCpgSuite {
     "Be correct with return node" in {
       cpg.method.name("foo").methodReturn.size shouldBe 1
       val List(x) = cpg.method.name("foo").methodReturn.l
-      // TODO: Touple handling needs to be done properly to return both the types.
+      // TODO: Tuple handling needs to be done properly to return both the types.
       x.typeFullName shouldBe "joern.io/sample/fpkg.Sample"
     }
   }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -67,16 +67,74 @@ class MethodTests extends GoCodeToCpgSuite {
       x.lineNumberEnd shouldBe Option(5)
     }
 
-    "check binding Node" in {
-      val List(x) = cpg.method.name("foo").bindingTypeDecl.l
-      x.name shouldBe "main.<global>"
-      x.fullName shouldBe "Test0.go:main.<global>"
+    "Be correct with return node" in {
+      cpg.method.name("foo").methodReturn.size shouldBe 1
+      val List(x) = cpg.method.name("foo").methodReturn.l
+      x.typeFullName shouldBe "int"
+    }
+  }
+
+  "Empty parameters with struct type return" should {
+    val cpg = code("""
+        |package main
+        |import "joern.io/sample/fpkg"
+        |func foo() fpkg.Sample{
+        |  return nil
+        |}
+        |""".stripMargin)
+
+    "Be correct with method node properties" in {
+      val List(x) = cpg.method.name("foo").l
+      x.name shouldBe "foo"
+      x.fullName shouldBe "main.foo"
+      x.code should startWith("func foo() fpkg.Sample{")
+      x.signature shouldBe "main.foo()joern.io/sample/fpkg.Sample"
+      x.isExternal shouldBe false
+      x.astParentType shouldBe NodeTypes.TYPE_DECL
+      x.astParentFullName shouldBe "Test0.go:main.<global>"
+      x.order shouldBe 2
+      x.filename shouldBe "Test0.go"
+      x.lineNumber shouldBe Option(4)
+      x.lineNumberEnd shouldBe Option(6)
     }
 
     "Be correct with return node" in {
       cpg.method.name("foo").methodReturn.size shouldBe 1
       val List(x) = cpg.method.name("foo").methodReturn.l
-      x.typeFullName shouldBe "int"
+      x.typeFullName shouldBe "joern.io/sample/fpkg.Sample"
+    }
+  }
+
+  "Empty parameters with tuple return" should {
+    val cpg = code("""
+        |package main
+        |import "joern.io/sample/fpkg"
+        |func foo() (fpkg.Sample,error){
+        |  return nil
+        |}
+        |""".stripMargin)
+
+    "Be correct with method node properties" ignore {
+      val List(x) = cpg.method.name("foo").l
+      x.name shouldBe "foo"
+      x.fullName shouldBe "main.foo"
+      x.code should startWith("func foo() (fpkg.Sample,error){")
+      // TODO: Touple handling needs to be done properly to return both the types.
+      x.signature shouldBe "main.foo()(joern.io/sample/fpkg.Sample,error)"
+      x.isExternal shouldBe false
+      x.astParentType shouldBe NodeTypes.TYPE_DECL
+      x.astParentFullName shouldBe "Test0.go:main.<global>"
+      x.order shouldBe 2
+      x.filename shouldBe "Test0.go"
+      x.lineNumber shouldBe Option(4)
+      x.lineNumberEnd shouldBe Option(6)
+    }
+
+    "Be correct with return node" in {
+      cpg.method.name("foo").methodReturn.size shouldBe 1
+      val List(x) = cpg.method.name("foo").methodReturn.l
+      // TODO: Touple handling needs to be done properly to return both the types.
+      x.typeFullName shouldBe "joern.io/sample/fpkg.Sample"
     }
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -74,6 +74,37 @@ class MethodTests extends GoCodeToCpgSuite {
     }
   }
 
+  "Empty parameters with int array return" should {
+    val cpg = code("""
+        |package main
+        |func foo() [5]int {
+        |	a := [5]int{1, 2}
+        |	return a
+        |}
+        |""".stripMargin)
+
+    "Be correct with method node properties" in {
+      val List(x) = cpg.method.name("foo").l
+      x.name shouldBe "foo"
+      x.fullName shouldBe "main.foo"
+      x.code should startWith("func foo() [5]int {")
+      x.signature shouldBe "main.foo()[]int"
+      x.isExternal shouldBe false
+      x.astParentType shouldBe NodeTypes.TYPE_DECL
+      x.astParentFullName shouldBe "Test0.go:main.<global>"
+      x.order shouldBe 1
+      x.filename shouldBe "Test0.go"
+      x.lineNumber shouldBe Option(3)
+      x.lineNumberEnd shouldBe Option(6)
+    }
+
+    "Be correct with return node" in {
+      cpg.method.name("foo").methodReturn.size shouldBe 1
+      val List(x) = cpg.method.name("foo").methodReturn.l
+      x.typeFullName shouldBe "[]int"
+    }
+  }
+
   "Empty parameters with struct type return" should {
     val cpg = code("""
         |package main

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -1,6 +1,7 @@
 package io.joern.go2cpg.passes.ast
 
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.joern.gosrc2cpg.astcreation.Defines
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes}
 import io.shiftleft.semanticcpg.language.*
 
@@ -8,7 +9,7 @@ import java.io.File
 
 class MethodTests extends GoCodeToCpgSuite {
 
-  "Empty parameters" should {
+  "Empty parameters with no return" should {
     val cpg = code("""
         |package main
         |func foo() {
@@ -20,7 +21,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo() {")
-      x.signature shouldBe "main.foo ()"
+      x.signature shouldBe "main.foo()"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -34,6 +35,48 @@ class MethodTests extends GoCodeToCpgSuite {
       val List(x) = cpg.method.name("foo").bindingTypeDecl.l
       x.name shouldBe "main.<global>"
       x.fullName shouldBe "Test0.go:main.<global>"
+    }
+
+    "check empty return node" in {
+      cpg.method.name("foo").methodReturn.size shouldBe 1
+      val List(x) = cpg.method.name("foo").methodReturn.l
+      x.typeFullName shouldBe Defines.voidTypeName
+    }
+  }
+
+  "Empty parameters with int return" should {
+    val cpg = code("""
+        |package main
+        |func foo() int{
+        |  return 0
+        |}
+        |""".stripMargin)
+
+    "Be correct with method node properties" in {
+      val List(x) = cpg.method.name("foo").l
+      x.name shouldBe "foo"
+      x.fullName shouldBe "main.foo"
+      x.code should startWith("func foo()")
+      x.signature shouldBe "main.foo()int"
+      x.isExternal shouldBe false
+      x.astParentType shouldBe NodeTypes.TYPE_DECL
+      x.astParentFullName shouldBe "Test0.go:main.<global>"
+      x.order shouldBe 1
+      x.filename shouldBe "Test0.go"
+      x.lineNumber shouldBe Option(3)
+      x.lineNumberEnd shouldBe Option(5)
+    }
+
+    "check binding Node" in {
+      val List(x) = cpg.method.name("foo").bindingTypeDecl.l
+      x.name shouldBe "main.<global>"
+      x.fullName shouldBe "Test0.go:main.<global>"
+    }
+
+    "Be correct with return node" in {
+      cpg.method.name("foo").methodReturn.size shouldBe 1
+      val List(x) = cpg.method.name("foo").methodReturn.l
+      x.typeFullName shouldBe "int"
     }
   }
 
@@ -52,7 +95,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo() {")
-      x.signature shouldBe "main.foo ()"
+      x.signature shouldBe "main.foo()"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -65,7 +108,7 @@ class MethodTests extends GoCodeToCpgSuite {
       y.name shouldBe "bar"
       y.fullName shouldBe "main.bar"
       y.code should startWith("func bar() {")
-      y.signature shouldBe "main.bar ()"
+      y.signature shouldBe "main.bar()"
       y.isExternal shouldBe false
       y.astParentType shouldBe NodeTypes.TYPE_DECL
       y.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -94,7 +137,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv string)")
-      x.signature shouldBe "main.foo (int, string)"
+      x.signature shouldBe "main.foo(int, string)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -145,7 +188,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc, arga int, argv string)")
-      x.signature shouldBe "main.foo (int, int, string)"
+      x.signature shouldBe "main.foo(int, int, string)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -205,7 +248,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc, arga int, argv ...string)")
-      x.signature shouldBe "main.foo (int, int, []string)"
+      x.signature shouldBe "main.foo(int, int, []string)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -264,7 +307,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc, arga int, argv []int)")
-      x.signature shouldBe "main.foo (int, int, []int)"
+      x.signature shouldBe "main.foo(int, int, []int)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -323,7 +366,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv *string)")
-      x.signature shouldBe "main.foo (int, *string)"
+      x.signature shouldBe "main.foo(int, *string)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -375,7 +418,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv **string)")
       // TODO: pointer to pointer use cae need to be hanled
-      x.signature shouldBe "main.foo (int, **string)"
+      x.signature shouldBe "main.foo(int, **string)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -427,7 +470,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv []*string)")
-      x.signature shouldBe "main.foo (int, []*string)"
+      x.signature shouldBe "main.foo(int, []*string)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -478,7 +521,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv ...*string)")
-      x.signature shouldBe "main.foo (int, []*string)"
+      x.signature shouldBe "main.foo(int, []*string)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -529,7 +572,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv *[]string)")
-      x.signature shouldBe "main.foo (int, *[]string)"
+      x.signature shouldBe "main.foo(int, *[]string)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -583,7 +626,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv Sample)")
-      x.signature shouldBe "main.foo (int, main.Sample)"
+      x.signature shouldBe "main.foo(int, main.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -651,7 +694,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv Sample)")
-      x.signature shouldBe "main.foo (int, main.Sample)"
+      x.signature shouldBe "main.foo(int, main.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -717,7 +760,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "joern.io/sample.foo"
       x.code should startWith("func foo(argc int, argv Sample)")
-      x.signature shouldBe "joern.io/sample.foo (int, joern.io/sample.Sample)"
+      x.signature shouldBe "joern.io/sample.foo(int, joern.io/sample.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:joern.io/sample.<global>"
@@ -784,7 +827,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv fpkg.Sample)")
-      x.signature shouldBe "main.foo (int, joern.io/sample/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, joern.io/sample/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -853,7 +896,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv ...fpkg.Sample)")
-      x.signature shouldBe "main.foo (int, []joern.io/sample/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, []joern.io/sample/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -914,7 +957,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv fpkg.Sample)")
-      x.signature shouldBe "main.foo (int, privado.ai/test/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -975,7 +1018,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv []fpkg.Sample)")
-      x.signature shouldBe "main.foo (int, []privado.ai/test/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, []privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -1036,7 +1079,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv *fpkg.Sample)")
-      x.signature shouldBe "main.foo (int, *privado.ai/test/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, *privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -1097,7 +1140,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv []*fpkg.Sample)")
-      x.signature shouldBe "main.foo (int, []*privado.ai/test/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, []*privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -1158,7 +1201,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv *[]fpkg.Sample)")
-      x.signature shouldBe "main.foo (int, *[]privado.ai/test/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, *[]privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -1219,7 +1262,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.name shouldBe "foo"
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv ...*fpkg.Sample)")
-      x.signature shouldBe "main.foo (int, []*privado.ai/test/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, []*privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"
@@ -1272,7 +1315,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.code should startWith(
         "func foo(argc any, argv interface{}, arga []interface{}, argb *interface{}, argd ...interface{})"
       )
-      x.signature shouldBe "main.foo (any, any, []any, *any, []any)"
+      x.signature shouldBe "main.foo(any, any, []any, *any, []any)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "Test0.go:main.<global>"
@@ -1361,7 +1404,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.fullName shouldBe "main.foo"
       x.code should startWith("func foo(argc int, argv Sample)")
       // TODO: wrong methodfull name being genearted when the packaged is imported with '.'
-      x.signature shouldBe "main.foo (int, privado.ai/test/fpkg.Sample)"
+      x.signature shouldBe "main.foo(int, privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
       x.astParentType shouldBe NodeTypes.TYPE_DECL
       x.astParentFullName shouldBe "main.go:main.<global>"


### PR DESCRIPTION
1. MethodReturn Node handling for single return type.
2. Refactored the code around `processTypeInfo` method.
3. Also removed unwanted white space between method name and `(` while generting the method signature. Made changes in unit tests to adjust to this change.

TODO:
1. Need to work on tuple handling.