### PR TITLE
Add file content flags and support to javasrc2cpg

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.3.1"
 
-val cpgVersion = "1.4.24"
+val cpgVersion = "1.4.25"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -120,12 +120,22 @@ class AstCreator(
   private val lineOffsetTable = OffsetUtils.getLineOffsetTable(fileContent)
 
   override protected def offset(node: Node): Option[(Int, Int)] = {
-    for {
-      lineNr      <- line(node)
-      columnNr    <- column(node)
-      lineEndNr   <- lineEnd(node)
-      columnEndNr <- columnEnd(node)
-    } yield OffsetUtils.coordinatesToOffset(lineOffsetTable, lineNr - 1, columnNr - 1, lineEndNr - 1, columnEndNr - 1)
+    Option
+      .when(fileContent.isDefined) {
+        for {
+          lineNr      <- line(node)
+          columnNr    <- column(node)
+          lineEndNr   <- lineEnd(node)
+          columnEndNr <- columnEnd(node)
+        } yield OffsetUtils.coordinatesToOffset(
+          lineOffsetTable,
+          lineNr - 1,
+          columnNr - 1,
+          lineEndNr - 1,
+          columnEndNr - 1
+        )
+      }
+      .flatten
   }
 
   // TODO: Handle static imports correctly.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -117,10 +117,15 @@ class AstCreator(
   protected def lineEnd(node: Node): Option[Integer]   = node.getEnd.map(x => Integer.valueOf(x.line)).toScala
   protected def columnEnd(node: Node): Option[Integer] = node.getEnd.map(x => Integer.valueOf(x.column)).toScala
 
-  private val lineOffsetIndex = OffsetUtils.getLineOffsetIndex(fileContent)
+  private val lineOffsetTable = OffsetUtils.getLineOffsetTable(fileContent)
 
   override protected def offset(node: Node): Option[(Int, Int)] = {
-    zeroIndexedCoordinates(node).flatMap(OffsetUtils.coordinatesToOffset(lineOffsetIndex, _))
+    for {
+      lineNr      <- line(node)
+      columnNr    <- column(node)
+      lineEndNr   <- lineEnd(node)
+      columnEndNr <- columnEnd(node)
+    } yield OffsetUtils.coordinatesToOffset(lineOffsetTable, lineNr - 1, columnNr - 1, lineEndNr - 1, columnEndNr - 1)
   }
 
   // TODO: Handle static imports correctly.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -330,17 +330,8 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
     val endLine      = declaration.getEnd.map(x => Integer.valueOf(x.line)).toScala
     val endColumn    = declaration.getEnd.map(x => Integer.valueOf(x.column)).toScala
 
-    val methodNode = NewMethod()
-      .name(declaration.getNameAsString)
-      .code(code)
-      .isExternal(false)
-      .filename(filename)
-      .lineNumber(line(declaration))
-      .columnNumber(columnNumber)
-      .lineNumberEnd(endLine)
-      .columnNumberEnd(endColumn)
-
-    methodNode
+    val placeholderFullName = ""
+    methodNode(declaration, declaration.getNameAsString(), code, placeholderFullName, None, filename)
   }
 
   def thisNodeForMethod(maybeTypeFullName: Option[String], lineNumber: Option[Integer]): NewMethodParameterIn = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -85,11 +85,12 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
 
     val parameters = thisParam ++ parametersWithoutThis
 
-    val lambdaMethodNode = createLambdaMethodNode(lambdaMethodName, parametersWithoutThis, returnType)
-    val returnNode       = newMethodReturnNode(returnType.getOrElse(TypeConstants.Any), None, line(expr), column(expr))
-    val virtualModifier  = Some(newModifierNode(ModifierTypes.VIRTUAL))
-    val staticModifier   = Option.when(thisParam.isEmpty)(newModifierNode(ModifierTypes.STATIC))
-    val privateModifier  = Some(newModifierNode(ModifierTypes.PRIVATE))
+    val lambdaMethodNode = createLambdaMethodNode(expr, lambdaMethodName, parametersWithoutThis, returnType)
+
+    val returnNode      = newMethodReturnNode(returnType.getOrElse(TypeConstants.Any), None, line(expr), column(expr))
+    val virtualModifier = Some(newModifierNode(ModifierTypes.VIRTUAL))
+    val staticModifier  = Option.when(thisParam.isEmpty)(newModifierNode(ModifierTypes.STATIC))
+    val privateModifier = Some(newModifierNode(ModifierTypes.PRIVATE))
 
     val modifiers = List(virtualModifier, staticModifier, privateModifier).flatten.map(Ast(_))
 
