### PR TITLE
[gosrc2cpg] - Made structural changes while creating initial AST nodes per file #3695

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
@@ -28,7 +28,8 @@ class GoSrc2Cpg extends X2CpgFrontend[Config] {
           astGenResult.parsedModFile.flatMap(modFile => GoAstJsonParser.readModFile(Paths.get(modFile)).map(x => x))
         )
         if config.fetchDependencies then new DownloadDependenciesPass(goMod).process()
-        val astCreators = new MethodAndTypeCacheBuilderPass(astGenResult.parsedFiles, config, goMod).process()
+        val astCreators =
+          new MethodAndTypeCacheBuilderPass(Some(cpg), astGenResult.parsedFiles, config, goMod).process()
         new AstCreationPass(cpg, astCreators, config, report).createAndApply()
 //        TypeNodePass.withRegisteredTypes(GoGlobal.typesSeen(), cpg).createAndApply()
         report.print()

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -1,6 +1,6 @@
 package io.joern.gosrc2cpg.astcreation
 
-import io.joern.gosrc2cpg.model.{GoMod, GoModHelper}
+import io.joern.gosrc2cpg.model.GoModHelper
 import io.joern.gosrc2cpg.parser.GoAstJsonParser.ParserResult
 import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
@@ -8,8 +8,7 @@ import io.joern.x2cpg.datastructures.Scope
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{NewNamespaceBlock, NewNode}
-import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 import ujson.Value
@@ -47,45 +46,27 @@ class AstCreator(val relPathFileName: String, val parserResult: ParserResult, go
   }
 
   private def astForTranslationUnit(rootNode: ParserNodeInfo): Ast = {
-    val namespaceBlock = NewNamespaceBlock()
-      .name(fullyQualifiedPackage)
-      .fullName(s"$relPathFileName:$fullyQualifiedPackage")
-      .filename(relPathFileName)
-    methodAstParentStack.push(namespaceBlock)
-    val rootAst = Ast(namespaceBlock).withChild(
-      astInFakeMethod(
-        fullyQualifiedPackage + "." + NamespaceTraversal.globalNamespaceName,
-        namespaceBlock.fullName + "." + NamespaceTraversal.globalNamespaceName,
+    val name     = s"$fullyQualifiedPackage.${parserResult.filename}"
+    val fullName = s"$relPathFileName:$name"
+    val fakeGlobalMethodForFile =
+      methodNode(
+        rootNode,
+        name,
+        name,
+        fullName,
+        None,
         relPathFileName,
-        rootNode
+        Option(NodeTypes.TYPE_DECL),
+        Option(fullyQualifiedPackage)
       )
-    )
-    methodAstParentStack.pop()
-    rootAst
-  }
-
-  /** Creates an AST of all declarations found in the translation unit - wrapped in a fake method.
-    */
-  private def astInFakeMethod(name: String, fullName: String, path: String, rootNode: ParserNodeInfo): Ast = {
-
-    val fakeGlobalTypeDecl =
-      typeDeclNode(rootNode, name, fullName, relPathFileName, name, NodeTypes.NAMESPACE_BLOCK, fullName)
-    methodAstParentStack.push(fakeGlobalTypeDecl)
-    val fakeGlobalMethod =
-      methodNode(rootNode, name, name, fullName, None, path, Option(NodeTypes.TYPE_DECL), Option(fullName))
-    methodAstParentStack.push(fakeGlobalMethod)
-    scope.pushNewScope(fakeGlobalMethod)
-    val blockNode_ = blockNode(rootNode, Defines.empty, Defines.anyTypeName)
-
+    methodAstParentStack.push(fakeGlobalMethodForFile)
+    scope.pushNewScope(fakeGlobalMethodForFile)
+    val blockNode_   = blockNode(rootNode, Defines.empty, Defines.anyTypeName)
     val methodReturn = methodReturnNode(rootNode, Defines.anyTypeName)
     val declsAsts    = rootNode.json(ParserKeys.Decls).arr.flatMap(item => astForNode(item)).toList
-    val ast = Ast(fakeGlobalTypeDecl).withChild(
-      methodAst(fakeGlobalMethod, Seq.empty, blockAst(blockNode_, declsAsts), methodReturn)
-    )
-    methodAstParentStack.pop()
     methodAstParentStack.pop()
     scope.popScope()
-    ast
+    methodAst(fakeGlobalMethodForFile, Seq.empty, blockAst(blockNode_, declsAsts), methodReturn)
   }
 
   protected def astForNode(nodeInfo: ParserNodeInfo): Seq[Ast] = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
@@ -3,6 +3,7 @@ package io.joern.gosrc2cpg.astcreation
 import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.parser.ParserAst.{GenDecl, ValueSpec}
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
+import io.joern.gosrc2cpg.utils.UtilityConstants.fileSeparateorPattern
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
 import io.shiftleft.codepropertygraph.generated.nodes.NewNamespaceBlock
@@ -34,7 +35,7 @@ trait CacheBuilder(implicit withSchemaValidation: ValidationMode) { this: AstCre
   }
 
   private def astForPackage(rootNode: ParserNodeInfo): Ast = {
-    val pathTokens = relPathFileName.split(File.separator)
+    val pathTokens = relPathFileName.split(fileSeparateorPattern)
     val packageFolderPath = if (pathTokens.nonEmpty && pathTokens.size > 1) {
       s"${File.separator}${pathTokens.dropRight(1).mkString(File.separator)}"
     } else {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
@@ -46,7 +46,7 @@ object GoGlobal extends Global {
     */
   val structTypeMemberTypeMapping: ConcurrentHashMap[String, String] = new ConcurrentHashMap()
 
-  def recordAliasToNamespaceMapping(alias: String, namespace: String): Unit = {
+  def recordAliasToNamespaceMapping(alias: String, namespace: String): String = {
     aliasToNameSpaceMapping.putIfAbsent(alias, namespace)
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/model/GoMod.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/model/GoMod.scala
@@ -5,12 +5,7 @@ import io.circe.{Decoder, HCursor}
 import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.utils.UtilityConstants.fileSeparateorPattern
 
-import java.io.File
-import scala.collection.mutable.ListBuffer
-
 class GoModHelper(config: Option[Config] = None, meta: Option[GoMod] = None) {
-
-  import java.util.regex.Pattern
 
   def getModMetaData(): Option[GoMod] = meta
   def getNameSpace(compilationUnitFilePath: String, pkg: String): String = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DownloadDependenciesPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DownloadDependenciesPass.scala
@@ -52,7 +52,7 @@ class DownloadDependenciesPass(parentGoMod: GoModHelper) {
         Some(config),
         astGenResult.parsedModFile.flatMap(modFile => GoAstJsonParser.readModFile(Paths.get(modFile)).map(x => x))
       )
-      new MethodAndTypeCacheBuilderPass(astGenResult.parsedFiles, config, goMod).process()
+      new MethodAndTypeCacheBuilderPass(None, astGenResult.parsedFiles, config, goMod).process()
     }
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/MethodAndTypeCacheBuilderPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/MethodAndTypeCacheBuilderPass.scala
@@ -1,18 +1,19 @@
 package io.joern.gosrc2cpg.passes
 
 import io.joern.gosrc2cpg.Config
-import io.joern.gosrc2cpg.astcreation.{AstCreator, CacheBuilder}
+import io.joern.gosrc2cpg.astcreation.AstCreator
 import io.joern.gosrc2cpg.model.GoModHelper
 import io.joern.gosrc2cpg.parser.GoAstJsonParser
-import io.joern.gosrc2cpg.parser.GoAstJsonParser.ParserResult
 import io.joern.x2cpg.SourceFiles
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
 
 import java.nio.file.Paths
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
-class MethodAndTypeCacheBuilderPass(astFiles: List[String], config: Config, goMod: GoModHelper) {
+class MethodAndTypeCacheBuilderPass(cpgOpt: Option[Cpg], astFiles: List[String], config: Config, goMod: GoModHelper) {
   def process(): Seq[AstCreator] = {
     val futures = astFiles
       .map(file => {
@@ -20,11 +21,20 @@ class MethodAndTypeCacheBuilderPass(astFiles: List[String], config: Config, goMo
           val parserResult    = GoAstJsonParser.readFile(Paths.get(file))
           val relPathFileName = SourceFiles.toRelativePath(parserResult.fullPath, config.inputPath)
           val astCreator      = new AstCreator(relPathFileName, parserResult, goMod)(config.schemaValidation)
-          astCreator.buildCache()
-          astCreator
+          val diffGraph       = astCreator.buildCache()
+          (astCreator, diffGraph)
         }
       })
-    val allResults: Future[List[AstCreator]] = Future.sequence(futures)
-    Await.result(allResults, Duration.Inf)
+    val allResults: Future[List[(AstCreator, DiffGraphBuilder)]] = Future.sequence(futures)
+    val results                                                  = Await.result(allResults, Duration.Inf)
+    val (astCreators, diffGraphs)                                = results.unzip
+    cpgOpt.map(cpg => {
+      diffGraphs.foreach(diffGraph => {
+        overflowdb.BatchedUpdate
+          .applyDiff(cpg.graph, diffGraph, null, null)
+          .transitiveModifications()
+      })
+    })
+    astCreators
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/MethodAndTypeCacheBuilderPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/MethodAndTypeCacheBuilderPass.scala
@@ -21,7 +21,7 @@ class MethodAndTypeCacheBuilderPass(cpgOpt: Option[Cpg], astFiles: List[String],
           val parserResult    = GoAstJsonParser.readFile(Paths.get(file))
           val relPathFileName = SourceFiles.toRelativePath(parserResult.fullPath, config.inputPath)
           val astCreator      = new AstCreator(relPathFileName, parserResult, goMod)(config.schemaValidation)
-          val diffGraph       = astCreator.buildCache()
+          val diffGraph       = astCreator.buildCache(cpgOpt)
           (astCreator, diffGraph)
         }
       })

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ArraysAndMapTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/ArraysAndMapTests.scala
@@ -351,7 +351,7 @@ class ArraysAndMapTests extends GoCodeToCpgSuite {
       )
 
     "check FILE Nodes" in {
-      cpg.file.size shouldBe 3
+      cpg.file.size shouldBe 4
     }
 
     "check LOCAL node" in {
@@ -422,7 +422,7 @@ class ArraysAndMapTests extends GoCodeToCpgSuite {
     )
 
     "check FILE Nodes" in {
-      cpg.file.size shouldBe 3
+      cpg.file.size shouldBe 5
     }
 
     "check LOCAL node" in {

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/FileTests.scala
@@ -18,9 +18,9 @@ class FileTests extends GoCodeToCpgSuite {
         |""".stripMargin)
 
     "should contain two file nodes in total, both with order=0" in {
-      cpg.file.order.l shouldBe List(0, 0)
+      cpg.file.order.l shouldBe List(0, 0, 0)
       cpg.file.name(FileTraversal.UNKNOWN).size shouldBe 1
-      cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 1
+      cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 2
     }
 
     "should contain exactly one placeholder file node with `name=\"<unknown>\"/order=0`" in {
@@ -33,11 +33,7 @@ class FileTests extends GoCodeToCpgSuite {
     }
 
     "should allow traversing from file to its methods via namespace block" in {
-      cpg.file.nameNot(FileTraversal.UNKNOWN).method.name.toSetMutable shouldBe Set(
-        s"main.${NamespaceTraversal.globalNamespaceName}",
-        "foo",
-        "bar"
-      )
+      cpg.file.nameNot(FileTraversal.UNKNOWN).method.name.toSetMutable shouldBe Set("main.Test0.go", "foo", "bar")
     }
 
     "should allow traversing from file to its type declarations via namespace block" in {
@@ -46,15 +42,15 @@ class FileTests extends GoCodeToCpgSuite {
         .typeDecl
         .name
         .l
-        .sorted shouldBe List("Sample", "main.<global>")
+        .sorted shouldBe List("Sample", "main")
     }
 
     "should allow traversing to namespaces" in {
       val List(ns1, ns2) = cpg.file.namespaceBlock.l
       ns1.filename shouldBe FileTraversal.UNKNOWN
       ns1.fullName shouldBe NamespaceTraversal.globalNamespaceName
-      ns2.filename shouldBe "Test0.go"
-      ns2.fullName shouldBe "Test0.go:main"
+      ns2.filename shouldBe File.separator
+      ns2.fullName shouldBe "main"
       cpg.file.namespace.l.size shouldBe 2
     }
   }
@@ -86,22 +82,19 @@ class FileTests extends GoCodeToCpgSuite {
     )
 
     "should contain two file nodes in total, both with order=0" in {
-      cpg.file.order.l shouldBe List(0, 0, 0)
+      cpg.file.order.l shouldBe List(0, 0, 0, 0, 0)
       cpg.file.name(FileTraversal.UNKNOWN).size shouldBe 1
-      cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 2
+      cpg.file.nameNot(FileTraversal.UNKNOWN).size shouldBe 4
     }
 
     "traversal from file to typedecl should work" in {
-      cpg.file(".*mainlib.go").size shouldBe 1
-      cpg.file(".*mainlib.go").typeDecl.fullName.l shouldBe List(
-        s"${Seq("fpkg", "mainlib.go").mkString(File.separator)}:joern.io/sample/fpkg.<global>",
-        "joern.io/sample/fpkg.Person"
-      )
+      cpg.file(".*fpkg.*").size shouldBe 2
+      cpg.file(".*fpkg.*").typeDecl.fullName.l shouldBe List("joern.io/sample/fpkg", "joern.io/sample/fpkg.Person")
     }
 
     "traversal from file to method should work" in {
       cpg.file("main.go").size shouldBe 1
-      cpg.file("main.go").method.fullName.l shouldBe List("main.go:main.<global>", "main.foo")
+      cpg.file("main.go").method.fullName.l shouldBe List("main.foo", "main.go:main.main.go")
     }
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/MethodTests.scala
@@ -113,7 +113,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo()joern.io/sample/fpkg.Sample"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "Test0.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(6)
@@ -188,7 +188,7 @@ class MethodTests extends GoCodeToCpgSuite {
       y.signature shouldBe "main.bar()"
       y.isExternal shouldBe false
 
-      y.order shouldBe 2
+      y.order shouldBe 1
       y.filename shouldBe "Test0.go"
       y.lineNumber shouldBe Option(6)
       y.lineNumberEnd shouldBe Option(7)
@@ -691,7 +691,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, main.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "Test0.go"
       x.lineNumber shouldBe Option(7)
       x.lineNumberEnd shouldBe Option(8)
@@ -889,7 +889,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, joern.io/sample/fpkg.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "main.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(5)
@@ -957,7 +957,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, []joern.io/sample/fpkg.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "main.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(5)
@@ -1017,7 +1017,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "main.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(5)
@@ -1077,7 +1077,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, []privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "main.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(5)
@@ -1137,7 +1137,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, *privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "main.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(5)
@@ -1197,7 +1197,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, []*privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "main.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(5)
@@ -1257,7 +1257,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, *[]privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "main.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(5)
@@ -1317,7 +1317,7 @@ class MethodTests extends GoCodeToCpgSuite {
       x.signature shouldBe "main.foo(int, []*privado.ai/test/fpkg.Sample)"
       x.isExternal shouldBe false
 
-      x.order shouldBe 2
+      x.order shouldBe 1
       x.filename shouldBe "main.go"
       x.lineNumber shouldBe Option(4)
       x.lineNumberEnd shouldBe Option(5)
@@ -1599,7 +1599,7 @@ class MethodTests extends GoCodeToCpgSuite {
 
     "test basic ast structure for identifiers" in {
 
-      val List(person, personName, _) = cpg.identifier.l
+      val List(personName, person, _) = cpg.identifier.l
       person.name shouldBe "person"
       personName.name shouldBe "personName"
       personName.typeFullName shouldBe "string"

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/VariableReferencingTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/VariableReferencingTests.scala
@@ -48,19 +48,19 @@ class VariableReferencingTests extends GoCodeToCpgSuite {
         |""".stripMargin)
 
     "test local variable exists" in {
-      val List(localNode) = cpg.method("main.<global>").local.nameExact("x").l
+      val List(localNode) = cpg.method("main.Test0.go").local.nameExact("x").l
       localNode.code shouldBe "x"
       localNode.closureBindingId shouldBe None
     }
 
     "test identifier association to local" in {
-      val List(localNode) = cpg.method("main.<global>").local.nameExact("x").l
+      val List(localNode) = cpg.method("main.Test0.go").local.nameExact("x").l
       localNode.referencingIdentifiers.lineNumber(2).code.head shouldBe "x"
       localNode.referencingIdentifiers.lineNumber(4).code.head shouldBe "x"
     }
 
     "test global variable line and column numbers" in {
-      val List(localNode) = cpg.method("main.<global>").local.nameExact("x").l
+      val List(localNode) = cpg.method("main.Test0.go").local.nameExact("x").l
       localNode.lineNumber shouldBe Some(2)
       localNode.columnNumber shouldBe Some(5)
     }


### PR DESCRIPTION
This is one more partial handling for package-level Global variable handling ticket #3695 

Earlier, we were creating an AST structure per file in the following way.

NameSpaceNode(`package prefixed with filename`)=>TypeDecl(`Fake TypeDecl node representing the given file`)=>Method(`Fake Method node representing the statements (imports, gobal var and constants, types and functions) in the given file`)=>Block(`all the direct statment asts as child nodes`)

With the new structure, we wanted to create a Fake TypeDecl node representing one package (One package can have multiple go files in it). In order to achieve this, we are following the order of nodes being created for a package and then for a file.

For package, i.e. per folder

NameSpaceNode(`one namespace node representing one package`)=>TypeDecl(`Fake TypeDecl node representing the give package. File path mentioned in this case will be the folder path`)

For each file in the package. The first fake node will be added as child node of the Package TypeDecl created in the previous cache pass.

Method(`Fake Method node representing the statements (imports, gobal var and constants, types and functions) in the given file`)=>Block(`all the direct statment asts as child nodes`)

- Added a few more unit tests covering the new use cases
- Changed the existing unit tests to adjust with the updated AST structure.

TODO:

- Handle the global variable and constants to be created as member fields of the package level Fake TypeDecl we are creating. As of now, it has been created as a `LOCAL` node under the Fake file level `METHOD` node we have created.
- If the Global variable or constant is getting accessed in the same package. As of now, that is being treated as an `IDENTIFIER`. We need to change it to be converted to the FieldAccess `CALL` node.
- With the above change, we might not require the File level fake `METHOD` node for Global variables or constants. We are going to treat them as Memnber fields of level Type Decl instead of `LOCAL` nodes. So we might eliminate this file level Fake `METHOD` node.