### PR TITLE
[gosrc2cpg] - Handling for scenario where package name is different than the enclosing folder name of the package

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -35,8 +35,9 @@ class AstCreator(val relPathFileName: String, val parserResult: ParserResult)(im
   protected val scope: Scope[String, (NewNode, String), NewNode]     = new Scope()
   protected val aliasToNameSpaceMapping: mutable.Map[String, String] = mutable.Map.empty
   protected val lineNumberMapping: Map[Int, String]                  = positionLookupTables(parserResult.fileContent)
+  protected val declaredPackageName = parserResult.json(ParserKeys.Name)(ParserKeys.Name).str
   protected val fullyQualifiedPackage =
-    GoMod.getNameSpace(parserResult.fullPath, parserResult.json(ParserKeys.Name)(ParserKeys.Name).str)
+    GoMod.getNameSpace(parserResult.fullPath, declaredPackageName)
 
   override def createAst(): DiffGraphBuilder = {
     val rootNode = createParserNodeInfo(parserResult.json)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -3,8 +3,8 @@ package io.joern.gosrc2cpg.astcreation
 import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserAst, ParserKeys, ParserNodeInfo}
-import io.joern.x2cpg.{Ast, Defines as XDefines}
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
+import io.joern.x2cpg.{Ast, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewModifier, NewNode}
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, ModifierTypes, PropertyNames}
 import org.apache.commons.lang.StringUtils
@@ -135,6 +135,9 @@ trait AstCreatorHelper { this: AstCreator =>
       .toMap
   }
 
