### PR TITLE
[gosrc2cpg] - fix for #3649 for additional node 

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -45,7 +45,7 @@ trait AstCreatorHelper { this: AstCreator =>
           case Some(value) => value
           case None        =>
             // If the parser node info does not exist in the cache, log a warning message and create a null-safe parser node info
-            val nodeType = json.obj.get("node_type")
+            val nodeType = json(ParserKeys.NodeType).str
             logger.warn(s"Unhandled node_type $nodeType filename: $relPathFileName")
             nullSafeCreateParserNodeInfo(None)
   }
@@ -60,7 +60,8 @@ trait AstCreatorHelper { this: AstCreator =>
           case _ =>
       case Ident =>
         Try(json(ParserKeys.Obj)(ParserKeys.Decl)) match
-          case Success(obj) =>
+          // NOTE: For now only handling caching for node reference id of struct type
+          case Success(obj) if obj(ParserKeys.NodeType).str == "ast.TypeSpec" =>
             createParserNodeInfo(obj)
           case _ =>
       case _ =>

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -40,7 +40,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
   def astForFuncDecl(funcDecl: ParserNodeInfo): Seq[Ast] = {
 
-    val filename     = relPathFileName
     val name         = funcDecl.json(ParserKeys.Name).obj(ParserKeys.Name).str
     val receiverInfo = getReceiverInfo(Try(funcDecl.json(ParserKeys.Recv)))
     val methodFullname = receiverInfo match
@@ -62,7 +61,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val signature =
       s"$methodFullname(${parameterSignature(params, genericTypeMethodMap)})$returnTypeStr"
     GoGlobal.recordFullNameToReturnType(methodFullname, returnTypeStr, Some(signature))
-    val methodNode_ = methodNode(funcDecl, name, funcDecl.code, methodFullname, Some(signature), filename)
+    val methodNode_ = methodNode(funcDecl, name, funcDecl.code, methodFullname, Some(signature), relPathFileName)
     methodAstParentStack.push(methodNode_)
     scope.pushNewScope(methodNode_)
     val receiverNode = astForReceiver(receiverInfo)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
@@ -6,15 +6,13 @@ import io.joern.x2cpg
 import io.joern.x2cpg.datastructures.Stack.StackWrapper
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
 import ujson.Value
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 trait AstForTypeDeclCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   def astForTypeSpec(typeSpecNode: ParserNodeInfo): Seq[Ast] = {
-    // TODO: Add support for member variables and methods
     methodAstParentStack.collectFirst { case t: NewTypeDecl => t } match {
       case Some(parentMethodAstNode) =>
         val nameNode = typeSpecNode.json(ParserKeys.Name)
@@ -28,7 +26,7 @@ trait AstForTypeDeclCreator(implicit withSchemaValidation: ValidationMode) { thi
             typeSpecNode,
             nameNode(ParserKeys.Name).str,
             fullName,
-            parserResult.filename,
+            relPathFileName,
             typeSpecNode.code,
             astParentType,
             astParentFullName

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
@@ -59,8 +59,8 @@ trait AstForTypeDeclCreator(implicit withSchemaValidation: ValidationMode) { thi
       .arrOpt
       .getOrElse(List())
       .flatMap(x => {
-        val typeInfo = createParserNodeInfo(x(ParserKeys.Type))
-        val (typeFullName, typeFullNameForCode, isVariadic, evaluationStrategy) = processTypeInfo(typeInfo)
+        val typeInfo                = createParserNodeInfo(x(ParserKeys.Type))
+        val (typeFullName, _, _, _) = processTypeInfo(typeInfo)
         x(ParserKeys.Names).arrOpt
           .getOrElse(List())
           .map(fieldInfo => {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/AstCreationPass.scala
@@ -23,7 +23,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
       val parseResult     = GoAstJsonParser.readFile(Paths.get(inputJsonFile))
       val fileLOC         = IOUtils.readLinesInFile(Paths.get(parseResult.fullPath)).size
       val relPathFileName = SourceFiles.toRelativePath(parseResult.fullPath, config.inputPath)
-      report.addReportInfo(parseResult.filename, fileLOC, parsed = true)
+      report.addReportInfo(relPathFileName, fileLOC, parsed = true)
       Try {
         val localDiff = new AstCreator(relPathFileName, parseResult)(config.schemaValidation).createAst()
         diffGraph.absorb(localDiff)

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
@@ -4,57 +4,105 @@ import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import java.io.File
 
 class FileTests extends GoCodeToCpgSuite {
-  private val cpg = code("""
-      |package main
-      |func foo() {}
-      |func bar() {}
-      |type Sample struct {
-      |	name int
-      |}
-      |""".stripMargin)
+  "be correct for single file nodes" should {
+    val cpg = code("""
+        |package main
+        |func foo() {}
+        |func bar() {}
+        |type Sample struct {
+        |	name int
+        |}
+        |""".stripMargin)
 
-  // TODO: Fix this unit test
-  "should contain two file nodes in total, both with order=0" ignore {
-    cpg.file.order.l shouldBe List(0, 0)
-    cpg.file.name(FileTraversal.UNKNOWN).size shouldBe 1
-    cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 1
+    "should contain two file nodes in total, both with order=0" in {
+      cpg.file.order.l shouldBe List(0, 0)
+      cpg.file.name(FileTraversal.UNKNOWN).size shouldBe 1
+      cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 1
+    }
+
+    "should contain exactly one placeholder file node with `name=\"<unknown>\"/order=0`" in {
+      cpg.file(FileTraversal.UNKNOWN).order.l shouldBe List(0)
+      cpg.file(FileTraversal.UNKNOWN).hash.l shouldBe List()
+    }
+
+    "should allow traversing from file to its namespace blocks" in {
+      cpg.file.nameNot(FileTraversal.UNKNOWN).namespaceBlock.name.toSetMutable shouldBe Set("main")
+    }
+
+    "should allow traversing from file to its methods via namespace block" in {
+      cpg.file.nameNot(FileTraversal.UNKNOWN).method.name.toSetMutable shouldBe Set(
+        s"main.${NamespaceTraversal.globalNamespaceName}",
+        "foo",
+        "bar"
+      )
+    }
+
+    // TODO: TypeDecl fix the unit test
+    "should allow traversing from file to its type declarations via namespace block" ignore {
+      cpg.file
+        .nameNot(FileTraversal.UNKNOWN)
+        .typeDecl
+        .name
+        .l
+        .sorted shouldBe List("main.<global>", "int", "Sample")
+    }
+
+    "should allow traversing to namespaces" in {
+      val List(ns1, ns2) = cpg.file.namespaceBlock.l
+      ns1.filename shouldBe FileTraversal.UNKNOWN
+      ns1.fullName shouldBe NamespaceTraversal.globalNamespaceName
+      ns2.filename shouldBe "Test0.go"
+      ns2.fullName shouldBe "Test0.go:main"
+      cpg.file.namespace.l.size shouldBe 2
+    }
   }
 
-  "should contain exactly one placeholder file node with `name=\"<unknown>\"/order=0`" in {
-    cpg.file(FileTraversal.UNKNOWN).order.l shouldBe List(0)
-    cpg.file(FileTraversal.UNKNOWN).hash.l shouldBe List()
-  }
-
-  "should allow traversing from file to its namespace blocks" in {
-    cpg.file.nameNot(FileTraversal.UNKNOWN).namespaceBlock.name.toSetMutable shouldBe Set("main")
-  }
-
-  "should allow traversing from file to its methods via namespace block" in {
-    cpg.file.nameNot(FileTraversal.UNKNOWN).method.name.toSetMutable shouldBe Set(
-      s"main.${NamespaceTraversal.globalNamespaceName}",
-      "foo",
-      "bar"
+  "be correct for multiple files" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package fpkg
+        |type Person struct {
+        |  name string
+        |}
+        |""".stripMargin,
+      Seq("fpkg", "mainlib.go").mkString(File.separator)
+    ).moreCode(
+      """
+        |package main
+        |import "joern.io/sample/fpkg"
+        |func foo() {
+        |  var c = fpkg.Person{"FirstName"}
+        |}
+        |""".stripMargin,
+      "main.go"
     )
-  }
 
-  // TODO: TypeDecl fix the unit test
-  "should allow traversing from file to its type declarations via namespace block" ignore {
-    cpg.file
-      .nameNot(FileTraversal.UNKNOWN)
-      .typeDecl
-      .name
-      .l
-      .sorted shouldBe List("main.<global>", "int", "Sample")
-  }
+    "should contain two file nodes in total, both with order=0" in {
+      cpg.file.order.l shouldBe List(0, 0, 0)
+      cpg.file.name(FileTraversal.UNKNOWN).size shouldBe 1
+      cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 2
+    }
 
-  "should allow traversing to namespaces" in {
-    val List(ns1, ns2) = cpg.file.namespaceBlock.l
-    ns1.filename shouldBe FileTraversal.UNKNOWN
-    ns1.fullName shouldBe NamespaceTraversal.globalNamespaceName
-    ns2.filename shouldBe "Test0.go"
-    ns2.fullName shouldBe "Test0.go:main"
-    cpg.file.namespace.l.size shouldBe 2
+    "traversal from file to typedecl should work" in {
+      cpg.file(".*mainlib.go").size shouldBe 1
+      cpg.file(".*mainlib.go").typeDecl.fullName.l shouldBe List(
+        "fpkg/mainlib.go:joern.io/sample/fpkg.<global>",
+        "joern.io/sample/fpkg.Person"
+      )
+    }
+
+    "traversal from file to method should work" in {
+      cpg.file("main.go").size shouldBe 1
+      cpg.file("main.go").method.fullName.l shouldBe List("main.go:main.<global>", "main.foo")
+    }
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
@@ -95,7 +95,7 @@ class FileTests extends GoCodeToCpgSuite {
     "traversal from file to typedecl should work" in {
       cpg.file(".*mainlib.go").size shouldBe 1
       cpg.file(".*mainlib.go").typeDecl.fullName.l shouldBe List(
-        "fpkg/mainlib.go:joern.io/sample/fpkg.<global>",
+        s"${Seq("fpkg", "mainlib.go").mkString(File.separator)}:joern.io/sample/fpkg.<global>",
         "joern.io/sample/fpkg.Person"
       )
     }


### PR DESCRIPTION
1. While creating TypeDecl node, we were using only fileName instead of the entire relative path. Made changes to fix along with respective unit tests

Fixes #3649