### PR TITLE
[CI/CD] GitHub Actions to Ignore `**.md` Edits

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master, main]
     tags: ["*"]
+    paths-ignore: ['**.md']
+
 jobs:
   test:
     concurrency: master

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,8 @@
 name: pr
-on: pull_request
+on:
+  pull_request:
+    paths-ignore: ['**.md']
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This prevents CI/CD to run if the only files edited are markdown files.

Docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

> When all the path names match patterns in paths-ignore, the workflow will not run. If any path names do not match patterns in paths-ignore, even if some path names match the patterns, the workflow will run.

Resolves #3803
