### PR TITLE
[rubysrc2cpg] Do-Block Function as Conditional

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -200,12 +200,12 @@ class AstCreator(
     case ctx: ProcDefinitionPrimaryContext   => astForProcDefinitionContext(ctx.procDefinition())
     case ctx: YieldWithOptionalArgumentPrimaryContext =>
       astForYieldCall(ctx, Option(ctx.yieldWithOptionalArgument().arguments()))
-    case ctx: IfExpressionPrimaryContext     => Seq(astForIfExpression(ctx.ifExpression()))
-    case ctx: UnlessExpressionPrimaryContext => Seq(astForUnlessExpression(ctx.unlessExpression()))
+    case ctx: IfExpressionPrimaryContext     => astForIfExpression(ctx.ifExpression())
+    case ctx: UnlessExpressionPrimaryContext => astForUnlessExpression(ctx.unlessExpression())
     case ctx: CaseExpressionPrimaryContext   => astForCaseExpressionPrimaryContext(ctx)
-    case ctx: WhileExpressionPrimaryContext  => Seq(astForWhileExpression(ctx.whileExpression()))
-    case ctx: UntilExpressionPrimaryContext  => Seq(astForUntilExpression(ctx.untilExpression()))
-    case ctx: ForExpressionPrimaryContext    => Seq(astForForExpression(ctx.forExpression()))
+    case ctx: WhileExpressionPrimaryContext  => astForWhileExpression(ctx.whileExpression())
+    case ctx: UntilExpressionPrimaryContext  => astForUntilExpression(ctx.untilExpression())
+    case ctx: ForExpressionPrimaryContext    => astForForExpression(ctx.forExpression())
     case ctx: ReturnWithParenthesesPrimaryContext =>
       Seq(returnAst(returnNode(ctx, text(ctx)), astForArgumentsWithParenthesesContext(ctx.argumentsWithParentheses())))
     case ctx: JumpExpressionPrimaryContext     => astForJumpExpressionPrimaryContext(ctx)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -223,6 +223,21 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       (as.toSeq, bs.toSeq)
     }
 
+    /** Partitions a sequence of Ast objects into the boilerplate for do-block functions and the call node at the end.
+      *
+      * @return
+      *   a tuple where the first element is the closure boilerplate and the latter is the last expression.
+      */
+    def partitionClosureFromExpr: (Seq[Ast], Option[Ast]) = {
+      val (as, bs) = a.partition(_.root match
+        case Some(_: NewMethod)                                          => true
+        case Some(_: NewTypeDecl)                                        => true
+        case Some(x: NewCall) if x.name.startsWith(Operators.assignment) => true
+        case _                                                           => false
+      )
+      (as.toSeq, bs.lastOption)
+    }
+
   }
 
 }


### PR DESCRIPTION
Fixed bug regarding do-block functions as control structure conditionals.

Example AST:
<img width="622" alt="Screenshot 2023-10-10 at 12 31 16" src="https://github.com/joernio/joern/assets/28294550/64401399-1848-4b92-bb92-552cb5ac4c7c">
