### PR TITLE
[jssrc2cpg] - Graceful handling of error situation for jssrc2cpg

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -26,7 +26,12 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
     astGenRunnerResult.skippedFiles.foreach { skippedFile =>
       val (rootPath, fileName) = skippedFile
       val filePath             = Paths.get(rootPath, fileName)
-      val fileLOC              = IOUtils.readLinesInFile(filePath).size
+      val fileLOC = Try(IOUtils.readLinesInFile(filePath)) match {
+        case Success(filecontent) => filecontent.size
+        case Failure(exception) =>
+          logger.warn(s"Failed to read file: '${filePath}'", exception)
+          0
+      }
       report.addReportInfo(fileName, fileLOC)
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/preprocessing/EjsPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/preprocessing/EjsPassTest.scala
@@ -70,6 +70,17 @@ class EjsPassTest extends AbstractPassTest {
           "user.name"
         )
     }
+
+    "invalid EJS file test" in AstFixture(
+      """
+        |<body>
+        |<h1>Welcome <%@#$= user.name %></h1>
+        |</body>
+        |""".stripMargin,
+      "index.js.ejs"
+    ) { cpg =>
+      cpg.file.l.size shouldBe 0
+    }
   }
 
 }


### PR DESCRIPTION
While processing `.ejs` files, if the astgen throws any error while parsing the file. We encountered this error in the Finish method where we read skipped file contents for the report. In the case of `.ejs` files as we preprocess and convert them into `.js` file. For some reason this `.js` file is not present at the expected place, we get a file not found exception. I have handled the situation gracefully in order to avoid breaking the entire process of generating the CPG.