### PR TITLE
[php2cpg] Resolve static method call name when called by self

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -973,7 +973,6 @@ class AstCreator(filename: String, phpAst: PhpFile)(implicit withSchemaValidatio
       }
 
       case Some(expr) =>
-        // composeMethodFullName(name, call.isStatic)
         s"$UnresolvedNamespace\\$codePrefix"
 
       case None if PhpBuiltins.FuncNames.contains(name) =>

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -967,10 +967,13 @@ class AstCreator(filename: String, phpAst: PhpFile)(implicit withSchemaValidatio
 
     val fullName = call.target match {
       // Static method call with a known class name
-      case Some(nameExpr: PhpNameExpr) if call.isStatic =>
-        s"${nameExpr.name}${StaticMethodDelimiter}$name"
+      case Some(nameExpr: PhpNameExpr) if call.isStatic => {
+        if (nameExpr.name == "self") composeMethodFullName(name, call.isStatic)
+        else s"${nameExpr.name}${StaticMethodDelimiter}$name"
+      }
 
       case Some(expr) =>
+        // composeMethodFullName(name, call.isStatic)
         s"$UnresolvedNamespace\\$codePrefix"
 
       case None if PhpBuiltins.FuncNames.contains(name) =>

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -98,7 +98,7 @@ class CallTests extends PhpCode2CpgFixture {
         |}
         |""".stripMargin)
 
-    "have the correct method node defined" in {
+    "resolve the correct method full name" in {
       val List(barCall) = cpg.call("bar").take(1).l
       barCall.name shouldBe "bar"
       barCall.methodFullName shouldBe s"ClassA::bar"

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -84,6 +84,30 @@ class CallTests extends PhpCode2CpgFixture {
     }
   }
 
+  /* This possibly should exist in NamespaceTests.scala */
+  "static method calls that refer to self" should {
+    val cpg = code("""
+        |<?php
+        |class ClassA {
+        |   function foo($x) {
+        |     return self::bar($x);
+        |   }
+        |   static function bar($param) {
+        |     return 0;
+        |   }
+        |}
+        |""".stripMargin)
+
+    "have the correct method node defined" in {
+      val List(barCall) = cpg.call("bar").take(1).l
+      barCall.name shouldBe "bar"
+      barCall.methodFullName shouldBe s"ClassA::bar"
+      barCall.receiver.isEmpty shouldBe true
+      barCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      barCall.code shouldBe "self::bar($x)"
+    }
+  }
+
   "method calls with simple names should be correct" in {
     val cpg = code("<?php\n$f->foo($x);")
 


### PR DESCRIPTION
When a static method call is made by referring to `self`, the AST node created for it failed to resolve the proper method full name.

For example:

```
<?php
class Foo {
    static function bar($x) {
        return 0;
    }
    function baz($x) {
        self::bar($x);
    }
}
```

The method full name of the call node for `self::bar($x)` is `self::bar`, but it should be `Foo::bar`.

This PR resolves the method full name of functions called by `self`.