### PR TITLE
[rubysrc2cpg] Basic Metaprogramming Handling

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/DoBlockTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/DoBlockTest.scala
@@ -1,0 +1,34 @@
+package io.joern.rubysrc2cpg.passes.ast
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class DoBlockTest extends RubyCode2CpgFixture {
+
+  "defining a method using metaprogramming and a do-block function" should {
+    val cpg = code(s"""
+        |define_method foo do |name, age|
+        | value = public_send("#{name}_value")
+        | unit = public_send("#{name}_unit")
+        |
+        | puts "My name is #{name} and age is #{age}"
+        |
+        | next unless value.present? && unit.present?
+        | value.public_send(unit)
+        |end
+        |""".stripMargin)
+
+    "create a do-block method called `foo`" in {
+      val nameMethod :: _ = cpg.method.nameExact("foo").l: @unchecked
+
+      val List(name, age) = nameMethod.parameter.l
+      name.name shouldBe "name"
+      age.name shouldBe "age"
+
+      val List(value, unit) = nameMethod.local.l
+      value.name shouldBe "value"
+      unit.name shouldBe "unit"
+    }
+  }
+
+}


### PR DESCRIPTION
* Handling method definitions using `define_method` keyword
* Fixed bug where do-block functions always assumed max 1 parameter

TODO: Method names defined by identifier values or other dynamic operations are not handled.