### PR TITLE
gosrc2cpg: Inbuilt method(make) support

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -114,7 +114,7 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
   }
 
   private def astForMapType(arg: ParserNodeInfo): Seq[Ast] = {
-    Seq(Ast(identifierNode(arg, Defines.map, arg.code, Defines.anyTypeName)))
+    Seq(Ast(literalNode(arg, arg.code, Defines.map)))
   }
 
   private def callMethodFullNameTypeFullNameAndSignature(

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -1,6 +1,6 @@
 package io.joern.gosrc2cpg.astcreation
 
-import io.joern.gosrc2cpg.parser.ParserAst.{BasicLit, Ident, SelectorExpr}
+import io.joern.gosrc2cpg.parser.ParserAst.{BasicLit, Ident, MapType, SelectorExpr}
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
@@ -93,10 +93,17 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
       .getOrElse(Seq.empty)
       .flatMap(x => {
         val argNode = createParserNodeInfo(x)
-        astForNode(argNode)
+        argNode.node match
+          case MapType => astForMapType(argNode)
+          case _       => astForNode(argNode)
       })
       .toSeq
   }
+
+  private def astForMapType(arg: ParserNodeInfo): Seq[Ast] = {
+    Seq(Ast(identifierNode(arg, Defines.map, arg.code, Defines.anyTypeName)))
+  }
+
   private def callMethodFullNameTypeFullNameAndSignature(
     methodName: String,
     aliasName: Option[(String, Value)] = None

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/Defines.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/Defines.scala
@@ -7,6 +7,7 @@ object Defines {
   val qualifiedNameSeparator: String = "::"
   val empty                          = "<empty>"
   val dot                            = "."
+  val map                            = "map"
 
   val primitiveTypeMap: Map[String, String] =
     // This list is prepared with reference to primitives defined at https://pkg.go.dev/builtin#pkg-types
@@ -47,6 +48,7 @@ object Defines {
       ("delete", ("delete(map[any]any, any)", "delete", voidTypeName)),
       ("imag", ("imag(ComplexType)FloatType", "imag", "FloatType")),
       ("len", ("len(any)int", "len", "int")),
+      ("make", ("make(map)map", "map", "map")),
       ("max", ("max[cmp.Ordered](cmp.Ordered, []cmp.Ordered)cmp.Ordered", "max", "cmp.Ordered")),
       ("min", ("min[cmp.Ordered](cmp.Ordered, []cmp.Ordered)cmp.Ordered", "min", "cmp.Ordered")),
       ("new", ("new(any)*any", "new", "*any")),

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserAst.scala
@@ -63,6 +63,7 @@ object ParserAst {
   object Unknown             extends ParserNode
   object FieldList           extends ParserNode
   object ArrayType           extends ParserNode
+  object MapType             extends ParserNode
   object Field               extends ParserNode
   object TypeSpec            extends ParserNode
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/BuiltInMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/BuiltInMethodCallTests.scala
@@ -31,11 +31,10 @@ class BuiltInMethodCallTests extends GoCodeToCpgSuite {
     }
 
     "check call node arguments" in {
-      val List(x) = cpg.call("make").argument.isIdentifier.l
-      x.name shouldBe "map"
+      val List(x) = cpg.call("make").argument.isLiteral.l
       x.code shouldBe "map[string]int"
       x.argumentIndex shouldBe 1
-      x.typeFullName shouldBe "ANY"
+      x.typeFullName shouldBe "map"
     }
 
   }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/BuiltInMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/BuiltInMethodCallTests.scala
@@ -1,0 +1,43 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.joern.dataflowengineoss.language.*
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.codepropertygraph.generated.nodes.*
+
+class BuiltInMethodCallTests extends GoCodeToCpgSuite {
+
+  "When inbuilt method(make) is used to create map" should {
+    val cpg = code("""package main
+        |
+        |func main() {
+        |	myMap := make(map[string]int)
+        |}""".stripMargin)
+    "check identifier properties" in {
+      val List(x) = cpg.identifier("myMap").l
+      x.lineNumber.get shouldBe 4
+      x.name shouldBe "myMap"
+    }
+
+    "check identifier(LHS) properties type" ignore {
+      val List(x) = cpg.identifier("myMap").l
+      x.typeFullName shouldBe "map"
+    }
+
+    "check call node properties" in {
+      val List(x) = cpg.call("make").l
+      x.name shouldBe "make"
+      x.typeFullName shouldBe "map"
+    }
+
+    "check call node arguments" in {
+      val List(x) = cpg.call("make").argument.isIdentifier.l
+      x.name shouldBe "map"
+      x.code shouldBe "map[string]int"
+      x.argumentIndex shouldBe 1
+      x.typeFullName shouldBe "ANY"
+    }
+
+  }
+
+}


### PR DESCRIPTION
Background:
In Go programming language, the  make  function is used to create and initialise slices, maps, and channels.
In current pull request I have added support for make function over a map.\
cc: @pandurangpatil @ankit-privado 
