### PR TITLE
[gosrc2cpg] - call node handling for method called on struct object

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -43,16 +43,16 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val filename     = relPathFileName
     val name         = funcDecl.json(ParserKeys.Name).obj(ParserKeys.Name).str
     val receiverInfo = getReceiverInfo(Try(funcDecl.json(ParserKeys.Recv)))
-    val (methodFullname, recSignStr) = receiverInfo match
+    val methodFullname = receiverInfo match
       case Some(_, typeFullName, evaluationStrategy, _) =>
         val signatureStr = evaluationStrategy match
           case EvaluationStrategies.BY_SHARING =>
             s"*$typeFullName"
           case EvaluationStrategies.BY_VALUE =>
             typeFullName
-        (s"$typeFullName.$name", s"($signatureStr)")
+        s"$typeFullName.$name"
       case _ =>
-        (s"$fullyQualifiedPackage.$name", "")
+        s"$fullyQualifiedPackage.$name"
     // TODO: handle multiple return type or tuple (int, int)
     val genericTypeMethodMap = processTypeParams(funcDecl.json(ParserKeys.Type))
     val (returnTypeStr, methodReturn) =
@@ -60,7 +60,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         .getOrElse(("", methodReturnNode(funcDecl, Defines.voidTypeName)))
     val params = funcDecl.json(ParserKeys.Type)(ParserKeys.Params)(ParserKeys.List)
     val signature =
-      s"$methodFullname$recSignStr(${parameterSignature(params, genericTypeMethodMap)})$returnTypeStr"
+      s"$methodFullname(${parameterSignature(params, genericTypeMethodMap)})$returnTypeStr"
     GoGlobal.recordFullNameToReturnType(methodFullname, returnTypeStr, Some(signature))
     val methodNode_ = methodNode(funcDecl, name, funcDecl.code, methodFullname, Some(signature), filename)
     methodAstParentStack.push(methodNode_)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -92,10 +92,17 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
           (s"$fullyQualifiedPackage.$methodName()", s"$fullyQualifiedPackage.$methodName", Defines.tobeFilled)
         )
       case Some(alias) =>
