### PR TITLE
[gosrc2cpg] - Struct type member Type information cache - fixes ticket #3665

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -3,10 +3,10 @@ package io.joern.gosrc2cpg.astcreation
 import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserAst, ParserKeys, ParserNodeInfo}
-import io.joern.x2cpg.Defines as XDefines
+import io.joern.x2cpg.{Ast, Defines as XDefines}
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
 import io.shiftleft.codepropertygraph.generated.nodes.{NewModifier, NewNode}
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, ModifierTypes}
+import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, ModifierTypes, PropertyNames}
 import org.apache.commons.lang.StringUtils
 import ujson.Value
 
@@ -50,7 +50,7 @@ trait AstCreatorHelper { this: AstCreator =>
             nullSafeCreateParserNodeInfo(None)
   }
 
-  def cacheReferenceNode(json: Value, node: ParserNode) = {
+  private def cacheReferenceNode(json: Value, node: ParserNode) = {
     // This is being called only to cache this objects
     node match
       case CallExpr =>
@@ -65,6 +65,13 @@ trait AstCreatorHelper { this: AstCreator =>
             createParserNodeInfo(obj)
           case _ =>
       case _ =>
+  }
+
+  protected def getTypeFullNameFromAstNode(ast: Seq[Ast]): String = {
+    ast.headOption
+      .flatMap(_.root)
+      .map(_.properties.get(PropertyNames.TYPE_FULL_NAME).get.toString)
+      .getOrElse(Defines.anyTypeName)
   }
 
   protected def addModifier(node: NewNode, name: String): NewModifier = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForExpressionCreator.scala
@@ -79,13 +79,6 @@ trait AstForExpressionCreator(implicit withSchemaValidation: ValidationMode) { t
     Seq(callAst(cNode, operand))
   }
 
-  protected def getTypeFullNameFromAstNode(ast: Seq[Ast]): String = {
-    ast.headOption
-      .flatMap(_.root)
-      .map(_.properties.get(PropertyNames.TYPE_FULL_NAME).get.toString)
-      .getOrElse(Defines.anyTypeName)
-  }
-
   private def astForUnaryExpr(unaryExpr: ParserNodeInfo): Seq[Ast] = {
     val operand      = astForNode(unaryExpr.json(ParserKeys.X))
     var typeFullName = getTypeFullNameFromAstNode(operand)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
@@ -4,7 +4,7 @@ import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import ujson.Value
 
 import scala.util.{Success, Try}
@@ -75,16 +75,11 @@ trait AstForGenDeclarationCreator(implicit withSchemaValidation: ValidationMode)
     rhsParserNode: ParserNodeInfo,
     typeFullName: Option[String]
   ): (Ast, Ast) = {
-    val rhsAst = astForBooleanLiteral(rhsParserNode)
-    val rhsTypeFullName = typeFullName.getOrElse(
-      rhsAst.headOption
-        .flatMap(_.root)
-        .map(_.properties.get(PropertyNames.TYPE_FULL_NAME).get.toString)
-        .getOrElse(Defines.anyTypeName)
-    )
-    val localAst  = astForLocalNode(lhsParserNode, Some(rhsTypeFullName))
-    val lhsAst    = astForNode(lhsParserNode)
-    val arguments = lhsAst ++: rhsAst
+    val rhsAst          = astForBooleanLiteral(rhsParserNode)
+    val rhsTypeFullName = typeFullName.getOrElse(getTypeFullNameFromAstNode(rhsAst))
+    val localAst        = astForLocalNode(lhsParserNode, Some(rhsTypeFullName))
+    val lhsAst          = astForNode(lhsParserNode)
+    val arguments       = lhsAst ++: rhsAst
     val cNode = callNode(
       rhsParserNode,
       lhsParserNode.code + rhsParserNode.code,

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -85,12 +85,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       .arr
       .map(createParserNodeInfo)
       .flatMap(astForBooleanLiteral)
-    val typeFullName = Some(
-      rhsAst.headOption
-        .flatMap(_.root)
-        .map(_.properties.get(PropertyNames.TYPE_FULL_NAME).get.toString)
-        .getOrElse(Defines.anyTypeName)
-    )
+    val typeFullName = Some(getTypeFullNameFromAstNode(rhsAst.toSeq))
     val (lhsAst, localAst) = assignStmt
       .json(ParserKeys.Lhs)
       .arr

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
@@ -1,11 +1,10 @@
 package io.joern.gosrc2cpg.astcreation
-
+import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg
-import io.joern.x2cpg.datastructures.Stack.StackWrapper
 import io.joern.x2cpg.utils.NodeBuilders.newOperatorCallNode
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.NewFieldIdentifier
 import ujson.Value
@@ -14,64 +13,51 @@ import scala.util.{Success, Try}
 
 trait AstForTypeDeclCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  def astForTypeSpec(typeSpecNode: ParserNodeInfo): Seq[Ast] = {
-    val nameNode = typeSpecNode.json(ParserKeys.Name)
-    val typeNode = createParserNodeInfo(typeSpecNode.json(ParserKeys.Type))
-
-    val fullName = fullyQualifiedPackage + Defines.dot + nameNode(ParserKeys.Name).str
+  protected def astForTypeSpec(typeSpecNode: ParserNodeInfo): Seq[Ast] = {
+    val (name, fullName, memberAsts) = processTypeSepc(typeSpecNode.json)
     val typeDeclNode_ =
-      typeDeclNode(typeSpecNode, nameNode(ParserKeys.Name).str, fullName, relPathFileName, typeSpecNode.code)
-
-    methodAstParentStack.push(typeDeclNode_)
-    scope.pushNewScope(typeDeclNode_)
-    val memberAsts = astForStructType(typeNode)
-
-    methodAstParentStack.pop()
-    scope.popScope()
-
-    val modifier = addModifier(typeDeclNode_, nameNode(ParserKeys.Name).str)
+      typeDeclNode(typeSpecNode, name, fullName, relPathFileName, typeSpecNode.code)
+    val modifier = addModifier(typeDeclNode_, name)
     Seq(Ast(typeDeclNode_).withChild(Ast(modifier)).withChildren(memberAsts))
   }
 
-  protected def astForStructType(expr: ParserNodeInfo): Seq[Ast] = {
+  protected def astForStructType(expr: ParserNodeInfo, typeDeclFullName: String): Seq[Ast] = {
     Try(expr.json(ParserKeys.Fields)) match
       case Success(fields) if fields != null =>
-        astForFieldList(createParserNodeInfo(fields))
+        fields(ParserKeys.List).arrOpt
+          .getOrElse(List())
+          .flatMap(x => {
+            val typeInfo                = createParserNodeInfo(x(ParserKeys.Type))
+            val (typeFullName, _, _, _) = processTypeInfo(typeInfo)
+            x(ParserKeys.Names).arrOpt
+              .getOrElse(List())
+              .map(fieldInfo => {
+                val fieldNodeInfo = createParserNodeInfo(fieldInfo)
+                val fieldName     = fieldNodeInfo.json(ParserKeys.Name).str
+                GoGlobal.recordStructTypeMemberType(typeDeclFullName + Defines.dot + fieldName, typeFullName)
+                Ast(memberNode(typeInfo, fieldName, fieldNodeInfo.code, typeFullName, Seq()))
+              })
+          })
+          .toSeq
       case _ => Seq.empty
   }
 
-  private def astForFieldList(fieldList: ParserNodeInfo): Seq[Ast] = {
-    fieldList
-      .json(ParserKeys.List)
-      .arrOpt
-      .getOrElse(List())
-      .flatMap(x => {
-        val typeInfo                = createParserNodeInfo(x(ParserKeys.Type))
-        val (typeFullName, _, _, _) = processTypeInfo(typeInfo)
-        x(ParserKeys.Names).arrOpt
-          .getOrElse(List())
-          .map(fieldInfo => {
-            val fieldNodeInfo = createParserNodeInfo(fieldInfo)
-            val fieldName     = fieldNodeInfo.json(ParserKeys.Name).str
-            Ast(memberNode(typeInfo, fieldName, fieldNodeInfo.code, typeFullName, Seq()))
-          })
-      })
-      .toSeq
-  }
-
   protected def astForFieldAccess(info: ParserNodeInfo): Seq[Ast] = {
-    // TODO: Need to identify a way to find the typeFullName of the field getting accessed
-    val fieldTypeFullName = Defines.anyTypeName
-    val callNode =
-      newOperatorCallNode(Operators.fieldAccess, info.code, Some(fieldTypeFullName), line(info), column(info))
-    val identifierAsts  = astForNode(info.json(ParserKeys.X))
-    val fieldIdentifier = info.json(ParserKeys.Sel)(ParserKeys.Name).str
+    val identifierAsts       = astForNode(info.json(ParserKeys.X))
+    val receiverTypeFullName = getTypeFullNameFromAstNode(identifierAsts)
+    val fieldIdentifier      = info.json(ParserKeys.Sel)(ParserKeys.Name).str
+    val fieldTypeFullName = GoGlobal.structTypeMemberTypeMapping.getOrDefault(
+      receiverTypeFullName + Defines.dot + fieldIdentifier,
+      XDefines.Unknown
+    )
     val fieldIdentifierNode = NewFieldIdentifier()
       .canonicalName(fieldIdentifier)
       .lineNumber(line(info))
       .columnNumber(column(info))
       .code(fieldIdentifier)
     val fieldIdAst = Ast(fieldIdentifierNode)
+    val callNode =
+      newOperatorCallNode(Operators.fieldAccess, info.code, Some(fieldTypeFullName), line(info), column(info))
     Seq(callAst(callNode, identifierAsts ++ Seq(fieldIdAst)))
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
@@ -3,6 +3,7 @@ package io.joern.gosrc2cpg.astcreation
 import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import ujson.{Arr, Obj, Value}
+import io.joern.x2cpg.Ast
 
 import scala.util.Try
 
@@ -54,6 +55,14 @@ trait CacheBuilder { this: AstCreator =>
         arr.value.foreach(subJson => findAndProcess(subJson))
       case _ =>
     }
+  }
+
+  protected def processTypeSepc(typeSepc: Value): (String, String, Seq[Ast]) = {
+    val name     = typeSepc(ParserKeys.Name)(ParserKeys.Name).str
+    val fullName = fullyQualifiedPackage + Defines.dot + name
+    val typeNode = createParserNodeInfo(typeSepc(ParserKeys.Type))
+    // astForStructType() function will record the member types
+    (name, fullName, astForStructType(typeNode, fullName))
   }
 
   protected def processImports(importDecl: Value): (String, String) = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
@@ -10,8 +10,13 @@ import scala.jdk.CollectionConverters.EnumerationHasAsScala
 object GoGlobal extends Global {
 
   val methodFullNameReturnTypeMap: ConcurrentHashMap[String, (String, String)] = new ConcurrentHashMap()
+  val structTypeMemberTypeMapping: ConcurrentHashMap[String, String]           = new ConcurrentHashMap()
 
-  def recordFullNameToReturnType(methodFullName: String, returnType: String, signature: String) = {
+  def recordStructTypeMemberType(memberFullName: String, memberType: String): Unit = {
+    structTypeMemberTypeMapping.putIfAbsent(memberFullName, memberType)
+  }
+
+  def recordFullNameToReturnType(methodFullName: String, returnType: String, signature: String): Unit = {
     methodFullNameReturnTypeMap.putIfAbsent(methodFullName, (returnType, signature))
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ConstructorCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ConstructorCallTests.scala
@@ -101,10 +101,7 @@ class ConstructorCallTests extends GoCodeToCpgSuite(withOssDataflow = true) {
       squareArgument.argumentIndex shouldBe 1
       squareArgument.order shouldBe 1
       squareArgument.code shouldBe "square"
-    }
-
-    "type full name of argument" ignore {
-      squareArgument.typeFullName shouldBe "main.Square.<init>"
+      squareArgument.typeFullName shouldBe "main.Square"
     }
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FieldAccessTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FieldAccessTests.scala
@@ -32,8 +32,7 @@ class FieldAccessTests extends GoCodeToCpgSuite {
     "External Field access test" in {
       val List(fieldAccessCall) = cpg.method("main").astChildren.fieldAccess.l
       fieldAccessCall.name shouldBe Operators.fieldAccess
-      // TODO: We need to find and set the right full name
-      fieldAccessCall.typeFullName shouldBe Defines.anyTypeName
+      fieldAccessCall.typeFullName shouldBe "string"
 
       val List(ident: Identifier, fieldIdent: FieldIdentifier) = fieldAccessCall.argument.l: @unchecked
       ident.name shouldBe "a"
@@ -50,21 +49,8 @@ class FieldAccessTests extends GoCodeToCpgSuite {
       val List(fieldAccessCall: Call) = cpg.call("println").argument.l: @unchecked
       fieldAccessCall.name shouldBe Operators.fieldAccess
     }
-    "some" in {
-      val cpg = code("""
-          |package main
-          |
-          |import "fmt"
-          |
-          |func main() {
-          |    // Define and immediately invoke an anonymous function
-          |    result := func(x, y int) int {
-          |        return x + y
-          |    }(5, 7)
-          |
-          |    fmt.Println(result) // Output: 12
-          |}
-          |""".stripMargin)
-    }
   }
 }
+
+//TODO: Add unit test for global public variable defined in one package and getting accessed in another package.
+// Its construct will be similar to fieldAccess

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
@@ -40,14 +40,13 @@ class FileTests extends GoCodeToCpgSuite {
       )
     }
 
-    // TODO: TypeDecl fix the unit test
-    "should allow traversing from file to its type declarations via namespace block" ignore {
+    "should allow traversing from file to its type declarations via namespace block" in {
       cpg.file
         .nameNot(FileTraversal.UNKNOWN)
         .typeDecl
         .name
         .l
-        .sorted shouldBe List("main.<global>", "int", "Sample")
+        .sorted shouldBe List("Sample", "main.<global>")
     }
 
     "should allow traversing to namespaces" in {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/NamespaceBlockTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/NamespaceBlockTests.scala
@@ -26,9 +26,11 @@ class NamespaceBlockTests extends GoCodeToCpgSuite {
     x.order shouldBe 1
   }
 
-  // TODO: Once the method node creation is done, this unit test needs to be fixed to add fullname for "func foo()" as well, along with dummy method representing the file.
-  "should allow traversing from namespace block to method" ignore {
-    cpg.namespaceBlock.filenameNot(FileTraversal.UNKNOWN).ast.isMethod.fullName.l shouldBe List("Test0.go:main")
+  "should allow traversing from namespace block to method" in {
+    cpg.namespaceBlock.filenameNot(FileTraversal.UNKNOWN).ast.isMethod.fullName.l shouldBe List(
+      "Test0.go:main.<global>",
+      "main.foo"
+    )
   }
 
   "should allow traversing from namespace block to type declaration" in {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
@@ -213,7 +213,7 @@ class TypeDeclMethodCallTests extends GoCodeToCpgSuite {
       cpg.call("bar").size shouldBe 1
       val List(x) = cpg.call("bar").l
       x.code shouldBe "ctx.data.bar(a)"
-      x.methodFullName shouldBe "ANY.bar"
+      x.methodFullName shouldBe "<unknown>.bar"
       x.order shouldBe 2
       x.lineNumber shouldBe Option(7)
       x.typeFullName shouldBe Defines.anyTypeName
@@ -236,7 +236,7 @@ class TypeDeclMethodCallTests extends GoCodeToCpgSuite {
       cpg.call("bar").size shouldBe 1
       val List(x) = cpg.call("bar").l
       x.code shouldBe "ctx.data1.data2.data3.data4.bar(a)"
-      x.methodFullName shouldBe "ANY.bar"
+      x.methodFullName shouldBe "<unknown>.bar"
       x.order shouldBe 2
       x.lineNumber shouldBe Option(7)
       x.typeFullName shouldBe Defines.anyTypeName

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclTests.scala
@@ -25,11 +25,6 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       typeDeclNode.columnNumber shouldBe Some(6)
     }
 
-    "test parent ast structure" in {
-      cpg.typeDecl("Foo").astParentFullName.l.head shouldBe "test.go:main.<global>"
-      cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
-    }
-
     "test fullName of TypeDecl nodes" in {
       typeDeclNode.fullName shouldBe "main.Foo"
     }
@@ -53,11 +48,6 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       typeDeclNode.code shouldBe "Foo string"
       typeDeclNode.lineNumber shouldBe Some(2)
       typeDeclNode.columnNumber shouldBe Some(6)
-    }
-
-    "test ast parent structure" in {
-      cpg.typeDecl("Foo").astParentFullName.l.head shouldBe "test.go:main.<global>"
-      cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
     "test fullName of TypeDecl nodes" in {
@@ -85,11 +75,6 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       typeDeclNode.columnNumber shouldBe Some(6)
     }
 
-    "test parent ast structure" in {
-      cpg.typeDecl("Foo").astParentFullName.l.head shouldBe "test.go:main.<global>"
-      cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
-    }
-
     "test fullName of TypeDecl nodes" in {
       typeDeclNode.fullName shouldBe "main.Foo"
     }
@@ -114,11 +99,6 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       typeDeclNode.code shouldBe "foo int"
       typeDeclNode.lineNumber shouldBe Some(2)
       typeDeclNode.columnNumber shouldBe Some(6)
-    }
-
-    "test ast parent structure" in {
-      cpg.typeDecl("foo").astParentFullName.l.head shouldBe "test.go:main.<global>"
-      cpg.typeDecl("foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
     "test fullName of TypeDecl nodes" in {
@@ -148,11 +128,6 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       typeDeclNode.columnNumber shouldBe Some(7)
     }
 
-    "test ast parent structure" in {
-      cpg.typeDecl("Sample").astParentFullName.l.head shouldBe "test.go:main.<global>"
-      cpg.typeDecl("Sample").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
-    }
-
     "test fullName of TypeDecl nodes" ignore {
       typeDeclNode.fullName shouldBe "main.main.Sample"
     }
@@ -178,11 +153,6 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       typeDeclNode.code shouldBe "Foo struct {}"
       typeDeclNode.lineNumber shouldBe Some(3)
       typeDeclNode.columnNumber shouldBe Some(2)
-    }
-
-    "test ast parent structure" in {
-      cpg.typeDecl("Foo").astParentFullName.l.head shouldBe "test.go:main.<global>"
-      cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
     "test fullName of TypeDecl nodes" in {
@@ -212,11 +182,6 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       typeDeclNode.columnNumber shouldBe Some(2)
     }
 
-    "test ast parent structure for Foo" in {
-      cpg.typeDecl("Foo").astParentFullName.l.head shouldBe "test.go:main.<global>"
-      cpg.typeDecl("Foo").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
-    }
-
     "test fullName of TypeDecl nodes for Foo" in {
       typeDeclNode.fullName shouldBe "main.Foo"
     }
@@ -231,11 +196,6 @@ class TypeDeclTests extends GoCodeToCpgSuite {
       typeDeclNodeBar.code shouldBe "bar interface {}"
       typeDeclNodeBar.lineNumber shouldBe Some(4)
       typeDeclNodeBar.columnNumber shouldBe Some(2)
-    }
-
-    "test parent ast structure for bar" in {
-      cpg.typeDecl("bar").astParentFullName.l.head shouldBe "test.go:main.<global>"
-      cpg.typeDecl("bar").astParentType.l.head shouldBe NodeTypes.TYPE_DECL
     }
 
     "test fullName of TypeDecl nodes for bar" in {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeFullNameTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeFullNameTests.scala
@@ -261,7 +261,7 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
       a.typeFullName shouldBe "string"
     }
 
-    "check for identifier nodes working" in {
+    "check for identifier nodes" in {
       val List(x) = cpg.identifier("x").typeFullName.dedup.l
       x shouldBe "int"
       val List(y) = cpg.identifier("y").typeFullName.dedup.l
@@ -270,10 +270,6 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
       xx shouldBe "string"
       val List(yy) = cpg.identifier("yy").typeFullName.dedup.l
       yy shouldBe "string"
-
-    }
-
-    "check for identifier nodes non working" in {
 
       val List(aaa, bbb, ccc) = cpg.identifier("aaa|bbb|ccc").l
       aaa.typeFullName shouldBe "int"
@@ -598,10 +594,6 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
       val List(a, b, c, d, e, f, g, h, i, j, k, l) = cpg.local.l
       a.typeFullName shouldBe "[][]string"
       g.typeFullName shouldBe "[]int"
-    }
-
-    "Type Check LOCAL nodes non working" in {
-      val List(a, b, c, d, e, f, g, h, i, j, k, l) = cpg.local.l
       b.typeFullName shouldBe "string"
       c.typeFullName shouldBe "[][]string"
       d.typeFullName shouldBe "[]string"
@@ -623,10 +615,6 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
       i.typeFullName shouldBe "[]int"
       j.typeFullName shouldBe "int"
       k.typeFullName shouldBe "[]float32"
-    }
-
-    "Type check for CALL nodes non working" in {
-      val List(a, b, c, d, e, f, g, h, i, j, k, l, m) = cpg.call.nameNot(Operators.assignment).l
       e.typeFullName shouldBe "[]string"
       f.typeFullName shouldBe "string"
       g.typeFullName shouldBe "string"
@@ -680,6 +668,8 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
         |  var compNameOne = perOne.fullName()
         |  var perThree = lib.Person{fname: "Ram", lname: "Thakur"}
         |  perFour := lib.Person{fname: "Seema", lname: "Dubey"}
+        |  b := perFour.fname
+        |  c := perFour.lname
         |}
         |""".stripMargin,
       "main.go"
@@ -695,7 +685,7 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
       createPerson.typeFullName shouldBe "joern.io/sample/lib.Person"
     }
 
-    "Call node typeFullName check for function call on receiver object usecase 1" ignore {
+    "Call node typeFullName check for function call on receiver object usecase 1" in {
       val List(fullName) = cpg.call("fullName").lineNumber(8).l
       fullName.typeFullName shouldBe "string"
     }
@@ -705,7 +695,7 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
       fullName.typeFullName shouldBe "string"
     }
 
-    "TODO variable type checks not working " in {
+    "Variable type checks" in {
       val List(a) = cpg.local("a").l
       a.typeFullName shouldBe "string"
 
@@ -727,11 +717,10 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
       val List(perFour) = cpg.identifier("perFour").lineNumber(12).l
       perFour.typeFullName shouldBe "joern.io/sample/lib.Person"
 
-    }
-
-    "variable type checks working" in {
       val List(perOne) = cpg.identifier("perOne").lineNumber(9).l
       perOne.typeFullName shouldBe "joern.io/sample/lib.Person"
     }
+
+    "Field access CALL node type check" in {}
   }
 }


### PR DESCRIPTION
fixes ticket #3665

Type Decl Member type cache and use the same
1. Processed `TypeSepc` information to build the cache mapping members to TypeFullName
2. Used this cached information to set the TypeFullName for FieldAccess `CALL` node.
3. Updated unit tests as well as added new unit test to verify these changes.
4. Gone through a few IGNORED unit tests and update those unit test in working state
5. Refactored a few TypeFullName tests to merge a few non-working and working tests.
2. Removed setting the ParentTypeFullName and ParentType for TypeDecl node as that was unnecessary. Removed respective unit tests checking the same.