### PR TITLE
gosrc2cpg: added range loop support

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -233,16 +233,22 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
   private def astForRangeStatement(rangeStmt: ParserNodeInfo): Ast = {
 
-    val keyParserNode  = createParserNodeInfo(rangeStmt.json(ParserKeys.Key))
-    val declParserNode = createParserNodeInfo(keyParserNode.json(ParserKeys.Obj)(ParserKeys.Decl))
-
-    val code    = s"for ${declParserNode.code}"
-    val forNode = controlStructureNode(rangeStmt, ControlStructureTypes.FOR, code)
-
-    val declAst = astsForStatement(declParserNode)
-    val initAst = astForNode(rangeStmt.json(ParserKeys.X))
-    val stmtAst = astsForStatement(rangeStmt.json(ParserKeys.Body))
-    controlStructureAst(forNode, None, initAst ++ declAst ++ stmtAst)
+    rangeStmt.json.obj.contains(ParserKeys.Key) match
+      case true =>
+        val keyParserNode  = createParserNodeInfo(rangeStmt.json(ParserKeys.Key))
+        val declParserNode = createParserNodeInfo(keyParserNode.json(ParserKeys.Obj)(ParserKeys.Decl))
+        val code    = s"for ${declParserNode.code}"
+        val forNode = controlStructureNode(rangeStmt, ControlStructureTypes.FOR, code)
+        val declAst = astsForStatement(declParserNode)
+        val initAst = astForNode(rangeStmt.json(ParserKeys.X))
+        val stmtAst = astsForStatement(rangeStmt.json(ParserKeys.Body))
+        controlStructureAst(forNode, None, initAst ++ declAst ++ stmtAst)
+      case false =>
+        val initAst = astForNode(rangeStmt.json(ParserKeys.X))
+        val code = s"for range ${createParserNodeInfo(rangeStmt.json(ParserKeys.X)).code}"
+        val forNode = controlStructureNode(rangeStmt, ControlStructureTypes.FOR, code)
+        val stmtAst = astsForStatement(rangeStmt.json(ParserKeys.Body))
+        controlStructureAst(forNode, None, initAst ++ stmtAst)
   }
 
   private def astForBranchStatement(branchStmt: ParserNodeInfo): Ast = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -237,15 +237,15 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case true =>
         val keyParserNode  = createParserNodeInfo(rangeStmt.json(ParserKeys.Key))
         val declParserNode = createParserNodeInfo(keyParserNode.json(ParserKeys.Obj)(ParserKeys.Decl))
-        val code    = s"for ${declParserNode.code}"
-        val forNode = controlStructureNode(rangeStmt, ControlStructureTypes.FOR, code)
-        val declAst = astsForStatement(declParserNode)
-        val initAst = astForNode(rangeStmt.json(ParserKeys.X))
-        val stmtAst = astsForStatement(rangeStmt.json(ParserKeys.Body))
+        val code           = s"for ${declParserNode.code}"
+        val forNode        = controlStructureNode(rangeStmt, ControlStructureTypes.FOR, code)
+        val declAst        = astsForStatement(declParserNode)
+        val initAst        = astForNode(rangeStmt.json(ParserKeys.X))
+        val stmtAst        = astsForStatement(rangeStmt.json(ParserKeys.Body))
         controlStructureAst(forNode, None, initAst ++ declAst ++ stmtAst)
       case false =>
         val initAst = astForNode(rangeStmt.json(ParserKeys.X))
-        val code = s"for range ${createParserNodeInfo(rangeStmt.json(ParserKeys.X)).code}"
+        val code    = s"for range ${createParserNodeInfo(rangeStmt.json(ParserKeys.X)).code}"
         val forNode = controlStructureNode(rangeStmt, ControlStructureTypes.FOR, code)
         val stmtAst = astsForStatement(rangeStmt.json(ParserKeys.Body))
         controlStructureAst(forNode, None, initAst ++ stmtAst)

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LoopsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LoopsTests.scala
@@ -219,4 +219,32 @@ class LoopsTests extends GoCodeToCpgSuite {
       body.astChildren.isCall.code.l shouldBe List("counter++")
     }
   }
+
+  "for loop with range not, having any index" should {
+    val cpg = code(
+      """
+        |package main
+        |
+        |func main() {
+        |
+        |	for range servers {
+        |       b := 10
+        |		success = success && <-shutdownChan
+        |	}
+        |}
+        |
+        |""".stripMargin)
+
+    "check nodes in body" in {
+      val List(identifierNode) = cpg.identifier("b").l
+      identifierNode.typeFullName shouldBe "int"
+    }
+
+    "check working AST structure is in place" in {
+      val List(forStmt) = cpg.method.name("main").controlStructure.l
+      forStmt.controlStructureType shouldBe ControlStructureTypes.FOR
+      val List(identifier: Identifier) = forStmt.astChildren.order(1).l: @unchecked
+      identifier.name shouldBe "servers"
+    }
+  }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LoopsTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LoopsTests.scala
@@ -221,8 +221,7 @@ class LoopsTests extends GoCodeToCpgSuite {
   }
 
   "for loop with range not, having any index" should {
-    val cpg = code(
-      """
+    val cpg = code("""
         |package main
         |
         |func main() {


### PR DESCRIPTION
In Go we can even write a for loop in below fashion:


      for range collections {

	     isTrue = isTrue && <-shutdownChan
       }
We can able to a iterator over item in collections is not mentioned here, Go handles this implicitly.