### PR TITLE
kotlin2cpg: deprecation fix: pattern match

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
@@ -514,10 +514,8 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val explicitTypeName = Option(expr.getTypeReference).map(_.getText).getOrElse(TypeConstants.any)
     val elem             = expr.getIdentifyingElement
 
-    val hasRHSCtorCall = expr.getDelegateExpressionOrInitializer match {
-      case typed: KtExpression => typeInfoProvider.isConstructorCall(typed).getOrElse(false)
-      case _                   => false
-    }
+    val hasRHSCtorCall =
+      Option(expr.getDelegateExpressionOrInitializer).flatMap(typeInfoProvider.isConstructorCall).getOrElse(false)
     val ctorCallExprMaybe =
       if (hasRHSCtorCall) {
         expr.getDelegateExpressionOrInitializer match {


### PR DESCRIPTION
```
[warn] -- [E121] Pattern Match Warning:
/home/mp/Projects/shiftleft/joern/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala:519:11
[warn] 519 |      case _                   => false
[warn]     |           ^
[warn]     |Unreachable case except for null (if this is intentional,
consider writing case null => instead).
```