### PR TITLE
odb2 transition: use plain Iterator rather than Traversal

### DIFF
--- a/benchmarks/src/test/scala/io/joern/benchmarks/testfixtures/BenchmarkFixture.scala
+++ b/benchmarks/src/test/scala/io/joern/benchmarks/testfixtures/BenchmarkFixture.scala
@@ -17,7 +17,6 @@ import io.shiftleft.utils.ProjectRoot
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import overflowdb.traversal.Traversal
 
 import scala.util.Failure
 
@@ -62,7 +61,7 @@ abstract class BenchmarkFixture(
 
   /** Makes sure there are flows between the source and the sink
     */
-  def assertIsInsecure(source: Traversal[CfgNode], sink: Traversal[CfgNode]): Assertion =
+  def assertIsInsecure(source: Iterator[CfgNode], sink: Iterator[CfgNode]): Assertion =
     if (sink.reachableBy(source).isEmpty) {
       fail("[False Negative] Source was not found to taint the sink")
     } else {
@@ -71,7 +70,7 @@ abstract class BenchmarkFixture(
 
   /** Makes sure there are no flows between the source and the sink.
     */
-  def assertIsSecure(source: Traversal[CfgNode], sink: Traversal[CfgNode]): Assertion =
+  def assertIsSecure(source: Iterator[CfgNode], sink: Iterator[CfgNode]): Assertion =
     if (sink.reachableBy(source).nonEmpty) {
       fail("[False positive] Source was found to taint the sink")
     } else {

--- a/console/src/main/scala/io/joern/console/scan/package.scala
+++ b/console/src/main/scala/io/joern/console/scan/package.scala
@@ -3,17 +3,16 @@ package io.joern.console
 import io.joern.console.Query
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeTypes
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import org.slf4j.{Logger, LoggerFactory}
-import overflowdb.traversal.Traversal
 
 package object scan {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   implicit class ScannerStarters(val cpg: Cpg) extends AnyVal {
-    def finding: Traversal[Finding] =
+    def finding: Iterator[Finding] =
       overflowdb.traversal.InitialTraversal.from[Finding](cpg.graph, NodeTypes.FINDING)
   }
 
@@ -52,17 +51,17 @@ package object scan {
     val score       = "score"
   }
 
-  implicit class ScannerFindingStep(val traversal: Traversal[Finding]) extends AnyRef {
+  implicit class ScannerFindingStep(val traversal: Iterator[Finding]) extends AnyRef {
 
-    def name: Traversal[String] = traversal.map(_.name)
+    def name: Iterator[String] = traversal.map(_.name)
 
-    def author: Traversal[String] = traversal.map(_.author)
+    def author: Iterator[String] = traversal.map(_.author)
 
-    def title: Traversal[String] = traversal.map(_.title)
+    def title: Iterator[String] = traversal.map(_.title)
 
-    def description: Traversal[String] = traversal.map(_.description)
+    def description: Iterator[String] = traversal.map(_.description)
 
-    def score: Traversal[Double] = traversal.map(_.score)
+    def score: Iterator[Double] = traversal.map(_.score)
 
   }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotCpg14Generator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotCpg14Generator.scala
@@ -4,11 +4,10 @@ import io.joern.dataflowengineoss.DefaultSemantics
 import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.dotgenerator.{AstGenerator, CdgGenerator, CfgGenerator, DotSerializer}
-import overflowdb.traversal.Traversal
 
 object DotCpg14Generator {
 
-  def toDotCpg14(traversal: Traversal[Method])(implicit semantics: Semantics = DefaultSemantics()): Traversal[String] =
+  def toDotCpg14(traversal: Iterator[Method])(implicit semantics: Semantics = DefaultSemantics()): Iterator[String] =
     traversal.map(dotGraphForMethod)
 
   private def dotGraphForMethod(method: Method)(implicit semantics: Semantics): String = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -1,14 +1,13 @@
 package io.joern.dataflowengineoss.dotgenerator
 
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.shiftleft.semanticcpg.dotgenerator.DotSerializer
-import overflowdb.traversal._
 
 object DotDdgGenerator {
 
-  def toDotDdg(traversal: Traversal[Method])(implicit semantics: Semantics = DefaultSemantics()): Traversal[String] =
+  def toDotDdg(traversal: Iterator[Method])(implicit semantics: Semantics = DefaultSemantics()): Iterator[String] =
     traversal.map(dotGraphForMethod)
 
   private def dotGraphForMethod(method: Method)(implicit semantics: Semantics): String = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotPdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DotPdgGenerator.scala
@@ -1,14 +1,13 @@
 package io.joern.dataflowengineoss.dotgenerator
 
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.shiftleft.semanticcpg.dotgenerator.{CdgGenerator, DotSerializer}
-import overflowdb.traversal.Traversal
 
 object DotPdgGenerator {
 
-  def toDotPdg(traversal: Traversal[Method])(implicit semantics: Semantics = DefaultSemantics()): Traversal[String] =
+  def toDotPdg(traversal: Iterator[Method])(implicit semantics: Semantics = DefaultSemantics()): Iterator[String] =
     traversal.map(dotGraphForMethod)
 
   private def dotGraphForMethod(method: Method)(implicit semantics: Semantics): String = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -1,8 +1,8 @@
 package io.joern.dataflowengineoss.language
 
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.joern.dataflowengineoss.queryengine.SourcesToStartingPoints.sourceTravsToStartingPoints
 import io.joern.dataflowengineoss.queryengine.*
+import io.joern.dataflowengineoss.queryengine.SourcesToStartingPoints.sourceTravsToStartingPoints
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
@@ -12,16 +12,16 @@ import scala.collection.parallel.CollectionConverters.*
 
 /** Base class for nodes that can occur in data flows
   */
-class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
+class ExtendedCfgNode(val traversal: Iterator[CfgNode]) extends AnyVal {
 
-  def ddgIn(implicit semantics: Semantics = DefaultSemantics()): Traversal[CfgNode] = {
+  def ddgIn(implicit semantics: Semantics = DefaultSemantics()): Iterator[CfgNode] = {
     val cache  = mutable.HashMap[CfgNode, Vector[PathElement]]()
     val result = traversal.flatMap(x => x.ddgIn(Vector(PathElement(x)), withInvisible = false, cache))
     cache.clear()
     result
   }
 
-  def ddgInPathElem(implicit semantics: Semantics = DefaultSemantics()): Traversal[PathElement] = {
+  def ddgInPathElem(implicit semantics: Semantics = DefaultSemantics()): Iterator[PathElement] = {
     val cache  = mutable.HashMap[CfgNode, Vector[PathElement]]()
     val result = traversal.flatMap(x => x.ddgInPathElem(Vector(PathElement(x)), withInvisible = false, cache))
     cache.clear()
@@ -30,7 +30,7 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
 
   def reachableBy[NodeType](sourceTrav: IterableOnce[NodeType], sourceTravs: IterableOnce[NodeType]*)(implicit
     context: EngineContext
-  ): Traversal[NodeType] = {
+  ): Iterator[NodeType] = {
     val sources = sourceTravsToStartingPoints(sourceTrav +: sourceTravs: _*)
     val reachedSources =
       reachableByInternal(sources).map(_.path.head.node)
@@ -39,7 +39,7 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
 
   def reachableByFlows[A](sourceTrav: IterableOnce[A], sourceTravs: IterableOnce[A]*)(implicit
     context: EngineContext
-  ): Traversal[Path] = {
+  ): Iterator[Path] = {
     val sources        = sourceTravsToStartingPoints(sourceTrav +: sourceTravs: _*)
     val startingPoints = sources.map(_.startingPoint)
     val paths = reachableByInternal(sources).par
@@ -62,7 +62,7 @@ class ExtendedCfgNode(val traversal: Traversal[CfgNode]) extends AnyVal {
     paths.iterator
   }
 
-  def reachableByDetailed[NodeType](sourceTrav: Traversal[NodeType], sourceTravs: Traversal[NodeType]*)(implicit
+  def reachableByDetailed[NodeType](sourceTrav: Iterator[NodeType], sourceTravs: Iterator[NodeType]*)(implicit
     context: EngineContext
   ): Vector[TableEntry] = {
     val sources = SourcesToStartingPoints.sourceTravsToStartingPoints(sourceTrav +: sourceTravs: _*)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/dotextension/DdgNodeDot.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/dotextension/DdgNodeDot.scala
@@ -1,21 +1,22 @@
 package io.joern.dataflowengineoss.language.dotextension
 
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.joern.dataflowengineoss.dotgenerator.{DotCpg14Generator, DotDdgGenerator, DotPdgGenerator}
-import io.joern.dataflowengineoss.language._
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.codepropertygraph.generated.nodes.Method
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.dotextension.{ImageViewer, Shared}
-import io.shiftleft.semanticcpg.language._
-class DdgNodeDot(val traversal: Traversal[Method]) extends AnyVal {
 
-  def dotDdg(implicit semantics: Semantics = DefaultSemantics()): Traversal[String] =
+class DdgNodeDot(val traversal: Iterator[Method]) extends AnyVal {
+
+  def dotDdg(implicit semantics: Semantics = DefaultSemantics()): Iterator[String] =
     DotDdgGenerator.toDotDdg(traversal)
 
-  def dotPdg(implicit semantics: Semantics = DefaultSemantics()): Traversal[String] =
+  def dotPdg(implicit semantics: Semantics = DefaultSemantics()): Iterator[String] =
     DotPdgGenerator.toDotPdg(traversal)
 
-  def dotCpg14(implicit semantics: Semantics = DefaultSemantics()): Traversal[String] =
+  def dotCpg14(implicit semantics: Semantics = DefaultSemantics()): Iterator[String] =
     DotCpg14Generator.toDotCpg14(traversal)
 
   def plotDotDdg(implicit viewer: ImageViewer, semantics: Semantics = DefaultSemantics()): Unit = {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
@@ -1,8 +1,8 @@
 package io.joern.dataflowengineoss.language.nodemethods
 
-import io.joern.dataflowengineoss.semanticsloader._
+import io.joern.dataflowengineoss.semanticsloader.*
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, Method}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 class ExpressionMethods[NodeType <: Expression](val node: NodeType) extends AnyVal {
 
@@ -72,13 +72,13 @@ class ExpressionMethods[NodeType <: Expression](val node: NodeType) extends AnyV
 
   /** Retrieve flow semantic for the call this argument is a part of.
     */
-  def semanticsForCallByArg(implicit semantics: Semantics): Traversal[FlowSemantic] = {
+  def semanticsForCallByArg(implicit semantics: Semantics): Iterator[FlowSemantic] = {
     argToMethods(node).flatMap { method =>
       semantics.forMethod(method.fullName)
     }
   }
 
-  private def argToMethods(arg: Expression): Traversal[Method] = {
+  private def argToMethods(arg: Expression): Iterator[Method] = {
     arg.inCall.flatMap { call =>
       NoResolve.getCalledMethods(call)
     }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
@@ -5,8 +5,7 @@ import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.semanticcpg.language.{Traversal, toExpressionMethods, *}
-import io.shiftleft.semanticcpg.utils.MemberAccess
+import io.shiftleft.semanticcpg.language.*
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
@@ -17,12 +16,12 @@ class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends An
     */
   def astNode: AstNode = node
 
-  def reachableBy[NodeType](sourceTrav: Traversal[NodeType], sourceTravs: IterableOnce[NodeType]*)(implicit
+  def reachableBy[NodeType](sourceTrav: Iterator[NodeType], sourceTravs: IterableOnce[NodeType]*)(implicit
     context: EngineContext
-  ): Traversal[NodeType] =
+  ): Iterator[NodeType] =
     node.start.reachableBy(sourceTrav, sourceTravs: _*)
 
-  def ddgIn(implicit semantics: Semantics = DefaultSemantics()): Traversal[CfgNode] = {
+  def ddgIn(implicit semantics: Semantics = DefaultSemantics()): Iterator[CfgNode] = {
     val cache  = mutable.HashMap[CfgNode, Vector[PathElement]]()
     val result = ddgIn(Vector(PathElement(node)), withInvisible = false, cache)
     cache.clear()
@@ -32,10 +31,10 @@ class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends An
   def ddgInPathElem(
     withInvisible: Boolean,
     cache: mutable.HashMap[CfgNode, Vector[PathElement]] = mutable.HashMap[CfgNode, Vector[PathElement]]()
-  )(implicit semantics: Semantics): Traversal[PathElement] =
+  )(implicit semantics: Semantics): Iterator[PathElement] =
     ddgInPathElem(Vector(PathElement(node)), withInvisible, cache)
 
-  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = {
+  def ddgInPathElem(implicit semantics: Semantics): Iterator[PathElement] = {
     val cache  = mutable.HashMap[CfgNode, Vector[PathElement]]()
     val result = ddgInPathElem(Vector(PathElement(node)), withInvisible = false, cache)
     cache.clear()
@@ -48,7 +47,7 @@ class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends An
     */
   def ddgIn(path: Vector[PathElement], withInvisible: Boolean, cache: mutable.HashMap[CfgNode, Vector[PathElement]])(
     implicit semantics: Semantics
-  ): Traversal[CfgNode] = {
+  ): Iterator[CfgNode] = {
     ddgInPathElem(path, withInvisible, cache).map(_.node.asInstanceOf[CfgNode])
   }
 
@@ -61,7 +60,7 @@ class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends An
     path: Vector[PathElement],
     withInvisible: Boolean,
     cache: mutable.HashMap[CfgNode, Vector[PathElement]]
-  )(implicit semantics: Semantics): Traversal[PathElement] = {
+  )(implicit semantics: Semantics): Iterator[PathElement] = {
     val result = ddgInPathElemInternal(path, withInvisible, cache).iterator
     result
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/package.scala
@@ -3,7 +3,6 @@ package io.joern.dataflowengineoss
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.joern.dataflowengineoss.language.dotextension.DdgNodeDot
 import io.joern.dataflowengineoss.language.nodemethods.{ExpressionMethods, ExtendedCfgNodeMethods}
-import overflowdb.traversal._
 
 package object language {
 
@@ -20,6 +19,6 @@ package object language {
     new DdgNodeDot(traversal.iterator)
 
   implicit def toDdgNodeDotSingle(method: Method): DdgNodeDot =
-    new DdgNodeDot(method.start)
+    new DdgNodeDot(Iterator.single(method))
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -1,11 +1,11 @@
 package io.joern
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Expression, Identifier, Literal}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 package object dataflowengineoss {
 
-  def globalFromLiteral(lit: Literal): Traversal[Expression] = lit.start
+  def globalFromLiteral(lit: Literal): Iterator[Expression] = lit.start
     .where(_.inAssignment.method.nameExact("<module>", ":package"))
     .inAssignment
     .argument(1)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -8,7 +8,6 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators, PropertyN
 import io.shiftleft.semanticcpg.accesspath.MatchResult
 import io.shiftleft.semanticcpg.language._
 import overflowdb.BatchedUpdate.DiffGraphBuilder
-import overflowdb.traversal.Traversal
 
 import scala.collection.{Set, mutable}
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -1,18 +1,18 @@
 package io.joern.dataflowengineoss.queryengine
 
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.joern.dataflowengineoss.language._
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.passes.reachingdef.EdgeValidator
 import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Properties}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.Edge
-import overflowdb.traversal.{NodeOps, Traversal}
-import java.util.concurrent._
+
+import java.util.concurrent.*
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
 /** The data flow engine allows determining paths to a set of sinks from a set of sources. To this end, it solves tasks
@@ -22,7 +22,7 @@ import scala.util.{Failure, Success, Try}
   */
 class Engine(context: EngineContext) {
 
-  import Engine._
+  import Engine.*
 
   private val logger: Logger                   = LoggerFactory.getLogger(this.getClass)
   private val executorService: ExecutorService = Executors.newWorkStealingPool()
@@ -267,7 +267,7 @@ object Engine {
       .toVector
   }
 
-  def argToOutputParams(arg: Expression): Traversal[MethodParameterOut] = {
+  def argToOutputParams(arg: Expression): Iterator[MethodParameterOut] = {
     argToMethods(arg).parameter
       .index(arg.argumentIndex)
       .asOutput

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/DataFlowBinToCpgSuite.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/fixtures/DataFlowBinToCpgSuite.scala
@@ -1,14 +1,13 @@
 package io.joern.ghidra2cpg.fixtures
 
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
-import io.shiftleft.semanticcpg.layers._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.layers.*
 
 import scala.sys.process.Process
 import scala.util.Try
@@ -37,12 +36,12 @@ class DataFlowBinToCpgSuite extends GhidraBinToCpgSuite {
   protected implicit def int2IntegerOption(x: Int): Option[Integer] =
     Some(x)
 
-  protected def getMemberOfType(cpg: Cpg, typeName: String, memberName: String): Traversal[Member] =
+  protected def getMemberOfType(cpg: Cpg, typeName: String, memberName: String): Iterator[Member] =
     cpg.typeDecl.nameExact(typeName).member.nameExact(memberName)
 
-  protected def getMethodOfType(cpg: Cpg, typeName: String, methodName: String): Traversal[Method] =
+  protected def getMethodOfType(cpg: Cpg, typeName: String, methodName: String): Iterator[Method] =
     cpg.typeDecl.nameExact(typeName).method.nameExact(methodName)
 
-  protected def getLiteralOfType(cpg: Cpg, typeName: String, literalName: String): Traversal[Literal] =
+  protected def getLiteralOfType(cpg: Cpg, typeName: String, literalName: String): Iterator[Literal] =
     cpg.typeDecl.nameExact(typeName).method.isLiteral.codeExact(literalName)
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeHintCallLinker.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeHintCallLinker.scala
@@ -5,13 +5,12 @@ import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
 
 import java.util.regex.Pattern
 
 class JavaTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
 
-  override protected def calls: Traversal[Call] = {
+  override protected def calls: Iterator[Call] = {
     cpg.call
       .nameNot("<operator>.*", "<operators>.*")
       .filter(c =>

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/StaticMemberTests.scala
@@ -1,9 +1,8 @@
 package io.joern.javasrc2cpg.querying.dataflow
 
+import io.joern.dataflowengineoss.language.*
 import io.joern.javasrc2cpg.testfixtures.JavaDataflowFixture
-import io.joern.dataflowengineoss.language._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 /** These tests are added as a wishlist for static member accesses. These results are consistent with static members in
   * C++ using c2cgp, however. For practical reasons, only handling `final` static members is probably the way to go, so

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -1,15 +1,14 @@
 package io.joern.javasrc2cpg.testfixtures
 
-import io.joern.dataflowengineoss.language._
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
 import io.joern.javasrc2cpg.JavaSrc2CpgTestContext
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import overflowdb.traversal.Traversal
 
 class JavaDataflowFixture(extraFlows: List[FlowSemantic] = List.empty) extends AnyFlatSpec with Matchers {
 
@@ -23,7 +22,7 @@ class JavaDataflowFixture(extraFlows: List[FlowSemantic] = List.empty) extends A
     methodName: String,
     sourceCode: String = "\"MALICIOUS\"",
     sinkPattern: String = ".*println.*"
-  ): (Traversal[Literal], Traversal[Expression]) = {
+  ): (Iterator[Literal], Iterator[Expression]) = {
     getMultiFnSourceSink(methodName, methodName, sourceCode, sinkPattern)
   }
 
@@ -32,7 +31,7 @@ class JavaDataflowFixture(extraFlows: List[FlowSemantic] = List.empty) extends A
     sinkMethodName: String,
     sourceCode: String = "\"MALICIOUS\"",
     sinkPattern: String = ".*println.*"
-  ): (Traversal[Literal], Traversal[Expression]) = {
+  ): (Iterator[Literal], Iterator[Expression]) = {
     val sourceMethod = cpg.method(s".*$sourceMethodName.*").head
     val sinkMethod   = cpg.method(s".*$sinkMethodName.*").head
     def source       = sourceMethod.literal.code(sourceCode)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -7,9 +7,8 @@ import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
-import overflowdb.traversal.Traversal
 
 import java.io.File
 
@@ -53,7 +52,7 @@ class JavaSrcCode2CpgFixture(withOssDataflow: Boolean = false, enableTypeRecover
     methodName: String,
     sourceCode: String = "\"MALICIOUS\"",
     sinkPattern: String = ".*println.*"
-  ): (Traversal[Literal], Traversal[Expression]) = {
+  ): (Iterator[Literal], Iterator[Expression]) = {
     getMultiFnSourceSink(cpg, methodName, methodName, sourceCode, sinkPattern)
   }
 
@@ -63,7 +62,7 @@ class JavaSrcCode2CpgFixture(withOssDataflow: Boolean = false, enableTypeRecover
     sinkMethodName: String,
     sourceCode: String = "\"MALICIOUS\"",
     sinkPattern: String = ".*println.*"
-  ): (Traversal[Literal], Traversal[Expression]) = {
+  ): (Iterator[Literal], Iterator[Expression]) = {
     val sourceMethod = cpg.method(s".*$sourceMethodName.*").head
     val sinkMethod   = cpg.method(s".*$sinkMethodName.*").head
     def source       = sourceMethod.literal.code(sourceCode)

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/StaticMemberTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/StaticMemberTests.scala
@@ -1,10 +1,9 @@
 package io.joern.jimple2cpg.querying.dataflow
 
-import io.joern.dataflowengineoss.language._
+import io.joern.dataflowengineoss.language.*
 import io.joern.jimple2cpg.testfixtures.JimpleDataFlowCodeToCpgSuite
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 /** These tests are added as a wishlist for static member accesses. These results are consistent with static members in
   * C++ using c2cgp, however. For practical reasons, only handling `final` static members is probably the way to go, so

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleDataflowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleDataflowCodeToCpgSuite.scala
@@ -1,15 +1,13 @@
 package io.joern.jimple2cpg.testfixtures
 
-import io.joern.dataflowengineoss.language.Path
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
-import overflowdb.traversal.Traversal
 
 class JimpleDataflowTestCpg(val extraFlows: List[FlowSemantic] = List.empty) extends JimpleTestCpg {
 
@@ -32,7 +30,7 @@ class JimpleDataFlowCodeToCpgSuite(val extraFlows: List[FlowSemantic] = List.emp
 
   def getConstSourceSink(methodName: String, sourceCode: String = "\"MALICIOUS\"", sinkPattern: String = ".*println.*")(
     implicit cpg: Cpg
-  ): (Traversal[Literal], Traversal[Expression]) = {
+  ): (Iterator[Literal], Iterator[Expression]) = {
     getMultiFnSourceSink(methodName, methodName, sourceCode, sinkPattern)
   }
 
@@ -41,7 +39,7 @@ class JimpleDataFlowCodeToCpgSuite(val extraFlows: List[FlowSemantic] = List.emp
     sinkMethodName: String,
     sourceCode: String = "\"MALICIOUS\"",
     sinkPattern: String = ".*println.*"
-  )(implicit cpg: Cpg): (Traversal[Literal], Traversal[Expression]) = {
+  )(implicit cpg: Cpg): (Iterator[Literal], Iterator[Expression]) = {
     val sourceMethod = cpg.method(s".*$sourceMethodName").head
     val sinkMethod   = cpg.method(s".*$sinkMethodName").head
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeHintCallLinker.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeHintCallLinker.scala
@@ -3,14 +3,13 @@ package io.joern.jssrc2cpg.passes
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 class JavaScriptTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
 
   override protected val pathSep = ':'
 
-  override protected def calls: Traversal[Call] = cpg.call
+  override protected def calls: Iterator[Call] = cpg.call
     .or(_.nameNot("<operator>.*", "<operators>.*"), _.name("<operator>.new"))
     .filter(c => calleeNames(c).nonEmpty && c.callee.isEmpty)
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -3,13 +3,12 @@ package io.joern.pysrc2cpg
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecovery.isDummyType
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodBase}
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.semanticcpg.language.*
 
 class PythonTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
 
-  override def calls: Traversal[Call] = super.calls.nameNot("^(import).*")
+  override def calls: Iterator[Call] = super.calls.nameNot("^(import).*")
 
   override def calleeNames(c: Call): Seq[String] = super.calleeNames(c).map {
     // Python call from  a type

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeHintCallLinker.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeHintCallLinker.scala
@@ -1,17 +1,12 @@
 package io.joern.rubysrc2cpg.passes
 
-import io.joern.rubysrc2cpg.astcreation.GlobalTypes
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
-import io.joern.x2cpg.passes.frontend.XTypeRecovery.isDummyType
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.semanticcpg.language.Traversal
 import io.shiftleft.semanticcpg.language.*
-
-import java.util.regex.Pattern
 
 class RubyTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
 
-  override def calls: Traversal[Call] = super.calls.nameNot("^(require).*")
+  override def calls: Iterator[Call] = super.calls.nameNot("^(require).*")
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryPass.scala
@@ -1,13 +1,9 @@
 package io.joern.rubysrc2cpg.passes
 
+import io.joern.x2cpg.passes.frontend.*
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.joern.x2cpg.passes.frontend.*
 import io.shiftleft.semanticcpg.language.*
-import io.joern.x2cpg.Defines.{ConstructorMethodName, DynamicCallUnknownFullName}
-import io.joern.x2cpg.Defines as XDefines
-import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
-import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.FieldAccess
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 class RubyTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())
@@ -18,7 +14,7 @@ class RubyTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecovery
 
 private class RubyTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
 
-  override def compilationUnit: Traversal[File] = cpg.file.iterator
+  override def compilationUnit: Iterator[File] = cpg.file.iterator
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,
@@ -47,7 +43,7 @@ private class RecoverForRubyFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, 
     resolvedImport <- i.call.tag
     alias          <- i.importedAs
   } {
-    import io.joern.x2cpg.passes.frontend.ImportsPass._
+    import io.joern.x2cpg.passes.frontend.ImportsPass.*
     ResolvedImport.tagToResolvedImport(resolvedImport).foreach {
       case ResolvedTypeDecl(fullName, _) =>
         symbolTable.append(LocalVar(fullName.split("\\.").lastOption.getOrElse(alias)), fullName)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportResolverPass.scala
@@ -1,14 +1,14 @@
 package io.joern.x2cpg.passes.frontend
 
 import io.joern.x2cpg.passes.frontend.ImportsPass.ResolvedImport
-import io.joern.x2cpg.passes.frontend.ImportsPass.ResolvedImport._
+import io.joern.x2cpg.passes.frontend.ImportsPass.ResolvedImport.*
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Import, Tag}
 import io.shiftleft.passes.ConcurrentWriterCpgPass
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import org.slf4j.{Logger, LoggerFactory}
 
-import java.io.{File => JFile}
+import java.io.File as JFile
 
 abstract class XImportResolverPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Import](cpg) {
 
@@ -47,8 +47,8 @@ object ImportsPass {
     def serialize: String
   }
 
-  implicit class TagToResolvedImportExt(traversal: Traversal[Tag]) {
-    def toResolvedImport: Traversal[ResolvedImport] =
+  implicit class TagToResolvedImportExt(traversal: Iterator[Tag]) {
+    def toResolvedImport: Iterator[ResolvedImport] =
       traversal.flatMap(ResolvedImport.tagToResolvedImport)
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -3,12 +3,11 @@ package io.joern.x2cpg.passes.frontend
 import io.joern.x2cpg.passes.base.MethodStubCreator
 import io.joern.x2cpg.passes.frontend.XTypeRecovery.isDummyType
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 import java.util.regex.Pattern
 import scala.collection.mutable
@@ -26,7 +25,7 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
   private val fileNamePattern                     = Pattern.compile("^(.*(.py|.js|.rb)).*$")
   protected val pathSep: Char                     = '.'
 
-  protected def calls: Traversal[Call] = cpg.call
+  protected def calls: Iterator[Call] = cpg.call
     .nameNot("<operator>.*", "<operators>.*")
     .filter(c => calleeNames(c).nonEmpty && c.callee.isEmpty)
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernFlow.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernFlow.scala
@@ -1,14 +1,12 @@
 package io.joern.joerncli
 
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.joern.dataflowengineoss.language._
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.joerncli.console.JoernWorkspaceLoader
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 case class FlowConfig(
   cpgFileName: String = "cpg.bin",

--- a/macros/src/main/scala/io/joern/console/Query.scala
+++ b/macros/src/main/scala/io/joern/console/Query.scala
@@ -2,7 +2,6 @@ package io.joern.console
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
-import overflowdb.traversal.Traversal
 
 case class CodeSnippet(content: String, filename: String)
 case class MultiFileCodeExamples(positive: List[List[CodeSnippet]], negative: List[List[CodeSnippet]])
@@ -14,7 +13,7 @@ case class Query(
   title: String,
   description: String,
   score: Double,
-  traversal: Cpg => Traversal[_ <: StoredNode],
+  traversal: Cpg => Iterator[_ <: StoredNode],
   traversalAsString: String = "",
   tags: List[String] = List(),
   language: String = "",
@@ -49,4 +48,4 @@ object Query {
   }
 }
 
-case class TraversalWithStrRep(traversal: Cpg => Traversal[_ <: StoredNode], strRep: String = "")
+case class TraversalWithStrRep(traversal: Cpg => Iterator[_ <: StoredNode], strRep: String = "")

--- a/macros/src/main/scala/io/joern/macros/QueryMacros.scala
+++ b/macros/src/main/scala/io/joern/macros/QueryMacros.scala
@@ -3,17 +3,16 @@ package io.joern.macros
 import io.joern.console.TraversalWithStrRep
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
-import overflowdb.traversal.Traversal
 
 import scala.quoted.{Expr, Quotes}
 
 object QueryMacros {
 
-  inline def withStrRep(inline traversal: Cpg => Traversal[_ <: StoredNode]): TraversalWithStrRep =
+  inline def withStrRep(inline traversal: Cpg => Iterator[_ <: StoredNode]): TraversalWithStrRep =
     ${ withStrRepImpl('{ traversal }) }
 
   private def withStrRepImpl(
-    travExpr: Expr[Cpg => Traversal[_ <: StoredNode]]
+    travExpr: Expr[Cpg => Iterator[_ <: StoredNode]]
   )(using quotes: Quotes): Expr[TraversalWithStrRep] = {
     import quotes.reflect._
     val pos  = travExpr.asTerm.pos

--- a/querydb/src/main/scala/io/joern/scanners/android/ExternalStorage.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/ExternalStorage.scala
@@ -1,12 +1,12 @@
 package io.joern.scanners.android
 
-import io.joern.scanners._
-import io.joern.console._
+import io.joern.console.*
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.macros.QueryMacros._
-import io.shiftleft.semanticcpg.language._
-import io.joern.dataflowengineoss.language._
+import io.joern.macros.QueryMacros.*
+import io.joern.scanners.*
+import io.shiftleft.semanticcpg.language.*
 
 object ExternalStorage extends QueryBundle {
   implicit val engineContext: EngineContext = EngineContext(Semantics.empty)
@@ -22,9 +22,8 @@ object ExternalStorage extends QueryBundle {
       description = "-",
       score = 9,
       withStrRep({ cpg =>
-        import overflowdb.traversal.Traversal
-        import io.shiftleft.semanticcpg.language.android._
         import io.joern.x2cpg.Defines.ConstructorMethodName
+        import io.shiftleft.semanticcpg.language.android.*
 
         def externalStorageReads =
           if (cpg.appManifest.hasReadExternalStoragePermission.nonEmpty)

--- a/querydb/src/main/scala/io/joern/scanners/android/JavaScriptInterface.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/JavaScriptInterface.scala
@@ -1,12 +1,12 @@
 package io.joern.scanners.android
 
-import io.joern.scanners._
-import io.joern.console._
+import io.joern.console.*
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.macros.QueryMacros._
-import io.shiftleft.semanticcpg.language._
-import io.joern.dataflowengineoss.language._
+import io.joern.macros.QueryMacros.*
+import io.joern.scanners.*
+import io.shiftleft.semanticcpg.language.*
 
 object JavaScriptInterface extends QueryBundle {
   implicit val engineContext: EngineContext = EngineContext(Semantics.empty)
@@ -23,9 +23,8 @@ object JavaScriptInterface extends QueryBundle {
       description = "-",
       score = 9,
       withStrRep({ cpg =>
-        import overflowdb.traversal.Traversal
-        import io.shiftleft.semanticcpg.language.android._
         import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
+        import io.shiftleft.semanticcpg.language.android.*
 
         def webViewsWithInsecureLoadUrlCalls =
           cpg.webView.callsEnableJS.where(_.loadUrlCalls.filter { callNode =>

--- a/querydb/src/main/scala/io/joern/scanners/android/Misconfigurations.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/Misconfigurations.scala
@@ -1,12 +1,11 @@
 package io.joern.scanners.android
 
-import io.joern.scanners._
-import io.joern.console._
+import io.joern.console.*
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.macros.QueryMacros._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
-import io.joern.dataflowengineoss.language._
+import io.joern.macros.QueryMacros.*
+import io.joern.scanners.*
+import io.shiftleft.semanticcpg.language.*
 
 object Misconfigurations extends QueryBundle {
 

--- a/querydb/src/main/scala/io/joern/scanners/android/UnprotectedAppParts.scala
+++ b/querydb/src/main/scala/io/joern/scanners/android/UnprotectedAppParts.scala
@@ -1,13 +1,12 @@
 package io.joern.scanners.android
 
-import io.joern.scanners._
-import io.joern.console._
+import io.joern.console.*
 import io.joern.dataflowengineoss.language.toExtendedCfgNode
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.macros.QueryMacros._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.joern.macros.QueryMacros.*
+import io.joern.scanners.*
+import io.shiftleft.semanticcpg.language.*
 
 object UnprotectedAppParts extends QueryBundle {
   implicit val engineContext: EngineContext = EngineContext(Semantics.empty)

--- a/querydb/src/main/scala/io/joern/scanners/c/FileOpRace.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/FileOpRace.scala
@@ -1,12 +1,11 @@
 package io.joern.scanners.c
 
-import io.joern.scanners.{Crew, QueryTags}
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.joern.console._
+import io.joern.console.*
 import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.shiftleft.semanticcpg.language._
-import io.joern.macros.QueryMacros._
-import overflowdb.traversal.Traversal
+import io.joern.macros.QueryMacros.*
+import io.joern.scanners.{Crew, QueryTags}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 object FileOpRace extends QueryBundle {
 
@@ -57,7 +56,7 @@ object FileOpRace extends QueryBundle {
           "unlink"     -> Seq(1)
         )
 
-        def fileCalls(calls: Traversal[Call]) =
+        def fileCalls(calls: Iterator[Call]) =
           calls.nameExact(operations.keys.toSeq: _*)
 
         def fileArgs(c: Call) =

--- a/querydb/src/main/scala/io/joern/scanners/c/QueryLangExtensions.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/QueryLangExtensions.scala
@@ -1,15 +1,14 @@
 package io.joern.scanners.c
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 import scala.util.Try
 
 object QueryLangExtensions {
 
-  implicit class CallExtension(callTrav: Traversal[nodes.Call]) {
-    def returnValueNotChecked: Traversal[nodes.Call] = {
+  implicit class CallExtension(callTrav: Iterator[nodes.Call]) {
+    def returnValueNotChecked: Iterator[nodes.Call] = {
       val notDirectlyChecked = callTrav.filterNot { y =>
         val code = y.code
         y.inAstMinusLeaf.isControlStructure.condition.code.exists { x =>
@@ -28,9 +27,9 @@ object QueryLangExtensions {
     }
   }
 
-  implicit class LiteralExtension(litTrav: Traversal[nodes.Literal]) {
+  implicit class LiteralExtension(litTrav: Iterator[nodes.Literal]) {
 
-    def toInt: Traversal[Int] = {
+    def toInt: Iterator[Int] = {
       litTrav.code.flatMap { lit => Try(Integer.decode(lit).intValue()).toOption }
     }
   }

--- a/querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
@@ -1,14 +1,13 @@
 package io.joern.scanners.c
 
+import io.joern.console.*
+import io.joern.dataflowengineoss.language.*
+import io.joern.dataflowengineoss.queryengine.EngineContext
+import io.joern.macros.QueryMacros.*
 import io.joern.scanners.{Crew, QueryTags}
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.joern.console._
-import io.shiftleft.semanticcpg.language._
-import io.joern.dataflowengineoss.language._
-import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.macros.QueryMacros._
-import overflowdb.traversal.Traversal
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 object UseAfterFree extends QueryBundle {
 

--- a/querydb/src/main/scala/io/joern/scanners/java/CertificateChecks.scala
+++ b/querydb/src/main/scala/io/joern/scanners/java/CertificateChecks.scala
@@ -1,11 +1,10 @@
 package io.joern.scanners.java
 
+import io.joern.console.*
+import io.joern.macros.QueryMacros.*
 import io.joern.scanners.{Crew, QueryTags}
-import io.shiftleft.codepropertygraph.generated._
-import io.joern.console._
-import io.joern.macros.QueryMacros._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.codepropertygraph.generated.*
+import io.shiftleft.semanticcpg.language.*
 
 object CertificateChecks extends QueryBundle {
 
@@ -41,7 +40,7 @@ object CertificateChecks extends QueryBundle {
             c.methodFullName == Operators.assignment && c.argument.forall(isPrologue)
           case _ => false
         }
-        def skipPrologue(node: nodes.CfgNode): Traversal[nodes.CfgNode] =
+        def skipPrologue(node: nodes.CfgNode): Iterator[nodes.CfgNode] =
           node.start.repeat(_.cfgNext)(_.until(_.filter(!isPrologue(_))))
 
         cpg.method

--- a/querydb/src/main/scala/io/joern/scanners/kotlin/NetworkProtocols.scala
+++ b/querydb/src/main/scala/io/joern/scanners/kotlin/NetworkProtocols.scala
@@ -1,11 +1,9 @@
 package io.joern.scanners.kotlin
 
+import io.joern.console.*
+import io.joern.macros.QueryMacros.*
 import io.joern.scanners.{Crew, QueryTags}
-import io.shiftleft.codepropertygraph.generated._
-import io.joern.console._
-import io.joern.macros.QueryMacros._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 object NetworkProtocols extends QueryBundle {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
@@ -1,11 +1,10 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
-import overflowdb.traversal._
 
 object DotAstGenerator {
 
-  def dotAst[T <: AstNode](traversal: Traversal[T]): Traversal[String] =
+  def dotAst[T <: AstNode](traversal: Iterator[T]): Iterator[String] =
     traversal.map(dotAst)
 
   def dotAst(astRoot: AstNode): String = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCallGraphGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCallGraphGenerator.scala
@@ -1,11 +1,10 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.Cpg
-import overflowdb.traversal._
 
 object DotCallGraphGenerator {
 
-  def dotCallGraph(cpg: Cpg): Traversal[String] = {
+  def dotCallGraph(cpg: Cpg): Iterator[String] = {
     val callGraph = new CallGraphGenerator().generate(cpg)
     Iterator(DotSerializer.dotGraph(None, callGraph))
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCdgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCdgGenerator.scala
@@ -1,11 +1,10 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes.Method
-import overflowdb.traversal._
 
 object DotCdgGenerator {
 
-  def dotCdg(traversal: Traversal[Method]): Traversal[String] =
+  def dotCdg(traversal: Iterator[Method]): Iterator[String] =
     traversal.map(dotCdg)
 
   def dotCdg(method: Method): String = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -1,11 +1,10 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes.Method
-import overflowdb.traversal._
 
 object DotCfgGenerator {
 
-  def dotCfg(traversal: Traversal[Method]): Traversal[String] =
+  def dotCfg(traversal: Iterator[Method]): Iterator[String] =
     traversal.map(dotCfg)
 
   def dotCfg(method: Method): String = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotTypeHierarchyGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotTypeHierarchyGenerator.scala
@@ -1,11 +1,10 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.Cpg
-import overflowdb.traversal._
 
 object DotTypeHierarchyGenerator {
 
-  def dotTypeHierarchy(cpg: Cpg): Traversal[String] = {
+  def dotTypeHierarchy(cpg: Cpg): Iterator[String] = {
     val typeHierarchy = new TypeHierarchyGenerator().generate(cpg)
     Iterator(DotSerializer.dotGraph(None, typeHierarchy))
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.generated.nodes.{CallRepr, Method}
-import overflowdb.traversal._
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 trait ICallResolver {
 
@@ -28,7 +27,7 @@ trait ICallResolver {
 
   /** Same as getCalledMethods but with traversal return type.
     */
-  def getCalledMethodsAsTraversal(callsite: CallRepr): Traversal[Method] =
+  def getCalledMethodsAsTraversal(callsite: CallRepr): Iterator[Method] =
     getCalledMethods(callsite).iterator
 
   /** Get callsites of the given method. This internally calls triggerMethodResolution.
@@ -48,7 +47,7 @@ trait ICallResolver {
 
   /** Same as getMethodCallsites but with traversal return type.
     */
-  def getMethodCallsitesAsTraversal(method: Method): Traversal[CallRepr] =
+  def getMethodCallsitesAsTraversal(method: Method): Iterator[CallRepr] =
     getMethodCallsites(method).iterator
 
   /** Starts data flow tracking to find all method which could be called at the given callsite. The result is stored in

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewNodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewNodeSteps.scala
@@ -2,13 +2,12 @@ package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import overflowdb.BatchedUpdate.DiffGraphBuilder
-import overflowdb.traversal._
 
 trait HasStoreMethod {
   def store()(implicit diffBuilder: DiffGraphBuilder): Unit
 }
 
-class NewNodeSteps[A <: NewNode](val traversal: Traversal[A]) extends HasStoreMethod {
+class NewNodeSteps[A <: NewNode](val traversal: Iterator[A]) extends HasStoreMethod {
 
   override def store()(implicit diffBuilder: DiffGraphBuilder): Unit =
     traversal.sideEffect(storeRecursively).iterate()
@@ -17,5 +16,5 @@ class NewNodeSteps[A <: NewNode](val traversal: Traversal[A]) extends HasStoreMe
     diffBuilder.addNode(newNode)
   }
 
-  def label: Traversal[String] = traversal.map(_.label)
+  def label: Iterator[String] = traversal.map(_.label)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewTagNodePairTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewTagNodePairTraversal.scala
@@ -3,9 +3,8 @@ package io.shiftleft.semanticcpg.language
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, NewTagNodePair, StoredNode}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
-import overflowdb.traversal._
 
-class NewTagNodePairTraversal(traversal: Traversal[NewTagNodePair]) extends HasStoreMethod {
+class NewTagNodePairTraversal(traversal: Iterator[NewTagNodePair]) extends HasStoreMethod {
   override def store()(implicit diffGraph: DiffGraphBuilder): Unit = {
     traversal.foreach { tagNodePair =>
       val tag      = tagNodePair.tag

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -13,7 +13,7 @@ import overflowdb.traversal.help.Doc
   * This is the base class for all steps defined on
   */
 @help.Traversal(elementType = classOf[StoredNode])
-class NodeSteps[NodeType <: StoredNode](val traversal: Traversal[NodeType]) extends AnyVal {
+class NodeSteps[NodeType <: StoredNode](val traversal: Iterator[NodeType]) extends AnyVal {
 
   @Doc(
     info = "The source file this code is in",
@@ -23,7 +23,7 @@ class NodeSteps[NodeType <: StoredNode](val traversal: Traversal[NodeType]) exte
       |the file node that represents that source file.
       |"""
   )
-  def file: Traversal[File] =
+  def file: Iterator[File] =
     traversal
       .choose(_.label) {
         case NodeTypes.NAMESPACE => _.in(EdgeTypes.REF).out(EdgeTypes.SOURCE_FILE)
@@ -45,7 +45,7 @@ class NodeSteps[NodeType <: StoredNode](val traversal: Traversal[NodeType]) exte
       |on the user's side.
       |"""
   )
-  def location(implicit finder: NodeExtensionFinder): Traversal[NewLocation] =
+  def location(implicit finder: NodeExtensionFinder): Iterator[NewLocation] =
     traversal.map(_.location)
 
   @Doc(
@@ -85,7 +85,7 @@ class NodeSteps[NodeType <: StoredNode](val traversal: Traversal[NodeType]) exte
   }
 
   /* follow the incoming edges of the given type as long as possible */
-  protected def walkIn(edgeType: String): Traversal[Node] =
+  protected def walkIn(edgeType: String): Iterator[Node] =
     traversal
       .repeat(_.in(edgeType))(_.until(_.in(edgeType).countTrav.filter(_ == 0)))
 
@@ -119,7 +119,7 @@ class NodeSteps[NodeType <: StoredNode](val traversal: Traversal[NodeType]) exte
     }.l
 
   @Doc(info = "Tags attached to this node")
-  def tag: Traversal[Tag] = {
+  def tag: Iterator[Tag] = {
     traversal.flatMap { node =>
       node.tag
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -1,21 +1,20 @@
 package io.shiftleft.semanticcpg.language
 
-import io.shiftleft.codepropertygraph.generated.nodes.{AbstractNode, NewNode, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.AbstractNode
 import org.json4s.native.Serialization.{write, writePretty}
 import org.json4s.{CustomSerializer, Extraction, Formats}
-import overflowdb.traversal.*
 import overflowdb.traversal.help.Doc
+import replpp.Colors
 import replpp.Operators.*
 
 import java.util.List as JList
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import replpp.Colors
 
 /** Base class for our DSL These are the base steps available in all steps of the query language. There are no
   * constraints on the element types, unlike e.g. [[NodeSteps]]
   */
-class Steps[A](val traversal: Traversal[A]) extends AnyVal {
+class Steps[A](val traversal: Iterator[A]) extends AnyVal {
 
   /** Execute the traversal and convert it to a mutable buffer
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
@@ -1,23 +1,22 @@
 package io.shiftleft.semanticcpg.language
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes._
-import overflowdb.traversal._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+
 import scala.reflect.ClassTag
 
-class TagTraversal(val traversal: Traversal[Tag]) extends AnyVal {
+class TagTraversal(val traversal: Iterator[Tag]) extends AnyVal {
 
-  def member: Traversal[Member]                   = tagged[Member]
-  def method: Traversal[Method]                   = tagged[Method]
-  def methodReturn: Traversal[MethodReturn]       = tagged[MethodReturn]
-  def parameter: Traversal[MethodParameterIn]     = tagged[MethodParameterIn]
-  def parameterOut: Traversal[MethodParameterOut] = tagged[MethodParameterOut]
-  def call: Traversal[Call]                       = tagged[Call]
-  def identifier: Traversal[Identifier]           = tagged[Identifier]
-  def literal: Traversal[Literal]                 = tagged[Literal]
-  def local: Traversal[Local]                     = tagged[Local]
-  def file: Traversal[File]                       = tagged[File]
+  def member: Iterator[Member]                   = tagged[Member]
+  def method: Iterator[Method]                   = tagged[Method]
+  def methodReturn: Iterator[MethodReturn]       = tagged[MethodReturn]
+  def parameter: Iterator[MethodParameterIn]     = tagged[MethodParameterIn]
+  def parameterOut: Iterator[MethodParameterOut] = tagged[MethodParameterOut]
+  def call: Iterator[Call]                       = tagged[Call]
+  def identifier: Iterator[Identifier]           = tagged[Identifier]
+  def literal: Iterator[Literal]                 = tagged[Literal]
+  def local: Iterator[Local]                     = tagged[Local]
+  def file: Iterator[File]                       = tagged[File]
 
-  private def tagged[A <: StoredNode: ClassTag]: Traversal[A] =
+  private def tagged[A <: StoredNode: ClassTag]: Iterator[A] =
     traversal._taggedByIn.collectAll[A].sortBy(_.id).iterator
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/ConfigFileTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/ConfigFileTraversal.scala
@@ -2,9 +2,8 @@ package io.shiftleft.semanticcpg.language.android
 
 import io.joern.semanticcpg.utils.SecureXmlParsing
 import io.shiftleft.codepropertygraph.generated.nodes
-import overflowdb.traversal._
 
-class ConfigFileTraversal(val traversal: Traversal[nodes.ConfigFile]) extends AnyVal {
+class ConfigFileTraversal(val traversal: Iterator[nodes.ConfigFile]) extends AnyVal {
   def usesCleartextTraffic =
     traversal
       .filter(_.name.endsWith(Constants.androidManifestXml))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/LocalTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/LocalTraversal.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.semanticcpg.language.android
 
 import io.shiftleft.codepropertygraph.generated.nodes.Local
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
-class LocalTraversal(val traversal: Traversal[Local]) extends AnyVal {
+class LocalTraversal(val traversal: Iterator[Local]) extends AnyVal {
   def callsEnableJS =
     traversal
       .where(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/MethodTraversal.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.semanticcpg.language.android
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
-class MethodTraversal(val traversal: Traversal[nodes.Method]) extends AnyVal {
+class MethodTraversal(val traversal: Iterator[nodes.Method]) extends AnyVal {
   def exposedToJS =
     traversal.where(_.annotation.fullNameExact("android.webkit.JavascriptInterface"))
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/android/NodeTypeStarters.scala
@@ -1,33 +1,32 @@
 package io.shiftleft.semanticcpg.language.android
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 class NodeTypeStarters(cpg: Cpg) {
-  def webView: Traversal[Local] =
+  def webView: Iterator[Local] =
     cpg.local.typeFullNameExact("android.webkit.WebView")
 
-  def appManifest: Traversal[ConfigFile] =
+  def appManifest: Iterator[ConfigFile] =
     cpg.configFile.filter(_.name.endsWith(Constants.androidManifestXml))
 
-  def getExternalStorageDir: Traversal[Call] =
+  def getExternalStorageDir: Iterator[Call] =
     cpg.call
       .nameExact("getExternalStorageDirectory")
       .where(_.argument(0).isIdentifier.typeFullNameExact("android.os.Environment"))
 
-  def dexClassLoader: Traversal[Local] =
+  def dexClassLoader: Iterator[Local] =
     cpg.local.typeFullNameExact("dalvik.system.DexClassLoader")
 
-  def broadcastReceivers: Traversal[TypeDecl] =
+  def broadcastReceivers: Iterator[TypeDecl] =
     cpg.method
       .nameExact("onReceive")
       .where(_.parameter.index(1).typeFullNameExact("android.content.Context"))
       .where(_.parameter.index(2).typeFullNameExact("android.content.Intent"))
       .typeDecl
 
-  def registerReceiver: Traversal[Call] =
+  def registerReceiver: Iterator[Call] =
     cpg.call
       .nameExact("registerReceiver")
       .where(_.argument(2).isIdentifier.typeFullNameExact("android.content.IntentFilter"))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/MethodTraversal.scala
@@ -1,17 +1,17 @@
 package io.shiftleft.semanticcpg.language.bindingextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Method, TypeDecl}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
-class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
+class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
 
   /** Traverse to type decl which have this method bound to it.
     */
-  def bindingTypeDecl: Traversal[TypeDecl] =
+  def bindingTypeDecl: Iterator[TypeDecl] =
     referencingBinding.bindingTypeDecl
 
   /** Traverse to bindings which reference to this method.
     */
-  def referencingBinding: Traversal[Binding] =
+  def referencingBinding: Iterator[Binding] =
     traversal.flatMap(_._bindingViaRefIn)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/TypeDeclTraversal.scala
@@ -1,18 +1,18 @@
 package io.shiftleft.semanticcpg.language.bindingextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Method, TypeDecl}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
-class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
+class TypeDeclTraversal(val traversal: Iterator[TypeDecl]) extends AnyVal {
 
   /** Traverse to methods bound to this type decl.
     */
-  def boundMethod: Traversal[Method] =
+  def boundMethod: Iterator[Method] =
     methodBinding.boundMethod
 
   /** Traverse to the method bindings of this type declaration.
     */
-  def methodBinding: Traversal[Binding] =
+  def methodBinding: Iterator[Binding] =
     traversal.canonicalType.flatMap(_.bindsOut)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/CallTraversal.scala
@@ -1,18 +1,18 @@
 package io.shiftleft.semanticcpg.language.callgraphextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Import, Method}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
-class CallTraversal(val traversal: Traversal[Call]) extends AnyVal {
+class CallTraversal(val traversal: Iterator[Call]) extends AnyVal {
 
   @deprecated("Use callee", "")
-  def calledMethod(implicit callResolver: ICallResolver): Traversal[Method] = callee
+  def calledMethod(implicit callResolver: ICallResolver): Iterator[Method] = callee
 
   /** The callee method */
-  def callee(implicit callResolver: ICallResolver): Traversal[Method] =
+  def callee(implicit callResolver: ICallResolver): Iterator[Method] =
     traversal.flatMap(callResolver.getCalledMethodsAsTraversal)
 
-  def referencedImports: Traversal[Import] =
+  def referencedImports: Iterator[Import] =
     traversal.flatMap(_._importViaIsCallForImportOut)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
@@ -2,11 +2,11 @@ package io.shiftleft.semanticcpg.language.dotextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
 import io.shiftleft.semanticcpg.dotgenerator.DotAstGenerator
-import overflowdb.traversal._
+import overflowdb.traversal.*
 
-class AstNodeDot[NodeType <: AstNode](val traversal: Traversal[NodeType]) extends AnyVal {
+class AstNodeDot[NodeType <: AstNode](val traversal: Iterator[NodeType]) extends AnyVal {
 
-  def dotAst: Traversal[String] = DotAstGenerator.dotAst(traversal)
+  def dotAst: Iterator[String] = DotAstGenerator.dotAst(traversal)
 
   def plotDotAst(implicit viewer: ImageViewer): Unit = {
     Shared.plotAndDisplay(dotAst.l, viewer)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
@@ -2,13 +2,13 @@ package io.shiftleft.semanticcpg.language.dotextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.shiftleft.semanticcpg.dotgenerator.{DotCdgGenerator, DotCfgGenerator}
-import overflowdb.traversal._
+import overflowdb.traversal.*
 
-class CfgNodeDot(val traversal: Traversal[Method]) extends AnyVal {
+class CfgNodeDot(val traversal: Iterator[Method]) extends AnyVal {
 
-  def dotCfg: Traversal[String] = DotCfgGenerator.dotCfg(traversal)
+  def dotCfg: Iterator[String] = DotCfgGenerator.dotCfg(traversal)
 
-  def dotCdg: Traversal[String] = DotCdgGenerator.dotCdg(traversal)
+  def dotCdg: Iterator[String] = DotCdgGenerator.dotCdg(traversal)
 
   def plotDotCfg(implicit viewer: ImageViewer): Unit = {
     Shared.plotAndDisplay(dotCfg.l, viewer)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/InterproceduralNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/InterproceduralNodeDot.scala
@@ -2,12 +2,11 @@ package io.shiftleft.semanticcpg.language.dotextension
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.dotgenerator.{DotCallGraphGenerator, DotTypeHierarchyGenerator}
-import overflowdb.traversal.Traversal
 
 class InterproceduralNodeDot(val cpg: Cpg) extends AnyVal {
 
-  def dotCallGraph: Traversal[String] = DotCallGraphGenerator.dotCallGraph(cpg)
+  def dotCallGraph: Iterator[String] = DotCallGraphGenerator.dotCallGraph(cpg)
 
-  def dotTypeHierarchy: Traversal[String] = DotTypeHierarchyGenerator.dotTypeHierarchy(cpg)
+  def dotTypeHierarchy: Iterator[String] = DotTypeHierarchyGenerator.dotTypeHierarchy(cpg)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -1,12 +1,11 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.Implicits.IterableOnceDeco
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.nodemethods.AstNodeMethods.lastExpressionInBlock
 import io.shiftleft.semanticcpg.utils.MemberAccess
-import overflowdb.traversal.Traversal
 
 class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
 
@@ -70,17 +69,17 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
 
   /** Direct children of node in the AST. Siblings are ordered by their `order` fields
     */
-  def astChildren: Traversal[AstNode] =
+  def astChildren: Iterator[AstNode] =
     node._astOut.cast[AstNode].sortBy(_.order).iterator
 
   /** Siblings of this node in the AST, ordered by their `order` fields
     */
-  def astSiblings: Traversal[AstNode] =
+  def astSiblings: Iterator[AstNode] =
     astParent.astChildren.filter(_ != node)
 
   /** Nodes of the AST rooted in this node, including the node itself.
     */
-  def ast: Traversal[AstNode] =
+  def ast: Iterator[AstNode] =
     Iterator.single(node).ast
 
   /** Textual representation of AST node

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -2,20 +2,19 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, _}
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLocation {
-  def receiver: Traversal[Expression] =
+  def receiver: Iterator[Expression] =
     node.receiverOut
 
-  def arguments(index: Int): Traversal[Expression] =
+  def arguments(index: Int): Iterator[Expression] =
     node._argumentOut
       .collect {
         case expr: Expression if expr.argumentIndex == index => expr
       }
 
-  def argument: Traversal[Expression] =
+  def argument: Iterator[Expression] =
     node._argumentOut.collectAll[Expression]
 
   def argument(index: Int): Expression =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -1,44 +1,43 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.Implicits.IterableOnceDeco
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
   /** Successors in the CFG
     */
-  def cfgNext: Traversal[CfgNode] = {
+  def cfgNext: Iterator[CfgNode] = {
     Iterator.single(node).cfgNext
   }
 
   /** Maps each node in the traversal to a traversal returning its n successors.
     */
-  def cfgNext(n: Int): Traversal[CfgNode] = n match {
+  def cfgNext(n: Int): Iterator[CfgNode] = n match {
     case 0 => Iterator.empty
     case _ => cfgNext.flatMap(x => List(x) ++ x.cfgNext(n - 1))
   }
 
   /** Maps each node in the traversal to a traversal returning its n predecessors.
     */
-  def cfgPrev(n: Int): Traversal[CfgNode] = n match {
+  def cfgPrev(n: Int): Iterator[CfgNode] = n match {
     case 0 => Iterator.empty
     case _ => cfgPrev.flatMap(x => List(x) ++ x.cfgPrev(n - 1))
   }
 
   /** Predecessors in the CFG
     */
-  def cfgPrev: Traversal[CfgNode] = {
+  def cfgPrev: Iterator[CfgNode] = {
     Iterator.single(node).cfgPrev
   }
 
   /** Recursively determine all nodes on which this CFG node is control-dependent.
     */
-  def controlledBy: Traversal[CfgNode] = {
+  def controlledBy: Iterator[CfgNode] = {
     expandExhaustively { v =>
       v._cdgIn
     }
@@ -46,7 +45,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
   /** Recursively determine all nodes which this CFG node controls
     */
-  def controls: Traversal[CfgNode] = {
+  def controls: Iterator[CfgNode] = {
     expandExhaustively { v =>
       v._cdgOut
     }
@@ -54,7 +53,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
   /** Recursively determine all nodes by which this node is dominated
     */
-  def dominatedBy: Traversal[CfgNode] = {
+  def dominatedBy: Iterator[CfgNode] = {
     expandExhaustively { v =>
       v._dominateIn
     }
@@ -62,7 +61,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
   /** Recursively determine all nodes which are dominated by this node
     */
-  def dominates: Traversal[CfgNode] = {
+  def dominates: Iterator[CfgNode] = {
     expandExhaustively { v =>
       v._dominateOut
     }
@@ -70,7 +69,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
   /** Recursively determine all nodes by which this node is post dominated
     */
-  def postDominatedBy: Traversal[CfgNode] = {
+  def postDominatedBy: Iterator[CfgNode] = {
     expandExhaustively { v =>
       v._postDominateIn
     }
@@ -78,7 +77,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
   /** Recursively determine all nodes which are post dominated by this node
     */
-  def postDominates: Traversal[CfgNode] = {
+  def postDominates: Iterator[CfgNode] = {
     expandExhaustively { v =>
       v._postDominateOut
     }
@@ -91,7 +90,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     * @return
     *   the traversal of this node if it passes through the included set.
     */
-  def passes(included: Set[CfgNode]): Traversal[CfgNode] =
+  def passes(included: Set[CfgNode]): Iterator[CfgNode] =
     Iterator.single(node).filter(_.postDominatedBy.exists(included.contains))
 
   /** Using the post dominator tree, will determine if this node passes through the excluded set of nodes and filter it
@@ -101,10 +100,10 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     * @return
     *   the traversal of this node if it does not pass through the excluded set.
     */
-  def passesNot(excluded: Set[CfgNode]): Traversal[CfgNode] =
+  def passesNot(excluded: Set[CfgNode]): Iterator[CfgNode] =
     Iterator.single(node).filterNot(_.postDominatedBy.exists(excluded.contains))
 
-  private def expandExhaustively(expand: CfgNode => Iterator[StoredNode]): Traversal[CfgNode] = {
+  private def expandExhaustively(expand: CfgNode => Iterator[StoredNode]): Iterator[CfgNode] = {
     var controllingNodes = List.empty[CfgNode]
     var visited          = Set.empty + node
     var worklist         = node :: Nil

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -1,15 +1,14 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.Implicits.IterableOnceDeco
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.ICallResolver
 import io.shiftleft.semanticcpg.utils.MemberAccess
-import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language.*
 
 import scala.annotation.tailrec
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 // Many method of this class should return individual nodes instead of Traversal[...].
 // But over time through some opague implicits the versions returning Traversal[...]
@@ -36,30 +35,30 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
     }
   }
 
-  def expressionUp: Traversal[Expression] = {
+  def expressionUp: Iterator[Expression] = {
     node._astIn.collectAll[Expression]
   }
 
-  def expressionDown: Traversal[Expression] = {
+  def expressionDown: Iterator[Expression] = {
     node._astOut.collectAll[Expression]
   }
 
-  def receivedCall: Traversal[Call] = {
+  def receivedCall: Iterator[Call] = {
     node._receiverIn.cast[Call]
   }
 
-  def isArgument: Traversal[Expression] = {
+  def isArgument: Iterator[Expression] = {
     if (node._argumentIn.hasNext) Iterator.single(node)
     else Iterator.empty
   }
 
-  def inCall: Traversal[Call] =
+  def inCall: Iterator[Call] =
     node._argumentIn.headOption match {
       case Some(c: Call) => Iterator.single(c)
       case _             => Iterator.empty
     }
 
-  def parameter(implicit callResolver: ICallResolver): Traversal[MethodParameterIn] = {
+  def parameter(implicit callResolver: ICallResolver): Iterator[MethodParameterIn] = {
     // Expressions can have incoming argument edges not just from CallRepr nodes but also
     // from Return nodes for which an expansion to parameter makes no sense. So we filter
     // for CallRepr.
@@ -71,7 +70,7 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
     } yield paramIn
   }
 
-  def typ: Traversal[Type] =
+  def typ: Iterator[Type] =
     node._evalTypeOut.cast[Type]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LocalMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LocalMethods.scala
@@ -2,8 +2,7 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Local, Method, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, _}
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 
 class LocalMethods(val local: Local) extends AnyVal with NodeExtension with HasLocation {
   override def location: NewLocation = {
@@ -12,6 +11,6 @@ class LocalMethods(val local: Local) extends AnyVal with NodeExtension with HasL
 
   /** The method hosting this local variable
     */
-  def method: Traversal[Method] =
+  def method: Iterator[Method] =
     Iterator.single(local).method
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,23 +1,22 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{Traversal, jIteratortoTraversal}
+import io.shiftleft.semanticcpg.language.*
 
 class MethodMethods(val method: Method) extends AnyVal with NodeExtension with HasLocation {
 
   /** Traverse to annotations of method
     */
-  def annotation: Traversal[Annotation] =
+  def annotation: Iterator[Annotation] =
     method._annotationViaAstOut
 
-  def local: Traversal[Local] =
+  def local: Iterator[Local] =
     method._blockViaContainsOut.local
 
   /** All control structures of this method
     */
-  def controlStructure: Traversal[ControlStructure] =
+  def controlStructure: Iterator[ControlStructure] =
     method.ast.isControlStructure
 
   def numberOfLines: Int = {
@@ -32,19 +31,19 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
     method.parameter.exists(_.isVariadic)
   }
 
-  def cfgNode: Traversal[CfgNode] =
+  def cfgNode: Iterator[CfgNode] =
     method._containsOut.collectAll[CfgNode]
 
   /** List of CFG nodes in reverse post order
     */
-  def reversePostOrder: Traversal[CfgNode] = {
+  def reversePostOrder: Iterator[CfgNode] = {
     def expand(x: CfgNode) = { x.cfgNext.iterator }
     NodeOrdering.reverseNodeList(NodeOrdering.postOrderNumbering(method, expand).toList).iterator
   }
 
   /** List of CFG nodes in post order
     */
-  def postOrder: Traversal[CfgNode] = {
+  def postOrder: Iterator[CfgNode] = {
     def expand(x: CfgNode) = { x.cfgNext.iterator }
     NodeOrdering.nodeList(NodeOrdering.postOrderNumbering(method, expand).toList).iterator
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
@@ -2,14 +2,14 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodReturn, NewLocation, Type}
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, _}
+import io.shiftleft.semanticcpg.language.*
 
 class MethodReturnMethods(val node: MethodReturn) extends AnyVal with NodeExtension with HasLocation {
   override def location: NewLocation = {
     LocationCreator(node, "$ret", node.label, node.lineNumber, node.method)
   }
 
-  def returnUser(implicit callResolver: ICallResolver): Traversal[Call] = {
+  def returnUser(implicit callResolver: ICallResolver): Iterator[Call] = {
     val method    = node._methodViaAstIn
     val callsites = callResolver.getMethodCallsites(method)
     // TODO for now we filter away all implicit calls because a change of the
@@ -19,5 +19,5 @@ class MethodReturnMethods(val node: MethodReturn) extends AnyVal with NodeExtens
     callsites.collectAll[Call]
   }
 
-  def typ: Traversal[Type] = node.evalTypeOut
+  def typ: Iterator[Type] = node.evalTypeOut
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
@@ -1,18 +1,18 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class StoredNodeMethods(val node: StoredNode) extends AnyVal with NodeExtension {
-  def tag: Traversal[Tag] = {
+  def tag: Iterator[Tag] = {
     node._taggedByOut
       .cast[Tag]
       .distinctBy(tag => (tag.name, tag.value))
   }
 
-  def file: Traversal[File] =
+  def file: Iterator[File] =
     Iterator.single(node).file
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
@@ -4,16 +4,16 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Identifier}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.help.Doc
 
-class ArrayAccessTraversal(val traversal: Traversal[OpNodes.ArrayAccess]) extends AnyVal {
+class ArrayAccessTraversal(val traversal: Iterator[OpNodes.ArrayAccess]) extends AnyVal {
 
   @Doc(info = "The expression representing the array")
-  def array: Traversal[Expression] = traversal.map(_.array)
+  def array: Iterator[Expression] = traversal.map(_.array)
 
   @Doc(info = "Offset at which the array is referenced (an expression)")
-  def offset: Traversal[Expression] = traversal.map(_.offset)
+  def offset: Iterator[Expression] = traversal.map(_.offset)
 
   @Doc(info = "All identifiers that are part of the offset")
-  def subscript: Traversal[Identifier] = traversal.flatMap(_.subscript)
+  def subscript: Iterator[Identifier] = traversal.flatMap(_.subscript)
 
   @Doc(
     info = "Determine whether array access has constant offset",
@@ -24,8 +24,8 @@ class ArrayAccessTraversal(val traversal: Traversal[OpNodes.ArrayAccess]) extend
         or even `buf[PROBABLY_A_CONSTANT]`.
         """
   )
-  def usesConstantOffset: Traversal[OpNodes.ArrayAccess] = traversal.filter(_.usesConstantOffset)
+  def usesConstantOffset: Iterator[OpNodes.ArrayAccess] = traversal.filter(_.usesConstantOffset)
 
   @Doc(info = "If `array` is a lone identifier, return its name")
-  def simpleName: Traversal[String] = traversal.flatMap(_.simpleName)
+  def simpleName: Iterator[String] = traversal.flatMap(_.simpleName)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
@@ -1,16 +1,16 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.help.Doc
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.help
+import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[OpNodes.Assignment])
-class AssignmentTraversal(val traversal: Traversal[OpNodes.Assignment]) extends AnyVal {
+class AssignmentTraversal(val traversal: Iterator[OpNodes.Assignment]) extends AnyVal {
 
   @Doc(info = "Left-hand sides of assignments")
-  def target: Traversal[Expression] = traversal.map(_.target)
+  def target: Iterator[Expression] = traversal.map(_.target)
 
   @Doc(info = "Right-hand sides of assignments")
-  def source: Traversal[Expression] = traversal.map(_.source)
+  def source: Iterator[Expression] = traversal.map(_.source)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/FieldAccessTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/FieldAccessTraversal.scala
@@ -1,25 +1,24 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{FieldIdentifier, Member, TypeDecl}
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.help.Doc
 
-class FieldAccessTraversal(val traversal: Traversal[OpNodes.FieldAccess]) extends AnyVal {
+class FieldAccessTraversal(val traversal: Iterator[OpNodes.FieldAccess]) extends AnyVal {
 
   @Doc(info = "Attempts to resolve the type declaration for this field access")
-  def typeDecl: Traversal[TypeDecl] =
+  def typeDecl: Iterator[TypeDecl] =
     traversal.flatMap(_.typeDecl)
 
   // TODO there are cases for the C++ frontend where argument(2) is a CALL or IDENTIFIER,
   // and we are not handling them at the moment
 
   @Doc(info = "The identifier of the referenced field (right-hand side)")
-  def fieldIdentifier: Traversal[FieldIdentifier] =
+  def fieldIdentifier: Iterator[FieldIdentifier] =
     traversal.flatMap(_.fieldIdentifier)
 
   @Doc(info = "Attempts to resolve the member referenced by this field access")
-  def member: Traversal[Member] =
+  def member: Iterator[Member] =
     traversal.flatMap(_.member)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Implicits.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Implicits.scala
@@ -3,29 +3,28 @@ package io.shiftleft.semanticcpg.language.operatorextension
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Expression}
 import io.shiftleft.semanticcpg.language.operatorextension.nodemethods._
-import overflowdb.traversal._
 
 trait Implicits {
   implicit def toNodeTypeStartersOperatorExtension(cpg: Cpg): NodeTypeStarters = new NodeTypeStarters(cpg)
 
   implicit def toArrayAccessExt(arrayAccess: OpNodes.ArrayAccess): ArrayAccessMethods =
     new ArrayAccessMethods(arrayAccess)
-  implicit def toArrayAccessTrav(steps: Traversal[OpNodes.ArrayAccess]): ArrayAccessTraversal =
+  implicit def toArrayAccessTrav(steps: Iterator[OpNodes.ArrayAccess]): ArrayAccessTraversal =
     new ArrayAccessTraversal(steps)
 
   implicit def toFieldAccessExt(fieldAccess: OpNodes.FieldAccess): FieldAccessMethods =
     new FieldAccessMethods(fieldAccess)
-  implicit def toFieldAccessTrav(steps: Traversal[OpNodes.FieldAccess]): FieldAccessTraversal =
+  implicit def toFieldAccessTrav(steps: Iterator[OpNodes.FieldAccess]): FieldAccessTraversal =
     new FieldAccessTraversal(steps)
 
   implicit def toAssignmentExt(assignment: OpNodes.Assignment): AssignmentMethods = new AssignmentMethods(assignment)
-  implicit def toAssignmentTrav(steps: Traversal[OpNodes.Assignment]): AssignmentTraversal =
+  implicit def toAssignmentTrav(steps: Iterator[OpNodes.Assignment]): AssignmentTraversal =
     new AssignmentTraversal(steps)
 
-  implicit def toTargetExt(call: Expression): TargetMethods                = new TargetMethods(call)
-  implicit def toTargetTrav(steps: Traversal[Expression]): TargetTraversal = new TargetTraversal(steps)
+  implicit def toTargetExt(call: Expression): TargetMethods               = new TargetMethods(call)
+  implicit def toTargetTrav(steps: Iterator[Expression]): TargetTraversal = new TargetTraversal(steps)
 
-  implicit def toOpAstNodeExt[A <: AstNode](node: A): OpAstNodeMethods[A]                = new OpAstNodeMethods(node)
-  implicit def toOpAstNodeTrav[A <: AstNode](steps: Traversal[A]): OpAstNodeTraversal[A] = new OpAstNodeTraversal(steps)
+  implicit def toOpAstNodeExt[A <: AstNode](node: A): OpAstNodeMethods[A]               = new OpAstNodeMethods(node)
+  implicit def toOpAstNodeTrav[A <: AstNode](steps: Iterator[A]): OpAstNodeTraversal[A] = new OpAstNodeTraversal(steps)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.help.{Doc, TraversalSource}
 
 /** Steps that allow traversing from `cpg` to operators.
@@ -10,22 +10,22 @@ import overflowdb.traversal.help.{Doc, TraversalSource}
 class NodeTypeStarters(cpg: Cpg) {
 
   @Doc(info = "All assignments, including shorthand assignments that perform arithmetic (e.g., '+=')")
-  def assignment: Traversal[OpNodes.Assignment] =
+  def assignment: Iterator[OpNodes.Assignment] =
     callsWithNameIn(allAssignmentTypes)
       .map(new OpNodes.Assignment(_))
 
   @Doc(info = "All arithmetic operations, including shorthand assignments that perform arithmetic (e.g., '+=')")
-  def arithmetic: Traversal[OpNodes.Arithmetic] =
+  def arithmetic: Iterator[OpNodes.Arithmetic] =
     callsWithNameIn(allArithmeticTypes)
       .map(new OpNodes.Arithmetic(_))
 
   @Doc(info = "All array accesses")
-  def arrayAccess: Traversal[OpNodes.ArrayAccess] =
+  def arrayAccess: Iterator[OpNodes.ArrayAccess] =
     callsWithNameIn(allArrayAccessTypes)
       .map(new OpNodes.ArrayAccess(_))
 
   @Doc(info = "Field accesses, both direct and indirect")
-  def fieldAccess: Traversal[OpNodes.FieldAccess] =
+  def fieldAccess: Iterator[OpNodes.FieldAccess] =
     callsWithNameIn(allFieldAccessTypes)
       .map(new OpNodes.FieldAccess(_))
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTraversal.scala
@@ -1,34 +1,34 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.help.Doc
 
-class OpAstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {
+class OpAstNodeTraversal[A <: AstNode](val traversal: Iterator[A]) extends AnyVal {
 
   @Doc(info = "Any assignments that this node is a part of (traverse up)")
-  def assignment: Traversal[OpNodes.Assignment] = traversal.flatMap(_.assignment)
+  def assignment: Iterator[OpNodes.Assignment] = traversal.flatMap(_.assignment)
 
   @Doc(info = "Arithmetic expressions nested in this tree")
-  def arithmetic: Traversal[OpNodes.Arithmetic] = traversal.flatMap(_.arithmetic)
+  def arithmetic: Iterator[OpNodes.Arithmetic] = traversal.flatMap(_.arithmetic)
 
   @Doc(info = "All array accesses")
-  def arrayAccess: Traversal[OpNodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
+  def arrayAccess: Iterator[OpNodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
 
   @Doc(info = "Field accesses, both direct and indirect")
-  def fieldAccess: Traversal[OpNodes.FieldAccess] =
+  def fieldAccess: Iterator[OpNodes.FieldAccess] =
     traversal.flatMap(_.fieldAccess)
 
   @Doc(info = "Any assignments that this node is a part of (traverse up)")
-  def inAssignment: Traversal[OpNodes.Assignment] = traversal.flatMap(_.inAssignment)
+  def inAssignment: Iterator[OpNodes.Assignment] = traversal.flatMap(_.inAssignment)
 
   @Doc(info = "Any arithmetic expression that this node is a part of (traverse up)")
-  def inArithmetic: Traversal[OpNodes.Arithmetic] = traversal.flatMap(_.inArithmetic)
+  def inArithmetic: Iterator[OpNodes.Arithmetic] = traversal.flatMap(_.inArithmetic)
 
   @Doc(info = "Any array access that this node is a part of (traverse up)")
-  def inArrayAccess: Traversal[OpNodes.ArrayAccess] = traversal.flatMap(_.inArrayAccess)
+  def inArrayAccess: Iterator[OpNodes.ArrayAccess] = traversal.flatMap(_.inArrayAccess)
 
   @Doc(info = "Any field access that this node is a part of (traverse up)")
-  def inFieldAccess: Traversal[OpNodes.FieldAccess] = traversal.flatMap(_.inFieldAccess)
+  def inFieldAccess: Iterator[OpNodes.FieldAccess] = traversal.flatMap(_.inFieldAccess)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.help.Doc
 
-class TargetTraversal(val traversal: Traversal[Expression]) extends AnyVal {
+class TargetTraversal(val traversal: Iterator[Expression]) extends AnyVal {
 
   @Doc(
     info = "Outer-most array access",
@@ -13,9 +13,9 @@ class TargetTraversal(val traversal: Traversal[Expression]) extends AnyVal {
         is returned, but not b(c) alone.
         """
   )
-  def arrayAccess: Traversal[OpNodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
+  def arrayAccess: Iterator[OpNodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
 
   @Doc(info = "Returns 'pointer' in assignments of the form *(pointer) = x")
-  def pointer: Traversal[Expression] = traversal.flatMap(_.pointer)
+  def pointer: Iterator[Expression] = traversal.flatMap(_.pointer)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Identifier}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
-import overflowdb.traversal.Traversal
 
 class ArrayAccessMethods(val arrayAccess: OpNodes.ArrayAccess) extends AnyVal {
 
@@ -12,7 +11,7 @@ class ArrayAccessMethods(val arrayAccess: OpNodes.ArrayAccess) extends AnyVal {
 
   def offset: Expression = arrayAccess.argument(2)
 
-  def subscript: Traversal[Identifier] =
+  def subscript: Iterator[Identifier] =
     offset.ast.isIdentifier
 
   def usesConstantOffset: Boolean = {
@@ -22,7 +21,7 @@ class ArrayAccessMethods(val arrayAccess: OpNodes.ArrayAccess) extends AnyVal {
     }
   }
 
-  def simpleName: Traversal[String] = {
+  def simpleName: Iterator[String] = {
     arrayAccess.array match {
       case id: Identifier => Iterator.single(id.name)
       case _              => Iterator.empty

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
@@ -1,15 +1,14 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
-import overflowdb.traversal.{NodeOps, Traversal}
 
 class FieldAccessMethods(val arrayAccess: OpNodes.FieldAccess) extends AnyVal {
 
-  def typeDecl: Traversal[TypeDecl] = resolveTypeDecl(arrayAccess.argument(1))
+  def typeDecl: Iterator[TypeDecl] = resolveTypeDecl(arrayAccess.argument(1))
 
-  private def resolveTypeDecl(expr: Expression): Traversal[TypeDecl] = {
+  private def resolveTypeDecl(expr: Expression): Iterator[TypeDecl] = {
     expr match {
       case x: Identifier => x.typ.referencedTypeDecl
       case x: Literal    => x.typ.referencedTypeDecl
@@ -18,7 +17,7 @@ class FieldAccessMethods(val arrayAccess: OpNodes.FieldAccess) extends AnyVal {
     }
   }
 
-  def fieldIdentifier: Traversal[FieldIdentifier] = arrayAccess.start.argument(2).isFieldIdentifier
+  def fieldIdentifier: Iterator[FieldIdentifier] = arrayAccess.start.argument(2).isFieldIdentifier
 
   def member: Option[Member] =
     arrayAccess.referencedMember.headOption

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
@@ -1,50 +1,43 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call}
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.{
-  OpNodes,
-  allArithmeticTypes,
-  allArrayAccessTypes,
-  allAssignmentTypes,
-  allFieldAccessTypes
-}
-import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.operatorextension.*
 
 class OpAstNodeMethods[A <: AstNode](val node: A) extends AnyVal {
 
-  def assignment: Traversal[OpNodes.Assignment] =
+  def assignment: Iterator[OpNodes.Assignment] =
     astDown(allAssignmentTypes).map(new OpNodes.Assignment(_))
 
-  def arithmetic: Traversal[OpNodes.Arithmetic] =
+  def arithmetic: Iterator[OpNodes.Arithmetic] =
     astDown(allArithmeticTypes).map(new OpNodes.Arithmetic(_))
 
-  def arrayAccess: Traversal[OpNodes.ArrayAccess] =
+  def arrayAccess: Iterator[OpNodes.ArrayAccess] =
     astDown(allArrayAccessTypes).map(new OpNodes.ArrayAccess(_))
 
-  def fieldAccess: Traversal[OpNodes.FieldAccess] =
+  def fieldAccess: Iterator[OpNodes.FieldAccess] =
     astDown(allFieldAccessTypes).map(new OpNodes.FieldAccess(_))
 
-  private def astDown(callNames: Set[String]): Traversal[Call] =
+  private def astDown(callNames: Set[String]): Iterator[Call] =
     node.ast.isCall.filter(x => callNames.contains(x.name))
 
-  def inAssignment: Traversal[OpNodes.Assignment] =
+  def inAssignment: Iterator[OpNodes.Assignment] =
     astUp(allAssignmentTypes)
       .map(new OpNodes.Assignment(_))
 
-  def inArithmetic: Traversal[OpNodes.Arithmetic] =
+  def inArithmetic: Iterator[OpNodes.Arithmetic] =
     astUp(allArithmeticTypes)
       .map(new OpNodes.Arithmetic(_))
 
-  def inArrayAccess: Traversal[OpNodes.ArrayAccess] =
+  def inArrayAccess: Iterator[OpNodes.ArrayAccess] =
     astUp(allArrayAccessTypes)
       .map(new OpNodes.ArrayAccess(_))
 
-  def inFieldAccess: Traversal[OpNodes.FieldAccess] =
+  def inFieldAccess: Iterator[OpNodes.FieldAccess] =
     astUp(allFieldAccessTypes)
       .map(new OpNodes.FieldAccess(_))
 
-  private def astUp(strings: Set[String]): Traversal[Call] =
+  private def astUp(strings: Set[String]): Iterator[Call] =
     node.inAstMinusLeaf.isCall
       .filter(x => strings.contains(x.name))
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -19,7 +19,6 @@ import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{
 import io.shiftleft.semanticcpg.language.types.expressions.{CallTraversal => OriginalCall, _}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 import io.shiftleft.semanticcpg.language.types.structure.{MethodTraversal => OriginalMethod, _}
-import overflowdb.traversal.Traversal
 import overflowdb.NodeOrDetachedNode
 
 /** Language for traversing the code property graph
@@ -178,22 +177,22 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
     *
     * In most places you should explicitly call `Iterator.single` instead of relying on this implicit.
     */
-  implicit def toTraversal[NodeType <: StoredNode](node: NodeType): Traversal[NodeType] =
+  implicit def toTraversal[NodeType <: StoredNode](node: NodeType): Iterator[NodeType] =
     Iterator.single(node)
 
   implicit def iterableOnceToSteps[A](iterableOnce: IterableOnce[A]): Steps[A] =
     new Steps(iterableOnce.iterator)
 
-  implicit def traversalToSteps[A](trav: Traversal[A]): Steps[A] =
+  implicit def traversalToSteps[A](trav: Iterator[A]): Steps[A] =
     new Steps(trav)
   implicit def iterOnceToNodeSteps[A <: StoredNode](a: IterableOnce[A]): NodeSteps[A] =
     new NodeSteps[A](a.iterator)
 
-  implicit def toNewNodeTrav[NodeType <: NewNode](trav: Traversal[NodeType]): NewNodeSteps[NodeType] =
+  implicit def toNewNodeTrav[NodeType <: NewNode](trav: Iterator[NodeType]): NewNodeSteps[NodeType] =
     new NewNodeSteps[NodeType](trav)
 
-  implicit def toNodeTypeStarters(cpg: Cpg): NodeTypeStarters     = new NodeTypeStarters(cpg)
-  implicit def toTagTraversal(trav: Traversal[Tag]): TagTraversal = new TagTraversal(trav)
+  implicit def toNodeTypeStarters(cpg: Cpg): NodeTypeStarters    = new NodeTypeStarters(cpg)
+  implicit def toTagTraversal(trav: Iterator[Tag]): TagTraversal = new TagTraversal(trav)
 
   // ~ EvalType accessors
   implicit def singleToEvalTypeAccessorsLocal[A <: Local](a: A): EvalTypeAccessors[A] =
@@ -258,7 +257,7 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
 
     /** Start a new traversal from this node
       */
-    def start: Traversal[NodeType] =
+    def start: Iterator[NodeType] =
       Iterator.single(node)
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -1,40 +1,40 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 /** A call site
   */
-class CallTraversal(val traversal: Traversal[Call]) extends AnyVal {
+class CallTraversal(val traversal: Iterator[Call]) extends AnyVal {
 
   /** Only statically dispatched calls
     */
-  def isStatic: Traversal[Call] =
+  def isStatic: Iterator[Call] =
     traversal.dispatchType("STATIC_DISPATCH")
 
   /** Only dynamically dispatched calls
     */
-  def isDynamic: Traversal[Call] =
+  def isDynamic: Iterator[Call] =
     traversal.dispatchType("DYNAMIC_DISPATCH")
 
   /** The receiver of a call if the call has a receiver associated.
     */
-  def receiver: Traversal[Expression] =
+  def receiver: Iterator[Expression] =
     traversal.flatMap(_.receiver)
 
   /** Arguments of the call
     */
-  def argument: Traversal[Expression] =
+  def argument: Iterator[Expression] =
     traversal.flatMap(_.argument)
 
   /** `i'th` arguments of the call
     */
-  def argument(i: Integer): Traversal[Expression] =
+  def argument(i: Integer): Iterator[Expression] =
     traversal.flatMap(_.arguments(i))
 
   /** To formal method return parameter
     */
-  def toMethodReturn(implicit callResolver: ICallResolver): Traversal[MethodReturn] =
+  def toMethodReturn(implicit callResolver: ICallResolver): Iterator[MethodReturn] =
     traversal
       .flatMap(callResolver.getCalledMethodsAsTraversal)
       .flatMap(_.methodReturn)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -1,77 +1,76 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, ControlStructure, Expression}
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Properties}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Properties}
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, toElementTraversal, toNodeTraversal}
 
 object ControlStructureTraversal {
   val secondChildIndex = 2
   val thirdChildIndex  = 3
 }
 
-class ControlStructureTraversal(val traversal: Traversal[ControlStructure]) extends AnyVal {
-  import ControlStructureTraversal._
+class ControlStructureTraversal(val traversal: Iterator[ControlStructure]) extends AnyVal {
+  import ControlStructureTraversal.*
 
   @Doc(info = "The condition associated with this control structure")
-  def condition: Traversal[Expression] =
+  def condition: Iterator[Expression] =
     traversal.flatMap(_.conditionOut).collectAll[Expression]
 
   @Doc(info = "Control structures where condition.code matches regex")
-  def condition(regex: String): Traversal[ControlStructure] =
+  def condition(regex: String): Iterator[ControlStructure] =
     traversal.where(_.condition.code(regex))
 
   @Doc(info = "Sub tree taken when condition evaluates to true")
-  def whenTrue: Traversal[AstNode] =
+  def whenTrue: Iterator[AstNode] =
     traversal.out.has(Properties.ORDER, secondChildIndex: Int).cast[AstNode]
 
   @Doc(info = "Sub tree taken when condition evaluates to false")
-  def whenFalse: Traversal[AstNode] =
+  def whenFalse: Iterator[AstNode] =
     traversal.out.has(Properties.ORDER, thirdChildIndex).cast[AstNode]
 
   @Doc(info = "Only `Try` control structures")
-  def isTry: Traversal[ControlStructure] =
+  def isTry: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.TRY)
 
   @Doc(info = "Only `If` control structures")
-  def isIf: Traversal[ControlStructure] =
+  def isIf: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.IF)
 
   @Doc(info = "Only `Else` control structures")
-  def isElse: Traversal[ControlStructure] =
+  def isElse: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.ELSE)
 
   @Doc(info = "Only `Switch` control structures")
-  def isSwitch: Traversal[ControlStructure] =
+  def isSwitch: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.SWITCH)
 
   @Doc(info = "Only `Do` control structures")
-  def isDo: Traversal[ControlStructure] =
+  def isDo: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.DO)
 
   @Doc(info = "Only `For` control structures")
-  def isFor: Traversal[ControlStructure] =
+  def isFor: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.FOR)
 
   @Doc(info = "Only `While` control structures")
-  def isWhile: Traversal[ControlStructure] =
+  def isWhile: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.WHILE)
 
   @Doc(info = "Only `Goto` control structures")
-  def isGoto: Traversal[ControlStructure] =
+  def isGoto: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.GOTO)
 
   @Doc(info = "Only `Break` control structures")
-  def isBreak: Traversal[ControlStructure] =
+  def isBreak: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.BREAK)
 
   @Doc(info = "Only `Continue` control structures")
-  def isContinue: Traversal[ControlStructure] =
+  def isContinue: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.CONTINUE)
 
   @Doc(info = "Only `Throw` control structures")
-  def isThrow: Traversal[ControlStructure] =
+  def isThrow: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.THROW)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTraversal.scala
@@ -1,15 +1,15 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Identifier}
-import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language.toTraversalSugarExt
 
 /** An identifier, e.g., an instance of a local variable, or a temporary variable
   */
-class IdentifierTraversal(val traversal: Traversal[Identifier]) extends AnyVal {
+class IdentifierTraversal(val traversal: Iterator[Identifier]) extends AnyVal {
 
   /** Traverse to all declarations of this identifier
     */
-  def refsTo: Traversal[Declaration] = {
+  def refsTo: Iterator[Declaration] = {
     traversal.flatMap(_.refOut).cast[Declaration]
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -1,78 +1,78 @@
 package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
+import overflowdb.traversal.help
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, help, toElementTraversal, toNodeTraversal}
 
 @help.Traversal(elementType = classOf[AstNode])
-class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {
+class AstNodeTraversal[A <: AstNode](val traversal: Iterator[A]) extends AnyVal {
 
   /** Nodes of the AST rooted in this node, including the node itself.
     */
   @Doc(info = "All nodes of the abstract syntax tree")
-  def ast: Traversal[AstNode] = {
+  def ast: Iterator[AstNode] = {
     traversal.repeat(_.out(EdgeTypes.AST))(_.emit).cast[AstNode]
   }
 
   /** All nodes of the abstract syntax tree rooted in this node, which match `predicate`. Equivalent of `match` in the
     * original CPG paper.
     */
-  def ast(predicate: AstNode => Boolean): Traversal[AstNode] =
+  def ast(predicate: AstNode => Boolean): Iterator[AstNode] =
     ast.filter(predicate)
 
-  def containsCallTo(regex: String): Traversal[A] =
+  def containsCallTo(regex: String): Iterator[A] =
     traversal.filter(_.ast.isCall.name(regex).nonEmpty)
 
   @Doc(info = "Depth of the abstract syntax tree")
-  def depth: Traversal[Int] =
+  def depth: Iterator[Int] =
     traversal.map(_.depth)
 
-  def depth(p: AstNode => Boolean): Traversal[Int] =
+  def depth(p: AstNode => Boolean): Iterator[Int] =
     traversal.map(_.depth(p))
 
-  def isCallTo(regex: String): Traversal[Call] =
+  def isCallTo(regex: String): Iterator[Call] =
     isCall.name(regex)
 
   /** Nodes of the AST rooted in this node, minus the node itself
     */
-  def astMinusRoot: Traversal[AstNode] =
+  def astMinusRoot: Iterator[AstNode] =
     traversal.repeat(_.out(EdgeTypes.AST))(_.emitAllButFirst).cast[AstNode]
 
   /** Direct children of node in the AST. Siblings are ordered by their `order` fields
     */
-  def astChildren: Traversal[AstNode] =
+  def astChildren: Iterator[AstNode] =
     traversal.flatMap(_.astChildren).sortBy(_.order).iterator
 
   /** Parent AST node
     */
-  def astParent: Traversal[AstNode] =
+  def astParent: Iterator[AstNode] =
     traversal.in(EdgeTypes.AST).cast[AstNode]
 
   /** Siblings of this node in the AST, ordered by their `order` fields
     */
-  def astSiblings: Traversal[AstNode] =
+  def astSiblings: Iterator[AstNode] =
     traversal.flatMap(_.astSiblings)
 
   /** Traverses up the AST and returns the first block node.
     */
-  def parentBlock: Traversal[Block] =
+  def parentBlock: Iterator[Block] =
     traversal.repeat(_.in(EdgeTypes.AST))(_.emit.until(_.hasLabel(NodeTypes.BLOCK))).collectAll[Block]
 
   /** Nodes of the AST obtained by expanding AST edges backwards until the method root is reached
     */
-  def inAst: Traversal[AstNode] =
+  def inAst: Iterator[AstNode] =
     inAst(null)
 
   /** Nodes of the AST obtained by expanding AST edges backwards until the method root is reached, minus this node
     */
-  def inAstMinusLeaf: Traversal[AstNode] =
+  def inAstMinusLeaf: Iterator[AstNode] =
     inAstMinusLeaf(null)
 
   /** Nodes of the AST obtained by expanding AST edges backwards until `root` or the method root is reached
     */
-  def inAst(root: AstNode): Traversal[AstNode] =
+  def inAst(root: AstNode): Iterator[AstNode] =
     traversal
       .repeat(_.in(EdgeTypes.AST))(
         _.emit
@@ -83,7 +83,7 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
   /** Nodes of the AST obtained by expanding AST edges backwards until `root` or the method root is reached, minus this
     * node
     */
-  def inAstMinusLeaf(root: AstNode): Traversal[AstNode] =
+  def inAstMinusLeaf(root: AstNode): Iterator[AstNode] =
     traversal
       .repeat(_.in(EdgeTypes.AST))(
         _.emitAllButFirst
@@ -93,122 +93,122 @@ class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal
 
   /** Traverse only to those AST nodes that are also control flow graph nodes
     */
-  def isCfgNode: Traversal[CfgNode] =
+  def isCfgNode: Iterator[CfgNode] =
     traversal.collectAll[CfgNode]
 
-  def isAnnotation: Traversal[Annotation] =
+  def isAnnotation: Iterator[Annotation] =
     traversal.collectAll[Annotation]
 
-  def isAnnotationLiteral: Traversal[AnnotationLiteral] =
+  def isAnnotationLiteral: Iterator[AnnotationLiteral] =
     traversal.collectAll[AnnotationLiteral]
 
-  def isArrayInitializer: Traversal[ArrayInitializer] =
+  def isArrayInitializer: Iterator[ArrayInitializer] =
     traversal.collectAll[ArrayInitializer]
 
   /** Traverse only to those AST nodes that are blocks
     */
-  def isBlock: Traversal[Block] =
+  def isBlock: Iterator[Block] =
     traversal.collectAll[Block]
 
   /** Traverse only to those AST nodes that are control structures
     */
-  def isControlStructure: Traversal[ControlStructure] =
+  def isControlStructure: Iterator[ControlStructure] =
     traversal.collectAll[ControlStructure]
 
   /** Traverse only to AST nodes that are expressions
     */
-  def isExpression: Traversal[Expression] =
+  def isExpression: Iterator[Expression] =
     traversal.collectAll[Expression]
 
   /** Traverse only to AST nodes that are calls
     */
-  def isCall: Traversal[Call] =
+  def isCall: Iterator[Call] =
     traversal.collectAll[Call]
 
   /** Cast to call if applicable and filter on call code `calleeRegex`
     */
-  def isCall(calleeRegex: String): Traversal[Call] =
+  def isCall(calleeRegex: String): Iterator[Call] =
     isCall.where(_.code(calleeRegex))
 
   /** Traverse only to AST nodes that are literals
     */
-  def isLiteral: Traversal[Literal] =
+  def isLiteral: Iterator[Literal] =
     traversal.collectAll[Literal]
 
-  def isLocal: Traversal[Local] =
+  def isLocal: Iterator[Local] =
     traversal.collectAll[Local]
 
   /** Traverse only to AST nodes that are identifier
     */
-  def isIdentifier: Traversal[Identifier] =
+  def isIdentifier: Iterator[Identifier] =
     traversal.collectAll[Identifier]
 
   /** Traverse only to AST nodes that are IMPORT nodes
     */
-  def isImport: Traversal[Import] =
+  def isImport: Iterator[Import] =
     traversal.collectAll[Import]
 
   /** Traverse only to FILE AST nodes
     */
-  def isFile: Traversal[File] =
+  def isFile: Iterator[File] =
     traversal.collectAll[File]
 
   /** Traverse only to AST nodes that are field identifier
     */
-  def isFieldIdentifier: Traversal[FieldIdentifier] =
+  def isFieldIdentifier: Iterator[FieldIdentifier] =
     traversal.collectAll[FieldIdentifier]
 
   /** Traverse only to AST nodes that are return nodes
     */
-  def isReturn: Traversal[Return] =
+  def isReturn: Iterator[Return] =
     traversal.collectAll[Return]
 
   /** Traverse only to AST nodes that are MEMBER
     */
-  def isMember: Traversal[Member] =
+  def isMember: Iterator[Member] =
     traversal.collectAll[Member]
 
   /** Traverse only to AST nodes that are method reference
     */
-  def isMethodRef: Traversal[MethodRef] =
+  def isMethodRef: Iterator[MethodRef] =
     traversal.collectAll[MethodRef]
 
   /** Traverse only to AST nodes that are type reference
     */
-  def isTypeRef: Traversal[TypeRef] =
+  def isTypeRef: Iterator[TypeRef] =
     traversal.collectAll[TypeRef]
 
   /** Traverse only to AST nodes that are METHOD
     */
-  def isMethod: Traversal[Method] =
+  def isMethod: Iterator[Method] =
     traversal.collectAll[Method]
 
   /** Traverse only to AST nodes that are MODIFIER
     */
-  def isModifier: Traversal[Modifier] =
+  def isModifier: Iterator[Modifier] =
     traversal.collectAll[Modifier]
 
   /** Traverse only to AST nodes that are NAMESPACE_BLOCK
     */
-  def isNamespaceBlock: Traversal[NamespaceBlock] =
+  def isNamespaceBlock: Iterator[NamespaceBlock] =
     traversal.collectAll[NamespaceBlock]
 
   /** Traverse only to AST nodes that are METHOD_PARAMETER_IN
     */
-  def isParameter: Traversal[MethodParameterIn] =
+  def isParameter: Iterator[MethodParameterIn] =
     traversal.collectAll[MethodParameterIn]
 
   /** Traverse only to AST nodes that are TemplateDom nodes
     */
-  def isTemplateDom: Traversal[TemplateDom] =
+  def isTemplateDom: Iterator[TemplateDom] =
     traversal.collectAll[TemplateDom]
 
   /** Traverse only to AST nodes that are TYPE_DECL
     */
-  def isTypeDecl: Traversal[TypeDecl] =
+  def isTypeDecl: Iterator[TypeDecl] =
     traversal.collectAll[TypeDecl]
 
-  def walkAstUntilReaching(labels: List[String]): Traversal[StoredNode] =
+  def walkAstUntilReaching(labels: List[String]): Iterator[StoredNode] =
     traversal
       .repeat(_.out(EdgeTypes.AST))(_.emitAllButFirst.until(_.hasLabel(labels: _*)))
       .dedup

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -1,30 +1,29 @@
 package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{help}
+import overflowdb.traversal.help
 import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[CfgNode])
-class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal {
+class CfgNodeTraversal[A <: CfgNode](val traversal: Iterator[A]) extends AnyVal {
 
   /** Textual representation of CFG node
     */
   @Doc(info = "Textual representation of CFG node")
-  def repr: Traversal[String] =
+  def repr: Iterator[String] =
     traversal.map(_.repr)
 
   /** Traverse to enclosing method
     */
-  def method: Traversal[Method] =
+  def method: Iterator[Method] =
     traversal.map(_.method) // refers to `semanticcpg.language.nodemethods.CfgNodeMethods.method`
 
   /** Traverse to next expression in CFG.
     */
 
   @Doc(info = "Nodes directly reachable via outgoing CFG edges")
-  def cfgNext: Traversal[CfgNode] =
+  def cfgNext: Iterator[CfgNode] =
     traversal._cfgOut
       .filterNot(_.isInstanceOf[MethodReturn])
       .cast[CfgNode]
@@ -32,69 +31,69 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
   /** Traverse to previous expression in CFG.
     */
   @Doc(info = "Nodes directly reachable via incoming CFG edges")
-  def cfgPrev: Traversal[CfgNode] =
+  def cfgPrev: Iterator[CfgNode] =
     traversal._cfgIn
       .filterNot(_.isInstanceOf[MethodReturn])
       .cast[CfgNode]
 
   /** All nodes reachable in the CFG by up to n forward expansions
     */
-  def cfgNext(n: Int): Traversal[CfgNode] = traversal.flatMap(_.cfgNext(n))
+  def cfgNext(n: Int): Iterator[CfgNode] = traversal.flatMap(_.cfgNext(n))
 
   /** All nodes reachable in the CFG by up to n backward expansions
     */
-  def cfgPrev(n: Int): Traversal[CfgNode] = traversal.flatMap(_.cfgPrev(n))
+  def cfgPrev(n: Int): Iterator[CfgNode] = traversal.flatMap(_.cfgPrev(n))
 
   /** Recursively determine all nodes on which any of the nodes in this traversal are control dependent
     */
   @Doc(info = "All nodes on which this node is control dependent")
-  def controlledBy: Traversal[CfgNode] =
+  def controlledBy: Iterator[CfgNode] =
     traversal.flatMap(_.controlledBy)
 
   /** Recursively determine all nodes which are control dependent on this node
     */
   @Doc(info = "All nodes control dependent on this node")
-  def controls: Traversal[CfgNode] =
+  def controls: Iterator[CfgNode] =
     traversal.flatMap(_.controls)
 
   /** Recursively determine all nodes by which this node is dominated
     */
   @Doc(info = "All nodes by which this node is dominated")
-  def dominatedBy: Traversal[CfgNode] =
+  def dominatedBy: Iterator[CfgNode] =
     traversal.flatMap(_.dominatedBy)
 
   /** Recursively determine all nodes which this node dominates
     */
   @Doc(info = "All nodes that are dominated by this node")
-  def dominates: Traversal[CfgNode] =
+  def dominates: Iterator[CfgNode] =
     traversal.flatMap(_.dominates)
 
   /** Recursively determine all nodes by which this node is post dominated
     */
   @Doc(info = "All nodes by which this node is post dominated")
-  def postDominatedBy: Traversal[CfgNode] =
+  def postDominatedBy: Iterator[CfgNode] =
     traversal.flatMap(_.postDominatedBy)
 
   /** Recursively determine all nodes which this node post dominates
     */
   @Doc(info = "All nodes that are post dominated by this node")
-  def postDominates: Traversal[CfgNode] =
+  def postDominates: Iterator[CfgNode] =
     traversal.flatMap(_.postDominates)
 
   /** Obtain hexadecimal string representation of lineNumber field.
     */
   @Doc(info = "Address of the code (for binary code)")
-  def address: Traversal[Option[String]] =
+  def address: Iterator[Option[String]] =
     traversal.map(_.address)
 
   @Doc(info = "Filters in paths that pass though the given traversal")
-  def passes(included: Traversal[CfgNode]): Traversal[CfgNode] = {
+  def passes(included: Iterator[CfgNode]): Iterator[CfgNode] = {
     val in = included.toSet
     traversal.flatMap(_.passes(in))
   }
 
   @Doc(info = "Filters out paths that pass though the given traversal")
-  def passesNot(excluded: Traversal[CfgNode]): Traversal[CfgNode] = {
+  def passesNot(excluded: Iterator[CfgNode]): Iterator[CfgNode] = {
     val ex = excluded.toSet
     traversal.flatMap(_.passesNot(ex))
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/DeclarationTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/DeclarationTraversal.scala
@@ -1,23 +1,24 @@
 package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
 import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Declaration, MethodRef, TypeRef}
-import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language.*
+import overflowdb.traversal.help
 
 /** A declaration, such as a local or parameter.
   */
 @help.Traversal(elementType = classOf[Declaration])
-class DeclarationTraversal[NodeType <: Declaration](val traversal: Traversal[NodeType]) extends AnyVal {
+class DeclarationTraversal[NodeType <: Declaration](val traversal: Iterator[NodeType]) extends AnyVal {
 
   /** The closure binding node referenced by this declaration
     */
-  def closureBinding: Traversal[ClosureBinding] = traversal.flatMap(_._refIn).collectAll[ClosureBinding]
+  def closureBinding: Iterator[ClosureBinding] = traversal.flatMap(_._refIn).collectAll[ClosureBinding]
 
   /** Methods that capture this declaration
     */
-  def capturedByMethodRef: Traversal[MethodRef] = closureBinding.flatMap(_._captureIn).collectAll[MethodRef]
+  def capturedByMethodRef: Iterator[MethodRef] = closureBinding.flatMap(_._captureIn).collectAll[MethodRef]
 
   /** Types that capture this declaration
     */
-  def capturedByTypeRef: Traversal[TypeRef] = closureBinding.flatMap(_._captureIn).collectAll[TypeRef]
+  def capturedByTypeRef: Iterator[TypeRef] = closureBinding.flatMap(_._captureIn).collectAll[TypeRef]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
@@ -3,62 +3,61 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{InitialTraversal, PathAwareTraversal, Traversal}
 
 /** An expression (base type)
   */
-class ExpressionTraversal[NodeType <: Expression](val traversal: Traversal[NodeType]) extends AnyVal {
+class ExpressionTraversal[NodeType <: Expression](val traversal: Iterator[NodeType]) extends AnyVal {
 
   /** Traverse to it's parent expression (e.g. call or return) by following the incoming AST It's continuing it's walk
     * until it hits an expression that's not a generic "member access operation", e.g., "<operator>.memberAccess".
     */
-  def parentExpression: Traversal[Expression] =
+  def parentExpression: Iterator[Expression] =
     traversal.flatMap(_.parentExpression)
 
   /** Traverse to enclosing expression
     */
-  def expressionUp: Traversal[Expression] =
+  def expressionUp: Iterator[Expression] =
     traversal.flatMap(_.expressionUp)
 
   /** Traverse to sub expressions
     */
-  def expressionDown: Traversal[Expression] =
+  def expressionDown: Iterator[Expression] =
     traversal.flatMap(_.expressionDown)
 
   /** If the expression is used as receiver for a call, this traverses to the call.
     */
-  def receivedCall: Traversal[Call] =
+  def receivedCall: Iterator[Call] =
     traversal.flatMap(_.receivedCall)
 
   /** Only those expressions which are (direct) arguments of a call
     */
-  def isArgument: Traversal[Expression] =
+  def isArgument: Iterator[Expression] =
     traversal.flatMap(_.isArgument)
 
   /** Traverse to surrounding call
     */
-  def inCall: Traversal[Call] =
+  def inCall: Iterator[Call] =
     traversal.flatMap(_.inCall)
 
   /** Traverse to surrounding call
     */
   @deprecated("Use inCall")
-  def call: Traversal[Call] =
+  def call: Iterator[Call] =
     inCall
 
   /** Traverse to related parameter
     */
   @deprecated("", "October 2019")
-  def toParameter(implicit callResolver: ICallResolver): Traversal[MethodParameterIn] = parameter
+  def toParameter(implicit callResolver: ICallResolver): Iterator[MethodParameterIn] = parameter
 
   /** Traverse to related parameter, if the expression is an argument to a call and the call can be resolved.
     */
-  def parameter(implicit callResolver: ICallResolver): Traversal[MethodParameterIn] =
+  def parameter(implicit callResolver: ICallResolver): Iterator[MethodParameterIn] =
     traversal.flatMap(_.parameter)
 
   /** Traverse to enclosing method
     */
-  def method: Traversal[Method] =
+  def method: Iterator[Method] =
     traversal._containsIn
       .flatMap {
         case x: Method   => x.start
@@ -68,7 +67,7 @@ class ExpressionTraversal[NodeType <: Expression](val traversal: Traversal[NodeT
 
   /** Traverse to expression evaluation type
     */
-  def typ: Traversal[Type] =
+  def typ: Iterator[Type] =
     traversal.flatMap(_._evalTypeOut).cast[Type]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
@@ -2,45 +2,45 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
 import io.shiftleft.codepropertygraph.generated.Properties
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
-import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language.*
 
-class EvalTypeAccessors[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {
+class EvalTypeAccessors[A <: AstNode](val traversal: Iterator[A]) extends AnyVal {
 
-  def evalType: Traversal[String] =
+  def evalType: Iterator[String] =
     evalType(traversal)
 
-  def evalType(regex: String): Traversal[A] = {
+  def evalType(regex: String): Iterator[A] = {
     traversal.where(evalType(_).filter(_.matches(regex)))
   }
 
-  def evalType(regexes: String*): Traversal[A] =
+  def evalType(regexes: String*): Iterator[A] =
     if (regexes.isEmpty) Iterator.empty
     else {
       val regexes0 = regexes.map(_.r).toSet
       traversal.where(evalType(_).filter(value => regexes0.exists(_.matches(value))))
     }
 
-  def evalTypeExact(value: String): Traversal[A] =
+  def evalTypeExact(value: String): Iterator[A] =
     traversal.where(evalType(_).filter(_ == value))
 
-  def evalTypeExact(values: String*): Traversal[A] =
+  def evalTypeExact(values: String*): Iterator[A] =
     if (values.isEmpty) Iterator.empty
     else {
       val valuesSet = values.to(Set)
       traversal.where(evalType(_).filter(valuesSet.contains))
     }
 
-  def evalTypeNot(regex: String): Traversal[A] =
+  def evalTypeNot(regex: String): Iterator[A] =
     traversal.where(evalType(_).filterNot(_.matches(regex)))
 
-  def evalTypeNot(regexes: String*): Traversal[A] =
+  def evalTypeNot(regexes: String*): Iterator[A] =
     if (regexes.isEmpty) Iterator.empty
     else {
       val regexes0 = regexes.map(_.r).toSet
       traversal.where(evalType(_).filter(value => !regexes0.exists(_.matches(value))))
     }
 
-  private def evalType(traversal: Traversal[A]): Traversal[String] =
+  private def evalType(traversal: Iterator[A]): Iterator[String] =
     traversal.flatMap(_._evalTypeOut).flatMap(_._refOut).property(Properties.FULL_NAME)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ModifierAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ModifierAccessors.scala
@@ -3,48 +3,48 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.codepropertygraph.generated.nodes.Modifier
 import io.shiftleft.codepropertygraph.generated.traversal.toModifierTraversalExtGen
-import overflowdb._
-import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language.*
+import overflowdb.*
 
-class ModifierAccessors[A <: Node](val traversal: Traversal[A]) extends AnyVal {
+class ModifierAccessors[A <: Node](val traversal: Iterator[A]) extends AnyVal {
 
   /** Filter: only `public` nodes */
-  def isPublic: Traversal[A] =
+  def isPublic: Iterator[A] =
     hasModifier(ModifierTypes.PUBLIC)
 
   /** Filter: only `private` nodes */
-  def isPrivate: Traversal[A] =
+  def isPrivate: Iterator[A] =
     hasModifier(ModifierTypes.PRIVATE)
 
   /** Filter: only `protected` nodes */
-  def isProtected: Traversal[A] =
+  def isProtected: Iterator[A] =
     hasModifier(ModifierTypes.PROTECTED)
 
   /** Filter: only `abstract` nodes */
-  def isAbstract: Traversal[A] =
+  def isAbstract: Iterator[A] =
     hasModifier(ModifierTypes.ABSTRACT)
 
   /** Filter: only `static` nodes */
-  def isStatic: Traversal[A] =
+  def isStatic: Iterator[A] =
     hasModifier(ModifierTypes.STATIC)
 
   /** Filter: only `native` nodes */
-  def isNative: Traversal[A] =
+  def isNative: Iterator[A] =
     hasModifier(ModifierTypes.NATIVE)
 
   /** Filter: only `constructor` nodes */
-  def isConstructor: Traversal[A] =
+  def isConstructor: Iterator[A] =
     hasModifier(ModifierTypes.CONSTRUCTOR)
 
   /** Filter: only `virtual` nodes */
-  def isVirtual: Traversal[A] =
+  def isVirtual: Iterator[A] =
     hasModifier(ModifierTypes.VIRTUAL)
 
-  def hasModifier(modifier: String): Traversal[A] =
+  def hasModifier(modifier: String): Iterator[A] =
     traversal.where(_.out.collectAll[Modifier].modifierType(modifier))
 
   /** Traverse to modifiers, e.g., "static", "public".
     */
-  def modifier: Traversal[Modifier] =
+  def modifier: Iterator[Modifier] =
     traversal.out.collectAll[Modifier]
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationParameterAssignTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationParameterAssignTraversal.scala
@@ -1,20 +1,20 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 /** An annotation parameter-assignment, e.g., `foo=value` in @Test(foo=value)
   */
-class AnnotationParameterAssignTraversal(val traversal: Traversal[AnnotationParameterAssign]) extends AnyVal {
+class AnnotationParameterAssignTraversal(val traversal: Iterator[AnnotationParameterAssign]) extends AnyVal {
 
   /** Traverse to all annotation parameters
     */
-  def parameter: Traversal[AnnotationParameter] =
+  def parameter: Iterator[AnnotationParameter] =
     traversal.flatMap(_._annotationParameterViaAstOut)
 
   /** Traverse to all values of annotation parameters
     */
-  def value: Traversal[Expression] =
+  def value: Iterator[Expression] =
     traversal
       .flatMap(_.astOut)
       .filterNot(_.isInstanceOf[AnnotationParameter])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/AnnotationTraversal.scala
@@ -5,30 +5,30 @@ import overflowdb.traversal._
 
 /** An (Java-) annotation, e.g., @Test.
   */
-class AnnotationTraversal(val traversal: Traversal[nodes.Annotation]) extends AnyVal {
+class AnnotationTraversal(val traversal: Iterator[nodes.Annotation]) extends AnyVal {
 
   /** Traverse to parameter assignments
     */
-  def parameterAssign: Traversal[nodes.AnnotationParameterAssign] =
+  def parameterAssign: Iterator[nodes.AnnotationParameterAssign] =
     traversal.flatMap(_._annotationParameterAssignViaAstOut)
 
   /** Traverse to methods annotated with this annotation.
     */
-  def method: Traversal[nodes.Method] =
+  def method: Iterator[nodes.Method] =
     traversal.flatMap(_._methodViaAstIn)
 
   /** Traverse to type declarations annotated by this annotation
     */
-  def typeDecl: Traversal[nodes.TypeDecl] =
+  def typeDecl: Iterator[nodes.TypeDecl] =
     traversal.flatMap(_._typeDeclViaAstIn)
 
   /** Traverse to member annotated by this annotation
     */
-  def member: Traversal[nodes.Member] =
+  def member: Iterator[nodes.Member] =
     traversal.flatMap(_._memberViaAstIn)
 
   /** Traverse to parameter annotated by this annotation
     */
-  def parameter: Traversal[nodes.MethodParameterIn] =
+  def parameter: Iterator[nodes.MethodParameterIn] =
     traversal.flatMap(_._methodParameterInViaAstIn)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/DependencyTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/DependencyTraversal.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.Import
-import overflowdb.traversal._
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
+import io.shiftleft.semanticcpg.language.*
 
-class DependencyTraversal(val traversal: Traversal[nodes.Dependency]) extends AnyVal {
-  def imports: Traversal[Import] = traversal.in(EdgeTypes.IMPORTS).cast[Import]
+class DependencyTraversal(val traversal: Iterator[nodes.Dependency]) extends AnyVal {
+  def imports: Iterator[Import] = traversal.in(EdgeTypes.IMPORTS).cast[Import]
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/FileTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/FileTraversal.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
-import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language.*
 
 /** A compilation unit
   */
-class FileTraversal(val traversal: Traversal[File]) extends AnyVal {
+class FileTraversal(val traversal: Iterator[File]) extends AnyVal {
 
-  def namespace: Traversal[Namespace] =
+  def namespace: Iterator[Namespace] =
     traversal.flatMap(_.namespaceBlock).flatMap(_._namespaceViaRefOut)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/ImportTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/ImportTraversal.scala
@@ -1,16 +1,15 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Import, NamespaceBlock}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
-class ImportTraversal(val traversal: Traversal[Import]) extends AnyVal {
+class ImportTraversal(val traversal: Iterator[Import]) extends AnyVal {
 
   /** Traverse to the call that represents the import in the AST
     */
-  def call: Traversal[Call] = traversal._isCallForImportIn.cast[Call]
+  def call: Iterator[Call] = traversal._isCallForImportIn.cast[Call]
 
-  def namespaceBlock: Traversal[NamespaceBlock] =
+  def namespaceBlock: Iterator[NamespaceBlock] =
     call.method.namespaceBlock
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LocalTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LocalTraversal.scala
@@ -2,15 +2,15 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language.*
 
 /** A local variable
   */
-class LocalTraversal(val traversal: Traversal[Local]) extends AnyVal {
+class LocalTraversal(val traversal: Iterator[Local]) extends AnyVal {
 
   /** The method hosting this local variable
     */
-  def method: Traversal[Method] = {
+  def method: Iterator[Method] = {
     // TODO The following line of code is here for backwards compatibility.
     // Use the lower commented out line once not required anymore.
     traversal.repeat(_.in(EdgeTypes.AST))(_.until(_.hasLabel(NodeTypes.METHOD))).cast[Method]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTraversal.scala
@@ -2,20 +2,20 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Member}
-import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language.*
 
 /** A member variable of a class/type.
   */
-class MemberTraversal(val traversal: Traversal[Member]) extends AnyVal {
+class MemberTraversal(val traversal: Iterator[Member]) extends AnyVal {
 
   /** Traverse to annotations of member
     */
-  def annotation: Traversal[nodes.Annotation] =
+  def annotation: Iterator[nodes.Annotation] =
     traversal.flatMap(_._annotationViaAstOut)
 
   /** Places where
     */
-  def ref: Traversal[Call] =
+  def ref: Iterator[Call] =
     traversal.flatMap(_._callViaRefIn)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -1,29 +1,29 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
-class MethodParameterOutTraversal(val traversal: Traversal[MethodParameterOut]) extends AnyVal {
+class MethodParameterOutTraversal(val traversal: Iterator[MethodParameterOut]) extends AnyVal {
 
-  def paramIn: Traversal[MethodParameterIn] = traversal.flatMap(_.parameterLinkIn.headOption)
+  def paramIn: Iterator[MethodParameterIn] = traversal.flatMap(_.parameterLinkIn.headOption)
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def index(num: Int): Traversal[MethodParameterOut] =
+  def index(num: Int): Iterator[MethodParameterOut] =
     traversal.filter { _.index == num }
 
   /* get all parameters from (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def indexFrom(num: Int): Traversal[MethodParameterOut] =
+  def indexFrom(num: Int): Iterator[MethodParameterOut] =
     traversal.filter(_.index >= num)
 
   /* get all parameters up to (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def indexTo(num: Int): Traversal[MethodParameterOut] =
+  def indexTo(num: Int): Iterator[MethodParameterOut] =
     traversal.filter(_.index <= num)
 
-  def argument: Traversal[Expression] =
+  def argument: Iterator[Expression] =
     for {
       paramOut <- traversal
       method = paramOut.method

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
@@ -1,34 +1,34 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.help
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /** Formal method input parameter
   */
 @help.Traversal(elementType = classOf[MethodParameterIn])
-class MethodParameterTraversal(val traversal: Traversal[MethodParameterIn]) extends AnyVal {
+class MethodParameterTraversal(val traversal: Iterator[MethodParameterIn]) extends AnyVal {
 
   /** Traverse to parameter annotations
     */
-  def annotation: Traversal[Annotation] =
+  def annotation: Iterator[Annotation] =
     traversal.flatMap(_._annotationViaAstOut)
 
   /** Traverse to all parameters with index greater or equal than `num`
     */
-  def indexFrom(num: Int): Traversal[MethodParameterIn] =
+  def indexFrom(num: Int): Iterator[MethodParameterIn] =
     traversal.filter(_.index >= num)
 
   /** Traverse to all parameters with index smaller or equal than `num`
     */
-  def indexTo(num: Int): Traversal[MethodParameterIn] =
+  def indexTo(num: Int): Iterator[MethodParameterIn] =
     traversal.filter(_.index <= num)
 
   /** Traverse to arguments (actual parameters) associated with this formal parameter
     */
-  def argument(implicit callResolver: ICallResolver): Traversal[Expression] =
+  def argument(implicit callResolver: ICallResolver): Iterator[Expression] =
     for {
       paramIn <- traversal
       call    <- callResolver.getMethodCallsites(paramIn.method)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
@@ -1,29 +1,29 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.traversal.help
 import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[MethodReturn])
-class MethodReturnTraversal(val traversal: Traversal[MethodReturn]) extends AnyVal {
+class MethodReturnTraversal(val traversal: Iterator[MethodReturn]) extends AnyVal {
 
   @Doc(info = "traverse to parent method")
-  def method: Traversal[Method] =
+  def method: Iterator[Method] =
     traversal.flatMap(_._methodViaAstIn)
 
-  def returnUser(implicit callResolver: ICallResolver): Traversal[Call] =
+  def returnUser(implicit callResolver: ICallResolver): Iterator[Call] =
     traversal.flatMap(_.returnUser)
 
   /** Traverse to last expressions in CFG. Can be multiple.
     */
   @Doc(info = "traverse to last expressions in CFG (can be multiple)")
-  def cfgLast: Traversal[CfgNode] =
+  def cfgLast: Iterator[CfgNode] =
     traversal.flatMap(_.cfgIn)
 
   /** Traverse to return type
     */
   @Doc(info = "traverse to return type")
-  def typ: Traversal[Type] =
+  def typ: Iterator[Type] =
     traversal.flatMap(_.evalTypeOut)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -1,11 +1,11 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated._
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
-import overflowdb._
+import io.shiftleft.codepropertygraph.generated.*
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+import overflowdb.*
+import overflowdb.traversal.help
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, help, toElementTraversal, toNodeTraversal}
 
 /** A method, function, or procedure
   */
@@ -14,68 +14,68 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
 
   /** Traverse to annotations of method
     */
-  def annotation: Traversal[nodes.Annotation] =
+  def annotation: Iterator[nodes.Annotation] =
     traversal.flatMap(_._annotationViaAstOut)
 
   /** All control structures of this method
     */
   @Doc(info = "Control structures (source frontends only)")
-  def controlStructure: Traversal[ControlStructure] =
+  def controlStructure: Iterator[ControlStructure] =
     traversal.ast.isControlStructure
 
   /** Shorthand to traverse to control structures where condition matches `regex`
     */
-  def controlStructure(regex: String): Traversal[ControlStructure] =
+  def controlStructure(regex: String): Iterator[ControlStructure] =
     traversal.ast.isControlStructure.code(regex)
 
   @Doc(info = "All try blocks (`ControlStructure` nodes)")
-  def tryBlock: Traversal[ControlStructure] =
+  def tryBlock: Iterator[ControlStructure] =
     controlStructure.isTry
 
   @Doc(info = "All if blocks (`ControlStructure` nodes)")
-  def ifBlock: Traversal[ControlStructure] =
+  def ifBlock: Iterator[ControlStructure] =
     controlStructure.isIf
 
   @Doc(info = "All else blocks (`ControlStructure` nodes)")
-  def elseBlock: Traversal[ControlStructure] =
+  def elseBlock: Iterator[ControlStructure] =
     controlStructure.isElse
 
   @Doc(info = "All switch blocks (`ControlStructure` nodes)")
-  def switchBlock: Traversal[ControlStructure] =
+  def switchBlock: Iterator[ControlStructure] =
     controlStructure.isSwitch
 
   @Doc(info = "All do blocks (`ControlStructure` nodes)")
-  def doBlock: Traversal[ControlStructure] =
+  def doBlock: Iterator[ControlStructure] =
     controlStructure.isDo
 
   @Doc(info = "All for blocks (`ControlStructure` nodes)")
-  def forBlock: Traversal[ControlStructure] =
+  def forBlock: Iterator[ControlStructure] =
     controlStructure.isFor
 
   @Doc(info = "All while blocks (`ControlStructure` nodes)")
-  def whileBlock: Traversal[ControlStructure] =
+  def whileBlock: Iterator[ControlStructure] =
     controlStructure.isWhile
 
   @Doc(info = "All gotos (`ControlStructure` nodes)")
-  def goto: Traversal[ControlStructure] =
+  def goto: Iterator[ControlStructure] =
     controlStructure.isGoto
 
   @Doc(info = "All breaks (`ControlStructure` nodes)")
-  def break: Traversal[ControlStructure] =
+  def break: Iterator[ControlStructure] =
     controlStructure.isBreak
 
   @Doc(info = "All continues (`ControlStructure` nodes)")
-  def continue: Traversal[ControlStructure] =
+  def continue: Iterator[ControlStructure] =
     controlStructure.isContinue
 
   @Doc(info = "All throws (`ControlStructure` nodes)")
-  def throws: Traversal[ControlStructure] =
+  def throws: Iterator[ControlStructure] =
     controlStructure.isThrow
 
   /** The type declaration associated with this method, e.g., the class it is defined in.
     */
   @Doc(info = "Type this method is defined in")
-  def definingTypeDecl: Traversal[TypeDecl] =
+  def definingTypeDecl: Iterator[TypeDecl] =
     traversal
       .repeat(_._astIn)(_.until(_.collectAll[TypeDecl]))
       .cast[TypeDecl]
@@ -83,52 +83,52 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
   /** The type declaration associated with this method, e.g., the class it is defined in. Alias for 'definingTypeDecl'
     */
   @Doc(info = "Type this method is defined in - alias for 'definingTypeDecl'")
-  def typeDecl: Traversal[TypeDecl] = definingTypeDecl
+  def typeDecl: Iterator[TypeDecl] = definingTypeDecl
 
   /** The method in which this method is defined
     */
   @Doc(info = "Method this method is defined in")
-  def definingMethod: Traversal[Method] =
+  def definingMethod: Iterator[Method] =
     traversal
       .repeat(_._astIn)(_.until(_.collectAll[Method]))
       .cast[Method]
 
   /** Traverse only to methods that are stubs, e.g., their code is not available or the method body is empty.
     */
-  def isStub: Traversal[Method] =
+  def isStub: Iterator[Method] =
     traversal.where(_.not(_._cfgOut.not(_.collectAll[MethodReturn])))
 
   /** Traverse only to methods that are not stubs.
     */
-  def isNotStub: Traversal[Method] =
+  def isNotStub: Iterator[Method] =
     traversal.where(_._cfgOut.not(_.collectAll[MethodReturn]))
 
   /** Traverse only to methods that accept variadic arguments.
     */
-  def isVariadic: Traversal[Method] = {
+  def isVariadic: Iterator[Method] = {
     traversal.filter(_.isVariadic)
   }
 
   /** Traverse to external methods, that is, methods not present but only referenced in the CPG.
     */
   @Doc(info = "External methods (called, but no body available)")
-  def external: Traversal[Method] =
+  def external: Iterator[Method] =
     traversal.isExternal(true)
 
   /** Traverse to internal methods, that is, methods for which code is included in this CPG.
     */
   @Doc(info = "Internal methods, i.e., a body is available")
-  def internal: Traversal[Method] =
+  def internal: Iterator[Method] =
     traversal.isExternal(false)
 
   /** Traverse to the methods local variables
     */
   @Doc(info = "Local variables declared in the method")
-  def local: Traversal[Local] =
+  def local: Iterator[Local] =
     traversal.block.ast.isLocal
 
   @Doc(info = "Top level expressions (\"Statements\")")
-  def topLevelExpressions: Traversal[Expression] =
+  def topLevelExpressions: Iterator[Expression] =
     traversal._astOut
       .collectAll[Block]
       ._astOut
@@ -136,29 +136,29 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
       .cast[Expression]
 
   @Doc(info = "Control flow graph nodes")
-  def cfgNode: Traversal[CfgNode] =
+  def cfgNode: Iterator[CfgNode] =
     traversal.flatMap(_.cfgNode)
 
   /** Traverse to last expression in CFG.
     */
   @Doc(info = "Last control flow graph node")
-  def cfgLast: Traversal[CfgNode] =
+  def cfgLast: Iterator[CfgNode] =
     traversal.methodReturn.cfgLast
 
   /** Traverse to method body (alias for `block`) */
   @Doc(info = "Alias for `block`")
-  def body: Traversal[Block] =
+  def body: Iterator[Block] =
     traversal.block
 
   /** Traverse to namespace */
   @Doc(info = "Namespace this method is declared in")
-  def namespace: Traversal[Namespace] = {
+  def namespace: Iterator[Namespace] = {
     traversal.namespaceBlock.namespace
   }
 
   /** Traverse to namespace block */
   @Doc(info = "Namespace block this method is declared in")
-  def namespaceBlock: Traversal[NamespaceBlock] = {
+  def namespaceBlock: Iterator[NamespaceBlock] = {
     traversal.flatMap { m =>
       m.astIn.headOption match {
         // some language frontends don't have a TYPE_DECL for a METHOD
@@ -169,6 +169,6 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
     }
   }
 
-  def numberOfLines: Traversal[Int] = traversal.map(_.numberOfLines)
+  def numberOfLines: Iterator[Int] = traversal.map(_.numberOfLines)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlockTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlockTraversal.scala
@@ -1,20 +1,20 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import overflowdb.traversal._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
-class NamespaceBlockTraversal(val traversal: Traversal[NamespaceBlock]) extends AnyVal {
+class NamespaceBlockTraversal(val traversal: Iterator[NamespaceBlock]) extends AnyVal {
 
   /** Namespaces for namespace blocks.
     */
-  def namespace: Traversal[Namespace] =
+  def namespace: Iterator[Namespace] =
     traversal.flatMap(_.refOut)
 
   /** The type declarations defined in this namespace
     */
-  def typeDecl: Traversal[TypeDecl] =
+  def typeDecl: Iterator[TypeDecl] =
     traversal.flatMap(_._typeDeclViaAstOut)
 
-  def method: Traversal[Method] =
+  def method: Iterator[Method] =
     traversal.flatMap(_._methodViaAstOut)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
@@ -1,31 +1,30 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 /** A namespace, e.g., Java package or C# namespace
   */
-class NamespaceTraversal(val traversal: Traversal[Namespace]) extends AnyVal {
+class NamespaceTraversal(val traversal: Iterator[Namespace]) extends AnyVal {
 
   /** The type declarations defined in this namespace
     */
-  def typeDecl: Traversal[TypeDecl] =
+  def typeDecl: Iterator[TypeDecl] =
     traversal.flatMap(_.refIn).flatMap(_._typeDeclViaAstOut)
 
   /** Methods defined in this namespace
     */
-  def method: Traversal[Method] =
+  def method: Iterator[Method] =
     traversal.flatMap(_.refIn).flatMap(_._methodViaAstOut)
 
   /** External namespaces - any namespaces which contain one or more external type.
     */
-  def external: Traversal[Namespace] =
+  def external: Iterator[Namespace] =
     traversal.where(_.typeDecl.external)
 
   /** Internal namespaces - any namespaces which contain one or more internal type
     */
-  def internal: Traversal[Namespace] =
+  def internal: Iterator[Namespace] =
     traversal.where(_.typeDecl.internal)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -1,88 +1,87 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 /** Type declaration - possibly a template that requires instantiation
   */
-class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
-  import TypeDeclTraversal._
+class TypeDeclTraversal(val traversal: Iterator[TypeDecl]) extends AnyVal {
+  import TypeDeclTraversal.*
 
   /** Annotations of the type declaration
     */
-  def annotation: Traversal[nodes.Annotation] =
+  def annotation: Iterator[nodes.Annotation] =
     traversal.flatMap(_._annotationViaAstOut)
 
   /** Types referencing to this type declaration.
     */
-  def referencingType: Traversal[Type] =
+  def referencingType: Iterator[Type] =
     traversal.flatMap(_.refIn)
 
   /** Namespace in which this type declaration is defined
     */
-  def namespace: Traversal[Namespace] =
+  def namespace: Iterator[Namespace] =
     traversal.flatMap(_.namespaceBlock).namespace
 
   /** Methods defined as part of this type
     */
-  def method: Traversal[Method] =
+  def method: Iterator[Method] =
     canonicalType.flatMap(_._methodViaAstOut)
 
   /** Filter for type declarations contained in the analyzed code.
     */
-  def internal: Traversal[TypeDecl] =
+  def internal: Iterator[TypeDecl] =
     canonicalType.isExternal(false)
 
   /** Filter for type declarations not contained in the analyzed code.
     */
-  def external: Traversal[TypeDecl] =
+  def external: Iterator[TypeDecl] =
     canonicalType.isExternal(true)
 
   /** Member variables
     */
-  def member: Traversal[Member] =
+  def member: Iterator[Member] =
     canonicalType.flatMap(_._memberViaAstOut)
 
   /** Direct base types in the inheritance graph.
     */
-  def baseType: Traversal[Type] =
+  def baseType: Iterator[Type] =
     canonicalType.flatMap(_._typeViaInheritsFromOut)
 
   /** Direct base type declaration.
     */
-  def derivedTypeDecl: Traversal[TypeDecl] =
+  def derivedTypeDecl: Iterator[TypeDecl] =
     referencingType.derivedTypeDecl
 
   /** Direct and transitive base type declaration.
     */
-  def derivedTypeDeclTransitive: Traversal[TypeDecl] =
+  def derivedTypeDeclTransitive: Iterator[TypeDecl] =
     traversal.repeat(_.derivedTypeDecl)(_.emitAllButFirst)
 
   /** Direct base type declaration.
     */
-  def baseTypeDecl: Traversal[TypeDecl] =
+  def baseTypeDecl: Iterator[TypeDecl] =
     traversal.baseType.referencedTypeDecl
 
   /** Direct and transitive base type declaration.
     */
-  def baseTypeDeclTransitive: Traversal[TypeDecl] =
+  def baseTypeDeclTransitive: Iterator[TypeDecl] =
     traversal.repeat(_.baseTypeDecl)(_.emitAllButFirst)
 
   /** Traverse to alias type declarations.
     */
-  def isAlias: Traversal[TypeDecl] =
+  def isAlias: Iterator[TypeDecl] =
     traversal.filter(_.aliasTypeFullName.isDefined)
 
   /** Traverse to canonical type declarations.
     */
-  def isCanonical: Traversal[TypeDecl] =
+  def isCanonical: Iterator[TypeDecl] =
     traversal.filter(_.aliasTypeFullName.isEmpty)
 
   /** If this is an alias type declaration, go to its underlying type declaration else unchanged.
     */
-  def unravelAlias: Traversal[TypeDecl] = {
+  def unravelAlias: Iterator[TypeDecl] = {
     traversal.map { typeDecl =>
       val alias = for {
         tpe      <- typeDecl.aliasedType.nextOption()
@@ -95,17 +94,17 @@ class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
 
   /** Traverse to canonical type which means unravel aliases until we find a non alias type declaration.
     */
-  def canonicalType: Traversal[TypeDecl] =
+  def canonicalType: Iterator[TypeDecl] =
     traversal.repeat(_.unravelAlias)(_.until(_.isCanonical).maxDepth(maxAliasExpansions))
 
   /** Direct alias type declarations.
     */
-  def aliasTypeDecl: Traversal[TypeDecl] =
+  def aliasTypeDecl: Iterator[TypeDecl] =
     referencingType.aliasTypeDecl
 
   /** Direct and transitive alias type declarations.
     */
-  def aliasTypeDeclTransitive: Traversal[TypeDecl] =
+  def aliasTypeDeclTransitive: Iterator[TypeDecl] =
     traversal.repeat(_.aliasTypeDecl)(_.emitAllButFirst)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
@@ -1,95 +1,94 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
-class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
+class TypeTraversal(val traversal: Iterator[Type]) extends AnyVal {
 
   /** Annotations of the corresponding type declaration.
     */
-  def annotation: Traversal[nodes.Annotation] =
+  def annotation: Iterator[nodes.Annotation] =
     traversal.referencedTypeDecl.annotation
 
   /** Namespaces in which the corresponding type declaration is defined.
     */
-  def namespace: Traversal[Namespace] =
+  def namespace: Iterator[Namespace] =
     traversal.referencedTypeDecl.namespace
 
   /** Methods defined on the corresponding type declaration.
     */
-  def method: Traversal[Method] =
+  def method: Iterator[Method] =
     traversal.referencedTypeDecl.method
 
   /** Filter for types whos corresponding type declaration is in the analyzed jar.
     */
-  def internal: Traversal[Type] =
+  def internal: Iterator[Type] =
     traversal.where(_.referencedTypeDecl.internal)
 
   /** Filter for types whos corresponding type declaration is not in the analyzed jar.
     */
-  def external: Traversal[Type] =
+  def external: Iterator[Type] =
     traversal.where(_.referencedTypeDecl.external)
 
   /** Member variables of the corresponding type declaration.
     */
-  def member: Traversal[Member] =
+  def member: Iterator[Member] =
     traversal.referencedTypeDecl.member
 
   /** Direct base types of the corresponding type declaration in the inheritance graph.
     */
-  def baseType: Traversal[Type] =
+  def baseType: Iterator[Type] =
     traversal.referencedTypeDecl.baseType
 
   /** Direct and transitive base types of the corresponding type declaration.
     */
-  def baseTypeTransitive: Traversal[Type] =
+  def baseTypeTransitive: Iterator[Type] =
     traversal.repeat(_.baseType)(_.emitAllButFirst)
 
   /** Direct derived types.
     */
-  def derivedType: Traversal[Type] =
+  def derivedType: Iterator[Type] =
     derivedTypeDecl.referencingType
 
   /** Direct and transitive derived types.
     */
-  def derivedTypeTransitive: Traversal[Type] =
+  def derivedTypeTransitive: Iterator[Type] =
     traversal.repeat(_.derivedType)(_.emitAllButFirst)
 
   /** Type declarations which derive from this type.
     */
-  def derivedTypeDecl: Traversal[TypeDecl] =
+  def derivedTypeDecl: Iterator[TypeDecl] =
     traversal.flatMap(_.inheritsFromIn)
 
   /** Direct alias types.
     */
-  def aliasType: Traversal[Type] =
+  def aliasType: Iterator[Type] =
     traversal.aliasTypeDecl.referencingType
 
   /** Direct and transitive alias types.
     */
-  def aliasTypeTransitive: Traversal[Type] =
+  def aliasTypeTransitive: Iterator[Type] =
     traversal.repeat(_.aliasType)(_.emitAllButFirst)
 
-  def localOfType: Traversal[Local] =
+  def localOfType: Iterator[Local] =
     traversal.flatMap(_._localViaEvalTypeIn)
 
-  def memberOfType: Traversal[Member] =
+  def memberOfType: Iterator[Member] =
     traversal.flatMap(_.evalTypeIn).collectAll[Member]
 
   @deprecated("Please use `parameterOfType`")
-  def parameter: Traversal[MethodParameterIn] = parameterOfType
+  def parameter: Iterator[MethodParameterIn] = parameterOfType
 
-  def parameterOfType: Traversal[MethodParameterIn] =
+  def parameterOfType: Iterator[MethodParameterIn] =
     traversal.flatMap(_.evalTypeIn).collectAll[MethodParameterIn]
 
-  def methodReturnOfType: Traversal[MethodReturn] =
+  def methodReturnOfType: Iterator[MethodReturn] =
     traversal.flatMap(_.evalTypeIn).collectAll[MethodReturn]
 
-  def expressionOfType: Traversal[Expression] = expression
+  def expressionOfType: Iterator[Expression] = expression
 
-  def expression: Traversal[Expression] =
+  def expression: Iterator[Expression] =
     traversal.flatMap(_.evalTypeIn).collectAll[Expression]
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -2,10 +2,10 @@ package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.Cpg.docSearchPackages
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Properties}
 import io.shiftleft.semanticcpg.testing.MockCpg
-import org.json4s._
+import org.json4s.*
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -151,7 +151,7 @@ class StepsTest extends AnyWordSpec with Matchers {
     }
 
     "render nodes as `(label,id): properties`" in {
-      def mainMethods: Traversal[Method] = cpg.method.name("woo")
+      def mainMethods: Iterator[Method] = cpg.method.name("woo")
 
       val nodeId  = mainMethods.head.id
       val printed = mainMethods.p.head
@@ -173,7 +173,7 @@ class StepsTest extends AnyWordSpec with Matchers {
         }
       }
 
-      import SomePackage._
+      import SomePackage.*
       def mainMethods: Steps[Method] = cpg.method.name("woo")
       mainMethods.p.head shouldBe "package defined pretty printer"
     }
@@ -310,13 +310,13 @@ class StepsTest extends AnyWordSpec with Matchers {
     methodRef.referencedMethod
     methodRef.headOption.map(_.referencedMethod)
 
-    def expression: Traversal[Expression] = cpg.identifier.name("anidentifier").cast[Expression]
+    def expression: Iterator[Expression] = cpg.identifier.name("anidentifier").cast[Expression]
     expression.expressionUp.isCall.size shouldBe 1
     expression.head.expressionUp.isCall.size shouldBe 1
 
-//    def cfg: Traversal[CfgNode] = cpg.method.name("add")
+//    def cfg: Iterator[CfgNode] = cpg.method.name("add")
 
-    def ast: Traversal[AstNode] = cpg.method.name("foo").cast[AstNode]
+    def ast: Iterator[AstNode] = cpg.method.name("foo").cast[AstNode]
     ast.astParent.property(Properties.NAME).head shouldBe "AClass"
     ast.head.astParent.property(Properties.NAME) shouldBe "AClass"
 


### PR DESCRIPTION
Context: we want to reduce direct odb namespace exposure, in order to simplify the transition to odbv2. Using Iterator rather than Traversal is a relatively low hanging fruit, and our imports can be cleaned up quite a bit. 

This is mostly refactoring, there's no structural changes. E.g. `semanticcpg.LowPrioImplicits` still `extends overflowdb.traversal.Implicits`. 
