### PR TITLE
[javasrc2cpg] Precise Variable Capturing by Lambdas

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -1,25 +1,11 @@
 package io.joern.javasrc2cpg.scope
 
-import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
-import io.shiftleft.codepropertygraph.generated.nodes.NewNamespace
-import io.shiftleft.codepropertygraph.generated.nodes.NewMethod
-import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
-import io.shiftleft.codepropertygraph.generated.nodes.NewTypeParameter
-import io.shiftleft.codepropertygraph.generated.nodes.NewImport
-import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
-import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterIn
-import io.shiftleft.codepropertygraph.generated.nodes.NewMember
-import io.shiftleft.codepropertygraph.generated.nodes.NewNode
-import io.shiftleft.codepropertygraph.generated.nodes.DeclarationNew
-
-import io.joern.javasrc2cpg.scope.Scope._
 import io.joern.javasrc2cpg.astcreation.ExpectedType
-
-import scala.collection.mutable
-import io.joern.x2cpg.utils.ListUtils._
-import io.shiftleft.codepropertygraph.generated.nodes.NewNamespaceBlock
-import io.joern.x2cpg.Ast
+import io.joern.javasrc2cpg.scope.Scope.*
 import io.joern.javasrc2cpg.util.NameConstants
+import io.joern.x2cpg.Ast
+import io.joern.x2cpg.utils.ListUtils.*
+import io.shiftleft.codepropertygraph.generated.nodes.*
 
 // TODO: Added for backwards compatibility with old scope methods, but is no longer
 //  strictly necessary due to stricter scope variable classes. Refactor AstCreator
@@ -181,7 +167,7 @@ class Scope {
   }
 
   // TODO: Refactor and remove this
-  def capturedVariables: List[ScopeVariable] = {
+  def variablesInScope: List[ScopeVariable] = {
     scopeStack
       .flatMap(_.getVariables())
       .collect {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -6,7 +6,8 @@ import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal, StoredNode}
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 


### PR DESCRIPTION
The closure bindings for Java lambdas are over-approximated to all variables in the surrounding context. This attempts to constrain this set to variables referenced in the AST body.

Note: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1739

Resolves #3790