### PR TITLE
make steps (`.s`, `.browse` etc.) available on `IterableOnce` also

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -181,7 +181,11 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
   implicit def toTraversal[NodeType <: StoredNode](node: NodeType): Traversal[NodeType] =
     Iterator.single(node)
 
-  implicit def toSteps[A](trav: Traversal[A]): Steps[A] = new Steps(trav)
+  implicit def iterableOnceToSteps[A](iterableOnce: IterableOnce[A]): Steps[A] =
+    new Steps(iterableOnce.iterator)
+
+  implicit def traversalToSteps[A](trav: Traversal[A]): Steps[A] =
+    new Steps(trav)
   implicit def iterOnceToNodeSteps[A <: StoredNode](a: IterableOnce[A]): NodeSteps[A] =
     new NodeSteps[A](a.iterator)
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -180,7 +180,7 @@ class StepsTest extends AnyWordSpec with Matchers {
   }
 
   "should work on both Iterator (e.g. Traversal) and IterableOnce (e.g. Seq)" in {
-    val values = Seq("a", "b")
+    val values  = Seq("a", "b")
     val stream1 = values.iterator.s
     val stream2 = values.s
     // most importantly we want to verify that it compiles ^

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -179,6 +179,16 @@ class StepsTest extends AnyWordSpec with Matchers {
     }
   }
 
+  "should work on both Iterator (e.g. Traversal) and IterableOnce (e.g. Seq)" in {
+    val values = Seq("a", "b")
+    val stream1 = values.iterator.s
+    val stream2 = values.s
+    // most importantly we want to verify that it compiles ^
+
+    stream1 shouldBe values
+    stream2 shouldBe values
+  }
+
   ".help step" should {
     "show domain overview" in {
       val domainStartersHelp = Cpg.emptyCpg.help


### PR DESCRIPTION
this fixes the following, since `.sorted` returns a `Seq`:
```
joern> cpg.method.external.fullName.sorted.browse
-- [E008] Not Found Error: -----------------------------------------------------
1 |cpg.method.external.fullName.sorted.browse
  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |value browse is not a member of Seq[String]
```