### PR TITLE
fix deprecation warnings in Test/compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ ThisBuild / compile / javacOptions ++= Seq(
 ThisBuild / scalacOptions ++= Seq(
   "-deprecation", // Emit warning and location for usages of deprecated APIs.
   "--release",
-  "11"
+  "11",
 )
 
 lazy val createDistribution = taskKey[File]("Create a complete Joern distribution")

--- a/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceLoaderTests.scala
+++ b/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceLoaderTests.scala
@@ -65,12 +65,6 @@ class WorkspaceLoaderTests extends AnyWordSpec with Matchers {
       jsonWrite(ProjectFile("foo", "aname")) shouldBe """{"inputPath":"foo","name":"aname"}"""
     }
 
-    "be deserializable from json" in {
-      val projectFile = jsonRead[ProjectFile]("""{"inputPath":"foo","name":"aname"}""")
-      projectFile.inputPath shouldBe "foo"
-      projectFile.name shouldBe "aname"
-    }
-
   }
 
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
@@ -156,9 +156,9 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
 
     "should contain a correctly lowered representation" in {
       val List(last: Return) =
-        cpg.method.nameExact("withFailListener").block.astChildren.l: @unchecked
+        cpg.method.nameExact("withFailListener").block.astChildren.isReturn.l
 
-      val List(c: Call) = last.astChildren.l: @unchecked
+      val List(c: Call) = last.astChildren.isCall.l
       c.methodFullName shouldBe "mypkg.PClass.addListener:void(mypkg.SomeInterface)"
       val List(objExpr: TypeDecl, l: Local, alloc: Call, init: Call, i: Identifier) =
         c.astChildren.isBlock.astChildren.l: @unchecked
@@ -187,7 +187,7 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
       val List(_: Local, last: Return) =
         cpg.method.nameExact("<lambda>").block.astChildren.l: @unchecked
 
-      val List(c: Call) = last.astChildren.l: @unchecked
+      val List(c: Call) = last.astChildren.isCall.l
       c.methodFullName shouldBe "mypkg.addListener:void(mypkg.SomeInterface)"
       val List(objExpr: TypeDecl, l: Local, alloc: Call, init: Call, i: Identifier) =
         c.astChildren.isBlock.astChildren.l: @unchecked

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
@@ -156,12 +156,12 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
 
     "should contain a correctly lowered representation" in {
       val List(last: Return) =
-        cpg.method.nameExact("withFailListener").block.astChildren.l
+        cpg.method.nameExact("withFailListener").block.astChildren.l: @unchecked
 
-      val List(c: Call) = last.astChildren.l
+      val List(c: Call) = last.astChildren.l: @unchecked
       c.methodFullName shouldBe "mypkg.PClass.addListener:void(mypkg.SomeInterface)"
       val List(objExpr: TypeDecl, l: Local, alloc: Call, init: Call, i: Identifier) =
-        c.astChildren.isBlock.astChildren.l
+        c.astChildren.isBlock.astChildren.l: @unchecked
       objExpr.fullName shouldBe "mypkg.withFailListener$object$1"
       l.code shouldBe "tmp_obj_1"
       alloc.code shouldBe "tmp_obj_1 = <alloc>"
@@ -185,12 +185,12 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
 
     "should contain a correctly lowered representation" in {
       val List(_: Local, last: Return) =
-        cpg.method.nameExact("<lambda>").block.astChildren.l
+        cpg.method.nameExact("<lambda>").block.astChildren.l: @unchecked
 
-      val List(c: Call) = last.astChildren.l
+      val List(c: Call) = last.astChildren.l: @unchecked
       c.methodFullName shouldBe "mypkg.addListener:void(mypkg.SomeInterface)"
       val List(objExpr: TypeDecl, l: Local, alloc: Call, init: Call, i: Identifier) =
-        c.astChildren.isBlock.astChildren.l
+        c.astChildren.isBlock.astChildren.l: @unchecked
       objExpr.fullName shouldBe "mypkg.f1$object$1"
       l.code shouldBe "tmp_obj_1"
       alloc.code shouldBe "tmp_obj_1 = <alloc>"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/CustomAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/CustomAssignmentTests.scala
@@ -14,7 +14,7 @@ class CustomAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
       val List(_, putsAssignmentCall) = cpg.call.l
       putsAssignmentCall.name shouldBe "<operator>.assignment"
 
-      val List(putsIdentifier: Identifier, putsBuiltInTypeRef: TypeRef) = putsAssignmentCall.argument.l
+      val List(putsIdentifier: Identifier, putsBuiltInTypeRef: TypeRef) = putsAssignmentCall.argument.l: @unchecked
 
       putsIdentifier.name shouldBe "puts"
       putsBuiltInTypeRef.code shouldBe "__builtin.puts"
@@ -40,7 +40,7 @@ class CustomAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
       val List(_, fooAssignmentCall) = cpg.call.l
       fooAssignmentCall.name shouldBe "<operator>.assignment"
 
-      val List(fooIdentifier: Identifier, fooMethodRef: MethodRef) = fooAssignmentCall.argument.l
+      val List(fooIdentifier: Identifier, fooMethodRef: MethodRef) = fooAssignmentCall.argument.l: @unchecked
 
       fooIdentifier.name shouldBe "foo"
       fooMethodRef.methodFullName shouldBe "Test0.rb::program.foo"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1351,7 +1351,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     val cpg = code("x = %i(yy zz)")
 
     val List(arrayInit)                        = cpg.call.name(Operators.arrayInitializer).l
-    val List(yyNode: Literal, zzNode: Literal) = arrayInit.argument.l: @unchecked
+    val List(yyNode: Literal, zzNode: Literal) = arrayInit.argument.isLiteral.l
 
     yyNode.code shouldBe "yy"
     yyNode.argumentIndex shouldBe 1
@@ -1447,7 +1447,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     val List(arrayInit)                                      = cpg.call.name(Operators.arrayInitializer).l
-    val List(xNode: Literal, yNode: Literal, zNode: Literal) = arrayInit.argument.l: @unchecked
+    val List(xNode: Literal, yNode: Literal, zNode: Literal) = arrayInit.argument.isLiteral.l
 
     xNode.code shouldBe "x"
     xNode.argumentIndex shouldBe 1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1351,7 +1351,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     val cpg = code("x = %i(yy zz)")
 
     val List(arrayInit)                        = cpg.call.name(Operators.arrayInitializer).l
-    val List(yyNode: Literal, zzNode: Literal) = arrayInit.argument.l
+    val List(yyNode: Literal, zzNode: Literal) = arrayInit.argument.l: @unchecked
 
     yyNode.code shouldBe "yy"
     yyNode.argumentIndex shouldBe 1
@@ -1447,7 +1447,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     val List(arrayInit)                                      = cpg.call.name(Operators.arrayInitializer).l
-    val List(xNode: Literal, yNode: Literal, zNode: Literal) = arrayInit.argument.l
+    val List(xNode: Literal, yNode: Literal, zNode: Literal) = arrayInit.argument.l: @unchecked
 
     xNode.code shouldBe "x"
     xNode.argumentIndex shouldBe 1


### PR DESCRIPTION
n.b. I dropped the test because I didn't deem it helpful - we don't
need to test a json library that we don't maintain