### PR TITLE
[gosrc2cpg] - support to exclude files

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 gosrc2cpg {
-    goastgen_version: "0.9.0"
+    goastgen_version: "0.10.0"
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
@@ -134,8 +134,10 @@ class AstGenRunner(config: Config) {
     }
   }
 
-  private def runAstGenNative(in: String, out: File, exclude: String): Try[Seq[String]] =
-    ExternalCommand.run(s"$astGenCommand -exclude ${exclude} -out ${out.toString()} $in", ".")
+  private def runAstGenNative(in: String, out: File, exclude: String): Try[Seq[String]] = {
+    val excludeCommand = if (exclude.isEmpty) "\"\"" else s"\"$exclude\""
+    ExternalCommand.run(s"$astGenCommand -exclude $excludeCommand -out ${out.toString()} $in", ".")
+  }
 
   def execute(out: File): AstGenRunnerResult = {
     val in = File(config.inputPath)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
@@ -135,8 +135,8 @@ class AstGenRunner(config: Config) {
   }
 
   private def runAstGenNative(in: String, out: File, exclude: String): Try[Seq[String]] = {
-    val excludeCommand = if (exclude.isEmpty) "\"\"" else s"\"$exclude\""
-    ExternalCommand.run(s"$astGenCommand -exclude $excludeCommand -out ${out.toString()} $in", ".")
+    val excludeCommand = if (exclude.isEmpty) "" else s"-exclude $exclude"
+    ExternalCommand.run(s"$astGenCommand $excludeCommand -out ${out.toString()} $in", ".")
   }
 
   def execute(out: File): AstGenRunnerResult = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
@@ -134,13 +134,13 @@ class AstGenRunner(config: Config) {
     }
   }
 
-  private def runAstGenNative(in: String, out: File): Try[Seq[String]] =
-    ExternalCommand.run(s"$astGenCommand -out ${out.toString()} $in", ".")
+  private def runAstGenNative(in: String, out: File, exclude: String): Try[Seq[String]] =
+    ExternalCommand.run(s"$astGenCommand -exclude ${exclude} -out ${out.toString()} $in", ".")
 
   def execute(out: File): AstGenRunnerResult = {
     val in = File(config.inputPath)
     logger.info(s"Running goastgen in '$config.inputPath' ...")
-    runAstGenNative(config.inputPath, out) match {
+    runAstGenNative(config.inputPath, out, config.ignoredFilesRegex.toString()) match {
       case Success(result) =>
         val srcFiles      = SourceFiles.determine(out.toString(), Set(".json"))
         val parsedModFile = filterModFile(srcFiles, out)


### PR DESCRIPTION
we can now exclude file for go frontend:

`importCode.golang.apply(inputPath = "path", projectName = "name", args = List("--exclude-regex", "regex"))`