### PR TITLE
[rubysrc2cpg] Major Refactoring of AstCreator

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AntlrParser.scala
@@ -8,13 +8,9 @@ import org.slf4j.LoggerFactory
 
 import scala.util.Try
 
-/** A consumable wrapper for the RubyParser class used to parse the given file and be disposed thereafter. This includes
-  * a "hacky" recovery of the parser when unsupported constructs are encountered by simply not parsing those lines.
+/** A consumable wrapper for the RubyParser class used to parse the given file and be disposed thereafter.
   * @param filename
   *   the file path to the file to be parsed.
-  * @param parsingTimeoutMs
-  *   grammar dependent, during development we may see input that would cause the parser to hang. To induce completion
-  *   we need a timeout.
   */
 class AntlrParser(filename: String) {
 
@@ -35,8 +31,6 @@ class AntlrParser(filename: String) {
   *
   * @param clearLimit
   *   the percentage of used heap to clear the DFA-cache on.
-  * @param parserTimeoutMs
-  *   how long the parser may attempt parsing a file before bailing out.
   */
 class ResourceManagedParser(clearLimit: Double) extends AutoCloseable {
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
@@ -1,0 +1,147 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.rubysrc2cpg.parser.RubyParser.{
+  BreakArgsInvocationWithoutParenthesesContext,
+  CaseExpressionPrimaryContext,
+  JumpExpressionPrimaryContext,
+  NextArgsInvocationWithoutParenthesesContext,
+  WhenArgumentContext
+}
+import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{NewControlStructure, NewReturn}
+
+import scala.jdk.CollectionConverters.*
+trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+
+  protected def astForWhenArgumentContext(ctx: WhenArgumentContext): Seq[Ast] = {
+    val expAsts =
+      ctx
+        .expressions()
+        .expression()
+        .asScala
+        .flatMap(astForExpressionContext)
+        .toList
+
+    if (ctx.splattingArgument() != null) {
+      expAsts ++ astForExpressionOrCommand(ctx.splattingArgument().expressionOrCommand())
+    } else {
+      expAsts
+    }
+  }
+
+  protected def astForCaseExpressionPrimaryContext(ctx: CaseExpressionPrimaryContext): Seq[Ast] = {
+    val code = s"case ${Option(ctx.caseExpression().expressionOrCommand).map(_.getText).getOrElse("")}".stripTrailing()
+    val switchNode = controlStructureNode(ctx, ControlStructureTypes.SWITCH, code)
+    val conditionAst = Option(ctx.caseExpression().expressionOrCommand()).toList
+      .flatMap(astForExpressionOrCommand)
+      .headOption
+
+    val whenThenAstsList = ctx
+      .caseExpression()
+      .whenClause()
+      .asScala
+      .flatMap(wh => {
+        val whenNode =
+          jumpTargetNode(wh, "case", s"case ${wh.getText}", Option(wh.getClass.getSimpleName))
+
+        val whenACondAsts = astForWhenArgumentContext(wh.whenArgument())
+        val thenAsts = astForCompoundStatement(
+          wh.thenClause().compoundStatement(),
+          isMethodBody = true,
+          canConsiderAsLeaf = false
+        ) ++ Seq(Ast(NewControlStructure().controlStructureType(ControlStructureTypes.BREAK)))
+        Seq(Ast(whenNode)) ++ whenACondAsts ++ thenAsts
+      })
+      .toList
+
+    val stmtAsts = whenThenAstsList ++ (Option(ctx.caseExpression().elseClause()) match
+      case Some(elseClause) =>
+        Ast(
+          // name = "default" for behaviour determined by CfgCreator.cfgForJumpTarget
+          jumpTargetNode(elseClause, "default", "else", Option(elseClause.getClass.getSimpleName))
+        ) +: astForCompoundStatement(elseClause.compoundStatement(), isMethodBody = true, canConsiderAsLeaf = false)
+      case None => Seq.empty[Ast]
+    )
+    val block = blockNode(ctx.caseExpression())
+    Seq(controlStructureAst(switchNode, conditionAst, Seq(Ast(block).withChildren(stmtAsts))))
+  }
+
+  protected def astsForNextArgsInvocation(ctx: NextArgsInvocationWithoutParenthesesContext) = {
+    /*
+     * While this is a `CONTINUE` for now, if we detect that this is the LHS of an `IF` then this becomes a `RETURN`
+     */
+    val node = NewControlStructure()
+      .controlStructureType(ControlStructureTypes.CONTINUE)
+      .lineNumber(ctx.NEXT().getSymbol.getLine)
+      .columnNumber(ctx.NEXT().getSymbol.getCharPositionInLine)
+      .code(Defines.ModifierNext)
+    Seq(
+      Ast(node)
+        .withChildren(astForArguments(ctx.arguments()))
+    )
+  }
+
+  protected def astForBreakArgsInvocation(ctx: BreakArgsInvocationWithoutParenthesesContext) = {
+    val args = ctx.arguments()
+    Option(args) match {
+      case Some(args) =>
+        /*
+         * This is break with args inside a block. The argument passed to break will be returned by the bloc
+         * Model this as a return since this is effectively a  return
+         */
+        val retNode = NewReturn()
+          .code(text(ctx))
+          .lineNumber(ctx.BREAK().getSymbol().getLine)
+          .columnNumber(ctx.BREAK().getSymbol().getCharPositionInLine)
+        val argAst = astForArguments(args)
+        Seq(returnAst(retNode, argAst))
+      case None =>
+        val node = NewControlStructure()
+          .controlStructureType(ControlStructureTypes.BREAK)
+          .lineNumber(ctx.BREAK().getSymbol.getLine)
+          .columnNumber(ctx.BREAK().getSymbol.getCharPositionInLine)
+          .code(text(ctx))
+        Seq(
+          Ast(node)
+            .withChildren(astForArguments(ctx.arguments()))
+        )
+    }
+  }
+
+  protected def astForJumpExpressionPrimaryContext(ctx: JumpExpressionPrimaryContext): Seq[Ast] = {
+    if (ctx.jumpExpression().BREAK() != null) {
+      val node = NewControlStructure()
+        .controlStructureType(ControlStructureTypes.BREAK)
+        .lineNumber(ctx.jumpExpression().BREAK().getSymbol.getLine)
+        .columnNumber(ctx.jumpExpression().BREAK().getSymbol.getCharPositionInLine)
+        .code(text(ctx))
+      Seq(Ast(node))
+    } else if (ctx.jumpExpression().NEXT() != null) {
+      val node = NewControlStructure()
+        .controlStructureType(ControlStructureTypes.CONTINUE)
+        .lineNumber(ctx.jumpExpression().NEXT().getSymbol.getLine)
+        .columnNumber(ctx.jumpExpression().NEXT().getSymbol.getCharPositionInLine)
+        .code(Defines.ModifierNext)
+      Seq(Ast(node))
+    } else if (ctx.jumpExpression().REDO() != null) {
+      val node = NewControlStructure()
+        .controlStructureType(ControlStructureTypes.CONTINUE)
+        .lineNumber(ctx.jumpExpression().REDO().getSymbol.getLine)
+        .columnNumber(ctx.jumpExpression().REDO().getSymbol.getCharPositionInLine)
+        .code(Defines.ModifierRedo)
+      Seq(Ast(node))
+    } else if (ctx.jumpExpression().RETRY() != null) {
+      val node = NewControlStructure()
+        .controlStructureType(ControlStructureTypes.CONTINUE)
+        .lineNumber(ctx.jumpExpression().RETRY().getSymbol.getLine)
+        .columnNumber(ctx.jumpExpression().RETRY().getSymbol.getCharPositionInLine)
+        .code(Defines.ModifierRetry)
+      Seq(Ast(node))
+    } else {
+      Seq(Ast())
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -13,6 +13,7 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 trait AstForDeclarationsCreator { this: AstCreator =>
 
   private val logger = LoggerFactory.getLogger(this.getClass)
+
   protected def astForArguments(ctx: ArgumentsContext): Seq[Ast] = {
     ctx.argument().asScala.flatMap(astForArgument).toSeq
   }
@@ -26,7 +27,7 @@ trait AstForDeclarationsCreator { this: AstCreator =>
       case ctx: CommandArgumentContext           => astForCommand(ctx.command)
       case ctx: HereDocArgumentContext           => astForHereDocArgument(ctx)
       case _ =>
-        logger.error(s"astForArgument() $filename, ${ctx.getText} All contexts mismatched.")
+        logger.error(s"astForArgument() $relativeFilename, ${ctx.getText} All contexts mismatched.")
         Seq()
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -4,7 +4,7 @@ import io.joern.rubysrc2cpg.parser.RubyParser.*
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewFieldIdentifier, NewNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, NewCall, NewIdentifier}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
 import org.antlr.v4.runtime.ParserRuleContext
 import org.slf4j.LoggerFactory
@@ -114,23 +114,199 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       Seq()
   }
 
-  protected def astForSymbol(ctx: SymbolContext): Seq[Ast] = {
+  private def astForSymbol(ctx: SymbolContext): Seq[Ast] = {
     if (
       ctx.stringExpression() != null && ctx.stringExpression().children.get(0).isInstanceOf[StringInterpolationContext]
     ) {
-      val node = NewCall()
-        .name(RubyOperators.formattedString)
-        .methodFullName(RubyOperators.formattedString)
-        .code(text(ctx))
-        .lineNumber(line(ctx))
-        .columnNumber(column(ctx))
-        .typeFullName(Defines.Any)
-        .dispatchType(DispatchTypes.STATIC_DISPATCH)
-
+      val node = callNode(
+        ctx,
+        text(ctx),
+        RubyOperators.formattedString,
+        RubyOperators.formattedString,
+        DispatchTypes.STATIC_DISPATCH,
+        None,
+        Option(Defines.Any)
+      )
       astForStringExpression(ctx.stringExpression()) ++ Seq(Ast(node))
     } else {
       Seq(astForSymbolLiteral(ctx))
     }
+  }
+
+  protected def astForMultipleRightHandSideContext(ctx: MultipleRightHandSideContext): Seq[Ast] =
+    if (ctx == null) {
+      Seq.empty
+    } else {
+      val expCmd = ctx.expressionOrCommands()
+      val exprAsts = Option(expCmd) match
+        case Some(expCmd) =>
+          expCmd.expressionOrCommand().asScala.flatMap(astForExpressionOrCommand).toSeq
+        case None =>
+          Seq.empty
+
+      if (ctx.splattingArgument != null) {
+        val splattingAsts = astForExpressionOrCommand(ctx.splattingArgument.expressionOrCommand)
+        exprAsts ++ splattingAsts
+      } else {
+        exprAsts
+      }
+    }
+
+  protected def astForSingleLeftHandSideContext(ctx: SingleLeftHandSideContext): Seq[Ast] = ctx match {
+    case ctx: VariableIdentifierOnlySingleLeftHandSideContext =>
+      Seq(astForVariableIdentifierHelper(ctx.variableIdentifier, true))
+    case ctx: PrimaryInsideBracketsSingleLeftHandSideContext =>
+      val primaryAsts     = astForPrimaryContext(ctx.primary)
+      val argsAsts        = astForArguments(ctx.arguments)
+      val indexAccessCall = createOpCall(ctx.LBRACK, Operators.indexAccess, text(ctx))
+      Seq(callAst(indexAccessCall, primaryAsts ++ argsAsts))
+    case ctx: XdotySingleLeftHandSideContext =>
+      // TODO handle obj.foo=arg being interpreted as obj.foo(arg) here.
+      val xAsts = astForPrimaryContext(ctx.primary)
+
+      Seq(ctx.LOCAL_VARIABLE_IDENTIFIER, ctx.CONSTANT_IDENTIFIER)
+        .flatMap(Option(_))
+        .headOption match
+        case Some(localVar) =>
+          val name = localVar.getSymbol.getText
+          val node = createIdentifierWithScope(ctx, name, name, Defines.Any, List(Defines.Any))
+          val yAst = Ast(node)
+
+          val callNode = createOpCall(localVar, Operators.fieldAccess, text(ctx))
+          Seq(callAst(callNode, xAsts ++ Seq(yAst)))
+        case None =>
+          Seq.empty
+    case ctx: ScopedConstantAccessSingleLeftHandSideContext =>
+      val localVar  = ctx.CONSTANT_IDENTIFIER
+      val varSymbol = localVar.getSymbol
+      val node = createIdentifierWithScope(ctx, varSymbol.getText, varSymbol.getText, Defines.Any, List(Defines.Any))
+      Seq(Ast(node))
+    case _ =>
+      logger.error(s"astForSingleLeftHandSideContext() $relativeFilename, ${text(ctx)} All contexts mismatched.")
+      Seq.empty
+  }
+
+  protected def astForSingleAssignmentExpressionContext(ctx: SingleAssignmentExpressionContext): Seq[Ast] = {
+    val rightAst = astForMultipleRightHandSideContext(ctx.multipleRightHandSide)
+    val leftAst  = astForSingleLeftHandSideContext(ctx.singleLeftHandSide)
+
+    val operatorName = getOperatorName(ctx.op)
+    val opCallNode =
+      callNode(ctx, text(ctx), operatorName, operatorName, DispatchTypes.STATIC_DISPATCH, None, Option(Defines.Any))
+        .lineNumber(ctx.op.getLine)
+        .columnNumber(ctx.op.getCharPositionInLine)
+    if (leftAst.size == 1 && rightAst.size > 1) {
+      /*
+       * This is multiple RHS packed into a single LHS. That is, packing left hand side.
+       * This is as good as multiple RHS packed into an array and put into a single LHS
+       */
+      val packedRHS = getPackedRHS(rightAst, wrapInBrackets = true)
+      Seq(callAst(opCallNode, leftAst ++ packedRHS))
+    } else {
+      Seq(callAst(opCallNode, leftAst ++ rightAst))
+    }
+  }
+
+  protected def astForMultipleAssignmentExpressionContext(ctx: MultipleAssignmentExpressionContext): Seq[Ast] = {
+    val rhsAsts      = astForMultipleRightHandSideContext(ctx.multipleRightHandSide())
+    val lhsAsts      = astForMultipleLeftHandSideContext(ctx.multipleLeftHandSide())
+    val operatorName = getOperatorName(ctx.EQ.getSymbol)
+
+    /*
+     * This is multiple LHS and multiple RHS
+     *Since we have multiple LHS and RHS elements here, we will now create synthetic assignment
+     * call nodes to model how ruby assigns values from RHS elements to LHS elements. We create
+     * tuples for each assignment and then pass them to the assignment calls nodes
+     */
+    val assigns =
+      if (lhsAsts.size < rhsAsts.size) {
+        /* The rightmost AST in the LHS is a packed variable.
+         * Pack the extra ASTs and the rightmost AST in the RHS in one array like the if() part
+         */
+        val diff        = rhsAsts.size - lhsAsts.size
+        val packedRHS   = getPackedRHS(rhsAsts.takeRight(diff + 1)).headOption.to(Seq)
+        val alignedAsts = lhsAsts.take(lhsAsts.size - 1) zip rhsAsts.take(lhsAsts.size - 1)
+        val packedAsts  = lhsAsts.takeRight(1) zip packedRHS
+        alignedAsts ++ packedAsts
+      } else {
+        lhsAsts.zip(rhsAsts)
+      }
+
+    assigns.map { case (lhsAst, rhsAst) =>
+      val lhsCode           = lhsAst.nodes.collectFirst { case x: AstNodeNew => x.code }.getOrElse("")
+      val rhsCode           = rhsAst.nodes.collectFirst { case x: AstNodeNew => x.code }.getOrElse("")
+      val code              = s"$lhsCode = $rhsCode"
+      val syntheticCallNode = createOpCall(ctx.EQ, operatorName, code)
+
+      callAst(syntheticCallNode, Seq(lhsAst, rhsAst))
+    }
+  }
+
+  protected def astForIndexingExpressionPrimaryContext(ctx: IndexingExpressionPrimaryContext): Seq[Ast] = {
+    val lhsExpressionAst = astForPrimaryContext(ctx.primary())
+    val rhsExpressionAst = Option(ctx.indexingArguments).map(astForIndexingArgumentsContext).getOrElse(Seq())
+
+    val operator = lhsExpressionAst.flatMap(_.nodes).collectFirst { case x: NewIdentifier => x } match
+      case Some(node) if node.name == "Array" => Operators.arrayInitializer
+      case _                                  => Operators.indexAccess
+
+    val callNode = createOpCall(ctx.LBRACK, operator, text(ctx))
+    Seq(callAst(callNode, lhsExpressionAst ++ rhsExpressionAst))
+
+  }
+
+  private def getPackedRHS(astsToConcat: Seq[Ast], wrapInBrackets: Boolean = false) = {
+    val code = astsToConcat
+      .flatMap(_.nodes)
+      .collect { case x: AstNodeNew => x.code }
+      .mkString(", ")
+
+    val callNode = NewCall()
+      .name(Operators.arrayInitializer)
+      .methodFullName(Operators.arrayInitializer)
+      .typeFullName(Defines.Any)
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .code(if (wrapInBrackets) s"[$code]" else code)
+    Seq(callAst(callNode, astsToConcat))
+  }
+
+  def astForStringInterpolationContext(ctx: InterpolatedStringExpressionContext): Seq[Ast] = {
+    val varAsts = ctx.stringInterpolation.interpolatedStringSequence.asScala
+      .flatMap(inter =>
+        Seq(
+          Ast(
+            callNode(
+              ctx,
+              text(inter),
+              RubyOperators.formattedValue,
+              RubyOperators.formattedValue,
+              DispatchTypes.STATIC_DISPATCH,
+              None,
+              Option(Defines.Any)
+            )
+          )
+        ) ++
+          astForStatements(inter.compoundStatement.statements, false, false)
+      )
+      .toSeq
+
+    val literalAsts = ctx
+      .stringInterpolation()
+      .DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE()
+      .asScala
+      .map(substr =>
+        Ast(
+          createLiteralNode(
+            substr.getText,
+            Defines.String,
+            List(Defines.String),
+            Option(substr.lineNumber),
+            Option(substr.columnNumber)
+          )
+        )
+      )
+      .toSeq
+    varAsts ++ literalAsts
   }
 
   // TODO: Return Ast instead of Seq[Ast]
@@ -216,6 +392,16 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     // TODO: for X in Y is not properly modelled by while Y
     val forRootAst = whileAst(forExprAst.headOption, forBodyAst, Some(text(ctx)), line(ctx), column(ctx))
     forVarAst.headOption.map(forRootAst.withChild).getOrElse(forRootAst)
+  }
+
+  private def astForForVariableContext(ctx: ForVariableContext): Seq[Ast] = {
+    if (ctx.singleLeftHandSide() != null) {
+      astForSingleLeftHandSideContext(ctx.singleLeftHandSide())
+    } else if (ctx.multipleLeftHandSide() != null) {
+      astForMultipleLeftHandSideContext(ctx.multipleLeftHandSide())
+    } else {
+      Seq(Ast())
+    }
   }
 
   protected def astForWhileExpression(ctx: WhileExpressionContext): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -307,24 +307,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     controlStructureAst(ifNode, testAst.headOption, thenAst ++ elseAst)
   }
 
-  protected def astForFieldAccess(ctx: ParserRuleContext, baseNode: NewNode): Ast = {
-    val fieldAccess =
-      callNode(ctx, text(ctx), Operators.fieldAccess, Operators.fieldAccess, DispatchTypes.STATIC_DISPATCH)
-    val fieldIdentifier = newFieldIdentifier(ctx)
-    val astChildren     = Seq(baseNode, fieldIdentifier)
-    callAst(fieldAccess, astChildren.map(Ast.apply))
-  }
-
-  protected def newFieldIdentifier(ctx: ParserRuleContext): NewFieldIdentifier = {
-    val code = text(ctx)
-    val name = code.replaceAll("@", "")
-    NewFieldIdentifier()
-      .code(code)
-      .canonicalName(name)
-      .lineNumber(ctx.start.getLine)
-      .columnNumber(ctx.start.getCharPositionInLine)
-  }
-
   protected def astForQuotedStringExpression(ctx: QuotedStringExpressionContext): Seq[Ast] = ctx match
     case ctx: NonExpandedQuotedStringLiteralContext => Seq(astForNonExpandedQuotedString(ctx))
     case _ =>
@@ -339,4 +321,5 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   protected def astForQuotedRegexInterpolation(ctx: QuotedRegexInterpolationContext): Seq[Ast] = {
     Seq(Ast(literalNode(ctx, text(ctx), Defines.Regexp)))
   }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -1,0 +1,154 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.rubysrc2cpg.parser.RubyParser.*
+import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.rubysrc2cpg.utils.PackageContext
+import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, ModifierTypes}
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+trait AstForFunctionsCreator(packageContext: PackageContext)(implicit withSchemaValidation: ValidationMode) {
+  this: AstCreator =>
+
+  /*
+   *Fake methods created from yield blocks and their yield calls will have this suffix in their names
+   */
+  protected val YIELD_SUFFIX = "_yield"
+
+  /*
+   * This is used to mark call nodes created due to yield calls. This is set in their names at creation.
+   * The appropriate name wrt the names of their actual methods is set later in them.
+   */
+  protected val UNRESOLVED_YIELD = "unresolved_yield"
+
+  /*
+   * Stack of variable identifiers incorrectly identified as method identifiers
+   * Each AST contains exactly one call or identifier node
+   */
+  protected val methodNameAsIdentifierStack: mutable.Stack[Ast]        = mutable.Stack.empty
+  protected val methodAliases: mutable.HashMap[String, String]         = mutable.HashMap.empty
+  protected val methodNameToMethod: mutable.HashMap[String, NewMethod] = mutable.HashMap.empty
+  protected val methodDefInArgument: ListBuffer[Ast]                   = ListBuffer.empty
+  protected val methodNamesWithYield: mutable.HashSet[String]          = mutable.HashSet.empty
+  protected val blockMethods: ListBuffer[Ast]                          = ListBuffer.empty
+
+  /** @return
+    *   the method name if found as an alias, or the given name if not found.
+    */
+  protected def resolveAlias(name: String): String = {
+    methodAliases.getOrElse(name, name)
+  }
+
+  protected def astForMethodDefinitionContext(ctx: MethodDefinitionContext): Seq[Ast] = {
+    val astMethodName = Option(ctx.methodNamePart()) match
+      case Some(ctxMethodNamePart) =>
+        astForMethodNamePartContext(ctxMethodNamePart)
+      case None =>
+        astForMethodIdentifierContext(ctx.methodIdentifier(), text(ctx))
+    val callNode = astMethodName.head.nodes.filter(node => node.isInstanceOf[NewCall]).head.asInstanceOf[NewCall]
+
+    // Create thisParameter if this is an instance method
+    // TODO may need to revisit to make this more robust
+
+    val (methodName, methodFullName) = if (callNode.name == Defines.Initialize) {
+      (XDefines.ConstructorMethodName, classStack.reverse :+ XDefines.ConstructorMethodName mkString pathSep)
+    } else {
+      (callNode.name, classStack.reverse :+ callNode.name mkString pathSep)
+    }
+    val newMethodNode = methodNode(ctx, methodName, text(ctx), methodFullName, None, relativeFilename)
+      .columnNumber(callNode.columnNumber)
+      .lineNumber(callNode.lineNumber)
+
+    scope.pushNewScope(newMethodNode)
+
+    val astMethodParamSeq = ctx.methodNamePart() match {
+      case _: SimpleMethodNamePartContext if !classStack.top.endsWith(":program") =>
+        val thisParameterNode = createMethodParameterIn(
+          "this",
+          typeFullName = callNode.methodFullName,
+          lineNumber = callNode.lineNumber,
+          colNumber = callNode.columnNumber,
+          index = 0,
+          order = 0
+        )
+        Seq(Ast(thisParameterNode)) ++ astForMethodParameterPartContext(ctx.methodParameterPart())
+      case _ => astForMethodParameterPartContext(ctx.methodParameterPart())
+    }
+
+    Option(ctx.END()).foreach(endNode => newMethodNode.lineNumberEnd(endNode.getSymbol.getLine))
+
+    callNode.methodFullName(methodFullName)
+
+    val classType = if (classStack.isEmpty) "Standalone" else classStack.top
+    val classPath = classStack.reverse.toList.mkString(pathSep)
+    packageContext.packageTable.addPackageMethod(packageContext.moduleName, callNode.name, classPath, classType)
+
+    val astBody = Option(ctx.bodyStatement()) match {
+      case Some(ctxBodyStmt) => astForBodyStatementContext(ctxBodyStmt, true)
+      case None =>
+        val expAst = astForExpressionContext(ctx.expression())
+        Seq(lastStmtAsReturnAst(ctx, expAst.head, Option(text(ctx.expression()))))
+    }
+
+    // process yield calls.
+    astBody
+      .flatMap(_.nodes.collect { case x: NewCall => x }.filter(_.name == UNRESOLVED_YIELD))
+      .foreach { yieldCallNode =>
+        val name           = newMethodNode.name
+        val methodFullName = classStack.reverse :+ callNode.name mkString pathSep
+        yieldCallNode.name(name + YIELD_SUFFIX)
+        yieldCallNode.methodFullName(methodFullName + YIELD_SUFFIX)
+        methodNamesWithYield.add(newMethodNode.name)
+        /*
+         * These are calls to the yield block of this method.
+         * Add this method to the list of yield blocks.
+         * The add() is idempotent and so adding the same method multiple times makes no difference.
+         * It just needs to be added at this place so that it gets added iff it has a yield block
+         */
+      }
+
+    val methodRetNode = NewMethodReturn().typeFullName(Defines.Any)
+
+    val modifierNode = lastModifier match {
+      case Some(modifier) => NewModifier().modifierType(modifier).code(modifier)
+      case None           => NewModifier().modifierType(ModifierTypes.PUBLIC).code(ModifierTypes.PUBLIC)
+    }
+    /*
+     * public/private/protected modifiers are in a separate statement
+     * TODO find out how they should be used. Need to do this iff it adds any value
+     */
+    if (methodName != XDefines.ConstructorMethodName) {
+      methodNameToMethod.put(newMethodNode.name, newMethodNode)
+    }
+
+    /* Before creating ast, we traverse the method params and identifiers and link them*/
+    val identifiers =
+      astBody.flatMap(ast => ast.nodes.filter(_.isInstanceOf[NewIdentifier])).asInstanceOf[Seq[NewIdentifier]]
+
+    val params = astMethodParamSeq
+      .flatMap(_.nodes.collect { case x: NewMethodParameterIn => x })
+      .toList
+    val locals = scope.createAndLinkLocalNodes(diffGraph, params.map(_.name).toSet)
+
+    params.foreach { param =>
+      identifiers.filter(_.name == param.name).foreach { identifier =>
+        diffGraph.addEdge(identifier, param, EdgeTypes.REF)
+      }
+    }
+    scope.popScope()
+
+    Seq(
+      methodAst(
+        newMethodNode,
+        astMethodParamSeq,
+        blockAst(blockNode(ctx), locals.map(Ast.apply) ++ astBody.toList),
+        methodRetNode,
+        Seq[NewModifier](modifierNode)
+      )
+    )
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -114,6 +114,11 @@ trait AstForStatementsCreator(filename: String)(implicit withSchemaValidation: V
           case Some(method: NewMethod) => returnAst(retNode, Seq(Ast(methodToMethodRef(ctx, method))))
           case _                       => returnAst(retNode, Seq(lastStmtAst))
 
+  protected def astForBodyStatementContext(ctx: BodyStatementContext, isMethodBody: Boolean = false): Seq[Ast] = {
+    if (ctx.rescueClause.size > 0) Seq(astForRescueClause(ctx))
+    else astForCompoundStatement(ctx.compoundStatement(), isMethodBody)
+  }
+
   protected def astForCompoundStatement(
     ctx: CompoundStatementContext,
     isMethodBody: Boolean = false,
@@ -376,7 +381,7 @@ trait AstForStatementsCreator(filename: String)(implicit withSchemaValidation: V
   ) = {
     blockMethodName match {
       case Some(blockMethodName) =>
-        astForBlockMethod(
+        astForBlockFunction(
           compoundStmtCtx.statements(),
           blockParamCtx,
           blockMethodName,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -5,6 +5,7 @@ import io.joern.rubysrc2cpg.parser.RubyParser.*
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
 import io.joern.x2cpg.Imports.createImportNodeAndLink
+import io.joern.x2cpg.X2Cpg.stripQuotes
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
@@ -13,36 +14,48 @@ import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
+trait AstForStatementsCreator(filename: String)(implicit withSchemaValidation: ValidationMode) {
   this: AstCreator =>
 
   private val logger = LoggerFactory.getLogger(this.getClass)
-  protected def astForAliasStatement(ctx: AliasStatementContext): Ast = {
+  private val prefixMethods = Set(
+    "attr_reader",
+    "attr_writer",
+    "attr_accessor",
+    "remove_method",
+    "public_class_method",
+    "private_class_method",
+    "private",
+    "protected",
+    "module_function"
+  )
+
+  private def astForAliasStatement(ctx: AliasStatementContext): Ast = {
     val aliasName  = ctx.definedMethodNameOrSymbol(0).getText.substring(1)
     val methodName = ctx.definedMethodNameOrSymbol(1).getText.substring(1)
     methodAliases.addOne(aliasName, methodName)
     Ast()
   }
 
-  protected def astForUndefStatement(ctx: UndefStatementContext): Ast = {
+  private def astForUndefStatement(ctx: UndefStatementContext): Ast = {
     val undefNames = ctx.definedMethodNameOrSymbol().asScala.flatMap(astForDefinedMethodNameOrSymbolContext).toSeq
     val call       = callNode(ctx, text(ctx), RubyOperators.undef, RubyOperators.undef, DispatchTypes.STATIC_DISPATCH)
     callAst(call, undefNames)
   }
 
-  protected def astForBeginStatement(ctx: BeginStatementContext): Ast = {
+  private def astForBeginStatement(ctx: BeginStatementContext): Ast = {
     val stmts     = Option(ctx.compoundStatement).map(astForCompoundStatement(_)).getOrElse(Seq())
     val blockNode = NewBlock().typeFullName(Defines.Any)
     blockAst(blockNode, stmts.toList)
   }
 
-  protected def astForEndStatement(ctx: EndStatementContext): Ast = {
+  private def astForEndStatement(ctx: EndStatementContext): Ast = {
     val stmts     = Option(ctx.compoundStatement).map(astForCompoundStatement(_)).getOrElse(Seq())
     val blockNode = NewBlock().typeFullName(Defines.Any)
     blockAst(blockNode, stmts.toList)
   }
 
-  protected def astForModifierStatement(ctx: ModifierStatementContext): Ast = ctx.mod.getType match {
+  private def astForModifierStatement(ctx: ModifierStatementContext): Ast = ctx.mod.getType match {
     case IF     => astForIfModifierStatement(ctx)
     case UNLESS => astForUnlessModifierStatement(ctx)
     case WHILE  => astForWhileModifierStatement(ctx)
@@ -50,7 +63,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     case RESCUE => astForRescueModifierStatement(ctx)
   }
 
-  protected def astForIfModifierStatement(ctx: ModifierStatementContext): Ast = {
+  private def astForIfModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs    = astForStatement(ctx.statement(0))
     val rhs    = astForStatement(ctx.statement(1)).headOption
     val ifNode = controlStructureNode(ctx, ControlStructureTypes.IF, text(ctx))
@@ -63,47 +76,43 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
       case _ => controlStructureAst(ifNode, rhs, lhs)
   }
 
-  protected def astForUnlessModifierStatement(ctx: ModifierStatementContext): Ast = {
+  private def astForUnlessModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs    = astForStatement(ctx.statement(0))
     val rhs    = astForStatement(ctx.statement(1))
     val ifNode = controlStructureNode(ctx, ControlStructureTypes.IF, text(ctx))
     controlStructureAst(ifNode, lhs.headOption, rhs)
   }
 
-  protected def astForWhileModifierStatement(ctx: ModifierStatementContext): Ast = {
+  private def astForWhileModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs = astForStatement(ctx.statement(0))
     val rhs = astForStatement(ctx.statement(1))
     whileAst(rhs.headOption, lhs, Some(text(ctx)))
   }
 
-  protected def astForUntilModifierStatement(ctx: ModifierStatementContext): Ast = {
+  private def astForUntilModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs = astForStatement(ctx.statement(0))
     val rhs = astForStatement(ctx.statement(1))
     whileAst(rhs.headOption, lhs, Some(text(ctx)))
   }
 
-  protected def astForRescueModifierStatement(ctx: ModifierStatementContext): Ast = {
+  private def astForRescueModifierStatement(ctx: ModifierStatementContext): Ast = {
     val lhs       = astForStatement(ctx.statement(0))
     val rhs       = astForStatement(ctx.statement(1))
     val throwNode = controlStructureNode(ctx, ControlStructureTypes.THROW, text(ctx))
     controlStructureAst(throwNode, rhs.headOption, lhs)
   }
 
-  protected def lastStmtAsReturn(code: String, lastStmtAst: Ast): Ast = {
-    val lastStmtIsAlreadyReturn = lastStmtAst.root match {
-      case Some(value) => value.isInstanceOf[NewReturn]
-      case None        => false
-    }
-
-    if (lastStmtIsAlreadyReturn) {
-      lastStmtAst
-    } else {
-      val retNode = NewReturn().code(code)
-      lastStmtAst.root match
-        case Some(method: NewMethod) => returnAst(retNode, Seq(Ast(methodToMethodRef(method))))
-        case _                       => returnAst(retNode, Seq[Ast](lastStmtAst))
-    }
-  }
+  /** If the last statement is a return, this is returned. If not, then a return node is created.
+    */
+  protected def lastStmtAsReturnAst(ctx: ParserRuleContext, lastStmtAst: Ast, maybeCode: Option[String] = None): Ast =
+    lastStmtAst.root.collectFirst { case x: NewReturn => x } match
+      case Some(_) => lastStmtAst
+      case None =>
+        val code    = maybeCode.getOrElse(text(ctx))
+        val retNode = returnNode(ctx, code)
+        lastStmtAst.root match
+          case Some(method: NewMethod) => returnAst(retNode, Seq(Ast(methodToMethodRef(ctx, method))))
+          case _                       => returnAst(retNode, Seq(lastStmtAst))
 
   protected def astForCompoundStatement(
     ctx: CompoundStatementContext,
@@ -112,13 +121,12 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   ): Seq[Ast] = {
     val stmtAsts = Option(ctx)
       .map(_.statements())
-      .map(st => { astForStatements(st, isMethodBody, canConsiderAsLeaf) })
-      .getOrElse(Seq())
+      .map(astForStatements(_, isMethodBody, canConsiderAsLeaf))
+      .getOrElse(Seq.empty)
     if (isMethodBody) {
       stmtAsts
     } else {
       Seq(blockAst(blockNode(ctx), stmtAsts.toList))
-
     }
   }
 
@@ -143,58 +151,47 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     isMethodBody: Boolean = false,
     canConsiderAsLeaf: Boolean = true
   ): Seq[Ast] = {
-    Option(ctx) match {
-      case Some(ctx) =>
-        val stmtCount   = ctx.statement().size()
-        var stmtCounter = 0
-        val myBlockId   = blockIdCounter
-        blockIdCounter += 1
-        val parentBlockId = currentBlockId
-        if (canConsiderAsLeaf) {
-          blockChildHash.update(parentBlockId, myBlockId)
+
+    def astsForStmtCtx(stCtx: StatementContext, stmtCount: Int, stmtCounter: Int): Seq[Ast] = {
+      if (isMethodBody) processingLastMethodStatement.lazySet(stmtCounter == stmtCount)
+      val stAsts = astForStatement(stCtx)
+      if (stAsts.nonEmpty && canConsiderAsLeaf && processingLastMethodStatement.get) {
+        blockChildHash.get(currentBlockId.get) match {
+          case Some(_) =>
+            // this is a non-leaf block
+            stAsts
+          case None =>
+            // this is a leaf block
+            processingLastMethodStatement.lazySet(!(isMethodBody && stmtCounter == stmtCount))
+            Seq(lastStmtAsReturnAst(stCtx, stAsts.head, Option(text(stCtx))))
         }
-        currentBlockId = myBlockId
+      } else {
+        stAsts
+      }
+    }
+
+    Option(ctx)
+      .map { ctx =>
+        val stmtCount     = ctx.statement.size
+        val parentBlockId = currentBlockId.get
+        if (canConsiderAsLeaf) blockChildHash.update(parentBlockId, currentBlockId.get)
+        currentBlockId.lazySet(blockIdCounter.addAndGet(1))
 
         val stmtAsts = Option(ctx)
-          .map(_.statement())
+          .map(_.statement)
           .map(_.asScala)
-          .getOrElse(Seq())
-          .flatMap(stCtx => {
-            stmtCounter += 1
-            if (isMethodBody) {
-              if (stmtCounter == stmtCount) {
-                processingLastMethodStatement = true
-              } else {
-                processingLastMethodStatement = false
-              }
-            }
-            val stAsts = astForStatement(stCtx)
-            if (stAsts.size > 0 && canConsiderAsLeaf && processingLastMethodStatement) {
-              blockChildHash.get(myBlockId) match {
-                case Some(value) =>
-                  // this is a non-leaf block
-                  stAsts
-                case None =>
-                  // this is a leaf block
-                  if (isMethodBody && stmtCounter == stmtCount) {
-                    processingLastMethodStatement = false
-                  }
-                  Seq(lastStmtAsReturn(text(stCtx), stAsts.head))
-              }
-            } else {
-              stAsts
-            }
-          })
+          .getOrElse(Seq.empty)
+          .zipWithIndex
+          .flatMap { case (stmtCtx, idx) => astsForStmtCtx(stmtCtx, stmtCount, idx + 1) }
           .toSeq
-        currentBlockId = parentBlockId
+        currentBlockId.lazySet(parentBlockId)
         stmtAsts
-      case None =>
-        Seq()
-    }
+      }
+      .getOrElse(Seq.empty)
   }
 
   // TODO: return Ast instead of Seq[Ast].
-  protected def astForStatement(ctx: StatementContext): Seq[Ast] = scanStmtForHereDoc(ctx match {
+  private def astForStatement(ctx: StatementContext): Seq[Ast] = scanStmtForHereDoc(ctx match {
     case ctx: AliasStatementContext               => Seq(astForAliasStatement(ctx))
     case ctx: UndefStatementContext               => Seq(astForUndefStatement(ctx))
     case ctx: BeginStatementContext               => Seq(astForBeginStatement(ctx))
@@ -214,74 +211,62 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
       Seq(Ast())
   }
 
-  protected def astForNotKeywordExpressionOrCommand(ctx: NotExpressionOrCommandContext): Ast = {
+  private def astForNotKeywordExpressionOrCommand(ctx: NotExpressionOrCommandContext): Ast = {
     val exprOrCommandAst = astForExpressionOrCommand(ctx.expressionOrCommand())
     val call             = callNode(ctx, text(ctx), Operators.not, Operators.not, DispatchTypes.STATIC_DISPATCH)
     callAst(call, exprOrCommandAst)
   }
 
-  protected def astForOrAndExpressionOrCommand(ctx: OrAndExpressionOrCommandContext): Ast = ctx.op.getType match {
+  private def astForOrAndExpressionOrCommand(ctx: OrAndExpressionOrCommandContext): Ast = ctx.op.getType match {
     case OR  => astForOrExpressionOrCommand(ctx)
     case AND => astForAndExpressionOrCommand(ctx)
   }
 
-  protected def astForOrExpressionOrCommand(ctx: OrAndExpressionOrCommandContext): Ast = {
+  private def astForOrExpressionOrCommand(ctx: OrAndExpressionOrCommandContext): Ast = {
     val argsAst = ctx.expressionOrCommand().asScala.flatMap(astForExpressionOrCommand)
     val call    = callNode(ctx, text(ctx), Operators.or, Operators.or, DispatchTypes.STATIC_DISPATCH)
     callAst(call, argsAst.toList)
   }
 
-  protected def astForAndExpressionOrCommand(ctx: OrAndExpressionOrCommandContext): Ast = {
+  private def astForAndExpressionOrCommand(ctx: OrAndExpressionOrCommandContext): Ast = {
     val argsAst = ctx.expressionOrCommand().asScala.flatMap(astForExpressionOrCommand)
     val call    = callNode(ctx, text(ctx), Operators.and, Operators.and, DispatchTypes.STATIC_DISPATCH)
     callAst(call, argsAst.toList)
   }
 
-  protected def astForSuperCommand(ctx: SuperCommandContext): Ast =
+  private def astForSuperCommand(ctx: SuperCommandContext): Ast =
     astForSuperCall(ctx, astForArguments(ctx.argumentsWithoutParentheses().arguments()))
 
-  protected def astForYieldCommand(ctx: YieldCommandContext): Ast =
+  private def astForYieldCommand(ctx: YieldCommandContext): Ast =
     astForYieldCall(ctx, Option(ctx.argumentsWithoutParentheses().arguments()))
 
-  protected def astForSimpleMethodCommand(ctx: SimpleMethodCommandContext): Seq[Ast] = {
+  private def astForSimpleMethodCommand(ctx: SimpleMethodCommandContext): Seq[Ast] = {
     val methodIdentifierAsts = astForMethodIdentifierContext(ctx.methodIdentifier(), text(ctx))
-    methodNameAsIdentifierStack.push(methodIdentifierAsts.head)
+    methodIdentifierAsts.headOption.foreach(methodNameAsIdentifierStack.push)
     val argsAsts = astForArguments(ctx.argumentsWithoutParentheses().arguments())
 
     /* get args without the method def in it */
-    val argAstsWithoutMethods = argsAsts.filterNot(_.nodes.headOption.getOrElse(None).isInstanceOf[NewMethod])
+    val argAstsWithoutMethods = argsAsts.filterNot(_.root.exists(_.isInstanceOf[NewMethod]))
 
     /* isolate methods from the original args and create identifier ASTs from it */
-    val methodDefAsts = argsAsts.filter(_.nodes.headOption.getOrElse(None).isInstanceOf[NewMethod])
-    val methodToIdentifierAsts = methodDefAsts.flatMap { ast =>
-      ast.nodes.collectFirst { case x: NewMethod => x }.map { methodNode =>
-        val id = NewIdentifier()
-          .name(methodNode.name)
-          .code(methodNode.name)
-          .typeFullName(Defines.Any)
-          .lineNumber(methodNode.lineNumber)
-          .columnNumber(methodNode.columnNumber)
-        scope.addToScope(methodNode.name, id)
-        Ast(id)
+    val methodDefAsts = argsAsts.filter(_.root.exists(_.isInstanceOf[NewMethod]))
+    val methodToIdentifierAsts = methodDefAsts.flatMap {
+      _.nodes.collectFirst { case methodNode: NewMethod =>
+        Ast(
+          createIdentifierWithScope(
+            methodNode.name,
+            methodNode.name,
+            Defines.Any,
+            Seq.empty,
+            methodNode.lineNumber,
+            methodNode.columnNumber
+          )
+        )
       }
     }
 
     /* TODO: we add the isolated method defs later on to the parent instead */
-    methodDefAsts.foreach { ast =>
-      methodDefInArgument.addOne(ast)
-    }
-
-    val prefixMethods = Set(
-      "attr_reader",
-      "attr_writer",
-      "attr_accessor",
-      "remove_method",
-      "public_class_method",
-      "private_class_method",
-      "private",
-      "protected",
-      "module_function"
-    )
+    methodDefInArgument.addAll(methodDefAsts)
 
     val callNodes = methodIdentifierAsts.head.nodes.collect { case x: NewCall => x }
     if (callNodes.size == 1) {
@@ -301,41 +286,38 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     }
   }
 
-  protected def astForMemberAccessCommand(ctx: MemberAccessCommandContext): Seq[Ast] = {
-    val argsAst    = astForArguments(ctx.argumentsWithoutParentheses().arguments)
-    val primaryAst = astForPrimaryContext(ctx.primary())
-    val methodCallNode = astForMethodNameContext(ctx.methodName()).head.nodes.head
-      .asInstanceOf[NewCall]
-    val callNode = NewCall()
-      .name(getActualMethodName(methodCallNode.name))
-      .code(text(ctx))
-      .methodFullName(DynamicCallUnknownFullName)
-      .signature("")
-      .dispatchType(DispatchTypes.STATIC_DISPATCH)
-      .typeFullName(Defines.Any)
-      .lineNumber(methodCallNode.lineNumber)
-      .columnNumber(methodCallNode.columnNumber)
-
-    primaryAst.headOption match {
-      case Some(value) =>
-        if (value.root.map(_.isInstanceOf[NewMethod]).getOrElse(false)) {
-          val methodNode    = value.root.head.asInstanceOf[NewMethod]
-          val methodRefNode = methodToMethodRef(methodNode)
-          blockMethods.addOne(primaryAst.head)
-          Seq(callAst(callNode, Seq(Ast(methodRefNode)) ++ argsAst))
-        } else {
-          Seq(callAst(callNode, argsAst, primaryAst.headOption))
-        }
-      case None => Seq(callAst(callNode, argsAst, primaryAst.headOption))
-    }
+  private def astForMemberAccessCommand(ctx: MemberAccessCommandContext): Seq[Ast] = {
+    astForMethodNameContext(ctx.methodName).headOption
+      .flatMap(_.root)
+      .collectFirst { case x: NewCall => resolveAlias(x.name) }
+      .map(methodName =>
+        callNode(
+          ctx,
+          text(ctx),
+          methodName,
+          DynamicCallUnknownFullName,
+          DispatchTypes.STATIC_DISPATCH,
+          None,
+          Option(Defines.Any)
+        )
+      ) match
+      case Some(newCall) =>
+        val primaryAst = astForPrimaryContext(ctx.primary())
+        val argsAst    = astForArguments(ctx.argumentsWithoutParentheses().arguments)
+        primaryAst.headOption
+          .flatMap(_.root)
+          .collectFirst { case x: NewMethod => x }
+          .map { methodNode =>
+            val methodRefNode = methodToMethodRef(ctx, methodNode)
+            blockMethods.addOne(primaryAst.head)
+            Seq(callAst(newCall, Seq(Ast(methodRefNode)) ++ argsAst))
+          }
+          .getOrElse(Seq(callAst(newCall, argsAst, primaryAst.headOption)))
+      case None => Seq.empty
   }
 
-  private def methodToMethodRef(methodNode: NewMethod): NewMethodRef = {
-    NewMethodRef()
-      .code("def " + methodNode.name + "(...)")
-      .methodFullName(methodNode.fullName)
-      .typeFullName(methodNode.fullName)
-  }
+  private def methodToMethodRef(ctx: ParserRuleContext, methodNode: NewMethod): NewMethodRef =
+    methodRefNode(ctx, s"def ${methodNode.name}(...)", methodNode.fullName, Defines.Any)
 
   protected def astForCommand(ctx: CommandContext): Seq[Ast] = ctx match {
     case ctx: YieldCommandContext        => Seq(astForYieldCommand(ctx))
@@ -344,11 +326,11 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     case ctx: MemberAccessCommandContext => astForMemberAccessCommand(ctx)
   }
 
-  protected def resolveRequireOrLoadPath(argsAst: Seq[Ast], callNode: NewCall): Seq[Ast] = {
-    val importedNode = argsAst.head.nodes.collect { case x: NewLiteral => x }
+  private def resolveRequireOrLoadPath(argsAst: Seq[Ast], callNode: NewCall): Seq[Ast] = {
+    val importedNode = argsAst.headOption.map(_.nodes.collect { case x: NewLiteral => x }).getOrElse(Seq.empty)
     if (importedNode.size == 1) {
       val node      = importedNode.head
-      val pathValue = node.code.replaceAll("'", "").replaceAll("\"", "")
+      val pathValue = stripQuotes(node.code)
       val result = pathValue match {
         case path if File(path).exists =>
           path
@@ -358,7 +340,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
           pathValue
       }
       packageStack.append(result)
-      val importNode = createImportNodeAndLink(result, "", Some(callNode), diffGraph)
+      val importNode = createImportNodeAndLink(result, pathValue, Some(callNode), diffGraph)
       Seq(callAst(callNode, argsAst), Ast(importNode))
     } else {
       Seq(callAst(callNode, argsAst))
@@ -369,13 +351,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     val importedNode = argsAst.head.nodes.collect { case x: NewLiteral => x }
     if (importedNode.size == 1) {
       val node        = importedNode.head
-      val pathValue   = node.code.replaceAll("'", "").replaceAll("\"", "")
+      val pathValue   = stripQuotes(node.code)
       val updatedPath = if (pathValue.endsWith(".rb")) pathValue else s"$pathValue.rb"
 
       val currentDirectory = File(currentFile).parent
       val file             = File(currentDirectory, updatedPath)
       packageStack.append(file.pathAsString)
-      val importNode = createImportNodeAndLink(updatedPath, "", Some(callNode), diffGraph)
+      val importNode = createImportNodeAndLink(updatedPath, pathValue, Some(callNode), diffGraph)
       Seq(callAst(callNode, argsAst), Ast(importNode))
     } else {
       Seq(callAst(callNode, argsAst))
@@ -415,7 +397,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     astForBlockHelper(ctx, Option(ctx.blockParameter), ctx.bodyStatement().compoundStatement(), blockMethodName)
   }
 
-  protected def astForBraceBlock(ctx: BraceBlockContext, blockMethodName: Option[String] = None): Ast = {
+  private def astForBraceBlock(ctx: BraceBlockContext, blockMethodName: Option[String] = None): Ast = {
     astForBlockHelper(ctx, Option(ctx.blockParameter), ctx.bodyStatement().compoundStatement(), blockMethodName)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.parser.RubyParser.{
+  BodyStatementContext,
   ClassDefinitionPrimaryContext,
   ClassOrModuleReferenceContext,
   ModuleDefinitionPrimaryContext,
@@ -10,7 +11,7 @@ import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.utils.*
 import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes, Operators, nodes}
 import org.antlr.v4.runtime.ParserRuleContext
 
 import scala.collection.mutable
@@ -18,22 +19,11 @@ import scala.collection.mutable
 trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   // Maps field references of known types
-  protected val fieldReferences        = mutable.HashMap.empty[String, Set[ParserRuleContext]]
-  protected val typeDeclNameToTypeDecl = mutable.HashMap[String, nodes.NewTypeDecl]()
+  protected val fieldReferences: mutable.HashMap[String, Set[ParserRuleContext]] = mutable.HashMap.empty
+  protected val typeDeclNameToTypeDecl: mutable.HashMap[String, NewTypeDecl]     = mutable.HashMap.empty
 
   def astForClassDeclaration(ctx: ClassDefinitionPrimaryContext): Seq[Ast] = {
-    val baseClassName = if (ctx.classDefinition().expressionOrCommand() != null) {
-      val parentClassNameAst = astForExpressionOrCommand(ctx.classDefinition().expressionOrCommand())
-      val nameNode = parentClassNameAst.head.nodes
-        .filter(node => node.isInstanceOf[NewIdentifier])
-        .head
-        .asInstanceOf[NewIdentifier]
-      Some(nameNode.name)
-    } else {
-      None
-    }
-
-    val className = ctx.className(baseClassName).getOrElse(Defines.Any)
+    val className = ctx.className.getOrElse(Defines.Any)
     if (className != Defines.Any) {
       classStack.push(className)
       val fullName = classStack.reverse.mkString(pathSep)
@@ -53,24 +43,18 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         classStack.pop()
       }
 
-      val typeDeclNode = NewTypeDecl()
-        .name(className)
-        .fullName(fullName)
-        .filename(relativeFilename)
-        .code(text(ctx).takeWhile(x => x != '\n'))
-        .lineNumber(line(ctx))
-        .columnNumber(column(ctx))
+      val typeDecl = typeDeclNode(ctx, className, fullName, relativeFilename, text(ctx).takeWhile(_ != '\n'))
 
       // create constructor if not explicitly defined
       val hasConstructor =
         bodyAst.flatMap(_.root).collect { case x: NewMethod => x.name }.contains(XDefines.ConstructorMethodName)
       val defaultConstructor =
         if (!hasConstructor)
-          createDefaultConstructor(ctx, typeDeclNode, bodyAst.flatMap(_.nodes).collect { case x: NewMember => x })
+          createDefaultConstructor(ctx, typeDecl, bodyAst.flatMap(_.nodes).collect { case x: NewMember => x })
         else Seq.empty
 
-      typeDeclNameToTypeDecl.put(className, typeDeclNode)
-      Seq(Ast(typeDeclNode).withChildren(defaultConstructor ++ bodyAst))
+      typeDeclNameToTypeDecl.put(className, typeDecl)
+      Seq(Ast(typeDecl).withChildren(defaultConstructor ++ bodyAst))
     } else {
       Seq.empty
     }
@@ -118,7 +102,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   }
 
   def astForModuleDefinitionPrimaryContext(ctx: ModuleDefinitionPrimaryContext): Seq[Ast] = {
-    val className = ctx.moduleDefinition().classOrModuleReference().classOrModuleName(None)
+    val className = ctx.moduleDefinition().classOrModuleReference().classOrModuleName
 
     if (className != Defines.Any) {
       classStack.push(className)
@@ -190,15 +174,82 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       }
       .toSeq
 
+  /** Handles body statements differently from [[astForBodyStatementContext]] by noting that method definitions should
+    * be on the root level and assignments where the LHS starts with @@ should be treated as fields.
+    */
+  private def astForClassBody(ctx: BodyStatementContext): Seq[Ast] = {
+    val rootStatements =
+      Option(ctx).map(_.compoundStatement()).map(_.statements()).map(astForStatements(_)).getOrElse(Seq())
+    retrieveAndGenerateClassChildren(ctx, rootStatements)
+  }
+
+  /** As class bodies are not treated much differently to other procedure bodies, we need to retrieve certain components
+    * that would result in the creation of interprocedural constructs.
+    *
+    * TODO: This is pretty hacky and the parser could benefit from more specific tokens
+    */
+  private def retrieveAndGenerateClassChildren(classCtx: BodyStatementContext, rootStatements: Seq[Ast]): Seq[Ast] = {
+    val (memberLikeStmts, blockStmts) = rootStatements
+      .flatMap { ast =>
+        ast.root match
+          case Some(_: NewMethod)                                 => Seq(ast)
+          case Some(x: NewCall) if x.name == Operators.assignment => Seq(ast) ++ membersFromStatementAsts(ast)
+          case _                                                  => Seq(ast)
+      }
+      .partition(_.root match
+        case Some(_: NewMethod) => true
+        case Some(_: NewMember) => true
+        case _                  => false
+      )
+
+    val methodStmts = memberLikeStmts.filter(_.root.exists(_.isInstanceOf[NewMethod]))
+    val memberNodes = memberLikeStmts.flatMap(_.root).collect { case m: NewMember => m }
+
+    val uniqueMemberReferences =
+      (memberNodes ++ fieldReferences.getOrElse(classStack.top, Set.empty).groupBy(_.getText).map { case (code, ctxs) =>
+        NewMember()
+          .name(code.replaceAll("@", ""))
+          .code(code)
+          .typeFullName(Defines.Any)
+      }).toList.distinctBy(_.name).map { m =>
+        val modifierType = m.name match
+          case x if x.startsWith("@@") => ModifierTypes.STATIC
+          case _                       => ModifierTypes.VIRTUAL
+        val modifierAst = Ast(NewModifier().modifierType(modifierType))
+        Ast(m).withChild(modifierAst)
+      }
+
+    // Create class initialization method to host all field initializers
+    val classInitMethodAst = if (blockStmts.nonEmpty) {
+      val classInitFullName = (classStack.reverse :+ XDefines.StaticInitMethodName).mkString(pathSep)
+      val classInitMethod = methodNode(
+        classCtx,
+        XDefines.StaticInitMethodName,
+        XDefines.StaticInitMethodName,
+        classInitFullName,
+        None,
+        relativeFilename,
+        Option(NodeTypes.TYPE_DECL),
+        Option(classStack.reverse.mkString(pathSep))
+      )
+      val classInitBody = blockAst(blockNode(classCtx), blockStmts.toList)
+      Seq(methodAst(classInitMethod, Seq.empty, classInitBody, methodReturnNode(classCtx, Defines.Any)))
+    } else {
+      Seq.empty
+    }
+
+    classInitMethodAst ++ uniqueMemberReferences ++ methodStmts
+  }
+
   implicit class ClassDefinitionPrimaryContextExt(val ctx: ClassDefinitionPrimaryContext) {
 
     def hasClassDefinition: Boolean = Option(ctx.classDefinition()).isDefined
 
-    def className(baseClassName: Option[String] = None): Option[String] =
+    def className: Option[String] =
       Option(ctx.classDefinition().classOrModuleReference()) match {
         case Some(classOrModuleReferenceCtx) =>
           Option(classOrModuleReferenceCtx)
-            .map(_.classOrModuleName(baseClassName))
+            .map(_.classOrModuleName)
         case None =>
           // TODO the below is just to avoid crashes. This needs to be implemented properly
           None
@@ -209,7 +260,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
     def hasScopedConstantReference: Boolean = Option(ctx.scopedConstantReference()).isDefined
 
-    def classOrModuleName(baseClassName: Option[String] = None): String =
+    def classOrModuleName: String =
       Option(ctx) match {
         case Some(ct) =>
           if (ct.hasScopedConstantReference)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyScope.scala
@@ -1,0 +1,101 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.x2cpg.datastructures.Scope
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{DeclarationNew, NewIdentifier, NewLocal, NewNode}
+import overflowdb.BatchedUpdate
+
+import scala.collection.mutable
+
+/** Extends the Scope class to help scope variables and create locals.
+  *
+  * TODO: Extend this to similarly link parameter nodes (especially `this` node) for consistency.
+  */
+class RubyScope extends Scope[String, NewIdentifier, NewNode] {
+
+  private type VarMap        = Map[String, VarGroup]
+  private type ScopeNodeType = NewNode
+
+  /** Groups a local node with its referencing identifiers.
+    */
+  private case class VarGroup(local: NewLocal, ids: List[NewIdentifier])
+
+  /** Links a scope to its variable groupings.
+    */
+  private val scopeToVarMap = mutable.HashMap.empty[ScopeNodeType, VarMap]
+
+  override def addToScope(identifier: String, variable: NewIdentifier): NewNode = {
+    val scopeNode = super.addToScope(identifier, variable)
+    stack.headOption.foreach(head => scopeToVarMap.appendIdentifierToVarGroup(head.scopeNode, variable))
+    scopeNode
+  }
+
+  override def popScope(): Option[NewNode] = {
+    stack.headOption.map(_.scopeNode).foreach(scopeToVarMap.remove)
+    super.popScope()
+  }
+
+  /** Will generate local nodes for this scope's variables, excluding those that reference parameters.
+    * @param paramNames
+    *   the names of parameters.
+    */
+  def createAndLinkLocalNodes(
+    diffGraph: BatchedUpdate.DiffGraphBuilder,
+    paramNames: Set[String] = Set.empty
+  ): List[DeclarationNew] = stack.headOption match
+    case Some(top) => scopeToVarMap.buildVariableGroupings(top.scopeNode, paramNames ++ Set("this"), diffGraph)
+    case None      => List.empty[DeclarationNew]
+
+  private implicit class IdentifierExt(node: NewIdentifier) {
+
+    /** Creates a new VarGroup and corresponding NewLocal for the given identifier.
+      */
+    def toNewVarGroup: VarGroup = {
+      val newLocal = NewLocal()
+        .name(node.name)
+        .code(node.name)
+        .lineNumber(node.lineNumber)
+        .columnNumber(node.columnNumber)
+        .typeFullName(node.typeFullName)
+      VarGroup(newLocal, List(node))
+    }
+
+  }
+
+  private implicit class ScopeExt(scopeMap: mutable.Map[ScopeNodeType, VarMap]) {
+
+    /** Registers the identifier to its corresponding variable grouping in the given scope.
+      */
+    def appendIdentifierToVarGroup(key: ScopeNodeType, identifier: NewIdentifier): Unit =
+      scopeMap.updateWith(key) {
+        case Some(varMap: VarMap) =>
+          Some(varMap.updatedWith(identifier.name) {
+            case Some(varGroup: VarGroup) => Some(varGroup.copy(ids = varGroup.ids :+ identifier))
+            case None                     => Some(identifier.toNewVarGroup)
+          })
+        case None =>
+          Some(Map(identifier.name -> identifier.toNewVarGroup))
+      }
+
+    /** Will persist the variable groupings that do not represent parameter nodes and link them with REF edges.
+      * @return
+      *   the list of persisted local nodes.
+      */
+    def buildVariableGroupings(
+      key: ScopeNodeType,
+      paramNames: Set[String],
+      diffGraph: BatchedUpdate.DiffGraphBuilder
+    ): List[DeclarationNew] =
+      scopeMap.get(key) match
+        case Some(varMap) =>
+          varMap.values
+            .filterNot { case VarGroup(local, _) => paramNames.contains(local.name) }
+            .map { case VarGroup(local, ids) =>
+              ids.foreach(id => diffGraph.addEdge(id, local, EdgeTypes.REF))
+              local
+            }
+            .toList
+        case None => List.empty[DeclarationNew]
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -32,5 +32,8 @@ object Defines {
   val TempIdentifier = "tmp"
   val TempParameter  = "param"
 
+  // Constructor method
+  val Initialize = "initialize"
+
   def getBuiltInType(typeInString: String) = s"${GlobalTypes.builtinPrefix}.$typeInString"
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ImportAstCreationTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/ImportAstCreationTest.scala
@@ -1,6 +1,5 @@
 package io.joern.rubysrc2cpg.passes.ast
 
-import io.joern.rubysrc2cpg.Config
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 
@@ -16,7 +15,7 @@ class ImportAstCreationTest extends RubyCode2CpgFixture {
     val calls   = cpg.call("require|require_relative|load").l
     "have a valid import node" in {
       imports.importedEntity.l shouldBe List("dummy_logger", "util/help.rb", "mymodule.rb")
-      imports.importedAs.l shouldBe List("", "", "")
+      imports.importedAs.l shouldBe List("dummy_logger", "util/help.rb", "mymodule.rb")
     }
 
     "have a valid call node" in {


### PR DESCRIPTION
Despite a new AstCreator and parser in the near future, it is difficult to manage and maintain the current AST creator until then. This refactors and improves on the technical debt accumulated from the fast development of the Ruby frontend.

* Introduced more traits to categorize AstCreator 
* Reduced number of mutable variables
* Made use of more `x2cpg` calls where possible
* Reduced redundancy
* Improved general readability, code quality, and cleaned up