### PR TITLE
[rubysrc2cpg] Creating Locals & Detecting Non-Parenthesis Calls

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -74,6 +74,7 @@ object RubySrc2Cpg {
   def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] =
     List(
       // TODO commented below two passes, as waiting on Dependency download PR to get merged
+      new IdentifierToCallPass(cpg),
       new ImportResolverPass(cpg, packageTableInfo),
       new RubyTypeRecoveryPass(cpg),
       new RubyTypeHintCallLinker(cpg),

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/IdentifierToCallPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/IdentifierToCallPass.scala
@@ -1,0 +1,68 @@
+package io.joern.rubysrc2cpg.passes
+
+import io.joern.x2cpg.Defines as XDefines
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Local, Method, NewCall}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language.*
+
+/** Scans for identifiers that are meant to be calls but are simply invoked without parenthesis'. Uses heuristics here
+  * and there to make the distinction.
+  */
+class IdentifierToCallPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Method](cpg) {
+
+  private val methodNameMap: Map[String, List[Method]] = cpg.method.groupBy(_.name)
+  private val methodNameSet: Set[String]               = methodNameMap.keySet
+
+  override def generateParts(): Array[Method] = cpg.method.toArray
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, part: Method): Unit =
+    part.local.referencingIdentifiers
+      .filter(sharesNameWithMethod)
+      .whereNot(isTargetOfAssignment)
+      .refsTo
+      .collectAll[Local]
+      .foreach(node => convertToCall(diffGraph, node))
+
+  /** @return
+    *   true if the call shares a name with a defined method, false if otherwise.
+    */
+  private def sharesNameWithMethod(node: Identifier): Boolean =
+    methodNameSet.contains(node.name)
+
+  /** Determines if the identifier is the LHS of an assignment.
+    */
+  private def isTargetOfAssignment(nodes: Iterator[Identifier]): Iterator[Identifier] =
+    if (nodes.nonEmpty) nodes.where(_.inAssignment).argumentIndex(1)
+    else nodes
+
+  /** Removes the local node and replaces all if its referencing identifiers with call nodes.
+    */
+  private def convertToCall(diffGraph: DiffGraphBuilder, node: Local): Unit = {
+    node.referencingIdentifiers.foreach { i =>
+      // Create call with not much type info - this will be handled in type propagation
+      val call = NewCall()
+        .name(i.name)
+        .code(i.code)
+        .typeFullName(Defines.Any)
+        .dispatchType(DispatchTypes.DYNAMIC_DISPATCH)
+        .methodFullName(XDefines.DynamicCallUnknownFullName)
+        .argumentName(i.argumentName)
+        .argumentIndex(i.argumentIndex)
+        .lineNumber(i.lineNumber)
+        .columnNumber(i.columnNumber)
+        .order(i.order)
+      // Persist node in-place
+      diffGraph.addNode(call)
+      i.outE.filterNot(_.label == EdgeTypes.REF).foreach(e => diffGraph.addEdge(call, e.inNode, e.label))
+      i.inE.foreach(e => diffGraph.addEdge(e.outNode, call, e.label))
+      // Remove identifiers
+      i.outE(EdgeTypes.REF).foreach(diffGraph.removeEdge)
+      diffGraph.removeNode(i)
+    }
+    // Finally, remove local
+    diffGraph.removeNode(node)
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -889,7 +889,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).l.size shouldBe 2
+      sink.reachableByFlows(source).l.size shouldBe 1
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/AssignCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/AssignCpgTests.scala
@@ -1,21 +1,27 @@
 package io.joern.rubysrc2cpg.passes.ast
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, NodeTypes, Operators, nodes}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, nodes}
 import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 class AssignCpgTests extends RubyCode2CpgFixture {
+
   "single target assign" should {
     val cpg = code("""x = 2""".stripMargin)
 
-    // TODO: .code property need to be fixed
-    "test assignment node properties" ignore {
+    "test local and identifier nodes" in {
+      val localX = cpg.local.head
+      localX.name shouldBe "x"
+      val List(idX) = localX.referencingIdentifiers.l: @unchecked
+      idX.name shouldBe "x"
+    }
+
+    "test assignment node properties" in {
       val assignCall = cpg.call.methodFullName(Operators.assignment).head
-      assignCall.code shouldBe "x = 2" // "="
+      assignCall.code shouldBe "x = 2"
       assignCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       assignCall.lineNumber shouldBe Some(1)
-      assignCall.columnNumber shouldBe Some(1)
+      assignCall.columnNumber shouldBe Some(2)
     }
 
     "test assignment node ast children" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/RescueKeywordCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/RescueKeywordCpgTests.scala
@@ -15,7 +15,7 @@ class RescueKeywordCpgTests extends RubyCode2CpgFixture {
     val methodNode = cpg.method.name("foo").head
     methodNode.name shouldBe "foo"
     methodNode.numberOfLines shouldBe 4
-    methodNode.astChildren.isBlock.astChildren.code.head shouldBe "try"
+    methodNode.astChildren.isBlock.astChildren.code.contains("try") shouldBe true
 
     val zeroDivisionErrorIdentifier = cpg.identifier("ZeroDivisionError").head
     zeroDivisionErrorIdentifier.code shouldBe "ZeroDivisionError"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -449,7 +449,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a assignment expression" in {
       val cpg            = code("x = y")
       val List(callNode) = cpg.call.name(Operators.assignment).l
-      callNode.code shouldBe "="
+      callNode.code shouldBe "x = y"
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(2)
     }
@@ -685,11 +685,11 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
       val List(argArgumentOfFoo, argArgumentOfPuts) = cpg.identifier.name("arg").l
       argArgumentOfFoo.code shouldBe "arg"
-      argArgumentOfFoo.lineNumber shouldBe Some(1)
+      argArgumentOfFoo.lineNumber shouldBe Some(2)
       argArgumentOfFoo.columnNumber shouldBe Some(5)
 
       argArgumentOfPuts.code shouldBe "arg"
-      argArgumentOfPuts.lineNumber shouldBe Some(2)
+      argArgumentOfPuts.lineNumber shouldBe Some(1)
     }
 
     "have correct structure for a hash initialisation" in {
@@ -948,7 +948,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
         "scope :get_all_doctors, -> { (select('id, first_name').where('role = :user_role', user_role: User.roles[:doctor])) }"
       )
       cpg.parameter.size shouldBe 6
-      cpg.call.name("proc_4").size shouldBe 1
+      cpg.call.name("proc_2").size shouldBe 1
       cpg.call.name("scope").size shouldBe 1
       cpg.call.name("where").size shouldBe 1
       cpg.call.name("select").size shouldBe 1
@@ -1259,7 +1259,6 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
         |  end
         |end
         |""".stripMargin)
-
     cpg.identifier("a").dedup.size shouldBe 1
     cpg.identifier("b").dedup.size shouldBe 1
     cpg.identifier("x").name.dedup.size shouldBe 1
@@ -1388,8 +1387,8 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     keyValueAssocOperator.astChildren.l(1).code shouldBe "1"
 
     val List(actualIdentifier, pseudoIdentifier) = cpg.identifier("bar").l
-    pseudoIdentifier.lineNumber shouldBe Some(4)
-    pseudoIdentifier.columnNumber shouldBe Some(2)
+    pseudoIdentifier.lineNumber shouldBe Some(2)
+    pseudoIdentifier.columnNumber shouldBe Some(0)
   }
 
   "have correct structure for regex match global variables" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/cfg/SimpleCfgCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/cfg/SimpleCfgCreationPassTest.scala
@@ -11,8 +11,8 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
     "have correct structure for empty array literal" ignore {
       implicit val cpg: Cpg = code("x = []")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("x") shouldBe expected(("=", AlwaysEdge))
-      succOf("=") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x") shouldBe expected(("x = []", AlwaysEdge))
+      succOf("x = []") shouldBe expected(("<empty>", AlwaysEdge))
     }
 
     "have correct structure for array literal with values" in {
@@ -24,33 +24,33 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
     "assigning a literal value" in {
       implicit val cpg: Cpg = code("x = 1")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("=") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = 1") shouldBe expected(("<empty>", AlwaysEdge))
     }
 
     "assigning a string literal value" in {
       implicit val cpg: Cpg = code("x = 'some literal'")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("=") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = 'some literal'") shouldBe expected(("<empty>", AlwaysEdge))
     }
 
     "addition of two numbers" in {
       implicit val cpg: Cpg = code("x = 1 + 2")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("=") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = 1 + 2") shouldBe expected(("<empty>", AlwaysEdge))
       succOf("x") shouldBe expected(("1", AlwaysEdge))
       succOf("2") shouldBe expected(("1 + 2", AlwaysEdge))
       succOf("1") shouldBe expected(("2", AlwaysEdge))
-      succOf("1 + 2") shouldBe expected(("=", AlwaysEdge))
+      succOf("1 + 2") shouldBe expected(("x = 1 + 2", AlwaysEdge))
     }
 
     "addition of two string" in {
       implicit val cpg: Cpg = code("x = 1 + 2")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("=") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = 1 + 2") shouldBe expected(("<empty>", AlwaysEdge))
       succOf("x") shouldBe expected(("1", AlwaysEdge))
       succOf("2") shouldBe expected(("1 + 2", AlwaysEdge))
       succOf("1") shouldBe expected(("2", AlwaysEdge))
-      succOf("1 + 2") shouldBe expected(("=", AlwaysEdge))
+      succOf("1 + 2") shouldBe expected(("x = 1 + 2", AlwaysEdge))
     }
 
     "addition of multiple string" in {
@@ -66,9 +66,9 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
       succOf("c") shouldBe expected(("\"do you like blueberries?\"", AlwaysEdge))
       succOf("a+b+c") shouldBe expected(("<empty>", AlwaysEdge))
       succOf("a+b") shouldBe expected(("c", AlwaysEdge))
-      succOf("\"Nice to meet you\"") shouldBe expected(("=", AlwaysEdge))
-      succOf("\", \"") shouldBe expected(("=", AlwaysEdge))
-      succOf("\"do you like blueberries?\"") shouldBe expected(("=", AlwaysEdge))
+      succOf("\"Nice to meet you\"") shouldBe expected(("a = \"Nice to meet you\"", AlwaysEdge))
+      succOf("\", \"") shouldBe expected(("b = \", \"", AlwaysEdge))
+      succOf("\"do you like blueberries?\"") shouldBe expected(("c = \"do you like blueberries?\"", AlwaysEdge))
     }
 
     "addition of multiple string and assign to variable" in {
@@ -82,11 +82,11 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
       succOf("a") shouldBe expected(("\"Nice to meet you\"", AlwaysEdge))
       succOf("b") shouldBe expected(("\", \"", AlwaysEdge))
       succOf("c") shouldBe expected(("\"do you like blueberries?\"", AlwaysEdge))
-      succOf("a+b+c") shouldBe expected(("=", AlwaysEdge))
+      succOf("a+b+c") shouldBe expected(("x = a+b+c", AlwaysEdge))
       succOf("a+b") shouldBe expected(("c", AlwaysEdge))
-      succOf("\"Nice to meet you\"") shouldBe expected(("=", AlwaysEdge))
-      succOf("\", \"") shouldBe expected(("=", AlwaysEdge))
-      succOf("\"do you like blueberries?\"") shouldBe expected(("=", AlwaysEdge))
+      succOf("\"Nice to meet you\"") shouldBe expected(("a = \"Nice to meet you\"", AlwaysEdge))
+      succOf("\", \"") shouldBe expected(("b = \", \"", AlwaysEdge))
+      succOf("\"do you like blueberries?\"") shouldBe expected(("c = \"do you like blueberries?\"", AlwaysEdge))
       succOf("x") shouldBe expected(("a", AlwaysEdge))
     }
 
@@ -98,7 +98,7 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
           |end
           |""".stripMargin)
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("1") shouldBe expected(("=", AlwaysEdge))
+      succOf("1") shouldBe expected(("x = 1", AlwaysEdge))
       succOf("x") shouldBe expected(("1", AlwaysEdge))
       succOf("2") shouldBe expected(("x > 2", AlwaysEdge))
     }
@@ -115,7 +115,7 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
           |end
           |""".stripMargin)
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("1") shouldBe expected(("=", AlwaysEdge))
+      succOf("1") shouldBe expected(("x = 1", AlwaysEdge))
       succOf("x") shouldBe expected(("1", AlwaysEdge))
       succOf("2") shouldBe expected(("x > 2", AlwaysEdge))
       succOf("x <= 2 and x!=0") subsetOf expected(("\"x is 1\"", AlwaysEdge))


### PR DESCRIPTION
This PR was intended to only address the issue where calls without parenthesis were detected as identifiers due to not having the method within immediate scope, but I found that Ruby CPGs do not generate `LOCAL` nodes which was necessary for this feature.

* Corrected `.code` property for binary operation calls
* Added `IdentifierToCallPass` to heuristically determine if an identifier is meant to be a call node and would replace it in-place.
* Modified the `scope` variable by introducing a new `RubyScope` subtype that can generate local variables of the given scope and link them to their identifiers.

This resulted in many tests to be modified if they checked on certain properties.

**Note**: `this` parameter nodes need to be tested as I saw this wasn't being generated implicitly.