### PR TITLE
Simplify XTypeRecovery

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeRecoveryPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeRecoveryPass.scala
@@ -16,7 +16,7 @@ class JavaTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecovery
 
 private class JavaTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[Method](cpg, state) {
 
-  override def compilationUnit: Iterator[Method] = cpg.method.isExternal(false).iterator
+  override def compilationUnits: Iterator[Method] = cpg.method.isExternal(false).iterator
 
   override def generateRecoveryForCompilationUnitTask(
     unit: Method,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeRecoveryPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/JavaTypeRecoveryPass.scala
@@ -22,8 +22,7 @@ private class JavaTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTyp
     unit: Method,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[Method] = {
-    val newConfig = state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-    new RecoverForJavaFile(cpg, unit, builder, state.copy(config = newConfig))
+    new RecoverForJavaFile(cpg, unit, builder, state)
   }
 }
 
@@ -59,7 +58,6 @@ private class RecoverForJavaFile(cpg: Cpg, cu: Method, builder: DiffGraphBuilder
 
   override protected def storeCallTypeInfo(c: Call, types: Seq[String]): Unit =
     if (types.nonEmpty) {
-      state.changesWereMade.compareAndSet(false, true)
       val signedTypes = types.map {
         case t if t.endsWith(c.signature) => t
         case t                            => s"$t:${c.signature}"

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -18,7 +18,7 @@ class JavaScriptTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRe
 
 private class JavaScriptTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
 
-  override def compilationUnit: Iterator[File] = cpg.file.iterator
+  override def compilationUnits: Iterator[File] = cpg.file.iterator
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -24,8 +24,7 @@ private class JavaScriptTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extend
     unit: File,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] = {
-    val newConfig = state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-    new RecoverForJavaScriptFile(cpg, unit, builder, state.copy(config = newConfig))
+    new RecoverForJavaScriptFile(cpg, unit, builder, state)
   }
 
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/KotlinTypeRecoveryPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/KotlinTypeRecoveryPass.scala
@@ -17,7 +17,7 @@ class KotlinTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecove
 
 private class KotlinTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
 
-  override def compilationUnit: Iterator[File] = cpg.file.iterator
+  override def compilationUnits: Iterator[File] = cpg.file.iterator
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/KotlinTypeRecoveryPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/KotlinTypeRecoveryPass.scala
@@ -23,8 +23,7 @@ private class KotlinTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XT
     unit: File,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] = {
-    val newConfig = state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-    new RecoverForKotlinFile(cpg, unit, builder, state.copy(config = newConfig))
+    new RecoverForKotlinFile(cpg, unit, builder, state)
   }
 }
 
@@ -71,7 +70,6 @@ private class RecoverForKotlinFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
 
   override protected def storeCallTypeInfo(c: Call, types: Seq[String]): Unit =
     if (types.nonEmpty) {
-      state.changesWereMade.compareAndSet(false, true)
       val signedTypes = types.map {
         case t if t.endsWith(c.signature) => t
         case t                            => s"$t:${c.signature}"

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/PhpTypeRecovery.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/PhpTypeRecovery.scala
@@ -28,8 +28,7 @@ private class PhpTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XType
     unit: NamespaceBlock,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[NamespaceBlock] = {
-    val newConfig = state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-    new RecoverForPhpFile(cpg, unit, builder, state.copy(config = newConfig))
+    new RecoverForPhpFile(cpg, unit, builder, state)
   }
 }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/PhpTypeRecovery.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/PhpTypeRecovery.scala
@@ -22,7 +22,7 @@ class PhpTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryC
 
 private class PhpTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[NamespaceBlock](cpg, state) {
 
-  override def compilationUnit: Iterator[NamespaceBlock] = cpg.file.namespaceBlock.iterator
+  override def compilationUnits: Iterator[NamespaceBlock] = cpg.file.namespaceBlock.iterator
 
   override def generateRecoveryForCompilationUnitTask(
     unit: NamespaceBlock,

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -19,7 +19,7 @@ class PythonTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecove
 
 private class PythonTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
 
-  override def compilationUnit: Iterator[File] = cpg.file.iterator
+  override def compilationUnits: Iterator[File] = cpg.file.iterator
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -25,8 +25,7 @@ private class PythonTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XT
     unit: File,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] = {
-    val newConfig = state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-    new RecoverForPythonFile(cpg, unit, builder, state.copy(config = newConfig))
+    new RecoverForPythonFile(cpg, unit, builder, state)
   }
 
 }
@@ -192,7 +191,6 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
         val existingTypes = (identifierTypes ++ otherTypes).distinct
         val resolvedTypes = identifierTypes.map(LocalVar.apply).flatMap(symbolTable.get)
         if (existingTypes != resolvedTypes && resolvedTypes.nonEmpty) {
-          state.changesWereMade.compareAndExchange(false, true)
           builder.setNodeProperty(t, PropertyNames.INHERITS_FROM_TYPE_FULL_NAME, resolvedTypes)
         }
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/passes/RubyTypeRecoveryPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/passes/RubyTypeRecoveryPass.scala
@@ -15,7 +15,7 @@ class RubyTypeRecoveryPass(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecovery
 
 private class RubyTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTypeRecovery[File](cpg, state) {
 
-  override def compilationUnit: Iterator[File] = cpg.file.iterator
+  override def compilationUnits: Iterator[File] = cpg.file.iterator
 
   override def generateRecoveryForCompilationUnitTask(
     unit: File,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/passes/RubyTypeRecoveryPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/passes/RubyTypeRecoveryPass.scala
@@ -21,8 +21,7 @@ private class RubyTypeRecovery(cpg: Cpg, state: XTypeRecoveryState) extends XTyp
     unit: File,
     builder: DiffGraphBuilder
   ): RecoverForXCompilationUnit[File] = {
-    val newConfig = state.config.copy(enabledDummyTypes = state.isFinalIteration && state.config.enabledDummyTypes)
-    new RecoverForRubyFile(cpg, unit, builder, state.copy(config = newConfig))
+    new RecoverForRubyFile(cpg, unit, builder, state)
   }
 }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -38,10 +38,11 @@ case class XTypeRecoveryConfig(iterations: Int = 2, enabledDummyTypes: Boolean =
 class XTypeRecoveryState(
   val config: XTypeRecoveryConfig = XTypeRecoveryConfig(),
   var currentIteration: Int = 0,
-  val isFieldCache: TrieMap[Long, Boolean] = TrieMap.empty[Long, Boolean]) {
+  val isFieldCache: TrieMap[Long, Boolean] = TrieMap.empty[Long, Boolean]
+) {
   def isFinalIteration: Boolean = currentIteration == config.iterations - 1
 
-  def enableDummyTypesForThisIteration:Boolean =  isFinalIteration && config.enabledDummyTypes
+  def enableDummyTypesForThisIteration: Boolean = isFinalIteration && config.enabledDummyTypes
 
   def isFirstIteration: Boolean = currentIteration == 0
 
@@ -65,9 +66,9 @@ abstract class XTypeRecoveryPass[CompilationUnitType <: AstNode](
 
   override def run(builder: BatchedUpdate.DiffGraphBuilder): Unit =
     if (config.iterations > 0) {
-      val state     = new XTypeRecoveryState(config)
+      val state = new XTypeRecoveryState(config)
       try {
-        for(i <- Range(0, config.iterations)){
+        for (i <- Range(0, config.iterations)) {
           state.currentIteration = i
           generateRecoveryPass(state).createAndApply()
         }
@@ -159,7 +160,7 @@ trait TypeRecoveryParserConfig[R <: X2CpgConfig[R]] { this: R =>
 abstract class XTypeRecovery[CompilationUnitType <: AstNode](cpg: Cpg, state: XTypeRecoveryState) extends CpgPass(cpg) {
 
   override def run(builder: DiffGraphBuilder): Unit = {
-    for(cu <- compilationUnits){
+    for (cu <- compilationUnits) {
       generateRecoveryForCompilationUnitTask(unit, builder).run()
     }
   }
@@ -1112,7 +1113,8 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   }
 
   protected def persistType(x: StoredNode, types: Set[String]): Unit = {
-    val filteredTypes = if (state.enableDummyTypesForThisIteration) types else types.filterNot(XTypeRecovery.isDummyType)
+    val filteredTypes =
+      if (state.enableDummyTypesForThisIteration) types else types.filterNot(XTypeRecovery.isDummyType)
     if (filteredTypes.nonEmpty) {
       storeNodeTypeInfo(x, filteredTypes.toSeq)
       x match {
@@ -1217,7 +1219,10 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   /** Allows one to modify the types assigned to locals.
     */
   protected def storeLocalTypeInfo(l: Local, types: Seq[String]): Unit = {
-    storeDefaultTypeInfo(l, if (state.enableDummyTypesForThisIteration) types else types.filterNot(XTypeRecovery.isDummyType))
+    storeDefaultTypeInfo(
+      l,
+      if (state.enableDummyTypesForThisIteration) types else types.filterNot(XTypeRecovery.isDummyType)
+    )
   }
 
   /** Allows an implementation to perform an operation once type persistence is complete.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -161,7 +161,7 @@ abstract class XTypeRecovery[CompilationUnitType <: AstNode](cpg: Cpg, state: XT
 
   override def run(builder: DiffGraphBuilder): Unit = {
     for (cu <- compilationUnits) {
-      generateRecoveryForCompilationUnitTask(unit, builder).run()
+      generateRecoveryForCompilationUnitTask(cu, builder).run()
     }
   }
 


### PR DESCRIPTION
XTypeRecovery contained multiple parts that were somewhat misleading. I clarified the code, in preparation for a more substrantial refactor.

1. The earlyStop system never worked because changesWereMade was not reset in between iterations. This means that this logic should either be removed in its entirety, or fixed and debugged. Per discord, removal it is.
2. The concurrency never worked, because iterators are lazy. Calling `iter.map{u => u.fork()}.map{future => future.get()}` is single threaded. It becomes concurrent if one does `iter.map{u => u.fork()}.toList.map{future => future.get()}` or something like that. This means that the concurrency logic should either be removed in its entirety, or fixed and debugged. Per discord, removal it is.

Future PRs will introduce concurrency logic that actually has a chance of working (removing and recreating is simpler than fixing).

My intention for this PR is bug-for-bug equivalent end-to-end behavior of the code.