### PR TITLE
[jimple2cpg] Declaration Ref Edges to Identifiers

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -1,7 +1,7 @@
 package io.joern.jimple2cpg
 
 import better.files.File
-import io.joern.jimple2cpg.passes.{AstCreationPass, SootAstCreationPass}
+import io.joern.jimple2cpg.passes.{AstCreationPass, DeclarationRefPass, SootAstCreationPass}
 import io.joern.jimple2cpg.util.ProgramHandlingUtil.{ClassFile, extractClassesInPackageLayout}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
@@ -117,6 +117,7 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
     TypeNodePass
       .withRegisteredTypes(global.usedTypes.keys().asScala.toList, cpg)
       .createAndApply()
+    DeclarationRefPass(cpg).createAndApply()
   }
 
   override def createCpg(config: Config): Try[Cpg] =

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreator.scala
@@ -173,6 +173,7 @@ class AstCreator(filename: String, cls: SootClass, global: Global)(implicit with
           .withChildren(astsForModifiers(methodDeclaration))
           .withChildren(parameterAsts)
           .withChildren(astsForHostTags(methodDeclaration))
+          .withChild(Ast(NewBlock()))
           .withChild(astForMethodReturn(methodDeclaration))
       } else {
         val lastOrder = 2 + methodDeclaration.getParameterCount

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/DeclarationRefPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/DeclarationRefPass.scala
@@ -1,0 +1,22 @@
+package io.joern.jimple2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Method}
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language.*
+
+/** Links declarations to their identifier nodes. Due to the flat AST of bytecode, we don't need to account for varying
+  * scope.
+  */
+class DeclarationRefPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Method](cpg) {
+
+  override def generateParts(): Array[Method] = cpg.method.toArray
+
+  override def runOnPart(builder: DiffGraphBuilder, part: Method): Unit = {
+    val identifiers  = part.ast.isIdentifier.toList
+    val declarations = (part.parameter ++ part.block.astChildren.isLocal).collectAll[Declaration].l
+    declarations.foreach(d => identifiers.nameExact(d.name).foreach(builder.addEdge(_, d, EdgeTypes.REF)))
+  }
+
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/LocalTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/LocalTests.scala
@@ -34,4 +34,14 @@ class LocalTests extends JimpleCode2CpgFixture {
     y.typeFullName shouldBe "java.lang.Integer"
     y.order shouldBe 2
   }
+
+  "should allow traversing from local to identifier" in {
+    val ys = cpg.local.nameExact("y").referencingIdentifiers.l
+    ys.size shouldBe 2
+    ys.head.name shouldBe "y"
+    val xs = cpg.local.nameExact("$stack3").referencingIdentifiers.l
+    xs.size shouldBe 3
+    xs.head.name shouldBe "$stack3"
+  }
+
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/MethodParameterTests.scala
@@ -10,7 +10,7 @@ class MethodParameterTests extends JimpleCode2CpgFixture {
   val cpg: Cpg = code("""package a;
       |class Foo {
       | int foo(int param1, Object param2) {
-      |  return 0;
+      |  return param1;
       | }
       |}
       """.stripMargin).cpg
@@ -45,6 +45,10 @@ class MethodParameterTests extends JimpleCode2CpgFixture {
 
   "should allow traversing from parameter to method" in {
     cpg.parameter.name("param1").method.filter(_.isExternal == false).name.l shouldBe List("foo")
+  }
+
+  "should allow traversing from parameter to identifier" in {
+    cpg.parameter.name("param1").referencingIdentifiers.name.l shouldBe List("param1")
   }
 
 }


### PR DESCRIPTION
Somehow, `jimple2cpg` has gone this long without parameter/locals with REF edges to identifiers.

A quick solution is following it with a ref edge pass, since the AST is flat so there is always one block under a method.