### PR TITLE
[gosrc2cpg] - Receiver node or `thisParameterIn` node handling while processing method declaration 

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -109,7 +109,7 @@ trait AstCreatorHelper { this: AstCreator =>
       .toMap
   }
 
-  private def generateTypeFullName(
+  protected def generateTypeFullName(
     typeName: Option[String] = None,
     genericTypeMethodMap: Map[String, List[String]] = Map.empty,
     aliasName: Option[String] = None

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -1,13 +1,13 @@
 package io.joern.gosrc2cpg.astcreation
 
 import io.joern.gosrc2cpg.datastructures.GoGlobal
-import io.joern.gosrc2cpg.parser.ParserAst.{BlockStmt, Ellipsis, Ident, SelectorExpr}
+import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.utils.StringUtils
+import io.joern.x2cpg.utils.{NodeBuilders, StringUtils}
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, NodeTypes, PropertyNames}
 import ujson.Value
 
 import scala.collection.mutable
@@ -37,44 +37,91 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val functionBinding = NewBinding().name(methodName).methodFullName(methodFullName).signature(signature)
     Ast(functionBinding).withBindsEdge(parentNode, functionBinding).withRefEdge(functionBinding, method)
   }
+
   def astForFuncDecl(funcDecl: ParserNodeInfo): Seq[Ast] = {
 
-    val filename = relPathFileName
-    val name     = funcDecl.json(ParserKeys.Name).obj(ParserKeys.Name).str
-    val fullname = s"$fullyQualifiedPackage.$name"
+    val filename     = relPathFileName
+    val name         = funcDecl.json(ParserKeys.Name).obj(ParserKeys.Name).str
+    val receiverInfo = getReceiverInfo(Try(funcDecl.json(ParserKeys.Recv)))
+    val (methodFullname, recSignStr) = receiverInfo match
+      case Some(_, typeFullName, evaluationStrategy, _) =>
+        val signatureStr = evaluationStrategy match
+          case EvaluationStrategies.BY_SHARING =>
+            s"*$typeFullName"
+          case EvaluationStrategies.BY_VALUE =>
+            typeFullName
+        (s"$typeFullName.$name", s"($signatureStr)")
+      case _ =>
+        (s"${fullyQualifiedPackage}.$name", "")
     // TODO: handle multiple return type or tuple (int, int)
     val genericTypeMethodMap = processTypeParams(funcDecl.json(ParserKeys.Type))
     val (returnTypeStr, methodReturn) =
       getReturnType(funcDecl.json(ParserKeys.Type), genericTypeMethodMap).headOption
         .getOrElse(("", methodReturnNode(funcDecl, Defines.voidTypeName)))
-    val templateParams = ""
-    val params         = funcDecl.json(ParserKeys.Type)(ParserKeys.Params)(ParserKeys.List)
+    val params = funcDecl.json(ParserKeys.Type)(ParserKeys.Params)(ParserKeys.List)
     val signature =
-      s"$fullname$templateParams(${parameterSignature(params, genericTypeMethodMap)})$returnTypeStr"
-    GoGlobal.recordFullNameToReturnType(fullname, returnTypeStr, Some(signature))
-    val methodNode_ = methodNode(funcDecl, name, funcDecl.code, fullname, Some(signature), filename)
+      s"$methodFullname$recSignStr(${parameterSignature(params, genericTypeMethodMap)})$returnTypeStr"
+    GoGlobal.recordFullNameToReturnType(methodFullname, returnTypeStr, Some(signature))
+    val methodNode_ = methodNode(funcDecl, name, funcDecl.code, methodFullname, Some(signature), filename)
     methodAstParentStack.push(methodNode_)
     scope.pushNewScope(methodNode_)
+    val receiverNode = astForReceiver(receiverInfo)
     val astForMethod =
       methodAst(
         methodNode_,
-        astForMethodParameter(params, genericTypeMethodMap),
+        receiverNode ++ astForMethodParameter(params, genericTypeMethodMap),
         astForMethodBody(funcDecl.json(ParserKeys.Body)),
         methodReturn
       )
     scope.popScope()
     methodAstParentStack.pop()
-//    if method is related to Struct then fill astParentFullName and astParentType
-    if (funcDecl.json.obj.contains(ParserKeys.Recv)) {
-      val receiverTypeDeclType =
-        parameterSignature(funcDecl.json(ParserKeys.Recv)(ParserKeys.List), Map.empty[String, List[String]])
-      methodNode_.astParentFullName = receiverTypeDeclType.replace("*", "")
-      methodNode_.astParentType = NodeTypes.TYPE_DECL
-      Ast.storeInDiffGraph(astForMethod, diffGraph)
-      Seq.empty
-    } else {
-      Seq(astForMethod)
-    }
+    receiverInfo match
+      case Some(_, typeFullName, _, _) =>
+        // if method is related to Struct then fill astParentFullName and astParentType
+        methodNode_.astParentFullName = typeFullName
+        methodNode_.astParentType = NodeTypes.TYPE_DECL
+        Ast.storeInDiffGraph(astForMethod, diffGraph)
+        Seq.empty
+      case _ =>
+        Seq(astForMethod)
+  }
+
+  private def astForReceiver(receiverInfo: Option[(String, String, String, ParserNodeInfo)]): Seq[Ast] = {
+    receiverInfo match
+      case Some(recName, typeFullName, evaluationStrategy, recNode) =>
+        val recParamNode = NodeBuilders.newThisParameterNode(
+          name = recName,
+          code = recNode.code,
+          typeFullName = typeFullName,
+          line = line(recNode),
+          column = column(recNode),
+          evaluationStrategy = evaluationStrategy
+        )
+        scope.addToScope(recName, (recParamNode, typeFullName))
+        Seq(Ast(recParamNode))
+      case _ => Seq.empty
+  }
+
+  private def getReceiverInfo(receiver: Try[Value]): Option[(String, String, String, ParserNodeInfo)] = {
+    receiver match
+      case Success(rec) if rec != null =>
+        val recnode        = createParserNodeInfo(rec)
+        val recValue       = rec(ParserKeys.List).arr.head
+        val recName        = recValue(ParserKeys.Names).arr.head(ParserKeys.Name).str
+        val typeParserNode = createParserNodeInfo(recValue(ParserKeys.Type))
+        val (typeFullName, evaluationStrategy) = typeParserNode.node match
+          case Ident =>
+            (
+              generateTypeFullName(typeName = typeParserNode.json(ParserKeys.Name).strOpt),
+              EvaluationStrategies.BY_VALUE
+            )
+          case StarExpr =>
+            (
+              generateTypeFullName(typeName = typeParserNode.json(ParserKeys.X)(ParserKeys.Name).strOpt),
+              EvaluationStrategies.BY_SHARING
+            )
+        Some(recName, typeFullName, evaluationStrategy, recnode)
+      case _ => None
   }
 
   private def astForMethodParameter(params: Value, genericTypeMethodMap: Map[String, List[String]]): Seq[Ast] = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -52,7 +52,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             typeFullName
         (s"$typeFullName.$name", s"($signatureStr)")
       case _ =>
