### PR TITLE
[rubysrc2cpg] log ANTLR errors and inclusion of log4j2.xml

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/log4j2.xml
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5p] %m%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="${env:SL_LOGGING_LEVEL:-info}">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
* rubysrc2cpg was missing the usual log4j2.xml configuration file. Added here.
* ANTLR's default logging mechanism is to print everything to stdout. Here we make it use our logger instead.