### PR TITLE
[gosrc2cpg] - Call node handling

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
@@ -4,12 +4,12 @@ import better.files.File
 import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.model.GoMod
 import io.joern.gosrc2cpg.parser.GoAstJsonParser
-import io.joern.gosrc2cpg.passes.AstCreationPass
+import io.joern.gosrc2cpg.passes.{AstCreationPass, CallTypeAndSigntureLinkerPass}
 import io.joern.gosrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
-import io.joern.x2cpg.utils.Report
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
+import io.joern.x2cpg.utils.Report
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import org.slf4j.LoggerFactory
@@ -30,7 +30,8 @@ class GoSrc2Cpg extends X2CpgFrontend[Config] {
           GoAstJsonParser.readModFile(Paths.get(modFile)).foreach(x => GoMod.meta = Some(x))
         )
         new AstCreationPass(cpg, astGenResult, config, report).createAndApply()
-        TypeNodePass.withRegisteredTypes(GoGlobal.typesSeen(), cpg).createAndApply()
+        new CallTypeAndSigntureLinkerPass(cpg).createAndApply()
+//        TypeNodePass.withRegisteredTypes(GoGlobal.typesSeen(), cpg).createAndApply()
         report.print()
       }
     }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -36,7 +36,7 @@ class AstCreator(val relPathFileName: String, val parserResult: ParserResult)(im
   protected val aliasToNameSpaceMapping: mutable.Map[String, String] = mutable.Map.empty
   protected val lineNumberMapping: Map[Int, String]                  = positionLookupTables(parserResult.fileContent)
   protected val fullyQualifiedPackage =
-    GoMod.getNameSpace(parserResult.filename, parserResult.json(ParserKeys.Name)(ParserKeys.Name).str)
+    GoMod.getNameSpace(parserResult.fullPath, parserResult.json(ParserKeys.Name)(ParserKeys.Name).str)
 
   override def createAst(): DiffGraphBuilder = {
     val rootNode = createParserNodeInfo(parserResult.json)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -36,9 +36,11 @@ trait AstCreatorHelper { this: AstCreator =>
         parserNodeCache.addOne(json(ParserKeys.NodeId).num.toLong, pni)
         node match
           case CallExpr =>
-            json(ParserKeys.Fun)(ParserKeys.Obj).objOpt.map(obj => {
-              createParserNodeInfo(obj(ParserKeys.Decl))
-            })
+            Try(json(ParserKeys.Fun)(ParserKeys.Obj)(ParserKeys.Decl)) match
+              case Success(obj) =>
+                // This is being called only to cache this objects
+                createParserNodeInfo(obj)
+              case _ =>
           case _ =>
         // Do nothing
         pni

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -52,7 +52,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val params         = funcDecl.json(ParserKeys.Type)(ParserKeys.Params)(ParserKeys.List)
     val signature =
       s"$fullname$templateParams(${parameterSignature(params)})$returnTypeStr"
-    GoGlobal.recordFullNameToReturnType(fullname, returnTypeStr, signature)
+    GoGlobal.recordFullNameToReturnType(fullname, returnTypeStr, Some(signature))
     val methodNode_ = methodNode(funcDecl, name, funcDecl.code, fullname, Some(signature), filename)
     methodAstParentStack.push(methodNode_)
     scope.pushNewScope(methodNode_)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -1,5 +1,6 @@
 package io.joern.gosrc2cpg.astcreation
 
+import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.parser.ParserAst.{BlockStmt, Ellipsis, Ident, SelectorExpr}
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg.datastructures.Stack.*
@@ -51,7 +52,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val params         = funcDecl.json(ParserKeys.Type)(ParserKeys.Params)(ParserKeys.List)
     val signature =
       s"$fullname$templateParams(${parameterSignature(params)})$returnTypeStr"
-
+    GoGlobal.recordFullNameToReturnType(fullname, returnTypeStr, signature)
     val methodNode_ = methodNode(funcDecl, name, funcDecl.code, fullname, Some(signature), filename)
     methodAstParentStack.push(methodNode_)
     scope.pushNewScope(methodNode_)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
@@ -3,11 +3,11 @@ package io.joern.gosrc2cpg.astcreation
 import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg
+import io.joern.x2cpg.datastructures.Stack.StackWrapper
 import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
 import ujson.Value
-import io.joern.x2cpg.datastructures.Stack.StackWrapper
-import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
 
 import scala.util.Try
 
@@ -77,14 +77,14 @@ trait AstForGenDeclarationCreator(implicit withSchemaValidation: ValidationMode)
       case _ =>
         Seq.empty
 
-    val localNodes = valueSpec.json(ParserKeys.Names).arr.map { parserNode =>
-      val localParserNode = createParserNodeInfo(parserNode)
-
+    val localNodes = valueSpec.json(ParserKeys.Names).arr.flatMap { parserNode =>
+      val localParserNode                                    = createParserNodeInfo(parserNode)
       val name                                               = parserNode(ParserKeys.Name).str
       val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeInfoNode)
       val node = localNode(localParserNode, name, localParserNode.code, typeFullName)
       scope.addToScope(name, (node, typeFullName))
-      Ast(node)
+      val identifierAst = if (valueSpec.json(ParserKeys.Values).isNull) then astForNode(localParserNode) else Seq.empty
+      identifierAst ++: Seq(Ast(node))
     }
 
     if (!valueSpec.json(ParserKeys.Values).isNull) {
@@ -99,12 +99,11 @@ trait AstForGenDeclarationCreator(implicit withSchemaValidation: ValidationMode)
               Operators.assignment,
               DispatchTypes.STATIC_DISPATCH
             )
-            val arguments = astForNode(lhsParserNode.json) ++: astForNode(rhsParserNode.json)
+            val arguments = astForNode(lhsParserNode) ++: astForNode(rhsParserNode)
             callAst(cNode, arguments)
           }
       localNodes.toList ::: callNodes ::: arrayInitializerNode.toList
     } else
       localNodes.toList ++ arrayInitializerNode.toList
   }
