### PR TITLE
[rubysrc2cpg] support missing `||=`, `&&=`, etc. assignments

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -68,10 +68,16 @@ trait AstCreatorHelper { this: AstCreator =>
     )
 
   protected val AssignmentOperatorNames: Map[String, String] = Map(
-    "="  -> Operators.assignment,
-    "+=" -> Operators.assignmentPlus,
-    "-=" -> Operators.assignmentMinus,
-    "*=" -> Operators.assignmentMultiplication
+    "="   -> Operators.assignment,
+    "+="  -> Operators.assignmentPlus,
+    "-="  -> Operators.assignmentMinus,
+    "*="  -> Operators.assignmentMultiplication,
+    "/="  -> Operators.assignmentDivision,
+    "%="  -> Operators.assignmentModulo,
+    "**=" -> Operators.assignmentExponentiation,
+    // Strictly speaking, `a ||= b` means `a || a = b`, but I reckon we wouldn't gain much representing it that way.
+    "||=" -> Operators.assignmentOr,
+    "&&=" -> Operators.assignmentAnd
   )
 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -42,6 +42,51 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
     rhs.code shouldBe "1"
   }
 
+  "`||=` is represented by an `assignmentOr` operator call" in {
+    val cpg = code("""
+        |x ||= false
+        |""".stripMargin)
+
+    val List(assignment) = cpg.call(Operators.assignmentOr).l
+    assignment.code shouldBe "x ||= false"
+    assignment.lineNumber shouldBe Some(2)
+    assignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+    val List(lhs, rhs) = assignment.argument.l
+    lhs.code shouldBe "x"
+    rhs.code shouldBe "false"
+  }
+
+  "`&&=` is represented by an `assignmentAnd` operator call" in {
+    val cpg = code("""
+        |x &&= true
+        |""".stripMargin)
+
+    val List(assignment) = cpg.call(Operators.assignmentAnd).l
+    assignment.code shouldBe "x &&= true"
+    assignment.lineNumber shouldBe Some(2)
+    assignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+    val List(lhs, rhs) = assignment.argument.l
+    lhs.code shouldBe "x"
+    rhs.code shouldBe "true"
+  }
+
+  "`/=` is represented by an `assignmentDivision` operator call" in {
+    val cpg = code("""
+        |x /= 10
+        |""".stripMargin)
+
+    val List(assignment) = cpg.call(Operators.assignmentDivision).l
+    assignment.code shouldBe "x /= 10"
+    assignment.lineNumber shouldBe Some(2)
+    assignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+    val List(lhs, rhs) = assignment.argument.l
+    lhs.code shouldBe "x"
+    rhs.code shouldBe "10"
+  }
+
   "`=` is right-associative" in {
     val cpg = code("""
                      |x = y = 1


### PR DESCRIPTION
Just completing the list of abbreviated arithmetical assignment operators.