### PR TITLE
[dataflowengineoss] Fix identifier name/code mismatch in the `sameVariable` function

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -356,7 +356,7 @@ private class UsageAnalyzer(
         call.argumentOption(1).exists(x => nodeToString(use).contains(x.code))
       case call: Call =>
         nodeToString(use).contains(call.code)
-      case identifier: Identifier => nodeToString(use).contains(identifier.code)
+      case identifier: Identifier => nodeToString(use).contains(identifier.name)
       case _                      => false
     }
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
@@ -16,8 +16,7 @@ class IntraMethodDataflowTests extends PhpCode2CpgFixture(runOssDataflow = true)
   }
 
   "flows between function calls should be found" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |function Foo() {
         |  $my_input = input();
         |  sink($my_input);
@@ -25,8 +24,8 @@ class IntraMethodDataflowTests extends PhpCode2CpgFixture(runOssDataflow = true)
         |""".stripMargin)
 
     val source = cpg.call("input")
-    val sink = cpg.call("sink")
-    val flows = sink.reachableByFlows(source)
+    val sink   = cpg.call("sink")
+    val flows  = sink.reachableByFlows(source)
 
     flows.size shouldBe 1
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
@@ -14,4 +14,20 @@ class IntraMethodDataflowTests extends PhpCode2CpgFixture(runOssDataflow = true)
 
     cpg.identifier.name("cmd").reachableBy(cpg.parameter.name("cmd")).size shouldBe 1
   }
+
+  "flows between function calls should be found" in {
+    val cpg = code(
+      """<?php
+        |function Foo() {
+        |  $my_input = input();
+        |  sink($my_input);
+        |}
+        |""".stripMargin)
+
+    val source = cpg.call("input")
+    val sink = cpg.call("sink")
+    val flows = sink.reachableByFlows(source)
+
+    flows.size shouldBe 1
+  }
 }


### PR DESCRIPTION
Fixes issue https://github.com/joernio/joern/issues/3745

I've discovered that no data flow is built between function calls, whereas data flows for the same code ported to `C` or `JavaScript` are found. Tracked down the problem to the function `sameVariable` of `DdgGenerator`. 

Problem is that this function compares two Nodes and tries to figures whether they are equal or not. With `PHP`, the node's _name_ is e.g. `my_input`, but the node's _code_ would be `$my_input` (mark the trailing $-sign). So the function fails by comparing the _name_ of the left node and the _code_ of the right node.

Added unit test.