### PR TITLE
Kotlin2Cpg - Introduction of TypeRecoveryPass

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -9,13 +9,19 @@ import org.slf4j.LoggerFactory
 import scala.util.Try
 import scala.jdk.CollectionConverters.{CollectionHasAsScala, EnumerationHasAsScala}
 import io.joern.kotlin2cpg.files.SourceFilesPicker
-import io.joern.kotlin2cpg.passes.{AstCreationPass, ConfigPass, DependenciesFromMavenCoordinatesPass}
+import io.joern.kotlin2cpg.passes.{
+  AstCreationPass,
+  ConfigPass,
+  DependenciesFromMavenCoordinatesPass,
+  KotlinTypeHintCallLinker,
+  KotlinTypeRecoveryPass
+}
 import io.joern.kotlin2cpg.compiler.{CompilerAPI, ErrorLoggingMessageCollector}
 import io.joern.kotlin2cpg.types.{ContentSourcesPicker, DefaultTypeInfoProvider}
 import io.joern.kotlin2cpg.utils.PathUtils
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
-import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
+import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass, XTypeRecoveryConfig}
 import io.joern.x2cpg.utils.dependency.{DependencyResolver, DependencyResolverParams, GradleConfigKeys}
 import io.joern.kotlin2cpg.interop.JavasrcInterop
 import io.joern.kotlin2cpg.jar4import.UsesService
@@ -28,6 +34,11 @@ object Kotlin2Cpg {
   val language = "KOTLIN"
   case class InputPair(content: String, fileName: String)
   type InputProvider = () => InputPair
+
+  def postProcessingPass(cpg: Cpg): Unit = {
+    new KotlinTypeRecoveryPass(cpg).createAndApply()
+    new KotlinTypeHintCallLinker(cpg).createAndApply()
+  }
 }
 
 case class KtFileWithMeta(f: KtFile, relativizedPath: String, filename: String)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
