### PR TITLE
[jimple2cpg] Add maximum depths for recurse unpack "jars in jars"

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -65,8 +65,7 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
   }
 
   /** Extract all class files found, place them in their package layout and load them into soot.
-   *
-   * @param input
+    * @param input
     *   The file/directory to traverse for class files.
     * @param tmpDir
     *   The directory to place the class files in their package layout

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -46,13 +46,13 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
   /** Load all class files from archives or directories recursively
     * @param recurse
     *   Whether to unpack recursively
-    * @param depths
-    *   Maximum depths of recurse
+    * @param depth
+    *   Maximum depth of recursion
     * @return
     *   The list of extracted class files whose package path could be extracted, placed on that package path relative to
     *   [[tmpDir]]
     */
-  private def loadClassFiles(src: File, tmpDir: File, recurse: Boolean, depths: Int): List[ClassFile] = {
+  private def loadClassFiles(src: File, tmpDir: File, recurse: Boolean, depth: Int): List[ClassFile] = {
     val archiveFileExtensions = Set(".jar", ".war", ".zip")
     extractClassesInPackageLayout(
       src,
@@ -60,7 +60,7 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
       isClass = e => e.extension.contains(".class"),
       isArchive = e => e.extension.exists(archiveFileExtensions.contains),
       recurse,
-      depths
+      depth
     )
   }
 
@@ -71,13 +71,13 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
     *   The directory to place the class files in their package layout
     * @param recurse
     *   Whether to unpack recursively
-    * @param depths
-    *   Maximum depths of recurse
+    * @param depth
+    *   Maximum depth of recursion
     */
-  private def sootLoad(input: File, tmpDir: File, recurse: Boolean, depths: Int): List[ClassFile] = {
+  private def sootLoad(input: File, tmpDir: File, recurse: Boolean, depth: Int): List[ClassFile] = {
     Options.v().set_soot_classpath(tmpDir.canonicalPath)
     Options.v().set_prepend_classpath(true)
-    val classFiles               = loadClassFiles(input, tmpDir, recurse, depths)
+    val classFiles               = loadClassFiles(input, tmpDir, recurse, depth)
     val fullyQualifiedClassNames = classFiles.flatMap(_.fullyQualifiedClassName)
     logger.info(s"Loading ${classFiles.size} program files")
     logger.debug(s"Source files are: ${classFiles.map(_.file.canonicalPath)}")
@@ -106,7 +106,7 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
           astCreator.global
         }
       case _ =>
-        val classFiles = sootLoad(input, tmpDir, config.recurse, config.depths)
+        val classFiles = sootLoad(input, tmpDir, config.recurse, config.depth)
         { () =>
           val astCreator = AstCreationPass(classFiles, cpg, config)
           astCreator.createAndApply()

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -54,7 +54,8 @@ private object Frontend {
         .action((_, config) => config.withRecurse(true)),
       opt[Int]("depths")
         .text("maximum depth of recursively unpack jars, default value 1")
-        .action((depths, config) => config.withDepths(depths)),
+        .action((depths, config) => config.withDepths(depths))
+        .validate(x => if (x > 0) success else failure("depths must be greater than 0")),
       opt[Seq[String]]("dynamic-dirs")
         .valueName("<dir1>,<dir2>,...")
         .text(

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -11,7 +11,8 @@ final case class Config(
   dynamicDirs: Seq[String] = Seq.empty,
   dynamicPkgs: Seq[String] = Seq.empty,
   fullResolver: Boolean = false,
-  recurse: Boolean = false
+  recurse: Boolean = false,
+  deep: Int = 1
 ) extends X2CpgConfig[Config] {
   def withAndroid(android: String): Config = {
     copy(android = Some(android)).withInheritedFields(this)
@@ -25,11 +26,12 @@ final case class Config(
   def withFullResolver(value: Boolean): Config = {
     copy(fullResolver = value).withInheritedFields(this)
   }
-
   def withRecurse(value: Boolean): Config = {
-    copy(recurse = value)
+    copy(recurse = value).withInheritedFields(this)
   }
-
+  def withDeep(value: Int): Config = {
+    copy(deep = value).withInheritedFields(this)
+  }
 }
 
 private object Frontend {
@@ -50,6 +52,9 @@ private object Frontend {
       opt[Unit]("recurse")
         .text("recursively unpack jars")
         .action((_, config) => config.withRecurse(true)),
+      opt[Int]("deep")
+        .text("maximum depth of recursion")
+        .action((deep, config) => config.withDeep(deep)),
       opt[Seq[String]]("dynamic-dirs")
         .valueName("<dir1>,<dir2>,...")
         .text(

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -12,7 +12,7 @@ final case class Config(
   dynamicPkgs: Seq[String] = Seq.empty,
   fullResolver: Boolean = false,
   recurse: Boolean = false,
-  deep: Int = 1
+  depths: Int = 1
 ) extends X2CpgConfig[Config] {
   def withAndroid(android: String): Config = {
     copy(android = Some(android)).withInheritedFields(this)
@@ -29,8 +29,8 @@ final case class Config(
   def withRecurse(value: Boolean): Config = {
     copy(recurse = value).withInheritedFields(this)
   }
-  def withDeep(value: Int): Config = {
-    copy(deep = value).withInheritedFields(this)
+  def withDepths(value: Int): Config = {
+    copy(depths = value).withInheritedFields(this)
   }
 }
 
@@ -52,9 +52,9 @@ private object Frontend {
       opt[Unit]("recurse")
         .text("recursively unpack jars")
         .action((_, config) => config.withRecurse(true)),
-      opt[Int]("deep")
-        .text("maximum depth of recursion")
-        .action((deep, config) => config.withDeep(deep)),
+      opt[Int]("depths")
+        .text("maximum depth of recursively unpack jars, default value 1")
+        .action((depths, config) => config.withDepths(depths)),
       opt[Seq[String]]("dynamic-dirs")
         .valueName("<dir1>,<dir2>,...")
         .text(

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -12,7 +12,7 @@ final case class Config(
   dynamicPkgs: Seq[String] = Seq.empty,
   fullResolver: Boolean = false,
   recurse: Boolean = false,
-  depths: Int = 1
+  depth: Int = 1
 ) extends X2CpgConfig[Config] {
   def withAndroid(android: String): Config = {
     copy(android = Some(android)).withInheritedFields(this)
@@ -29,8 +29,8 @@ final case class Config(
   def withRecurse(value: Boolean): Config = {
     copy(recurse = value).withInheritedFields(this)
   }
-  def withDepths(value: Int): Config = {
-    copy(depths = value).withInheritedFields(this)
+  def withDepth(value: Int): Config = {
+    copy(depth = value).withInheritedFields(this)
   }
 }
 
@@ -52,10 +52,10 @@ private object Frontend {
       opt[Unit]("recurse")
         .text("recursively unpack jars")
         .action((_, config) => config.withRecurse(true)),
-      opt[Int]("depths")
-        .text("maximum depth of recursively unpack jars, default value 1")
-        .action((depths, config) => config.withDepths(depths))
-        .validate(x => if (x > 0) success else failure("depths must be greater than 0")),
+      opt[Int]("depth")
+        .text("maximum depth to recursively unpack jars, default value 1")
+        .action((depth, config) => config.withDepth(depth))
+        .validate(x => if (x > 0) success else failure("depth must be greater than 0")),
       opt[Seq[String]]("dynamic-dirs")
         .valueName("<dir1>,<dir2>,...")
         .text(

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -86,8 +86,8 @@ object ProgramHandlingUtil {
     *   Whether an entry is a class file
     * @param recurse
     *   Whether to unpack recursively
-    * @param depths
-    *   Maximum depths of recurse
+    * @param depth
+    *   Maximum depth of recursion
     * @return
     *   The list of class files found, which may either be in [[src]] or in an extracted archive under [[tmpDir]]
     */
@@ -97,7 +97,7 @@ object ProgramHandlingUtil {
     isArchive: Entry => Boolean,
     isClass: Entry => Boolean,
     recurse: Boolean,
-    depths: Int
+    depth: Int
   ): IterableOnce[ClassFile] = {
 
     // filter archive file unless recurse was enabled
@@ -119,12 +119,12 @@ object ProgramHandlingUtil {
               logger.warn(s"Failed to extract archive", e)
               List.empty
           }
-          // This can always be ture, since the archive file was filter by shouldExtract if not enable recurse options.
+          // This can always be true, since the archive file was filtered by shouldExtract if recurse options not enabled.
           Right(Map(true -> unzipDirs))
         case _ =>
           Right(Map(false -> List.empty))
       },
-      depths
+      depth
     )
   }
 
@@ -207,8 +207,8 @@ object ProgramHandlingUtil {
     *   Whether an entry is a class file
     * @param recurse
     *   Whether to unpack recursively
-    * @param depths
-    *   Maximum depths of recurse
+    * @param depth
+    *   Maximum depth of recursion
     * @return
     *   The copied class files in destDir
     */
@@ -218,12 +218,12 @@ object ProgramHandlingUtil {
     isClass: Entry => Boolean,
     isArchive: Entry => Boolean,
     recurse: Boolean,
-    depths: Int
+    depth: Int
   ): List[ClassFile] =
     File
       .temporaryDirectory("extract-classes-")
       .apply(tmpDir =>
-        extractClassesToTmp(src, tmpDir, isArchive, isClass, recurse: Boolean, depths: Int).iterator
+        extractClassesToTmp(src, tmpDir, isArchive, isClass, recurse: Boolean, depth: Int).iterator
           .flatMap(_.copyToPackageLayoutIn(destDir))
           .toList
       )

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -42,8 +42,8 @@ object ProgramHandlingUtil {
     * @param src
     *   The file/directory to traverse
     * @param emitOrUnpack
-    *   A function that takes a file and either emits a value or returns more files to traverse.
-    *   The key of Right was used to identify whether the file was unfold from an archive
+    *   A function that takes a file and either emits a value or returns more files to traverse. The key of Right was
+    *   used to identify whether the file was unfold from an archive
     * @param maxDepth
     *   The max recursion depth of unpacking an archive (e.g. jars inside jars)
     * @tparam A
@@ -51,22 +51,26 @@ object ProgramHandlingUtil {
     * @return
     *   The emitted values
     */
-  private def unfoldArchives[A](src: File, emitOrUnpack: File => Either[A, Map[Boolean, List[File]]], maxDepth: Int): IterableOnce[A] = {
+  private def unfoldArchives[A](
+    src: File,
+    emitOrUnpack: File => Either[A, Map[Boolean, List[File]]],
+    maxDepth: Int
+  ): IterableOnce[A] = {
     if (maxDepth < -1)
       logger.warn("Maximum recursion depth reached.")
       Seq()
     else
       emitOrUnpack(src) match {
-        case Left(a)             => Seq(a)
-        case Right(disposeFiles) => disposeFiles.flatMap(
-          x => x._2.flatMap(
-            f =>
+        case Left(a) => Seq(a)
+        case Right(disposeFiles) =>
+          disposeFiles.flatMap(x =>
+            x._2.flatMap(f =>
               if (x._1)
                 unfoldArchives(f, emitOrUnpack, maxDepth - 1)
               else
                 unfoldArchives(f, emitOrUnpack, maxDepth)
+            )
           )
-        )
       }
   }
 
@@ -81,9 +85,9 @@ object ProgramHandlingUtil {
     * @param isClass
     *   Whether an entry is a class file
     * @param recurse
-    *    Whether to unpack recursively
+    *   Whether to unpack recursively
     * @param depths
-    *    Maximum depths of recurse
+    *   Maximum depths of recurse
     * @return
     *   The list of class files found, which may either be in [[src]] or in an extracted archive under [[tmpDir]]
     */
@@ -204,7 +208,7 @@ object ProgramHandlingUtil {
     * @param recurse
     *   Whether to unpack recursively
     * @param depths
-    *    Maximum depths of recurse
+    *   Maximum depths of recurse
     * @return
     *   The copied class files in destDir
     */

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
@@ -16,21 +16,29 @@ import scala.util.{Failure, Success, Try}
 
 class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
-  var validCpgs: Map[String, Cpg] = _
+  var recurseCpgs: Map[String, Cpg] = _
+  var noRecurseCpgs: Map[String, Cpg] = _
+  var depthsCpgs: Map[String, Cpg]    = _
   var slippyCpg: Cpg              = _
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    validCpgs = List("HelloWorld.jar", "NestedHelloWorld.jar", "helloworld")
-      .map(k => (k, getUnpackingCpg(k)))
+    recurseCpgs = List("HelloWorld.jar", "NestedHelloWorld.jar", "helloworld")
+      .map(k => (k, getUnpackingCpg(k, true, 1)))
+      .toMap
+    noRecurseCpgs = List("HelloWorld.jar", "NestedHelloWorld.jar", "helloworld")
+      .map(k => (k, getUnpackingCpg(k, false)))
+      .toMap
+    depthsCpgs = List("HelloWorld.jar", "NestedHelloWorld.jar", "helloworld")
+      .map(k => (k, getUnpackingCpg(k, false, depths = 2)))
       .toMap
     slippyCpg = getUnpackingCpg("slippy.zip")
   }
 
-  private def getUnpackingCpg(path: String): Cpg =
+  private def getUnpackingCpg(path: String, recurse: Boolean = true, depths: Int = 1): Cpg =
     Try(getClass.getResource(s"/unpacking/${path}").toURI) match {
       case Success(x) =>
-        implicit val config: Config = Config().withRecurse(true)
+        implicit val config: Config = Config().withRecurse(recurse)
         new Jimple2Cpg().createCpg(Paths.get(x).toString).get
       case Failure(x: Throwable) =>
         fail("Unable to obtain test resources.", x)
@@ -46,7 +54,7 @@ class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll
   }
 
   "should reflect the correct package order" in {
-    for ((name, cpg) <- validCpgs) {
+    for ((name, cpg) <- recurseCpgs) {
       val List(foo) = cpg.typeDecl.fullNameExact("Foo").l
       foo.name shouldBe "Foo"
 
@@ -59,6 +67,52 @@ class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll
         "pac.Bar.sub:int(int,int)",
         "pac.Bar.<init>:void()"
       )
+    }
+  }
+
+  "Bar should not contain in no recurse case" in {
+    for ((name, cpg) <- noRecurseCpgs) {
+      val List(foo) = cpg.typeDecl.fullNameExact("Foo").l
+      foo.name shouldBe "Foo"
+
+      if (name == "NestedHelloWorld.jar")
+        cpg.typeDecl.fullNameExact("pac.Bar").l shouldBe Nil
+        cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set(
+          "Foo.<init>:void()",
+          "Foo.add:int(int,int)"
+        )
+      else
+        val List(bar) = cpg.typeDecl.fullNameExact("pac.Bar").l
+        bar.name shouldBe "Bar"
+        cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set(
+          "Foo.<init>:void()",
+          "Foo.add:int(int,int)",
+          "pac.Bar.sub:int(int,int)",
+          "pac.Bar.<init>:void()"
+        )
+    }
+  }
+
+  "Single using depth should not unpack recursively" in {
+    for ((name, cpg) <- depthsCpgs) {
+      val List(foo) = cpg.typeDecl.fullNameExact("Foo").l
+      foo.name shouldBe "Foo"
+
+      if (name == "NestedHelloWorld.jar")
+        cpg.typeDecl.fullNameExact("pac.Bar").l shouldBe Nil
+        cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set(
+          "Foo.<init>:void()",
+          "Foo.add:int(int,int)"
+        )
+      else
+        val List(bar) = cpg.typeDecl.fullNameExact("pac.Bar").l
+        bar.name shouldBe "Bar"
+        cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set(
+          "Foo.<init>:void()",
+          "Foo.add:int(int,int)",
+          "pac.Bar.sub:int(int,int)",
+          "pac.Bar.<init>:void()"
+        )
     }
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
@@ -16,10 +16,10 @@ import scala.util.{Failure, Success, Try}
 
 class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
-  var recurseCpgs: Map[String, Cpg] = _
+  var recurseCpgs: Map[String, Cpg]   = _
   var noRecurseCpgs: Map[String, Cpg] = _
   var depthsCpgs: Map[String, Cpg]    = _
-  var slippyCpg: Cpg              = _
+  var slippyCpg: Cpg                  = _
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -77,10 +77,7 @@ class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll
 
       if (name == "NestedHelloWorld.jar")
         cpg.typeDecl.fullNameExact("pac.Bar").l shouldBe Nil
-        cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set(
-          "Foo.<init>:void()",
-          "Foo.add:int(int,int)"
-        )
+        cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set("Foo.<init>:void()", "Foo.add:int(int,int)")
       else
         val List(bar) = cpg.typeDecl.fullNameExact("pac.Bar").l
         bar.name shouldBe "Bar"
@@ -100,10 +97,7 @@ class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll
 
       if (name == "NestedHelloWorld.jar")
         cpg.typeDecl.fullNameExact("pac.Bar").l shouldBe Nil
-        cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set(
-          "Foo.<init>:void()",
-          "Foo.add:int(int,int)"
-        )
+        cpg.method.filterNot(_.isExternal).fullName.toSet shouldBe Set("Foo.<init>:void()", "Foo.add:int(int,int)")
       else
         val List(bar) = cpg.typeDecl.fullNameExact("pac.Bar").l
         bar.name shouldBe "Bar"

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
@@ -24,7 +24,7 @@ class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     recurseCpgs = List("HelloWorld.jar", "NestedHelloWorld.jar", "helloworld")
-      .map(k => (k, getUnpackingCpg(k, true, 1)))
+      .map(k => (k, getUnpackingCpg(k, true)))
       .toMap
     noRecurseCpgs = List("HelloWorld.jar", "NestedHelloWorld.jar", "helloworld")
       .map(k => (k, getUnpackingCpg(k, false)))


### PR DESCRIPTION
The [PR 3170](https://github.com/joernio/joern/pull/3170) added a optino `--recurse` for `jimple2cpg`, but without max-depths limit.

And also, this make the behavior of `jimple2cpg` odd. If you want to scanning a directory with some jar file you have to specify the `--recurse` option. However, `--recurse` should only control whether to unpack "jars in jars" as described.

This PR correct the behavior, we can now scanning a directory directly without `--recurse` option. If want to enable the `recurse`, set the `--recurse`. And I have add a option `--depths` to control the max-depths of recurse, the default value of max-depth is 1, that's meaning all the jars in a jar file will be unpack but the jars in theses jar will no be unpack again (unless you set the `--depths` to 2).
