### PR TITLE
[gosrc2cpg] - Handling for package level global variable access. Fixes #3695

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -49,7 +49,7 @@ class AstCreator(val relPathFileName: String, val parserResult: ParserResult, go
   private def astForTranslationUnit(rootNode: ParserNodeInfo): Ast = {
     val namespaceBlock = NewNamespaceBlock()
       .name(fullyQualifiedPackage)
-      .fullName(s"$relPathFileName:${fullyQualifiedPackage}")
+      .fullName(s"$relPathFileName:$fullyQualifiedPackage")
       .filename(relPathFileName)
     methodAstParentStack.push(namespaceBlock)
     val rootAst = Ast(namespaceBlock).withChild(

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForMethodCallExpressionCreator.scala
@@ -138,7 +138,10 @@ trait AstForMethodCallExpressionCreator(implicit withSchemaValidation: Validatio
     val callMethodFullName = s"$receiverTypeFullName.$methodName"
     val (returnTypeFullNameCache, signatureCache) =
       GoGlobal.methodFullNameReturnTypeMap
-        .getOrDefault(callMethodFullName, (Defines.anyTypeName, s"$callMethodFullName()"))
+        .getOrDefault(
+          callMethodFullName,
+          (s"$receiverTypeFullName.$methodName.${Defines.ReturnType}.${XDefines.Unknown}", s"$callMethodFullName()")
+        )
     (methodName, signatureCache, callMethodFullName, returnTypeFullNameCache, receiverAst)
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
@@ -52,7 +52,7 @@ trait AstForTypeDeclCreator(implicit withSchemaValidation: ValidationMode) { thi
             // The presence of "Obj" field indicates its variable identifier and not an alias
             receiverAstAndFullName(xnode, fieldIdentifier)
           case _ =>
-            // Otherwise its an alias to imported namespace on which method call is made
+            // Otherwise its an alias to imported namespace using which global variable is getting accessed
             val alias            = xnode.json(ParserKeys.Name).str
             val receiverFullName = resolveAliasToFullName(alias, fieldIdentifier)
             (
@@ -63,8 +63,7 @@ trait AstForTypeDeclCreator(implicit withSchemaValidation: ValidationMode) { thi
               )
             )
       case _ =>
-        // This will take care of chained method calls. It will call `astForCallExpression` in recursive way,
-        // and the call node is used as receiver to this current call node.
+        // This will take care of chained calls
         receiverAstAndFullName(xnode, fieldIdentifier)
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
@@ -42,14 +42,44 @@ trait AstForTypeDeclCreator(implicit withSchemaValidation: ValidationMode) { thi
       case _ => Seq.empty
   }
 
-  protected def astForFieldAccess(info: ParserNodeInfo): Seq[Ast] = {
-    val identifierAsts       = astForNode(info.json(ParserKeys.X))
+  private def processReceiver(info: ParserNodeInfo): (Seq[Ast], String) = {
+    val xnode           = createParserNodeInfo(info.json(ParserKeys.X))
+    val fieldIdentifier = info.json(ParserKeys.Sel)(ParserKeys.Name).str
+    xnode.node match
+      case Ident =>
+        Try(xnode.json(ParserKeys.Obj)) match
+          case Success(_) =>
+            // The presence of "Obj" field indicates its variable identifier and not an alias
+            receiverAstAndFullName(xnode, fieldIdentifier)
+          case _ =>
+            // Otherwise its an alias to imported namespace on which method call is made
+            val alias            = xnode.json(ParserKeys.Name).str
+            val receiverFullName = resolveAliasToFullName(alias, fieldIdentifier)
+            (
+              astForNode(xnode),
+              GoGlobal.structTypeMemberTypeMapping.getOrDefault(
+                receiverFullName,
+                s"$receiverFullName${Defines.dot}${Defines.FieldAccess}${Defines.dot}${XDefines.Unknown}"
+              )
+            )
+      case _ =>
+        // This will take care of chained method calls. It will call `astForCallExpression` in recursive way,
+        // and the call node is used as receiver to this current call node.
+        receiverAstAndFullName(xnode, fieldIdentifier)
+  }
+
+  private def receiverAstAndFullName(xnode: ParserNodeInfo, fieldIdentifier: String): (Seq[Ast], String) = {
+    val identifierAsts       = astForNode(xnode)
     val receiverTypeFullName = getTypeFullNameFromAstNode(identifierAsts)
-    val fieldIdentifier      = info.json(ParserKeys.Sel)(ParserKeys.Name).str
     val fieldTypeFullName = GoGlobal.structTypeMemberTypeMapping.getOrDefault(
-      receiverTypeFullName + Defines.dot + fieldIdentifier,
-      XDefines.Unknown
+      s"$receiverTypeFullName${Defines.dot}$fieldIdentifier",
+      s"$receiverTypeFullName${Defines.dot}$fieldIdentifier${Defines.dot}${Defines.FieldAccess}${Defines.dot}${XDefines.Unknown}"
     )
+    (identifierAsts, fieldTypeFullName)
+  }
+  protected def astForFieldAccess(info: ParserNodeInfo): Seq[Ast] = {
+    val (identifierAsts, fieldTypeFullName) = processReceiver(info)
+    val fieldIdentifier                     = info.json(ParserKeys.Sel)(ParserKeys.Name).str
     val fieldIdentifierNode = NewFieldIdentifier()
       .canonicalName(fieldIdentifier)
       .lineNumber(line(info))

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/Defines.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/Defines.scala
@@ -10,6 +10,8 @@ object Defines {
   val chan                           = "chan"
   val This: String                   = "this"
   val Bool                           = "bool"
+  val FieldAccess                    = "<FieldAccess>"
+  val ReturnType                     = "<ReturnType>"
 
   val primitiveTypeMap: Map[String, String] =
     // This list is prepared with reference to primitives defined at https://pkg.go.dev/builtin#pkg-types

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
@@ -22,9 +22,29 @@ object GoGlobal extends Global {
     *
     * In above sample as the package name `fpkg` is different from `lib` this one will be cached in the map
     */
-  val aliasToNameSpaceMapping: ConcurrentHashMap[String, String]               = new ConcurrentHashMap()
+  val aliasToNameSpaceMapping: ConcurrentHashMap[String, String] = new ConcurrentHashMap()
+
+  // Mapping method fullname to its return type and signature
   val methodFullNameReturnTypeMap: ConcurrentHashMap[String, (String, String)] = new ConcurrentHashMap()
-  val structTypeMemberTypeMapping: ConcurrentHashMap[String, String]           = new ConcurrentHashMap()
+
+  /** Mapping fully qualified name of the member variable of a struct type to it's type It will also maintain the type
+    * mapping for package level global variables. e.g.
+    *
+    * module namespace = joern.io/sample
+    *
+    * package sample
+    *
+    * type Person struct{ Age int}
+    *
+    * var ( HostURL = "http://api.sample.com" )
+    *
+    * It will map
+    *
+    * `joern.io/sample.Person.Age` - `int`
+    *
+    * `joern.io/sample.HostURL` - `string`
+    */
+  val structTypeMemberTypeMapping: ConcurrentHashMap[String, String] = new ConcurrentHashMap()
 
   def recordAliasToNamespaceMapping(alias: String, namespace: String): Unit = {
     aliasToNameSpaceMapping.putIfAbsent(alias, namespace)

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/DownloadDependencyTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/DownloadDependencyTest.scala
@@ -2,6 +2,7 @@ package io.joern.go2cpg.passes.ast
 
 import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
 import io.joern.gosrc2cpg.Config
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.*
 
 class DownloadDependencyTest extends GoCodeToCpgSuite {
@@ -18,7 +19,7 @@ class DownloadDependencyTest extends GoCodeToCpgSuite {
       "go.mod"
     ).moreCode("""
         |package main
-        |
+        |import "github.com/google/uuid"
         |func main()  {
         |  var uud = uuid.NewString()
         |}
@@ -28,6 +29,39 @@ class DownloadDependencyTest extends GoCodeToCpgSuite {
     "Check CALL Node" in {
       val List(x) = cpg.call("NewString").l
       x.typeFullName shouldBe "string"
+    }
+  }
+
+  "unresolved dependency tests" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |require (
+        |	joern.io/sampletwo v1.3.1
+        |)
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode("""
+          |package main
+          |import "joern.io/sampletwo"
+          |func main()  {
+          |  var a = sampletwo.Person{Name:"Pandurang"}
+          |  var b = a.Name
+          |  var c = a.FullName()
+          |  var d = a.Process().FullName()
+          |  var e = a.Process().SomeField
+          |}
+          |""".stripMargin)
+
+    "Be correct for CALL Node typeFullNames" in {
+      val List(a, b, c, d, e, f, g) = cpg.call.nameNot(Operators.assignment).l
+      a.typeFullName shouldBe "joern.io/sampletwo.Person"
+      b.typeFullName shouldBe "joern.io/sampletwo.Person.Name.<FieldAccess>.<unknown>"
+      c.typeFullName shouldBe "joern.io/sampletwo.Person.FullName.<ReturnType>.<unknown>"
+      d.typeFullName shouldBe "joern.io/sampletwo.Person.Process.<ReturnType>.<unknown>.FullName.<ReturnType>.<unknown>"
+      e.typeFullName shouldBe "joern.io/sampletwo.Person.Process.<ReturnType>.<unknown>"
+      f.typeFullName shouldBe "joern.io/sampletwo.Person.Process.<ReturnType>.<unknown>.SomeField.<FieldAccess>.<unknown>"
     }
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/GlobalVariableAndConstantTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/GlobalVariableAndConstantTests.scala
@@ -1,0 +1,190 @@
+package io.joern.go2cpg.passes.ast
+
+import io.joern.go2cpg.testfixtures.GoCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language.*
+
+import java.io.File
+
+class GlobalVariableAndConstantTests extends GoCodeToCpgSuite {
+
+  "Global variable declaration check" should {
+    val cpg = code("""
+        |package main
+        |const (
+        |	FooConst = "Test"
+        |)
+        |var (
+        |	BarVar = 100
+        |)
+        |func main() {
+        |  println(FooConst)
+        |}
+        |""".stripMargin)
+
+    "Check LOCAL node" in {
+      val List(a, b) = cpg.local.l
+      a.typeFullName shouldBe "string"
+      b.typeFullName shouldBe "int"
+    }
+  }
+
+  "Var defined(with type mentioned) in one package used in another package" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package lib1
+        |
+        |var(
+        |	SchemeHTTP string =  "http"
+        |)
+        |
+        |""".stripMargin,
+      Seq("lib1", "typelib.go").mkString(File.separator)
+    ).moreCode(
+      """
+        |package main
+        |import "joern.io/sample/lib1"
+        |func main() {
+        |	var a = lib1.SchemeHTTP.value()
+        |}
+        |""".stripMargin,
+      "main.go"
+    )
+
+    "Be correct for Field Access CALL Node for Global variable access" in {
+      val List(x) = cpg.call(Operators.fieldAccess).l
+      x.typeFullName shouldBe "string"
+    }
+
+    "Check methodfullname of variable imported from other package " in {
+      val List(callNode) = cpg.call("value").l
+      callNode.methodFullName shouldBe "string.value"
+    }
+  }
+
+  "Var defined(without type mentioned) in one package used in another package" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package lib1
+        |
+        |var(
+        |	SchemeHTTP =  "http"
+        |)
+        |
+        |""".stripMargin,
+      Seq("lib1", "typelib.go").mkString(File.separator)
+    ).moreCode(
+      """
+        |package main
+        |import "joern.io/sample/lib1"
+        |func main() {
+        |	var a = lib1.SchemeHTTP.value()
+        |}
+        |""".stripMargin,
+      "main.go"
+    )
+
+    "Be correct for Field Access CALL Node for Global variable access" in {
+      val List(x) = cpg.call(Operators.fieldAccess).l
+      x.typeFullName shouldBe "string"
+    }
+
+    "Check methodfullname of variable imported from other package " in {
+      val List(callNode) = cpg.call("value").l
+      callNode.methodFullName shouldBe "string.value"
+    }
+  }
+  "Const defined(with type mentioned) in one package used in another package" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package lib1
+        |
+        |const (
+        |	SchemeHTTP string =  "http"
+        |)
+        |
+        |""".stripMargin,
+      Seq("lib1", "typelib.go").mkString(File.separator)
+    ).moreCode(
+      """
+        |package main
+        |import "joern.io/sample/lib1"
+        |func main() {
+        |	var a = lib1.SchemeHTTP.value()
+        |}
+        |""".stripMargin,
+      "main.go"
+    )
+
+    "Be correct for Field Access CALL Node for Global variable access" in {
+      val List(x) = cpg.call(Operators.fieldAccess).l
+      x.typeFullName shouldBe "string"
+    }
+
+    "Check methodfullname of constant imported from other package " in {
+      val List(callNode) = cpg.call("value").l
+      callNode.methodFullName shouldBe "string.value"
+    }
+  }
+
+  "const defined(without type mentioned) in one package used in another package" should {
+    val cpg = code(
+      """
+        |module joern.io/sample
+        |go 1.18
+        |""".stripMargin,
+      "go.mod"
+    ).moreCode(
+      """
+        |package lib1
+        |
+        |const (
+        |	SchemeHTTP =  "http"
+        |)
+        |
+        |""".stripMargin,
+      Seq("lib1", "typelib.go").mkString(File.separator)
+    ).moreCode(
+      """
+        |package main
+        |import "joern.io/sample/lib1"
+        |import "joern.io/sample/lib2"
+        |func main() {
+        |	var a = lib1.SchemeHTTP.value()
+        |   var b = lib2.SchemeHTTP.value()
+        |}
+        |""".stripMargin,
+      "main.go"
+    )
+
+    "Be correct for Field Access CALL Node for Global variable access" in {
+      val List(a, b) = cpg.call(Operators.fieldAccess).l
+      a.typeFullName shouldBe "string"
+      b.typeFullName shouldBe "joern.io/sample/lib2.SchemeHTTP.<FieldAccess>.<unknown>"
+    }
+
+    "Check methodfullname of constant imported from other package " in {
+      val List(callNode, callNode2) = cpg.call("value").l
+      callNode.methodFullName shouldBe "string.value"
+      callNode2.methodFullName shouldBe "joern.io/sample/lib2.SchemeHTTP.<FieldAccess>.<unknown>.value"
+    }
+  }
+}

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMethodCallTests.scala
@@ -213,10 +213,10 @@ class TypeDeclMethodCallTests extends GoCodeToCpgSuite {
       cpg.call("bar").size shouldBe 1
       val List(x) = cpg.call("bar").l
       x.code shouldBe "ctx.data.bar(a)"
-      x.methodFullName shouldBe "<unknown>.bar"
+      x.methodFullName shouldBe "main.context.data.<FieldAccess>.<unknown>.bar"
       x.order shouldBe 2
       x.lineNumber shouldBe Option(7)
-      x.typeFullName shouldBe Defines.anyTypeName
+      x.typeFullName shouldBe "main.context.data.<FieldAccess>.<unknown>.bar.<ReturnType>.<unknown>"
     }
 
     "Check call node properties on five times chained" in {
@@ -236,10 +236,10 @@ class TypeDeclMethodCallTests extends GoCodeToCpgSuite {
       cpg.call("bar").size shouldBe 1
       val List(x) = cpg.call("bar").l
       x.code shouldBe "ctx.data1.data2.data3.data4.bar(a)"
-      x.methodFullName shouldBe "<unknown>.bar"
+      x.methodFullName shouldBe "main.context.data1.<FieldAccess>.<unknown>.data2.<FieldAccess>.<unknown>.data3.<FieldAccess>.<unknown>.data4.<FieldAccess>.<unknown>.bar"
       x.order shouldBe 2
       x.lineNumber shouldBe Option(7)
-      x.typeFullName shouldBe Defines.anyTypeName
+      x.typeFullName shouldBe "main.context.data1.<FieldAccess>.<unknown>.data2.<FieldAccess>.<unknown>.data3.<FieldAccess>.<unknown>.data4.<FieldAccess>.<unknown>.bar.<ReturnType>.<unknown>"
     }
 
   }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
@@ -17,7 +17,7 @@ trait Go2CpgFrontend extends LanguageFrontend {
     cpgOutFile.deleteOnExit()
     val go2cpg = new GoSrc2Cpg()
     val config = getConfig()
-      .map(_.asInstanceOf[Config])
+      .collectFirst { case x: Config => x }
       .getOrElse(Config())
       .withInputPath(sourceCodePath.getAbsolutePath)
       .withOutputPath(cpgOutFile.pathAsString)

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
@@ -52,5 +52,7 @@ class GoCodeToCpgSuite(fileSuffix: String = ".go", withOssDataflow: Boolean = fa
 
   override def beforeEach(): Unit = {
     GoGlobal.methodFullNameReturnTypeMap.clear()
+    GoGlobal.aliasToNameSpaceMapping.clear()
+    GoGlobal.structTypeMemberTypeMapping.clear()
   }
 }


### PR DESCRIPTION
Handling for package level global variable access. Fixes #3695

1. Handled package level global variable access with FieldAccess `CALL` node with respective handling to set the TypeFullName properly.
2. Made changes to handle the situation where we couldn't identify the TypeFullName in that situation, we are setting the TypeFullName of the receiver with respective labels postfixed to it like `<FieldAccess>` or `<ReturnType>`.
3. Updated respective unit tests along with a few more unit tests.

TODO:
Need to handle Global Variable Declaration.