### PR TITLE
[rubysrc2cpg] support `if-then-elsif-else-end` expressions

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -118,4 +118,73 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     r.lineNumber shouldBe Some(3)
   }
 
+  "implicit RETURN node for `if-end` expression" in {
+    val cpg = code("""
+        |def f
+        | if true then
+        |   20
+        | end
+        |end""".stripMargin)
+
+    // Lowered as `def f; return true ? 20 : nil; end`
+    val List(f)         = cpg.method.name("f").l
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+    val List(c: Call)   = r.astChildren.isCall.l
+
+    c.methodFullName shouldBe Operators.conditional
+    val test      = c.argument(1)
+    val blockThen = c.argument(2)
+    val blockElse = c.argument(3)
+
+    test.code shouldBe "true"
+    test.lineNumber shouldBe Some(3)
+    blockThen.isBlock shouldBe true
+    blockElse.isBlock shouldBe true
+
+    val List(twenty: Literal) = blockThen.astChildren.l: @unchecked
+    twenty.code shouldBe "20"
+    twenty.lineNumber shouldBe Some(4)
+    twenty.typeFullName shouldBe "__builtin.Integer"
+
+    val List(nil: Literal) = blockElse.astChildren.l: @unchecked
+    nil.code shouldBe "nil"
+    nil.typeFullName shouldBe "__builtin.NilClass"
+  }
+
+  "implicit RETURN node for `if-else-end` expression" in {
+    val cpg = code("""
+        |def f
+        | if true then
+        |   20
+        | else
+        |   40
+        | end
+        |end
+        |""".stripMargin)
+
+    val List(f)         = cpg.method.name("f").l
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+    val List(c: Call)   = r.astChildren.isCall.l
+
+    c.methodFullName shouldBe Operators.conditional
+    val test      = c.argument(1)
+    val blockThen = c.argument(2)
+    val blockElse = c.argument(3)
+
+    test.code shouldBe "true"
+    test.lineNumber shouldBe Some(3)
+    blockThen.isBlock shouldBe true
+    blockElse.isBlock shouldBe true
+
+    val List(twenty: Literal) = blockThen.astChildren.l: @unchecked
+    twenty.code shouldBe "20"
+    twenty.lineNumber shouldBe Some(4)
+    twenty.typeFullName shouldBe "__builtin.Integer"
+
+    val List(forty: Literal) = blockElse.astChildren.l: @unchecked
+    forty.code shouldBe "40"
+    forty.lineNumber shouldBe Some(6)
+    forty.typeFullName shouldBe "__builtin.Integer"
+  }
+
 }


### PR DESCRIPTION
Previously there was only support for `if-then-elsif-else-end` statements. Here we convert them to ternary conditionals when they are used as expressions, e.g. on the RHS of an assignment.
