### PR TITLE
fix strange scaladoc warning

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/JsValueVisitor.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/JsValueVisitor.scala
@@ -37,6 +37,10 @@ object JsValueVisitor extends AstTransformer[Value] {
   override def visitJsonableObject(length: Int, index: Int): ObjVisitor[Value, Value] =
     new JsAstObjVisitor[upickle.core.LinkedHashMap[String, Value]](xs => ujson.Obj(xs))
 
+  /**
+   * @param index json source position at the start of the `[` being visited
+   * @return a [[upickle.core.Visitor]] used for visiting the elements of the array
+   */
   override def visitArray(length: Int, index: Int): ArrVisitor[Value, Value] =
     new JsAstArrVisitor[ArrayBuffer](xs => ujson.Arr(xs))
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/JsValueVisitor.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/JsValueVisitor.scala
@@ -37,10 +37,11 @@ object JsValueVisitor extends AstTransformer[Value] {
   override def visitJsonableObject(length: Int, index: Int): ObjVisitor[Value, Value] =
     new JsAstObjVisitor[upickle.core.LinkedHashMap[String, Value]](xs => ujson.Obj(xs))
 
-  /**
-   * @param index json source position at the start of the `[` being visited
-   * @return a [[upickle.core.Visitor]] used for visiting the elements of the array
-   */
+  /** @param index
+    *   json source position at the start of the `[` being visited
+    * @return
+    *   a [[upickle.core.Visitor]] used for visiting the elements of the array
+    */
   override def visitArray(length: Int, index: Int): ArrVisitor[Value, Value] =
     new JsAstArrVisitor[ArrayBuffer](xs => ujson.Arr(xs))
 


### PR DESCRIPTION
this PR makes the following warning disappear:
```
[warn] -- Warning: joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/JsValueVisitor.scala:40:15
[warn] 40 |  override def visitArray(length: Int, index: Int): ArrVisitor[Value, Value] =
[warn]    |               ^
[warn]    |               No DRI found for query: Visitor
[warn] -- Warning: ujson/src/ujson/JsVisitor.scala:76:15 ------------------------------
```

Context: the warning "No DRI..." comes from scaladoc as it tries to
lookup all references. The referenced `Visitor` is actually in the
parent class that's not within this repo. Copying and adapting it
works though...


There's one more that seems even more obscure...
```
sbt:joern> jssrc2cpg/Compile/doc
[info] Main Scala API documentation to /home/mp/Projects/shiftleft/joern/joern-cli/frontends/jssrc2cpg/target/scala-3.3.0/api...
[warn] Flag -project set repeatedly
[warn] -- Warning: ujson/src/ujson/JsVisitor.scala:76:15 ------------------------------
[warn] No DRI found for query: ObjVisitor
```