### PR TITLE
gosrc2cpg: structure support

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -25,6 +25,7 @@ class AstCreator(val relPathFileName: String, val parserResult: ParserResult)(im
     with AstForFunctionsCreator
     with AstForPrimitivesCreator
     with AstForStatementsCreator
+    with AstForStructuresCreator
     with X2CpgAstNodeBuilder[ParserNodeInfo, AstCreator] {
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
@@ -27,10 +27,10 @@ trait AstForExpressionCreator(implicit withSchemaValidation: ValidationMode) { t
     field.node match
       case Field => {
         val typeInfo = createParserNodeInfo(field.json(ParserKeys.Type))
-        val (typeFullName, typeFullNameForcode, isVariadic, evaluationStrategy) = processTypeInfo(typeInfo)
+        val (typeFullName, typeFullNameForCode, isVariadic, evaluationStrategy) = processTypeInfo(typeInfo)
         val fieldNodeInfo = createParserNodeInfo(field.json(ParserKeys.Names).arr.head)
         val fieldName     = fieldNodeInfo.json(ParserKeys.Name).str
-        Ast(memberNode(typeInfo, fieldName, s"${fieldName} ${typeFullNameForcode}", typeFullName, Seq()))
+        Ast(memberNode(typeInfo, fieldName, s"$fieldName $typeFullNameForCode", typeFullName, Seq()))
       }
       case _ => {
         Ast()

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
@@ -21,20 +21,7 @@ trait AstForExpressionCreator(implicit withSchemaValidation: ValidationMode) { t
     }
   }
 
-  protected def astForStructType(expr: ParserNodeInfo): Seq[Ast] = {
-    astForFieldList(createParserNodeInfo(expr.json(ParserKeys.Fields)))
-  }
-
-  private def astForFieldList(fieldList: ParserNodeInfo): Seq[Ast] = {
-    fieldList
-      .json(ParserKeys.List)
-      .arr
-      .map(createParserNodeInfo)
-      .map(astForField)
-      .toSeq
-  }
-
-  private def astForField(field: ParserNodeInfo): Ast = {
+  protected def astForField(field: ParserNodeInfo): Ast = {
     field.node match
       case Field => {
         val typeInfo = createParserNodeInfo(field.json(ParserKeys.Type))

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
@@ -21,24 +21,27 @@ trait AstForExpressionCreator(implicit withSchemaValidation: ValidationMode) { t
     }
   }
 
-  private def astForStructType(expr: ParserNodeInfo): Seq[Ast] = {
-    val fieldListAsts = astForFieldList(createParserNodeInfo(expr.json(ParserKeys.Fields)))
-    Seq(Ast())
+  protected def astForStructType(expr: ParserNodeInfo): Seq[Ast] = {
+    astForFieldList(createParserNodeInfo(expr.json(ParserKeys.Fields)))
   }
 
   private def astForFieldList(fieldList: ParserNodeInfo): Seq[Ast] = {
-    val fieldAsts = fieldList
+    fieldList
       .json(ParserKeys.List)
       .arr
       .map(createParserNodeInfo)
       .map(astForField)
-    Seq(Ast())
+      .toSeq
   }
 
   private def astForField(field: ParserNodeInfo): Ast = {
     field.node match
       case Field => {
-        Ast()
+        val typeInfo = createParserNodeInfo(field.json(ParserKeys.Type))
+        val (typeFullName, typeFullNameForcode, isVariadic, evaluationStrategy) = processTypeInfo(typeInfo)
+        val fieldNodeInfo = createParserNodeInfo(field.json(ParserKeys.Names).arr.head)
+        val fieldName     = fieldNodeInfo.json(ParserKeys.Name).str
+        Ast(memberNode(typeInfo, fieldName, s"${fieldName} ${typeFullNameForcode}", typeFullName, Seq()))
       }
       case _ => {
         Ast()

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
@@ -27,41 +27,6 @@ trait AstForGenDeclarationCreator(implicit withSchemaValidation: ValidationMode)
       .toSeq
   }
 
-  private def astForTypeSpec(typeSpecNode: ParserNodeInfo): Seq[Ast] = {
-    // TODO: Add support for member variables and methods
-    Option(typeSpecNode) match {
-      case Some(typeSpec) =>
-        val nameNode          = typeSpec.json(ParserKeys.Name)
-        val typeNode          = createParserNodeInfo(typeSpec.json(ParserKeys.Type))
-        val a: NewTypeDecl    = methodAstParentStack.collectFirst { case t: NewTypeDecl => t }.get
-        val astParentType     = a.label
-        val astParentFullName = a.fullName
-        val fullName          = nameNode(ParserKeys.Name).str // TODO: Discuss fullName structure
-        val typeDeclNode_ =
-          typeDeclNode(
-            typeSpec,
-            nameNode(ParserKeys.Name).str,
-            fullName,
-            parserResult.filename,
-            typeSpec.code,
-            astParentType,
-            astParentFullName
-          )
-
-        methodAstParentStack.push(typeDeclNode_)
-        scope.pushNewScope(typeDeclNode_)
-        val memberAsts = astForStructType(typeNode)
-
-        methodAstParentStack.pop()
-        scope.popScope()
-
-        val modifier = addModifier(typeDeclNode_, nameNode(ParserKeys.Name).str)
-        Seq(Ast(typeDeclNode_).withChild(Ast(modifier)).withChildren(memberAsts.toSeq))
-      case None =>
-        Seq.empty
-    }
-  }
-
   private def astForImport(nodeInfo: ParserNodeInfo): Seq[Ast] = {
     val basicLit       = createParserNodeInfo(nodeInfo.json(ParserKeys.Path))
     val importedEntity = nodeInfo.json(ParserKeys.Path).obj(ParserKeys.Value).str.replaceAll("\"", "")

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
@@ -60,7 +60,8 @@ trait AstForStructuresCreator(implicit withSchemaValidation: ValidationMode) { t
   private def astForFieldList(fieldList: ParserNodeInfo): Seq[Ast] = {
     fieldList
       .json(ParserKeys.List)
-      .arrOpt.getOrElse(List())
+      .arrOpt
+      .getOrElse(List())
       .map(createParserNodeInfo)
       .map(astForField)
       .toSeq

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
@@ -18,12 +18,12 @@ trait AstForStructuresCreator(implicit withSchemaValidation: ValidationMode) { t
   def astForTypeSpec(typeSpecNode: ParserNodeInfo): Seq[Ast] = {
     // TODO: Add support for member variables and methods
     methodAstParentStack.collectFirst { case t: NewTypeDecl => t } match {
-      case Some(methodAstNode) =>
+      case Some(parentMethodAstNode) =>
         val nameNode = typeSpecNode.json(ParserKeys.Name)
         val typeNode = createParserNodeInfo(typeSpecNode.json(ParserKeys.Type))
 
-        val astParentType     = methodAstNode.label
-        val astParentFullName = methodAstNode.fullName
+        val astParentType     = parentMethodAstNode.label
+        val astParentFullName = parentMethodAstNode.fullName
         val fullName          = nameNode(ParserKeys.Name).str // TODO: Discuss fullName structure
         val typeDeclNode_ =
           typeDeclNode(

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
@@ -19,9 +19,12 @@ trait AstForStructuresCreator(implicit withSchemaValidation: ValidationMode) { t
     // TODO: Add support for member variables and methods
     Option(typeSpecNode) match {
       case Some(typeSpec) =>
-        val nameNode          = typeSpec.json(ParserKeys.Name)
-        val typeNode          = createParserNodeInfo(typeSpec.json(ParserKeys.Type))
-        val a: NewTypeDecl    = methodAstParentStack.collectFirst { case t: NewTypeDecl => t }.get
+        val nameNode = typeSpec.json(ParserKeys.Name)
+        val typeNode = createParserNodeInfo(typeSpec.json(ParserKeys.Type))
+        val a = methodAstParentStack.collectFirst { case t: NewTypeDecl => t } match {
+          case Some(value) => value
+          case None        => NewTypeDecl()
+        }
         val astParentType     = a.label
         val astParentFullName = a.fullName
         val fullName          = nameNode(ParserKeys.Name).str // TODO: Discuss fullName structure

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
@@ -1,0 +1,65 @@
+package io.joern.gosrc2cpg.astcreation
+
+import io.joern.x2cpg.ValidationMode
+import io.joern.gosrc2cpg.parser.ParserAst.*
+import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
+import io.joern.x2cpg
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
+import ujson.Value
+import io.joern.x2cpg.datastructures.Stack.StackWrapper
+import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
+
+import scala.util.Try
+
+trait AstForStructuresCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+
+  def astForTypeSpec(typeSpecNode: ParserNodeInfo): Seq[Ast] = {
+    // TODO: Add support for member variables and methods
+    Option(typeSpecNode) match {
+      case Some(typeSpec) =>
+        val nameNode          = typeSpec.json(ParserKeys.Name)
+        val typeNode          = createParserNodeInfo(typeSpec.json(ParserKeys.Type))
+        val a: NewTypeDecl    = methodAstParentStack.collectFirst { case t: NewTypeDecl => t }.get
+        val astParentType     = a.label
+        val astParentFullName = a.fullName
+        val fullName          = nameNode(ParserKeys.Name).str // TODO: Discuss fullName structure
+        val typeDeclNode_ =
+          typeDeclNode(
+            typeSpec,
+            nameNode(ParserKeys.Name).str,
+            fullName,
+            parserResult.filename,
+            typeSpec.code,
+            astParentType,
+            astParentFullName
+          )
+
+        methodAstParentStack.push(typeDeclNode_)
+        scope.pushNewScope(typeDeclNode_)
+        val memberAsts = astForStructType(typeNode)
+
+        methodAstParentStack.pop()
+        scope.popScope()
+
+        val modifier = addModifier(typeDeclNode_, nameNode(ParserKeys.Name).str)
+        Seq(Ast(typeDeclNode_).withChild(Ast(modifier)).withChildren(memberAsts.toSeq))
+      case None =>
+        Seq.empty
+    }
+  }
+
+  protected def astForStructType(expr: ParserNodeInfo): Seq[Ast] = {
+    astForFieldList(createParserNodeInfo(expr.json(ParserKeys.Fields)))
+  }
+
+  private def astForFieldList(fieldList: ParserNodeInfo): Seq[Ast] = {
+    fieldList
+      .json(ParserKeys.List)
+      .arr
+      .map(createParserNodeInfo)
+      .map(astForField)
+      .toSeq
+  }
+
+}

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
@@ -9,6 +9,7 @@ import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Opera
 import ujson.Value
 import io.joern.x2cpg.datastructures.Stack.StackWrapper
 import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
+import scala.util.{Failure, Success, Try}
 
 import scala.util.Try
 
@@ -50,13 +51,16 @@ trait AstForStructuresCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   protected def astForStructType(expr: ParserNodeInfo): Seq[Ast] = {
-    astForFieldList(createParserNodeInfo(expr.json(ParserKeys.Fields)))
+    Try(expr.json(ParserKeys.Fields)) match
+      case Success(fields) if fields != null =>
+        astForFieldList(createParserNodeInfo(fields))
+      case _ => Seq.empty
   }
 
   private def astForFieldList(fieldList: ParserNodeInfo): Seq[Ast] = {
     fieldList
       .json(ParserKeys.List)
-      .arr
+      .arrOpt.getOrElse(List())
       .map(createParserNodeInfo)
       .map(astForField)
       .toSeq

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStructuresCreator.scala
@@ -17,24 +17,21 @@ trait AstForStructuresCreator(implicit withSchemaValidation: ValidationMode) { t
 
   def astForTypeSpec(typeSpecNode: ParserNodeInfo): Seq[Ast] = {
     // TODO: Add support for member variables and methods
-    Option(typeSpecNode) match {
-      case Some(typeSpec) =>
-        val nameNode = typeSpec.json(ParserKeys.Name)
-        val typeNode = createParserNodeInfo(typeSpec.json(ParserKeys.Type))
-        val a = methodAstParentStack.collectFirst { case t: NewTypeDecl => t } match {
-          case Some(value) => value
-          case None        => NewTypeDecl()
-        }
-        val astParentType     = a.label
-        val astParentFullName = a.fullName
+    methodAstParentStack.collectFirst { case t: NewTypeDecl => t } match {
+      case Some(methodAstNode) =>
+        val nameNode = typeSpecNode.json(ParserKeys.Name)
+        val typeNode = createParserNodeInfo(typeSpecNode.json(ParserKeys.Type))
+
+        val astParentType     = methodAstNode.label
+        val astParentFullName = methodAstNode.fullName
         val fullName          = nameNode(ParserKeys.Name).str // TODO: Discuss fullName structure
         val typeDeclNode_ =
           typeDeclNode(
-            typeSpec,
+            typeSpecNode,
             nameNode(ParserKeys.Name).str,
             fullName,
             parserResult.filename,
-            typeSpec.code,
+            typeSpecNode.code,
             astParentType,
             astParentFullName
           )
@@ -48,9 +45,9 @@ trait AstForStructuresCreator(implicit withSchemaValidation: ValidationMode) { t
 
         val modifier = addModifier(typeDeclNode_, nameNode(ParserKeys.Name).str)
         Seq(Ast(typeDeclNode_).withChild(Ast(modifier)).withChildren(memberAsts.toSeq))
-      case None =>
-        Seq.empty
+      case None => Seq.empty
     }
+
   }
 
   protected def astForStructType(expr: ParserNodeInfo): Seq[Ast] = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
@@ -25,7 +25,7 @@ object ParserAst {
   object BlockStmt  extends BaseStmt
   object DeclStmt   extends BaseStmt
   object ValueSpec  extends ParserNode
-  object Ident      extends BasePrimitive
+  object Ident      extends ParserNode
   object AssignStmt extends BaseStmt
   object ExprStmt   extends BaseStmt
   object BinaryExpr extends BaseExpr

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
@@ -37,7 +37,7 @@ object ParserAst {
   object LabeledStmt         extends BaseStmt
   sealed trait BasePrimitive extends ParserNode
   object BasicLit            extends BasePrimitive
-  object Ident               extends ParserNode
+  object Ident               extends BasePrimitive
   object CompositeLit        extends BasePrimitive
   object File                extends ParserNode
   object GenDecl             extends ParserNode

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForStructureTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForStructureTests.scala
@@ -1,0 +1,46 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
+import scala.collection.immutable.List
+
+class ASTCreationForStructureTests extends GoCodeToCpgSuite {
+  "AST Creation for structures" should {
+    "structure with single element" in {
+
+      val cpg = code("""
+          package main
+          |
+          |type Person struct {
+          |    Name string
+          |}
+  """.stripMargin)
+      cpg.typeDecl.name("Person").size shouldBe 1
+      cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
+      cpg.typeDecl.name("Person").member.size shouldBe 1
+      cpg.typeDecl("Person").member.name("Name").size shouldBe 1
+    }
+
+    "structure with multiple element" in {
+
+      val cpg = code("""
+          package main
+          |
+          |type Person struct {
+          |    Name string
+          |    Age  int
+          |}
+  """.stripMargin)
+      cpg.typeDecl.name("Person").size shouldBe 1
+      cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
+      cpg.typeDecl.name("Person").member.size shouldBe 2
+      cpg.typeDecl("Person").member.name("Name").size shouldBe 1
+      cpg.typeDecl("Person").member.name("Age").size shouldBe 1
+    }
+  }
+}

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForStructureTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForStructureTests.scala
@@ -48,7 +48,7 @@ class ASTCreationForStructureTests extends GoCodeToCpgSuite {
       cpg.typeDecl("Person").member.name("Age").typeFullName.head shouldBe "int"
     }
 
-    "structure with element of type anaother structure" in {
+    "structure with element of type another structure" in {
 
       val cpg = code("""
           package main

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForStructureTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForStructureTests.scala
@@ -10,26 +10,31 @@ import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import scala.collection.immutable.List
 
 class ASTCreationForStructureTests extends GoCodeToCpgSuite {
-  "AST Creation for structures" should {
-    "structure with single element" in {
 
-      val cpg = code("""
+  "structure with single element" should {
+
+    val cpg = code("""
           package main
           |
           |type Person struct {
           |    Name string
           |}
   """.stripMargin)
-      cpg.typeDecl.name("Person").size shouldBe 1
-      cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
-      cpg.typeDecl.name("Person").member.size shouldBe 1
-      cpg.typeDecl("Person").member.name("Name").size shouldBe 1
-      cpg.typeDecl("Person").member.name("Name").typeFullName.head shouldBe "string"
+    cpg.typeDecl.name("Person").size shouldBe 1
+    cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
+    cpg.typeDecl.name("Person").member.size shouldBe 1
+
+    "Check member node under type decl node" in {
+      val typeDeclNodes = cpg.typeDecl("Person").l
+      typeDeclNodes.member.name("Name").size shouldBe 1
+      typeDeclNodes.member.name("Name").typeFullName.head shouldBe "string"
+
     }
+  }
 
-    "structure with multiple element" in {
+  "structure with multiple element" should {
 
-      val cpg = code("""
+    val cpg = code("""
           package main
           |
           |type Person struct {
@@ -37,20 +42,27 @@ class ASTCreationForStructureTests extends GoCodeToCpgSuite {
           |    Age  int
           |}
   """.stripMargin)
-      cpg.typeDecl.name("Person").size shouldBe 1
-      cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
+    cpg.typeDecl.name("Person").size shouldBe 1
+    cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
+    cpg.typeDecl.name("Person").member.size shouldBe 2
 
-      cpg.typeDecl.name("Person").member.size shouldBe 2
-      cpg.typeDecl("Person").member.name("Name").size shouldBe 1
-
-      cpg.typeDecl("Person").member.name("Age").size shouldBe 1
-      cpg.typeDecl("Person").member.name("Name").typeFullName.head shouldBe "string"
-      cpg.typeDecl("Person").member.name("Age").typeFullName.head shouldBe "int"
+    "Check member node under type decl node" in {
+      val typeDeclNodes = cpg.typeDecl("Person").l
+      typeDeclNodes.member.name("Name").size shouldBe 1
+      typeDeclNodes.member.name("Age").size shouldBe 1
+      typeDeclNodes.member.name("Name").typeFullName.head shouldBe "string"
+      typeDeclNodes.member.name("Age").typeFullName.head shouldBe "int"
     }
 
-    "structure with element of type another structure" in {
+    "Traversing member node to typedecl node" in {
+      val typeDeclNode = cpg.member.name("Name").typeDecl.head
+      typeDeclNode.fullName shouldBe "Person"
+    }
+  }
 
-      val cpg = code("""
+  "structure with element of type another structure" should {
+
+    val cpg = code("""
           package main
           |
           |type Person struct {
@@ -63,24 +75,39 @@ class ASTCreationForStructureTests extends GoCodeToCpgSuite {
           |    Salary  int
           |}
   """.stripMargin)
-      cpg.typeDecl.name("Person").size shouldBe 1
-      cpg.typeDecl.name("Employee").size shouldBe 1
+    cpg.typeDecl.name("Person").size shouldBe 1
+    cpg.typeDecl.name("Employee").size shouldBe 1
 
-      cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
-      cpg.typeDecl.name("Employee").head.fullName shouldBe "Employee"
+    cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
+    cpg.typeDecl.name("Employee").head.fullName shouldBe "Employee"
 
-      cpg.typeDecl.name("Person").member.size shouldBe 2
-      cpg.typeDecl.name("Employee").member.size shouldBe 2
+    "Check member node under type decl node for Person typeDecl" in {
+      val personNode = cpg.typeDecl.name("Person").l
 
-      cpg.typeDecl("Person").member.name("Name").size shouldBe 1
-      cpg.typeDecl("Person").member.name("Age").size shouldBe 1
-      cpg.typeDecl("Employee").member.name("Salary").size shouldBe 1
-
-      cpg.typeDecl("Person").member.name("Name").typeFullName.head shouldBe "string"
-      cpg.typeDecl("Person").member.name("Age").typeFullName.head shouldBe "int"
-
-      cpg.typeDecl("Employee").member.name("Salary").typeFullName.head shouldBe "int"
-      cpg.typeDecl("Employee").member.name("person").typeFullName.head shouldBe "main.Person"
+      personNode.member.size shouldBe 2
+      personNode.member.name("Name").size shouldBe 1
+      personNode.member.name("Age").size shouldBe 1
+      personNode.member.name("Name").typeFullName.head shouldBe "string"
+      personNode.member.name("Age").typeFullName.head shouldBe "int"
     }
+
+    "Check member node under type decl node for Employee typeDecl" in {
+      val employeeNode = cpg.typeDecl("Employee").l
+      employeeNode.member.size shouldBe 2
+      employeeNode.member.name("Salary").size shouldBe 1
+      employeeNode.member.name("Salary").typeFullName.head shouldBe "int"
+      employeeNode.member.name("person").typeFullName.head shouldBe "main.Person"
+    }
+
+    "traverse from member node to typedecl node" in {
+      val memberNodes = cpg.member.l
+      memberNodes.name("person").typeDecl.head.fullName shouldBe "Employee"
+      memberNodes.name("Salary").typeDecl.head.fullName shouldBe "Employee"
+
+      memberNodes.name("Name").typeDecl.head.fullName shouldBe "Person"
+      memberNodes.name("Age").typeDecl.head.fullName shouldBe "Person"
+
+    }
+
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForStructureTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForStructureTests.scala
@@ -24,6 +24,7 @@ class ASTCreationForStructureTests extends GoCodeToCpgSuite {
       cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
       cpg.typeDecl.name("Person").member.size shouldBe 1
       cpg.typeDecl("Person").member.name("Name").size shouldBe 1
+      cpg.typeDecl("Person").member.name("Name").typeFullName.head shouldBe "string"
     }
 
     "structure with multiple element" in {
@@ -38,9 +39,48 @@ class ASTCreationForStructureTests extends GoCodeToCpgSuite {
   """.stripMargin)
       cpg.typeDecl.name("Person").size shouldBe 1
       cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
+
       cpg.typeDecl.name("Person").member.size shouldBe 2
       cpg.typeDecl("Person").member.name("Name").size shouldBe 1
+
       cpg.typeDecl("Person").member.name("Age").size shouldBe 1
+      cpg.typeDecl("Person").member.name("Name").typeFullName.head shouldBe "string"
+      cpg.typeDecl("Person").member.name("Age").typeFullName.head shouldBe "int"
+    }
+
+    "structure with element of type anaother structure" in {
+
+      val cpg = code("""
+          package main
+          |
+          |type Person struct {
+          |    Name string
+          |    Age  int
+          |}
+          |
+          |type Employee struct {
+          |    person Person
+          |    Salary  int
+          |}
+  """.stripMargin)
+      cpg.typeDecl.name("Person").size shouldBe 1
+      cpg.typeDecl.name("Employee").size shouldBe 1
+
+      cpg.typeDecl.name("Person").head.fullName shouldBe "Person"
+      cpg.typeDecl.name("Employee").head.fullName shouldBe "Employee"
+
+      cpg.typeDecl.name("Person").member.size shouldBe 2
+      cpg.typeDecl.name("Employee").member.size shouldBe 2
+
+      cpg.typeDecl("Person").member.name("Name").size shouldBe 1
+      cpg.typeDecl("Person").member.name("Age").size shouldBe 1
+      cpg.typeDecl("Employee").member.name("Salary").size shouldBe 1
+
+      cpg.typeDecl("Person").member.name("Name").typeFullName.head shouldBe "string"
+      cpg.typeDecl("Person").member.name("Age").typeFullName.head shouldBe "int"
+
+      cpg.typeDecl("Employee").member.name("Salary").typeFullName.head shouldBe "int"
+      cpg.typeDecl("Employee").member.name("person").typeFullName.head shouldBe "main.Person"
     }
   }
 }


### PR DESCRIPTION
Changes:
1. Added support for Go's structure.
2. Covered test cases having simple structure definition to complex(one structure used under another)