### PR TITLE
[rubysrc2cpg] implicit RETURN node handling for array/hash literals and method declarations

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -27,13 +27,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val stmtBlockAst = ParserAst(node.body) match
       case stmtList: StatementList => astForStatementListReturningLastExpression(stmtList)
-      case _: StaticLiteral =>
-        astForStatementListReturningLastExpression(StatementList(node.body, List(node.body)))
-      case _: BinaryExpression =>
-        astForStatementListReturningLastExpression(StatementList(node.body, List(node.body)))
-      case _: SingleAssignment =>
-        astForStatementListReturningLastExpression(StatementList(node.body, List(node.body)))
-      case _: SimpleIdentifier =>
+      case _: (StaticLiteral | BinaryExpression | SingleAssignment | SimpleIdentifier | ArrayLiteral | HashLiteral) =>
         astForStatementListReturningLastExpression(StatementList(node.body, List(node.body)))
       case body =>
         logger.warn(

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/ReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/ReturnTests.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.deprecated.passes.ast
 
-import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.joern.rubysrc2cpg.testfixtures.{DifferentInNewFrontend, RubyCode2CpgFixture}
 import io.shiftleft.codepropertygraph.generated.nodes.MethodRef
 import io.shiftleft.semanticcpg.language.*
 
@@ -13,7 +13,7 @@ class ReturnTests extends RubyCode2CpgFixture(useDeprecatedFrontend = true) {
         |end
         |""".stripMargin)
 
-    "return a method ref" in {
+    "return a method ref" taggedAs DifferentInNewFrontend in {
       val List(mRef: MethodRef) = cpg.method("new2").ast.isReturn.astChildren.l: @unchecked
       mRef.methodFullName shouldBe "Test0.rb::program.end_date"
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -1,8 +1,9 @@
 package io.joern.rubysrc2cpg.querying
 
+import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Return}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Return}
 import io.shiftleft.semanticcpg.language.*
 
 class MethodReturnTests extends RubyCode2CpgFixture {
@@ -54,6 +55,54 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
     r.code shouldBe "x"
     r.lineNumber shouldBe Some(3)
+  }
+
+  "implicit RETURN node for `[]` exists" in {
+    val cpg = code("""
+        |def f
+        | []
+        |end
+        |""".stripMargin)
+
+    val List(f)         = cpg.method.name("f").l
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+
+    r.code shouldBe "[]"
+    r.lineNumber shouldBe Some(3)
+
+    val List(c: Call) = r.astChildren.isCall.l
+    c.methodFullName shouldBe Operators.arrayInitializer
+  }
+
+  "implicit RETURN node for `{x:0}` exists" in {
+    val cpg = code("""
+        |def f = {x:0}
+        |""".stripMargin)
+
+    val List(f)         = cpg.method.name("f").l
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+
+    r.code shouldBe "{x:0}"
+    r.lineNumber shouldBe Some(2)
+
+    val List(c: Call) = r.astChildren.isCall.l
+    c.methodFullName shouldBe RubyOperators.hashInitializer
+  }
+
+  "implicit RETURN node for `def f ... end` exists" in {
+    val cpg = code("""
+        |def f
+        | def g = 0
+        |end
+        |""".stripMargin)
+
+    // Lowered as `def f; def g = 0; return :g; end`
+    val List(f)         = cpg.method.name("f").l
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+
+    val List(s: Literal) = r.astChildren.isLiteral.l
+    s.code shouldBe ":g"
+    s.typeFullName shouldBe "__builtin.Symbol"
   }
 
   "explicit RETURN node for `\"\"` exists" in {


### PR DESCRIPTION
* Expands the implicit RETURN node handling for array and hash literals.
* When the last statement in a method is another method declaration, the result of invoking the outer method is the name of the inner method, e.g. invoking `f` after the following snippet returns `:g` (a symbol literal), rather than the method declaration itself:

```ruby
def f
  def g = 0
end
f # returns :g
```

In the "v1" ruby frontend we would return a METHOD_REF. In the "v2" we explicitly return the symbol name.