### PR TITLE
[(js|kotlin)src2cpg] - Refactor the Local Node Creation to use `localNode` Where Possible

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -4,7 +4,7 @@ import io.joern.jssrc2cpg.datastructures.*
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.{Ast, ValidationMode, AstNodeBuilder}
 import io.joern.x2cpg.utils.NodeBuilders.{newClosureBindingNode, newLocalNode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies}
@@ -69,9 +69,9 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     defaultName
       .orElse(codeForBabelNodeInfo(nodeInfo).headOption)
       .getOrElse {
-        val tmpName   = generateUnusedVariableName(usedVariableNames, "_tmp")
-        val localNode = newLocalNode(tmpName, Defines.Any).order(0)
-        diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
+        val tmpName    = generateUnusedVariableName(usedVariableNames, "_tmp")
+        val nLocalNode = localNode(nodeInfo, tmpName, tmpName, Defines.Any).order(0)
+        diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
         tmpName
       }
   }
@@ -313,6 +313,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     methodScopeNodeId: NewNode,
     variableName: String
   ): (NewNode, ScopeType) = {
+    println("createMethodLocalForUnresolvedReference: " + variableName)
     val local = newLocalNode(variableName, Defines.Any).order(0)
     diffGraph.addEdge(methodScopeNodeId, local, EdgeTypes.AST)
     (local, MethodScope)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -313,7 +313,6 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     methodScopeNodeId: NewNode,
     variableName: String
   ): (NewNode, ScopeType) = {
-    println("createMethodLocalForUnresolvedReference: " + variableName)
     val local = newLocalNode(variableName, Defines.Any).order(0)
     diffGraph.addEdge(methodScopeNodeId, local, EdgeTypes.AST)
     (local, MethodScope)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -4,9 +4,9 @@ import io.joern.jssrc2cpg.datastructures.{BlockScope, MethodScope, ScopeType}
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.{Ast, ValidationMode, AstNodeBuilder}
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.utils.NodeBuilders.{newDependencyNode, newLocalNode}
+import io.joern.x2cpg.utils.NodeBuilders.{newDependencyNode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewImport}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes}
 import ujson.Value
@@ -132,10 +132,10 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     } else {
       val strippedCode = cleanImportName(fromName).stripPrefix("_")
       val id           = identifierNode(declaration, s"_$strippedCode")
-      val localNode    = newLocalNode(id.code, Defines.Any).order(0)
-      scope.addVariable(id.code, localNode, BlockScope)
+      val nLocalNode   = localNode(declaration, id.code, id.code, Defines.Any).order(0)
+      scope.addVariable(id.code, nLocalNode, BlockScope)
       scope.addVariableReference(id.code, id)
-      diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
+      diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
 
       val sourceCallArgNode = literalNode(declaration, s"\"${fromName.stripPrefix("_")}\"", None)
       val sourceCall =
@@ -340,9 +340,9 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       case Identifier => idNodeInfo.json("name").str
       case _          => idNodeInfo.code
     }
