### PR TITLE
[rubysrc2cpg] allow implicit return of simple calls and member accesses

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -26,7 +26,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val stmtBlockAst = node.body match
       case stmtList: StatementList => astForStatementListReturningLastExpression(stmtList)
-      case _: (StaticLiteral | BinaryExpression | SingleAssignment | SimpleIdentifier | ArrayLiteral | HashLiteral) =>
+      case _: (StaticLiteral | BinaryExpression | SingleAssignment | SimpleIdentifier | ArrayLiteral | HashLiteral |
+            SimpleCall | MemberAccess | MemberCall) =>
         astForStatementListReturningLastExpression(StatementList(List(node.body))(node.body.span))
       case body =>
         logger.warn(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -190,7 +190,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   private def astsForImplicitReturnStatement(node: RubyNode): List[Ast] = {
     node match
       case _: (ArrayLiteral | HashLiteral | StaticLiteral | BinaryExpression | UnaryExpression | SimpleIdentifier |
-            IfExpression) =>
+            IfExpression | SimpleCall | MemberAccess) =>
         astForReturnStatement(ReturnExpression(List(node))(node.span)) :: Nil
       case node: SingleAssignment =>
         astForSingleAssignment(node) :: List(astForReturnStatement(ReturnExpression(List(node.lhs))(node.span)))

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -57,6 +57,38 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     r.lineNumber shouldBe Some(3)
   }
 
+  "implicit RETURN node for `puts x` exists" in {
+    val cpg = code("""
+        |def f(x)
+        | puts x
+        |end
+        |""".stripMargin)
+
+    val List(f)         = cpg.method.name("f").l
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+
+    r.code shouldBe "puts x"
+    r.lineNumber shouldBe Some(3)
+
+    val List(c: Call) = r.astChildren.isCall.l
+    c.methodFullName shouldBe "puts"
+    c.lineNumber shouldBe Some(3)
+    c.code shouldBe "puts x"
+  }
+
+  "implicit RETURN node for `x.class` exists" in {
+    val cpg = code("""
+        |def f(x)
+        | x.class
+        |end""".stripMargin)
+
+    val List(f)         = cpg.method.name("f").l
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+
+    r.code shouldBe "x.class"
+    r.lineNumber shouldBe Some(3)
+  }
+
   "implicit RETURN node for `[]` exists" in {
     val cpg = code("""
         |def f

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.Return
 import io.shiftleft.semanticcpg.language.*
 
 class MethodTests extends RubyCode2CpgFixture {
@@ -12,7 +13,6 @@ class MethodTests extends RubyCode2CpgFixture {
 
     val List(f) = cpg.method.name("f").l
 
-    f.name shouldBe "f"
     f.fullName shouldBe "Test0.rb:<global>::program:f"
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
@@ -33,12 +33,47 @@ class MethodTests extends RubyCode2CpgFixture {
 
     val List(f) = cpg.method.name("f").l
 
-    f.name shouldBe "f"
     f.fullName shouldBe "Test0.rb:<global>::program:f"
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 3
     f.parameter.size shouldBe 0
+  }
+
+  "`def f = puts 'hi'` is represented by a METHOD node returning `puts 'hi'`" in {
+    val cpg = code("""
+        |def f = puts 'hi'
+        |""".stripMargin)
+
+    val List(f) = cpg.method.name("f").l
+
+    f.fullName shouldBe "Test0.rb:<global>::program:f"
+    f.isExternal shouldBe false
+    f.lineNumber shouldBe Some(2)
+    f.numberOfLines shouldBe 1
+    f.parameter.size shouldBe 0
+
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+    r.code shouldBe "puts 'hi'"
+    r.lineNumber shouldBe Some(2)
+  }
+
+  "`def f(x) = x.class` is represented by a METHOD node returning `x.class`" in {
+    val cpg = code("""
+        |def f(x) = x.class
+        |""".stripMargin)
+
+    val List(f) = cpg.method.name("f").l
+
+    f.fullName shouldBe "Test0.rb:<global>::program:f"
+    f.isExternal shouldBe false
+    f.lineNumber shouldBe Some(2)
+    f.numberOfLines shouldBe 1
+    f.parameter.size shouldBe 1
+
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+    r.code shouldBe "x.class"
+    r.lineNumber shouldBe Some(2)
   }
 
 }


### PR DESCRIPTION
Allows the creation of implicit returns also for simple invocations and member accesses. The basic support was already in place, all that was required was allowing the conversion.