### PR TITLE
Fix javasrc crash that occurs when builtin types cannot be read from JDK

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -70,7 +70,7 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
       case refType: ResolvedReferenceType =>
         nameOrFullName(refType.getTypeDeclaration.get, fullyQualified)
       case lazyType: LazyType =>
-        lazyType match {
+        Try(lazyType match {
           case _ if lazyType.isReferenceType =>
             nameOrFullName(lazyType.asReferenceType(), typeParamValues, fullyQualified)
           case _ if lazyType.isTypeVariable =>
@@ -81,7 +81,7 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
             nameOrFullName(lazyType.asPrimitive(), typeParamValues, fullyQualified)
           case _ if lazyType.isWildcard =>
             nameOrFullName(lazyType.asWildcard(), typeParamValues, fullyQualified)
-        }
+        }).toOption.flatten
       case tpe @ (_: ResolvedVoidType | _: ResolvedPrimitiveType) =>
         Some(tpe.describe())
       case arrayType: ResolvedArrayType =>


### PR DESCRIPTION
The body of this match can throw an `UnsolvedException` under certain conditions (definitely when the JDK types are missing, possibly others), so this PR handles that more gracefully.

During testing, I also noticed that schema violation issues where parameters were missing edges to their defining methods were fixed by this change as well, so it seems they were caused by an incomplete AST due to the crash.