### PR TITLE
[Performance] Replace `.ast` with `CONTAINS` Traversals where Possible

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -1,8 +1,8 @@
 package io.joern.dataflowengineoss.passes.reachingdef
 
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.utils.MemberAccess.{isFieldAccess, isGenericMemberAccessName}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -227,14 +227,10 @@ class ReachingDefTransferFunction(flowGraph: ReachingDefFlowGraph)
   private def initKill(method: Method, gen: Map[StoredNode, Set[Definition]]): Map[StoredNode, Set[Definition]] = {
 
     val allIdentifiers: Map[String, List[CfgNode]] = {
-      val results = mutable.Map.empty[String, List[CfgNode]]
-      method.ast
-        .collect {
-          case identifier: Identifier =>
-            (identifier.name, identifier)
-          case methodParameterIn: MethodParameterIn =>
-            (methodParameterIn.name, methodParameterIn)
-        }
+      val results             = mutable.Map.empty[String, List[CfgNode]]
+      val identifierName2Node = method._identifierViaContainsOut.map { identifier => (identifier.name, identifier) }
+      val paramName2Node      = method.parameter.map { parameter => (parameter.name, parameter) }
+      (identifierName2Node ++ paramName2Node)
         .foreach { case (name, node) =>
           val oldValues = results.getOrElse(name, Nil)
           results.put(name, node :: oldValues)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -1,12 +1,12 @@
 package io.joern.jssrc2cpg.passes
 
+import io.joern.x2cpg.Defines as XDefines
 import io.joern.x2cpg.Defines.ConstructorMethodName
-import io.joern.x2cpg.passes.frontend._
-import io.joern.x2cpg.{Defines => XDefines}
+import io.joern.x2cpg.passes.frontend.*
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.FieldAccess
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
@@ -94,8 +94,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
 
   private lazy val exportedIdentifiers = cu.method
     .nameExact(":program")
-    .ast
-    .isCall
+    .flatMap(_._callViaContainsOut)
     .nameExact(Operators.assignment)
     .filter(_.code.startsWith("exports.*"))
     .argument
@@ -185,7 +184,8 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
 
   override protected def postSetTypeInformation(): Unit = {
     // often there are "this" identifiers with type hints but this can be set to a type hint if they meet the criteria
-    cu.ast.isIdentifier
+    cu.method
+      .flatMap(_._identifierViaContainsOut)
       .nameExact("this")
       .where(_.typeFullNameExact(Defines.Any))
       .filterNot(_.dynamicTypeHintFullName.isEmpty)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XInheritanceFullNamePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XInheritanceFullNamePass.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.passes.ForkJoinParallelCpgPass
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 import java.io.File
 import java.nio.file.Paths
@@ -57,7 +57,9 @@ abstract class XInheritanceFullNamePass(cpg: Cpg) extends ForkJoinParallelCpgPas
   }
 
   protected def resolveInheritedTypeFullName(td: TypeDecl, builder: DiffGraphBuilder): Seq[TypeDeclBase] = {
-    val qualifiedNamesInScope = td.file.ast
+    val callsOfInterest     = td.file.method.flatMap(_._callViaContainsOut)
+    val typeDeclsOfInterest = td.file.typeDecl
+    val qualifiedNamesInScope = (callsOfInterest ++ typeDeclsOfInterest)
       .flatMap(extractTypeDeclFromNode)
       .filterNot(_.endsWith(moduleName))
       .l

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -321,14 +321,24 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     case x => x.getKnownTypes.nonEmpty
   }
 
-  protected def assignments: Iterator[Assignment] =
-    cu.ast.isCall.nameExact(Operators.assignment).map(new OpNodes.Assignment(_))
+  protected def assignments: Iterator[Assignment] = cu match {
+    case x: File =>
+      x.method.flatMap(_._callViaContainsOut).nameExact(Operators.assignment).map(new OpNodes.Assignment(_))
+    case x: Method => x.flatMap(_._callViaContainsOut).nameExact(Operators.assignment).map(new OpNodes.Assignment(_))
+    case x         => x.ast.isCall.nameExact(Operators.assignment).map(new OpNodes.Assignment(_))
+  }
 
-  protected def members: Iterator[Member] = cu.ast.isMember
+  protected def returns: Iterator[Return] = cu match {
+    case x: File   => x.method.flatMap(_._returnViaContainsOut)
+    case x: Method => x._returnViaContainsOut
+    case x         => x.ast.isReturn
+  }
 
-  protected def returns: Iterator[Return] = cu.ast.isReturn
-
-  protected def importNodes: Iterator[Import] = cu.ast.isCall.referencedImports
+  protected def importNodes: Iterator[Import] = cu match {
+    case x: File   => x.method.flatMap(_._callViaContainsOut).referencedImports
+    case x: Method => x.file.method.flatMap(_._callViaContainsOut).referencedImports
+    case x         => x.ast.isCall.referencedImports
+  }
 
   override def compute(): Boolean = try {
     // Set known aliases that point to imports for local and external methods/modules


### PR DESCRIPTION
Upon ingesting code bases with large methods that contain many child methods, the `.ast` call becomes extremely expensive on the top of the AST. This work reviews the performance of the CPG generation using the code reported in #3778 to inspect various "hanging" points which were largely related `.ast` calls. These `.ast` calls were replaced by their `_.containsOut` equivalent where appropriate to minimize the traversal depths.

Unfortunately, `XTypeRecovery` is still experimental and relies on `.ast`. Future work is planned to move this to `.statement` instead, and recover select symbols from which shortcut edges can be used. If `XTypeRecovery` hangs, the recommendation is to reduce the iterations to `1` or `0`.

Resolves #3778