### PR TITLE
Don't follow symlinks when finding jdk jars

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JdkJarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JdkJarTypeSolver.scala
@@ -134,7 +134,7 @@ object JdkJarTypeSolver {
   }
 
   def fromJdkPath(jdkPath: String): JdkJarTypeSolver = {
-    val jarPaths = SourceFiles.determine(jdkPath, Set(JarExtension, JmodExtension))
+    val jarPaths = SourceFiles.determine(jdkPath, Set(JarExtension, JmodExtension), followSymlinks = false)
     if (jarPaths.isEmpty) {
       throw new IllegalArgumentException(s"No .jar or .jmod files found at JDK path ${jdkPath}")
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -80,10 +80,11 @@ object SourceFiles {
     sourceFileExtensions: Set[String],
     ignoredDefaultRegex: Option[Seq[Regex]] = None,
     ignoredFilesRegex: Option[Regex] = None,
-    ignoredFilesPath: Option[Seq[String]] = None
+    ignoredFilesPath: Option[Seq[String]] = None,
+    followSymlinks: Boolean = true
   ): List[String] = {
     filterFiles(
-      determine(Set(inputPath), sourceFileExtensions),
+      determine(Set(inputPath), sourceFileExtensions, followSymlinks),
       inputPath,
       ignoredDefaultRegex,
       ignoredFilesRegex,
@@ -93,7 +94,7 @@ object SourceFiles {
 
   /** For a given array of input paths, determine all source files by inspecting filename extensions.
     */
-  def determine(inputPaths: Set[String], sourceFileExtensions: Set[String]): List[String] = {
+  def determine(inputPaths: Set[String], sourceFileExtensions: Set[String], followSymlinks: Boolean): List[String] = {
     def hasSourceFileExtension(file: File): Boolean =
       file.extension.exists(sourceFileExtensions.contains)
 
@@ -102,9 +103,10 @@ object SourceFiles {
 
     val (dirs, files) = inputFiles.partition(_.isDirectory)
 
+    val followOption  = if (followSymlinks) VisitOptions.follow else VisitOptions.default
     val matchingFiles = files.filter(hasSourceFileExtension).map(_.toString)
     val matchingFilesFromDirs = dirs
-      .flatMap(_.listRecursively(VisitOptions.follow))
+      .flatMap(_.listRecursively(followOption))
       .filter(hasSourceFileExtension)
       .map(_.pathAsString)
 


### PR DESCRIPTION
Following symlinks is leading to `FileSystemLoopExceptions` in some cases when finding jdk jars or jmods for the javasrc type solver. We shouldn't need to follow these in this case, so this just disables that. This could mean that an explicit jdk path argument must be given if the frontend is invoked via a symlinked java distribution.