### PR TITLE
Updated astgen version

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.5.0"
+    astgen_version: "3.6.0"
 }


### PR DESCRIPTION
Latest astgen uses compressed binaries also for Windows. (40mb -> 20mb)