### PR TITLE
[TypeRecovery] Prevent Adding Method Refs Under Operators

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -1064,7 +1064,12 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
         .filterNot(m => addedNodes.contains(s"${funcPtr.id()}${NodeTypes.METHOD_REF}$pathSep${m.fullName}"))
         .map(m => m -> createMethodRef(baseName, funcName, m.fullName, funcPtr.lineNumber, funcPtr.columnNumber))
         .foreach { case (m, mRef) =>
-          funcPtr.astParent
+          funcPtr
+            .map { ptr =>
+              ptr.astParent match
+                case parent: Call if parent.name.startsWith("<operator>") => ptr
+                case parent                                               => parent
+            }
             .filterNot(_.astChildren.isMethodRef.exists(_.methodFullName == mRef.methodFullName))
             .foreach { inCall =>
               state.changesWereMade.compareAndSet(false, true)


### PR DESCRIPTION
Fixes a bug where method refs may add an additional argument under an operator assignment.