### PR TITLE
[dataflowengine] Force at least 1 source argument for `reachableBy`

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -2,19 +2,13 @@ package io.joern.dataflowengineoss.language
 
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.queryengine.SourcesToStartingPoints.sourceTravsToStartingPoints
-import io.joern.dataflowengineoss.queryengine.{
-  Engine,
-  EngineContext,
-  PathElement,
-  SourcesToStartingPoints,
-  StartingPointWithSource,
-  TableEntry
-}
+import io.joern.dataflowengineoss.queryengine.*
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
 import scala.collection.mutable
-import scala.collection.parallel.CollectionConverters._
+import scala.collection.parallel.CollectionConverters.*
 
 /** Base class for nodes that can occur in data flows
   */
@@ -34,17 +28,19 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     result
   }
 
-  def reachableBy[NodeType](
-    sourceTravs: IterableOnce[NodeType]*
-  )(implicit context: EngineContext): Traversal[NodeType] = {
-    val sources = sourceTravsToStartingPoints(sourceTravs: _*)
+  def reachableBy[NodeType](sourceTrav: IterableOnce[NodeType], sourceTravs: IterableOnce[NodeType]*)(implicit
+    context: EngineContext
+  ): Traversal[NodeType] = {
+    val sources = sourceTravsToStartingPoints(sourceTrav +: sourceTravs: _*)
     val reachedSources =
       reachableByInternal(sources).map(_.path.head.node)
     reachedSources.cast[NodeType]
   }
 
-  def reachableByFlows[A](sourceTravs: IterableOnce[A]*)(implicit context: EngineContext): Traversal[Path] = {
-    val sources        = sourceTravsToStartingPoints(sourceTravs: _*)
+  def reachableByFlows[A](sourceTrav: IterableOnce[A], sourceTravs: IterableOnce[A]*)(implicit
+    context: EngineContext
+  ): Traversal[Path] = {
+    val sources        = sourceTravsToStartingPoints(sourceTrav +: sourceTravs: _*)
     val startingPoints = sources.map(_.startingPoint)
     val paths = reachableByInternal(sources).par
       .map { result =>
@@ -66,10 +62,10 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     paths.iterator
   }
 
-  def reachableByDetailed[NodeType](
-    sourceTravs: Traversal[NodeType]*
-  )(implicit context: EngineContext): Vector[TableEntry] = {
-    val sources = SourcesToStartingPoints.sourceTravsToStartingPoints(sourceTravs: _*)
+  def reachableByDetailed[NodeType](sourceTrav: Traversal[NodeType], sourceTravs: Traversal[NodeType]*)(implicit
+    context: EngineContext
+  ): Vector[TableEntry] = {
+    val sources = SourcesToStartingPoints.sourceTravsToStartingPoints(sourceTrav +: sourceTravs: _*)
     reachableByInternal(sources)
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
@@ -1,15 +1,15 @@
 package io.joern.dataflowengineoss.language.nodemethods
 
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.joern.dataflowengineoss.language._
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.shiftleft.semanticcpg.language.{toExpressionMethods, _}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.{Traversal, toExpressionMethods, *}
 import io.shiftleft.semanticcpg.utils.MemberAccess
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends AnyVal {
 
@@ -17,10 +17,10 @@ class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends An
     */
   def astNode: AstNode = node
 
-  def reachableBy[NodeType](sourceTravs: IterableOnce[NodeType]*)(implicit
+  def reachableBy[NodeType](sourceTrav: Traversal[NodeType], sourceTravs: IterableOnce[NodeType]*)(implicit
     context: EngineContext
   ): Traversal[NodeType] =
-    node.start.reachableBy(sourceTravs: _*)
+    node.start.reachableBy(sourceTrav, sourceTravs: _*)
 
   def ddgIn(implicit semantics: Semantics = DefaultSemantics()): Traversal[CfgNode] = {
     val cache  = mutable.HashMap[CfgNode, Vector[PathElement]]()


### PR DESCRIPTION
One can silently fail by accidentally calling `sink.reachableBy()` and there will not be any feedback due to the variadic style of the arguments. This change forces at least 1 source to be given, with optional extra sources to follow.