### PR TITLE
gosrc2cpg: for loop without break condition

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -215,7 +215,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   private def astForForStatement(forStmt: ParserNodeInfo): Ast = {
 
     val initParserNode = nullSafeCreateParserNodeInfo(forStmt.json.obj.get(ParserKeys.Init))
-    val condParserNode = createParserNodeInfo(forStmt.json(ParserKeys.Cond))
+    val condParserNode = nullSafeCreateParserNodeInfo(forStmt.json.obj.get(ParserKeys.Cond))
     val iterParserNode = nullSafeCreateParserNodeInfo(forStmt.json.obj.get(ParserKeys.Post))
 
     val code    = s"for ${initParserNode.code};${condParserNode.code};${iterParserNode.code}"

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LoopsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LoopsTests.scala
@@ -74,6 +74,34 @@ class LoopsTests extends GoCodeToCpgSuite {
       }
     }
 
+    "for-loop without breaking condition" in {
+      val cpg = code("""
+          package main
+          |var a = 10
+          |func main() {
+          |	for {
+          | a++
+          |	}
+          |}
+          |
+          |""".stripMargin)
+
+      inside(cpg.method.name("main").controlStructure.l) { case List(forStmt) =>
+        forStmt.controlStructureType shouldBe ControlStructureTypes.FOR
+        inside(forStmt.astChildren.order(1).l) { case List(initializerBlock: Block) =>
+          initializerBlock.astChildren.size shouldBe 0
+        }
+
+        // order 2 is braking condition
+        forStmt.astChildren.order(2).size shouldBe 0
+        forStmt.astChildren.order(3).size shouldBe 0
+
+        inside(forStmt.astChildren.order(4).l) { case List(body: Block) =>
+          body.astChildren.isCall.code.l shouldBe List("a++")
+        }
+      }
+    }
+
     "be correct for for-loop case 3" in {
       val cpg = code("""
          |package main


### PR DESCRIPTION
In Go Language we can define `for-loop` even without break condition.
Example:

```
package main

func main() {
	for {
	}
}
```

Changes:
1. Handled case where `initParserNode` and `condParserNode` can be empty for `for-loop`