### PR TITLE
rubysrc ast creation: fix double handled 'MemberAccess' case

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -190,7 +190,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   private def astsForImplicitReturnStatement(node: RubyNode): List[Ast] = {
     node match
       case _: (ArrayLiteral | HashLiteral | StaticLiteral | BinaryExpression | UnaryExpression | SimpleIdentifier |
-            IfExpression | SimpleCall | MemberAccess) =>
+            IfExpression | SimpleCall) =>
         astForReturnStatement(ReturnExpression(List(node))(node.span)) :: Nil
       case node: SingleAssignment =>
         astForSingleAssignment(node) :: List(astForReturnStatement(ReturnExpression(List(node.lhs))(node.span)))


### PR DESCRIPTION
Before this PR, `MemberAccess` is handled twice, which thankfully scalac notifies us about:
```
[warn] -- [E030] Match case Unreachable Warning: /home/mp/Projects/shiftleft/joern/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala:203:11
[warn] 203 |      case node: MemberAccess    => astForReturnMemberCall(node) :: Nil
[warn]     |           ^^^^^^^^^^^^^^^^^^
[warn]     |           Unreachable case
```

I'm not familiar with the ruby frontend, but given that MemberAccess is handled separately, we can probably drop it from the first case. 