### PR TITLE
Exposes couple of cdt performance options

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -14,7 +14,9 @@ final case class Config(
   logProblems: Boolean = false,
   logPreprocessor: Boolean = false,
   printIfDefsOnly: Boolean = false,
-  includePathsAutoDiscovery: Boolean = false
+  includePathsAutoDiscovery: Boolean = false,
+  skipFunctionBodies: Boolean = false,
+  noImageLocations: Boolean = false
 ) extends X2CpgConfig[Config] {
   def withIncludePaths(includePaths: Set[String]): Config = {
     this.copy(includePaths = includePaths).withInheritedFields(this)
@@ -42,6 +44,14 @@ final case class Config(
 
   def withIncludePathsAutoDiscovery(value: Boolean): Config = {
     this.copy(includePathsAutoDiscovery = value).withInheritedFields(this)
+  }
+
+  def withSkipFunctionBodies(value: Boolean): Config = {
+    this.copy(skipFunctionBodies = value).withInheritedFields(this)
+  }
+
+  def withNoImageLocations(value: Boolean): Config = {
+    this.copy(noImageLocations = value).withInheritedFields(this)
   }
 }
 
@@ -75,6 +85,14 @@ private object Frontend {
       opt[Unit]("with-include-auto-discovery")
         .text("enables auto discovery of system header include paths")
         .action((_, c) => c.withIncludePathsAutoDiscovery(true)),
+      opt[Unit]("skip-function-bodies")
+        .text("instructs the parser to skip function and method bodies.")
+        .action((_, c) => c.withSkipFunctionBodies(true)),
+      opt[Unit]("no-image-locations")
+        .text(
+          "performance optimization, allows the parser not to create image-locations. An image location explains how a name made it into the translation unit. Eg: via macro expansion or preprocessor."
+        )
+        .action((_, c) => c.withNoImageLocations(true)),
       opt[String]("define")
         .unbounded()
         .text("define a name")

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -44,7 +44,11 @@ class CdtParser(config: Config) extends ParseProblemsLogger with PreprocessorSta
   private val log              = new DefaultLogService
 
   // enables parsing of code behind disabled preprocessor defines:
-  private val opts: Int = ILanguage.OPTION_PARSE_INACTIVE_CODE
+  private var opts: Int = ILanguage.OPTION_PARSE_INACTIVE_CODE
+  // instructs the parser to skip function and method bodies
+  if (config.skipFunctionBodies) opts |= ILanguage.OPTION_SKIP_FUNCTION_BODIES
+  // performance optimization, allows the parser not to create image-locations
+  if (config.noImageLocations) opts |= ILanguage.OPTION_NO_IMAGE_LOCATIONS
 
   private def createParseLanguage(file: Path): ILanguage = {
     if (FileDefaults.isCPPFile(file.toString)) {


### PR DESCRIPTION
The documentation for the options are listed here:

https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.cdt.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fcdt%2Fcore%2Fdom%2Fparser%2FAbstractCLikeLanguage.html

Skipping function and method bodies enables downstream tools to perform a faster signature-only parsing.