### PR TITLE
[rubysrc2cpg] Follow-Up to Local Node & Identifier Handling 

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -110,7 +110,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case ctx: RegularExpressionLiteralContext => Seq(astForRegularExpressionLiteral(ctx))
     case ctx: HereDocLiteralContext           => Seq(astForHereDocLiteral(ctx))
     case _ =>
-      logger.error(s"astForLiteralPrimaryExpression() $filename, ${text(ctx)} All contexts mismatched.")
+      logger.error(s"astForLiteralPrimaryExpression() $relativeFilename, ${text(ctx)} All contexts mismatched.")
       Seq()
   }
 
@@ -279,7 +279,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         case Some(xs) => Option(xs ++ Set(ctx))
         case None     => Option(Set(ctx))
       }
-      val thisNode = createIdentifierWithScope(ctx, "this", "this", Defines.Any, List.empty)
+      val thisNode = createThisIdentifier(ctx)
       astForFieldAccess(ctx, thisNode)
     } else if (definitelyIdentifier || scope.lookupVariable(variableName).isDefined) {
       val node = createIdentifierWithScope(ctx, variableName, variableName, Defines.Any, List())

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -253,13 +253,17 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
 
     /* isolate methods from the original args and create identifier ASTs from it */
     val methodDefAsts = argsAsts.filter(_.nodes.headOption.getOrElse(None).isInstanceOf[NewMethod])
-    val methodToIdentifierAsts = methodDefAsts.map { ast =>
-      val id = NewIdentifier()
-        .name(ast.nodes.head.asInstanceOf[NewMethod].name)
-        .code(ast.nodes.head.asInstanceOf[NewMethod].name)
-        .typeFullName(Defines.Any)
-        .lineNumber(ast.nodes.head.asInstanceOf[NewMethod].lineNumber)
-      Ast(id)
+    val methodToIdentifierAsts = methodDefAsts.flatMap { ast =>
+      ast.nodes.collectFirst { case x: NewMethod => x }.map { methodNode =>
+        val id = NewIdentifier()
+          .name(methodNode.name)
+          .code(methodNode.name)
+          .typeFullName(Defines.Any)
+          .lineNumber(methodNode.lineNumber)
+          .columnNumber(methodNode.columnNumber)
+        scope.addToScope(methodNode.name, id)
+        Ast(id)
+      }
     }
 
     /* TODO: we add the isolated method defs later on to the parent instead */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -210,7 +210,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     case ctx: OrAndExpressionOrCommandContext      => Seq(astForOrAndExpressionOrCommand(ctx))
     case ctx: ExpressionExpressionOrCommandContext => astForExpressionContext(ctx.expression())
     case _ =>
-      logger.error(s"astForExpressionOrCommand() $filename, ${text(ctx)} All contexts mismatched.")
+      logger.error(s"astForExpressionOrCommand() $relativeFilename, ${text(ctx)} All contexts mismatched.")
       Seq(Ast())
   }
 
@@ -353,7 +353,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
         case path if File(path).exists =>
           path
         case path if File(s"$path.rb").exists =>
-          s"${path}.rb"
+          s"$path.rb"
         case _ =>
           pathValue
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -889,7 +889,7 @@ class DataFlowTests extends RubyCode2CpgFixture(withPostProcessing = true, withD
     "find flows to the sink" in {
       val source = cpg.identifier.name("x").l
       val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).l.size shouldBe 1
+      sink.reachableByFlows(source).l.size shouldBe 2
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DataFlowTests.scala
@@ -1,7 +1,6 @@
 package io.joern.rubysrc2cpg.dataflow
 
 import io.joern.dataflowengineoss.language.*
-import io.joern.rubysrc2cpg.RubySrc2Cpg
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -12,6 +12,7 @@ import io.joern.x2cpg.passes.frontend.ImportsPass.{
 import io.shiftleft.semanticcpg.language.*
 
 import scala.collection.immutable.List
+import io.joern.x2cpg.Defines as XDefines
 
 object RubyTypeRecoveryTests {
   def getPackageTable: PackageTable = {
@@ -102,9 +103,9 @@ class RubyTypeRecoveryTests
       maxCall.methodFullName shouldBe "__builtin.puts"
     }
 
-    "conservatively present either option when an imported function uses the same name as a builtin" in {
+    "present the declared method name when a built-in with the same name is used in the same compilation unit" in {
       val List(absCall) = cpg.call("sleep").l
-      absCall.dynamicTypeHintFullName.l shouldBe Seq("__builtin.sleep", "main.rb::program.sleep")
+      absCall.methodFullName shouldBe "main.rb::program.sleep"
     }
   }
 
@@ -202,7 +203,7 @@ class RubyTypeRecoveryTests
 
     "resolve correct imports via tag nodes" in {
       val List(logging: ResolvedMethod, _) = cpg.call.where(_.referencedImports).tag.toResolvedImport.toList: @unchecked
-      logging.fullName shouldBe "logger::program.Logger.new"
+      logging.fullName shouldBe s"logger::program.Logger.${XDefines.ConstructorMethodName}"
     }
 
     "provide a dummy type" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/CustomAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/CustomAssignmentTests.scala
@@ -11,7 +11,7 @@ class CustomAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
         |puts "This is ruby"
         |""".stripMargin)
     "be created for builtin presence" in {
-      val List(_, putsAssignmentCall) = cpg.call.l
+      val List(putsAssignmentCall, _) = cpg.call.l
       putsAssignmentCall.name shouldBe "<operator>.assignment"
 
       val List(putsIdentifier: Identifier, putsBuiltInTypeRef: TypeRef) = putsAssignmentCall.argument.l: @unchecked
@@ -22,7 +22,7 @@ class CustomAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
     }
 
     "resolve type for `puts`" in {
-      val List(putsCall, _) = cpg.call.l
+      val List(_, putsCall) = cpg.call.l
       putsCall.name shouldBe "puts"
       putsCall.methodFullName shouldBe "__builtin.puts"
     }
@@ -37,7 +37,7 @@ class CustomAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
         |foo()
         |""".stripMargin)
     "be created" in {
-      val List(_, fooAssignmentCall) = cpg.call.l
+      val List(fooAssignmentCall, _) = cpg.call.l
       fooAssignmentCall.name shouldBe "<operator>.assignment"
 
       val List(fooIdentifier: Identifier, fooMethodRef: MethodRef) = fooAssignmentCall.argument.l: @unchecked
@@ -48,7 +48,7 @@ class CustomAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
     }
 
     "resolve type for `foo`" in {
-      val List(fooCall, _) = cpg.call.l
+      val List(_, fooCall) = cpg.call.l
       fooCall.name shouldBe "foo"
       fooCall.methodFullName shouldBe "Test0.rb::program.foo"
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/FileTests.scala
@@ -34,7 +34,7 @@ class FileTests extends RubyCode2CpgFixture {
   }
 
   "should allow traversing from file to its methods via namespace block" in {
-    cpg.file.nameNot(FileTraversal.UNKNOWN).method.name.toSetMutable shouldBe Set(":program", "foo", "bar")
+    cpg.file.nameNot(FileTraversal.UNKNOWN).method.name.toSetMutable shouldBe Set("foo", "bar", "<init>", ":program")
   }
 
   // TODO: TypeDecl fix this unit test

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/MethodOneTests.scala
@@ -21,7 +21,7 @@ class MethodOneTests extends RubyCode2CpgFixture {
         x.fullName shouldBe "Test0.rb::program.foo"
         x.code should startWith("def foo(a, b)")
         x.isExternal shouldBe false
-        x.order shouldBe 1
+        x.order shouldBe 3
         x.filename endsWith "Test0.rb"
         x.lineNumber shouldBe Option(2)
         x.lineNumberEnd shouldBe Option(4)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/NamespaceBlockTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/NamespaceBlockTest.scala
@@ -4,6 +4,7 @@ import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import io.joern.x2cpg.Defines
 
 class NamespaceBlockTest extends RubyCode2CpgFixture {
   val cpg = code("""puts 123
@@ -29,7 +30,11 @@ class NamespaceBlockTest extends RubyCode2CpgFixture {
   }
 
   "should allow traversing from namespace block to method" in {
-    cpg.namespaceBlock.filenameNot(FileTraversal.UNKNOWN).ast.isMethod.name.l shouldBe List(":program", "foo")
+    cpg.namespaceBlock.filenameNot(FileTraversal.UNKNOWN).ast.isMethod.name.l shouldBe List(
+      ":program",
+      "foo",
+      Defines.ConstructorMethodName
+    )
   }
 
   "should allow traversing from namespace block to type declaration" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -14,17 +14,17 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a single command call" in {
       val cpg = code("""puts 123""")
 
-      val List(call1, call2) = cpg.call.l
-      val List(arg)          = call1.argument.isLiteral.l
+      val List(assign, puts) = cpg.call.l
+      val List(arg)          = puts.argument.isLiteral.l
 
-      call1.code shouldBe "puts 123"
-      call1.lineNumber shouldBe Some(1)
+      puts.code shouldBe "puts 123"
+      puts.lineNumber shouldBe Some(1)
 
       arg.code shouldBe "123"
       arg.lineNumber shouldBe Some(1)
       arg.columnNumber shouldBe Some(5)
 
-      call2.name shouldBe "<operator>.assignment" // call node for builtin typeRef assignment
+      assign.name shouldBe "<operator>.assignment" // call node for builtin typeRef assignment
     }
 
     "have correct structure for an unsigned, decimal integer literal" in {
@@ -314,7 +314,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     "have correct structure for a single-line regular expression literal passed as argument to a command" in {
       val cpg = code("puts /x/")
 
-      val List(callNode, _) = cpg.call.l
+      val List(_, callNode) = cpg.call.l
       callNode.code shouldBe "puts /x/"
       callNode.name shouldBe "puts"
       callNode.lineNumber shouldBe Some(1)
@@ -416,7 +416,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
 
     "have correct structure for a call node" in {
       val cpg               = code("puts \"something\"")
-      val List(callNode, _) = cpg.call.l
+      val List(_, callNode) = cpg.call.l
       callNode.code shouldBe "puts \"something\""
       callNode.lineNumber shouldBe Some(1)
       callNode.columnNumber shouldBe Some(0)
@@ -683,7 +683,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
       callNode3.lineNumber shouldBe Some(2)
       callNode3.columnNumber shouldBe Some(0)
 
-      val List(argArgumentOfFoo, argArgumentOfPuts) = cpg.identifier.name("arg").l
+      val List(argArgumentOfPuts, argArgumentOfFoo) = cpg.identifier.name("arg").l
       argArgumentOfFoo.code shouldBe "arg"
       argArgumentOfFoo.lineNumber shouldBe Some(2)
       argArgumentOfFoo.columnNumber shouldBe Some(5)
@@ -1191,7 +1191,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     methodNode.name shouldBe "foo"
     methodNode.lineNumber shouldBe Some(2)
 
-    val List(divisionOperator, assignmentOperator) = cpg.method.name(".*operator.*").l
+    val List(assignmentOperator, divisionOperator) = cpg.method.name(".*operator.*").l
     divisionOperator.name shouldBe "<operator>.division"
     assignmentOperator.name shouldBe "<operator>.assignment"
   }
@@ -1386,7 +1386,7 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     keyValueAssocOperator.code shouldBe ":x=>1"
     keyValueAssocOperator.astChildren.l(1).code shouldBe "1"
 
-    val List(actualIdentifier, pseudoIdentifier) = cpg.identifier("bar").l
+    val List(pseudoIdentifier, actualIdentifier) = cpg.identifier("bar").l
     pseudoIdentifier.lineNumber shouldBe Some(2)
     pseudoIdentifier.columnNumber shouldBe Some(0)
   }
@@ -1475,12 +1475,12 @@ class SimpleAstCreationPassTest extends RubyCode2CpgFixture {
     args1.head.code shouldBe "some_lhs"
     args1.tail.code.l.head shouldBe "some_rhs"
 
-    val callNode2 = cpg.call.code("pack_lhs = pack_rhs1,pack_rhs2").l.head
+    val callNode2 = cpg.call.code("pack_lhs = pack_rhs1, pack_rhs2").l.head
     callNode2.lineNumber shouldBe Some(2)
     callNode2.columnNumber shouldBe Some(19)
     val args2 = callNode2.argument.l
     args2.size shouldBe 2
     args2.head.code shouldBe "pack_lhs"
-    args2.tail.code.l.head shouldBe "pack_rhs1,pack_rhs2"
+    args2.tail.code.l.head shouldBe "pack_rhs1, pack_rhs2"
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/TypeDeclAstCreationPassTest.scala
@@ -66,7 +66,7 @@ class TypeDeclAstCreationPassTest extends RubyCode2CpgFixture {
       vehicle.name shouldBe "Vehicle"
       vehicle.fullName shouldBe "Test0.rb::program.Vehicle"
 
-      val List(speeding, halting, driving) = vehicle.method.l
+      val List(_, speeding, halting, driving) = vehicle.method.l
       speeding.name shouldBe "speeding"
       halting.name shouldBe "halting"
       driving.name shouldBe "driving"
@@ -155,7 +155,7 @@ class TypeDeclAstCreationPassTest extends RubyCode2CpgFixture {
       myClass.name shouldBe "MyClass"
       myClass.fullName shouldBe "Test0.rb::program.MyClass"
 
-      val List(_, m1, m2, m3, m4) = myClass.method.l
+      val List(_, _, m1, m2, m3, m4) = myClass.method.l
       m1.name shouldBe "method1"
       m2.name shouldBe "method2"
       m3.name shouldBe "method3"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/cfg/SimpleCfgCreationPassTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/cfg/SimpleCfgCreationPassTest.scala
@@ -12,31 +12,31 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
       implicit val cpg: Cpg = code("x = []")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
       succOf("x") shouldBe expected(("x = []", AlwaysEdge))
-      succOf("x = []") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = []") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "have correct structure for array literal with values" in {
       implicit val cpg: Cpg = code("x = [1, 2]")
       succOf("1") shouldBe expected(("2", AlwaysEdge))
-      succOf("x = [1, 2]") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = [1, 2]") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "assigning a literal value" in {
       implicit val cpg: Cpg = code("x = 1")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("x = 1") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = 1") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "assigning a string literal value" in {
       implicit val cpg: Cpg = code("x = 'some literal'")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("x = 'some literal'") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = 'some literal'") shouldBe expected(("RET", AlwaysEdge))
     }
 
     "addition of two numbers" in {
       implicit val cpg: Cpg = code("x = 1 + 2")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("x = 1 + 2") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = 1 + 2") shouldBe expected(("RET", AlwaysEdge))
       succOf("x") shouldBe expected(("1", AlwaysEdge))
       succOf("2") shouldBe expected(("1 + 2", AlwaysEdge))
       succOf("1") shouldBe expected(("2", AlwaysEdge))
@@ -46,7 +46,7 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
     "addition of two string" in {
       implicit val cpg: Cpg = code("x = 1 + 2")
       succOf(":program") shouldBe expected(("x", AlwaysEdge))
-      succOf("x = 1 + 2") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("x = 1 + 2") shouldBe expected(("RET", AlwaysEdge))
       succOf("x") shouldBe expected(("1", AlwaysEdge))
       succOf("2") shouldBe expected(("1 + 2", AlwaysEdge))
       succOf("1") shouldBe expected(("2", AlwaysEdge))
@@ -64,7 +64,7 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
       succOf("a") shouldBe expected(("\"Nice to meet you\"", AlwaysEdge))
       succOf("b") shouldBe expected(("\", \"", AlwaysEdge))
       succOf("c") shouldBe expected(("\"do you like blueberries?\"", AlwaysEdge))
-      succOf("a+b+c") shouldBe expected(("<empty>", AlwaysEdge))
+      succOf("a+b+c") shouldBe expected(("RET", AlwaysEdge))
       succOf("a+b") shouldBe expected(("c", AlwaysEdge))
       succOf("\"Nice to meet you\"") shouldBe expected(("a = \"Nice to meet you\"", AlwaysEdge))
       succOf("\", \"") shouldBe expected(("b = \", \"", AlwaysEdge))
@@ -97,7 +97,10 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
           |   puts "x is greater than 2"
           |end
           |""".stripMargin)
-      succOf(":program") shouldBe expected(("x", AlwaysEdge))
+      succOf(":program") shouldBe expected(("puts", AlwaysEdge))
+      succOf("puts") shouldBe expected(("__builtin.puts", AlwaysEdge))
+      succOf("__builtin.puts") shouldBe expected(("puts = __builtin.puts", AlwaysEdge))
+      succOf("puts = __builtin.puts") shouldBe expected(("x", AlwaysEdge))
       succOf("1") shouldBe expected(("x = 1", AlwaysEdge))
       succOf("x") shouldBe expected(("1", AlwaysEdge))
       succOf("2") shouldBe expected(("x > 2", AlwaysEdge))
@@ -114,12 +117,15 @@ class SimpleCfgCreationPassTest extends CfgTestFixture(() => new RubyCfgTestCpg(
           |   puts "I can't guess the number"
           |end
           |""".stripMargin)
-      succOf(":program") shouldBe expected(("x", AlwaysEdge))
+      succOf(":program") shouldBe expected(("puts", AlwaysEdge))
+      succOf("puts") shouldBe expected(("__builtin.puts", AlwaysEdge))
+      succOf("__builtin.puts") shouldBe expected(("puts = __builtin.puts", AlwaysEdge))
+      succOf("puts = __builtin.puts") shouldBe expected(("x", AlwaysEdge))
       succOf("1") shouldBe expected(("x = 1", AlwaysEdge))
       succOf("x") shouldBe expected(("1", AlwaysEdge))
       succOf("2") shouldBe expected(("x > 2", AlwaysEdge))
       succOf("x <= 2 and x!=0") subsetOf expected(("\"x is 1\"", AlwaysEdge))
-      succOf("x <= 2 and x!=0") subsetOf expected(("<empty>", AlwaysEdge))
+      succOf("x <= 2 and x!=0") subsetOf expected(("RET", AlwaysEdge))
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FunctionTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FunctionTests.scala
@@ -1,8 +1,9 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 class FunctionTests extends RubyCode2CpgFixture {
 
@@ -35,7 +36,7 @@ class FunctionTests extends RubyCode2CpgFixture {
       cpg.identifier.name("age").size shouldBe 1
       cpg.fieldAccess.fieldIdentifier.canonicalName("name").size shouldBe 2
       cpg.fieldAccess.fieldIdentifier.canonicalName("age").size shouldBe 4
-      cpg.identifier.size shouldBe 16 // 4 identifier node is for `puts = typeDef(__builtin.puts)` and methodRef's assignment, 1 node for class Person = typeDef
+      cpg.identifier.size shouldBe 13 // 4 identifier node is for `puts = typeDef(__builtin.puts)` 1 node for class Person = typeDef
     }
 
     "recognize all call nodes" in {
@@ -44,7 +45,9 @@ class FunctionTests extends RubyCode2CpgFixture {
     }
 
     "recognize all method nodes" in {
-      cpg.method.name("initialize").size shouldBe 1
+      // Initialize => <init>
+      cpg.method.name("initialize").size shouldBe 0
+      cpg.method.name(Defines.ConstructorMethodName).size shouldBe 1
       cpg.method.name("greet").size shouldBe 1
       cpg.method.name("have_birthday").size shouldBe 1
     }
@@ -73,16 +76,17 @@ class FunctionTests extends RubyCode2CpgFixture {
     "recognise all method nodes" in {
       cpg.method.name("\\[]").size shouldBe 1
       cpg.method.name("\\[]=").size shouldBe 1
-      cpg.method.name("initialize").size shouldBe 1
+      cpg.method.name("initialize").size shouldBe 0
+      cpg.method.name(Defines.ConstructorMethodName).size shouldBe 1
     }
 
     "recognize all call nodes" in {
       cpg.call
         .name(Operators.assignment)
-        .size shouldBe 7 // 3 identifier node is for methodRef's assignment, 1 identifier node for TypeRef's assignment
+        .size shouldBe 4 //  +1 identifier node for TypeRef's assignment
       cpg.call.name("to_s").size shouldBe 2
-      cpg.call.name("new").size shouldBe 1
-      cpg.call.size shouldBe 15 // 3 identifier node is for methodRef's assignment, 1 identifier node for TypeRef's assignment
+      cpg.call.name(Defines.ConstructorMethodName).size shouldBe 1
+      cpg.call.size shouldBe 12 // 1 identifier node for TypeRef's assignment
     }
 
     "recognize all identifier nodes" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MiscTests.scala
@@ -1,7 +1,8 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.semanticcpg.language._
+import io.joern.x2cpg.Defines
+import io.shiftleft.semanticcpg.language.*
 
 class MiscTests extends RubyCode2CpgFixture {
 
@@ -46,7 +47,7 @@ class MiscTests extends RubyCode2CpgFixture {
     "recognise all identifier and call nodes" in {
       cpg.call.name("application").size shouldBe 1
       cpg.call.name("configure").size shouldBe 1
-      cpg.call.name("new").size shouldBe 1
+      cpg.call.name(Defines.ConstructorMethodName).size shouldBe 1
       cpg.call.name("<operator>.scopeResolution").size shouldBe 2
       cpg.identifier.name("Rails").size shouldBe 1
       cpg.identifier.name("config").size shouldBe 1


### PR DESCRIPTION
This PR follows up from the discussion of https://github.com/joernio/joern/pull/3611. It was found that some identifiers were not linked via REF edges to their local nodes and thus causing issues with dataflow.

* Fixed instances of dangling identifier nodes from their referencing local nodes by extending `RubyScope` functionality.
* Fixed code for RHS of arrays
* Moved type/method ref assignments at the beginning of the block (after locals) so that it is before their references
* Made `signature` and `name` properties consistent with arrays and binops
* Added ScalaDoc comments to RubyScope
* Implemented constructors
* Moved to using x2cpg AstBase methods where possible
* Use `relativeFilename` instead of `filename`
* Lots of general optimizations

cc @khemrajrathore 