+  protected def resolveAliasToFullName(alias: String, typeOrMethodName: String): String = {
+    s"${aliasToNameSpaceMapping.getOrElse(alias, GoGlobal.aliasToNameSpaceMapping.getOrDefault(alias, s"${XDefines.Unknown}.<$alias>"))}.$typeOrMethodName"
+  }
   protected def generateTypeFullName(
     typeName: Option[String] = None,
     genericTypeMethodMap: Map[String, List[String]] = Map.empty,
@@ -157,7 +160,7 @@ trait AstCreatorHelper { this: AstCreator =>
               Defines.primitiveTypeMap.getOrElse(typname, s"$fullyQualifiedPackage.$typname")
             }
           case Some(alias) =>
-            s"${aliasToNameSpaceMapping.getOrElse(alias, s"${XDefines.Unknown}.<$alias>")}.$typname"
+            resolveAliasToFullName(alias, typname)
 
   }
   private def internalTypeFullName(

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -112,7 +112,7 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
                 // Otherwise its an alias to imported namespace on which method call is made
                 val alias = xnode.json(ParserKeys.Name).str
                 val callMethodFullName =
-                  s"${aliasToNameSpaceMapping.getOrElse(alias, s"${XDefines.Unknown}.<$alias>")}.$methodName"
+                  resolveAliasToFullName(alias, methodName)
                 val (returnTypeFullNameCache, signatureCache) =
                   GoGlobal.methodFullNameReturnTypeMap
                     .getOrDefault(callMethodFullName, (Defines.anyTypeName, s"$callMethodFullName()"))

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
@@ -2,8 +2,8 @@ package io.joern.gosrc2cpg.astcreation
 
 import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
-import ujson.{Arr, Obj, Value}
 import io.joern.x2cpg.Ast
+import ujson.{Arr, Obj, Value}
 
 import scala.util.Try
 
@@ -12,6 +12,10 @@ trait CacheBuilder { this: AstCreator =>
   def buildCache(): Unit = {
     try {
       findAndProcess(parserResult.json)
+      // Declared package name and namespace ending folder token is not matching then cache the alias to namespace mapping
+      if (!fullyQualifiedPackage.endsWith(declaredPackageName)) {
+        GoGlobal.recordAliasToNamespaceMapping(declaredPackageName, fullyQualifiedPackage)
+      }
     } catch
       case ex: Exception =>
         logger.warn(s"Error: While processing - ${parserResult.fullPath}", ex)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
@@ -38,6 +38,7 @@ trait CacheBuilder { this: AstCreator =>
           )
         ) {
           createParserNodeInfo(obj)
+          processTypeSepc(obj)
         } else if (
           json.obj
             .contains(ParserKeys.NodeType) && obj(ParserKeys.NodeType).str == "ast.FuncDecl" && !json.obj.contains(

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
@@ -9,8 +9,26 @@ import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 object GoGlobal extends Global {
 
+  /** This map will only contain the mapping for those packages whose package name is different from the enclosing
+    * folder name
+    *
+    * e.g
+    *
+    * module namespace = joern.io/sample
+    *
+    * folder path = <project_root>/lib
+    *
+    * package name = fpkg
+    *
+    * In above sample as the package name `fpkg` is different from `lib` this one will be cached in the map
+    */
+  val aliasToNameSpaceMapping: ConcurrentHashMap[String, String]               = new ConcurrentHashMap()
   val methodFullNameReturnTypeMap: ConcurrentHashMap[String, (String, String)] = new ConcurrentHashMap()
   val structTypeMemberTypeMapping: ConcurrentHashMap[String, String]           = new ConcurrentHashMap()
+
+  def recordAliasToNamespaceMapping(alias: String, namespace: String): Unit = {
+    aliasToNameSpaceMapping.putIfAbsent(alias, namespace)
+  }
 
   def recordStructTypeMemberType(memberFullName: String, memberType: String): Unit = {
     structTypeMemberTypeMapping.putIfAbsent(memberFullName, memberType)

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeFullNameTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeFullNameTests.scala
@@ -784,4 +784,69 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
       d.typeFullName shouldBe "joern.io/sample/lib.Address"
     }
   }
+
+  "Use case where namespace folder is not matching with declared package name" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package fpkg
+        |type Sample struct {
+        |  Name string
+        |}
+        |func Woo(a int) int{
+        |   return 0
+        |}
+        |""".stripMargin,
+      Seq("lib", "lib.go").mkString(File.separator)
+    ).moreCode(
+      """
+        |package main
+        |import "joern.io/sample/lib"
+        |func main() {
+        |  var a = fpkg.Woo(10)
+        |  var b = fpkg.Sample{name: "Pandurang"}
+        |  var c = b.Name
+        |  var d fpkg.Sample
+        |}
+        |""".stripMargin,
+      "main.go"
+    )
+
+    "Check METHOD Node" in {
+      cpg.method("Woo").size shouldBe 1
+      val List(x) = cpg.method("Woo").l
+      x.fullName shouldBe "joern.io/sample/lib.Woo"
+      x.signature shouldBe "joern.io/sample/lib.Woo(int)int"
+    }
+
+    "Check CALL Node" in {
+      val List(x) = cpg.call("Woo").l
+      x.methodFullName shouldBe "joern.io/sample/lib.Woo"
+      x.typeFullName shouldBe "int"
+    }
+
+    "Traversal from call to callee method node" in {
+      val List(x) = cpg.call("Woo").callee.l
+      x.fullName shouldBe "joern.io/sample/lib.Woo"
+      x.isExternal shouldBe false
+    }
+
+    "Check TypeDecl Node" in {
+      val List(x) = cpg.typeDecl("Sample").l
+      x.fullName shouldBe "joern.io/sample/lib.Sample"
+    }
+
+    "Check LOCAL Nodes" in {
+      val List(a, b, c, d) = cpg.local.l
+      a.typeFullName shouldBe "int"
+      b.typeFullName shouldBe "joern.io/sample/lib.Sample"
+      c.typeFullName shouldBe "string"
+      d.typeFullName shouldBe "joern.io/sample/lib.Sample"
+    }
+  }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeFullNameTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeFullNameTests.scala
@@ -785,6 +785,30 @@ class TypeFullNameTests extends GoCodeToCpgSuite {
     }
   }
 
+  "Struct type used before defining it" should {
+    val cpg = code("""
+        |package main
+        |func main() {
+        |  var p = Person{name: "Pandurang"}
+        |  var c = p.name
+        |}
+        |type Person struct{
+        |  name string
+        |}
+        |""".stripMargin)
+    "LOCAL Node type check" in {
+      val List(p, c) = cpg.local.l
+      p.typeFullName shouldBe "main.Person"
+      c.typeFullName shouldBe "string"
+    }
+
+    "CALL Node type check" in {
+      val List(a, b) = cpg.call.nameNot(Operators.assignment).l
+      a.typeFullName shouldBe "main.Person"
+      b.typeFullName shouldBe "string"
+    }
+  }
+
   "Use case where namespace folder is not matching with declared package name" should {
     val cpg = code(
       """


### PR DESCRIPTION
**package name is different from the namespace folder name**
Handling for the scenario when the package name and namespace folder name are different.
In the below example, we are importing `joern.io/sample/lib` but `fpkg` alias is getting used. We created a global cache for this mapping and did the lookup if the alias to namespace lookup fails for the file level mapping we maintain.

```
package main
import "joern.io/sample/lib"
func main() {
	var a = fpkg.Woo(10)
	var b = fpkg.Sample{name: "Pandurang"}
	var c = b.Name
	var d fpkg.Sample
}
```
**Type declared after its being used**

Member Type cache wasn't getting populated before AST Creation pass is invoked. It seems the respective unit test didn't cover the scenario, which will cover this scenario where it is required to have a cache built before AST creation pass.

Added respective unit tests along with the fix for the same.