### PR TITLE
[gosrc2cpg] - Refactoring of test file names

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ArraysTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ArraysTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Dispatch
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 
-class AstCreationForArraysTests extends GoCodeToCpgSuite {
+class ArraysTests extends GoCodeToCpgSuite {
   "AST Creation for Array Initialization" should {
     "be correct when a int array is declared" in {
       val cpg = code("""

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ConditionalsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ConditionalsTests.scala
@@ -9,7 +9,7 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import scala.collection.immutable.List
 
-class ASTCreationForConditionalsTests extends GoCodeToCpgSuite {
+class ConditionalsTests extends GoCodeToCpgSuite {
   "AST Creation for conditionals" should {
     "be correct for if" in {
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/DeclarationsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/DeclarationsTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
 
-class ASTCreationForDeclarationsTests extends GoCodeToCpgSuite {
+class DeclarationsTests extends GoCodeToCpgSuite {
   "AST Creation for declarations" should {
     "be correct for decl assignment" in {
       val cpg = code("""

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ExpressionsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ExpressionsTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 
-class ASTCreationForExpressionsTests extends GoCodeToCpgSuite {
+class ExpressionsTests extends GoCodeToCpgSuite {
   "AST Creation for expressions" should {
     "be correct for nested expression" in {
       val cpg = code("""

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LoopsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LoopsTests.scala
@@ -9,7 +9,7 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import scala.collection.immutable.List
 
-class ASTCreationForLoopsTests extends GoCodeToCpgSuite {
+class LoopsTests extends GoCodeToCpgSuite {
   "AST Structure for for-loops" should {
     "be correct for for-loop case 1" in {
       val cpg = code("""

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodCallTests.scala
@@ -9,7 +9,7 @@ import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.{jIteratortoTraversal, toNodeTraversal}
 import io.joern.dataflowengineoss.language._
 import java.io.File
-class ASTCreationForMethodCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
+class MethodCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
 
   "Simple method call use case" should {
     val cpg = code("""

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/OperatorsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/OperatorsTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
 
-class AstCreationForOperatorsTests extends GoCodeToCpgSuite {
+class OperatorsTests extends GoCodeToCpgSuite {
 
   "Ast nodes for Operators" should {
     "be created for binary operators" in {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/SwitchTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/SwitchTests.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
 
-class AstCreationForSwitchTests extends GoCodeToCpgSuite {
+class SwitchTests extends GoCodeToCpgSuite {
   "AST Creation for switch case" should {
     "be correct for switch case 1" in {
       val cpg = code("""

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclTests.scala
@@ -12,7 +12,7 @@ import io.shiftleft.codepropertygraph.generated.{
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 
-class AstCreationForTypeDeclTests extends GoCodeToCpgSuite {
+class TypeDeclTests extends GoCodeToCpgSuite {
   "when struct type is declared with a member node" should {
     val cpg = code(
       """package main

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/VariableReferencingTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/VariableReferencingTests.scala
@@ -66,5 +66,4 @@ class VariableReferencingTests extends GoCodeToCpgSuite {
     }
 
   }
-
 }


### PR DESCRIPTION
The Test file names were not very quickly readable because every files starts with `AstCreationFor` removed the unwanted prefix for all the tests to make it more readable.