### PR TITLE
Kotlin2Cpg - Add handling when getting class name for unknown nodes

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -25,6 +25,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
 }
 import org.apache.commons.lang.StringUtils
 
+import scala.util.Try
 trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
   protected def line(node: Node): Option[Integer]
   protected def column(node: Node): Option[Integer]
@@ -46,7 +47,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
 
   protected def unknownNode(node: Node, code: String): NewUnknown = {
     NewUnknown()
-      .parserTypeName(node.getClass.getSimpleName)
+      .parserTypeName(Try(node.getClass.getSimpleName).toOption.getOrElse(Defines.Unknown))
       .code(code)
       .lineNumber(line(node))
       .columnNumber(column(node))


### PR DESCRIPTION
Currently, when forming an Unknown node there is a change that we are unable to get the `className` effectively. This PR aims to add handling for such cases.