### PR TITLE
[rubysrc2cpg] Fixed Duplicate Do-Blocks Due to Side-Effect

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -332,12 +332,6 @@ class AstCreator(
           columnEnd(ctx).head
         )
 
-      blockMethodAsts.foreach { ast =>
-        ast.root match
-          case Some(_: NewMethod) => blockMethods.addOne(ast)
-          case _                  =>
-      }
-
       blockMethodAsts :+ blockMethodAsts
         .flatMap(_.nodes)
         .collectFirst { case methodRefNode: NewMethodRef =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/DoBlockTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ast/DoBlockTest.scala
@@ -67,4 +67,17 @@ class DoBlockTest extends RubyCode2CpgFixture {
     }
   }
 
+  "a do-block function wrapped within a chained invocation inside of a call argument" should {
+    val cpg = code("OpenStruct.new(obj.map { |key, val| [key, to_recursive_ostruct(val)] }.to_h)")
+
+    "create a do-block method named from the surrounding function" in {
+      val mapMethod :: _ = cpg.method.name("map.*").l: @unchecked
+      mapMethod.name should startWith("map")
+      mapMethod.parameter.size shouldBe 2
+      val k :: v :: _ = mapMethod.parameter.l: @unchecked
+      k.name shouldBe "key"
+      v.name shouldBe "val"
+    }
+  }
+
 }


### PR DESCRIPTION
Removed adding do block functions from chained invocations to the block method map to reduce duplicate method creation.