### PR TITLE
[dataflowengineoss] - Graceful Error Handling for AccessPathUsage

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/AccessPathUsage.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/AccessPathUsage.scala
@@ -40,7 +40,7 @@ object AccessPathUsage {
           val path         = AccessPathHandling.memberAccessToPath(memberAccess, tail)
           (base, path)
         case _ =>
-          logger.error(s"Missing handling for node type ${node.getClass}.")
+          logger.warn(s"Missing handling for node type ${node.getClass}.")
           (TrackedUnknown, Nil)
       }
     }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/AccessPathUsage.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/AccessPathUsage.scala
@@ -39,6 +39,9 @@ object AccessPathUsage {
           val (base, tail) = toTrackedBaseAndAccessPathInternal(argOne.get)
           val path         = AccessPathHandling.memberAccessToPath(memberAccess, tail)
           (base, path)
+        case _ =>
+          logger.error(s"Missing handling for node type ${node.getClass}.")
+          (TrackedUnknown, Nil)
       }
     }
   }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -126,6 +126,22 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         val typeInfo                                           = createParserNodeInfo(x(ParserKeys.Type))
         val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeInfo, genericTypeMethodMap)
         x(ParserKeys.Names).arrOpt
+          /*
+          While generating the signature for a function structure
+
+          func test(a, b int, c string) int {
+          }
+
+          it works because if there is no situation where there will not be a parameter name exist.
+
+          When I reuse the same function for generating the signature for lambda types as below
+
+          type Operation func(int, int) int
+
+          Now in this case there is no parameter name exist, in order to handle this situation add this empty string as default value,
+
+          which only facilitates adding the parameter type to list.
+           */
           .getOrElse(List(""))
           .map(_ => {
             // We are returning same type from x object for each name in the names array.

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -126,22 +126,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         val typeInfo                                           = createParserNodeInfo(x(ParserKeys.Type))
         val (typeFullName, typeFullNameForcode, isVariadic, _) = processTypeInfo(typeInfo, genericTypeMethodMap)
         x(ParserKeys.Names).arrOpt
-          /*
-          While generating the signature for a function structure
-
-          func test(a, b int, c string) int {
-          }
-
-          it works because if there is no situation where there will not be a parameter name exist.
-
-          When I reuse the same function for generating the signature for lambda types as below
-
-          type Operation func(int, int) int
-
-          Now in this case there is no parameter name exist, in order to handle this situation add this empty string as default value,
-
-          which only facilitates adding the parameter type to list.
-           */
           .getOrElse(List(""))
           .map(_ => {
             // We are returning same type from x object for each name in the names array.

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -695,4 +695,16 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
       sink.reachableBy(identifierSource).size shouldBe 1
     }
   }
+  "Field access on TemplatedDom directly" should {
+    val cpg = code("""
+                     |import { useRouter } from "next/router";
+                     |
+                     |const tabComponentType = (<Tab title={"typeComponent"} />).type;
+                     |
+        |""".stripMargin)
+    "Not throw error and get handled it gracefully" in {
+      val List(x) = cpg.identifier("tabComponentType").l
+      x.lineNumber shouldBe Some(4)
+    }
+  }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/dataflow/DataflowTest.scala
@@ -695,6 +695,7 @@ class DataflowTest extends DataFlowCodeToCpgSuite {
       sink.reachableBy(identifierSource).size shouldBe 1
     }
   }
+
   "Field access on TemplatedDom directly" should {
     val cpg = code("""
                      |import { useRouter } from "next/router";


### PR DESCRIPTION
1. Added ERROR log for missing node handling and continued with further processing. Added respective unit tests for the same. Note: This is not the fix, this will just unblock the further processing of the CPG.
2. Added a few comments as a result of suggestions from past PR review comments.