@@ -212,8 +212,8 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   def astForImportDirective(directive: KtImportDirective): Ast = {
-    val importedAs = Try(directive.getImportedName.getIdentifier).toOption.getOrElse("")
-    val isWildcard = importedAs == Constants.wildcardImportName || directive.getImportedName == null
+    val importedAs = Try(directive.getImportedName.getIdentifier).toOption
+    val isWildcard = importedAs.contains(Constants.wildcardImportName) || directive.getImportedName == null
     val node =
       NewImport()
         .isWildcard(isWildcard)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
@@ -31,6 +31,7 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import scala.jdk.CollectionConverters.*
 
 import scala.annotation.unused
+import scala.util.Try
 
 trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) {
   this: AstCreator =>
@@ -211,11 +212,13 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   def astForImportDirective(directive: KtImportDirective): Ast = {
-    val isWildcard = directive.getLastChild.getText == Constants.wildcardImportName || directive.getImportedName == null
+    val importedAs = Try(directive.getImportedName.getIdentifier).toOption.getOrElse("")
+    val isWildcard = importedAs == Constants.wildcardImportName || directive.getImportedName == null
     val node =
       NewImport()
         .isWildcard(isWildcard)
         .isExplicit(true)
+        .importedAs(importedAs)
         .importedEntity(directive.getImportPath.getPathStr)
         .code(s"${Constants.importKeyword} ${directive.getImportPath.getPathStr}")
         .lineNumber(line(directive))

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/KotlinTypeHintCallLinker.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/KotlinTypeHintCallLinker.scala
@@ -1,0 +1,21 @@
+package io.joern.kotlin2cpg.passes
+
+import io.joern.x2cpg.Defines
+import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.semanticcpg.language._
+
+import java.util.regex.Pattern
+
+class KotlinTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
+
+  override protected def calls: Iterator[Call] = {
+    cpg.call
+      .nameNot("<operator>.*", "<operators>.*")
+      .filter(c =>
+        calleeNames(c).nonEmpty && c.callee.fullNameNot(Pattern.quote(Defines.UnresolvedNamespace) + ".*").isEmpty
+      )
+  }
+
+}

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/KotlinTypeRecoveryPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/KotlinTypeRecoveryPass.scala
@@ -1,0 +1,82 @@
+package io.joern.kotlin2cpg.passes
+
+import io.joern.kotlin2cpg.Constants
+import io.joern.x2cpg.Defines
+import io.joern.x2cpg.passes.frontend.*
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+import overflowdb.BatchedUpdate.DiffGraphBuilder
+
+class KotlinTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())
+    extends XTypeRecoveryPass[File](cpg, config) {
+  override protected def generateRecoveryPass(state: XTypeRecoveryState): XTypeRecovery[File] =
+    new KotlinTypeRecovery(cpg, state)
+}
+
+private class KotlinTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
+
+  override def compilationUnit: Iterator[File] = cpg.file.iterator
+
+  override def generateRecoveryForCompilationUnitTask(
+    unit: File,
+    builder: DiffGraphBuilder
+  ): RecoverForXCompilationUnit[File] = {
+    val newConfig = state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
+    new RecoverForKotlinFile(cpg, unit, builder, state.copy(config = newConfig))
+  }
+}
+
+private class RecoverForKotlinFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, state: XTypeRecoveryState)
+    extends RecoverForXCompilationUnit[File](cpg, cu, builder, state) {
+
+  private def kotlinNodeToLocalKey(n: AstNode): Option[LocalKey] = n match {
+    case i: Identifier if i.name == "this" && i.code == "super" => Option(LocalVar("super"))
+    case _                                                      => SBKey.fromNodeToLocalKey(n)
+  }
+
+  override protected val symbolTable = new SymbolTable[LocalKey](kotlinNodeToLocalKey)
+
+  override protected def importNodes: Iterator[Import] = cu.ast.isImport
+  override protected def visitImport(i: Import): Unit = {
+
+    val alias    = i.importedAs.getOrElse("")
+    val fullName = i.importedEntity.getOrElse("")
+    if (alias != Constants.wildcardImportName) {
+      symbolTable.append(CallAlias(alias), fullName)
+      symbolTable.append(LocalVar(alias), fullName)
+    }
+  }
+
+  override protected def isConstructor(c: Call): Boolean = isConstructor(c.name)
+
+  override protected def isConstructor(name: String): Boolean = !name.isBlank && name.charAt(0).isUpper
+
+  override protected def postVisitImports(): Unit = {
+    symbolTable.view.foreach { case (k, ts) =>
+      val tss = ts.filterNot(_.startsWith(Defines.UnresolvedNamespace))
+      if (tss.isEmpty)
+        symbolTable.remove(k)
+      else
+        symbolTable.put(k, tss)
+    }
+  }
+
+  // There seems to be issues with inferring these, often due to situations where super and this are confused on name
+  // and code properties.
+  override protected def storeIdentifierTypeInfo(i: Identifier, types: Seq[String]): Unit = if (i.name != "this") {
+    super.storeIdentifierTypeInfo(i, types)
+  }
+
+  override protected def storeCallTypeInfo(c: Call, types: Seq[String]): Unit =
+    if (types.nonEmpty) {
+      state.changesWereMade.compareAndSet(false, true)
+      val signedTypes = types.map {
+        case t if t.endsWith(c.signature) => t
+        case t                            => s"$t:${c.signature}"
+      }
+      builder.setNodeProperty(c, PropertyNames.DYNAMIC_TYPE_HINT_FULL_NAME, signedTypes)
+    }
+
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/postProcessing/TypeRecoveryPassTest.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/postProcessing/TypeRecoveryPassTest.scala
@@ -1,0 +1,40 @@
+package io.joern.kotlin2cpg.postProcessing
+
+import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
+import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
+import io.shiftleft.semanticcpg.language._
+
+class TypeRecoveryPassTest extends KotlinCode2CpgFixture(withPostProcessing = true) {
+
+  implicit val resolver: ICallResolver = NoResolve
+
+  "Identifier exposed via import" should {
+    val cpg = code("""
+        |package mypkg
+        |import com.firebase.ui.auth.AuthUI
+        |
+        |fun main() {
+        |   val intent = AuthUI.getInstance().createSignInIntentBuilder()
+        |                    .setAvailableProviders(signInProviders)
+        |                    .setLogo(R.drawable.ic_fire_emoji)
+        |                    .build()
+        |}
+        |""".stripMargin)
+
+    "have type resolved for identifier" in {
+      val List(i) = cpg.identifier("AuthUI").l
+      i.typeFullName shouldBe "com.firebase.ui.auth.AuthUI"
+    }
+
+    "be able to faciliate methodFullName resolution for call made from identifier object" in {
+      cpg.call("getInstance").methodFullName.l shouldBe List("com.firebase.ui.auth.AuthUI.getInstance:ANY()")
+    }
+
+    "be able to faciliate methodFullName resolution for call chaining" ignore {
+      cpg.call("createSignInIntentBuilder").methodFullName.l shouldBe List(
+        "com.firebase.ui.auth.AuthUI.getInstance:ANY().<returnValue>.createSignInIntentBuilder"
+      )
+    }
+  }
+
+}

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -31,10 +31,15 @@ trait KotlinFrontend extends LanguageFrontend {
 }
 
 class KotlinTestCpg(override protected val withTestResourcePaths: Boolean) extends TestCpg with KotlinFrontend {
-  private var _withOssDataflow = false
+  private var _withOssDataflow    = false
+  private var _withPostProcessing = false
 
   def withOssDataflow(value: Boolean = true): this.type = {
     _withOssDataflow = value
+    this
+  }
+  def withPostProcessing(value: Boolean = true): this.type = {
+    _withPostProcessing = value
     this
   }
 
@@ -46,11 +51,20 @@ class KotlinTestCpg(override protected val withTestResourcePaths: Boolean) exten
       val options = new OssDataFlowOptions()
       new OssDataFlow(options).run(context)
     }
+
+    if (_withPostProcessing) {
+      Kotlin2Cpg.postProcessingPass(this)
+    }
   }
 }
 
-class KotlinCode2CpgFixture(withOssDataflow: Boolean = false, withDefaultJars: Boolean = false)
-    extends Code2CpgFixture(() => new KotlinTestCpg(withDefaultJars).withOssDataflow(withOssDataflow)) {
+class KotlinCode2CpgFixture(
+  withOssDataflow: Boolean = false,
+  withDefaultJars: Boolean = false,
+  withPostProcessing: Boolean = false
+) extends Code2CpgFixture(() =>
+      new KotlinTestCpg(withDefaultJars).withOssDataflow(withOssDataflow).withPostProcessing(withPostProcessing)
+    ) {
 
   implicit val context: EngineContext = EngineContext()
 


### PR DESCRIPTION
The PR contains
- Introduction of TypeRecoveryPass as a Post processing step
- Fix - To get the actual import name and assign it to importNode while AST Creation
- 3 test case to validate the TypeRecovery changes, out of which 1 test case is in ignored state, which will be worked on in subsequent PR's

Note - The TypeRecoveryPass changes have been referred from Java Frontend