### PR TITLE
[gosrc2cpg] - FieldAccess call node handling along with Receiver identifier handling for method call node.

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -66,7 +66,7 @@ trait AstCreatorHelper { this: AstCreator =>
       case None        => ParserNodeInfo(ParserAst.Unknown, ujson.Null, "", None, None, None, None)
   }
 
-  private def nodeType(node: Value): ParserNode = fromString(node(ParserKeys.NodeType).str)
+  private def nodeType(node: Value): ParserNode = fromString(node(ParserKeys.NodeType).str, relPathFileName)
   protected def code(node: Value): Try[String] = Try {
 
     val lineNumber    = line(node).get

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -119,6 +119,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
               generateTypeFullName(typeName = typeParserNode.json(ParserKeys.X)(ParserKeys.Name).strOpt),
               EvaluationStrategies.BY_SHARING
             )
+          case x =>
+            logger.warn(s"Unhandled class ${x.getClass} under getReceiverInfo!")
+            ("", "")
         Some(recName, typeFullName, evaluationStrategy, recnode)
       case _ => None
   }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -47,6 +47,9 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
           Some(typeNode.json(ParserKeys.X)(ParserKeys.Name).str, typeNode.json(ParserKeys.X)),
           typeNode.json(ParserKeys.Sel)(ParserKeys.Name).str
         )
+      case x =>
+        logger.warn(s"Unhandled class ${x.getClass} under astForConstructorCall!")
+        (None, "")
     val (signature, fullName, _, _) = callMethodFullNameTypeFullNameAndSignature(methodName, alias)
 
     val cpgCall = callNode(
@@ -67,8 +70,8 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
       .flatMap(x => {
         val argument = createParserNodeInfo(x)
         argument.node match
-          case BasicLit => astForPrimitive(argument)
-          case _        => astForPrimitive(createParserNodeInfo(argument.json(ParserKeys.Value)))
+          case BasicLit => astForNode(argument)
+          case _        => astForNode(createParserNodeInfo(argument.json(ParserKeys.Value)))
       })
       .toSeq
   }
