### PR TITLE
Increase `.sbtops` Memory Alloc

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,2 @@
 -J-Xms4G
--J-Xmx6G
+-J-Xmx5G

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,2 @@
--J-Xms3G
--J-Xmx4G
+-J-Xms4G
+-J-Xmx6G

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,2 @@
--J-Xms4G
--J-Xmx5G
+-J-Xms3584M
+-J-Xmx4608M


### PR DESCRIPTION
I've recently noticed `jssrc2cpg` and `pysrc2cpg` tests bombing because of memory related issues once again. This bumps the memory a bit closer to the [Windows and Linux runner limits](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).