### PR TITLE
c2cpg: removed org.jline dependency

### DIFF
--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -5,7 +5,6 @@ dependsOn(Projects.semanticcpg, Projects.dataflowengineoss % Test, Projects.x2cp
 libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
   "com.diffplug.spotless"   % "spotless-eclipse-cdt"       % "10.5.0",
-  "org.jline"               % "jline"                      % "3.23.0",
   "org.scalatest"          %% "scalatest"                  % Versions.scalatest % Test
 )
 


### PR DESCRIPTION
I don't know how this dependency slipped in there but it looks like it is not used at all.

@mpollmeier any idea? You added it with: https://github.com/joernio/joern/pull/816

All tests work fine and a locally build joern also works.