@@ -77,8 +80,8 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
     args.arrOpt
       .getOrElse(Seq.empty)
       .flatMap(x => {
-        val primitiveNode = createParserNodeInfo(x)
-        astForPrimitive(primitiveNode)
+        val argNode = createParserNodeInfo(x)
+        astForNode(argNode)
       })
       .toSeq
   }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -48,7 +48,7 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { t
     val variableOption = scope.lookupVariable(identifierName)
     variableOption match {
       case Some((variable, variableTypeName)) =>
-        val node = identifierNode(ident, identifierName, ident.json(ParserKeys.Name).str, variableTypeName)
+        val node = identifierNode(ident, identifierName, ident.code, variableTypeName)
         Ast(node).withRefEdge(node, variable)
       case _ =>
         // TODO: something is wrong here. Refer to SwitchTests -> "be correct for switch case 4"

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
@@ -1,17 +1,28 @@
 package io.joern.gosrc2cpg.parser
 
-object ParserAst {
+import io.joern.gosrc2cpg.astcreation.AstCreator
+import io.joern.gosrc2cpg.utils.AstGenRunner.getClass
+import org.slf4j.{Logger, LoggerFactory}
 
+object ParserAst {
+  private val logger                     = LoggerFactory.getLogger(getClass)
   private val QualifiedClassName: String = ParserAst.getClass.getName
 
-  def fromString(nodeName: String): ParserNode = {
-    val clazz = Class.forName(s"$QualifiedClassName${nodeName.stripPrefix("ast.")}$$")
-    clazz.getField("MODULE$").get(clazz).asInstanceOf[ParserNode]
+  def fromString(nodeName: String, fileName: String): ParserNode = {
+    try {
+      val clazz = Class.forName(s"$QualifiedClassName${nodeName.stripPrefix("ast.")}$$")
+      clazz.getField("MODULE$").get(clazz).asInstanceOf[ParserNode]
+    } catch {
+      case _ =>
+        logger.warn(s"`$nodeName` AST type is not handled. We found this inside '$fileName'")
+        NotHandledType
+    }
   }
 
   sealed trait ParserNode {
     override def toString: String = this.getClass.getSimpleName.stripSuffix("$")
   }
+  object NotHandledType      extends ParserNode
   sealed trait BaseExpr      extends ParserNode
   object BinaryExpr          extends BaseExpr
   object KeyValueExpr        extends BaseExpr

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/dataflow/MethodAndCallDataFlowTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/dataflow/MethodAndCallDataFlowTests.scala
@@ -150,4 +150,35 @@ class MethodAndCallDataFlowTests extends GoCodeToCpgSuite(withOssDataflow = true
       sink.reachableByFlows(srcone).size shouldBe 1
     }
   }
+
+  "data flow test through struct type" should {
+    val cpg = code("""
+        |package main
+        |type Person struct {
+        |	fname string
+        |	lname string
+        |}
+        |func (person Person) fullName() string {
+        |	return person.fname + " " + person.lname
+        |}
+        |func main() {
+        |	var a Person = Person{fname: "Pandurang", lname: "Patil"}
+        |	var fulname string = a.fullName()
+        |}
+        |""".stripMargin)
+    "data flow from literal passed to constructor to identifier" ignore {
+      val src  = cpg.literal("Pandurang").l
+      val sink = cpg.identifier("a").l
+      sink.reachableByFlows(src).size shouldBe 1
+
+      val sinkOne = cpg.identifier("fulname").l
+      sinkOne.reachableByFlows(src).size shouldBe 1
+    }
+
+    "data flow use case 2" in {
+      val src  = cpg.identifier("a").l
+      val sink = cpg.identifier("fulname").l
+      sink.reachableByFlows(src).size shouldBe 2
+    }
+  }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ArraysTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ArraysTests.scala
@@ -147,14 +147,7 @@ class ArraysTests extends GoCodeToCpgSuite {
       val List(localNode) = cpg.local.l
       localNode.code shouldBe "a"
       localNode.lineNumber shouldBe Some(4)
-
-      val List(arrayInitializerNode) = cpg.method("main").ast.isCall.l
-      arrayInitializerNode.name shouldBe Operators.arrayInitializer
-      arrayInitializerNode.code shouldBe "[2]int"
-      arrayInitializerNode.lineNumber shouldBe Some(4)
-      arrayInitializerNode.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      arrayInitializerNode.typeFullName shouldBe "[]int"
-
+      localNode.typeFullName shouldBe "[]int"
     }
 
     "be correct when global variable is initialized using array length" in {
@@ -169,13 +162,7 @@ class ArraysTests extends GoCodeToCpgSuite {
       val List(localNode) = cpg.local.l
       localNode.code shouldBe "a"
       localNode.lineNumber shouldBe Some(3)
-
-      val List(arrayInitializerNode) = cpg.call.l
-      arrayInitializerNode.name shouldBe Operators.arrayInitializer
-      arrayInitializerNode.code shouldBe "[2]int"
-      arrayInitializerNode.lineNumber shouldBe Some(3)
-      arrayInitializerNode.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      arrayInitializerNode.typeFullName shouldBe "[]int"
+      localNode.typeFullName shouldBe "[]int"
 
     }
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ConstructorCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ConstructorCallTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language.*
 
 import scala.collection.immutable.List
 
-class StructureCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
+class ConstructorCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
 
   "when structure declared with multiple argument" should {
     val cpg = code(
@@ -125,8 +125,8 @@ class StructureCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       "test.go"
     )
 
-    val List(squareCallNode, _) = cpg.call("Square").l
     "check argument of Square call node" in {
+      val List(squareCallNode) = cpg.call("Square").l
       val List(squareArgument) = squareCallNode.argument.isLiteral.l
       squareArgument.argumentIndex shouldBe 1
       squareArgument.order shouldBe 1
@@ -134,7 +134,7 @@ class StructureCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       squareArgument.typeFullName shouldBe "int"
     }
 
-    "Single call node getting created for Structure declaration" ignore {
+    "Single call node getting created for Structure declaration" in {
       cpg.call("Square").size shouldBe 1
     }
   }
@@ -157,8 +157,8 @@ class StructureCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       "test.go"
     )
 
-    val List(squareCallNode, _) = cpg.call("Square").l
     "check argument of Square call node" in {
+      val List(squareCallNode) = cpg.call("Square").l
       val List(squareArgument) = squareCallNode.argument.isLiteral.l
       squareArgument.argumentIndex shouldBe 1
       squareArgument.order shouldBe 1
@@ -166,7 +166,7 @@ class StructureCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       squareArgument.typeFullName shouldBe "int"
     }
 
-    "Single call node getting created for Structure declaration" ignore {
+    "Single call node getting created for Structure declaration" in {
       cpg.call("Square").size shouldBe 1
     }
   }
@@ -189,8 +189,8 @@ class StructureCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       "test.go"
     )
 
-    val List(squareCallNode, _) = cpg.call("Rectangle").l
     "check argument of Rectangle call node" in {
+      val List(squareCallNode)                               = cpg.call("Rectangle").l
       val List(rectangleArgumentFirst, squareArgumentSecond) = squareCallNode.argument.isLiteral.l
       rectangleArgumentFirst.argumentIndex shouldBe 1
       rectangleArgumentFirst.order shouldBe 1
@@ -203,7 +203,7 @@ class StructureCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       squareArgumentSecond.typeFullName shouldBe "int"
     }
 
-    "Single call node getting created for Structure declaration" ignore {
+    "Single call node getting created for Structure declaration" in {
       cpg.call("Rectangle").size shouldBe 1
     }
   }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FieldAccessTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FieldAccessTests.scala
@@ -1,0 +1,70 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.joern.gosrc2cpg.astcreation.Defines
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier, Literal, MethodParameterIn}
+import io.shiftleft.semanticcpg.language.*
+
+class FieldAccessTests extends GoCodeToCpgSuite {
+
+  "simple field access test" should {
+    val cpg = code("""
+        |package main
+        |type Person struct {
+        |	fname string
+        |	lname string
+        |}
+        |func (person Person) fullName() string {
+        |	return person.fname + " " + person.lname
+        |}
+        |func main() {
+        |	var a Person = Person{fname: "Pandurang", lname: "Patil"}
+        |	var fn string = a.fname
+        |}
+        |
+        |func foo() {
+        |   var a Person = Person{fname: "Pandurang", lname: "Patil"}
+        |   println(a.fname)
+        |}
+        |""".stripMargin)
+
+    "External Field access test" in {
+      val List(fieldAccessCall) = cpg.method("main").astChildren.fieldAccess.l
+      fieldAccessCall.name shouldBe Operators.fieldAccess
+      // TODO: We need to find and set the right full name
+      fieldAccessCall.typeFullName shouldBe Defines.anyTypeName
+
+      val List(ident: Identifier, fieldIdent: FieldIdentifier) = fieldAccessCall.argument.l: @unchecked
+      ident.name shouldBe "a"
+      fieldIdent.canonicalName shouldBe "fname"
+    }
+
+    "Field access test for internal function of struct" in {
+      val List(facFname, facLname) = cpg.method("fullName").astChildren.fieldAccess.l
+      facFname.name shouldBe Operators.fieldAccess
+      facLname.name shouldBe Operators.fieldAccess
+    }
+
+    "Field access test while passing argument to method call" in {
+      val List(fieldAccessCall: Call) = cpg.call("println").argument.l: @unchecked
+      fieldAccessCall.name shouldBe Operators.fieldAccess
+    }
+    "some" in {
+      val cpg = code("""
+          |package main
+          |
+          |import "fmt"
+          |
+          |func main() {
+          |    // Define and immediately invoke an anonymous function
+          |    result := func(x, y int) int {
+          |        return x + y
+          |    }(5, 7)
+          |
+          |    fmt.Println(result) // Output: 12
+          |}
+          |""".stripMargin)
+    }
+  }
+}

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodCallTests.scala
@@ -459,11 +459,9 @@ class MethodCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
 
     "Check arguments nodes" in {
       cpg.call("bar").argument.size shouldBe 2
-      val List(a, b) = cpg.call("bar").argument.l
-      a.isInstanceOf[nodes.Identifier] shouldBe true
-      a.asInstanceOf[nodes.Identifier].name shouldBe "a"
-      b.isInstanceOf[nodes.Identifier] shouldBe true
-      b.asInstanceOf[nodes.Identifier].name shouldBe "b"
+      val List(a: Identifier, b: Identifier) = cpg.call("bar").argument.l: @unchecked
+      a.name shouldBe "a"
+      b.name shouldBe "b"
     }
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodCallTests.scala
@@ -456,6 +456,15 @@ class MethodCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       x.name shouldBe "bar"
       x.isExternal shouldBe true
     }
+
+    "Check arguments nodes" in {
+      cpg.call("bar").argument.size shouldBe 2
+      val List(a, b) = cpg.call("bar").argument.l
+      a.isInstanceOf[nodes.Identifier] shouldBe true
+      a.asInstanceOf[nodes.Identifier].name shouldBe "a"
+      b.isInstanceOf[nodes.Identifier] shouldBe true
+      b.asInstanceOf[nodes.Identifier].name shouldBe "b"
+    }
   }
 
   "Method call to builtin method recover()" should {
@@ -514,7 +523,7 @@ class MethodCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       x.code shouldBe "println(b)"
       x.methodFullName shouldBe "println"
       x.signature shouldBe "println([]any)"
-      x.order shouldBe 6
+      x.order shouldBe 5
       x.lineNumber shouldBe Option(6)
     }
 
@@ -536,6 +545,7 @@ class MethodCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       arg1.asInstanceOf[nodes.Identifier].name shouldBe "a"
       arg1.code shouldBe "a"
       arg1.order shouldBe 1
+      arg1.argumentIndex shouldBe 1
     }
 
     "traversal from argument to call node" in {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
@@ -1,7 +1,7 @@
 package io.joern.go2cpg.passes.ast
 
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
-import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, nodes}
 import io.shiftleft.semanticcpg.language.*
 
 class TypeDeclMethodCallTests extends GoCodeToCpgSuite {
@@ -44,6 +44,15 @@ class TypeDeclMethodCallTests extends GoCodeToCpgSuite {
       x.lineNumber shouldBe Option(12)
       x.typeFullName shouldBe "string"
       x.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    }
+
+    "check this/receiver argument is correctly getting passed" in {
+      cpg.call("fullName").argument.size shouldBe 1
+      val List(x) = cpg.call("fullName").argument.l
+      x.order shouldBe 1
+      x.argumentIndex shouldBe 0
+      x.isInstanceOf[nodes.Identifier] shouldBe true
+      x.asInstanceOf[nodes.Identifier].name shouldBe "a"
     }
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
@@ -1,6 +1,7 @@
 package io.joern.go2cpg.passes.ast
 
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, nodes}
 import io.shiftleft.semanticcpg.language.*
 
@@ -48,11 +49,10 @@ class TypeDeclMethodCallTests extends GoCodeToCpgSuite {
 
     "check this/receiver argument is correctly getting passed" in {
       cpg.call("fullName").argument.size shouldBe 1
-      val List(x) = cpg.call("fullName").argument.l
+      val List(x: Identifier) = cpg.call("fullName").argument.l: @unchecked
       x.order shouldBe 1
       x.argumentIndex shouldBe 0
-      x.isInstanceOf[nodes.Identifier] shouldBe true
-      x.asInstanceOf[nodes.Identifier].name shouldBe "a"
+      x.name shouldBe "a"
     }
   }
 }


### PR DESCRIPTION
1. Receiver argument handling for method call nodes
2. Fixed the duplicate call nodes getting created for Constructor call nodes.
3. Few additional unit tests
4. FieldAccess call node handling along with field identifier.
5. Created `NotHandledType` for the ast types which we have not yet handled and logged the warning.
6. Some other code refactoring.