### PR TITLE
[CfgCreator] Fixed fringe erasure in try-blocks

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/TryTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/TryTests.scala
@@ -120,6 +120,23 @@ class TryTests extends JavaDataflowFixture {
       |
       |        System.out.println(s);
       |    }
+      |
+      |    public static int tryWithExplicitReturn(String args) {
+      |        try {
+      |            var x = 1;
+      |            System.out.println("in begin");
+      |            return x;
+      |         } catch (Exception e) {
+      |            System.out.println("Something went wrong." + args);
+      |         }
+      |         return 1;
+      |    }
+      |
+      |    public static void test10(String[] args) {
+      |       String s = "MALICIOUS";
+      |       tryWithExplicitReturn(s);
+      |    }
+      |
       |}
       |""".stripMargin
 
@@ -167,5 +184,10 @@ class TryTests extends JavaDataflowFixture {
   it should "not find a path if `MALICIOUS` is reassigned in FINALLY" in {
     val (source, sink) = getConstSourceSink("test9")
     sink.reachableBy(source).size shouldBe 0
+  }
+
+  it should "find a path if `MALICIOUS` is given to a call in CATCH" in {
+    val (source, sink) = getMultiFnSourceSink("test10", "tryWithExplicitReturn")
+    sink.reachableBy(source).size shouldBe 2
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -522,7 +522,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
 
     val diffGraphs = tryToCatchEdges ++ catchToFinallyEdges ++ tryToFinallyEdges
 
-    val struff = if (maybeTryBlock.isEmpty) {
+    if (maybeTryBlock.isEmpty) {
       // This case deals with the situation where the try block is empty. In this case,
       // no catch block can be executed since nothing can be thrown, but the finally block
       // will still be executed.
@@ -541,7 +541,6 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
           }
         )
     }
-    struff
   }
 
   /** The CFGs for match cases are modeled after PHP match expressions and assumes that a case will always consist of

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -1,9 +1,9 @@
 package io.joern.x2cpg.passes.controlflow.cfgcreation
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, EdgeTypes, Operators}
-import io.shiftleft.semanticcpg.language._
 import io.joern.x2cpg.passes.controlflow.cfgcreation.Cfg.CfgEdgeType
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, EdgeTypes, Operators}
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 /** Translation of abstract syntax trees into control flow graphs
@@ -40,8 +40,8 @@ import overflowdb.BatchedUpdate.DiffGraphBuilder
   */
 class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
 
-  import io.joern.x2cpg.passes.controlflow.cfgcreation.Cfg._
-  import io.joern.x2cpg.passes.controlflow.cfgcreation.CfgCreator._
+  import io.joern.x2cpg.passes.controlflow.cfgcreation.Cfg.*
+  import io.joern.x2cpg.passes.controlflow.cfgcreation.CfgCreator.*
 
   /** Control flow graph definitions often feature a designated entry and exit node for each method. While these nodes
     * are no-ops from a computational point of view, they are useful to guarantee that a method has exactly one entry
@@ -251,6 +251,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
   /** Return statements may contain expressions as return values, and therefore, the CFG for a return statement consists
     * of the CFG for calculation of that expression, appended to a CFG containing only the return node, connected with a
     * single edge to the method exit node. The fringe is empty.
+    *
+    * @param inheritFringe
+    *   indicates if the resulting Cfg object must contain the fringe value of the return value's children.
     */
   protected def cfgForReturn(actualRet: Return, inheritFringe: Boolean = false): Cfg = {
     val childrenCfg = cfgForChildren(actualRet)


### PR DESCRIPTION
In the case of a try-block, if an explicit return node was given then the fringe would be erased (due to the nature of the `++` operator) and the Cfg would no longer be a graph rooted in the method node. The first statement in the try block would have it's fringe erased by the Cfg of the return node and thus be dangling.

This change would detect if the return node is within a try-block and conditionally inherit the fringe.

E.g.
```
    public static int tryWithExplicitReturn(String args) {
        try {
            var x = 1;
            System.out.println("in begin");
            return x;          // <---- the culprit
         } catch (Exception e) {
            System.out.println("Something went wrong." + args);
         }
         return 1;
    }

    public static void test10(String[] args) {
       String s = "MALICIOUS";
       tryWithExplicitReturn(s);
    }
```

#### CFG Before this commit, with the return node in the try block
![graphviz-2](https://github.com/joernio/joern/assets/28294550/6cf5d2dc-2ea9-4b3d-b945-ce44d77ac19b)
#### CFG After this commit, with the return node in the try block
![graphviz-3](https://github.com/joernio/joern/assets/28294550/777acf9e-d1ac-4bdf-91fa-ae3c49b419f8)