@@ -133,6 +134,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
   }
 
   private def createLambdaMethodNode(
+    lambdaExpr: LambdaExpr,
     lambdaName: String,
     parameters: Seq[Ast],
     returnType: Option[String]
@@ -141,12 +143,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
     val signature         = lambdaMethodSignature(returnType, parameters)
     val lambdaFullName    = composeMethodFullName(enclosingTypeName, lambdaName, signature)
 
-    NewMethod()
-      .name(lambdaName)
-      .fullName(lambdaFullName)
-      .signature(signature)
-      .filename(filename)
-      .code("<lambda>")
+    methodNode(lambdaExpr, lambdaName, "<lambda>", lambdaFullName, Some(signature), filename)
   }
 
   private def createAndPushLambdaTypeDecl(

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jpastprinter/JavaParserAstPrinter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jpastprinter/JavaParserAstPrinter.scala
@@ -15,7 +15,7 @@ object JavaParserAstPrinter {
 
     SourceParser.getSourceFilenames(config).foreach { filename =>
       val relativeFilename = Path.of(config.inputPath).relativize(Path.of(filename)).toString
-      sourceParser.parseAnalysisFile(relativeFilename).foreach { case (compilationUnit, _) =>
+      sourceParser.parseAnalysisFile(relativeFilename, saveFileContent = false).foreach { case (compilationUnit, _) =>
         println(relativeFilename)
         println(printer.output(compilationUnit))
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jpastprinter/JavaParserAstPrinter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jpastprinter/JavaParserAstPrinter.scala
@@ -15,7 +15,7 @@ object JavaParserAstPrinter {
 
     SourceParser.getSourceFilenames(config).foreach { filename =>
       val relativeFilename = Path.of(config.inputPath).relativize(Path.of(filename)).toString
-      sourceParser.parseAnalysisFile(relativeFilename).foreach { compilationUnit =>
+      sourceParser.parseAnalysisFile(relativeFilename).foreach { case (compilationUnit, _) =>
         println(relativeFilename)
         println(printer.output(compilationUnit))
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -51,7 +51,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
     sourceParser.parseAnalysisFile(relativeFilename) match {
       case Some(compilationUnit, fileContent) =>
         symbolSolver.inject(compilationUnit)
-        val contentToUse = if (config.enableFileContent) fileContent else None
+        val contentToUse = if (!config.disableFileContent) fileContent else None
         diffGraph.absorb(
           new AstCreator(relativeFilename, compilationUnit, contentToUse, global, symbolSolver)(config.schemaValidation)
             .createAst()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -48,7 +48,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
 
   override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
     val relativeFilename = Path.of(config.inputPath).relativize(Path.of(filename)).toString
-    sourceParser.parseAnalysisFile(relativeFilename) match {
+    sourceParser.parseAnalysisFile(relativeFilename, !config.disableFileContent) match {
       case Some(compilationUnit, fileContent) =>
         symbolSolver.inject(compilationUnit)
         val contentToUse = if (!config.disableFileContent) fileContent else None

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -49,10 +49,12 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
   override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
     val relativeFilename = Path.of(config.inputPath).relativize(Path.of(filename)).toString
     sourceParser.parseAnalysisFile(relativeFilename) match {
-      case Some(compilationUnit) =>
+      case Some(compilationUnit, fileContent) =>
         symbolSolver.inject(compilationUnit)
+        val contentToUse = if (config.enableFileContent) fileContent else None
         diffGraph.absorb(
-          new AstCreator(relativeFilename, compilationUnit, global, symbolSolver)(config.schemaValidation).createAst()
+          new AstCreator(relativeFilename, compilationUnit, contentToUse, global, symbolSolver)(config.schemaValidation)
+            .createAst()
         )
 
       case None => logger.warn(s"Skipping AST creation for $filename")

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -32,15 +32,21 @@ class SourceParser private (originalInputPath: Path, analysisRoot: Path, typesRo
     * @param relativeFilename
     *   path to the input file relative to the project root.
     */
-  def parseAnalysisFile(relativeFilename: String): Option[(CompilationUnit, Option[String])] = {
+  def parseAnalysisFile(
+    relativeFilename: String,
+    saveFileContent: Boolean
+  ): Option[(CompilationUnit, Option[String])] = {
     val analysisFilename = analysisRoot.resolve(relativeFilename).toString
     // Need to store tokens for position information.
     fileIfExists(analysisFilename).flatMap { file =>
       val compilationUnit = parse(file, storeTokens = true)
-      val fileContent =
-        Try(file.contentAsString(Charset.defaultCharset()))
-          .orElse(Try(file.contentAsString(StandardCharsets.ISO_8859_1)))
-          .toOption
+      val fileContent = Option
+        .when(saveFileContent) {
+          Try(file.contentAsString(Charset.defaultCharset()))
+            .orElse(Try(file.contentAsString(StandardCharsets.ISO_8859_1)))
+            .toOption
+        }
+        .flatten
 
       compilationUnit.map(cu => (cu, fileContent))
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -32,10 +32,18 @@ class SourceParser private (originalInputPath: Path, analysisRoot: Path, typesRo
     * @param relativeFilename
     *   path to the input file relative to the project root.
     */
-  def parseAnalysisFile(relativeFilename: String): Option[CompilationUnit] = {
+  def parseAnalysisFile(relativeFilename: String): Option[(CompilationUnit, Option[String])] = {
     val analysisFilename = analysisRoot.resolve(relativeFilename).toString
     // Need to store tokens for position information.
-    fileIfExists(analysisFilename).flatMap(parse(_, storeTokens = true))
+    fileIfExists(analysisFilename).flatMap { file =>
+      val compilationUnit = parse(file, storeTokens = true)
+      val fileContent =
+        Try(file.contentAsString(Charset.defaultCharset()))
+          .orElse(Try(file.contentAsString(StandardCharsets.ISO_8859_1)))
+          .toOption
+
+      compilationUnit.map(cu => (cu, fileContent))
+    }
   }
 
   /** Parse the given file into a JavaParser CompliationUnit that will be used for reading type information. These

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/OffsetTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/OffsetTests.scala
@@ -5,7 +5,7 @@ import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 
 class OffsetTests extends JavaSrcCode2CpgFixture {
-  val contentEnabled = Config().withEnableFileContent(true)
+  val contentEnabled = Config().withDisableFileContent(false)
 
   "a class with a single method without file content enabled" should {
     val source = """

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/OffsetTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/OffsetTests.scala
@@ -1,0 +1,192 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.Config
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class OffsetTests extends JavaSrcCode2CpgFixture {
+  val contentEnabled = Config().withEnableFileContent(true)
+
+  "a class with a single method without file content enabled" should {
+    val source = """
+        |class Foo {
+        |  void foo(int x) {
+        |    System.out.println(x);
+        |  }
+        |}
+        |""".stripMargin
+
+    val cpg = code(source, fileName = "Foo.java")
+
+    "have an empty content field" in {
+      cpg.file.name(".*Foo.java").content.l shouldBe List("<empty>")
+    }
+
+    "not have offsets for the foo method" in {
+      def method = cpg.method.name("foo").head
+      method.offset shouldBe None
+      method.offsetEnd shouldBe None
+
+    }
+
+    "not have offsets set for the default constructor" in {
+      def method = cpg.method.nameExact("<init>").head
+      method.offset shouldBe None
+      method.offsetEnd shouldBe None
+    }
+  }
+
+  "a class with a single method" should {
+    val source = """
+        |class Foo {
+        |  void foo(int x) {
+        |    System.out.println(x);
+        |  }
+        |}
+        |""".stripMargin
+
+    val cpg = code(source, fileName = "Foo.java").withConfig(contentEnabled)
+
+    "have the file content field set correctly" in {
+      cpg.file.name(".*Foo.java").content.l shouldBe List(source)
+    }
+
+    "have the method be retrievable via the offset fields" in {
+      def method    = cpg.method.name("foo").head
+      val offset    = method.offset.get
+      val offsetEnd = method.offsetEnd.get
+
+      cpg.file.name(".*Foo.java").content.head.substring(offset, offsetEnd) shouldBe
+        """void foo(int x) {
+          |    System.out.println(x);
+          |  }""".stripMargin
+    }
+
+    "not have offsets set for the default constructor" in {
+      def method = cpg.method.nameExact("<init>").head
+      method.offset shouldBe None
+      method.offsetEnd shouldBe None
+    }
+  }
+
+  "a class with multiple methods" should {
+    val method1 = """void method1(int param1) {
+    |    System.out.println(param1);
+    |  }""".stripMargin
+
+    val method2 = """void method2(int param2) {
+    |    System.out.println(param2);
+    |  }""".stripMargin
+
+    val cpg = code(
+      s"""
+       |class Foo {
+       |  $method1
+       |
+       |  $method2
+       |}
+       |""".stripMargin,
+      fileName = "Foo.java"
+    ).withConfig(contentEnabled)
+
+    "have the first method retrievable via the offset fields" in {
+      def method    = cpg.method.name("method1").head
+      val offset    = method.offset.get
+      val offsetEnd = method.offsetEnd.get
+
+      cpg.file.name(".*Foo.java").content.head.substring(offset, offsetEnd) shouldBe method1
+    }
+
+    "have the second method retrievable via the offset fields" in {
+      def method    = cpg.method.name("method2").head
+      val offset    = method.offset.get
+      val offsetEnd = method.offsetEnd.get
+
+      cpg.file.name(".*Foo.java").content.head.substring(offset, offsetEnd) shouldBe method2
+    }
+
+    "not have offsets set for the default constructor" in {
+      def method = cpg.method.nameExact("<init>").head
+      method.offset shouldBe None
+      method.offsetEnd shouldBe None
+    }
+  }
+
+  "a class with an explicit constructor and multiple methods" should {
+    val constructor = """Foo() {
+    |    // Do nothing
+    |  }""".stripMargin
+
+    val method1 = """void method1(int param1) {
+    |    System.out.println(param1);
+    |  }""".stripMargin
+
+    val method2 = """void method2(int param2) {
+    |    System.out.println(param2);
+    |  }""".stripMargin
+
+    val cpg = code(
+      s"""
+       |class Foo {
+       |  $method1
+       |
+       |  $method2
+       |
+       |  $constructor
+       |}
+       |""".stripMargin,
+      fileName = "Foo.java"
+    ).withConfig(contentEnabled)
+
+    "have the first method retrievable via the offset fields" in {
+      def method    = cpg.method.name("method1").head
+      val offset    = method.offset.get
+      val offsetEnd = method.offsetEnd.get
+
+      cpg.file.name(".*Foo.java").content.head.substring(offset, offsetEnd) shouldBe method1
+    }
+
+    "have the second method retrievable via the offset fields" in {
+      def method    = cpg.method.name("method2").head
+      val offset    = method.offset.get
+      val offsetEnd = method.offsetEnd.get
+
+      cpg.file.name(".*Foo.java").content.head.substring(offset, offsetEnd) shouldBe method2
+    }
+
+    "have the constructor be retrievable via the offset fields" in {
+      def method    = cpg.method.nameExact("<init>").head
+      val offset    = method.offset.get
+      val offsetEnd = method.offsetEnd.get
+
+      cpg.file.name(".*Foo.java").content.head.substring(offset, offsetEnd) shouldBe constructor
+    }
+  }
+
+  "a class with a lambda method" should {
+    "have the lambda method source be retrievable via the synthetic method offsets" in {
+      val cpg = code(
+        """
+          |import java.util.function.Consumer;
+          |
+          |class Foo {
+          |  Consumer<String> buildConsumer() {
+          |    return value -> System.out.println(value);
+          |  }
+          |}
+          """.stripMargin,
+        fileName = "Foo.java"
+      ).withConfig(contentEnabled)
+
+      def method    = cpg.method.name(".*lambda.*").head
+      val offset    = method.offset.get
+      val offsetEnd = method.offsetEnd.get
+
+      cpg.file
+        .name(".*Foo.java")
+        .content
+        .head
+        .substring(offset, offsetEnd) shouldBe "value -> System.out.println(value)"
+    }
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -31,15 +31,6 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
   protected def lineEnd(node: Node): Option[Integer]
   protected def columnEnd(element: Node): Option[Integer]
 
-  protected def zeroIndexedCoordinates(node: Node): Option[ZeroIndexedCoordinates] = {
-    for {
-      lineNum      <- line(node)
-      columnNum    <- column(node)
-      lineEndNum   <- lineEnd(node)
-      columnEndNum <- columnEnd(node)
-    } yield ZeroIndexedCoordinates(lineNum - 1, columnNum - 1, lineEndNum - 1, columnEndNum - 1)
-  }
-
   protected def offset(node: Node): Option[(Int, Int)] = None
 
   protected def unknownNode(node: Node, code: String): NewUnknown = {
@@ -328,8 +319,4 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
       .lineNumber(line(node))
       .columnNumber(column(node))
   }
-}
-
-object AstNodeBuilder {
-  case class ZeroIndexedCoordinates(line: Int, column: Int, lineEnd: Int, columnEnd: Int)
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -24,7 +24,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewTypeRef,
   NewUnknown
 }
-import io.shiftleft.semanticcpg.utils.Statements.countAll
 import org.apache.commons.lang.StringUtils
 trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
   protected def line(node: Node): Option[Integer]

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -1,6 +1,5 @@
 package io.joern.x2cpg
 
-import io.joern.x2cpg.AstNodeBuilder.ZeroIndexedCoordinates
 import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.nodes.Block.{PropertyDefaults => BlockDefaults}
 import io.shiftleft.codepropertygraph.generated.nodes.{

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -65,12 +65,27 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
     this.asInstanceOf[R]
   }
 
+  var enableFileContent: Boolean  = false
+  var disableFileContent: Boolean = true
+
+  def withEnableFileContent(value: Boolean): R = {
+    this.enableFileContent = value
+    this.asInstanceOf[R]
+  }
+
+  def withDisableFileContent(value: Boolean): R = {
+    this.disableFileContent = value
+    this.asInstanceOf[R]
+  }
+
   def withInheritedFields(config: R): R = {
     this.inputPath = config.inputPath
     this.outputPath = config.outputPath
     this.defaultIgnoredFilesRegex = config.defaultIgnoredFilesRegex
     this.ignoredFilesRegex = config.ignoredFilesRegex
     this.ignoredFiles = config.ignoredFiles
+    this.enableFileContent = config.enableFileContent
+    this.disableFileContent = config.disableFileContent
     this.asInstanceOf[R]
   }
 }
@@ -228,6 +243,15 @@ object X2Cpg {
       opt[Unit]("enable-early-schema-checking")
         .action((_, c) => c.withSchemaValidation(ValidationMode.Enabled))
         .text("enables early schema validation during AST creation (disabled by default)"),
+      opt[Unit]("enable-file-content")
+        .action((_, c) => c.withEnableFileContent(true))
+        .text(
+          "add the raw source code to the content field of FILE nodes to allow for method source retrieval via offset fields (disabled by default)"
+        ),
+      opt[Unit]("disable-file-content")
+        .action((_, c) => c.withDisableFileContent(true))
+        .hidden()
+        .text("currently unused option that will replace enable-file-content"),
       help("help").text("display this help message"),
       frontendSpecific
     )

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -65,13 +65,7 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
     this.asInstanceOf[R]
   }
 
-  var enableFileContent: Boolean  = false
   var disableFileContent: Boolean = true
-
-  def withEnableFileContent(value: Boolean): R = {
-    this.enableFileContent = value
-    this.asInstanceOf[R]
-  }
 
   def withDisableFileContent(value: Boolean): R = {
     this.disableFileContent = value
@@ -84,7 +78,6 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
     this.defaultIgnoredFilesRegex = config.defaultIgnoredFilesRegex
     this.ignoredFilesRegex = config.ignoredFilesRegex
     this.ignoredFiles = config.ignoredFiles
-    this.enableFileContent = config.enableFileContent
     this.disableFileContent = config.disableFileContent
     this.asInstanceOf[R]
   }
@@ -244,7 +237,7 @@ object X2Cpg {
         .action((_, c) => c.withSchemaValidation(ValidationMode.Enabled))
         .text("enables early schema validation during AST creation (disabled by default)"),
       opt[Unit]("enable-file-content")
-        .action((_, c) => c.withEnableFileContent(true))
+        .action((_, c) => c.withDisableFileContent(false))
         .text(
           "add the raw source code to the content field of FILE nodes to allow for method source retrieval via offset fields (disabled by default)"
         ),

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/OffsetUtils.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/OffsetUtils.scala
@@ -1,0 +1,30 @@
+package io.joern.x2cpg.utils
+
+import io.joern.x2cpg.AstNodeBuilder.ZeroIndexedCoordinates
+
+object OffsetUtils {
+  def getLineOffsetIndex(fileContent: Option[String]): Array[Int] = {
+    fileContent
+      .map { content =>
+        var totalCharsCounted = 0
+        content.linesWithSeparators.map { line =>
+          val lineStartOffset = totalCharsCounted
+          totalCharsCounted += line.length()
+          lineStartOffset
+        }.toArray
+      }
+      .getOrElse(Array.empty)
+  }
+
+  def coordinatesToOffset(lineOffsetIndex: Array[Int], coordinates: ZeroIndexedCoordinates): Option[(Int, Int)] = {
+    coordinates.match {
+      case ZeroIndexedCoordinates(startLine, startColumn, endLine, endColumn)
+          if endLine <= lineOffsetIndex.length - 1 =>
+        val offset    = lineOffsetIndex(startLine) + startColumn
+        val offsetEnd = lineOffsetIndex(endLine) + endColumn + 1
+        Some((offset, offsetEnd))
+
+      case _ => None
+    }
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/OffsetUtils.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/OffsetUtils.scala
@@ -1,9 +1,7 @@
 package io.joern.x2cpg.utils
 
-import io.joern.x2cpg.AstNodeBuilder.ZeroIndexedCoordinates
-
 object OffsetUtils {
-  def getLineOffsetIndex(fileContent: Option[String]): Array[Int] = {
+  def getLineOffsetTable(fileContent: Option[String]): Array[Int] = {
     fileContent
       .map { content =>
         var totalCharsCounted = 0
@@ -16,15 +14,15 @@ object OffsetUtils {
       .getOrElse(Array.empty)
   }
 
-  def coordinatesToOffset(lineOffsetIndex: Array[Int], coordinates: ZeroIndexedCoordinates): Option[(Int, Int)] = {
-    coordinates.match {
-      case ZeroIndexedCoordinates(startLine, startColumn, endLine, endColumn)
-          if endLine <= lineOffsetIndex.length - 1 =>
-        val offset    = lineOffsetIndex(startLine) + startColumn
-        val offsetEnd = lineOffsetIndex(endLine) + endColumn + 1
-        Some((offset, offsetEnd))
-
-      case _ => None
-    }
+  def coordinatesToOffset(
+    lineOffsetTable: Array[Int],
+    startLine: Int,
+    startColumn: Int,
+    endLine: Int,
+    endColumn: Int
+  ): (Int, Int) = {
+    val offset    = lineOffsetTable(startLine) + startColumn
+    val offsetEnd = lineOffsetTable(endLine) + endColumn + 1
+    (offset, offsetEnd)
   }
 }


### PR DESCRIPTION
This PR implements the FILE_CONTENT property changes introduced in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1737. 

Currently a temporary `enable-file-content` option is added (disabled by default) to avoid accidental source in commercial CPGs due to release schedules, but a `disable-file-content` is also added with the intent of enabling file content by default which can be turned off by this flag (currently unused).