-        (
-          s"${aliasToNameSpaceMapping.getOrElse(alias, s"${XDefines.Unknown}.<$alias>")}.$methodName()",
-          s"${aliasToNameSpaceMapping.getOrElse(alias, s"${XDefines.Unknown}.<$alias>")}.$methodName",
-          Defines.tobeFilled
-        )
+        // Note check if given alias is an object, in that case we will find the expected variable in scope.
+        val variableOption = scope.lookupVariable(alias)
+        variableOption match {
+          case Some((_, variableTypeName)) =>
+            (s"$variableTypeName.$methodName()", s"$variableTypeName.$methodName", Defines.tobeFilled)
+          case _ =>
+            (
+              s"${aliasToNameSpaceMapping.getOrElse(alias, s"${XDefines.Unknown}.<$alias>")}.$methodName()",
+              s"${aliasToNameSpaceMapping.getOrElse(alias, s"${XDefines.Unknown}.<$alias>")}.$methodName",
+              Defines.tobeFilled
+            )
+        }
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -45,17 +45,14 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { t
 
   private def astForIdentifier(ident: ParserNodeInfo): Ast = {
     val identifierName = ident.json(ParserKeys.Name).str
-
     val variableOption = scope.lookupVariable(identifierName)
-    val identifierType = variableOption match {
-      case Some((_, variableTypeName)) => variableTypeName
-      case _                           => ""
-    }
-    val node = identifierNode(ident, identifierName, ident.json(ParserKeys.Name).str, identifierType)
     variableOption match {
-      case Some((variable, _)) =>
+      case Some((variable, variableTypeName)) =>
+        val node = identifierNode(ident, identifierName, ident.json(ParserKeys.Name).str, variableTypeName)
         Ast(node).withRefEdge(node, variable)
-      case None => Ast(node)
+      case _ =>
+        // TODO: something is wrong here. Refer to SwitchTests -> "be correct for switch case 4"
+        Ast(identifierNode(ident, identifierName, ident.json(ParserKeys.Name).str, Defines.anyTypeName))
     }
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodCallTests.scala
@@ -41,6 +41,16 @@ class MethodCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       x.name shouldBe "bar"
       x.isExternal shouldBe false
     }
+
+    "traversal from method to call node" in {
+      val List(x) = cpg.method("bar").callIn.l
+      x.name shouldBe "bar"
+    }
+
+    "traversal from method to all the child call nodes" in {
+      val List(x) = cpg.method("foo").call.l
+      x.name shouldBe "bar"
+    }
   }
 
   "Method defined in the same file and after method is called." should {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/SwitchTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/SwitchTests.scala
@@ -1,12 +1,10 @@
 package io.joern.go2cpg.passes.ast
 
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
-
-import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
 
 class SwitchTests extends GoCodeToCpgSuite {
   "AST Creation for switch case" should {
@@ -134,25 +132,24 @@ class SwitchTests extends GoCodeToCpgSuite {
         |   }
         |}
     """.stripMargin)
-    inside(cpg.method.name("method").controlStructure.l) { case List(controlStruct: ControlStructure) =>
-      controlStruct.code shouldBe "switch x.(type)"
-      controlStruct.controlStructureType shouldBe ControlStructureTypes.SWITCH
-      inside(controlStruct.astChildren.l) { case List(identifier: Identifier, switchBlock: Block) =>
-        identifier.code shouldBe "x"
-        switchBlock.astChildren.size shouldBe 9
-        switchBlock.astChildren.code.l shouldBe List(
-          "case nil",
-          "nil",
-          "y = 5",
-          "case int",
-          "int",
-          "y = 8",
-          "case float64",
-          "float64",
-          "y = 12"
-        )
-      }
-    }
+    val List(controlStruct: ControlStructure) = cpg.method.name("method").controlStructure.l
+    controlStruct.code shouldBe "switch x.(type)"
+    controlStruct.controlStructureType shouldBe ControlStructureTypes.SWITCH
+    val List(identifier: Identifier, switchBlock: Block) = controlStruct.astChildren.l
+    identifier.code shouldBe "x"
+    switchBlock.astChildren.size shouldBe 9
+    // TODO: something is wrong here. Identifier is being created for int, nil and float64
+    switchBlock.astChildren.code.l shouldBe List(
+      "case nil",
+      "nil",
+      "y = 5",
+      "case int",
+      "int",
+      "y = 8",
+      "case float64",
+      "float64",
+      "y = 12"
+    )
   }
 
   // TODO Need to handle `fallthrough` statements

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
@@ -1,0 +1,49 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.semanticcpg.language.*
+
+class TypeDeclMethodCallTests extends GoCodeToCpgSuite {
+
+  "basic method call test on struct type object test" should {
+    val cpg = code("""
+        |package main
+        |type Person struct {
+        |	fname string
+        |	lname string
+        |}
+        |func (person Person) fullName() string {
+        |	return person.fname + " " + person.lname
+        |}
+        |func main() {
+        |	var a Person = Person{fname: "Pandurang", lname: "Patil"}
+        |	var fulname string = a.fullName()
+        |}
+        |""".stripMargin)
+
+    "Check method node properties" in {
+      cpg.method("fullName").size shouldBe 1
+      val List(x) = cpg.method("fullName").l
+      x.name shouldBe "fullName"
+      x.fullName shouldBe "main.Person.fullName"
+      x.code should startWith("func (person Person) fullName() string {")
+      x.signature shouldBe "main.Person.fullName()string"
+      x.isExternal shouldBe false
+      x.order shouldBe 1
+      x.filename shouldBe "Test0.go"
+    }
+
+    "Check call node properties" in {
+      cpg.call("fullName").size shouldBe 1
+      val List(x) = cpg.call("fullName").l
+      x.code shouldBe "a.fullName()"
+      x.methodFullName shouldBe "main.Person.fullName"
+      x.signature shouldBe "main.Person.fullName()string"
+      x.order shouldBe 2
+      x.lineNumber shouldBe Option(12)
+      x.typeFullName shouldBe "string"
+      x.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    }
+  }
+}

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeFullNameTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeFullNameTests.scala
@@ -1,0 +1,58 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.semanticcpg.language.*
+
+class TypeFullNameTests extends GoCodeToCpgSuite {
+  "Type check for declared primitive types" should {
+    val cpg = code("""
+        |package main
+        |func main() {
+        |   var a int = 1
+        |   var b, c float32
+        |   var d []int
+        |}
+        |""".stripMargin)
+
+    "Check for local nodes" in {
+      val List(a, b, c, d) = cpg.local.l
+      a.typeFullName shouldBe "int"
+      b.typeFullName shouldBe "float32"
+      c.typeFullName shouldBe "float32"
+      d.typeFullName shouldBe "[]int"
+    }
+
+    "check for identifier nodes" in {
+      val List(a, b, c, d) = cpg.identifier.l
+      a.typeFullName shouldBe "int"
+      b.typeFullName shouldBe "float32"
+      c.typeFullName shouldBe "float32"
+      d.typeFullName shouldBe "[]int"
+    }
+  }
+
+  "Type check for implicit Type based on assigned literal" ignore {
+    val cpg = code("""
+        |package main
+        |func main() {
+        |   var a = 10
+        |   var b = 20.5
+        |   var c = [5]int{1,2}
+        |}
+        |""".stripMargin)
+
+    "Check for local nodes" in {
+      val List(a, b, c) = cpg.local.l
+      a.typeFullName shouldBe "int"
+      b.typeFullName shouldBe "float32"
+      c.typeFullName shouldBe "[]int"
+    }
+
+    "check for identifier nodes" in {
+      val List(a, b, c) = cpg.identifier.l
+      a.typeFullName shouldBe "int"
+      b.typeFullName shouldBe "float32"
+      c.typeFullName shouldBe "[]int"
+    }
+  }
+}


### PR DESCRIPTION
1. Initial call node handling for struct object to set proper method fullname and signature.
2. Refactored some code inside `AstForPrimitivesCreator.astForIdentifier`. Along with that, I refactored some unit tests to make it them more readable.
3. Added few unit test for TypeFullName Checks.
4. Changed method signature for method node to remove the receiver type prefixed as its already been prefixed in the method name used in the signature.

TODO:
1. 0th index argument node handling.
2. Issue identified in switch case handling.
3. Updating typeFullName of the LHS identifier when type is not declared and it is inferred from RHS.
4. FieldAccess call node handling.