### PR TITLE
[ruby] fix: double splat issue  

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/MethodOneTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/MethodOneTests.scala
@@ -183,4 +183,17 @@ class MethodOneTests extends RubyCode2CpgFixture(useDeprecatedFrontend = true) {
       }
     }
   }
+
+  "Function with double splat arg without explicit hash" should {
+    val cpg = code("""
+        |def foo(**)
+        |  x(y.merge(**),)
+        |end
+        |""".stripMargin)
+
+    "have a method node created for it" in {
+      cpg.method.name("foo").size shouldBe 1
+      cpg.method.name("foo").parameter.name("param_0").size shouldBe 1
+    }
+  }
 }


### PR DESCRIPTION
Ruby allows using double splat arguments without the attached hash for whatever reasons 🙄 Recently saw this in production code where the parser/frontend breaks. For example this is valid function definition:

```
def foo(**)
  bar(**)
end
```

While I've just added a test for now, there is a fix needed in both the new as well as old parsers