### PR TITLE
[kotlin2cpg] - Use Defaults when Using Head/Last Calls

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
@@ -75,8 +75,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       classDeclarations.collectAll[KtProperty].filter(_.getInitializer != null).map { decl =>
         val initializerAsts = astsForExpression(decl.getInitializer, None)
         val rhsAst =
-          if (initializerAsts.size == 1)
-            initializerAsts.headOption.getOrElse(Ast(unknownNode(decl.getInitializer, Constants.empty)))
+          if (initializerAsts.size == 1) initializerAsts.head
           else Ast(unknownNode(decl, "<empty>"))
 
         val thisIdentifier = newIdentifierNode(Constants.this_, classFullName, Seq(classFullName))

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
@@ -112,7 +112,10 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     lhsArgs.dropRight(1) ++ rhsArgs.dropRight(1) ++ Seq(
       callAst(
         withArgumentIndex(node, argIdx).argumentName(argNameMaybe),
-        List(lhsArgs.lastOption.getOrElse(Ast()), rhsArgs.lastOption.getOrElse(Ast()))
+        List(
+          lhsArgs.lastOption.getOrElse(Ast(unknownNode(expr.getLeft, Constants.empty))),
+          rhsArgs.lastOption.getOrElse(Ast(unknownNode(expr.getRight, Constants.empty)))
+        )
       )
         .withChildren(annotations.map(astForAnnotationEntry))
     )
@@ -123,8 +126,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     argIdx: Option[Int],
     argNameMaybe: Option[String]
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(1)).headOption.getOrElse(Ast())
-    val argAsts     = selectorExpressionArgAsts(expr)
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(1)).headOption
+      .getOrElse(Ast(unknownNode(expr.getReceiverExpression, Constants.empty)))
+    val argAsts = selectorExpressionArgAsts(expr)
     registerType(typeInfoProvider.containingDeclType(expr, TypeConstants.any))
     val retType = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
     val node = withArgumentIndex(
@@ -139,8 +143,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     argIdx: Option[Int],
     argNameMaybe: Option[String]
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(0)).headOption.getOrElse(Ast())
-    val argAsts     = selectorExpressionArgAsts(expr)
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(0)).headOption
+      .getOrElse(Ast(unknownNode(expr.getReceiverExpression, Constants.empty)))
+    val argAsts = selectorExpressionArgAsts(expr)
 
     val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
     val (fullName, signature) =
@@ -169,8 +174,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     argIdx: Option[Int],
     argNameMaybe: Option[String]
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(0)).headOption.getOrElse(Ast())
-    val argAsts     = selectorExpressionArgAsts(expr)
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(0)).headOption
+      .getOrElse(Ast(unknownNode(expr.getReceiverExpression, Constants.empty)))
+    val argAsts = selectorExpressionArgAsts(expr)
 
     val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
     val (fullName, signature) =
@@ -266,8 +272,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     argIdx: Option[Int],
     argNameMaybe: Option[String]
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(1)).headOption.getOrElse(Ast())
-    val argAsts     = selectorExpressionArgAsts(expr)
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(1)).headOption
+      .getOrElse(Ast(unknownNode(expr.getReceiverExpression, Constants.empty)))
+    val argAsts = selectorExpressionArgAsts(expr)
 
     val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
     val (fullName, signature) =
@@ -303,8 +310,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       if (callKind == CallKinds.DynamicCall) DispatchTypes.DYNAMIC_DISPATCH
       else DispatchTypes.STATIC_DISPATCH
 
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(argIdxForReceiver)).headOption.getOrElse(Ast())
-    val argAsts     = selectorExpressionArgAsts(expr)
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(argIdxForReceiver)).headOption
+      .getOrElse(Ast(unknownNode(expr.getReceiverExpression, Constants.empty)))
+    val argAsts = selectorExpressionArgAsts(expr)
 
     val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
     val (fullName, signature) =