-
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -16,7 +16,7 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
       case SelectorExpr =>
         (funcDetails.json(ParserKeys.X)(ParserKeys.Name).strOpt, funcDetails.json(ParserKeys.Sel)(ParserKeys.Name).str)
     val (signature, fullName, typeFullName) =
-      callMethodFullNameAndSignature(methodName, alias, expr.json(ParserKeys.Args))
+      callMethodFullNameTypeFullNameAndSignature(methodName, alias, expr.json(ParserKeys.Args))
     val cpgCall = callNode(
       expr,
       expr.code,
@@ -31,10 +31,7 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
   private def astForArgs(args: Value): Seq[Ast] = {
     Seq.empty
   }
-  private def returnTypeFullName(): String = {
-    ""
-  }
-  private def callMethodFullNameAndSignature(
+  private def callMethodFullNameTypeFullNameAndSignature(
     methodName: String,
     aliasName: Option[String] = None,
     args: Value

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -1,22 +1,30 @@
 package io.joern.gosrc2cpg.astcreation
 
+import io.joern.gosrc2cpg.parser.ParserAst.{Ident, SelectorExpr}
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import ujson.Value
 
 trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   def astForCallExpression(expr: ParserNodeInfo): Seq[Ast] = {
-    val methodName = expr.json(ParserKeys.Fun)(ParserKeys.Name).str
+    val funcDetails = createParserNodeInfo(expr.json(ParserKeys.Fun))
+    val (alias, methodName) = funcDetails.node match
+      case Ident =>
+        (None, funcDetails.json(ParserKeys.Name).str)
+      case SelectorExpr =>
+        (funcDetails.json(ParserKeys.X)(ParserKeys.Name).strOpt, funcDetails.json(ParserKeys.Sel)(ParserKeys.Name).str)
+    val (signature, fullName, typeFullName) =
+      callMethodFullNameAndSignature(methodName, alias, expr.json(ParserKeys.Args))
     val cpgCall = callNode(
       expr,
       expr.code,
       methodName,
-      callMethodFullName(methodName),
+      fullName,
       DispatchTypes.STATIC_DISPATCH,
-      Some(callMethodSignature(methodName, expr.json(ParserKeys.Args))),
-      Some(returnTypeFullName())
+      Some(signature),
+      Some(typeFullName)
     )
     Seq(callAst(cpgCall, astForArgs(expr.json(ParserKeys.Args))))
   }
@@ -26,10 +34,27 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
   private def returnTypeFullName(): String = {
     ""
   }
-  private def callMethodFullName(methodName: String): String = {
-    s"$fullyQualifiedPackage.$methodName"
-  }
-  private def callMethodSignature(methodName: String, args: Value): String = {
-    s"$fullyQualifiedPackage.$methodName()"
+  private def callMethodFullNameAndSignature(
+    methodName: String,
+    aliasName: Option[String] = None,
+    args: Value
+  ): (String, String, String) = {
+    // NOTE: There is an assumption that the import nodes have been processed before this method is being called
+    // and mapping of alias to their respective namespace is already done.
+    aliasName match
+      case None =>
+        // NOTE: If the given type is not found in primitiveTypeMap.
+        // Then we are assuming the type is custom type defined inside same pacakge as that of current file's package.
+        // This assumption will be invalid when another package is imported with alias "."
+        Defines.builtinFunctions.getOrElse(
+          methodName,
+          (s"$fullyQualifiedPackage.$methodName()", s"$fullyQualifiedPackage.$methodName", Defines.tobeFilled)
+        )
+      case Some(alias) =>
+        (
+          s"${aliasToNameSpaceMapping.getOrElse(alias, s"${XDefines.Unknown}.<$alias>")}.$methodName()",
+          s"${aliasToNameSpaceMapping.getOrElse(alias, s"${XDefines.Unknown}.<$alias>")}.$methodName",
+          Defines.tobeFilled
+        )
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -29,7 +29,13 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
     Seq(callAst(cpgCall, astForArgs(expr.json(ParserKeys.Args))))
   }
   private def astForArgs(args: Value): Seq[Ast] = {
-    Seq.empty
+    args.arrOpt
+      .getOrElse(Seq.empty)
+      .flatMap(x => {
+        val primitiveNode = createParserNodeInfo(x)
+        astForPrimitive(primitiveNode)
+      })
+      .toSeq
   }
   private def callMethodFullNameTypeFullNameAndSignature(
     methodName: String,

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/Defines.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/Defines.scala
@@ -37,22 +37,22 @@ object Defines {
   val builtinFunctions: Map[String, (String, String, String)] =
     // Prepared referring to this - https://pkg.go.dev/builtin#pkg-functions
     Map(
-      ("append", ("append([]any, []any) []any", "append", "[]any")),
-      ("cap", ("cap(any) int", "cap", "int")),
+      ("append", ("append([]any, []any)[]any", "append", "[]any")),
+      ("cap", ("cap(any)int", "cap", "int")),
       ("clear", ("clear[[]any|map[any]any](any)", "clear", voidTypeName)),
       ("close", ("close(chan<-any)", "close", voidTypeName)),
-      ("complex", ("complex(FloatType) ComplexType", "complex", "ComplexType")),
-      ("copy", ("copy([]any, []any) int", "copy", "int")),
+      ("complex", ("complex(FloatType)ComplexType", "complex", "ComplexType")),
+      ("copy", ("copy([]any, []any)int", "copy", "int")),
       ("delete", ("delete(map[any]any, any)", "delete", voidTypeName)),
-      ("imag", ("imag(ComplexType) FloatType", "imag", "FloatType")),
-      ("len", ("len(any) int", "len", "int")),
-      ("max", ("max[cmp.Ordered](cmp.Ordered, []cmp.Ordered) cmp.Ordered", "max", "cmp.Ordered")),
-      ("min", ("min[cmp.Ordered](cmp.Ordered, []cmp.Ordered) cmp.Ordered", "min", "cmp.Ordered")),
-      ("new", ("new(any) *any", "new", "*any")),
+      ("imag", ("imag(ComplexType)FloatType", "imag", "FloatType")),
+      ("len", ("len(any)int", "len", "int")),
+      ("max", ("max[cmp.Ordered](cmp.Ordered, []cmp.Ordered)cmp.Ordered", "max", "cmp.Ordered")),
+      ("min", ("min[cmp.Ordered](cmp.Ordered, []cmp.Ordered)cmp.Ordered", "min", "cmp.Ordered")),
+      ("new", ("new(any)*any", "new", "*any")),
       ("panic", ("panic(any)", "panic", voidTypeName)),
       ("print", ("print([]any)", "print", voidTypeName)),
       ("println", ("println([]any)", "println", voidTypeName)),
       ("real", ("real(ComplexType)", "real", voidTypeName)),
-      ("recover", ("recover() any", "recover", "any"))
+      ("recover", ("recover()any", "recover", "any"))
     )
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/Defines.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/Defines.scala
@@ -2,6 +2,7 @@ package io.joern.gosrc2cpg.astcreation
 
 object Defines {
   val anyTypeName: String            = "ANY"
+  val tobeFilled: String             = "<TO_BE_FILLED>"
   val voidTypeName: String           = "void"
   val qualifiedNameSeparator: String = "::"
   val empty                          = "<empty>"
@@ -32,5 +33,26 @@ object Defines {
       ("uint32", "uint32"),
       ("uint64", "uint64"),
       ("uintptr", "uintptr")
+    )
+  val builtinFunctions: Map[String, (String, String, String)] =
+    // Prepared referring to this - https://pkg.go.dev/builtin#pkg-functions
+    Map(
+      ("append", ("append([]any, []any) []any", "append", "[]any")),
+      ("cap", ("cap(any) int", "cap", "int")),
+      ("clear", ("clear[[]any|map[any]any](any)", "clear", voidTypeName)),
+      ("close", ("close(chan<-any)", "close", voidTypeName)),
+      ("complex", ("complex(FloatType) ComplexType", "complex", "ComplexType")),
+      ("copy", ("copy([]any, []any) int", "copy", "int")),
+      ("delete", ("delete(map[any]any, any)", "delete", voidTypeName)),
+      ("imag", ("imag(ComplexType) FloatType", "imag", "FloatType")),
+      ("len", ("len(any) int", "len", "int")),
+      ("max", ("max[cmp.Ordered](cmp.Ordered, []cmp.Ordered) cmp.Ordered", "max", "cmp.Ordered")),
+      ("min", ("min[cmp.Ordered](cmp.Ordered, []cmp.Ordered) cmp.Ordered", "min", "cmp.Ordered")),
+      ("new", ("new(any) *any", "new", "*any")),
+      ("panic", ("panic(any)", "panic", voidTypeName)),
+      ("print", ("print([]any)", "print", voidTypeName)),
+      ("println", ("println([]any)", "println", voidTypeName)),
+      ("real", ("real(ComplexType)", "real", voidTypeName)),
+      ("recover", ("recover() any", "recover", "any"))
     )
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
@@ -8,9 +8,9 @@ import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 object GoGlobal extends Global {
 
-  val methodFullNameReturnTypeMap: ConcurrentHashMap[String, (String, String)] = new ConcurrentHashMap()
+  val methodFullNameReturnTypeMap: ConcurrentHashMap[String, (String, Option[String])] = new ConcurrentHashMap()
 
-  def recordFullNameToReturnType(methodFullName: String, returnType: String, signature: String) = {
+  def recordFullNameToReturnType(methodFullName: String, returnType: String, signature: Option[String]) = {
     methodFullNameReturnTypeMap.putIfAbsent(methodFullName, (returnType, signature))
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
@@ -3,9 +3,16 @@ package io.joern.gosrc2cpg.datastructures
 import io.joern.gosrc2cpg.astcreation.Defines
 import io.joern.x2cpg.datastructures.Global
 
+import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 object GoGlobal extends Global {
+
+  val methodFullNameReturnTypeMap: ConcurrentHashMap[String, (String, String)] = new ConcurrentHashMap()
+
+  def recordFullNameToReturnType(methodFullName: String, returnType: String, signature: String) = {
+    methodFullNameReturnTypeMap.putIfAbsent(methodFullName, (returnType, signature))
+  }
 
   def typesSeen(): List[String] = {
     val types = usedTypes.keys().asScala.filterNot(_ == Defines.anyTypeName).toList

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/CallTypeAndSigntureLinkerPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/CallTypeAndSigntureLinkerPass.scala
@@ -1,0 +1,22 @@
+package io.joern.gosrc2cpg.passes
+
+import io.joern.gosrc2cpg.astcreation.Defines
+import io.joern.gosrc2cpg.datastructures.GoGlobal
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.passes.CpgPass
+import io.shiftleft.semanticcpg.language.*
+import overflowdb.BatchedUpdate
+
+class CallTypeAndSigntureLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
+  override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit =
+    cpg.call
+      .typeFullNameExact(Defines.tobeFilled)
+      .foreach(call => {
+        val (returnTypeFullName, signature) =
+          GoGlobal.methodFullNameReturnTypeMap.getOrDefault(call.methodFullName, (Defines.anyTypeName, null))
+        builder.setNodeProperty(call, PropertyNames.TYPE_FULL_NAME, returnTypeFullName)
+        if (signature != null)
+          builder.setNodeProperty(call, PropertyNames.SIGNATURE, signature)
+      })
+}

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/CallTypeAndSigntureLinkerPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/CallTypeAndSigntureLinkerPass.scala
@@ -14,9 +14,12 @@ class CallTypeAndSigntureLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
       .typeFullNameExact(Defines.tobeFilled)
       .foreach(call => {
         val (returnTypeFullName, signature) =
-          GoGlobal.methodFullNameReturnTypeMap.getOrDefault(call.methodFullName, (Defines.anyTypeName, null))
+          GoGlobal.methodFullNameReturnTypeMap
+            .getOrDefault(call.methodFullName, (Defines.anyTypeName, Option.empty[String]))
         builder.setNodeProperty(call, PropertyNames.TYPE_FULL_NAME, returnTypeFullName)
-        if (signature != null)
-          builder.setNodeProperty(call, PropertyNames.SIGNATURE, signature)
+        signature match
+          case Some(sig) =>
+            builder.setNodeProperty(call, PropertyNames.SIGNATURE, sig)
+          case _ =>
       })
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForDeclarationsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForDeclarationsTests.scala
@@ -55,8 +55,13 @@ class ASTCreationForDeclarationsTests extends GoCodeToCpgSuite {
           ("salary", "float32")
         )
 
-        identifiers.size shouldBe 2
-        identifiers.map(loc => (loc.name, loc.typeFullName)).l shouldBe List(("f", "float32"), ("salary", "float32"))
+        identifiers.size shouldBe 4
+        identifiers.map(loc => (loc.name, loc.typeFullName)).l shouldBe List(
+          ("i", "int"),
+          ("j", "int"),
+          ("f", "float32"),
+          ("salary", "float32")
+        )
       }
     }
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForExpressionsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForExpressionsTests.scala
@@ -21,11 +21,11 @@ class ASTCreationForExpressionsTests extends GoCodeToCpgSuite {
           |}
   """.stripMargin)
 
-      val localX = cpg.local.order(1)
+      val localX = cpg.local.order(2)
       localX.name.l shouldBe List("x")
-      val localY = cpg.local.order(2)
+      val localY = cpg.local.order(4)
       localY.name.l shouldBe List("y")
-      val localZ = cpg.local.order(3)
+      val localZ = cpg.local.order(6)
       localZ.name.l shouldBe List("z")
 
       inside(cpg.method.name("method").ast.isCall.name(Operators.assignment).map(new OpNodes.Assignment(_)).l) {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForMethodCallTests.scala
@@ -2,9 +2,11 @@ package io.joern.go2cpg.passes.ast
 
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
 import io.joern.gosrc2cpg.astcreation.Defines
-import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.edges.Ref
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, nodes}
 import io.shiftleft.semanticcpg.language.*
-
+import overflowdb.traversal.{jIteratortoTraversal, toNodeTraversal}
 class ASTCreationForMethodCallTests extends GoCodeToCpgSuite {
 
   "Simple method call use case" should {
@@ -25,5 +27,214 @@ class ASTCreationForMethodCallTests extends GoCodeToCpgSuite {
       x.order shouldBe 1
       x.lineNumber shouldBe Option(4)
     }
+
+    "traversal from call to caller method node" in {
+      val List(x) = cpg.call("bar").method.l
+      x.name shouldBe "foo"
+    }
+
+    "traversal from call to callee method node" in {
+      val List(x) = cpg.call("bar").callee.l
+      x.name shouldBe "bar"
+      x.isExternal shouldBe false
+    }
   }
+
+  "Method defined in the same file and after method is called." should {
+    val cpg = code("""
+        |package main
+        |func foo() {
+        |  var a = bar()
+        |}
+        |func bar() int {
+        |  return 0
+        |}
+        |""".stripMargin)
+    "Check call node properties" in {
+      cpg.call("bar").size shouldBe 1
+      val List(x) = cpg.call("bar").l
+      x.code shouldBe "bar()"
+      x.methodFullName shouldBe "main.bar"
+      x.signature shouldBe "main.bar()int"
+      x.order shouldBe 2
+      x.lineNumber shouldBe Option(4)
+      x.typeFullName shouldBe "int"
+    }
+
+    "traversal from call to caller method node" in {
+      val List(x) = cpg.call("bar").method.l
+      x.name shouldBe "foo"
+    }
+
+    "traversal from call to callee method node" in {
+      val List(x) = cpg.call("bar").callee.l
+      x.name shouldBe "bar"
+      x.isExternal shouldBe false
+    }
+  }
+
+  "Method defined in the same file and before method is called." should {
+    val cpg = code("""
+        |package main
+        |func bar() int {
+        |  return 0
+        |}
+        |func foo() {
+        |  var a = bar()
+        |}
+        |""".stripMargin)
+    "Check call node properties" in {
+      cpg.call("bar").size shouldBe 1
+      val List(x) = cpg.call("bar").l
+      x.code shouldBe "bar()"
+      x.methodFullName shouldBe "main.bar"
+      x.signature shouldBe "main.bar()int"
+      x.order shouldBe 2
+      x.lineNumber shouldBe Option(7)
+      x.typeFullName shouldBe "int"
+    }
+
+    "traversal from call to caller method node" in {
+      val List(x) = cpg.call("bar").method.l
+      x.name shouldBe "foo"
+    }
+
+    "traversal from call to callee method node" in {
+      val List(x) = cpg.call("bar").callee.l
+      x.name shouldBe "bar"
+      x.isExternal shouldBe false
+    }
+  }
+
+  "Method call to method from the same package but from other file" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package main
+        |func bar() {
+        |}
+        |""".stripMargin,
+      "mainlib.go"
+    ).moreCode(
+      """
+        |package main
+        |func foo() {
+        |  bar()
+        |}
+        |""".stripMargin,
+      "main.go"
+    )
+    "Check call node properties" in {
+      cpg.call("bar").size shouldBe 1
+      val List(x) = cpg.call("bar").l
+      x.code shouldBe "bar()"
+      x.methodFullName shouldBe "main.bar"
+      x.signature shouldBe "main.bar()"
+      x.order shouldBe 1
+      x.lineNumber shouldBe Option(4)
+    }
+
+    "traversal from call to caller method node" in {
+      val List(x) = cpg.call("bar").method.l
+      x.name shouldBe "foo"
+    }
+
+    "traversal from call to callee method node" in {
+      val List(x) = cpg.call("bar").callee.l
+      x.name shouldBe "bar"
+      x.isExternal shouldBe false
+    }
+  }
+
+  "Method call to method imported from another package" should {
+    val cpg = code("""
+        |package main
+        |import "joern.io/sample/fpkg"
+        |func foo() {
+        |  fpkg.bar()
+        |}
+        |""".stripMargin)
+
+    "Check call node properties" in {
+      cpg.call("bar").size shouldBe 1
+      val List(x) = cpg.call("bar").l
+      x.code shouldBe "fpkg.bar()"
+      x.methodFullName shouldBe "joern.io/sample/fpkg.bar"
+      x.signature shouldBe "joern.io/sample/fpkg.bar()"
+      x.order shouldBe 1
+      x.lineNumber shouldBe Option(5)
+    }
+
+    "traversal from call to caller method node" in {
+      val List(x) = cpg.call("bar").method.l
+      x.name shouldBe "foo"
+    }
+
+    "traversal from call to callee method node" in {
+      val List(x) = cpg.call("bar").callee.l
+      x.name shouldBe "bar"
+      x.isExternal shouldBe true
+    }
+  }
+
+  "Method call to method from builtin packages" should {
+    val cpg = code("""
+        |package main
+        |func foo() {
+        |  recover()
+        |}
+        |""".stripMargin)
+
+    "Check call node properties" in {
+      cpg.call("recover").size shouldBe 1
+      val List(x) = cpg.call("recover").l
+      x.code shouldBe "recover()"
+      x.methodFullName shouldBe "recover"
+      x.signature shouldBe "recover() any"
+      x.order shouldBe 1
+      x.lineNumber shouldBe Option(4)
+    }
+
+    "traversal from call to caller method node" in {
+      val List(x) = cpg.call("recover").method.l
+      x.name shouldBe "foo"
+    }
+
+    "traversal from call to callee method node" in {
+      val List(x) = cpg.call("recover").callee.l
+      x.name shouldBe "recover"
+      x.isExternal shouldBe true
+    }
+  }
+
+  // TODO : Unit test with new function
+//  package main
+//
+//  import
+//
+//  "fmt"
+//
+//  type Person
+//  struct {
+//    Name string
+//      Age int
+//  }
+//
+//  func main () {
+//    // Using the new function to create a pointer to a new zero-initialized Person
+//    p := new(Person)
+//
+//    // You can also initialize the fields directly
+//    p.Name = "John"
+//    p.Age = 30
+//
+//    fmt.Println("Name:", p.Name)
+//    fmt.Println("Age:", p.Age)
+//  }
+
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForMethodCallTests.scala
@@ -247,6 +247,7 @@ class ASTCreationForMethodCallTests extends GoCodeToCpgSuite(withOssDataflow = t
       x.isExternal shouldBe false
     }
   }
+
   "Method call to method with int return and argument from the same project but another package" should {
     val cpg = code(
       """
@@ -386,6 +387,7 @@ class ASTCreationForMethodCallTests extends GoCodeToCpgSuite(withOssDataflow = t
       x.signature shouldBe "joern.io/sample/fpkg.bar()"
       x.order shouldBe 1
       x.lineNumber shouldBe Option(5)
+      x.typeFullName shouldBe Defines.anyTypeName
     }
 
     "traversal from call to caller method node" in {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ASTCreationForMethodCallTests.scala
@@ -247,6 +247,72 @@ class ASTCreationForMethodCallTests extends GoCodeToCpgSuite(withOssDataflow = t
       x.isExternal shouldBe false
     }
   }
+  "Method call to method with int return and argument from the same project but another package" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package fpkg
+        |func bar(a int, b string) int{
+        |  return 0
+        |}
+        |""".stripMargin,
+      Seq("fpkg", "mainlib.go").mkString(File.separator)
+    ).moreCode(
+      """
+        |package main
+        |import "joern.io/sample/fpkg"
+        |func foo() {
+        |  var a = fpkg.bar(10, "somestr")
+        |}
+        |""".stripMargin,
+      "main.go"
+    )
+    "Check call node properties" in {
+      cpg.call("bar").size shouldBe 1
+      val List(x) = cpg.call("bar").l
+      x.code shouldBe "fpkg.bar(10, \"somestr\")"
+      x.methodFullName shouldBe "joern.io/sample/fpkg.bar"
+      x.signature shouldBe "joern.io/sample/fpkg.bar(int, string)int"
+      x.order shouldBe 2
+      x.lineNumber shouldBe Option(5)
+      x.typeFullName shouldBe "int"
+    }
+
+    "traversal from call to caller method node" in {
+      val List(x) = cpg.call("bar").method.l
+      x.name shouldBe "foo"
+    }
+
+    "traversal from call to callee method node" in {
+      val List(x) = cpg.call("bar").callee.l
+      x.name shouldBe "bar"
+      x.isExternal shouldBe false
+    }
+
+    "traversal from call to arguments" in {
+      val List(a, b) = cpg.call("bar").argument.l
+      a.isInstanceOf[nodes.Literal] shouldBe true
+      a.code shouldBe "10"
+      a.order shouldBe 1
+
+      b.isInstanceOf[nodes.Literal] shouldBe true
+      b.code shouldBe "\"somestr\""
+      b.order shouldBe 2
+    }
+
+    "traversal from argument to call node" in {
+      val List(x) = cpg.argument("10").inCall.l
+      x.name shouldBe "bar"
+
+      val List(y) = cpg.argument("\"somestr\"").inCall.l
+      x.name shouldBe "bar"
+    }
+  }
 
   "Method call to method with struct type return from the same project but another package" should {
     val cpg = code(
@@ -415,7 +481,8 @@ class ASTCreationForMethodCallTests extends GoCodeToCpgSuite(withOssDataflow = t
     }
 
     "traversal from argument to call node" in {
-      val List(call) = cpg.argument("a").inCall.lineNumber(5).l
+      val List(assignment, call) = cpg.argument("a").inCall.l
+      assignment.name shouldBe "<operator>.assignment"
       call.name shouldBe "cap"
 
       val List(printlnCall) = cpg.argument("b").inCall.lineNumber(6).l

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/AstCreationForArraysTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/AstCreationForArraysTests.scala
@@ -8,6 +8,18 @@ import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 
 class AstCreationForArraysTests extends GoCodeToCpgSuite {
   "AST Creation for Array Initialization" should {
+    "be correct when a int array is declared" in {
+      val cpg = code("""
+          |package main
+          |func main() {
+          |	var a []int 
+          |}
+          |""".stripMargin)
+      cpg.local("a").size shouldBe 1
+      cpg.identifier("a").size shouldBe 1
+      val List(x) = cpg.identifier("a").l
+      x.code shouldBe "a"
+    }
     "be correct when a int array is initialized" in {
       val cpg = code("""
           |package main

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -1532,7 +1532,11 @@ class MethodTests extends GoCodeToCpgSuite {
       argv.name shouldBe "argv"
     }
   }
-
+  // TODO: add unit test for "sem chan int"
+  //        resultErrChan := make(chan error)
+  //		sem := make(chan int, concurrency)
+  // As well as example of "map"
+  // TODO: Add unit tests for lambda expression as a parameter
   // TODO: Add unit test for tuple return
   // TODO: Add unit tests with Generics
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
@@ -3,10 +3,12 @@ package io.joern.go2cpg.testfixtures
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
+import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend}
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import org.scalatest.Inside
 trait Go2CpgFrontend extends LanguageFrontend {
@@ -43,5 +45,10 @@ class DefaultTestCpgWithGo(val fileSuffix: String) extends DefaultTestCpg with G
 class GoCodeToCpgSuite(fileSuffix: String = ".go", withOssDataflow: Boolean = false)
     extends Code2CpgFixture(() => new DefaultTestCpgWithGo(fileSuffix).withOssDataflow(withOssDataflow))
     with Inside {
+  implicit val resolver: ICallResolver           = NoResolve
   implicit lazy val engineContext: EngineContext = EngineContext()
+
+  override def beforeEach(): Unit = {
+    GoGlobal.methodFullNameReturnTypeMap.clear()
+  }
 }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/Code2CpgFixture.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/Code2CpgFixture.scala
@@ -1,6 +1,6 @@
 package io.joern.x2cpg.testfixtures
 
-import org.scalatest.{BeforeAndAfterAll, Inside}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Inside}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -17,6 +17,7 @@ class Code2CpgFixture[T <: TestCpg](testCpgFactory: () => T)
     extends AnyWordSpec
     with Matchers
     with BeforeAndAfterAll
+    with BeforeAndAfterEach
     with Inside {
   private val cpgs = mutable.ArrayBuffer.empty[TestCpg]
 


### PR DESCRIPTION
1. Updated call node methodFullName, typeFullName and signature recovered for methods defined within the same project. We first tag identified call nodes TypeFullName with `<TO_BE_FILLED>`. While processing method declarations, we cache the Method Return type full name and signature. With additional `CallTypeAndSigntureLinkerPass` pass, we look for call nodes whose TypeFullName is tagged with `<TO_BE_FILLED>` and update their type fullname and signature by doing a lookup inside the cache.
2. Listed builtin functions of go while identifying  return type and signature
3. Respective unit tests covering call node use cases. TODO: There are a few more use cases that need to be added.
4. Made changes to create `IDENTIFIER` node when a variable is only declared.
5. Identified bug while setting up the fully qualified name of the file when it's getting processed. Added unit test for use case `call to method from the same project but from another package`
6. Initial handling for argument node along with a unit test for basic dataflow across the function


TODO: 
1. Additional unit tests for built-in function call nodes.
2. Argument node handling. - Basic one is already done. Need to handle using type information to update the call method signature and add more unit tests around the same.
3. TypeDecl related handling
   - Receiver node handling
   - Constructor call handling