### PR TITLE
gosrc2cpg: handledling ast creation when reference id found in node

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -1492,6 +1492,34 @@ class MethodTests extends GoCodeToCpgSuite {
       argv.name shouldBe "argv"
     }
   }
+
+  "When ast of struct node is coming under method's body" should {
+    val cpg = code("""package main
+        |
+        |func foo() Node {
+        |   var boo = int64(0)
+        |   return Node{
+        |     value: boo,
+        |   }
+        |}
+        |
+        |type Node struct {
+        |   value string
+        |}""".stripMargin)
+
+    "Be correct with method node properties" in {
+      val List(x) = cpg.method("foo").l
+      x.fullName shouldBe "main.foo"
+      // TODO: confirm if signature is correct
+      x.signature shouldBe "main.foo()main.Node"
+    }
+
+    "Be correct with typeDecl node properties" ignore {
+      val List(x) = cpg.typeDecl("Node").l
+      x.fullName shouldBe "main.Node"
+    }
+
+  }
   // TODO: add unit test for "sem chan int"
   //        resultErrChan := make(chan error)
   //		sem := make(chan int, concurrency)


### PR DESCRIPTION
Handling:
If key is not found under parserNodeCache (https://github.com/joernio/joern/blob/master/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala#L47) program is breaking with `key not found` exception which is halting further processing of file.

Test Case:
Added breaking test case for which processing is skipped (where node_reference_id is exist). We need to handle it separately.
cc: @pandurangpatil @ankit-privado 