### PR TITLE
[pysrc2cpg] Literals in Method Return Fix

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -9,6 +9,8 @@ import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.FieldAccess
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
+import scala.collection.immutable.{AbstractSet, SortedSet}
+
 class PythonTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())
     extends XTypeRecoveryPass[File](cpg, config) {
 
@@ -170,7 +172,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     (s.startsWith("\"") || s.startsWith("'")) && (s.endsWith("\"") || s.endsWith("'"))
 
   override def getLiteralType(l: Literal): Set[String] = {
-    (l.code match {
+    val literalTypes = (l.code match {
       case code if code.toIntOption.isDefined                  => Some(s"${PythonAstVisitor.builtinPrefix}int")
       case code if code.toDoubleOption.isDefined               => Some(s"${PythonAstVisitor.builtinPrefix}float")
       case code if "True".equals(code) || "False".equals(code) => Some(s"${PythonAstVisitor.builtinPrefix}bool")
@@ -178,6 +180,8 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
       case code if isPyString(code)                            => Some(s"${PythonAstVisitor.builtinPrefix}str")
       case _                                                   => None
     }).toSet
+    setTypes(l, literalTypes.toSeq)
+    literalTypes
   }
 
   override def createCallFromIdentifierTypeFullName(typeFullName: String, callName: String): String = {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1180,4 +1180,22 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
   }
 
+  "Literals as the returns of calls" should {
+    val cpg = code("""
+        |def foo():
+        | return "bar"
+        |
+        |x = foo()
+        |""".stripMargin)
+
+    "set the literal's type" in {
+      val barLiteral :: Nil = cpg.method("foo").methodReturn.toReturn.ast.isLiteral.l: @unchecked
+      barLiteral.typeFullName shouldBe "__builtin.str"
+    }
+
+    "set the method's return value correctly" in {
+      cpg.method("foo").methodReturn.typeFullName.head shouldBe "__builtin.str"
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -899,8 +899,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     )
     @tailrec
     def extractTypes(xs: List[CfgNode]): Set[String] = xs match {
-      case ::(head: Literal, Nil) if head.typeFullName != "ANY" =>
-        Set(head.typeFullName)
+      case ::(head: Literal, Nil) => getLiteralType(head)
       case ::(head: Call, Nil) if head.name == Operators.fieldAccess =>
         val fieldAccess = new FieldAccess(head)
         val (sym, ts)   = getSymbolFromCall(fieldAccess)


### PR DESCRIPTION
Fixes literals in method returns not having type information populated. This done via the type recovery pass.