### PR TITLE
[gosrc2cpg] - Fix for issue #3698

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -62,14 +62,18 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { t
 
   private def astForIdentifier(ident: ParserNodeInfo): Ast = {
     val identifierName = ident.json(ParserKeys.Name).str
-    val variableOption = scope.lookupVariable(identifierName)
-    variableOption match {
-      case Some((variable, variableTypeName)) =>
-        val node = identifierNode(ident, identifierName, ident.code, variableTypeName)
-        Ast(node).withRefEdge(node, variable)
-      case _ =>
-        // TODO: something is wrong here. Refer to SwitchTests -> "be correct for switch case 4"
-        Ast(identifierNode(ident, identifierName, ident.json(ParserKeys.Name).str, Defines.anyTypeName))
+    if identifierName != "_" then {
+      val variableOption = scope.lookupVariable(identifierName)
+      variableOption match {
+        case Some((variable, variableTypeName)) =>
+          val node = identifierNode(ident, identifierName, ident.code, variableTypeName)
+          Ast(node).withRefEdge(node, variable)
+        case _ =>
+          // TODO: something is wrong here. Refer to SwitchTests -> "be correct for switch case 4"
+          Ast(identifierNode(ident, identifierName, ident.json(ParserKeys.Name).str, Defines.anyTypeName))
+      }
+    } else {
+      Ast()
     }
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/dataflow/ParameterInDataFlowTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/dataflow/ParameterInDataFlowTests.scala
@@ -20,4 +20,36 @@ class ParameterInDataFlowTests extends GoCodeToCpgSuite(withOssDataflow = true) 
       sink.reachableByFlows(source).size shouldBe 1
     }
   }
+
+  "Simple parameter in to call argument data flow use case" should {
+    val cpg = code("""
+        |package main
+        |func foo(argv string) {
+        |  sample("sample", argv)
+        |  var a, _ = sample("sample", argv)
+        |  b, _ := sample("sample", argv)
+        |  c, d := sample("sample", argv)
+        |}
+        |""".stripMargin)
+
+    "data flow from parameterIn to identifier" in {
+      val source = cpg.parameter("argv").l
+      val sink   = cpg.identifier("argv").l
+      sink.reachableByFlows(source).size shouldBe 4
+    }
+
+    "data flow from parameterIn to CALL Node" in {
+      val source = cpg.parameter("argv").l
+      val sink   = cpg.call("sample").l
+      sink.reachableByFlows(source).size shouldBe 4
+    }
+
+    "data flow from parameterIn to lhs varaible" in {
+      val source = cpg.parameter("argv").l
+      source.size shouldBe 1
+      val sink = cpg.identifier("[a|b|c]").l
+      sink.size shouldBe 3
+      sink.reachableByFlows(source).size shouldBe 3
+    }
+  }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/AssignmentOperatorTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/AssignmentOperatorTests.scala
@@ -1,0 +1,49 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language.*
+
+class AssignmentOperatorTests extends GoCodeToCpgSuite {
+  "Multiple varables declared and assigned with value in single statement" should {
+    val cpg = code("""
+          |package main
+          |func main() {
+          |	var a, b = "first", "second"
+          | c, d := 10, "forth"
+          |}
+          |
+          |""".stripMargin)
+    "Check CALL Nodes" in {
+      cpg.call(Operators.assignment).size shouldBe 4
+      val List(a, b, c, d) = cpg.call(Operators.assignment).l
+      a.typeFullName shouldBe "string"
+      b.typeFullName shouldBe "string"
+      c.typeFullName shouldBe "int"
+      d.typeFullName shouldBe "string"
+    }
+  }
+
+  "Multiple varables declared and assigned with value in single statement with one function call" should {
+    val cpg = code("""
+        |package main
+        |func foo() int{
+        |  return 0
+        |}
+        |func main() {
+        |	var a, b = "first", "second"
+        |   c, d, e := 10, "forth", foo()
+        |}
+        |""".stripMargin)
+    "Check CALL Nodes" in {
+      cpg.call(Operators.assignment).size shouldBe 5
+      val List(a, b, c, d, e) = cpg.call(Operators.assignment).l
+      a.typeFullName shouldBe "string"
+      b.typeFullName shouldBe "string"
+      c.typeFullName shouldBe "int"
+      d.typeFullName shouldBe "string"
+      e.typeFullName shouldBe "int"
+    }
+  }
+}


### PR DESCRIPTION
1. `:=` operator wasn't creating multiple assignment call nodes if more than one variable is declared along with assignment. Fixed the respective use case as well as added few more respective unit tests to cover the use case.

2. Along with that handled a situation when `_` is being used for not using a returned value. So we are not creating respective `LOCAL` and `IDENTIFIER` nodes for the same.