### PR TITLE
[RubyTypeRecovery] Using Defensive `argumentOption(1)` Check

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -99,16 +99,20 @@ abstract class XTypeRecoveryPass[CompilationUnitType <: AstNode](
     import io.joern.x2cpg.passes.frontend.XTypeRecovery.AllNodeTypesFromNodeExt
 
     def getFieldBaseTypes(fieldAccess: FieldAccess): Iterator[TypeDecl] = {
-      fieldAccess.argument(1) match
-        case x: Call if x.name == Operators.fieldAccess =>
-          cpg.typeDecl.fullNameExact(FieldAccess(x).referencedMember.getKnownTypes.toSeq*)
-        case x: Call if !x.name.startsWith("<operator>") =>
-          if (!x.typeFullName.matches(XTypeRecovery.unknownTypePattern.pattern.pattern()))
-            cpg.typeDecl.fullNameExact(x.typeFullName)
-          else
-            Iterator.empty
-        case x: Expression =>
-          cpg.typeDecl.fullNameExact(x.getKnownTypes.toSeq*)
+      fieldAccess.argumentOption(1) match
+        case Some(y) =>
+          y match
+            case x: Call if x.name == Operators.fieldAccess =>
+              cpg.typeDecl.fullNameExact(FieldAccess(x).referencedMember.getKnownTypes.toSeq*)
+            case x: Call if !x.name.startsWith("<operator>") =>
+              if (!x.typeFullName.matches(XTypeRecovery.unknownTypePattern.pattern.pattern()))
+                cpg.typeDecl.fullNameExact(x.typeFullName)
+              else
+                Iterator.empty
+            case x: Expression =>
+              cpg.typeDecl.fullNameExact(x.getKnownTypes.toSeq*)
+        case None =>
+          Iterator.empty
     }
 
     // Set all now-typed fieldAccess calls to their referencing members (if they exist)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -99,20 +99,20 @@ abstract class XTypeRecoveryPass[CompilationUnitType <: AstNode](
     import io.joern.x2cpg.passes.frontend.XTypeRecovery.AllNodeTypesFromNodeExt
 
     def getFieldBaseTypes(fieldAccess: FieldAccess): Iterator[TypeDecl] = {
-      fieldAccess.argumentOption(1) match
-        case Some(y) =>
-          y match
-            case x: Call if x.name == Operators.fieldAccess =>
-              cpg.typeDecl.fullNameExact(FieldAccess(x).referencedMember.getKnownTypes.toSeq*)
-            case x: Call if !x.name.startsWith("<operator>") =>
-              if (!x.typeFullName.matches(XTypeRecovery.unknownTypePattern.pattern.pattern()))
-                cpg.typeDecl.fullNameExact(x.typeFullName)
-              else
-                Iterator.empty
-            case x: Expression =>
-              cpg.typeDecl.fullNameExact(x.getKnownTypes.toSeq*)
-        case None =>
-          Iterator.empty
+      fieldAccess
+        .argumentOption(1)
+        .map {
+          case x: Call if x.name == Operators.fieldAccess =>
+            cpg.typeDecl.fullNameExact(FieldAccess(x).referencedMember.getKnownTypes.toSeq*)
+          case x: Call if !x.name.startsWith("<operator>") =>
+            if (!x.typeFullName.matches(XTypeRecovery.unknownTypePattern.pattern.pattern()))
+              cpg.typeDecl.fullNameExact(x.typeFullName)
+            else
+              Iterator.empty
+          case x: Expression =>
+            cpg.typeDecl.fullNameExact(x.getKnownTypes.toSeq*)
+        }
+        .getOrElse(Iterator.empty)
     }
 
     // Set all now-typed fieldAccess calls to their referencing members (if they exist)


### PR DESCRIPTION
getting the following error while scanning https://github.com/odinsride/olubalance repository. This may not be the proper fix, but at least the scan will continue instead of abruptly exiting the scan with an error.

```
java.util.NoSuchElementException: next on empty iterator
	at scala.collection.Iterator$$anon$19.next(Iterator.scala:973) ~[org.scala-lang.scala-library-2.13.10.jar:?]
	at scala.collection.Iterator$$anon$19.next(Iterator.scala:971) ~[org.scala-lang.scala-library-2.13.10.jar:?]
	at scala.collection.Iterator$$anon$7.next(Iterator.scala:535) ~[org.scala-lang.scala-library-2.13.10.jar:?]
	at overflowdb.traversal.TraversalSugarExt$.head$extension(Traversal.scala:64) ~[io.shiftleft.overflowdb-traversal_3-1.181.jar:1.181]
	at io.shiftleft.semanticcpg.language.nodemethods.CallMethods$.argument$extension(CallMethods.scala:21) ~[io.joern.semanticcpg_3-2.0.162.jar:2.0.162]
	at io.joern.x2cpg.passes.frontend.XTypeRecoveryPass.getFieldBaseTypes$1(XTypeRecovery.scala:104) ~[io.joern.x2cpg_3-2.0.162.jar:2.0.162]
```