-    val localNode = newLocalNode(idName, typeFullName).order(0)
-    scope.addVariable(idName, localNode, scopeType)
-    diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
+    val nLocalNode = localNode(declNodeInfo, idName, idName, typeFullName).order(0)
+    scope.addVariable(idName, nLocalNode, scopeType)
+    diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
 
     if (initNodeInfo.isEmpty) {
       Ast()
@@ -407,12 +407,12 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     isImportN: Boolean,
     nodeInfo: BabelNodeInfo
   ): Ast = {
-    val destName  = alias.getOrElse(name)
-    val destNode  = identifierNode(nodeInfo, destName)
-    val localNode = newLocalNode(destName, Defines.Any).order(0)
-    scope.addVariable(destName, localNode, BlockScope)
+    val destName   = alias.getOrElse(name)
+    val destNode   = identifierNode(nodeInfo, destName)
+    val nLocalNode = localNode(nodeInfo, destName, destName, Defines.Any).order(0)
+    scope.addVariable(destName, nLocalNode, BlockScope)
     scope.addVariableReference(destName, destNode)
-    diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
+    diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
 
     val destAst           = Ast(destNode)
     val sourceCallArgNode = literalNode(nodeInfo, s"\"$from\"", None)
@@ -526,9 +526,9 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
   private def convertDestructingObjectElement(element: BabelNodeInfo, key: BabelNodeInfo, localTmpName: String): Ast = {
     val valueAst = astForNode(element.json)
 
-    val localNode = newLocalNode(element.code, Defines.Any).order(0)
-    diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
-    scope.addVariable(element.code, localNode, MethodScope)
+    val nLocalNode = localNode(element, element.code, element.code, Defines.Any).order(0)
+    diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
+    scope.addVariable(element.code, nLocalNode, MethodScope)
 
     val fieldAccessTmpNode = identifierNode(element, localTmpName)
     val keyNode            = createFieldIdentifierNode(key.code, key.lineNumber, key.columnNumber)
@@ -545,9 +545,9 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
   private def convertDestructingArrayElement(element: BabelNodeInfo, index: Int, localTmpName: String): Ast = {
     val valueAst = astForNode(element.json)
 
-    val localNode = newLocalNode(element.code, Defines.Any).order(0)
-    diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
-    scope.addVariable(element.code, localNode, MethodScope)
+    val nLocalNode = localNode(element, element.code, element.code, Defines.Any).order(0)
+    diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
+    scope.addVariable(element.code, nLocalNode, MethodScope)
 
     val fieldAccessTmpNode = identifierNode(element, localTmpName)
     val keyNode            = literalNode(element, index.toString, Option(Defines.Number))
@@ -672,10 +672,10 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     scope.pushNewBlockScope(blockNode)
     localAstParentStack.push(blockNode)
 
-    val localNode = newLocalNode(localTmpName, Defines.Any).order(0)
-    val tmpNode   = identifierNode(pattern, localTmpName)
-    diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
-    scope.addVariable(localTmpName, localNode, BlockScope)
+    val nLocalNode = localNode(pattern, localTmpName, localTmpName, Defines.Any).order(0)
+    val tmpNode    = identifierNode(pattern, localTmpName)
+    diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
+    scope.addVariable(localTmpName, nLocalNode, BlockScope)
     scope.addVariableReference(localTmpName, tmpNode)
 
     val rhsAssignmentAst = paramName.map(createParamAst(pattern, _, sourceAst)).getOrElse(sourceAst)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -3,9 +3,8 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.{Defines, EcmaBuiltins, GlobalBuiltins}
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.{Ast, ValidationMode, AstNodeBuilder}
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.utils.NodeBuilders.newLocalNode
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
 
@@ -110,7 +109,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     localAstParentStack.push(blockNode)
 
     val tmpAllocName      = generateUnusedVariableName(usedVariableNames, "_tmp")
-    val localTmpAllocNode = newLocalNode(tmpAllocName, Defines.Any).order(0)
+    val localTmpAllocNode = localNode(newExpr, tmpAllocName, tmpAllocName, Defines.Any).order(0)
     val tmpAllocNode1     = identifierNode(newExpr, tmpAllocName)
     diffGraph.addEdge(localAstParentStack.head, localTmpAllocNode, EdgeTypes.AST)
     scope.addVariableReference(tmpAllocName, tmpAllocNode1)
@@ -356,7 +355,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       localAstParentStack.push(blockNode)
 
       val tmpName      = generateUnusedVariableName(usedVariableNames, "_tmp")
-      val localTmpNode = newLocalNode(tmpName, Defines.Any).order(0)
+      val localTmpNode = localNode(arrExpr, tmpName, tmpName, Defines.Any).order(0)
       val tmpArrayNode = identifierNode(arrExpr, tmpName)
       diffGraph.addEdge(localAstParentStack.head, localTmpNode, EdgeTypes.AST)
       scope.addVariableReference(tmpName, tmpArrayNode)
@@ -425,9 +424,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     scope.pushNewBlockScope(blockNode)
     localAstParentStack.push(blockNode)
 
-    val tmpName   = generateUnusedVariableName(usedVariableNames, "_tmp")
-    val localNode = newLocalNode(tmpName, Defines.Any).order(0)
-    diffGraph.addEdge(localAstParentStack.head, localNode, EdgeTypes.AST)
+    val tmpName      = generateUnusedVariableName(usedVariableNames, "_tmp")
+    val localTmpNode = localNode(objExpr, tmpName, tmpName, Defines.Any).order(0)
+    diffGraph.addEdge(localAstParentStack.head, localTmpNode, EdgeTypes.AST)
 
     val propertiesAsts = objExpr.json("properties").arr.toList.map { property =>
       val nodeInfo = createBabelNodeInfo(property)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -4,8 +4,7 @@ import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.{Ast, ValidationMode}
-import io.joern.x2cpg.utils.NodeBuilders.newLocalNode
+import io.joern.x2cpg.{Ast, ValidationMode, AstNodeBuilder}
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
@@ -306,7 +305,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     // _iterator assignment:
     val iteratorName      = generateUnusedVariableName(usedVariableNames, "_iterator")
-    val iteratorLocalNode = newLocalNode(iteratorName, Defines.Any).order(0)
+    val iteratorLocalNode = localNode(forInOfStmt, iteratorName, iteratorName, Defines.Any).order(0)
     val iteratorNode      = identifierNode(forInOfStmt, iteratorName)
     diffGraph.addEdge(localAstParentStack.head, iteratorLocalNode, EdgeTypes.AST)
     scope.addVariableReference(iteratorName, iteratorNode)
@@ -336,7 +335,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     // _result:
     val resultName      = generateUnusedVariableName(usedVariableNames, "_result")
-    val resultLocalNode = newLocalNode(resultName, Defines.Any).order(0)
+    val resultLocalNode = localNode(forInOfStmt, resultName, resultName, Defines.Any).order(0)
     val resultNode      = identifierNode(forInOfStmt, resultName)
     diffGraph.addEdge(localAstParentStack.head, resultLocalNode, EdgeTypes.AST)
     scope.addVariableReference(resultName, resultNode)
@@ -344,7 +343,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     // loop variable:
     val loopVariableName = idNodeInfo.code
 
-    val loopVariableLocalNode = newLocalNode(loopVariableName, Defines.Any).order(0)
+    val loopVariableLocalNode = localNode(forInOfStmt, loopVariableName, loopVariableName, Defines.Any).order(0)
     val loopVariableNode      = identifierNode(forInOfStmt, loopVariableName)
     diffGraph.addEdge(localAstParentStack.head, loopVariableLocalNode, EdgeTypes.AST)
     scope.addVariableReference(loopVariableName, loopVariableNode)
@@ -457,7 +456,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     // _iterator assignment:
     val iteratorName      = generateUnusedVariableName(usedVariableNames, "_iterator")
-    val iteratorLocalNode = newLocalNode(iteratorName, Defines.Any).order(0)
+    val iteratorLocalNode = localNode(forInOfStmt, iteratorName, iteratorName, Defines.Any).order(0)
     val iteratorNode      = identifierNode(forInOfStmt, iteratorName)
     diffGraph.addEdge(localAstParentStack.head, iteratorLocalNode, EdgeTypes.AST)
     scope.addVariableReference(iteratorName, iteratorNode)
@@ -487,7 +486,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     // _result:
     val resultName      = generateUnusedVariableName(usedVariableNames, "_result")
-    val resultLocalNode = newLocalNode(resultName, Defines.Any).order(0)
+    val resultLocalNode = localNode(forInOfStmt, resultName, resultName, Defines.Any).order(0)
     val resultNode      = identifierNode(forInOfStmt, resultName)
     diffGraph.addEdge(localAstParentStack.head, resultLocalNode, EdgeTypes.AST)
     scope.addVariableReference(resultName, resultNode)
@@ -599,7 +598,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     // _iterator assignment:
     val iteratorName      = generateUnusedVariableName(usedVariableNames, "_iterator")
-    val iteratorLocalNode = newLocalNode(iteratorName, Defines.Any).order(0)
+    val iteratorLocalNode = localNode(forInOfStmt, iteratorName, iteratorName, Defines.Any).order(0)
     val iteratorNode      = identifierNode(forInOfStmt, iteratorName)
     diffGraph.addEdge(localAstParentStack.head, iteratorLocalNode, EdgeTypes.AST)
     scope.addVariableReference(iteratorName, iteratorNode)
@@ -628,7 +627,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     // _result:
     val resultName      = generateUnusedVariableName(usedVariableNames, "_result")
-    val resultLocalNode = newLocalNode(resultName, Defines.Any).order(0)
+    val resultLocalNode = localNode(forInOfStmt, resultName, resultName, Defines.Any).order(0)
     val resultNode      = identifierNode(forInOfStmt, resultName)
     diffGraph.addEdge(localAstParentStack.head, resultLocalNode, EdgeTypes.AST)
     scope.addVariableReference(resultName, resultNode)
@@ -636,7 +635,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     // loop variable:
     val loopVariableNames = idNodeInfo.json("properties").arr.toList.map(code)
 
-    val loopVariableLocalNodes = loopVariableNames.map(newLocalNode(_, Defines.Any).order(0))
+    val loopVariableLocalNodes = loopVariableNames.map(varName => localNode(forInOfStmt, varName, varName, Defines.Any))
     val loopVariableNodes      = loopVariableNames.map(identifierNode(forInOfStmt, _))
     loopVariableLocalNodes.foreach(diffGraph.addEdge(localAstParentStack.head, _, EdgeTypes.AST))
     loopVariableNames.zip(loopVariableNodes).foreach { case (loopVariableName, loopVariableNode) =>
@@ -753,7 +752,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     // _iterator assignment:
     val iteratorName      = generateUnusedVariableName(usedVariableNames, "_iterator")
-    val iteratorLocalNode = newLocalNode(iteratorName, Defines.Any).order(0)
+    val iteratorLocalNode = localNode(forInOfStmt, iteratorName, iteratorName, Defines.Any).order(0)
     val iteratorNode      = identifierNode(forInOfStmt, iteratorName)
     diffGraph.addEdge(localAstParentStack.head, iteratorLocalNode, EdgeTypes.AST)
     scope.addVariableReference(iteratorName, iteratorNode)
@@ -781,7 +780,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     // _result:
     val resultName      = generateUnusedVariableName(usedVariableNames, "_result")
-    val resultLocalNode = newLocalNode(resultName, Defines.Any).order(0)
+    val resultLocalNode = localNode(forInOfStmt, resultName, resultName, Defines.Any).order(0)
     val resultNode      = identifierNode(forInOfStmt, resultName)
     diffGraph.addEdge(localAstParentStack.head, resultLocalNode, EdgeTypes.AST)
     scope.addVariableReference(resultName, resultNode)
@@ -789,7 +788,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     // loop variable:
     val loopVariableNames = idNodeInfo.json("elements").arr.toList.map(code)
 
-    val loopVariableLocalNodes = loopVariableNames.map(newLocalNode(_, Defines.Any).order(0))
+    val loopVariableLocalNodes = loopVariableNames.map(varName => localNode(forInOfStmt, varName, varName, Defines.Any))
     val loopVariableNodes      = loopVariableNames.map(identifierNode(forInOfStmt, _))
     loopVariableLocalNodes.foreach(diffGraph.addEdge(localAstParentStack.head, _, EdgeTypes.AST))
     loopVariableNames.zip(loopVariableNodes).foreach { case (loopVariableName, loopVariableNode) =>

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -4,9 +4,9 @@ import io.joern.jssrc2cpg.datastructures.BlockScope
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.jssrc2cpg.passes.Defines
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.{Ast, ValidationMode, AstNodeBuilder}
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newLocalNode}
+import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, ModifierTypes, Operators}
 import ujson.Value
@@ -389,7 +389,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       val constructorRefNode =
         methodRefNode(clazz, constructorNode.code, constructorNode.fullName, constructorNode.fullName)
 
-      val idLocal = newLocalNode(typeName, Defines.Any).order(0)
+      val idLocal = localNode(clazz, typeName, typeName, Defines.Any).order(0)
       diffGraph.addEdge(localAstParentStack.head, idLocal, EdgeTypes.AST)
       scope.addVariable(typeName, idLocal, BlockScope)
       scope.addVariableReference(typeName, classIdNode)

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/slicing/JsUsageSliceTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/slicing/JsUsageSliceTests.scala
@@ -54,7 +54,7 @@ class JsUsageSliceTests extends DataFlowCodeToCpgSuite {
     "extract 'express.js' slice" in {
       val slice = programSlice.objectSlices.find(x => x.fullName == "main.js::program").flatMap(_.slices.headOption).get
       slice.definedBy shouldBe Some(CallDef("express", "ANY", Option("express"), Option(2), Option(12)))
-      slice.targetObj shouldBe LocalDef("app", "express:<returnValue>")
+      slice.targetObj shouldBe LocalDef("app", "express:<returnValue>", Some(2), Some(6))
 
       val inv1 = slice.invokedCalls.find(_.callName == "get").get
       val inv2 = slice.invokedCalls.find(_.callName == "listen").get
@@ -93,7 +93,7 @@ class JsUsageSliceTests extends DataFlowCodeToCpgSuite {
       slice.definedBy shouldBe Some(
         CallDef("new Car", "main.js::program:Car", Option("main.js::program:Car"), Some(32), Some(14))
       )
-      slice.targetObj shouldBe LocalDef("c", "main.js::program:Car")
+      slice.targetObj shouldBe LocalDef("c", "main.js::program:Car", Some(32), Some(10))
 
       val inv1 = slice.invokedCalls.find(_.callName == "Car").get
       val inv2 = slice.invokedCalls.find(_.callName == "rev").get
@@ -150,7 +150,7 @@ class JsUsageSliceTests extends DataFlowCodeToCpgSuite {
 
     "extract 'x' local variable" in {
       val slice = programSlice.objectSlices.find(x => x.fullName == "main.js::program").flatMap(_.slices.headOption).get
-      slice.targetObj shouldBe LocalDef("x", "main.js::program:Foo")
+      slice.targetObj shouldBe LocalDef("x", "main.js::program:Foo", Some(17), Some(6))
       slice.definedBy shouldBe Option(
         CallDef("new Foo", "main.js::program:Foo", Some("main.js::program:Foo"), Some(17), Some(10))
       )

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
@@ -6,8 +6,8 @@ import io.joern.kotlin2cpg.psi.PsiUtils
 import io.joern.kotlin2cpg.psi.PsiUtils.nonUnderscoreDestructuringEntries
 import io.joern.kotlin2cpg.types.{AnonymousObjectContext, TypeConstants, TypeInfoProvider}
 import io.joern.x2cpg.utils.NodeBuilders
-import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newIdentifierNode, newLocalNode, newMethodReturnNode}
-import io.joern.x2cpg.{Ast, Defines, ValidationMode}
+import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newIdentifierNode, newMethodReturnNode}
+import io.joern.x2cpg.{Ast, AstNodeBuilder, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewCall, NewMethod, NewTypeDecl}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
@@ -248,7 +248,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       case _                   => false
     }
     val tmpName         = s"${Constants.tmpLocalPrefix}${tmpKeyPool.next}"
-    val localForTmpNode = newLocalNode(tmpName, callRhsTypeFullName)
+    val localForTmpNode = localNode(expr, tmpName, tmpName, callRhsTypeFullName)
     scope.addToScope(localForTmpNode.name, localForTmpNode)
     val localForTmpAst = Ast(localForTmpNode)
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
@@ -3,8 +3,7 @@ package io.joern.kotlin2cpg.ast
 import io.joern.kotlin2cpg.Constants
 import io.joern.kotlin2cpg.ast.Nodes.operatorCallNode
 import io.joern.kotlin2cpg.types.{CallKinds, TypeConstants, TypeInfoProvider}
-import io.joern.x2cpg.utils.NodeBuilders.newLocalNode
-import io.joern.x2cpg.{Ast, Defines, ValidationMode}
+import io.joern.x2cpg.{Ast, AstNodeBuilder, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import org.jetbrains.kotlin.lexer.{KtToken, KtTokens}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewMethodRef}
@@ -480,7 +479,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     val typeFullName = registerType(typeInfoProvider.expressionType(expr, Defines.UnresolvedNamespace))
     val tmpBlockNode = blockNode(expr, "", typeFullName)
     val tmpName      = s"${Constants.tmpLocalPrefix}${tmpKeyPool.next}"
-    val tmpLocalNode = newLocalNode(tmpName, typeFullName)
+    val tmpLocalNode = localNode(expr, tmpName, tmpName, typeFullName)
     scope.addToScope(tmpName, tmpLocalNode)
     val tmpLocalAst = Ast(tmpLocalNode)
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -4,8 +4,8 @@ import io.joern.kotlin2cpg.Constants
 import io.joern.kotlin2cpg.ast.Nodes.modifierNode
 import io.joern.kotlin2cpg.types.{TypeConstants, TypeInfoProvider}
 import io.joern.x2cpg.utils.NodeBuilders
-import io.joern.x2cpg.{Ast, ValidationMode}
-import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newClosureBindingNode, newLocalNode, newMethodReturnNode}
+import io.joern.x2cpg.{Ast, AstNodeBuilder, ValidationMode}
+import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newClosureBindingNode, newMethodReturnNode}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, ModifierTypes}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewLocal, NewMember, NewMethodParameterIn, NewNode}
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -146,7 +146,13 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
 
     val localsForCaptured = closureBindingEntriesForCaptured.map { case (closureBindingNode, capturedNodeContext) =>
       val node =
-        newLocalNode(capturedNodeContext.name, capturedNodeContext.typeFullName, closureBindingNode.closureBindingId)
+        localNode(
+          fn,
+          capturedNodeContext.name,
+          capturedNodeContext.name,
+          capturedNodeContext.typeFullName,
+          closureBindingNode.closureBindingId
+        )
       scope.addToScope(capturedNodeContext.name, node)
       node
     }
@@ -236,7 +242,13 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
 
     val localsForCaptured = closureBindingEntriesForCaptured.map { case (closureBindingNode, capturedNodeContext) =>
       val node =
-        newLocalNode(capturedNodeContext.name, capturedNodeContext.typeFullName, closureBindingNode.closureBindingId)
+        localNode(
+          expr,
+          capturedNodeContext.name,
+          capturedNodeContext.name,
+          capturedNodeContext.typeFullName,
+          closureBindingNode.closureBindingId
+        )
       scope.addToScope(capturedNodeContext.name, node)
       node
     }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -3,8 +3,8 @@ package io.joern.kotlin2cpg.ast
 import io.joern.kotlin2cpg.Constants
 import io.joern.kotlin2cpg.ast.Nodes.operatorCallNode
 import io.joern.kotlin2cpg.types.{TypeConstants, TypeInfoProvider}
-import io.joern.x2cpg.{Ast, ValidationMode}
-import io.joern.x2cpg.utils.NodeBuilders.{newIdentifierNode, newLocalNode}
+import io.joern.x2cpg.{Ast, AstNodeBuilder, ValidationMode}
+import io.joern.x2cpg.utils.NodeBuilders.{newIdentifierNode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import org.jetbrains.kotlin.psi.{
@@ -61,7 +61,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForForWithDestructuringLHS(expr: KtForExpression)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
     val loopRangeText         = expr.getLoopRange.getText
     val iteratorName          = s"${Constants.iteratorPrefix}${iteratorKeyPool.next()}"
-    val localForIterator      = newLocalNode(iteratorName, TypeConstants.any)
+    val localForIterator      = localNode(expr, iteratorName, iteratorName, TypeConstants.any)
     val iteratorAssignmentLhs = newIdentifierNode(iteratorName, TypeConstants.any)
     val iteratorLocalAst      = Ast(localForIterator).withRefEdge(iteratorAssignmentLhs, localForIterator)
 
@@ -117,7 +117,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
         .toList
 
     val tmpName     = s"${Constants.tmpLocalPrefix}${tmpKeyPool.next}"
-    val localForTmp = newLocalNode(tmpName, TypeConstants.any)
+    val localForTmp = localNode(expr, tmpName, tmpName, TypeConstants.any)
     scope.addToScope(localForTmp.name, localForTmp)
     val localForTmpAst = Ast(localForTmp)
 
@@ -180,7 +180,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForForWithSimpleVarLHS(expr: KtForExpression)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
     val loopRangeText         = expr.getLoopRange.getText
     val iteratorName          = s"${Constants.iteratorPrefix}${iteratorKeyPool.next()}"
-    val iteratorLocal         = newLocalNode(iteratorName, TypeConstants.any)
+    val iteratorLocal         = localNode(expr, iteratorName, iteratorName, TypeConstants.any)
     val iteratorAssignmentLhs = newIdentifierNode(iteratorName, TypeConstants.any)
     val iteratorLocalAst      = Ast(iteratorLocal).withRefEdge(iteratorAssignmentLhs, iteratorLocal)
 
@@ -226,7 +226,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
       typeInfoProvider.typeFullName(expr.getLoopParameter, TypeConstants.any)
     )
     val loopParameterName  = expr.getLoopParameter.getText
-    val loopParameterLocal = newLocalNode(loopParameterName, loopParameterTypeFullName)
+    val loopParameterLocal = localNode(expr, loopParameterName, loopParameterName, loopParameterTypeFullName)
     scope.addToScope(loopParameterName, loopParameterLocal)
 
     val loopParameterIdentifier = newIdentifierNode(loopParameterName, TypeConstants.any)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -236,7 +236,6 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
       .columnNumber(column(node))
   }
 
-  // USING THIS METHOD
   protected def localNode(
     node: Node,
     name: String,

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -236,6 +236,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
       .columnNumber(column(node))
   }
 
+  // USING THIS METHOD
   protected def localNode(
     node: Node,
     name: String,


### PR DESCRIPTION
Current creation of Local nodes in JS & kotlin dosen't have columnNumber, lineNumber.
We used same method to create LocalNodes as in other frontends.