@@ -502,7 +510,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       withIndex(expr.getValueArguments.asScala.toSeq) { case (arg, idx) =>
         val argNameOpt = if (arg.isNamed) Option(arg.getArgumentName.getAsName.toString) else None
         val asts       = astsForExpression(arg.getArgumentExpression, Option(idx), argNameOpt)
-        (asts.dropRight(1), asts.lastOption.getOrElse(Ast()))
+        (asts.dropRight(1), asts.lastOption.getOrElse(Ast(unknownNode(arg.getArgumentExpression, Constants.empty))))
       }
     val astsForTrails    = argAstsWithTrail.map(_._2)
     val astsForNonTrails = argAstsWithTrail.map(_._1).flatten

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
@@ -110,7 +110,10 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     val lhsArgs = astsForExpression(expr.getLeft, None)
     val rhsArgs = astsForExpression(expr.getRight, None)
     lhsArgs.dropRight(1) ++ rhsArgs.dropRight(1) ++ Seq(
-      callAst(withArgumentIndex(node, argIdx).argumentName(argNameMaybe), List(lhsArgs.last, rhsArgs.last))
+      callAst(
+        withArgumentIndex(node, argIdx).argumentName(argNameMaybe),
+        List(lhsArgs.lastOption.getOrElse(Ast()), rhsArgs.lastOption.getOrElse(Ast()))
+      )
         .withChildren(annotations.map(astForAnnotationEntry))
     )
   }
@@ -120,7 +123,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     argIdx: Option[Int],
     argNameMaybe: Option[String]
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(1)).head
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(1)).headOption.getOrElse(Ast())
     val argAsts     = selectorExpressionArgAsts(expr)
     registerType(typeInfoProvider.containingDeclType(expr, TypeConstants.any))
     val retType = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
@@ -136,7 +139,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     argIdx: Option[Int],
     argNameMaybe: Option[String]
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(0)).head
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(0)).headOption.getOrElse(Ast())
     val argAsts     = selectorExpressionArgAsts(expr)
 
     val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
@@ -166,7 +169,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     argIdx: Option[Int],
     argNameMaybe: Option[String]
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(0)).head
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(0)).headOption.getOrElse(Ast())
     val argAsts     = selectorExpressionArgAsts(expr)
 
     val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
@@ -263,7 +266,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     argIdx: Option[Int],
     argNameMaybe: Option[String]
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(1)).head
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(1)).headOption.getOrElse(Ast())
     val argAsts     = selectorExpressionArgAsts(expr)
 
     val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
@@ -300,7 +303,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       if (callKind == CallKinds.DynamicCall) DispatchTypes.DYNAMIC_DISPATCH
       else DispatchTypes.STATIC_DISPATCH
 
-    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(argIdxForReceiver)).head
+    val receiverAst = astsForExpression(expr.getReceiverExpression, Some(argIdxForReceiver)).headOption.getOrElse(Ast())
     val argAsts     = selectorExpressionArgAsts(expr)
 
     val (astDerivedMethodFullName, astDerivedSignature) = astDerivedFullNameWithSignature(expr, argAsts)
@@ -499,7 +502,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       withIndex(expr.getValueArguments.asScala.toSeq) { case (arg, idx) =>
         val argNameOpt = if (arg.isNamed) Option(arg.getArgumentName.getAsName.toString) else None
         val asts       = astsForExpression(arg.getArgumentExpression, Option(idx), argNameOpt)
-        (asts.dropRight(1), asts.last)
+        (asts.dropRight(1), asts.lastOption.getOrElse(Ast()))
       }
     val astsForTrails    = argAstsWithTrail.map(_._2)
     val astsForNonTrails = argAstsWithTrail.map(_._1).flatten

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -57,7 +57,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
             val blockChildAsts =
               if (asts.nonEmpty) {
                 val allStatementsButLast = asts.dropRight(1)
-                val lastStatementAst     = asts.lastOption.getOrElse(Ast())
+                val lastStatementAst     = asts.lastOption.getOrElse(Ast(unknownNode(expr, Constants.empty)))
                 val returnAst_           = returnAst(returnNode(expr, Constants.retCode), Seq(lastStatementAst))
                 (allStatementsButLast ++ Seq(returnAst_)).toList
               } else List()
@@ -71,7 +71,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     methodAstParentStack.pop()
     scope.popScope()
 
-    val bodyAst           = bodyAsts.headOption.getOrElse(Ast())
+    val bodyAst           = bodyAsts.headOption.getOrElse(Ast(unknownNode(ktFn, Constants.empty)))
     val otherBodyAsts     = bodyAsts.drop(1)
     val explicitTypeName  = Option(ktFn.getTypeReference).map(_.getText).getOrElse(TypeConstants.any)
     val typeFullName      = registerType(typeInfoProvider.returnType(ktFn, explicitTypeName))
@@ -172,7 +172,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     val returnTypeFullName     = TypeConstants.javaLangObject
     val lambdaTypeDeclFullName = fullName.split(":").head
 