-        (s"${fullyQualifiedPackage}.$name", "")
+        (s"$fullyQualifiedPackage.$name", "")
     // TODO: handle multiple return type or tuple (int, int)
     val genericTypeMethodMap = processTypeParams(funcDecl.json(ParserKeys.Type))
     val (returnTypeStr, methodReturn) =
@@ -78,8 +78,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     receiverInfo match
       case Some(_, typeFullName, _, _) =>
         // if method is related to Struct then fill astParentFullName and astParentType
-        methodNode_.astParentFullName = typeFullName
-        methodNode_.astParentType = NodeTypes.TYPE_DECL
+        methodNode_.astParentType(NodeTypes.TYPE_DECL).astParentFullName(typeFullName)
         Ast.storeInDiffGraph(astForMethod, diffGraph)
         Seq.empty
       case _ =>

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -1498,5 +1498,4 @@ class MethodTests extends GoCodeToCpgSuite {
   // As well as example of "map"
   // TODO: Add unit tests for lambda expression as a parameter
   // TODO: Add unit test for tuple return
-  // TODO: Add unit tests with Generics
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMembersAndMemberMethodsTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMembersAndMemberMethodsTest.scala
@@ -196,14 +196,14 @@ class TypeDeclMembersAndMemberMethodsTest extends GoCodeToCpgSuite {
   "structure with comma separated member" should {
 
     val cpg = code("""
-        package main
+        |package main
         |
         |type Rect struct {
         |  len, wid int
         |}
         |""".stripMargin)
 
-    "Check number of member nodes" ignore {
+    "Check number of member nodes" in {
       val List(typeDeclNode) = cpg.typeDecl.name("Rect").l
       typeDeclNode.member.size shouldBe 2
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMembersAndMemberMethodsTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMembersAndMemberMethodsTest.scala
@@ -10,7 +10,7 @@ import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import scala.collection.immutable.List
 import io.joern.gosrc2cpg.astcreation.Defines
 
-class TypeDeclMembersTest extends GoCodeToCpgSuite {
+class TypeDeclMembersAndMemberMethodsTest extends GoCodeToCpgSuite {
 
   "structure with single element" should {
 
@@ -128,7 +128,7 @@ class TypeDeclMembersTest extends GoCodeToCpgSuite {
   "structure with associated method" should {
 
     val cpg = code("""
-        package main
+        |package main
         |
         |type Rect struct {
         |  len, wid int
@@ -151,6 +151,23 @@ class TypeDeclMembersTest extends GoCodeToCpgSuite {
       areaByValueNode.name shouldBe "Area_by_value"
       areaByReferenceNode.name shouldBe "Area_by_reference"
     }
+
+//    "Check 'this' parameter node" in {
+//      cpg.parameter.name("this").size shouldBe 2
+//      val List(thisParam, thisParamsec) = cpg.parameter.name("this").l
+//      thisParam.order shouldBe 0
+//      thisParam.index shouldBe 0
+//      thisParamsec.order shouldBe 0
+//      thisParamsec.index shouldBe 0
+//    }
+
+//    "Traversal from 'this'/receiver parameter to method node" in {
+//      cpg.parameter.name("re").method.name.l shouldBe List("Area_by_value", "Area_by_reference")
+//    }
+//
+//    "Traversal from method to 'this'/receiver parameter node" in {
+//      cpg.method("Area_by_value").parameter.name.l shouldBe List("re")
+//    }
   }
 
   "structure with no associated method" should {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMembersAndMemberMethodsTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMembersAndMemberMethodsTest.scala
@@ -149,25 +149,27 @@ class TypeDeclMembersAndMemberMethodsTest extends GoCodeToCpgSuite {
 
       val List(areaByValueNode, areaByReferenceNode) = typeDeclNode.astChildren.isMethod.l
       areaByValueNode.name shouldBe "Area_by_value"
+      areaByValueNode.fullName shouldBe "main.Rect.Area_by_value"
       areaByReferenceNode.name shouldBe "Area_by_reference"
+      areaByReferenceNode.fullName shouldBe "main.Rect.Area_by_reference"
     }
 
-//    "Check 'this' parameter node" in {
-//      cpg.parameter.name("this").size shouldBe 2
-//      val List(thisParam, thisParamsec) = cpg.parameter.name("this").l
-//      thisParam.order shouldBe 0
-//      thisParam.index shouldBe 0
-//      thisParamsec.order shouldBe 0
-//      thisParamsec.index shouldBe 0
-//    }
+    "Check 'this'/receiver parameter node" in {
+      cpg.parameter.name("re").size shouldBe 2
+      val List(thisParam, thisParamsec) = cpg.parameter.name("re").l
+      thisParam.order shouldBe 0
+      thisParam.index shouldBe 0
+      thisParamsec.order shouldBe 0
+      thisParamsec.index shouldBe 0
+    }
 
-//    "Traversal from 'this'/receiver parameter to method node" in {
-//      cpg.parameter.name("re").method.name.l shouldBe List("Area_by_value", "Area_by_reference")
-//    }
-//
-//    "Traversal from method to 'this'/receiver parameter node" in {
-//      cpg.method("Area_by_value").parameter.name.l shouldBe List("re")
-//    }
+    "Traversal from 'this'/receiver parameter to method node" in {
+      cpg.parameter.name("re").method.name.l shouldBe List("Area_by_value", "Area_by_reference")
+    }
+
+    "Traversal from method to 'this'/receiver parameter node" in {
+      cpg.method("Area_by_value").parameter.name.l shouldBe List("re")
+    }
   }
 
   "structure with no associated method" should {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclTests.scala
@@ -2,13 +2,7 @@ package io.joern.go2cpg.passes.ast
 
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.codepropertygraph.generated.{
-  ControlStructureTypes,
-  DispatchTypes,
-  ModifierTypes,
-  NodeTypes,
-  Operators
-}
+import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 
@@ -36,8 +30,8 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
-    "test fullName of TypeDecl nodes" ignore {
-      typeDeclNode.fullName shouldBe "test.go::main.<global>::Foo"
+    "test fullName of TypeDecl nodes" in {
+      typeDeclNode.fullName shouldBe "main.Foo"
     }
 
     "test the modifier" in {
@@ -66,8 +60,8 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
-    "test fullName of TypeDecl nodes" ignore {
-      typeDeclNode.fullName shouldBe "test.go::main.<global>::Foo"
+    "test fullName of TypeDecl nodes" in {
+      typeDeclNode.fullName shouldBe "main.Foo"
     }
 
     "test the modifier" in {
@@ -96,8 +90,8 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
-    "test fullName of TypeDecl nodes" ignore {
-      typeDeclNode.fullName shouldBe "test.go::main.<global>::Foo"
+    "test fullName of TypeDecl nodes" in {
+      typeDeclNode.fullName shouldBe "main.Foo"
     }
 
     "test the modifier" in {
@@ -127,8 +121,8 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       cpg.typeDecl("foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
-    "test fullName of TypeDecl nodes" ignore {
-      typeDeclNode.fullName shouldBe "test.go::main.<global>::foo"
+    "test fullName of TypeDecl nodes" in {
+      typeDeclNode.fullName shouldBe "main.foo"
     }
 
     "test the modifier" in {
@@ -160,7 +154,7 @@ class TypeDeclTests extends GoCodeToCpgSuite {
     }
 
     "test fullName of TypeDecl nodes" ignore {
-      typeDeclNode.fullName shouldBe "test.go::main.<global>::main::Sample"
+      typeDeclNode.fullName shouldBe "main.main.Sample"
     }
 
     "test the modifier" in {
@@ -191,8 +185,8 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
-    "test fullName of TypeDecl nodes" ignore {
-      typeDeclNode.fullName shouldBe "test.go::main.<global>::main::Foo"
+    "test fullName of TypeDecl nodes" in {
+      typeDeclNode.fullName shouldBe "main.Foo"
     }
 
     "test the modifier" in {
@@ -223,8 +217,8 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
-    "test fullName of TypeDecl nodes for Foo" ignore {
-      typeDeclNode.fullName shouldBe "test.go::main.<global>::main::Foo"
+    "test fullName of TypeDecl nodes for Foo" in {
+      typeDeclNode.fullName shouldBe "main.Foo"
     }
 
     "test the modifier for Foo" in {
@@ -244,8 +238,8 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       cpg.typeDecl("bar").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
-    "test fullName of TypeDecl nodes for bar" ignore {
-      typeDeclNodeBar.fullName shouldBe "test.go::main.<global>::bar"
+    "test fullName of TypeDecl nodes for bar" in {
+      typeDeclNodeBar.fullName shouldBe "main.bar"
     }
 
     "test the modifier for bar" in {
@@ -254,3 +248,12 @@ class TypeDeclTests extends GoCodeToCpgSuite {
     }
   }
 }
+
+//TODO: Add unit tests for nested struct within a block
+//func bar (x int) int {
+//  if true {
+//    type mx struct {
+//      something string
+//    }
+//  }
+//}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -834,7 +834,11 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     lineNumber: Option[Integer]
   ): NewMethodParameterIn = {
     val typeFullName = typeInfoCalc.registerType(maybeTypeFullName.getOrElse(TypeConstants.Any))
-    NodeBuilders.newThisParameterNode(typeFullName, maybeTypeFullName.toSeq, lineNumber)
+    NodeBuilders.newThisParameterNode(
+      typeFullName = typeFullName,
+      dynamicTypeHintFullName = maybeTypeFullName.toSeq,
+      line = lineNumber
+    )
   }
 
   private def convertAnnotationValueExpr(expr: Expression): Option[Ast] = {

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -726,7 +726,11 @@ class AstCreator(filename: String, cls: SootClass, global: Global)(implicit with
             .argumentIndex(0)
             .dynamicTypeHintFullName(Seq(parentType))
         case _: NewMethodParameterIn =>
-          NodeBuilders.newThisParameterNode(parentType, Seq(parentType), line(Try(method.tryResolve()).getOrElse(null)))
+          NodeBuilders.newThisParameterNode(
+            typeFullName = parentType,
+            dynamicTypeHintFullName = Seq(parentType),
+            line = line(Try(method.tryResolve()).getOrElse(null))
+          )
         case x => x
       })
     } else {

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
@@ -76,7 +76,8 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val defaultFullName       = s"$classFullName.${TypeConstants.initPrefix}:$defaultSignature"
     val (fullName, signature) = typeInfoProvider.fullNameWithSignature(primaryCtor, (defaultFullName, defaultSignature))
     val primaryCtorMethodNode = methodNode(primaryCtor, TypeConstants.initPrefix, fullName, signature, relativizedPath)
-    val ctorThisParam         = NodeBuilders.newThisParameterNode(classFullName, Seq(classFullName))
+    val ctorThisParam =
+      NodeBuilders.newThisParameterNode(typeFullName = classFullName, dynamicTypeHintFullName = Seq(classFullName))
     scope.addToScope(Constants.this_, ctorThisParam)
 
     val constructorParamsAsts = Seq(Ast(ctorThisParam)) ++ withIndex(constructorParams) { (p, idx) =>
@@ -385,7 +386,8 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     parameters.zipWithIndex.map { case (valueParam, idx) =>
       val typeFullName = registerType(typeInfoProvider.typeFullName(valueParam, TypeConstants.any))
 
-      val thisParam      = NodeBuilders.newThisParameterNode(typeDecl.fullName, Seq())
+      val thisParam =
+        NodeBuilders.newThisParameterNode(typeFullName = typeDecl.fullName, dynamicTypeHintFullName = Seq())
       val thisIdentifier = newIdentifierNode(Constants.this_, typeDecl.fullName, Seq(typeDecl.fullName))
       val thisAst        = Ast(thisIdentifier).withRefEdge(thisIdentifier, thisParam)
 
@@ -423,7 +425,8 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
         methodNode(ctor, Constants.init, fullName, signature, relativizedPath)
       scope.pushNewScope(secondaryCtorMethodNode)
 
-      val ctorThisParam = NodeBuilders.newThisParameterNode(classFullName, Seq(classFullName))
+      val ctorThisParam =
+        NodeBuilders.newThisParameterNode(typeFullName = classFullName, dynamicTypeHintFullName = Seq(classFullName))
       scope.addToScope(Constants.this_, ctorThisParam)
 
       val constructorParamsAsts = Seq(Ast(ctorThisParam)) ++

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -36,7 +36,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
 
     val thisParameterMaybe = if (needsThisParameter) {
       val typeDeclFullName = registerType(typeInfoProvider.containingTypeDeclFullName(ktFn, TypeConstants.any))
-      val node             = NodeBuilders.newThisParameterNode(typeDeclFullName, Seq(typeDeclFullName))
+      val node = NodeBuilders.newThisParameterNode(
+        typeFullName = typeDeclFullName,
+        dynamicTypeHintFullName = Seq(typeDeclFullName)
+      )
       scope.addToScope(Constants.this_, node)
       Option(node)
     } else None

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -142,14 +142,16 @@ object NodeBuilders {
   }
 
   def newThisParameterNode(
+    name: String = "this",
+    code: String = "this",
     typeFullName: String,
     dynamicTypeHintFullName: Seq[String] = Seq.empty,
     line: Option[Integer] = None,
     column: Option[Integer] = None
   ): NewMethodParameterIn = {
     NewMethodParameterIn()
-      .name("this")
-      .code("this")
+      .name(name)
+      .code(code)
       .lineNumber(line)
       .columnNumber(column)
       .dynamicTypeHintFullName(dynamicTypeHintFullName)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -147,7 +147,8 @@ object NodeBuilders {
     typeFullName: String,
     dynamicTypeHintFullName: Seq[String] = Seq.empty,
     line: Option[Integer] = None,
-    column: Option[Integer] = None
+    column: Option[Integer] = None,
+    evaluationStrategy: String = EvaluationStrategies.BY_SHARING
   ): NewMethodParameterIn = {
     NewMethodParameterIn()
       .name(name)
@@ -155,7 +156,7 @@ object NodeBuilders {
       .lineNumber(line)
       .columnNumber(column)
       .dynamicTypeHintFullName(dynamicTypeHintFullName)
-      .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+      .evaluationStrategy(evaluationStrategy)
       .typeFullName(typeFullName)
       .index(0)
       .order(0)


### PR DESCRIPTION
1. Changed the signature of `x2cpg` `NodeBuilders.newThisParameterNode` method to take `name` and `code` as a parameter and set defaults to `this`. This is done to use the receiver name as is defined in the code instead of naming it as `this`. This will make sure to have `ref` edges built as natural processing of `Identifiers.`  Have updated the places where this method was getting called to adjust with the updated interface.
2. `ThisParameterNode` handling while generating AST for method declaration that can be called with struct  type receiver

```
type Rect struct {
  len, wid int
}

func (re Rect) Area_by_value() int {
  return re.len * re.wid
}
```
3. Handling for more than one member, defined as a `,` separated list of the same type. 

```
package main

type Rect struct {
  len, wid int
}
```