-    val bodyAst = bodyAsts.headOption.getOrElse(Ast())
+    val bodyAst = bodyAsts.headOption.getOrElse(Ast(unknownNode(fn, Constants.empty)))
     val lambdaMethodAst = methodAst(
       lambdaMethodNode,
       parametersAsts,
@@ -293,7 +293,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     val returnTypeFullName     = registerType(typeInfoProvider.returnTypeFullName(expr))
     val lambdaTypeDeclFullName = fullName.split(":").head
 
-    val bodyAst = bodyAsts.headOption.getOrElse(Ast())
+    val bodyAst = bodyAsts.headOption.getOrElse(Ast(unknownNode(expr, Constants.empty)))
     val lambdaMethodAst = methodAst(
       lambdaMethodNode,
       parametersAsts,

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -57,7 +57,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
             val blockChildAsts =
               if (asts.nonEmpty) {
                 val allStatementsButLast = asts.dropRight(1)
-                val lastStatementAst     = asts.last
+                val lastStatementAst     = asts.lastOption.getOrElse(Ast())
                 val returnAst_           = returnAst(returnNode(expr, Constants.retCode), Seq(lastStatementAst))
                 (allStatementsButLast ++ Seq(returnAst_)).toList
               } else List()
@@ -71,7 +71,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     methodAstParentStack.pop()
     scope.popScope()
 
-    val bodyAst           = bodyAsts.head
+    val bodyAst           = bodyAsts.headOption.getOrElse(Ast())
     val otherBodyAsts     = bodyAsts.drop(1)
     val explicitTypeName  = Option(ktFn.getTypeReference).map(_.getText).getOrElse(TypeConstants.any)
     val typeFullName      = registerType(typeInfoProvider.returnType(ktFn, explicitTypeName))
@@ -172,7 +172,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     val returnTypeFullName     = TypeConstants.javaLangObject
     val lambdaTypeDeclFullName = fullName.split(":").head
 
-    val bodyAst = bodyAsts.head
+    val bodyAst = bodyAsts.headOption.getOrElse(Ast())
     val lambdaMethodAst = methodAst(
       lambdaMethodNode,
       parametersAsts,
@@ -293,7 +293,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     val returnTypeFullName     = registerType(typeInfoProvider.returnTypeFullName(expr))
     val lambdaTypeDeclFullName = fullName.split(":").head
 
-    val bodyAst = bodyAsts.head
+    val bodyAst = bodyAsts.headOption.getOrElse(Ast())
     val lambdaMethodAst = methodAst(
       lambdaMethodNode,
       parametersAsts,

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -509,13 +509,19 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
       if (implicitReturnAroundLastStatement && statements.nonEmpty) {
         val _returnNode          = returnNode(statements.last, Constants.retCode)
         val astsForLastStatement = astsForExpression(statements.last, Some(1))
-        (
-          astsForLastStatement.dropRight(1),
-          Some(returnAst(_returnNode, Seq(astsForLastStatement.lastOption.getOrElse(Ast()))))
-        )
+        if (astsForLastStatement.isEmpty)
+          (Seq(), None)
+        else
+          (
+            astsForLastStatement.dropRight(1),
+            Some(returnAst(_returnNode, Seq(astsForLastStatement.lastOption.getOrElse(Ast()))))
+          )
       } else if (statements.nonEmpty) {
         val astsForLastStatement = astsForExpression(statements.last, None)
-        (astsForLastStatement.dropRight(1), Some(astsForLastStatement.lastOption.getOrElse(Ast())))
+        if (astsForLastStatement.isEmpty)
+          (Seq(), None)
+        else
+          (astsForLastStatement.dropRight(1), Some(astsForLastStatement.lastOption.getOrElse(Ast())))
       } else (Seq(), None)
 
     if (pushToScope) scope.popScope()

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -509,10 +509,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
       if (implicitReturnAroundLastStatement && statements.nonEmpty) {
         val _returnNode          = returnNode(statements.last, Constants.retCode)
         val astsForLastStatement = astsForExpression(statements.last, Some(1))
-        (astsForLastStatement.dropRight(1), Some(returnAst(_returnNode, Seq(astsForLastStatement.last))))
+        (
+          astsForLastStatement.dropRight(1),
+          Some(returnAst(_returnNode, Seq(astsForLastStatement.lastOption.getOrElse(Ast()))))
+        )
       } else if (statements.nonEmpty) {
         val astsForLastStatement = astsForExpression(statements.last, None)
-        (astsForLastStatement.dropRight(1), Some(astsForLastStatement.last))
+        (astsForLastStatement.dropRight(1), Some(astsForLastStatement.lastOption.getOrElse(Ast())))
       } else (Seq(), None)
 
     if (pushToScope) scope.popScope()


### PR DESCRIPTION
This PR aims to use `headOption` and `lastOption` instead of `head` and `last` when accessing from Seq[Ast]