### PR TITLE
[javasrc2cpg] Add anonymous classes and captures for inner classes

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -164,9 +164,7 @@ class AstCreator(
         .importedAs(name)
         .importedEntity(typeFullName)
 
-      if (importStmt.isStatic) {
-        // TODO: Deal with this case
-      } else {
+      if (!importStmt.isStatic) {
         scope.addTopLevelType(name, typeFullName)
       }
       importNode

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -16,7 +16,11 @@ import com.github.javaparser.ast.expr.{
 import com.github.javaparser.ast.nodeTypes.{NodeWithName, NodeWithSimpleName}
 import com.github.javaparser.ast.{CompilationUnit, Node, PackageDeclaration}
 import com.github.javaparser.resolution.UnsolvedSymbolException
-import com.github.javaparser.resolution.declarations.{ResolvedMethodLikeDeclaration, ResolvedReferenceTypeDeclaration}
+import com.github.javaparser.resolution.declarations.{
+  ResolvedMethodDeclaration,
+  ResolvedMethodLikeDeclaration,
+  ResolvedReferenceTypeDeclaration
+}
 import com.github.javaparser.resolution.types.ResolvedType
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
@@ -29,7 +33,17 @@ import io.joern.javasrc2cpg.scope.Scope.*
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 import io.joern.javasrc2cpg.util.BindingTable.createBindingTable
-import io.joern.javasrc2cpg.util.{BindingTable, BindingTableAdapterForJavaparser, NameConstants}
+import io.joern.javasrc2cpg.util.MultiBindingTableAdapterForJavaparser.{
+  InnerClassDeclaration,
+  JavaparserBindingDeclType,
+  RegularClassDeclaration
+}
+import io.joern.javasrc2cpg.util.{
+  BindingTable,
+  BindingTableAdapterForJavaparser,
+  MultiBindingTableAdapterForJavaparser,
+  NameConstants
+}
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.utils.OffsetUtils
 import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, ValidationMode}
@@ -102,7 +116,7 @@ class AstCreator(
 
   /** Copy nodes/edges of given `AST` into the diff graph
     */
-  private def storeInDiffGraph(ast: Ast): Unit = {
+  def storeInDiffGraph(ast: Ast): Unit = {
     Ast.storeInDiffGraph(ast, diffGraph)
   }
 
@@ -150,10 +164,10 @@ class AstCreator(
         .importedAs(name)
         .importedEntity(typeFullName)
 
-      if (importStmt.isStatic()) {
-        scope.addStaticImport(importNode)
+      if (importStmt.isStatic) {
+        // TODO: Deal with this case
       } else {
-        scope.addType(name, typeFullName)
+        scope.addTopLevelType(name, typeFullName)
       }
       importNode
     }
@@ -185,19 +199,18 @@ class AstCreator(
       val importNodes = addImportsToScope(compilationUnit).map(Ast(_))
 
       val typeDeclAsts = compilationUnit.getTypes.asScala.map { typ =>
-        astForTypeDecl(typ, astParentType = NodeTypes.NAMESPACE_BLOCK, astParentFullName = namespaceBlock.fullName)
+        astForTypeDeclaration(typ)
       }
 
       // TODO: Add ASTs
-      scope.popScope()
+      scope.popNamespaceScope()
       Ast(namespaceBlock).withChildren(typeDeclAsts).withChildren(importNodes)
     } catch {
       case t: UnsolvedSymbolException =>
         logger.error(s"Unsolved symbol exception caught in $filename")
         Ast()
       case t: Throwable =>
-        logger.error(s"Parsing file $filename failed with $t")
-        logger.error(s"Caused by ${t.getCause}")
+        logger.error(s"Parsing file $filename failed", t)
         Ast()
     }
   }
@@ -230,20 +243,36 @@ class AstCreator(
     }
   }
 
-  def getBindingTable(typeDecl: ResolvedReferenceTypeDeclaration): BindingTable = {
-    val fullName = typeInfoCalc.fullName(typeDecl).getOrElse {
+  private def fullNameForBindingTable(typeDecl: ResolvedReferenceTypeDeclaration): String = {
+    typeInfoCalc.fullNameWithoutRegistering(typeDecl).getOrElse {
       val qualifiedName = typeDecl.getQualifiedName
       logger.warn(s"Could not get full name for resolved type decl $qualifiedName. THIS SHOULD NOT HAPPEN!")
       qualifiedName
     }
+  }
+
+  def getMultiBindingTable(typeDecl: JavaparserBindingDeclType): BindingTable = {
+    val fullName = typeDecl match {
+      case RegularClassDeclaration(resolvedRefType, _) => fullNameForBindingTable(resolvedRefType)
+
+      case innerClassDeclaration: InnerClassDeclaration => innerClassDeclaration.fullName
+    }
     bindingTableCache.getOrElseUpdate(
       fullName,
-      createBindingTable(fullName, typeDecl, getBindingTable, new BindingTableAdapterForJavaparser(methodSignature))
+      createBindingTable(
+        fullName,
+        typeDecl,
+        getMultiBindingTable,
+        new MultiBindingTableAdapterForJavaparser(methodSignature)
+      )
     )
   }
 
-  def expressionReturnTypeFullName(expr: Expression): Option[String] = {
+  def getBindingTable(typeDecl: ResolvedReferenceTypeDeclaration): BindingTable = {
+    getMultiBindingTable(RegularClassDeclaration(typeDecl, ResolvedTypeParametersMap.empty()))
+  }
 
+  def expressionReturnTypeFullName(expr: Expression): Option[String] = {
     val resolvedTypeOption = tryWithSafeStackOverflow(expr.calculateResolvedType()) match {
       case Failure(ex) =>
         ex match {
@@ -261,7 +290,7 @@ class AstCreator(
             }
           case _ => None
         }
-      case Success(resolvedType) => typeInfoCalc.fullName(resolvedType)
+      case Success(resolvedType) => typeInfoCalc.fullNameWithoutRegistering(resolvedType)
     }
     resolvedTypeOption.orElse(exprNameFromStack(expr))
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -61,7 +61,6 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
       ExpectedType(returnTypeFullName, expectedReturnType),
       methodDeclaration.isStatic()
     )
-    // TODO: Is this correct?
     typeParameters.foreach { typeParameter => scope.addTopLevelType(typeParameter.name, typeParameter.typeFullName) }
 
     val parameterAsts  = astsForParameterList(methodDeclaration.getParameters)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -1,7 +1,15 @@
 package io.joern.javasrc2cpg.astcreation.declarations
 
+import io.joern.x2cpg.utils.AstPropertiesUtil.*
 import com.github.javaparser.ast.NodeList
-import com.github.javaparser.ast.body.{CallableDeclaration, ConstructorDeclaration, MethodDeclaration, Parameter}
+import com.github.javaparser.ast.body.{
+  CallableDeclaration,
+  ConstructorDeclaration,
+  FieldDeclaration,
+  MethodDeclaration,
+  Parameter,
+  VariableDeclarator
+}
 import com.github.javaparser.ast.stmt.{BlockStmt, ExplicitConstructorInvocationStmt}
 import com.github.javaparser.resolution.declarations.{ResolvedMethodDeclaration, ResolvedMethodLikeDeclaration}
 import com.github.javaparser.resolution.types.ResolvedType
@@ -21,10 +29,18 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewModifier
 }
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, ModifierTypes}
+import io.joern.javasrc2cpg.scope.JavaScopeElement.fullName
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.Try
+import io.shiftleft.codepropertygraph.generated.nodes.AstNodeNew
+import io.shiftleft.codepropertygraph.generated.nodes.NewCall
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import com.github.javaparser.ast.Node
+import io.joern.javasrc2cpg.astcreation.declarations.AstForMethodsCreator.PartialConstructorDeclaration
 
 private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   def astForMethod(methodDeclaration: MethodDeclaration): Ast = {
@@ -40,13 +56,18 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
       .orElse(scope.lookupType(simpleMethodReturnType))
       .orElse(typeParameters.find(_.name == simpleMethodReturnType).map(_.typeFullName))
 
-    scope.pushMethodScope(methodNode, ExpectedType(returnTypeFullName, expectedReturnType))
-    typeParameters.foreach { typeParameter => scope.addType(typeParameter.name, typeParameter.typeFullName) }
+    scope.pushMethodScope(
+      methodNode,
+      ExpectedType(returnTypeFullName, expectedReturnType),
+      methodDeclaration.isStatic()
+    )
+    // TODO: Is this correct?
+    typeParameters.foreach { typeParameter => scope.addTopLevelType(typeParameter.name, typeParameter.typeFullName) }
 
     val parameterAsts  = astsForParameterList(methodDeclaration.getParameters)
     val parameterTypes = argumentTypesForMethodLike(maybeResolved)
     val signature      = composeSignature(returnTypeFullName, parameterTypes, parameterAsts.size)
-    val namespaceName  = scope.enclosingTypeDeclFullName.getOrElse(Defines.UnresolvedNamespace)
+    val namespaceName  = scope.enclosingTypeDecl.fullName.getOrElse(Defines.UnresolvedNamespace)
     val methodFullName = composeMethodFullName(namespaceName, methodDeclaration.getNameAsString, signature)
 
     methodNode
@@ -54,13 +75,13 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
       .signature(signature)
 
     val thisNode = Option.when(!methodDeclaration.isStatic) {
-      val typeFullName = scope.enclosingTypeDeclFullName
+      val typeFullName = scope.enclosingTypeDecl.fullName
       thisNodeForMethod(typeFullName, line(methodDeclaration))
     }
     val thisAst = thisNode.map(Ast(_)).toList
 
     thisNode.foreach { node =>
-      scope.addParameter(node)
+      scope.enclosingMethod.get.addParameter(node)
     }
 
     val bodyAst = methodDeclaration.getBody.toScala.map(astForBlockStatement(_)).getOrElse(Ast(NewBlock()))
@@ -75,7 +96,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
 
     val modifiers = modifiersForMethod(methodDeclaration)
 
-    scope.popScope()
+    scope.popMethodScope()
 
     methodAstWithAnnotations(methodNode, thisAst ++ parameterAsts, bodyAst, methodReturn, modifiers, annotationAsts)
   }
@@ -95,7 +116,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   }
 
   private def modifiersForMethod(methodDeclaration: CallableDeclaration[_]): List[NewModifier] = {
-    val isInterfaceMethod = scope.enclosingTypeDecl.exists(_.code.contains("interface "))
+    val isInterfaceMethod = scope.enclosingTypeDecl.isInterface
 
     val abstractModifier = abstractModifierForCallable(methodDeclaration, isInterfaceMethod)
 
@@ -134,14 +155,25 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   def clinitAstFromStaticInits(staticInits: Seq[Ast]): Option[Ast] = {
     Option.when(staticInits.nonEmpty) {
       val signature         = composeMethodLikeSignature(TypeConstants.Void, Nil)
-      val enclosingDeclName = scope.enclosingTypeDeclFullName.getOrElse(Defines.UnresolvedNamespace)
+      val enclosingDeclName = scope.enclosingTypeDecl.fullName.getOrElse(Defines.UnresolvedNamespace)
       val fullName          = composeMethodFullName(enclosingDeclName, Defines.StaticInitMethodName, signature)
       staticInitMethodAst(staticInits.toList, fullName, Some(signature), TypeConstants.Void)
     }
   }
 
-  def astForDefaultConstructor(): Ast = {
-    val typeFullName = scope.enclosingTypeDeclFullName
+  private def astsForFieldInitializers(fieldDeclarations: List[FieldDeclaration]): List[Ast] = {
+    fieldDeclarations.flatMap { fieldDeclaration =>
+      fieldDeclaration.getVariables.asScala.filter(_.getInitializer.isPresent).toList.flatMap { variableDeclaration =>
+        scope.pushFieldDeclScope(fieldDeclaration.isStatic, variableDeclaration.getNameAsString)
+        val assignmentAsts = assignmentsForVarDecl(variableDeclaration :: Nil)
+        scope.popFieldDeclScope()
+        assignmentAsts
+      }
+    }
+  }
+
+  def astForDefaultConstructor(originNode: Node, instanceFieldDeclarations: List[FieldDeclaration]): Ast = {
+    val typeFullName = scope.enclosingTypeDecl.fullName
     val signature    = s"${TypeConstants.Void}()"
     val fullName = composeMethodFullName(
       typeFullName.getOrElse(Defines.UnresolvedNamespace),
@@ -155,14 +187,31 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
       .filename(filename)
       .isExternal(false)
 
-    val thisAst = Ast(thisNodeForMethod(typeFullName, lineNumber = None))
-    val bodyAst = Ast(NewBlock()).withChildren(scope.memberInitializers)
+    scope.pushMethodScope(constructorNode, ExpectedType.Void, isStatic = false)
+
+    val thisNode = thisNodeForMethod(typeFullName, lineNumber = None)
+    scope.enclosingMethod.foreach(_.addParameter(thisNode))
+    val bodyStatementAsts = astsForFieldInitializers(instanceFieldDeclarations)
 
     val returnNode = newMethodReturnNode(TypeConstants.Void, line = None, column = None)
 
     val modifiers = List(newModifierNode(ModifierTypes.CONSTRUCTOR), newModifierNode(ModifierTypes.PUBLIC))
+    val partialConstructor =
+      PartialConstructorDeclaration(
+        originNode,
+        constructorNode,
+        thisNode,
+        explicitParameterAsts = Nil,
+        bodyStatementAsts = bodyStatementAsts,
+        methodReturn = returnNode,
+        annotationAsts = Nil,
+        modifiers = modifiers,
+        startsWithThisCall = false
+      )
 
-    methodAstWithAnnotations(constructorNode, Seq(thisAst), bodyAst, returnNode, modifiers)
+    val constructorAst = completePartialConstructor(partialConstructor)
+    scope.popMethodScope()
+    constructorAst
   }
 
   private def astForParameter(parameter: Parameter, childNum: Int): Ast = {
@@ -189,7 +238,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
     val annotationAsts = parameter.getAnnotations.asScala.map(astForAnnotationExpr)
     val ast            = Ast(parameterNode)
 
-    scope.addParameter(parameterNode)
+    scope.enclosingMethod.get.addParameter(parameterNode)
 
     ast.withChildren(annotationAsts)
   }
@@ -240,59 +289,159 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
     }
   }
 
-  def astForConstructor(constructorDeclaration: ConstructorDeclaration): Ast = {
-    val constructorNode = createPartialMethod(constructorDeclaration)
-      .name(io.joern.x2cpg.Defines.ConstructorMethodName)
+  private def partialConstructorAsts(
+    constructorDeclarations: List[ConstructorDeclaration],
+    instanceFieldDeclarations: List[FieldDeclaration]
+  ): List[PartialConstructorDeclaration] = {
+    constructorDeclarations.map { constructorDeclaration =>
+      val constructorNode = createPartialMethod(constructorDeclaration)
+        .name(io.joern.x2cpg.Defines.ConstructorMethodName)
 
-    scope.pushMethodScope(constructorNode, ExpectedType.Void)
-    val maybeResolved = tryWithSafeStackOverflow(constructorDeclaration.resolve())
+      scope.pushMethodScope(constructorNode, ExpectedType.Void, isStatic = false)
+      val maybeResolved = tryWithSafeStackOverflow(constructorDeclaration.resolve())
 
-    val parameterAsts = astsForParameterList(constructorDeclaration.getParameters).toList
-    val paramTypes    = argumentTypesForMethodLike(maybeResolved)
-    val signature     = composeSignature(Some(TypeConstants.Void), paramTypes, parameterAsts.size)
-    val typeFullName  = scope.enclosingTypeDeclFullName
-    val fullName =
-      composeMethodFullName(
-        typeFullName.getOrElse(Defines.UnresolvedNamespace),
-        Defines.ConstructorMethodName,
-        signature
-      )
+      val parameterAsts = astsForParameterList(constructorDeclaration.getParameters).toList
+      val paramTypes    = argumentTypesForMethodLike(maybeResolved)
+      val signature     = composeSignature(Some(TypeConstants.Void), paramTypes, parameterAsts.size)
+      val typeFullName  = scope.enclosingTypeDecl.fullName
+      val fullName =
+        composeMethodFullName(
+          typeFullName.getOrElse(Defines.UnresolvedNamespace),
+          Defines.ConstructorMethodName,
+          signature
+        )
 
-    constructorNode
-      .fullName(fullName)
-      .signature(signature)
+      constructorNode
+        .fullName(fullName)
+        .signature(signature)
 
-    parameterAsts.foreach { ast =>
-      ast.root match {
-        case Some(parameter: NewMethodParameterIn) => scope.addParameter(parameter)
-        case _                                     => // This should never happen
+      parameterAsts.foreach { ast =>
+        ast.root match {
+          case Some(parameter: NewMethodParameterIn) => scope.enclosingMethod.get.addParameter(parameter)
+          case _                                     => // This should never happen
+        }
       }
+
+      val thisNode = thisNodeForMethod(typeFullName, line(constructorDeclaration))
+      scope.enclosingMethod.get.addParameter(thisNode)
+
+      scope.pushBlockScope()
+      val bodyStatements = constructorDeclaration.getBody.getStatements.asScala.toList
+      val bodyContainsThis = bodyStatements.headOption
+        .collect { case consInvocation: ExplicitConstructorInvocationStmt => consInvocation.isThis }
+        .getOrElse(false)
+      val fieldAssignments =
+        if (bodyContainsThis)
+          Nil
+        else
+          astsForFieldInitializers(instanceFieldDeclarations)
+
+      // The this(...) call must always be the first statement in the body, but adding the fieldAssignments
+      // before the body asts here is safe, since the list will be empty if the body does start with this()
+      val bodyAsts = fieldAssignments ++ bodyStatements.flatMap(astsForStatement)
+      scope.popBlockScope()
+      val methodReturn = constructorReturnNode(constructorDeclaration)
+
+      val annotationAsts = constructorDeclaration.getAnnotations.asScala.map(astForAnnotationExpr).toList
+
+      val modifiers =
+        NewModifier().modifierType(ModifierTypes.CONSTRUCTOR) :: modifiersForMethod(constructorDeclaration).filterNot(
+          _.modifierType == ModifierTypes.VIRTUAL
+        )
+
+      scope.popMethodScope()
+      PartialConstructorDeclaration(
+        constructorDeclaration,
+        constructorNode,
+        thisNode,
+        parameterAsts,
+        bodyAsts.toList,
+        methodReturn,
+        annotationAsts,
+        modifiers,
+        bodyContainsThis
+      )
+    }
+  }
+
+  private def assignmentForCapture(
+    originNode: Node,
+    parameter: NewMethodParameterIn,
+    thisParam: NewMethodParameterIn
+  ): Ast = {
+    val assignment =
+      newOperatorCallNode(
+        Operators.assignment,
+        s"this.${parameter.name} = ${parameter.name}",
+        Some(parameter.typeFullName),
+        parameter.lineNumber,
+        parameter.columnNumber
+      )
+    val fieldAccess = newOperatorCallNode(
+      Operators.fieldAccess,
+      s"this.${parameter.name}",
+      Some(thisParam.typeFullName),
+      parameter.lineNumber,
+      parameter.columnNumber
+    )
+
+    val fieldAccessTarget =
+      identifierNode(originNode, "this", "this", thisParam.typeFullName, List(thisParam.typeFullName))
+    val fieldIdentifier = fieldIdentifierNode(originNode, parameter.name, parameter.name)
+
+    val sourceIdentifier =
+      identifierNode(originNode, parameter.name, parameter.name, parameter.typeFullName)
+
+    diffGraph.addEdge(fieldAccessTarget, thisParam, EdgeTypes.REF)
+    diffGraph.addEdge(sourceIdentifier, parameter, EdgeTypes.REF)
+
+    val fieldAccessAst = callAst(fieldAccess, List(fieldAccessTarget, fieldIdentifier).map(Ast(_)))
+
+    callAst(assignment, List(fieldAccessAst, Ast(sourceIdentifier)))
+
+  }
+
+  private def completePartialConstructor(partialConstructor: PartialConstructorDeclaration): Ast = {
+    val paramsForCaptures = scope.enclosingTypeDecl.getUsedCaptures().zipWithIndex.map { case (variable, index) =>
+      parameterInNode(
+        partialConstructor.originNode,
+        variable.name,
+        variable.name,
+        partialConstructor.explicitParameterAsts.length + 1 + index,
+        isVariadic = false,
+        EvaluationStrategies.BY_VALUE,
+        variable.typeFullName
+      )
     }
 
-    val thisNode = thisNodeForMethod(typeFullName, line(constructorDeclaration))
-    scope.addParameter(thisNode)
-    val thisAst = Ast(thisNode)
+    val thisNode = partialConstructor.thisNode
+    val assignmentsForCaptures =
+      if (partialConstructor.startsWithThisCall)
+        Nil
+      else
+        paramsForCaptures.map(assignmentForCapture(partialConstructor.originNode, _, partialConstructor.thisNode))
 
-    val bodyAst      = astForConstructorBody(Some(constructorDeclaration.getBody))
-    val methodReturn = constructorReturnNode(constructorDeclaration)
-
-    val annotationAsts = constructorDeclaration.getAnnotations.asScala.map(astForAnnotationExpr).toList
-
-    val modifiers =
-      NewModifier().modifierType(ModifierTypes.CONSTRUCTOR) :: modifiersForMethod(constructorDeclaration).filterNot(
-        _.modifierType == ModifierTypes.VIRTUAL
-      )
-
-    scope.popScope()
+    val bodyAst =
+      astForConstructorBody(partialConstructor.originNode, partialConstructor.bodyStatementAsts, assignmentsForCaptures)
 
     methodAstWithAnnotations(
-      constructorNode,
-      thisAst :: parameterAsts,
+      partialConstructor.constructorNode,
+      Ast(partialConstructor.thisNode) :: (partialConstructor.explicitParameterAsts ++ paramsForCaptures.map(Ast(_))),
       bodyAst,
-      methodReturn,
-      modifiers,
-      annotationAsts
+      partialConstructor.methodReturn,
+      partialConstructor.modifiers,
+      partialConstructor.annotationAsts
     )
+  }
+
+  def astsForConstructors(
+    constructorDeclarations: List[ConstructorDeclaration],
+    instanceFieldDeclarations: List[FieldDeclaration]
+  ): Map[Node, Ast] = {
+    val partialConstructors = partialConstructorAsts(constructorDeclarations, instanceFieldDeclarations)
+    partialConstructors.map { partialConstructor =>
+      partialConstructor.originNode -> completePartialConstructor(partialConstructor)
+    }.toMap
   }
 
   private def constructorReturnNode(constructorDeclaration: ConstructorDeclaration): NewMethodReturn = {
@@ -301,24 +450,22 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
     newMethodReturnNode(TypeConstants.Void, None, line, column)
   }
 
-  private def astForConstructorBody(body: Option[BlockStmt]): Ast = {
-    val containsThisInvocation =
-      body
-        .flatMap(_.getStatements.asScala.headOption)
-        .collect { case e: ExplicitConstructorInvocationStmt => e }
-        .exists(_.isThis)
+  private def astForConstructorBody(originNode: Node, bodyStmts: List[Ast], captureInitializers: List[Ast]): Ast = {
+    val hasThisCall = bodyStmts.headOption
+      .flatMap(_.root)
+      .collect { case thisCall: NewCall => thisCall.name == "<init>" }
+      .getOrElse(false)
 
-    val memberInitializers =
-      if (containsThisInvocation)
-        Seq.empty
-      else
-        scope.memberInitializers
+    val statementsInOrder = bodyStmts match {
+      case Nil => captureInitializers
 
-    body match {
-      case Some(b) => astForBlockStatement(b, prefixAsts = memberInitializers)
+      case head :: tail if hasThisCall =>
+        head :: (captureInitializers ++ tail)
 
-      case None => Ast(NewBlock()).withChildren(memberInitializers)
+      case bodyStmts => captureInitializers ++ bodyStmts
     }
+
+    Ast(blockNode(originNode)).withChildren(statementsInOrder)
   }
 
   /** Constructor and Method declarations share a lot of fields, so this method adds the fields they have in common.
@@ -342,4 +489,18 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
       line = lineNumber
     )
   }
+}
+
+object AstForMethodsCreator {
+  private case class PartialConstructorDeclaration(
+    originNode: Node,
+    constructorNode: NewMethod,
+    thisNode: NewMethodParameterIn,
+    explicitParameterAsts: List[Ast],
+    bodyStatementAsts: List[Ast],
+    methodReturn: NewMethodReturn,
+    annotationAsts: List[Ast],
+    modifiers: List[NewModifier],
+    startsWithThisCall: Boolean
+  )
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -33,11 +33,13 @@ import com.github.javaparser.ast.expr.{
   StringLiteralExpr,
   TextBlockLiteralExpr
 }
-import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration
+import com.github.javaparser.resolution.declarations.{
+  ResolvedReferenceTypeDeclaration,
+  ResolvedTypeParameterDeclaration
+}
 import io.joern.javasrc2cpg.astcreation.AstCreator
-import io.joern.javasrc2cpg.astcreation.declarations.AstForTypeDeclsCreator.AstWithStaticInit
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
-import io.joern.javasrc2cpg.util.{BindingTable, BindingTableEntry}
+import io.joern.javasrc2cpg.util.{BindingTable, BindingTableEntry, NameConstants, Util}
 import io.joern.x2cpg.utils.NodeBuilders.*
 import io.joern.x2cpg.{Ast, Defines}
 import io.shiftleft.codepropertygraph.generated.nodes.{
@@ -53,6 +55,26 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.{Success, Try}
+import com.github.javaparser.ast.expr.ObjectCreationExpr
+import com.github.javaparser.ast.stmt.LocalClassDeclarationStmt
+import com.github.javaparser.ast.body.AnnotationMemberDeclaration
+import com.github.javaparser.ast.body.CompactConstructorDeclaration
+import com.github.javaparser.ast.body.EnumDeclaration
+import io.joern.javasrc2cpg.scope.Scope.ScopeVariable
+import com.github.javaparser.ast.Node
+import com.github.javaparser.resolution.types.ResolvedReferenceType
+import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
+import io.shiftleft.codepropertygraph.generated.nodes.NewCall
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.joern.javasrc2cpg.scope.JavaScopeElement.PartialInit
+import io.joern.javasrc2cpg.util.MultiBindingTableAdapterForJavaparser.{
+  InnerClassDeclaration,
+  JavaparserBindingDeclType,
+  RegularClassDeclaration
+}
+import io.shiftleft.codepropertygraph.generated.nodes.ExpressionNew
+
+import scala.jdk.OptionConverters.RichOptional
 
 object AstForTypeDeclsCreator {
   case class AstWithStaticInit(ast: Seq[Ast], staticInits: Seq[Ast])
@@ -68,90 +90,394 @@ object AstForTypeDeclsCreator {
 private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  def astForTypeDecl(typ: TypeDeclaration[_], astParentType: String, astParentFullName: String): Ast = {
-    val isInterface = typ match {
-      case classDeclaration: ClassOrInterfaceDeclaration => classDeclaration.isInterface
-      case _                                             => false
-    }
+  def astForAnonymousClassDecl(
+    expr: ObjectCreationExpr,
+    body: List[BodyDeclaration[_]],
+    typeName: String,
+    typeFullName: Option[String],
+    baseTypeFullName: Option[String]
+  ): Ast = {
+    val (astParentType, astParentFullName) = getAstParentInfo()
 
-    val typeDeclNode = createTypeDeclNode(typ, astParentType, astParentFullName, isInterface)
+    val typeDeclRoot =
+      typeDeclNode(
+        expr,
+        typeName,
+        typeFullName.getOrElse(typeName),
+        filename,
+        expr.toString(),
+        astParentType,
+        astParentFullName,
+        baseTypeFullName.getOrElse(TypeConstants.Object) :: Nil
+      )
 
-    scope.pushTypeDeclScope(typeDeclNode)
-    addTypeDeclTypeParamsToScope(typ)
+    typeFullName.foreach(scope.addInnerType(typeName, _))
 
-    val enumEntryAsts = if (typ.isEnumDeclaration) {
-      typ.asEnumDeclaration().getEntries.asScala.map(astForEnumEntry).toList
-    } else {
-      List.empty
-    }
+    val declaredMethodNames = body.collect { case methodDeclaration: MethodDeclaration =>
+      methodDeclaration.getNameAsString
+    }.toSet
 
-    val staticInits: mutable.Buffer[Ast] = mutable.Buffer()
-    val memberAsts = typ.getMembers.asScala.flatMap { member =>
-      val astWithInits =
-        astForTypeDeclMember(member, astParentFullName = NodeTypes.TYPE_DECL)
-      staticInits.appendAll(astWithInits.staticInits)
-      astWithInits.ast
-    }
-
-    val defaultConstructorAst = if (!isInterface && typ.getConstructors.isEmpty) {
-      Some(astForDefaultConstructor())
-    } else {
-      None
-    }
-
-    val annotationAsts = typ.getAnnotations.asScala.map(astForAnnotationExpr)
-
-    val clinitAst = clinitAstFromStaticInits(staticInits.toSeq)
+    scope.pushTypeDeclScope(typeDeclRoot, scope.isEnclosingScopeStatic, declaredMethodNames)
+    val memberAsts = astsForTypeDeclMembers(expr, body, isInterface = false, typeFullName)
 
     val localDecls    = scope.localDeclsInScope
     val lambdaMethods = scope.lambdaMethodsInScope
 
-    val modifiers = modifiersForTypeDecl(typ, isInterface)
+    val declScope = scope.popTypeDeclScope()
+    scope.enclosingTypeDecl.foreach(_.registerCapturesForType(declScope.typeDecl.fullName, declScope.getUsedCaptures()))
 
-    val typeDeclAst = Ast(typeDeclNode)
-      .withChildren(enumEntryAsts)
+    tryWithSafeStackOverflow(expr.getType.resolve().asReferenceType()).toOption.foreach { ancestorType =>
+      val parentType = bindingTypeForReferenceType(ancestorType)
+      val resolvedMethods = body
+        .collect { case method: MethodDeclaration =>
+          tryWithSafeStackOverflow(method.resolve())
+        }
+        .collect { case Success(resolvedMethod) =>
+          resolvedMethod
+        }
+      val bindingType = InnerClassDeclaration(
+        typeFullName.getOrElse(typeName),
+        parentType.toList,
+        resolvedMethods,
+        ancestorType.typeParametersMap()
+      )
+
+      val bindingTable = getMultiBindingTable(bindingType)
+      declScope.getBindingTableEntries.foreach(bindingTable.add)
+      BindingTable.createBindingNodes(diffGraph, typeDeclRoot, bindingTable)
+    }
+
+    Ast(typeDeclRoot)
       .withChildren(memberAsts)
-      .withChildren(defaultConstructorAst.toList)
+      .withChildren(localDecls)
+      .withChildren(lambdaMethods)
+  }
+
+  def astForLocalClassDeclaration(localClassDecl: LocalClassDeclarationStmt): Ast = {
+    val name                  = localClassDecl.getClassDeclaration.getNameAsString
+    val enclosingMethodPrefix = scope.enclosingMethod.getMethodFullName.takeWhile(_ != ':')
+    val fullName              = s"$enclosingMethodPrefix.$name"
+    scope.addInnerType(name, fullName)
+    astForTypeDeclaration(localClassDecl.getClassDeclaration, fullNameOverride = Some(fullName))
+  }
+
+  def astForTypeDeclaration(typeDeclaration: TypeDeclaration[_], fullNameOverride: Option[String] = None): Ast = {
+    val isInterface = typeDeclaration match {
+      case classDeclaration: ClassOrInterfaceDeclaration => classDeclaration.isInterface
+      case _                                             => false
+    }
+
+    val (astParentType, astParentFullName) = getAstParentInfo()
+
+    val typeDeclRoot =
+      createTypeDeclNode(typeDeclaration, astParentType, astParentFullName, isInterface, fullNameOverride)
+
+    val declaredMethodNames = typeDeclaration.getMethods.asScala.map(_.getNameAsString).toSet
+    scope.pushTypeDeclScope(typeDeclRoot, typeDeclaration.isStatic, declaredMethodNames)
+    addTypeDeclTypeParamsToScope(typeDeclaration)
+
+    val annotationAsts = typeDeclaration.getAnnotations.asScala.map(astForAnnotationExpr)
+    val modifiers      = modifiersForTypeDecl(typeDeclaration, isInterface)
+    val enumEntries = typeDeclaration match {
+      case enumDeclaration: EnumDeclaration => enumDeclaration.getEntries.asScala.toList
+      case _                                => Nil
+    }
+    val memberAsts =
+      astsForTypeDeclMembers(
+        typeDeclaration,
+        enumEntries ++ typeDeclaration.getMembers.asScala.toList,
+        isInterface,
+        fullNameOverride
+      )
+
+    val localDecls    = scope.localDeclsInScope
+    val lambdaMethods = scope.lambdaMethodsInScope
+
+    val typeDeclAst = Ast(typeDeclRoot)
+      .withChildren(memberAsts)
       .withChildren(annotationAsts)
-      .withChildren(clinitAst.toSeq)
       .withChildren(localDecls)
       .withChildren(lambdaMethods)
       .withChildren(modifiers.map(Ast(_)))
 
-    val defaultConstructorBindingEntry =
-      defaultConstructorAst
-        .flatMap(_.root)
-        .collect { case defaultConstructor: NewMethod =>
-          BindingTableEntry(
-            io.joern.x2cpg.Defines.ConstructorMethodName,
-            defaultConstructor.signature,
-            defaultConstructor.fullName
-          )
-        }
+    val declScope = scope.popTypeDeclScope()
+    scope.enclosingTypeDecl.foreach(_.registerCapturesForType(declScope.typeDecl.fullName, declScope.getUsedCaptures()))
 
     // Annotation declarations need no binding table as objects of this
     // typ never get called from user code.
     // Furthermore the parser library throws an exception when trying to
     // access e.g. the declared methods of an annotation declaration.
-    if (!typ.isInstanceOf[AnnotationDeclaration]) {
-      tryWithSafeStackOverflow(typ.resolve()).toOption.foreach { resolvedTypeDecl =>
-        val bindingTable = getBindingTable(resolvedTypeDecl)
-        defaultConstructorBindingEntry.foreach(bindingTable.add)
-        BindingTable.createBindingNodes(diffGraph, typeDeclNode, bindingTable)
+    if (!typeDeclaration.isInstanceOf[AnnotationDeclaration]) {
+      tryWithSafeStackOverflow(typeDeclaration.resolve()).toOption.foreach { resolvedTypeDecl =>
+        val bindingTable = fullNameOverride match {
+          case None =>
+            getBindingTable(resolvedTypeDecl)
+
+          case Some(fullName) =>
+            val declBindingType = bindingTypeForLocalClass(fullName, resolvedTypeDecl)
+            scope.addDeclBinding(resolvedTypeDecl.getName, declBindingType)
+            getMultiBindingTable(declBindingType)
+
+        }
+
+        declScope.getBindingTableEntries.foreach(bindingTable.add)
+        BindingTable.createBindingNodes(diffGraph, typeDeclRoot, bindingTable)
       }
     }
 
-    scope.popScope()
-
     typeDeclAst
+  }
+
+  private def bindingTypeForReferenceType(typ: ResolvedReferenceType): Option[JavaparserBindingDeclType] = {
+    typ.getTypeDeclaration.toScala.map(typeDecl =>
+      scope.getDeclBinding(typeDecl.getName) match {
+        case None => RegularClassDeclaration(typeDecl, typ.typeParametersMap())
+
+        case Some(regularClass: RegularClassDeclaration) =>
+          regularClass.copy(typeParametersMap = typ.typeParametersMap())
+
+        case Some(innerClass: InnerClassDeclaration) => innerClass.copy(typeParametersMap = typ.typeParametersMap())
+
+      }
+    )
+  }
+
+  private def bindingTypeForLocalClass(
+    fullName: String,
+    typeDeclaration: ResolvedReferenceTypeDeclaration
+  ): JavaparserBindingDeclType = {
+    val directParents = Util.safeGetAncestors(typeDeclaration).flatMap(bindingTypeForReferenceType)
+
+    InnerClassDeclaration(
+      fullName,
+      directParents.toList,
+      typeDeclaration.getDeclaredMethods.asScala.toList,
+      ResolvedTypeParametersMap.empty()
+    )
+  }
+
+  private def getAstParentInfo(): (String, String) = {
+    scope.enclosingTypeDecl
+      .map { scope =>
+        (NodeTypes.TYPE_DECL, scope.typeDecl.fullName)
+      }
+      .orElse {
+        scope.enclosingNamespace.map { scope =>
+          (NodeTypes.NAMESPACE_BLOCK, scope.namespace.fullName)
+        }
+      }
+      .getOrElse((NameConstants.Unknown, NameConstants.Unknown))
+  }
+
+  private def getTypeDeclNameAndFullName(
+    typeDecl: TypeDeclaration[_],
+    fullNameOverride: Option[String]
+  ): (String, String) = {
+    val resolvedType    = tryWithSafeStackOverflow(typeDecl.resolve()).toOption
+    val defaultFullName = s"${Defines.UnresolvedNamespace}.${typeDecl.getNameAsString}"
+    val name            = resolvedType.flatMap(typeInfoCalc.name).getOrElse(typeDecl.getNameAsString)
+    val fullName = fullNameOverride.orElse(resolvedType.flatMap(typeInfoCalc.fullName)).getOrElse(defaultFullName)
+
+    (name, fullName)
+  }
+
+  private def astsForTypeDeclMembers(
+    originNode: Node,
+    members: List[BodyDeclaration[_]],
+    isInterface: Boolean,
+    fullNameOverride: Option[String]
+  ): List[Ast] = {
+    members.collect { case typeDeclaration: TypeDeclaration[_] =>
+      val (name, fullName) = getTypeDeclNameAndFullName(typeDeclaration, fullNameOverride)
+
+      scope.addInnerType(name, fullName)
+    }
+
+    val fields = members.collect { case fieldDeclaration: FieldDeclaration => fieldDeclaration }
+
+    val fieldToFieldAsts = members.collect { case fieldDeclaration: FieldDeclaration =>
+      val result =
+        fieldDeclaration -> fieldDeclaration.getVariables.asScala.map { variable =>
+          val fieldAst = astForFieldVariable(variable, fieldDeclaration)
+          fieldAst
+        }.toList
+      result
+    }.toMap
+
+    val (staticFields, instanceFields) = fields.partition(_.isStatic)
+    val staticFieldInitializers        = getStaticFieldInitializers(staticFields)
+
+    val clinitAst = clinitAstFromStaticInits(staticFieldInitializers)
+
+    val membersAstPairs: List[(Node, List[Ast])] = members.map { member =>
+      val memberAsts = member match {
+        case annotationMember: AnnotationMemberDeclaration =>
+          // TODO: Add support for this
+          Nil
+
+        case constructor: ConstructorDeclaration =>
+          // Added later to create params for captures
+          Nil
+
+        case method: MethodDeclaration =>
+          astForMethod(method) :: Nil
+
+        case compactConstructorDeclaration: CompactConstructorDeclaration =>
+          // TODO: Add this when adding records
+          Nil
+
+        case enumConstantDeclaration: EnumConstantDeclaration =>
+          // TODO: Create initializers
+          astForEnumEntry(enumConstantDeclaration) :: Nil
+
+        case field: FieldDeclaration => fieldToFieldAsts.getOrElse(field, Nil)
+
+        case initialiserDeclaration: InitializerDeclaration =>
+          // Handled with field initialisers
+          Nil
+
+        case typeDeclaration: TypeDeclaration[_] =>
+          astForTypeDeclaration(typeDeclaration) :: Nil
+      }
+      (member, memberAsts)
+    }
+
+    val constructorAstMap = astsForConstructors(
+      members.collect { case constructor: ConstructorDeclaration =>
+        constructor
+      },
+      instanceFields
+    )
+
+    val membersAsts = membersAstPairs.flatMap {
+      case (constructor: ConstructorDeclaration, _) =>
+        constructorAstMap.get(constructor)
+      case (_, asts) => asts
+    }
+
+    val defaultConstructorAst = Option.when(!(isInterface || members.exists(_.isInstanceOf[ConstructorDeclaration]))) {
+      astForDefaultConstructor(originNode, instanceFields)
+    }
+
+    (defaultConstructorAst.toList ++ constructorAstMap.values)
+      .flatMap(_.root)
+      .collect { case constructorRoot: NewMethod =>
+        BindingTableEntry(
+          io.joern.x2cpg.Defines.ConstructorMethodName,
+          constructorRoot.signature,
+          constructorRoot.fullName
+        )
+      }
+      .foreach { bindingTableEntry =>
+        scope.enclosingTypeDecl.foreach(_.addBindingTableEntry(bindingTableEntry))
+      }
+
+    val capturedMembersAsts = membersForCapturedVariables(originNode, scope.enclosingTypeDecl.getUsedCaptures())
+
+    val allMembersAsts = List(capturedMembersAsts, membersAsts, defaultConstructorAst.toList, clinitAst.toList).flatten
+    val allInitCallNodes = (allMembersAsts ++ scope.enclosingTypeDecl.map(_.registeredLambdaMethods).getOrElse(Nil))
+      .flatMap(_.nodes)
+      .collect { case call: NewCall if call.name == "<init>" => call }
+      .toSet
+
+    addArgsToPartialInits(allInitCallNodes)
+
+    allMembersAsts
+  }
+
+  private def addArgsToPartialInits(allInitCallNodes: Set[NewCall]): Unit = {
+    scope.enclosingTypeDecl.getInitsToComplete.foreach {
+      case PartialInit(typeFullName, callAst, receiverAst, args, capturedThis) =>
+        callAst.root match {
+          case Some(initRoot: NewCall) if allInitCallNodes.contains(initRoot) =>
+            val usedCaptures = if (scope.enclosingTypeDecl.map(_.typeDecl.fullName).contains(typeFullName)) {
+              scope.enclosingTypeDecl.getUsedCaptures()
+            } else {
+              scope.enclosingTypeDecl.getCapturesForType(typeFullName)
+            }
+
+            receiverAst.root.foreach(receiver => diffGraph.addEdge(initRoot, receiver, EdgeTypes.RECEIVER))
+
+            val capturesAsts =
+              usedCaptures.filterNot(capturedThis.isDefined && _.name == NameConstants.OuterClass).zipWithIndex.map {
+                (usedCapture, index) =>
+                  val identifier = NewIdentifier()
+                    .name(usedCapture.name)
+                    .code(usedCapture.name)
+                    .typeFullName(usedCapture.typeFullName)
+                    .lineNumber(initRoot.lineNumber)
+                    .columnNumber(initRoot.columnNumber)
+
+                  diffGraph.addEdge(identifier, usedCapture.node, EdgeTypes.REF)
+
+                  Ast(identifier)
+              }
+
+            val capturedThisIdentifier =
+              Option
+                // TODO: This is broken. Only add this to scope when in a non-static context and use the existence
+                //  of capturedThis to decide if this needs to be added.
+                .when(usedCaptures.exists(_.name == NameConstants.OuterClass))(capturedThis.map { thisNode =>
+                  val identifier = NewIdentifier()
+                    .name(thisNode.name)
+                    .code(thisNode.code)
+                    .typeFullName(thisNode.typeFullName)
+                    .lineNumber(initRoot.lineNumber)
+                    .columnNumber(initRoot.columnNumber)
+
+                  diffGraph.addEdge(identifier, thisNode, EdgeTypes.REF)
+
+                  Ast(identifier)
+                })
+                .flatten
+
+            (receiverAst :: args ++ capturedThisIdentifier.toList ++ capturesAsts)
+              .map { argAst =>
+                storeInDiffGraph(argAst)
+                argAst.root
+              }
+              .collect { case Some(expression: ExpressionNew) =>
+                expression
+              }
+              .zipWithIndex
+              .foreach { (argRoot, index) =>
+                argRoot.argumentIndex_=(index)
+                argRoot.order_=(index + 1)
+
+                diffGraph.addEdge(initRoot, argRoot, EdgeTypes.AST)
+                diffGraph.addEdge(initRoot, argRoot, EdgeTypes.ARGUMENT)
+              }
+
+          case _ => // Do nothing to avoid adding unused inits to the graph
+        }
+    }
+  }
+
+  private def membersForCapturedVariables(originNode: Node, captures: List[ScopeVariable]): List[Ast] = {
+    captures.map { variable =>
+      val node = memberNode(originNode, variable.name, variable.name, variable.typeFullName)
+      Ast(node)
+    }
+  }
+
+  private def getStaticFieldInitializers(staticFields: List[FieldDeclaration]): List[Ast] = {
+    staticFields.flatMap { field =>
+      field.getVariables.asScala.toList.flatMap { variable =>
+        scope.pushFieldDeclScope(isStatic = true, name = variable.getNameAsString)
+        val assignment = assignmentsForVarDecl(variable :: Nil)
+        scope.popFieldDeclScope()
+        assignment
+      }
+    }
   }
 
   private[declarations] def astForAnnotationExpr(annotationExpr: AnnotationExpr): Ast = {
     val fallbackType = s"${Defines.UnresolvedNamespace}.${annotationExpr.getNameAsString}"
     val fullName     = expressionReturnTypeFullName(annotationExpr).getOrElse(fallbackType)
-    val code         = annotationExpr.toString
-    val name         = annotationExpr.getName.getIdentifier
-    val node         = annotationNode(annotationExpr, code, name, fullName)
+    typeInfoCalc.registerType(fullName)
+    val code = annotationExpr.toString
+    val name = annotationExpr.getName.getIdentifier
+    val node = annotationNode(annotationExpr, code, name, fullName)
     annotationExpr match {
       case _: MarkerAnnotationExpr =>
         annotationAst(node, List.empty)
@@ -256,50 +582,6 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     List(accessModifier, abstractModifier).flatten
   }
 
-  private def astForTypeDeclMember(member: BodyDeclaration[_], astParentFullName: String): AstWithStaticInit = {
-    member match {
-      case constructor: ConstructorDeclaration =>
-        val ast = astForConstructor(constructor)
-
-        AstWithStaticInit(ast)
-
-      case method: MethodDeclaration =>
-        val ast = astForMethod(method)
-
-        AstWithStaticInit(ast)
-
-      case typeDeclaration: TypeDeclaration[_] =>
-        AstWithStaticInit(astForTypeDecl(typeDeclaration, NodeTypes.TYPE_DECL, astParentFullName))
-
-      case fieldDeclaration: FieldDeclaration =>
-        val memberAsts = fieldDeclaration.getVariables.asScala.toList.map { variable =>
-          astForFieldVariable(variable, fieldDeclaration)
-        }
-
-        val assignments = assignmentsForVarDecl(
-          fieldDeclaration.getVariables.asScala.toList,
-          line(fieldDeclaration),
-          column(fieldDeclaration)
-        )
-
-        val staticInitAsts = if (fieldDeclaration.isStatic) assignments else Nil
-        if (!fieldDeclaration.isStatic) scope.addMemberInitializers(assignments)
-
-        AstWithStaticInit(memberAsts, staticInitAsts)
-
-      case initDeclaration: InitializerDeclaration =>
-        val stmts = initDeclaration.getBody.getStatements
-        val asts  = stmts.asScala.flatMap(astsForStatement).toList
-        AstWithStaticInit(ast = Seq.empty, staticInits = asts)
-
-      case unhandled =>
-        // AnnotationMemberDeclarations and InitializerDeclarations as children of typeDecls are the
-        // expected cases.
-        logger.info(s"Found unhandled typeDecl member ${unhandled.getClass} in file $filename")
-        AstWithStaticInit.empty
-    }
-  }
-
   private def astForFieldVariable(v: VariableDeclarator, fieldDeclaration: FieldDeclaration): Ast = {
     // TODO: Should be able to find expected type here
     val annotations = fieldDeclaration.getAnnotations
@@ -322,8 +604,8 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
       ) {
         val splitByLeftAngular = v.getTypeAsString.split(Defines.LeftAngularBracket)
         scope.lookupType(splitByLeftAngular.head) match {
-          case Some(fullName) =>
-            fullName + splitByLeftAngular
+          case Some(foundType) =>
+            foundType + splitByLeftAngular
               .slice(1, splitByLeftAngular.size)
               .mkString(Defines.LeftAngularBracket, Defines.LeftAngularBracket, "")
           case None => typeFullNameWithoutGenericSplit
@@ -337,7 +619,7 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
 
     val fieldDeclModifiers = modifiersForFieldDeclaration(fieldDeclaration)
 
-    scope.addMember(node, fieldDeclaration.isStatic)
+    scope.enclosingTypeDecl.get.addMember(node, fieldDeclaration.isStatic)
 
     memberAst
       .withChildren(annotationAsts)
@@ -367,7 +649,8 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     typ: TypeDeclaration[_],
     astParentType: String,
     astParentFullName: String,
-    isInterface: Boolean
+    isInterface: Boolean,
+    fullNameOverride: Option[String]
   ): NewTypeDecl = {
     val baseTypeFullNames = if (typ.isClassOrInterfaceDeclaration) {
       val decl             = typ.asClassOrInterfaceDeclaration()
@@ -388,23 +671,11 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
       List.empty[String]
     }
 
-    val resolvedType    = tryWithSafeStackOverflow(typ.resolve()).toOption
-    val defaultFullName = s"${Defines.UnresolvedNamespace}.${typ.getNameAsString}"
-    val name            = resolvedType.flatMap(typeInfoCalc.name).getOrElse(typ.getNameAsString)
-    val typeFullName    = resolvedType.flatMap(typeInfoCalc.fullName).getOrElse(defaultFullName)
+    val (name, fullName) = getTypeDeclNameAndFullName(typ, fullNameOverride)
 
     val code = codeForTypeDecl(typ, isInterface)
 
-    NewTypeDecl()
-      .name(name)
-      .fullName(typeFullName)
-      .lineNumber(line(typ))
-      .columnNumber(column(typ))
-      .inheritsFromTypeFullName(baseTypeFullNames)
-      .filename(filename)
-      .code(code)
-      .astParentType(astParentType)
-      .astParentFullName(astParentFullName)
+    typeDeclNode(typ, name, fullName, filename, code, astParentType, astParentFullName, baseTypeFullNames)
   }
 
   private def codeForTypeDecl(typ: TypeDeclaration[_], isInterface: Boolean): String = {
@@ -449,7 +720,7 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
         resolvedTypeParams
           .map(identifierForResolvedTypeParameter)
           .foreach { typeParamIdentifier =>
-            scope.addType(typeParamIdentifier.name, typeParamIdentifier.typeFullName)
+            scope.addTopLevelType(typeParamIdentifier.name, typeParamIdentifier.typeFullName)
           }
 
       case _ => // Nothing to do here

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -415,8 +415,6 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
 
             val capturedThisIdentifier =
               Option
-                // TODO: This is broken. Only add this to scope when in a non-static context and use the existence
-                //  of capturedThis to decide if this needs to be added.
                 .when(usedCaptures.exists(_.name == NameConstants.OuterClass))(capturedThis.map { thisNode =>
                   val identifier = NewIdentifier()
                     .name(thisNode.name)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -30,18 +30,26 @@ import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Opera
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.{Success, Try}
+import javassist.compiler.ast.CallExpr
+import io.joern.javasrc2cpg.scope.Scope.ScopeInnerType
+import io.joern.javasrc2cpg.scope.Scope.SimpleVariable
+import io.joern.javasrc2cpg.scope.Scope.ScopeParameter
+import io.joern.javasrc2cpg.scope.JavaScopeElement.PartialInit
 
 object AstForCallExpressionsCreator {
-  case class PartialConstructor(initNode: NewCall, initArgs: Seq[Ast], blockAst: Ast)
+  case class PartialConstructor(typeFullName: Option[String], initNode: NewCall, initArgs: Seq[Ast], blockAst: Ast)
 }
 
 trait AstForCallExpressionsCreator { this: AstCreator =>
+
+  private var tempConstCount = 0
 
   private[expressions] def astForMethodCall(call: MethodCallExpr, expectedReturnType: ExpectedType): Ast = {
     val maybeResolvedCall = tryWithSafeStackOverflow(call.resolve())
     val argumentAsts      = argAstsForCall(call, maybeResolvedCall, call.getArguments)
 
-    val expressionTypeFullName = expressionReturnTypeFullName(call).orElse(expectedReturnType.fullName)
+    val expressionTypeFullName =
+      expressionReturnTypeFullName(call).orElse(expectedReturnType.fullName).map(typeInfoCalc.registerType)
 
     val argumentTypes = argumentTypesForMethodLike(maybeResolvedCall)
     val returnType = maybeResolvedCall
@@ -59,23 +67,21 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
       case Some(scope) => astsForExpression(scope, ExpectedType(receiverTypeOption))
 
       case None =>
-        val objectNode =
-          createObjectNode(receiverTypeOption, call, dispatchType)
-        for {
-          obj       <- objectNode
-          thisParam <- scope.lookupVariable(NameConstants.This).variableNode
-        } diffGraph.addEdge(obj, thisParam, EdgeTypes.REF)
-        objectNode.map(Ast(_)).toList
+        Option
+          .when(dispatchType == DispatchTypes.DYNAMIC_DISPATCH) {
+            astForImplicitCallReceiver(receiverTypeOption, call)
+          }
+          .toList
     }
 
-    val receiverType = receiverTypeOption.orElse(scopeAsts.rootType).filter(_ != TypeConstants.Any)
+    val receiverType = scopeAsts.rootType.filter(_ != TypeConstants.Any).orElse(receiverTypeOption)
 
     val argumentsCode = getArgumentCodeString(call.getArguments)
     val codePrefix    = codePrefixForMethodCall(call)
     val callCode      = s"$codePrefix${call.getNameAsString}($argumentsCode)"
 
     val callName       = call.getNameAsString
-    val namespace      = receiverType.getOrElse(Defines.UnresolvedNamespace)
+    val namespace      = receiverType.filter(_ != TypeConstants.Any).getOrElse(Defines.UnresolvedNamespace)
     val signature      = composeSignature(returnType, argumentTypes, argumentAsts.size)
     val methodFullName = composeMethodFullName(namespace, callName, signature)
     val callRoot = NewCall()
@@ -89,6 +95,38 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
       .typeFullName(expressionTypeFullName.getOrElse(TypeConstants.Any))
 
     callAst(callRoot, argumentAsts, scopeAsts.headOption)
+  }
+
+  private def astForImplicitCallReceiver(declaringType: Option[String], call: MethodCallExpr): Ast = {
+    val typeFullName = scope.lookupVariable(NameConstants.This).typeFullName.getOrElse(TypeConstants.Any)
+    val thisIdentifier =
+      identifierNode(call, NameConstants.This, NameConstants.This, typeFullName)
+    scope.lookupVariable(NameConstants.This) match {
+      case SimpleVariable(ScopeParameter(thisParam)) => diffGraph.addEdge(thisIdentifier, thisParam, EdgeTypes.REF)
+      case _ => // Do nothing. This shouldn't happen for valid code, but could occur in cases where methods could not be resolved
+    }
+    val thisAst = Ast(thisIdentifier)
+
+    scope.lookupMethodName(call.getNameAsString).drop(1) match {
+      case Nil =>
+        thisAst
+
+      case typeDeclChain =>
+        val lineNumber   = line(call)
+        val columnNumber = column(call)
+        typeDeclChain.foldLeft(thisAst) { case (accAst, typeDecl) =>
+          val rootNode = newOperatorCallNode(
+            Operators.fieldAccess,
+            s"${accAst.rootCodeOrEmpty}.${NameConstants.OuterClass}",
+            Some(typeDecl.fullName),
+            lineNumber,
+            columnNumber
+          )
+
+          val outerClassIdentifier = fieldIdentifierNode(call, NameConstants.OuterClass, NameConstants.OuterClass)
+          callAst(rootNode, List(accAst, Ast(outerClassIdentifier)))
+        }
+    }
   }
 
   /** The below representation for constructor invocations and object creations was chosen for the sake of consistency
@@ -120,9 +158,29 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     val maybeResolvedExpr = tryWithSafeStackOverflow(expr.resolve())
     val argumentAsts      = argAstsForCall(expr, maybeResolvedExpr, expr.getArguments)
 
-    val typeFullName = tryWithSafeStackOverflow(typeInfoCalc.fullName(expr.getType)).toOption.flatten
-      .orElse(scope.lookupType(expr.getTypeAsString))
-      .orElse(expectedType.fullName)
+    val anonymousClassBody = expr.getAnonymousClassBody.toScala.map(_.asScala.toList)
+    val nameSuffix         = if (anonymousClassBody.isEmpty) "" else s"$$${scope.getNextAnonymousClassIndex()}"
+    val typeName           = s"${expr.getTypeAsString}$nameSuffix"
+
+    val baseTypeFromScope = scope.lookupScopeType(expr.getTypeAsString)
+    // These will be the same for non-anonymous type decls, but in that case only the typeFullName will be used.
+    val baseTypeFullName =
+      baseTypeFromScope
+        .map(_.typeFullName)
+        .orElse(
+          tryWithSafeStackOverflow(typeInfoCalc.fullName(expr.getType)).toOption.flatten.orElse(expectedType.fullName)
+        )
+    val typeFullName =
+      if (anonymousClassBody.isEmpty)
+        baseTypeFullName.map(typeFullName => s"$typeFullName$nameSuffix")
+      else {
+        scope.scopeFullName().map(enclosingScopeName => s"$enclosingScopeName.$typeName")
+      }
+
+    anonymousClassBody.foreach { bodyStmts =>
+      val anonymousClassDecl = astForAnonymousClassDecl(expr, bodyStmts, typeName, typeFullName, baseTypeFullName)
+      scope.addLocalDecl(anonymousClassDecl)
+    }
 
     val argumentTypes = argumentTypesForMethodLike(maybeResolvedExpr)
 
@@ -142,13 +200,16 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
       line(expr)
     )
 
+    val isInnerType = anonymousClassBody.isDefined || baseTypeFromScope.exists(_.isInstanceOf[ScopeInnerType])
+
     // Assume that a block ast is required, since there isn't enough information to decide otherwise.
     // This simplifies logic elsewhere, and unnecessary blocks will be garbage collected soon.
-    val blockAst = blockAstForConstructorInvocation(line(expr), column(expr), allocNode, initCall, argumentAsts)
+    val blockAst =
+      blockAstForConstructorInvocation(line(expr), column(expr), allocNode, initCall, argumentAsts, isInnerType)
 
     expr.getParentNode.toScala match {
       case Some(parent) if parent.isInstanceOf[VariableDeclarator] || parent.isInstanceOf[AssignExpr] =>
-        val partialConstructor = PartialConstructor(initCall, argumentAsts, blockAst)
+        val partialConstructor = PartialConstructor(typeFullName, initCall, argumentAsts, blockAst)
         partialConstructorQueue.append(partialConstructor)
         Ast(allocNode)
 
@@ -190,6 +251,104 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     }
   }
 
+  private def getExpectedParamType(maybeResolvedCall: Try[ResolvedMethodLikeDeclaration], idx: Int): ExpectedType = {
+    maybeResolvedCall.toOption
+      .map { methodDecl =>
+        val paramCount = methodDecl.getNumberOfParams
+
+        val resolvedType = if (idx < paramCount) {
+          Some(methodDecl.getParam(idx).getType)
+        } else if (paramCount > 0 && methodDecl.getParam(paramCount - 1).isVariadic) {
+          Some(methodDecl.getParam(paramCount - 1).getType)
+        } else {
+          None
+        }
+
+        val typeName = resolvedType.flatMap(typeInfoCalc.fullName)
+        ExpectedType(typeName, resolvedType)
+      }
+      .getOrElse(ExpectedType.empty)
+  }
+
+  def initNode(
+    namespaceName: Option[String],
+    argumentTypes: Option[List[String]],
+    argsSize: Int,
+    code: String,
+    lineNumber: Option[Integer] = None,
+    columnNumber: Option[Integer] = None
+  ): NewCall = {
+    val initSignature = argumentTypes match {
+      case Some(tpe)          => composeMethodLikeSignature(TypeConstants.Void, tpe)
+      case _ if argsSize == 0 => composeMethodLikeSignature(TypeConstants.Void, Nil)
+      case _                  => composeUnresolvedSignature(argsSize)
+    }
+    val namespace          = namespaceName.getOrElse(Defines.UnresolvedNamespace)
+    val initMethodFullName = composeMethodFullName(namespace, Defines.ConstructorMethodName, initSignature)
+    NewCall()
+      .name(Defines.ConstructorMethodName)
+      .methodFullName(initMethodFullName)
+      .signature(initSignature)
+      .typeFullName(TypeConstants.Void)
+      .code(code)
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+  }
+
+  private def blockAstForConstructorInvocation(
+    lineNumber: Option[Integer],
+    columnNumber: Option[Integer],
+    allocNode: NewCall,
+    initNode: NewCall,
+    args: Seq[Ast],
+    isInnerType: Boolean
+  ): Ast = {
+    val blockNode = NewBlock()
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+      .typeFullName(allocNode.typeFullName)
+
+    val tempName = "$obj" ++ tempConstCount.toString
+    tempConstCount += 1
+    val identifier    = newIdentifierNode(tempName, allocNode.typeFullName)
+    val identifierAst = Ast(identifier)
+
+    val allocAst = Ast(allocNode)
+
+    val assignmentNode = newOperatorCallNode(Operators.assignment, PropertyDefaults.Code, Some(allocNode.typeFullName))
+
+    val assignmentAst = callAst(assignmentNode, List(identifierAst, allocAst))
+
+    val identifierWithDefaultOrder = identifier.copy.order(PropertyDefaults.Order)
+    val identifierForInit          = identifierWithDefaultOrder.copy
+    val initCopyWithDefaultOrder   = initNode.copy.order(PropertyDefaults.Order)
+
+    val returnAst = Ast(identifierWithDefaultOrder.copy)
+
+    val capturedThis = scope.lookupVariable(NameConstants.This) match {
+      case SimpleVariable(param: ScopeParameter) => Some(param.node)
+      case _                                     => None
+    }
+
+    val initAst = if (isInnerType) {
+      val initCallAst = Ast(initCopyWithDefaultOrder)
+      scope.enclosingTypeDecl.foreach(
+        _.registerInitToComplete(
+          PartialInit(allocNode.typeFullName, initCallAst, Ast(identifierForInit), args.toList, capturedThis)
+        )
+      )
+      initCallAst
+    } else {
+      callAst(initCopyWithDefaultOrder, args, Some(Ast(identifierForInit)))
+    }
+
+    Ast(blockNode)
+      .withChild(assignmentAst)
+      .withChild(initAst)
+      .withChild(returnAst)
+  }
+
   private def getArgumentCodeString(args: NodeList[Expression]): String = {
     args.asScala
       .map {
@@ -217,22 +376,23 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
   private def targetTypeForCall(callExpr: MethodCallExpr): Option[String] = {
     val maybeType = callExpr.getScope.toScala match {
       case Some(callScope: ThisExpr) =>
+        // TODO Can't we just use the enclosing decl? Would need to pay attention to `this` in lambda
         expressionReturnTypeFullName(callScope)
-          .orElse(scope.enclosingTypeDeclFullName)
+          .orElse(scope.enclosingTypeDecl.fullName)
 
       case Some(callScope: SuperExpr) =>
         expressionReturnTypeFullName(callScope)
-          .orElse(scope.enclosingTypeDecl.flatMap(_.inheritsFromTypeFullName.headOption))
+          .orElse(scope.enclosingTypeDecl.flatMap(_.typeDecl.inheritsFromTypeFullName.headOption))
 
       case Some(scope) => expressionReturnTypeFullName(scope)
 
       case None =>
         tryWithSafeStackOverflow(callExpr.resolve()).toOption
           .flatMap { methodDeclOption =>
-            if (methodDeclOption.isStatic) typeInfoCalc.fullName(methodDeclOption.declaringType())
-            else scope.enclosingTypeDeclFullName
+            typeInfoCalc.fullNameWithoutRegistering(methodDeclOption.declaringType())
           }
-          .orElse(scope.enclosingTypeDeclFullName)
+          // TODO: Check for the method name in scope
+          .orElse(scope.enclosingTypeDecl.fullName)
     }
 
     maybeType.map(typeInfoCalc.registerType)
@@ -249,25 +409,6 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
       val name = maybeScope.map(_.toString).getOrElse(NameConstants.This)
       identifierNode(call, name, name, typeFullName.getOrElse("ANY"))
     }
-  }
-
-  private def getExpectedParamType(maybeResolvedCall: Try[ResolvedMethodLikeDeclaration], idx: Int): ExpectedType = {
-    maybeResolvedCall.toOption
-      .map { methodDecl =>
-        val paramCount = methodDecl.getNumberOfParams
-
-        val resolvedType = if (idx < paramCount) {
-          Some(methodDecl.getParam(idx).getType)
-        } else if (paramCount > 0 && methodDecl.getParam(paramCount - 1).isVariadic) {
-          Some(methodDecl.getParam(paramCount - 1).getType)
-        } else {
-          None
-        }
-
-        val typeName = resolvedType.flatMap(typeInfoCalc.fullName)
-        ExpectedType(typeName, resolvedType)
-      }
-      .getOrElse(ExpectedType.empty)
   }
 
   private def codePrefixForMethodCall(call: MethodCallExpr): String = {
@@ -316,69 +457,6 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
 
       case _ => None
     }
-  }
-
-  def initNode(
-    namespaceName: Option[String],
-    argumentTypes: Option[List[String]],
-    argsSize: Int,
-    code: String,
-    lineNumber: Option[Integer] = None,
-    columnNumber: Option[Integer] = None
-  ): NewCall = {
-    val initSignature = argumentTypes match {
-      case Some(tpe)          => composeMethodLikeSignature(TypeConstants.Void, tpe)
-      case _ if argsSize == 0 => composeMethodLikeSignature(TypeConstants.Void, Nil)
-      case _                  => composeUnresolvedSignature(argsSize)
-    }
-    val namespace          = namespaceName.getOrElse(Defines.UnresolvedNamespace)
-    val initMethodFullName = composeMethodFullName(namespace, Defines.ConstructorMethodName, initSignature)
-    NewCall()
-      .name(Defines.ConstructorMethodName)
-      .methodFullName(initMethodFullName)
-      .signature(initSignature)
-      .typeFullName(TypeConstants.Void)
-      .code(code)
-      .dispatchType(DispatchTypes.STATIC_DISPATCH)
-      .lineNumber(lineNumber)
-      .columnNumber(columnNumber)
-  }
-
-  private var tempConstCount = 0
-  private def blockAstForConstructorInvocation(
-    lineNumber: Option[Integer],
-    columnNumber: Option[Integer],
-    allocNode: NewCall,
-    initNode: NewCall,
-    args: Seq[Ast]
-  ): Ast = {
-    val blockNode = NewBlock()
-      .lineNumber(lineNumber)
-      .columnNumber(columnNumber)
-      .typeFullName(allocNode.typeFullName)
-
-    val tempName = "$obj" ++ tempConstCount.toString
-    tempConstCount += 1
-    val identifier    = newIdentifierNode(tempName, allocNode.typeFullName)
-    val identifierAst = Ast(identifier)
-
-    val allocAst = Ast(allocNode)
-
-    val assignmentNode = newOperatorCallNode(Operators.assignment, PropertyDefaults.Code, Some(allocNode.typeFullName))
-
-    val assignmentAst = callAst(assignmentNode, List(identifierAst, allocAst))
-
-    val identifierWithDefaultOrder = identifier.copy.order(PropertyDefaults.Order)
-    val identifierForInit          = identifierWithDefaultOrder.copy
-    val initWithDefaultOrder       = initNode.order(PropertyDefaults.Order)
-    val initAst                    = callAst(initWithDefaultOrder, args, Some(Ast(identifierForInit)))
-
-    val returnAst = Ast(identifierWithDefaultOrder.copy)
-
-    Ast(blockNode)
-      .withChild(assignmentAst)
-      .withChild(initAst)
-      .withChild(returnAst)
   }
 
   private def someWithDotSuffix(prefix: String): Option[String] = Some(s"$prefix.")

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
@@ -9,20 +9,76 @@ import io.joern.x2cpg.{Ast, Defines}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewLocal, NewMethodParameterIn}
 
 import scala.util.Success
+import io.joern.javasrc2cpg.scope.Scope.{
+  CapturedVariable,
+  NotInScope,
+  ScopeMember,
+  ScopeParameter,
+  ScopeStaticImport,
+  ScopeVariable,
+  SimpleVariable
+}
+import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
+import org.slf4j.LoggerFactory
+import io.shiftleft.codepropertygraph.generated.nodes.NewUnknown
+import io.joern.x2cpg.utils.AstPropertiesUtil.*
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.joern.x2cpg.utils.NodeBuilders.newOperatorCallNode
 
 trait AstForNameExpressionsCreator { this: AstCreator =>
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
   private[expressions] def astForNameExpr(nameExpr: NameExpr, expectedType: ExpectedType): Ast = {
     val name = nameExpr.getName.toString
     val typeFullName = expressionReturnTypeFullName(nameExpr)
       .orElse(expectedType.fullName)
       .map(typeInfoCalc.registerType)
 
+    scope.lookupVariable(name) match {
+      case NotInScope =>
+        astForStaticImportOrUnknown(nameExpr, name, typeFullName)
+
+      case SimpleVariable(variable: ScopeMember) =>
+        val targetName =
+          Option.when(variable.isStatic)(scope.enclosingTypeDecl.fullName).flatten.getOrElse(NameConstants.This)
+        fieldAccessAst(
+          targetName,
+          scope.enclosingTypeDecl.fullName,
+          variable.name,
+          Some(variable.typeFullName),
+          line(nameExpr),
+          column(nameExpr)
+        )
+
+      case SimpleVariable(variable: ScopeStaticImport) =>
+        val targetName   = variable.typeFullName.stripSuffix(s".${variable.name}")
+        val typeFullName = expressionReturnTypeFullName(nameExpr).map(typeInfoCalc.registerType)
+        fieldAccessAst(targetName, Some(targetName), variable.name, typeFullName, line(nameExpr), column(nameExpr))
+
+      case SimpleVariable(variable) =>
+        val identifier = identifierNode(nameExpr, name, name, typeFullName.getOrElse(TypeConstants.Any))
+        val captured = variable.node match {
+          case param: NewMethodParameterIn => Some(param)
+          case local: NewLocal             => Some(local)
+          case _                           => None
+        }
+        captured.foldLeft(Ast(identifier))((ast, variableNode) => ast.withRefEdge(identifier, variableNode))
+
+      case capturedVariable: CapturedVariable =>
+        scope.registerCaptureUse(capturedVariable)
+        astForCapturedVariable(nameExpr, capturedVariable)
+    }
+  }
+
+  private def astForStaticImportOrUnknown(nameExpr: NameExpr, name: String, typeFullName: Option[String]): Ast = {
     tryWithSafeStackOverflow(nameExpr.resolve()) match {
       case Success(value) if value.isField =>
         val identifierName = if (value.asField.isStatic) {
+          // TODO: v is wrong. Statically imported expressions can also be represented by just the name.
           // A static field represented by a NameExpr must belong to the class in which it's used. Static fields
           // from other classes are represented by a FieldAccessExpr instead.
-          scope.enclosingTypeDecl.map(_.name).getOrElse(s"${Defines.UnresolvedNamespace}.$name")
+          scope.enclosingTypeDecl.map(_.typeDecl.name).getOrElse(s"${Defines.UnresolvedNamespace}.$name")
         } else {
           NameConstants.This
         }
@@ -39,19 +95,62 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
         fieldAccessAst(identifierName, identifierTypeFullName, name, typeFullName, line(nameExpr), column(nameExpr))
 
       case _ =>
-        val identifier = identifierNode(nameExpr, name, name, typeFullName.getOrElse(TypeConstants.Any))
-
-        val variableOption = scope
-          .lookupVariable(name)
-          .variableNode
-          .collect {
-            case parameter: NewMethodParameterIn => parameter
-
-            case local: NewLocal => local
-          }
-
-        variableOption.foldLeft(Ast(identifier))((ast, variableNode) => ast.withRefEdge(identifier, variableNode))
+        Ast(identifierNode(nameExpr, name, name, typeFullName.getOrElse(TypeConstants.Any)))
     }
+  }
 
+  private def astForCapturedVariable(nameExpr: NameExpr, capturedVariable: CapturedVariable): Ast = {
+    val variable      = capturedVariable.variable
+    val typeDeclChain = capturedVariable.typeDeclChain
+
+    scope.enclosingMethod.map(_.lookupVariable("this")) match {
+      case None | Some(NotInScope) | Some(CapturedVariable(_, _)) =>
+        logger.warn(
+          s"Attempted to create AST for captured variable ${variable.name}, but could not find `this` param in direct scope."
+        )
+        Ast(NewUnknown().code(variable.name).lineNumber(line(nameExpr)).columnNumber(column(nameExpr)))
+
+      case Some(SimpleVariable(ScopeParameter(thisNode: NewMethodParameterIn))) =>
+        val thisIdentifier = identifierNode(
+          nameExpr,
+          thisNode.name,
+          thisNode.code,
+          thisNode.typeFullName,
+          thisNode.dynamicTypeHintFullName
+        )
+        val thisAst = Ast(thisIdentifier).withRefEdge(thisIdentifier, thisNode)
+
+        val lineNumber   = line(nameExpr)
+        val columnNumber = column(nameExpr)
+        val outerClassChain = typeDeclChain.foldLeft(thisAst) { case (accAst, typeDecl) =>
+          val rootNode = newOperatorCallNode(
+            Operators.fieldAccess,
+            s"${accAst.rootCodeOrEmpty}.${NameConstants.OuterClass}",
+            Some(typeDecl.fullName),
+            lineNumber,
+            columnNumber
+          )
+
+          val outerClassIdentifier = fieldIdentifierNode(nameExpr, NameConstants.OuterClass, NameConstants.OuterClass)
+          callAst(rootNode, List(accAst, Ast(outerClassIdentifier)))
+        }
+
+        val finalFieldAccess = newOperatorCallNode(
+          Operators.fieldAccess,
+          s"${outerClassChain.rootCodeOrEmpty}.${variable.name}",
+          Some(variable.typeFullName),
+          lineNumber,
+          columnNumber
+        )
+
+        val captureFieldIdentifier = fieldIdentifierNode(nameExpr, variable.name, variable.name)
+        callAst(finalFieldAccess, List(outerClassChain, Ast(captureFieldIdentifier)))
+
+      case Some(SimpleVariable(thisNode)) =>
+        logger.warn(
+          s"Attempted to create AST for captured variable ${variable.name}, but found non-parameter `this`: ${thisNode}."
+        )
+        Ast(NewUnknown().code(variable.name).lineNumber(line(nameExpr)).columnNumber(column(nameExpr)))
+    }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -35,6 +35,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
         .getOrElse(TypeConstants.Any)
     val callNode = newOperatorCallNode(
       Operators.indexAccess,
@@ -60,8 +61,11 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     }
 
     maybeInitializerAst.getOrElse {
-      val typeFullName = expressionReturnTypeFullName(expr).orElse(expectedType.fullName).getOrElse(TypeConstants.Any)
-      val callNode     = newOperatorCallNode(Operators.alloc, code = expr.toString, typeFullName = Some(typeFullName))
+      val typeFullName = expressionReturnTypeFullName(expr)
+        .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
+        .getOrElse(TypeConstants.Any)
+      val callNode = newOperatorCallNode(Operators.alloc, code = expr.toString, typeFullName = Some(typeFullName))
       val levelAsts = expr.getLevels.asScala.flatMap { lvl =>
         lvl.getDimension.toScala match {
           case Some(dimension) => astsForExpression(dimension, ExpectedType.Int)
@@ -77,6 +81,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
         .getOrElse(TypeConstants.Any)
     val callNode = newOperatorCallNode(
       Operators.arrayInitializer,
@@ -93,7 +98,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
       // back to known information or primitive types. While this certainly isn't ideal,
       // it shouldn't cause issues since resolvedType is only used where the extra type
       // information not available in typeName is necessary.
-      val typeName     = expressionReturnTypeFullName(value)
+      val typeName     = expressionReturnTypeFullName(value).map(typeInfoCalc.registerType)
       val resolvedType = tryWithSafeStackOverflow(value.calculateResolvedType()).toOption
       ExpectedType(typeName, resolvedType)
     }
@@ -147,6 +152,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
         .orElse(args.headOption.flatMap(_.rootType))
         .orElse(args.lastOption.flatMap(_.rootType))
         .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
         .getOrElse(TypeConstants.Any)
 
     val callNode = newOperatorCallNode(
@@ -215,6 +221,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
         .orElse(thenAst.headOption.flatMap(_.rootType))
         .orElse(elseAst.headOption.flatMap(_.rootType))
         .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
         .getOrElse(TypeConstants.Any)
 
     val callNode =
@@ -231,6 +238,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
         .getOrElse(TypeConstants.Any)
 
     val callNode =
@@ -302,7 +310,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
   }
 
   private[expressions] def astForLiteralExpr(expr: LiteralExpr): Ast = {
-    val typeFullName = expressionReturnTypeFullName(expr).getOrElse(TypeConstants.Any)
+    val typeFullName = expressionReturnTypeFullName(expr).map(typeInfoCalc.registerType).getOrElse(TypeConstants.Any)
     val literalNode =
       NewLiteral()
         .code(expr.toString)
@@ -316,9 +324,8 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val typeFullName =
       expressionReturnTypeFullName(superExpr)
         .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
         .getOrElse(TypeConstants.Any)
-
-    typeInfoCalc.registerType(typeFullName)
 
     val identifier = identifierNode(superExpr, NameConstants.This, NameConstants.Super, typeFullName)
     Ast(identifier)
@@ -328,6 +335,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val typeFullName =
       expressionReturnTypeFullName(expr)
         .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
 
     val identifier = identifierNode(expr, expr.toString, expr.toString, typeFullName.getOrElse("ANY"))
     val thisParam  = scope.lookupVariable(NameConstants.This).variableNode
@@ -357,6 +365,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
       expressionReturnTypeFullName(expr)
         .orElse(argsAsts.headOption.flatMap(_.rootType))
         .orElse(expectedType.fullName)
+        .map(typeInfoCalc.registerType)
         .getOrElse(TypeConstants.Any)
 
     val callNode = newOperatorCallNode(

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -81,6 +81,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
   def astForForEach(stmt: ForEachStmt): Seq[Ast] = {
     scope.pushBlockScope()
 
+    // TODO: Does the type need to be registered here?
     val ast = expressionReturnTypeFullName(stmt.getIterable) match {
       case Some(typeFullName) if typeFullName.endsWith("[]") =>
         astsForNativeForEach(stmt, Some(typeFullName))
@@ -89,7 +90,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
         astForIterableForEach(stmt, maybeType)
     }
 
-    scope.popScope()
+    scope.popBlockScope()
     ast
   }
 
@@ -237,7 +238,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
         .typeFullName(typeFullName)
         .code(idxName)
         .lineNumber(lineNo)
-    scope.addLocal(idxLocal)
+    scope.enclosingBlock.get.addLocal(idxLocal)
     idxLocal
   }
 
@@ -331,7 +332,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
           .code(variable.getNameAsString)
           .typeFullName(typeFullName)
 
-        scope.addLocal(localNode)
+        scope.enclosingBlock.get.addLocal(localNode)
         localNode
 
       case None =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForStatementsCreator.scala
@@ -24,6 +24,7 @@ import com.github.javaparser.ast.stmt.{
 import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
 import io.joern.x2cpg.Ast
 import org.slf4j.LoggerFactory
+import com.github.javaparser.ast.stmt.LocalClassDeclarationStmt
 
 trait AstForStatementsCreator extends AstForSimpleStatementsCreator with AstForForLoopsCreator { this: AstCreator =>
 
@@ -37,24 +38,24 @@ trait AstForStatementsCreator extends AstForSimpleStatementsCreator with AstForF
     statement match {
       case x: ExplicitConstructorInvocationStmt =>
         Seq(astForExplicitConstructorInvocation(x))
-      case x: AssertStmt       => Seq(astForAssertStatement(x))
-      case x: BlockStmt        => Seq(astForBlockStatement(x))
-      case x: BreakStmt        => Seq(astForBreakStatement(x))
-      case x: ContinueStmt     => Seq(astForContinueStatement(x))
-      case x: DoStmt           => Seq(astForDo(x))
-      case _: EmptyStmt        => Seq() // Intentionally skipping this
-      case x: ExpressionStmt   => astsForExpression(x.getExpression, ExpectedType.Void)
-      case x: ForEachStmt      => astForForEach(x)
-      case x: ForStmt          => Seq(astForFor(x))
-      case x: IfStmt           => Seq(astForIf(x))
-      case x: LabeledStmt      => astsForLabeledStatement(x)
-      case x: ReturnStmt       => Seq(astForReturnNode(x))
-      case x: SwitchStmt       => Seq(astForSwitchStatement(x))
-      case x: SynchronizedStmt => Seq(astForSynchronizedStatement(x))
-      case x: ThrowStmt        => Seq(astForThrow(x))
-      case x: TryStmt          => astsForTry(x)
-      case x: WhileStmt        => Seq(astForWhile(x))
-      // case x: LocalClassDeclarationStmt => Seq(astForLocalClassDeclarationStmt(x))
+      case x: AssertStmt                => Seq(astForAssertStatement(x))
+      case x: BlockStmt                 => Seq(astForBlockStatement(x))
+      case x: BreakStmt                 => Seq(astForBreakStatement(x))
+      case x: ContinueStmt              => Seq(astForContinueStatement(x))
+      case x: DoStmt                    => Seq(astForDo(x))
+      case _: EmptyStmt                 => Seq() // Intentionally skipping this
+      case x: ExpressionStmt            => astsForExpression(x.getExpression, ExpectedType.Void)
+      case x: ForEachStmt               => astForForEach(x)
+      case x: ForStmt                   => Seq(astForFor(x))
+      case x: IfStmt                    => Seq(astForIf(x))
+      case x: LabeledStmt               => astsForLabeledStatement(x)
+      case x: ReturnStmt                => Seq(astForReturnNode(x))
+      case x: SwitchStmt                => Seq(astForSwitchStatement(x))
+      case x: SynchronizedStmt          => Seq(astForSynchronizedStatement(x))
+      case x: ThrowStmt                 => Seq(astForThrow(x))
+      case x: TryStmt                   => astsForTry(x)
+      case x: WhileStmt                 => Seq(astForWhile(x))
+      case x: LocalClassDeclarationStmt => Seq(astForLocalClassDeclaration(x))
       case x =>
         logger.warn(s"Attempting to generate AST for unknown statement of type ${x.getClass}")
         Seq(unknownAst(x))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
@@ -2,46 +2,47 @@ package io.joern.javasrc2cpg.scope
 
 import io.joern.javasrc2cpg.scope.Scope.*
 import io.joern.javasrc2cpg.scope.JavaScopeElement.*
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  NewImport,
-  NewMethod,
-  NewNamespaceBlock,
-  NewTypeDecl,
-  NewTypeParameter
-}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewImport, NewMethod, NewNamespaceBlock, NewTypeDecl}
 
 import scala.collection.mutable
 import io.joern.javasrc2cpg.astcreation.ExpectedType
+import io.joern.javasrc2cpg.util.MultiBindingTableAdapterForJavaparser.JavaparserBindingDeclType
+import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterIn
+import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
+import io.shiftleft.codepropertygraph.generated.nodes.NewMember
+import io.joern.javasrc2cpg.util.{BindingTable, BindingTableEntry, NameConstants}
+import io.shiftleft.passes.IntervalKeyPool
 import io.joern.x2cpg.Ast
-import io.shiftleft.codepropertygraph.generated.nodes.AstNodeNew
 
 trait JavaScopeElement {
   private val variables                        = mutable.Map[String, ScopeVariable]()
-  private val types                            = mutable.Map[String, String]()
+  private val types                            = mutable.Map[String, ScopeType]()
   private var wildcardImports: WildcardImports = NoWildcard
 
-  def addVariableToScope(variable: ScopeVariable): Unit = {
+  def isStatic: Boolean
+
+  private[JavaScopeElement] def addVariableToScope(variable: ScopeVariable): Unit = {
     variables.put(variable.name, variable)
   }
 
-  def lookupVariable(name: String): Option[ScopeVariable] = {
-    variables.get(name)
+  def lookupVariable(name: String): VariableLookupResult = {
+    variables.get(name).map(SimpleVariable(_)).getOrElse(NotInScope)
   }
 
-  def addTypeToScope(name: String, typeFullName: String): Unit = {
-    types.put(name, typeFullName)
+  def addTypeToScope(name: String, scopeType: ScopeType): Unit = {
+    types.put(name, scopeType)
   }
 
-  def lookupType(name: String, includeWildcards: Boolean): Option[String] = {
+  def lookupType(name: String, includeWildcards: Boolean): Option[ScopeType] = {
     types.get(name) match {
       case None if includeWildcards => getNameWithWildcardPrefix(name)
       case result                   => result
     }
   }
 
-  def getNameWithWildcardPrefix(name: String): Option[String] = {
+  def getNameWithWildcardPrefix(name: String): Option[ScopeType] = {
     wildcardImports match {
-      case SingleWildcard(prefix) => Some(s"$prefix.$name")
+      case SingleWildcard(prefix) => Some(ScopeTopLevelType(s"$prefix.$name"))
 
       case _ => None
     }
@@ -57,40 +58,127 @@ trait JavaScopeElement {
     }
   }
 
-  // TODO: Refactor and remove this
   def getVariables(): List[ScopeVariable] = variables.values.toList
 }
 
-private object JavaScopeElement {
+object JavaScopeElement {
   sealed trait WildcardImports
   case object NoWildcard                    extends WildcardImports
   case class SingleWildcard(prefix: String) extends WildcardImports
   case object MultipleWildcards             extends WildcardImports
-}
 
-class NamespaceScope(val namespace: NewNamespaceBlock) extends JavaScopeElement with TypeDeclContainer
+  trait AnonymousClassCounter {
+    private val anonymousClassKeyPool = IntervalKeyPool(0, Long.MaxValue)
 
-class BlockScope extends JavaScopeElement
-
-class MethodScope(val method: NewMethod, val returnType: ExpectedType) extends JavaScopeElement
-
-class TypeDeclScope(val typeDecl: NewTypeDecl) extends JavaScopeElement with TypeDeclContainer {
-  private val memberInitializers = mutable.ListBuffer[Ast]()
-
-  // TODO: Refactor and remove this.
-  def addMemberInitializers(initializers: Seq[Ast]): Unit = {
-    memberInitializers.appendAll(initializers)
+    def getNextAnonymousClassIndex(): Long = anonymousClassKeyPool.next
   }
 
-  // TODO: Refactor and remove this.
-  def getMemberInitializers(): List[Ast] = {
-    memberInitializers.toList.flatMap { ast =>
-      ast.root match {
-        case Some(root: AstNodeNew) =>
-          Some(ast.subTreeCopy(root))
+  class NamespaceScope(val namespace: NewNamespaceBlock) extends JavaScopeElement with TypeDeclContainer {
+    val isStatic = false
 
-        case _ => None
+    def addStaticImport(staticImport: NewImport): Unit = {
+      addVariableToScope(ScopeStaticImport(staticImport))
+    }
+  }
+
+  class BlockScope extends JavaScopeElement {
+    val isStatic = false
+
+    def addLocal(local: NewLocal): Unit = {
+      addVariableToScope(ScopeLocal(local))
+    }
+  }
+
+  class MethodScope(val method: NewMethod, val returnType: ExpectedType, override val isStatic: Boolean)
+      extends JavaScopeElement
+      with AnonymousClassCounter {
+    def addParameter(parameter: NewMethodParameterIn): Unit = {
+      addVariableToScope(ScopeParameter(parameter))
+    }
+  }
+
+  class FieldDeclScope(override val isStatic: Boolean, val name: String) extends JavaScopeElement
+
+  class TypeDeclScope(
+    val typeDecl: NewTypeDecl,
+    override val isStatic: Boolean,
+    private[scope] val capturedVariables: Map[String, CapturedVariable],
+    outerClassType: Option[String],
+    val declaredMethodNames: Set[String]
+  ) extends JavaScopeElement
+      with TypeDeclContainer
+      with AnonymousClassCounter {
+    private val bindingTableEntries            = mutable.ListBuffer[BindingTableEntry]()
+    private val usedCaptureParams              = mutable.Set[ScopeVariable]()
+    private[scope] val initsToComplete         = mutable.ListBuffer[PartialInit]()
+    private[scope] val capturesForTypesInScope = mutable.Map[String, List[ScopeVariable]]()
+
+    override def lookupVariable(name: String): VariableLookupResult = {
+      super.lookupVariable(name) match {
+        case NotInScope => capturedVariables.get(name).getOrElse(NotInScope)
+
+        case result => result
       }
     }
+
+    def addBindingTableEntry(bindingTableEntry: BindingTableEntry): Unit = {
+      bindingTableEntries.addOne(bindingTableEntry)
+    }
+
+    def getBindingTableEntries: List[BindingTableEntry] = bindingTableEntries.toList
+
+    def addMember(member: NewMember, isStatic: Boolean): Unit = {
+      addVariableToScope(ScopeMember(member, isStatic))
+    }
+
+    def registerCaptureUse(variable: ScopeVariable): Unit = {
+      usedCaptureParams.addOne(variable)
+    }
+
+    def registerInitToComplete(partialInit: PartialInit): Unit = {
+      initsToComplete.append(partialInit)
+    }
+
+    def registerCapturesForType(typeFullName: String, captures: List[ScopeVariable]): Unit = {
+      capturesForTypesInScope.put(typeFullName, captures)
+    }
+
+    def getUsedCaptures(): List[ScopeVariable] = {
+      val outerScope = outerClassType.map(typ =>
+        ScopeLocal(NewLocal().name(NameConstants.OuterClass).typeFullName(typ).code(NameConstants.OuterClass))
+      )
+
+      val sortedUsedCaptures = usedCaptureParams.toList.sortBy(_.name)
+      val usedLocals         = sortedUsedCaptures.collect { case local: ScopeLocal => local }
+      val usedParameters     = sortedUsedCaptures.collect { case param: ScopeParameter => param }
+      // Don't include members since they're accessed through "outerClass"
+      outerScope.toList ++ usedLocals ++ usedParameters
+    }
+
+    private[scope] def getUsedCapturesForType(typeFullName: String): List[ScopeVariable] = {
+      capturesForTypesInScope.getOrElse(typeFullName, Nil)
+    }
+  }
+
+  case class PartialInit(
+    typeFullName: String,
+    callAst: Ast,
+    receiverAst: Ast,
+    argsAsts: List[Ast],
+    capturedThis: Option[NewMethodParameterIn]
+  )
+
+  extension (typeDeclScope: Option[TypeDeclScope]) {
+    def fullName: Option[String]               = typeDeclScope.map(_.typeDecl.fullName)
+    def name: Option[String]                   = typeDeclScope.map(_.typeDecl.name)
+    def isInterface: Boolean                   = typeDeclScope.exists(_.typeDecl.code.contains("interface "))
+    def getUsedCaptures(): List[ScopeVariable] = typeDeclScope.map(_.getUsedCaptures()).getOrElse(Nil)
+    def getCapturesForType(typeFullName: String): List[ScopeVariable] =
+      typeDeclScope.map(_.getUsedCapturesForType(typeFullName)).getOrElse(Nil)
+    def getInitsToComplete: List[PartialInit] = typeDeclScope.map(_.initsToComplete.toList).getOrElse(Nil)
+  }
+
+  extension (methodScope: Option[MethodScope]) {
+    def getMethodFullName: String = methodScope.get.method.fullName
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -2,10 +2,15 @@ package io.joern.javasrc2cpg.scope
 
 import io.joern.javasrc2cpg.astcreation.ExpectedType
 import io.joern.javasrc2cpg.scope.Scope.*
+import io.joern.javasrc2cpg.scope.JavaScopeElement.*
+import io.joern.javasrc2cpg.util.MultiBindingTableAdapterForJavaparser.JavaparserBindingDeclType
 import io.joern.javasrc2cpg.util.NameConstants
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.utils.ListUtils.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
 
 // TODO: Added for backwards compatibility with old scope methods, but is no longer
 //  strictly necessary due to stricter scope variable classes. Refactor AstCreator
@@ -18,104 +23,193 @@ case class NodeTypeInfo(
   isStatic: Boolean = false
 )
 class Scope {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
   private var scopeStack: List[JavaScopeElement] = Nil
 
   def pushBlockScope(): Unit = {
     scopeStack = new BlockScope() :: scopeStack
   }
 
-  def pushMethodScope(method: NewMethod, returnType: ExpectedType): Unit = {
-    scopeStack = new MethodScope(method, returnType) :: scopeStack
+  def pushMethodScope(method: NewMethod, returnType: ExpectedType, isStatic: Boolean): Unit = {
+    scopeStack = new MethodScope(method, returnType, isStatic) :: scopeStack
   }
 
-  def pushTypeDeclScope(typeDecl: NewTypeDecl): Unit = {
-    scopeStack = new TypeDeclScope(typeDecl) :: scopeStack
+  def pushFieldDeclScope(isStatic: Boolean, name: String): Unit = {
+    scopeStack = new FieldDeclScope(isStatic, name) :: scopeStack
+  }
+
+  def pushTypeDeclScope(typeDecl: NewTypeDecl, isStatic: Boolean, methodNames: Set[String] = Set.empty): Unit = {
+    val captures = getCapturesForNewScope(isStatic)
+    val outerClassType = scopeStack.takeUntil(_.isInstanceOf[TypeDeclScope]) match {
+      case Nil => None
+
+      case (head: TypeDeclScope) :: Nil => Option.unless(isStatic)(head.typeDecl.fullName)
+
+      case head :: Nil =>
+        // make exhaustive match checker happy, but is impossible
+        None
+
+      case scopes =>
+        Option
+          .unless(isStatic || scopes.init.exists(_.isStatic)) {
+            scopes.lastOption.collectFirst { case typeDeclScope: TypeDeclScope => typeDeclScope.typeDecl.fullName }
+          }
+          .flatten
+    }
+    scopeStack = new TypeDeclScope(typeDecl, isStatic, captures, outerClassType, methodNames) :: scopeStack
   }
 
   def pushNamespaceScope(namespace: NewNamespaceBlock): Unit = {
     scopeStack = new NamespaceScope(namespace) :: scopeStack
   }
 
-  def popScope(): JavaScopeElement = {
+  def popBlockScope(): BlockScope = popScope[BlockScope]()
+
+  def popMethodScope(): MethodScope = popScope[MethodScope]()
+
+  def popFieldDeclScope(): FieldDeclScope = popScope[FieldDeclScope]()
+
+  def popTypeDeclScope(): TypeDeclScope = popScope[TypeDeclScope]()
+
+  def popNamespaceScope(): NamespaceScope = popScope[NamespaceScope]()
+
+  private def popScope[ScopeType <: JavaScopeElement](): ScopeType = {
     val scope = scopeStack.head
     scopeStack = scopeStack.tail
-    scope
+    scope.asInstanceOf[ScopeType]
   }
 
-  def addParameter(parameter: NewMethodParameterIn): Unit = {
-    addVariable(ScopeParameter(parameter))
+  def addTopLevelType(name: String, typeFullName: String): Unit = {
+    val scopeType = ScopeTopLevelType(typeFullName)
+    scopeStack.head.addTypeToScope(name, scopeType)
   }
 
-  def addLocal(local: NewLocal): Unit = {
-    addVariable(ScopeLocal(local))
-  }
-
-  def addMember(member: NewMember, isStatic: Boolean): Unit = {
-    addVariable(ScopeMember(member, isStatic))
-  }
-
-  def addStaticImport(importNode: NewImport): Unit = {
-    addVariable(ScopeStaticImport(importNode))
-  }
-
-  private def addVariable(variable: ScopeVariable): Unit = {
-    scopeStack.head.addVariableToScope(variable)
-  }
-
-  def addType(name: String, typeFullName: String): Unit = {
-    scopeStack.head.addTypeToScope(name, typeFullName)
+  def addInnerType(name: String, typeFullName: String): Unit = {
+    val scopeType = ScopeInnerType(typeFullName)
+    scopeStack.head.addTypeToScope(name, scopeType)
   }
 
   def addWildcardImport(prefix: String): Unit = {
     scopeStack.head.addWildcardImport(prefix)
   }
 
-  def lookupVariable(name: String): VariableLookupResult = {
-    scopeStack.takeUntil(_.lookupVariable(name).isDefined) match {
-      case Nil => NotInScope
-
-      case foundSubstack =>
-        // Know the last will contain the lookup variable since that is the condition to terminate
-        // the takeUntil
-        val variable = foundSubstack.last.lookupVariable(name).get
-        lookupResultFromFound(foundSubstack, variable)
+  def addDeclBinding(name: String, declBindingInfo: JavaparserBindingDeclType): Unit = {
+    scopeStack.collectFirst { case declContainer: TypeDeclContainer =>
+      declContainer.addDeclBinding(name, declBindingInfo)
     }
   }
 
-  def lookupType(simpleName: String): Option[String] = {
-    lookupType(simpleName, includeWildcards = true)
+  def getDeclBinding(name: String): Option[JavaparserBindingDeclType] = {
+    scopeStack.iterator
+      .collect { case declContainer: TypeDeclContainer => declContainer.getDeclBinding(name) }
+      .collectFirst { case Some(result) => result }
   }
 
-  private def lookupType(simpleName: String, includeWildcards: Boolean): Option[String] = {
+  def lookupVariable(name: String): VariableLookupResult = {
+    scopeStack
+      .takeUntil(_.isInstanceOf[TypeDeclScope])
+      .iterator
+      .map(_.lookupVariable(name))
+      .collectFirst {
+        case result: SimpleVariable   => result
+        case result: CapturedVariable => result
+      }
+      .getOrElse(lookupStaticImportVariable(name))
+  }
+
+  def lookupMethodName(name: String): List[NewTypeDecl] = {
+    scopeStack
+      .collect { case typeDeclScope: TypeDeclScope => typeDeclScope }
+      .takeUntil(_.declaredMethodNames.contains(name))
+      .map(_.typeDecl)
+  }
+
+  private def lookupStaticImportVariable(name: String): VariableLookupResult = {
+    scopeStack.lastOption.map(_.lookupVariable(name)) match {
+      case Some(SimpleVariable(staticImport: ScopeStaticImport)) => SimpleVariable(staticImport)
+      case _                                                     => NotInScope
+    }
+  }
+
+  def lookupType(simpleName: String, includeWildcards: Boolean = true): Option[String] = {
+    lookupScopeType(simpleName, includeWildcards).map(_.typeFullName)
+  }
+
+  def getNextAnonymousClassIndex(): Long = {
+    scopeStack.collectFirst { case counter: AnonymousClassCounter => counter.getNextAnonymousClassIndex() }.get
+  }
+
+  def lookupScopeType(simpleName: String): Option[ScopeType] = {
+    lookupScopeType(simpleName, includeWildcards = false)
+  }
+
+  def lookupScopeType(simpleName: String, includeWildcards: Boolean): Option[ScopeType] = {
     scopeStack.iterator
       .map(_.lookupType(simpleName, includeWildcards))
-      .collectFirst { case Some(typeFullName) => typeFullName }
+      .collectFirst { case Some(foundType) => foundType }
   }
 
   def lookupVariableOrType(name: String): Option[String] = {
-    lookupVariable(name).typeFullName.orElse(lookupType(name, includeWildcards = false))
+    lookupVariable(name).typeFullName.orElse(lookupScopeType(name, includeWildcards = false).map(_.typeFullName))
   }
 
-  private def lookupResultFromFound(
-    foundSubstack: List[JavaScopeElement],
-    variable: ScopeVariable
-  ): VariableLookupResult = {
-    val typeDecls = foundSubstack.collect { case td: TypeDeclScope => td }
+  def getCapturesForNewScope(isStaticScope: Boolean): Map[String, CapturedVariable] = {
+    // This will return an empty list if no enclosing type decl is found, but this is okay since
+    // this means the new decl must be a top-level type decl which doesn't capture anything.
+    val capturedScopes = scopeStack.takeUntil(scope => scope.isInstanceOf[TypeDeclScope]) match {
+      case Nil => Nil
 
-    val isCaptureChain = typeDecls.size > 1 || (typeDecls.nonEmpty && !foundSubstack.last.isInstanceOf[TypeDeclScope])
+      // Don't capture the enclosing type decl if the new scope is static
+      case scopes if isStaticScope || scopes.init.exists(_.isStatic) => scopes.init
 
-    if (isCaptureChain) {
-      CapturedVariable(typeDecls.map(_.typeDecl), variable)
-    } else {
-      SimpleVariable(variable)
+      case scopes => scopes
+    }
+
+    val capturedVariables = capturedScopes.flatMap {
+      case scope: TypeDeclScope =>
+        val typeDecl = scope.typeDecl
+
+        val capturedMembers =
+          scope
+            .getVariables()
+            .map(variable => variable.name -> CapturedVariable(List(scope.typeDecl), variable))
+
+        val capturedCaptures = scope.capturedVariables.map { case name -> capturedVariable =>
+          name -> capturedVariable.copy(typeDeclChain = scope.typeDecl :: capturedVariable.typeDeclChain)
+        }
+
+        capturedMembers ++ capturedCaptures
+
+      case scope =>
+        scope.getVariables().map(variable => variable.name -> CapturedVariable(Nil, variable))
+    }
+
+    // Reverse the captured variables before toMap to match Java shadowing behaviour
+    capturedVariables.reverse.toMap
+  }
+
+  def registerCaptureUse(capturedVariable: CapturedVariable): Unit = {
+    capturedVariable.variable match {
+      case _: ScopeMember =>
+      // Do nothing, since members are accessed through the `outerClass` field, which is always created for non-static decls
+
+      case variable =>
+        scopeStack.collect { case td: TypeDeclScope => td }.drop(capturedVariable.typeDeclChain.size).headOption match {
+          case None => logger.warn(s"Cannot register $capturedVariable as used")
+
+          case Some(typeDeclScope) => typeDeclScope.registerCaptureUse(variable)
+        }
     }
   }
 
-  def enclosingTypeDecl: Option[NewTypeDecl] = scopeStack.collectFirst { case typeDeclScope: TypeDeclScope =>
-    typeDeclScope.typeDecl
-  }
+  def enclosingNamespace: Option[NamespaceScope] = scopeStack.collectFirst { case scope: NamespaceScope => scope }
 
-  def enclosingTypeDeclFullName: Option[String] = enclosingTypeDecl.map(_.fullName)
+  def enclosingTypeDecl: Option[TypeDeclScope] = scopeStack.collectFirst { case scope: TypeDeclScope => scope }
+
+  def enclosingMethod: Option[MethodScope] = scopeStack.collectFirst { case scope: MethodScope => scope }
+
+  def enclosingBlock: Option[BlockScope] = scopeStack.collectFirst { case scope: BlockScope => scope }
 
   def enclosingMethodReturnType: Option[ExpectedType] = scopeStack.collectFirst { case methodScope: MethodScope =>
     methodScope.returnType
@@ -125,21 +219,17 @@ class Scope {
     scopeStack.collectFirst { case typeDeclContainer: TypeDeclContainer => typeDeclContainer.registerTypeDecl(decl) }
   }
 
+  def isEnclosingScopeStatic: Boolean = scopeStack
+    .collectFirst {
+      case scope: TypeDeclScope  => scope.isStatic
+      case scope: FieldDeclScope => scope.isStatic
+      case scope: MethodScope    => scope.isStatic
+    }
+    .getOrElse(false)
+
   // TODO: The below section of todos are all methods that have been added for simple compatibility with the old
   //  scope. The plan is to refactor the code to handle these directly in the AstCreator to make the code easier
   //  to reason about, so these should be removed when that happens.
-
-  // TODO: Refactor and remove this
-  def addMemberInitializers(initializers: Seq[Ast]): Unit = {
-    scopeStack.collectFirst { case typeDeclScope: TypeDeclScope => typeDeclScope.addMemberInitializers(initializers) }
-  }
-
-  // TODO: Refactor and remove this
-  def memberInitializers: List[Ast] = {
-    scopeStack
-      .collectFirst { case typeDeclScope: TypeDeclScope => typeDeclScope.getMemberInitializers() }
-      .getOrElse(Nil)
-  }
 
   // TODO: Refactor and remove this
   def localDeclsInScope: List[Ast] = {
@@ -176,11 +266,58 @@ class Scope {
         case parameter: ScopeParameter if parameter.name != NameConstants.This => parameter
       }
   }
+
+  def scopeFullName(dropScopeCount: Int = 0): Option[String] = {
+    scopeStack.drop(dropScopeCount).headOption.flatMap {
+      case typeDeclScope: TypeDeclScope   => Some(typeDeclScope.typeDecl.fullName)
+      case namespaceScope: NamespaceScope => Some(namespaceScope.namespace.fullName)
+
+      case methodScope: MethodScope =>
+        Some(methodScope.method.fullName.stripSuffix(s":${methodScope.method.signature}"))
+
+      case fieldDeclScope: FieldDeclScope =>
+        val enclosingDeclPrefix = scopeStack.collectFirst { case typeDeclScope: TypeDeclScope =>
+          typeDeclScope.typeDecl.fullName
+        }
+        enclosingDeclPrefix.map(prefix => s"$prefix.${fieldDeclScope.name}")
+
+      case _: BlockScope => scopeFullName(dropScopeCount = 1)
+
+    }
+  }
 }
 
 object Scope {
   type NewScopeNode    = NewBlock | NewMethod | NewTypeDecl | NewNamespaceBlock
   type NewVariableNode = NewLocal | NewMethodParameterIn | NewMember | NewImport
+
+  sealed trait ScopeType {
+    def typeFullName: String
+  }
+
+  /** Used for top-level type declarations and imports that do not have captures to be concerned about or synthetic
+    * names in the cpg
+    */
+  final case class ScopeTopLevelType(override val typeFullName: String) extends ScopeType
+
+  final class ScopeInnerType(override val typeFullName: String) extends ScopeType {
+    private val usedCaptures: mutable.ListBuffer[ScopeVariable] = mutable.ListBuffer()
+
+    override def equals(other: Any): Boolean = {
+      other match {
+        case otherInnerType: ScopeInnerType => typeFullName == otherInnerType.typeFullName
+        case _                              => false
+      }
+    }
+
+    override def hashCode(): Int = typeFullName.hashCode()
+  }
+
+  object ScopeInnerType {
+    def apply(typeFullName: String): ScopeInnerType = {
+      new ScopeInnerType(typeFullName)
+    }
+  }
 
   sealed trait ScopeVariable {
     def node: NewVariableNode
@@ -189,19 +326,20 @@ object Scope {
   }
   final case class ScopeLocal(override val node: NewLocal) extends ScopeVariable {
     val typeFullName: String = node.typeFullName
-    val name                 = node.name
+    val name: String         = node.name
   }
   final case class ScopeParameter(override val node: NewMethodParameterIn) extends ScopeVariable {
     val typeFullName: String = node.typeFullName
-    val name                 = node.name
+    val name: String         = node.name
   }
   final case class ScopeMember(override val node: NewMember, isStatic: Boolean) extends ScopeVariable {
     val typeFullName: String = node.typeFullName
-    val name                 = node.name
+    val name: String         = node.name
   }
+
   final case class ScopeStaticImport(override val node: NewImport) extends ScopeVariable {
     val typeFullName: String = node.importedEntity.get
-    val name                 = node.importedAs.get
+    val name: String         = node.importedAs.get
   }
 
   sealed trait VariableLookupResult {
@@ -225,6 +363,10 @@ object Scope {
       val nodeTypeInfo = variable match {
         case ScopeMember(memberNode, isStatic) =>
           NodeTypeInfo(memberNode, memberNode.name, Some(memberNode.typeFullName), true, isStatic)
+
+        case staticImport: ScopeStaticImport =>
+          // TODO: IsField may or may not be true. Is it safe to assume it is?
+          NodeTypeInfo(staticImport.node, staticImport.name, Some(staticImport.typeFullName), true, true)
 
         case variable => NodeTypeInfo(variable.node, variable.name, Some(variable.typeFullName), false, false)
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/TypeDeclContainer.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/TypeDeclContainer.scala
@@ -1,12 +1,14 @@
 package io.joern.javasrc2cpg.scope
 
+import io.joern.javasrc2cpg.util.MultiBindingTableAdapterForJavaparser.JavaparserBindingDeclType
 import io.joern.x2cpg.Ast
 
 import scala.collection.mutable
 
 trait TypeDeclContainer {
-  private val typeDeclsToAdd = mutable.ListBuffer[Ast]()
-  private val lambdaMethods  = mutable.ListBuffer[Ast]()
+  private val typeDeclsToAdd         = mutable.ListBuffer[Ast]()
+  private val lambdaMethods          = mutable.ListBuffer[Ast]()
+  private val localClassBindingTypes = mutable.Map[String, JavaparserBindingDeclType]()
 
   def registerTypeDecl(typeDecl: Ast) = {
     typeDeclsToAdd.append(typeDecl)
@@ -20,4 +22,12 @@ trait TypeDeclContainer {
   }
 
   def registeredLambdaMethods: List[Ast] = lambdaMethods.toList
+
+  def addDeclBinding(name: String, declBindingInfo: JavaparserBindingDeclType): Unit = {
+    localClassBindingTypes.put(name, declBindingInfo)
+  }
+
+  def getDeclBinding(name: String): Option[JavaparserBindingDeclType] = {
+    localClassBindingTypes.get(name)
+  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
@@ -35,7 +35,10 @@ class EagerSourceTypeSolver(
               case Some(fullyQualifiedName) => fullyQualifiedName
               case None =>
                 val name = typeDeclaration.getNameAsString
-                logger.error(s"Could not find fully qualified name for typeDecl $name")
+                // Local classes aren't expected to have a fully qualified name
+                if (typeDeclaration.isTopLevelType() || typeDeclaration.isNestedType()) {
+                  logger.warn(s"Could not find fully qualified name for typeDecl $name")
+                }
                 name
             }
             TypeSizeReducer.simplifyType(typeDeclaration)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -39,6 +39,10 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
     nameOrFullName(typ, typeParamValues, fullyQualified = true).map(registerType)
   }
 
+  def fullNameWithoutRegistering(typ: ResolvedType): Option[String] = {
+    nameOrFullName(typ, emptyTypeParamValues, fullyQualified = true)
+  }
+
   private def typesSubstituted(
     trySubstitutedType: Try[ResolvedType],
     typeParamDecl: ResolvedTypeParameterDeclaration
@@ -162,6 +166,10 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
 
   def fullName(decl: ResolvedDeclaration): Option[String] = {
     nameOrFullName(decl, fullyQualified = true).map(registerType)
+  }
+
+  def fullNameWithoutRegistering(decl: ResolvedDeclaration): Option[String] = {
+    nameOrFullName(decl, fullyQualified = true)
   }
 
   private def nameOrFullName(decl: ResolvedDeclaration, fullyQualified: Boolean): Option[String] = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/NameConstants.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/NameConstants.scala
@@ -4,4 +4,6 @@ object NameConstants {
   val Super: String              = "super"
   val This: String               = "this"
   val WildcardImportName: String = "*"
+  val Unknown                    = "<unknown>"
+  val OuterClass                 = "outerClass"
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnonymousClassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnonymousClassTests.scala
@@ -1,0 +1,353 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.JavaSrc2Cpg
+import io.shiftleft.semanticcpg.language.*
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Block, Call, FieldIdentifier, Identifier, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.Operators
+
+class AnonymousClassTests extends JavaSrcCode2CpgFixture {
+
+  "simple anonymous classes extending interfaces in method bodies" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Bar {
+        |  void bar();
+        |}
+        |
+        |class Foo {
+        |  static void sink(String s) {}
+        |
+        |  void foo() {
+        |    Bar b = new Bar() {
+        |      public void bar() {
+        |        sink("BAR");
+        |      }
+        |    };
+        |
+        |    b.bar();
+        |  }
+        |}
+        """.stripMargin)
+
+    def anonymousDeclQuery = cpg.typeDecl.name("Foo").ast.collectAll[TypeDecl].nameExact("Bar$0")
+
+    "have a binding for the explicit method" in {
+      inside(cpg.all.collectAll[Binding].name("bar").sortBy(_.methodFullName.length).l) {
+        case List(interfaceBinding, anonBinding) =>
+          interfaceBinding.methodFullName shouldBe "foo.Bar.bar:void()"
+          interfaceBinding.bindingTypeDecl.fullName shouldBe "foo.Bar"
+
+          anonBinding.methodFullName shouldBe "foo.Foo.foo.Bar$0.bar:void()"
+          anonBinding.bindingTypeDecl.fullName shouldBe "foo.Foo.foo.Bar$0"
+      }
+    }
+
+    "have a type declaration for the anonymous class" in {
+      cpg.typeDecl.name("Bar.*").name.toSet shouldBe Set("Bar", "Bar$0")
+      cpg.typeDecl.name("Bar.*").fullName.toSet shouldBe Set("foo.Bar", "foo.Foo.foo.Bar$0")
+    }
+
+    "have the inheritsFromTypeFullName property correctly set" in {
+      anonymousDeclQuery.inheritsFromTypeFullName.toList shouldBe List("foo.Bar")
+    }
+
+    "define a default constructor with parameters and initializers for captures" in {
+      inside(anonymousDeclQuery.method.nameExact("<init>").l) { case List(constructor) =>
+        constructor.fullName shouldBe "foo.Foo.foo.Bar$0.<init>:void()"
+
+        inside(constructor.parameter.l) { case List(thisParam, outerClassParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo.foo.Bar$0"
+          thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.foo.Bar$0")
+
+          outerClassParam.name shouldBe "outerClass"
+          outerClassParam.typeFullName shouldBe "foo.Foo"
+        }
+
+        inside(constructor.body.astChildren.l) { case List(outerClassAssign: Call) =>
+          outerClassAssign.name shouldBe Operators.assignment
+          outerClassAssign.code shouldBe "this.outerClass = outerClass"
+        }
+      }
+    }
+
+    "have the correct fullName" in {
+      anonymousDeclQuery.fullName.l shouldBe List("foo.Foo.foo.Bar$0")
+    }
+
+    "be constructed correctly where the class is defined" in {
+      inside(cpg.method.name("foo").call.nameExact("<init>").l) { case List(initCall) =>
+        initCall.methodFullName shouldBe "foo.Foo.foo.Bar$0.<init>:void()"
+        inside(initCall.argument.l) { case List(thisArgument: Identifier, outerClassArgument: Identifier) =>
+          thisArgument.name shouldBe "b"
+          thisArgument.typeFullName shouldBe "foo.Bar"
+
+          outerClassArgument.name shouldBe "this"
+          outerClassArgument.refOut.l shouldBe cpg.method.name("foo").parameter.name("this").l
+        }
+      }
+    }
+  }
+
+  "simple anonymous classes extending classes in fields" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Bar {
+        |  void bar();
+        |}
+        |
+        |class Foo {
+        |  Bar b = new Bar() {
+        |    void bar() {
+        |      sink("BAR");
+        |    }
+        |  };
+        |
+        |  void foo() {
+        |    b.bar();
+        |  }
+        |}
+        |""".stripMargin)
+
+    def anonymousDeclQuery = cpg.typeDecl.name("Foo").ast.collectAll[TypeDecl].nameExact("Bar$0")
+
+    "the correct fullName" in {
+      anonymousDeclQuery.fullName.toList shouldBe List("foo.Foo.b.Bar$0")
+    }
+
+    "have the inheritsFromTypeFullName property correctly set" in {
+      anonymousDeclQuery.inheritsFromTypeFullName.toSet shouldBe Set("foo.Bar")
+    }
+
+    "be constructed correctly in the enclosing class's init" in {
+      inside(cpg.typeDecl.name("Foo").method.nameExact("<init>").call.nameExact("<init>").l) { case List(initCall) =>
+        initCall.methodFullName shouldBe "foo.Foo.b.Bar$0.<init>:void()"
+        inside(initCall.argument.l) { case List(thisArgument: Call, outerClassArgument: Identifier) =>
+          thisArgument.name shouldBe Operators.fieldAccess
+          thisArgument.typeFullName shouldBe "foo.Bar"
+          inside(thisArgument.argument.l) { case List(thisNode: Identifier, bMember: FieldIdentifier) =>
+            thisNode.name shouldBe "this"
+            thisNode.typeFullName shouldBe "foo.Foo"
+
+            bMember.canonicalName shouldBe "b"
+          }
+
+          outerClassArgument.name shouldBe "this"
+          outerClassArgument.refOut.l shouldBe cpg.typeDecl
+            .name("Foo")
+            .method
+            .nameExact("<init>")
+            .parameter
+            .name("this")
+            .l
+        }
+      }
+    }
+  }
+
+  "simple anonymous classes extending classes in static fields" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Bar {
+        |  void bar();
+        |}
+        |
+        |class Foo {
+        |  static Bar b = new Bar() {
+        |    public void bar() {
+        |      sink("BAR");
+        |    }
+        |  };
+        |
+        |  void foo() {
+        |    b.bar();
+        |  }
+        |}
+        |""".stripMargin)
+
+    def anonymousDeclQuery = cpg.typeDecl.name("Foo").ast.collectAll[TypeDecl].nameExact("Bar$0")
+
+    "be constructed correctly in the enclosing class's clinit" in {
+      inside(cpg.typeDecl.name("Foo").method.nameExact("<clinit>").call.nameExact("<init>").l) { case List(initCall) =>
+        initCall.methodFullName shouldBe "foo.Foo.b.Bar$0.<init>:void()"
+        inside(initCall.argument.l) { case List(fieldAccess: Call) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.typeFullName shouldBe "foo.Bar"
+
+          inside(fieldAccess.argument.l) { case List(fooIdentifier: Identifier, bField: FieldIdentifier) =>
+            fooIdentifier.name shouldBe "Foo"
+            fooIdentifier.typeFullName shouldBe "foo.Foo"
+
+            bField.canonicalName shouldBe "b"
+          }
+        }
+      }
+    }
+  }
+
+  "simple anonymous classes extending classes for enum entries" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |enum Foo {
+        |  ENTRY(42) {
+        |    @Override
+        |    int getValue() {
+        |      return value + 7;
+        |    }
+        |  };
+        |
+        |  protected int value;
+        |
+        |  int getValue() {
+        |    return value;
+        |  }
+        |
+        |  Foo(int value) {
+        |    this.value = value;
+        |  }
+        |}
+        |""".stripMargin)
+    "be constructed correctly in the enclosing class's clinit" in {
+      pendingUntilFixed {
+        inside(cpg.typeDecl.name("Foo").method.nameExact("<clinit>").call.nameExact("<init>").l) {
+          case List(initCall) =>
+            initCall.methodFullName shouldBe "foo.Foo$0.<init>:void()"
+            inside(initCall.argument.l) { case List(thisArgument: Identifier) =>
+              thisArgument.name shouldBe "ENTRY"
+              thisArgument.typeFullName shouldBe "foo.Foo$0"
+            }
+        }
+      }
+    }
+  }
+
+  "anonymous classes extending non-trivial classes" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |abstract class Bar {
+        |  int barMember = 0;
+        |  void bar();
+        |  void sink(int input) {}
+        |}
+        |
+        |class Foo {
+        |  static Bar b = new Bar() {
+        |    public void bar() {
+        |      sink(barMember);
+        |    }
+        |  };
+        |
+        |  void foo() {
+        |    b.bar();
+        |  }
+        |}
+        """.stripMargin)
+
+    "be able to access members and methods from the superclass" in {
+      inside(cpg.method.name("bar").call.name("sink").l) { case List(sinkCall) =>
+        sinkCall.methodFullName shouldBe "foo.Foo.b.Bar$0.sink:void(int)"
+
+        inside(sinkCall.argument.l) { case List(thisArgument: Identifier, memberAccess: Call) =>
+          thisArgument.name shouldBe "this"
+          thisArgument.typeFullName shouldBe "foo.Foo.b.Bar$0"
+
+          memberAccess.code shouldBe "this.barMember"
+        }
+      }
+    }
+  }
+
+  "multiple anonymous classes in the same method" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Bar {
+        |  void bar();
+        |}
+        |
+        |class Foo {
+        |  void foo() {
+        |    Bar a = new Bar() {
+        |      void bar() {
+        |        sink("A");
+        |      }
+        |    };
+        |    Bar b = new Bar() {
+        |      void bar() {
+        |        sink("B");
+        |      }
+        |    };
+        |
+        |    a.bar();
+        |    b.bar();
+        |  }
+        |}
+        """.stripMargin)
+
+    "have different names" in {
+      cpg.typeDecl.name("Bar.*").fullName.toSet shouldBe Set("foo.Bar", "foo.Foo.foo.Bar$0", "foo.Foo.foo.Bar$1")
+    }
+
+    "have the correct names matched to the correct constructors" in {
+      cpg.method.name("foo").call.nameExact("<init>").methodFullName.toList shouldBe List(
+        "foo.Foo.foo.Bar$0.<init>:void()",
+        "foo.Foo.foo.Bar$1.<init>:void()"
+      )
+    }
+
+    "have the correct types assigned to the bars" in {
+      cpg.method
+        .name("foo")
+        .call
+        .nameExact(Operators.assignment)
+        .flatMap(call => call.argument.collectFirst { case call: Call => call })
+        .typeFullName
+        .toList shouldBe List("foo.Foo.foo.Bar$0", "foo.Foo.foo.Bar$1")
+    }
+  }
+
+  // TODO: Probably ignore this case
+  "anonymous classes that inherit non-trivial constructors from a local class with captures" ignore {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Bar {
+        |  int barMember;
+        |  public Bar(int barParam) {
+        |    barMember = barParam;
+        |  }
+        |}
+        |
+        |class OuterClass {
+        |  void outerMethod(int outerParam) {
+        |    class InnerClass {
+        |      void innerMethod(int innerParam) {
+        |        Bar b = new Bar(innerParam) {
+        |          int bar() {
+        |            return barMember + innerParam + outerParam;
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+    "have the correct constructor parameters" in {
+      ???
+    }
+
+    "initialize captures in the constructor" in {
+      ???
+    }
+
+    "call the super constructor with the correct arguments" in {
+      ???
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -56,6 +56,26 @@ class NewConstructorInvocationTests extends JavaSrcCode2CpgFixture {
       }
     }
   }
+
+  "an object creation expression as an argument to an unresolved call should still be created correctly" in {
+    val cpg = code("""
+        |class Foo {
+        |  public Foo(int x) {}
+        |
+        |  void foo() {
+        |    sink(new Foo(42));
+        |  }
+        |}
+        |""".stripMargin)
+
+    inside(cpg.call.name("sink").argument.l) { case List(_: Identifier, initBlock: Block) =>
+      inside(initBlock.ast.collectAll[Call].nameExact("<init>").l) { case List(initCall) =>
+        inside(initCall.argument.l) { case List(_: Identifier, givenArg: Literal) =>
+          givenArg.code shouldBe "42"
+        }
+      }
+    }
+  }
 }
 
 class ConstructorInvocationTests extends JavaSrcCode2CpgFixture {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -713,4 +713,28 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
     }
 
   }
+
+  "object creation expressions in lambdas" should {
+    val cpg = code("""
+        |import java.util.ArrayList;
+        |
+        |public class Foo {
+        |  public Integer method(ArrayList<Integer> list, Integer aaa) {
+        |    ArrayList<Integer> mappedList = list.stream().map(integer -> {
+        |      ArrayList<Integer> nestedList = new ArrayList<>();
+        |    });
+        |
+        |    return 0;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "not create identifiers without parents" in {
+      cpg.identifier.name("nestedList").astParent.nonEmpty shouldBe true
+    }
+
+    "have init args created correctly" in {
+      cpg.call.nameExact("<init>").count(_.argument.isEmpty) shouldBe 0
+    }
+  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
@@ -1,0 +1,1580 @@
+package io.joern.javasrc2cpg.querying
+
+import io.shiftleft.semanticcpg.language.*
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Call, FieldIdentifier, Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+
+class LocalClassTests extends JavaSrcCode2CpgFixture {
+  "simple local classes" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    int capturedMember;
+        |    static int staticMember;
+        |
+        |    void enclosingMethod(int capturedParam) {
+        |        int capturedLocal = 1;
+        |        class Local {
+        |            void noCaptures(int localParam) {
+        |                sink(localParam);
+        |            } 
+        |
+        |            void capturesParam() {
+        |                sink(capturedParam);
+        |            }
+        |
+        |            void capturesMember() {
+        |                sink(capturedMember);
+        |            }
+        |
+        |            void capturesLocal() {
+        |                sink(capturedLocal);
+        |            }
+        |
+        |            void staticAccess() {
+        |                sink(staticMember);
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    @inline def localDecl = cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local")
+
+    "have only one Local typeDecl" in {
+      cpg.typeDecl.name(".*Local.*").fullName.toSet shouldBe Set("foo.Foo.enclosingMethod.Local")
+    }
+
+    "have the correct bindings for methods defined in the local class" in {
+      inside(cpg.all.collectAll[Binding].nameExact("noCaptures").l) { case List(noCapturesBinding) =>
+        noCapturesBinding.methodFullName shouldBe "foo.Foo.enclosingMethod.Local.noCaptures:void(int)"
+        noCapturesBinding.bindingTypeDecl.fullName shouldBe "foo.Foo.enclosingMethod.Local"
+        noCapturesBinding.signature shouldBe "void(int)"
+      }
+    }
+
+    "have the correct binding for the default constructor" in {
+      inside(cpg.all.collectAll[Binding].nameExact("<init>").methodFullName(".*Local.*").l) {
+        case List(noCapturesBinding) =>
+          noCapturesBinding.methodFullName shouldBe "foo.Foo.enclosingMethod.Local.<init>:void()"
+          noCapturesBinding.bindingTypeDecl.fullName shouldBe "foo.Foo.enclosingMethod.Local"
+          noCapturesBinding.signature shouldBe "void()"
+      }
+    }
+
+    "have the correct code set" in {
+      localDecl.code.l shouldBe List("class Local")
+    }
+
+    "have the correct inheritsFromTypeFullName set" in {
+      localDecl.inheritsFromTypeFullName.l shouldBe List("java.lang.Object")
+    }
+
+    "have the correct line and column numbers set" in {
+      localDecl.lineNumber.l shouldBe List(10)
+      localDecl.columnNumber.l shouldBe List(9)
+    }
+
+    "have the correct number of members created for captures" in {
+      localDecl.member.size shouldBe 3
+    }
+
+    "have an outerClass member for the captured class" in {
+      localDecl.member.name("outerClass").typeFullName.l shouldBe List("foo.Foo")
+    }
+
+    "have a member for the captured parameter" in {
+      localDecl.member.name("capturedParam").typeFullName.l shouldBe List("int")
+    }
+
+    "have a member for the captured local" in {
+      localDecl.member.name("capturedLocal").typeFullName.l shouldBe List("int")
+    }
+
+    "not have a member for the static member in the outer class" in {
+      localDecl.member.name("staticMember").isEmpty shouldBe true
+    }
+
+    "not have a member for the captured member in the outer class" in {
+      localDecl.member.name("capturedMember").isEmpty shouldBe true
+    }
+
+    "have a default constructor with parameters for captured variables" in {
+      localDecl.method.nameExact("<init>").parameter.l match {
+        case List(thisParam, outerClassParam, capturedLocalParam, capturedParamParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+          thisParam.index shouldBe 0
+          thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod.Local")
+
+          outerClassParam.name shouldBe "outerClass"
+          outerClassParam.typeFullName shouldBe "foo.Foo"
+          outerClassParam.index shouldBe 1
+
+          capturedLocalParam.name shouldBe "capturedLocal"
+          capturedLocalParam.typeFullName shouldBe "int"
+          capturedLocalParam.index shouldBe 2
+
+          capturedParamParam.name shouldBe "capturedParam"
+          capturedParamParam.typeFullName shouldBe "int"
+          capturedParamParam.index shouldBe 3
+
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+
+    "have assignments for captured variables in the default constructor" in {
+      localDecl.method.nameExact("<init>").l match {
+        case List(localInit) =>
+          localDecl.method.nameExact("<init>").body.astChildren.l match {
+            case List(outerClassAssign: Call, capturedLocalAssign: Call, capturedParamAssign: Call) =>
+              outerClassAssign.methodFullName shouldBe Operators.assignment
+              capturedLocalAssign.methodFullName shouldBe Operators.assignment
+              capturedParamAssign.methodFullName shouldBe Operators.assignment
+
+              outerClassAssign.argument.l match {
+                case List(thisOuterClass: Call, outerClass: Identifier) =>
+                  thisOuterClass.methodFullName shouldBe Operators.fieldAccess
+                  thisOuterClass.argument.l match {
+                    case List(thisIdentifier: Identifier, field: FieldIdentifier) =>
+                      thisIdentifier.name shouldBe "this"
+                      thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+                      thisIdentifier.refOut.l shouldBe localInit.parameter.name("this").l
+
+                      field.canonicalName shouldBe "outerClass"
+
+                    case result => fail(s"Unexpected result ${result}")
+                  }
+
+                  outerClass.name shouldBe "outerClass"
+                  outerClass.typeFullName shouldBe "foo.Foo"
+                  outerClass.refOut.l shouldBe localInit.parameter.name("outerClass").l
+
+                case result => fail(s"Unexpected result ${result}")
+              }
+
+              capturedLocalAssign.argument.l match {
+                case List(thisCapturedLocal: Call, capturedLocal: Identifier) =>
+                  thisCapturedLocal.methodFullName shouldBe Operators.fieldAccess
+                  thisCapturedLocal.argument.l match {
+                    case List(thisIdentifier: Identifier, field: FieldIdentifier) =>
+                      thisIdentifier.name shouldBe "this"
+                      thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+                      thisIdentifier.refOut.l shouldBe localInit.parameter.name("this").l
+
+                      field.canonicalName shouldBe "capturedLocal"
+                    case result => fail(s"Unexpected result ${result}")
+                  }
+
+                  capturedLocal.name shouldBe "capturedLocal"
+                  capturedLocal.typeFullName shouldBe "int"
+                  capturedLocal.refOut.l shouldBe localInit.parameter.name("capturedLocal").l
+                case result => fail(s"Unexpected result ${result}")
+              }
+
+              capturedParamAssign.argument.l match {
+                case List(thisCapturedParam: Call, capturedParam: Identifier) =>
+                  thisCapturedParam.methodFullName shouldBe Operators.fieldAccess
+                  thisCapturedParam.argument.l match {
+                    case List(thisIdentifier: Identifier, field: FieldIdentifier) =>
+                      thisIdentifier.name shouldBe "this"
+                      thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+                      thisIdentifier.refOut.l shouldBe localInit.parameter.name("this").l
+
+                      field.canonicalName shouldBe "capturedParam"
+                    case result => fail(s"Unexpected result ${result}")
+                  }
+
+                  capturedParam.name shouldBe "capturedParam"
+                  capturedParam.typeFullName shouldBe "int"
+                  capturedParam.refOut.l shouldBe localInit.parameter.name("capturedParam").l
+                case result => fail(s"Unexpected result ${result}")
+              }
+            case result => fail(s"Unexpected result ${result}")
+          }
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+  }
+
+  "local classes in a static context" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    int member;
+        |    static int staticMember;
+        |
+        |    static void enclosingMethod(int capturedParam) {
+        |        int capturedLocal = 1;
+        |        class Local {
+        |            void noCaptures(int localParam) {
+        |                sink(localParam);
+        |            }
+        |
+        |            void capturesParam() {
+        |                sink(capturedParam);
+        |            }
+        |
+        |            void capturesMember() {
+        |                // This is not legal Java code
+        |                sink(member);
+        |            }
+        |
+        |            void staticAccess() {
+        |                sink(staticMember);
+        |            }
+        |
+        |            void capturesLocal() {
+        |                sink(capturedLocal);
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    @inline def localDecl = cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local")
+
+    "have only one Local typeDecl" in {
+      cpg.typeDecl.name(".*Local.*").fullName.toSet shouldBe Set("foo.Foo.enclosingMethod.Local")
+    }
+
+    "have the correct number of members created for captures" in {
+      localDecl.member.size shouldBe 2
+    }
+
+    "have an not outerClass member for a captured class" in {
+      localDecl.member.name("outerClass").isEmpty shouldBe true
+    }
+
+    "have a member for the captured parameter" in {
+      localDecl.member.name("capturedParam").typeFullName.l shouldBe List("int")
+    }
+
+    "have a member for the captured local" in {
+      localDecl.member.name("capturedLocal").typeFullName.l shouldBe List("int")
+    }
+
+    "not have a member for the static member in the outer class" in {
+      localDecl.member.name("staticMember").isEmpty shouldBe true
+    }
+
+    "not have a member for the captured member in the outer class" in {
+      localDecl.member.name("capturedMember").isEmpty shouldBe true
+    }
+
+    "have a default constructor with a parameter for the captured parameter" in {
+      localDecl.method.nameExact("<init>").parameter.l match {
+        case List(thisParam, capturedLocalParam, capturedParamParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+          thisParam.index shouldBe 0
+          thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod.Local")
+
+          capturedLocalParam.name shouldBe "capturedLocal"
+          capturedLocalParam.typeFullName shouldBe "int"
+          capturedLocalParam.index shouldBe 1
+
+          capturedParamParam.name shouldBe "capturedParam"
+          capturedParamParam.typeFullName shouldBe "int"
+          capturedParamParam.index shouldBe 2
+        case result => fail(s"Unexpected result ${result.map(_.name)}")
+      }
+    }
+
+    "have an assignment for the captured parameter in the default constructor" in {
+      localDecl.method.nameExact("<init>").l match {
+        case List(localInit) =>
+          localDecl.method.nameExact("<init>").body.astChildren.l match {
+            case List(capturedLocalAssign: Call, capturedParamAssign: Call) =>
+              capturedParamAssign.methodFullName shouldBe Operators.assignment
+              capturedLocalAssign.methodFullName shouldBe Operators.assignment
+
+              capturedParamAssign.argument.l match {
+                case List(thisCapturedParam: Call, capturedParam: Identifier) =>
+                  thisCapturedParam.methodFullName shouldBe Operators.fieldAccess
+                  thisCapturedParam.argument.l match {
+                    case List(thisIdentifier: Identifier, field: FieldIdentifier) =>
+                      thisIdentifier.name shouldBe "this"
+                      thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+                      thisIdentifier.refOut.l shouldBe localInit.parameter.name("this").l
+
+                      field.canonicalName shouldBe "capturedParam"
+                    case result => fail(s"Unexpected result ${result}")
+                  }
+
+                  capturedParam.name shouldBe "capturedParam"
+                  capturedParam.typeFullName shouldBe "int"
+                  capturedParam.refOut.l shouldBe localInit.parameter.name("capturedParam").l
+                case result => fail(s"Unexpected result ${result}")
+              }
+
+              capturedLocalAssign.argument.l match {
+                case List(thisCapturedLocal: Call, capturedLocal: Identifier) =>
+                  thisCapturedLocal.methodFullName shouldBe Operators.fieldAccess
+                  thisCapturedLocal.argument.l match {
+                    case List(thisIdentifier: Identifier, field: FieldIdentifier) =>
+                      thisIdentifier.name shouldBe "this"
+                      thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+                      thisIdentifier.refOut.l shouldBe localInit.parameter.name("this").l
+
+                      field.canonicalName shouldBe "capturedLocal"
+                    case result => fail(s"Unexpected result ${result}")
+                  }
+
+                  capturedLocal.name shouldBe "capturedLocal"
+                  capturedLocal.typeFullName shouldBe "int"
+                  capturedLocal.refOut.l shouldBe localInit.parameter.name("capturedLocal").l
+                case result => fail(s"Unexpected result ${result}")
+              }
+            case result => fail(s"Unexpected result ${result}")
+          }
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+  }
+
+  "object creation expressions for local classes without used captures" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    void enclosingMethod(int outerParam) {
+        |        int outerLocal = 2;
+        |        class Local {
+        |            String foo() {
+        |                return "Local";
+        |            }
+        |        };
+        |        Local l = new Local();
+        |    }
+        |}
+        |""".stripMargin)
+
+    @inline def localDecl = cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local")
+
+    "have only one Local typeDecl" in {
+      cpg.typeDecl.name(".*Local.*").fullName.toSet shouldBe Set("foo.Foo.enclosingMethod.Local")
+    }
+
+    "have a field for the captured outer class" in {
+      localDecl.member.l match {
+        case List(outerClassMember) =>
+          outerClassMember.name shouldBe "outerClass"
+          outerClassMember.typeFullName shouldBe "foo.Foo"
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+
+    "have an init parameter for the captured outer class" in {
+      localDecl.method.nameExact("<init>").parameter.l match {
+        case List(thisParam, outerClassParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.index shouldBe 0
+          thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+          thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod.Local")
+
+          outerClassParam.name shouldBe "outerClass"
+          outerClassParam.typeFullName shouldBe "foo.Foo"
+          outerClassParam.index shouldBe 1
+
+        case result => fail(s"Found unexpected output ${result}")
+      }
+    }
+
+    "have an assignment for the captured outer class in the default constructor" in {
+      localDecl.method.nameExact("<init>").l match {
+        case List(localInit) =>
+          localDecl.method.nameExact("<init>").body.astChildren.l match {
+            case List(outerClassAssign: Call) =>
+              outerClassAssign.methodFullName shouldBe Operators.assignment
+              outerClassAssign.argument.l match {
+                case List(thisOuterClass: Call, outerClass: Identifier) =>
+                  thisOuterClass.methodFullName shouldBe Operators.fieldAccess
+                  thisOuterClass.argument.l match {
+                    case List(thisIdentifier: Identifier, field: FieldIdentifier) =>
+                      thisIdentifier.name shouldBe "this"
+                      thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+                      thisIdentifier.refOut.l shouldBe localInit.parameter.name("this").l
+
+                      field.canonicalName shouldBe "outerClass"
+                    case result => fail(s"Unexpected result ${result}")
+                  }
+
+                  outerClass.name shouldBe "outerClass"
+                  outerClass.typeFullName shouldBe "foo.Foo"
+                  outerClass.refOut.l shouldBe localInit.parameter.name("outerClass").l
+                case result => fail(s"Unexpected result ${result}")
+              }
+            case result => fail(s"Unexpected result ${result}")
+          }
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+  }
+
+  // TODO: Actually add object creation test
+  "object creation expressions for local classes in a static context without used captures" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    static void enclosingMethod(int outerParam) {
+        |        int outerLocal = 2;
+        |        class Local {
+        |            String foo() {
+        |                return "Local";
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    @inline def localDecl = cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local")
+
+    "have only one Local typeDecl" in {
+      cpg.typeDecl.name(".*Local.*").fullName.toSet shouldBe Set("foo.Foo.enclosingMethod.Local")
+    }
+
+    "not have a field for the captured outer class" in {
+      localDecl.member.isEmpty shouldBe true
+    }
+
+    "not have an init parameter for the outer class" in {
+      localDecl.method.nameExact("<init>").parameter.l match {
+        case List(thisParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.index shouldBe 0
+          thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+          thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod.Local")
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+
+    "not have an assignment for the outer class in the default constructor" in {
+      localDecl.method.nameExact("<init>").body.astChildren.isEmpty shouldBe true
+    }
+  }
+
+  "local classes with some used captures and some unused" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    int capturedMember;
+        |    static int staticMember;
+        |
+        |    void enclosingMethod(int capturedParam) {
+        |        int capturedLocal = 1;
+        |        class Local {
+        |            void noCaptures(int localParam) {
+        |                sink(localParam);
+        |            } 
+        |
+        |            void capturesMember() {
+        |                sink(capturedMember);
+        |            }
+        |
+        |            void capturesLocal() {
+        |                sink(capturedLocal);
+        |            }
+        |
+        |            void staticAccess() {
+        |                sink(staticMember);
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    @inline def localDecl = cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local")
+
+    "have only one Local typeDecl" in {
+      cpg.typeDecl.name(".*Local.*").fullName.toSet shouldBe Set("foo.Foo.enclosingMethod.Local")
+    }
+
+    "have the correct full name set" in {
+      localDecl.fullName.l shouldBe List("foo.Foo.enclosingMethod.Local")
+    }
+
+    "have the correct code set" in {
+      localDecl.code.l shouldBe List("class Local")
+    }
+
+    "have the correct inheritsFromTypeFullName set" in {
+      localDecl.inheritsFromTypeFullName.l shouldBe List("java.lang.Object")
+    }
+
+    "have the correct line and column numbers set" in {
+      localDecl.lineNumber.l shouldBe List(10)
+      localDecl.columnNumber.l shouldBe List(9)
+    }
+
+    "have the correct number of members created for captures" in {
+      localDecl.member.size shouldBe 2
+    }
+
+    "have an outerClass member for the captured class" in {
+      localDecl.member.name("outerClass").typeFullName.l shouldBe List("foo.Foo")
+    }
+
+    "not have a member for the unused captured parameter" in {
+      localDecl.member.name("capturedParam").isEmpty shouldBe true
+    }
+
+    "have a member for the captured local" in {
+      localDecl.member.name("capturedLocal").typeFullName.l shouldBe List("int")
+    }
+
+    "not have a member for the static member in the outer class" in {
+      localDecl.member.name("staticMember").isEmpty shouldBe true
+    }
+
+    "not have a member for the captured member in the outer class" in {
+      localDecl.member.name("capturedMember").isEmpty shouldBe true
+    }
+
+    "have a default constructor with parameters for used captures" in {
+      localDecl.method.nameExact("<init>").parameter.l match {
+        case List(thisParam, outerClassParam, capturedLocalParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+          thisParam.index shouldBe 0
+          thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod.Local")
+
+          outerClassParam.name shouldBe "outerClass"
+          outerClassParam.typeFullName shouldBe "foo.Foo"
+          outerClassParam.index shouldBe 1
+
+          capturedLocalParam.name shouldBe "capturedLocal"
+          capturedLocalParam.typeFullName shouldBe "int"
+          capturedLocalParam.index shouldBe 2
+
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+
+    "have assignments for used captures in the default constructor" in {
+      localDecl.method.nameExact("<init>").l match {
+        case List(localInit) =>
+          localDecl.method.nameExact("<init>").body.astChildren.l match {
+            case List(outerClassAssign: Call, capturedLocalAssign: Call) =>
+              outerClassAssign.methodFullName shouldBe Operators.assignment
+              capturedLocalAssign.methodFullName shouldBe Operators.assignment
+
+              outerClassAssign.argument.l match {
+                case List(thisOuterClass: Call, outerClass: Identifier) =>
+                  thisOuterClass.methodFullName shouldBe Operators.fieldAccess
+                  thisOuterClass.argument.l match {
+                    case List(thisIdentifier: Identifier, field: FieldIdentifier) =>
+                      thisIdentifier.name shouldBe "this"
+                      thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+                      thisIdentifier.refOut.l shouldBe localInit.parameter.name("this").l
+
+                      field.canonicalName shouldBe "outerClass"
+                    case result => fail(s"Unexpected result ${result}")
+                  }
+
+                  outerClass.name shouldBe "outerClass"
+                  outerClass.typeFullName shouldBe "foo.Foo"
+                  outerClass.refOut.l shouldBe localInit.parameter.name("outerClass").l
+                case result => fail(s"Unexpected result ${result}")
+              }
+
+              capturedLocalAssign.argument.l match {
+                case List(thisCapturedLocal: Call, capturedLocal: Identifier) =>
+                  thisCapturedLocal.methodFullName shouldBe Operators.fieldAccess
+                  thisCapturedLocal.argument.l match {
+                    case List(thisIdentifier: Identifier, field: FieldIdentifier) =>
+                      thisIdentifier.name shouldBe "this"
+                      thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+                      thisIdentifier.refOut.l shouldBe localInit.parameter.name("this").l
+
+                      field.canonicalName shouldBe "capturedLocal"
+                    case result => fail(s"Unexpected result ${result}")
+                  }
+
+                  capturedLocal.name shouldBe "capturedLocal"
+                  capturedLocal.typeFullName shouldBe "int"
+                  capturedLocal.refOut.l shouldBe localInit.parameter.name("capturedLocal").l
+                case result => fail(s"Unexpected result ${result}")
+              }
+            case result => fail(s"Unexpected result ${result}")
+          }
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+  }
+
+  "local classes with a single explicit constructor" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    void enclosingMethod(int outerParam) {
+        |        int outerLocal = 2;
+        |        class Local {
+        |            public Local(int ctxParam) {
+        |              sink(ctxParam);
+        |            }
+        |
+        |            void captureOuters() {
+        |              sink(outerParam + outerLocal);
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    @inline def localConstructor = cpg.typeDecl.name(".*Local.*").method.nameExact("<init>")
+
+    "have the original parameter followed by params for captures" in {
+      localConstructor.parameter.l match {
+        case List(thisParam, ctxParam, outerClassParam, outerLocalParam, outerParamParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.index shouldBe 0
+
+          ctxParam.name shouldBe "ctxParam"
+          ctxParam.index shouldBe 1
+
+          outerClassParam.name shouldBe "outerClass"
+          outerClassParam.index shouldBe 2
+
+          outerLocalParam.name shouldBe "outerLocal"
+          outerLocalParam.index shouldBe 3
+
+          outerParamParam.name shouldBe "outerParam"
+          outerParamParam.index shouldBe 4
+
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+
+    "have assignments for captures before the constructor body" in {
+      localConstructor.body.astChildren.code.l shouldBe List(
+        "this.outerClass = outerClass",
+        "this.outerLocal = outerLocal",
+        "this.outerParam = outerParam",
+        "sink(ctxParam)"
+      )
+    }
+  }
+
+  "local classes with multiple unchained explicit constructors" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    void enclosingMethod(int outerParam) {
+        |        class Local {
+        |            public Local() { }
+        |
+        |            public Local(int ctxParam) {
+        |              sink(ctxParam);
+        |            }
+        |
+        |            void captureOuters() {
+        |              sink(outerParam);
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    @inline def constructors =
+      cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local").method.nameExact("<init>").sortBy(_.parameter.size)
+
+    "have correct bindings for the explicit constructors" in {
+      val bindings = cpg.all.collectAll[Binding].toList
+      inside(cpg.all.collectAll[Binding].nameExact("<init>").methodFullName(".*Local.*").sortBy(_.signature.length).l) {
+        case List(noArgBinding, explicitArgBinding) =>
+          noArgBinding.methodFullName shouldBe "foo.Foo.enclosingMethod.Local.<init>:void()"
+          noArgBinding.bindingTypeDecl.fullName shouldBe "foo.Foo.enclosingMethod.Local"
+          noArgBinding.signature shouldBe "void()"
+
+          explicitArgBinding.methodFullName shouldBe "foo.Foo.enclosingMethod.Local.<init>:void(int)"
+          explicitArgBinding.bindingTypeDecl.fullName shouldBe "foo.Foo.enclosingMethod.Local"
+          explicitArgBinding.signature shouldBe "void(int)"
+      }
+    }
+
+    "have params for captured members for both constructors" in {
+      constructors.head.parameter.name.l shouldBe List("this", "outerClass", "outerParam")
+      constructors.last.parameter.name.l shouldBe List("this", "ctxParam", "outerClass", "outerParam")
+    }
+
+    "have assignments for the captures in both constructors" in {
+      constructors.head.body.astChildren.code.l shouldBe List(
+        "this.outerClass = outerClass",
+        "this.outerParam = outerParam"
+      )
+      constructors.last.body.astChildren.code.l shouldBe List(
+        "this.outerClass = outerClass",
+        "this.outerParam = outerParam",
+        "sink(ctxParam)"
+      )
+    }
+  }
+
+  "local classes with chained explicit constructors" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    void enclosingMethod(int outerParam) {
+        |        class Local {
+        |            public Local() { }
+        |
+        |            public Local(int ctxParam) {
+        |              this();
+        |              sink(ctxParam);
+        |            }
+        |
+        |            void captureOuters() {
+        |              sink(outerParam);
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    @inline def constructors =
+      cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local").method.nameExact("<init>").sortBy(_.parameter.size)
+
+    "have params for captured members for both constructors" in {
+      constructors.head.parameter.name.l shouldBe List("this", "outerClass", "outerParam")
+      constructors.last.parameter.name.l shouldBe List("this", "ctxParam", "outerClass", "outerParam")
+    }
+
+    "have assignments for the captures only in constructors that do not call further constructors" in {
+      constructors.head.body.astChildren.code.l shouldBe List(
+        "this.outerClass = outerClass",
+        "this.outerParam = outerParam"
+      )
+      val lastBody = constructors.last.body.astChildren.l
+      inside(constructors.last.body.astChildren.l) { case List(thisCall: Call, sinkCall: Call) =>
+        thisCall.argument.code.l shouldBe List("this", "outerClass", "outerParam")
+        sinkCall.code shouldBe "sink(ctxParam)"
+      }
+    }
+  }
+
+  "local classes with calls to captured methods" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    void foo() {}
+        |
+        |    void enclosingMethod(int outerParam) {
+        |        class Local {
+        |            void callsOuter() {
+        |                foo();
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    "call the captured method on the outerClass field" in {
+      cpg.call.name("foo").l match {
+        case List(fooCall) =>
+          fooCall.name shouldBe "foo"
+          fooCall.methodFullName shouldBe "foo.Foo.foo:void()"
+          fooCall.code shouldBe "this.outerClass.foo()"
+          fooCall.signature shouldBe "void()"
+          fooCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+
+          fooCall.receiver.l match {
+            case List(receiverFieldAccess: Call) =>
+              receiverFieldAccess.name shouldBe Operators.fieldAccess
+              receiverFieldAccess.typeFullName shouldBe "foo.Foo"
+
+              receiverFieldAccess.argument.l match {
+                case List(thisIdentifier: Identifier, outerClassFieldId: FieldIdentifier) =>
+                  thisIdentifier.name shouldBe "this"
+                  thisIdentifier.typeFullName shouldBe "foo.Foo.enclosingMethod.Local"
+
+                  outerClassFieldId.canonicalName shouldBe "outerClass"
+                case result => fail(s"Unexpected result ${result}")
+              }
+            case result => fail(s"Unexpected result ${result}")
+          }
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+  }
+
+  "local classes with calls to static methods in the outer class" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |    static void foo() {}
+        |
+        |    void enclosingMethod(int outerParam) {
+        |        class Local {
+        |            void callsOuter() {
+        |                foo();
+        |            }
+        |        };
+        |    }
+        |}
+        |""".stripMargin)
+
+    "not represent the call as a call to the outerClass field" in {
+      cpg.call.name("foo").l match {
+        case List(fooCall) =>
+          fooCall.name shouldBe "foo"
+          fooCall.methodFullName shouldBe "foo.Foo.foo:void()"
+          fooCall.code shouldBe "foo()"
+          fooCall.signature shouldBe "void()"
+          fooCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+          fooCall.receiver.isEmpty shouldBe true
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+  }
+
+  "object creation expressions for local classes" when {
+    "it is a local class with captures and explicit constructor arguments" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  int fooMember;
+          |
+          |  void fooMethod(int fooParam) {
+          |    int fooLocal = 0;
+          |    class Local {
+          |      public Local(int argument) {}
+          |
+          |      void usesCaptures() {
+          |        sink(fooMember, fooLocal, fooParam);
+          |      }
+          |    }
+          |
+          |    sink(new Local(0));
+          |  }
+          |}
+          |""".stripMargin)
+
+      @inline def initCall = cpg.call.name("sink").ast.collectAll[Call].nameExact("<init>")
+
+      "have the correct init node properties" in {
+        initCall.l match {
+          case List(call) =>
+            call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
+            call.signature shouldBe "void(int)"
+            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the correct init receiver" in {
+        initCall.receiver.l match {
+          case List(receiver: Identifier) =>
+            receiver.typeFullName shouldBe "foo.Foo.fooMethod.Local"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the explicit and capture arguments in the correct order" in {
+        initCall.argument.l match {
+          case List(
+                _,
+                explicitArg: Literal,
+                outerClass: Identifier,
+                capturedLocal: Identifier,
+                capturedParam: Identifier
+              ) =>
+            explicitArg.code shouldBe "0"
+            explicitArg.argumentIndex shouldBe 1
+
+            outerClass.name shouldBe "this"
+            outerClass.argumentIndex shouldBe 2
+            outerClass.refOut.l shouldBe cpg.method.name("fooMethod").parameter.index(0).l
+
+            capturedLocal.name shouldBe "fooLocal"
+            capturedLocal.argumentIndex shouldBe 3
+            capturedLocal.refOut.l shouldBe cpg.method.name("fooMethod").local.name("fooLocal").l
+
+            capturedParam.name shouldBe "fooParam"
+            capturedParam.argumentIndex shouldBe 4
+            capturedParam.refOut.l shouldBe cpg.method.name("fooMethod").parameter.name("fooParam").l
+
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+
+    "it is a local class with captures and no explicit constructor arguments" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  int fooMember;
+          |
+          |  void foo(int fooParam) {
+          |    int fooLocal = 0;
+          |
+          |    class Local {
+          |      public Local() {}
+          |      void usesCaptures() {
+          |        sink(fooMember, fooLocal, fooParam);
+          |      }
+          |    }
+          |
+          |    sink(new Local());
+          |  }
+          |}
+          |""".stripMargin)
+
+      @inline def initCall = cpg.call.name("sink").ast.collectAll[Call].nameExact("<init>")
+
+      "have the correct init node properties" in {
+        initCall.l match {
+          case List(call) =>
+            call.methodFullName shouldBe "foo.Foo.foo.Local.<init>:void()"
+            call.signature shouldBe "void()"
+            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the correct init receiver" in {
+        initCall.receiver.l match {
+          case List(receiver: Identifier) =>
+            receiver.typeFullName shouldBe "foo.Foo.foo.Local"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the explicit and capture arguments in the correct order" in {
+        initCall.argument.l match {
+          case List(_, outerClass: Identifier, capturedLocal: Identifier, capturedParam: Identifier) =>
+            outerClass.name shouldBe "this"
+            outerClass.argumentIndex shouldBe 1
+            outerClass.refOut.l shouldBe cpg.method.name("foo").parameter.index(0).l
+
+            capturedLocal.name shouldBe "fooLocal"
+            capturedLocal.argumentIndex shouldBe 2
+            capturedLocal.refOut.l shouldBe cpg.method.name("foo").local.name("fooLocal").l
+
+            capturedParam.name shouldBe "fooParam"
+            capturedParam.argumentIndex shouldBe 3
+            capturedParam.refOut.l shouldBe cpg.method.name("foo").parameter.name("fooParam").l
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+
+    "it is a local class with only some used captures" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  int fooMember;
+          |
+          |  void fooMethod(int fooParam) {
+          |    int fooLocal = 0;
+          |
+          |    class Local {
+          |      public Local() {}
+          |      void usesCaptures() {
+          |        sink(fooMember, fooLocal);
+          |      }
+          |    }
+          |
+          |    sink(new Local());
+          |  }
+          |}
+          |""".stripMargin)
+
+      @inline def initCall = cpg.call.name("sink").ast.collectAll[Call].nameExact("<init>")
+
+      "have the correct init node properties" in {
+        initCall.l match {
+          case List(call) =>
+            call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
+            call.signature shouldBe "void()"
+            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the correct init receiver" in {
+        initCall.receiver.l match {
+          case List(receiver: Identifier) =>
+            receiver.typeFullName shouldBe "foo.Foo.fooMethod.Local"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the explicit and capture arguments in the correct order" in {
+        initCall.argument.l match {
+          case List(_, outerClass: Identifier, capturedLocal: Identifier) =>
+            outerClass.name shouldBe "this"
+            outerClass.argumentIndex shouldBe 1
+            outerClass.refOut.l shouldBe cpg.method.name("fooMethod").parameter.index(0).l
+
+            capturedLocal.name shouldBe "fooLocal"
+            capturedLocal.argumentIndex shouldBe 2
+            capturedLocal.refOut.l shouldBe cpg.method.name("fooMethod").local.name("fooLocal").l
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+
+    "it is a local class without any captures" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  int fooMember;
+          |
+          |  void fooMethod(int fooParam) {
+          |    int fooLocal = 0;
+          |
+          |    class Local {
+          |      public Local() {}
+          |    }
+          |
+          |    sink(new Local());
+          |  }
+          |}
+          |""".stripMargin)
+
+      @inline def initCall = cpg.call.name("sink").ast.collectAll[Call].nameExact("<init>")
+
+      "have the correct init node properties" in {
+        initCall.l match {
+          case List(call) =>
+            call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
+            call.signature shouldBe "void()"
+            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the correct init receiver" in {
+        initCall.receiver.l match {
+          case List(receiver: Identifier) =>
+            receiver.typeFullName shouldBe "foo.Foo.fooMethod.Local"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the explicit and capture arguments in the correct order" in {
+        initCall.argument.l match {
+          case List(_, outerClass: Identifier) =>
+            outerClass.name shouldBe "this"
+            outerClass.argumentIndex shouldBe 1
+            outerClass.refOut.l shouldBe cpg.method.name("fooMethod").parameter.index(0).l
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+
+    "it is a local class in a static context with captures all used" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  int fooMember;
+          |
+          |  static void fooMethod(int fooParam) {
+          |    int fooLocal = 0;
+          |    class Local {
+          |      public Local(int argument) {}
+          |
+          |      void usesCaptures() {
+          |        sink(fooLocal, fooParam);
+          |      }
+          |    }
+          |
+          |    sink(new Local(0));
+          |  }
+          |}
+          |""".stripMargin)
+
+      @inline def initCall = cpg.call.name("sink").ast.collectAll[Call].nameExact("<init>")
+
+      "have the correct init node properties" in {
+        initCall.l match {
+          case List(call) =>
+            call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
+            call.signature shouldBe "void(int)"
+            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the correct init receiver" in {
+        initCall.receiver.l match {
+          case List(receiver: Identifier) =>
+            receiver.typeFullName shouldBe "foo.Foo.fooMethod.Local"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the explicit and capture arguments in the correct order" in {
+        initCall.argument.l match {
+          case List(_, explicitArg: Literal, capturedLocal: Identifier, capturedParam: Identifier) =>
+            explicitArg.code shouldBe "0"
+            explicitArg.argumentIndex shouldBe 1
+
+            capturedLocal.name shouldBe "fooLocal"
+            capturedLocal.argumentIndex shouldBe 2
+            capturedLocal.refOut.l shouldBe cpg.method.name("fooMethod").local.name("fooLocal").l
+
+            capturedParam.name shouldBe "fooParam"
+            capturedParam.argumentIndex shouldBe 3
+            capturedParam.refOut.l shouldBe cpg.method.name("fooMethod").parameter.name("fooParam").l
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+
+    "it is a local class in a static context with only some used captures" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  int fooMember;
+          |
+          |  static void fooMethod(int fooParam) {
+          |    int fooLocal = 0;
+          |    class Local {
+          |      public Local() {}
+          |
+          |      void usesCaptures() {
+          |        sink(fooLocal);
+          |      }
+          |    }
+          |
+          |    sink(new Local());
+          |  }
+          |}
+          |""".stripMargin)
+
+      @inline def initCall = cpg.call.name("sink").ast.collectAll[Call].nameExact("<init>")
+
+      "have the correct init node properties" in {
+        initCall.l match {
+          case List(call) =>
+            call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
+            call.signature shouldBe "void()"
+            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the correct init receiver" in {
+        initCall.receiver.l match {
+          case List(receiver: Identifier) =>
+            receiver.typeFullName shouldBe "foo.Foo.fooMethod.Local"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the explicit and capture arguments in the correct order" in {
+        initCall.argument.l match {
+          case List(_, capturedLocal: Identifier) =>
+            capturedLocal.name shouldBe "fooLocal"
+            capturedLocal.argumentIndex shouldBe 1
+            capturedLocal.refOut.l shouldBe cpg.method.name("fooMethod").local.name("fooLocal").l
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+
+    "it is a local class in a static context without any captures" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  int fooMember;
+          |
+          |  static void fooMethod(int fooParam) {
+          |    int fooLocal = 0;
+          |    class Local {
+          |      public Local(int argument) {}
+          |    }
+          |
+          |    sink(new Local(0));
+          |  }
+          |}
+          |""".stripMargin)
+
+      @inline def initCall = cpg.call.name("sink").ast.collectAll[Call].nameExact("<init>")
+
+      "have the correct init node properties" in {
+        initCall.l match {
+          case List(call) =>
+            call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
+            call.signature shouldBe "void(int)"
+            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have the correct init receiver" in {
+        initCall.receiver.l match {
+          case List(receiver: Identifier) =>
+            receiver.typeFullName shouldBe "foo.Foo.fooMethod.Local"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "only the explicit arg" in {
+        initCall.argument.l match {
+          case List(_, explicitArg: Literal) =>
+            explicitArg.code shouldBe "0"
+            explicitArg.argumentIndex shouldBe 1
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+  }
+
+  "nested local classes without any static contexts" when {
+    "there is a member access to an outer class member, which is in turn a capture" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  void foo(int fooParam) {
+          |    class Bar {
+          |      void bar() {
+          |        class Baz {
+          |          void baz() {
+          |            sink(fooParam);
+          |          }
+          |        }
+          |      }
+          |    }
+          |  }
+          |}
+          |""".stripMargin)
+
+      "have the correct nested structure for the access" in {
+        cpg.call.name("sink").argument.l match {
+          case List(thisArg: Identifier, fooAccess: Call) =>
+            thisArg.name shouldBe "this"
+
+            fooAccess.name shouldBe Operators.fieldAccess
+            fooAccess.typeFullName shouldBe "int"
+
+            fooAccess.argument.l match {
+              case List(outerClassAccess: Call, fooFieldIdentifier: FieldIdentifier) =>
+                outerClassAccess.name shouldBe Operators.fieldAccess
+                outerClassAccess.typeFullName shouldBe "foo.Foo.foo.Bar"
+
+                outerClassAccess.argument.l match {
+                  case List(thisIdentifier: Identifier, outerFieldIdentifier: FieldIdentifier) =>
+                    thisIdentifier.name shouldBe "this"
+                    thisIdentifier.typeFullName shouldBe "foo.Foo.foo.Bar.bar.Baz"
+                    thisIdentifier.refOut.l shouldBe cpg.method.name("baz").parameter.index(0).l
+
+                    outerFieldIdentifier.canonicalName shouldBe "outerClass"
+                  case result => fail(s"Unexpected result ${result}")
+                }
+
+                fooFieldIdentifier.canonicalName shouldBe "fooParam"
+              case result => fail(s"Unexpected result ${result}")
+            }
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "have a constructor parameter for the captured param in the outer local class" in {
+        cpg.typeDecl.name("Bar").method.nameExact("<init>").parameter.l match {
+          case List(thisParam, outerClassParam, capturedParamParam) =>
+            thisParam.name shouldBe "this"
+            thisParam.typeFullName shouldBe "foo.Foo.foo.Bar"
+
+            outerClassParam.name shouldBe "outerClass"
+            outerClassParam.typeFullName shouldBe "foo.Foo"
+
+            capturedParamParam.name shouldBe "fooParam"
+            capturedParamParam.typeFullName shouldBe "int"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+
+      "not have a constructor paramater for the captured param in the inner local class" in {
+        cpg.typeDecl.name("Baz").method.nameExact("<init>").parameter.l match {
+          case List(thisParam, outerClassParam) =>
+            thisParam.name shouldBe "this"
+            thisParam.typeFullName shouldBe "foo.Foo.foo.Bar.bar.Baz"
+
+            outerClassParam.name shouldBe "outerClass"
+            outerClassParam.typeFullName shouldBe "foo.Foo.foo.Bar"
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+
+    "there is a member access to the outer-outer class" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  int fooMember;
+          |  void foo() {
+          |    class Bar {
+          |      void bar() {
+          |        class Baz {
+          |          void baz() {
+          |            sink(fooMember);
+          |          }
+          |        };
+          |      }
+          |    };
+          |  }
+          |}
+          |""".stripMargin)
+      // The member access happens through a double outer class access
+      "have the correct double outer class access structure" in {
+        cpg.call.name("sink").argument.l match {
+          case List(thisArg: Identifier, fooMemberAccess: Call) =>
+            thisArg.name shouldBe "this"
+
+            fooMemberAccess.name shouldBe Operators.fieldAccess
+            fooMemberAccess.code shouldBe "this.outerClass.outerClass.fooMember"
+            fooMemberAccess.typeFullName shouldBe "int"
+
+            fooMemberAccess.argument.l match {
+              case List(barMemberAccess: Call, fooMemberIdentifier: FieldIdentifier) =>
+                fooMemberIdentifier.canonicalName shouldBe "fooMember"
+
+                barMemberAccess.name shouldBe Operators.fieldAccess
+                barMemberAccess.code shouldBe "this.outerClass.outerClass"
+                barMemberAccess.typeFullName shouldBe "foo.Foo"
+
+                barMemberAccess.argument.l match {
+                  case List(bazMemberAccess: Call, barClassIdentifier: FieldIdentifier) =>
+                    barClassIdentifier.canonicalName shouldBe "outerClass"
+
+                    bazMemberAccess.name shouldBe Operators.fieldAccess
+                    bazMemberAccess.code shouldBe "this.outerClass"
+                    bazMemberAccess.typeFullName shouldBe "foo.Foo.foo.Bar"
+
+                    bazMemberAccess.argument.l match {
+                      case List(thisIdentifier: Identifier, bazClassIdentifier: FieldIdentifier) =>
+                        thisIdentifier.name shouldBe "this"
+                        thisIdentifier.refOut.l shouldBe cpg.method.name("baz").parameter.index(0).l
+                        thisIdentifier.typeFullName shouldBe "foo.Foo.foo.Bar.bar.Baz"
+
+                        bazClassIdentifier.canonicalName shouldBe "outerClass"
+                      case result => fail(s"Unexpected result ${result}")
+                    }
+                  case result => fail(s"Unexpected result ${result}")
+                }
+              case result => fail(s"Unexpected result ${result}")
+            }
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+
+    "there is a call to a method in the outer-outer class" should {
+      val cpg = code("""
+          |package foo;
+          |
+          |class Foo {
+          |  void outerCall() {}
+          |  void foo() {
+          |    class Bar {
+          |      void bar() {
+          |        class Baz {
+          |          void baz() {
+          |            outerCall();
+          |          }
+          |        };
+          |      }
+          |    };
+          |  }
+          |}
+        """.stripMargin)
+
+      "have the correct receiver structure" in {
+        cpg.call.name("outerCall").l match {
+          case List(outerCallCall: Call) =>
+            outerCallCall.methodFullName shouldBe "foo.Foo.outerCall:void()"
+
+            outerCallCall.receiver.l match {
+              case List(barMemberAccess: Call) =>
+                barMemberAccess.name shouldBe Operators.fieldAccess
+                barMemberAccess.code shouldBe "this.outerClass.outerClass"
+                barMemberAccess.typeFullName shouldBe "foo.Foo"
+
+                barMemberAccess.argument.l match {
+                  case List(bazMemberAccess: Call, barClassIdentifier: FieldIdentifier) =>
+                    barClassIdentifier.canonicalName shouldBe "outerClass"
+
+                    bazMemberAccess.name shouldBe Operators.fieldAccess
+                    bazMemberAccess.code shouldBe "this.outerClass"
+                    bazMemberAccess.typeFullName shouldBe "foo.Foo.foo.Bar"
+
+                    bazMemberAccess.argument.l match {
+                      case List(thisIdentifier: Identifier, bazClassIdentifier: FieldIdentifier) =>
+                        thisIdentifier.name shouldBe "this"
+                        thisIdentifier.refOut.l shouldBe cpg.method.name("baz").parameter.index(0).l
+                        thisIdentifier.typeFullName shouldBe "foo.Foo.foo.Bar.bar.Baz"
+
+                        bazClassIdentifier.canonicalName shouldBe "outerClass"
+                      case result => fail(s"Unexpected result ${result}")
+                    }
+                  case result => fail(s"Unexpected result ${result}")
+                }
+              case result => fail(s"Unexpected result ${result}")
+            }
+          case result => fail(s"Unexpected result ${result}")
+        }
+      }
+    }
+  }
+
+  "local classes in a nested static context" should {
+    val cpg = code("""
+        |public class Test {
+        |    int testMember = 1;
+        |
+        |    void test(int testParam) {
+        |        int testLocal = 2;
+        |
+        |        class Foo {
+        |            int fooMember = 4;
+        |
+        |            static void foo(int fooParam) {
+        |                int fooLocal = 8;
+        |
+        |                class Bar {
+        |                    int barMember = 16;
+        |
+        |                    void bar(int barParam) {
+        |                        int barLocal = 32;
+        |
+        |                        class Baz {
+        |                            void baz() {
+        |                                // testMember, testParam, testLocal, fooMember not captured
+        |                                sink(fooParam, fooLocal, barMember, barParam, barLocal);
+        |                            }
+        |                        }
+        |                    }
+        |                }
+        |            }
+        |
+        |            void fooCaptures() {
+        |                 sink(testMember, testParam, testLocal);
+        |            }
+        |        }
+        |    }
+        |}
+        """.stripMargin)
+
+    "have the correct parameters for the outermost local class constructor" in {
+      cpg.typeDecl.name("Foo").method.nameExact("<init>").parameter.l match {
+        case List(thisParam, outerClassParam, capturedLocalParam, capturedParamParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "Test.test.Foo"
+
+          outerClassParam.name shouldBe "outerClass"
+          outerClassParam.typeFullName shouldBe "Test"
+
+          capturedLocalParam.name shouldBe "testLocal"
+          capturedLocalParam.typeFullName shouldBe "int"
+
+          capturedParamParam.name shouldBe "testParam"
+          capturedParamParam.typeFullName shouldBe "int"
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+
+    "have the correct parameters for the outermost static local class constructor" in {
+      cpg.typeDecl.name("Bar").method.nameExact("<init>").parameter.l match {
+        case List(thisParam, capturedLocalParam, capturedParamParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "Test.test.Foo.foo.Bar"
+
+          capturedLocalParam.name shouldBe "fooLocal"
+          capturedLocalParam.typeFullName shouldBe "int"
+
+          capturedParamParam.name shouldBe "fooParam"
+          capturedParamParam.typeFullName shouldBe "int"
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+
+    "have the correct parameters for the innermost local class constructor" in {
+      cpg.typeDecl.name("Baz").method.nameExact("<init>").parameter.l match {
+        case List(thisParam, outerClassParam, capturedLocalParam, capturedParamParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "Test.test.Foo.foo.Bar.bar.Baz"
+
+          outerClassParam.name shouldBe "outerClass"
+          outerClassParam.typeFullName shouldBe "Test.test.Foo.foo.Bar"
+
+          capturedLocalParam.name shouldBe "barLocal"
+          capturedLocalParam.typeFullName shouldBe "int"
+
+          capturedParamParam.name shouldBe "barParam"
+          capturedParamParam.typeFullName shouldBe "int"
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+
+    "have the correct members for the outermost local class" in {
+      cpg.typeDecl.name("Foo").member.l match {
+        case List(outerClassMember, capturedLocalMember, capturedParamMember, fooMember) =>
+          outerClassMember.name shouldBe "outerClass"
+          outerClassMember.typeFullName shouldBe "Test"
+
+          capturedLocalMember.name shouldBe "testLocal"
+          capturedLocalMember.typeFullName shouldBe "int"
+
+          capturedParamMember.name shouldBe "testParam"
+          capturedParamMember.typeFullName shouldBe "int"
+
+          fooMember.name shouldBe "fooMember"
+          fooMember.typeFullName shouldBe "int"
+        case result => fail(s"Unexpected result ${result.map(_.code)}")
+      }
+    }
+
+    "have the correct members for the outermost static local class" in {
+      cpg.typeDecl.name("Bar").member.l match {
+        case List(capturedLocalMember, capturedParamMember, barMember) =>
+          capturedLocalMember.name shouldBe "fooLocal"
+          capturedLocalMember.typeFullName shouldBe "int"
+
+          capturedParamMember.name shouldBe "fooParam"
+          capturedParamMember.typeFullName shouldBe "int"
+
+          barMember.name shouldBe "barMember"
+          barMember.typeFullName shouldBe "int"
+        case result => fail(s"Unexpected result ${result.map(_.name)}")
+      }
+    }
+
+    "have the correct members for the innermost local class" in {
+      cpg.typeDecl.name("Baz").member.l match {
+        case List(outerClassMember, capturedLocalMember, capturedParamMember) =>
+          outerClassMember.name shouldBe "outerClass"
+          outerClassMember.typeFullName shouldBe "Test.test.Foo.foo.Bar"
+
+          capturedLocalMember.name shouldBe "barLocal"
+          capturedLocalMember.typeFullName shouldBe "int"
+
+          capturedParamMember.name shouldBe "barParam"
+          capturedParamMember.typeFullName shouldBe "int"
+        case result => fail(s"Unexpected result ${result}")
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
@@ -164,7 +164,8 @@ class TypeDeclTests extends JavaSrcCode2CpgFixture {
       ModifierTypes.PUBLIC
     )
 
-    constructor.parameter.size shouldBe 1
+    constructor.parameter.size shouldBe 2
+    constructor.parameter.name.toList shouldBe List("this", "outerClass")
     val thisParam = constructor.parameter.head
     thisParam.name shouldBe "this"
     thisParam.typeFullName shouldBe typeFullName

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/ScopeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/ScopeTests.scala
@@ -1,0 +1,165 @@
+package io.joern.javasrc2cpg.util
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import io.joern.javasrc2cpg.scope.Scope
+import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
+import io.shiftleft.codepropertygraph.generated.nodes.NewMember
+import io.shiftleft.codepropertygraph.generated.nodes.NewMethod
+import io.joern.javasrc2cpg.astcreation.ExpectedType
+import io.joern.javasrc2cpg.scope.Scope.SimpleVariable
+import io.joern.javasrc2cpg.scope.Scope.ScopeMember
+import io.joern.javasrc2cpg.scope.Scope.CapturedVariable
+import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterIn
+import io.joern.javasrc2cpg.scope.Scope.ScopeParameter
+import io.joern.javasrc2cpg.scope.Scope.NotInScope
+
+class ScopeTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  behavior of "javasrc2cpg scope"
+
+  it should "find a simple variable for a member" in {
+    val typeDecl = NewTypeDecl().name("FooDecl")
+    val member   = NewMember().name("fooMember")
+    val method   = NewMethod().name("fooMethod")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(typeDecl, isStatic = false)
+    scope.enclosingTypeDecl.get.addMember(member, isStatic = false)
+    scope.pushMethodScope(method, ExpectedType.empty, isStatic = false)
+
+    scope.lookupVariable("fooMember") shouldBe SimpleVariable(ScopeMember(member, false))
+  }
+
+  it should "find a capture chain for a captured member in an outer class" in {
+    val outerTypeDecl = NewTypeDecl().name("FooDecl")
+    val outerMember   = NewMember().name("fooMember")
+    val method        = NewMethod().name("fooMethod")
+    val innerTypeDecl = NewTypeDecl().name("InnerDecl")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
+    scope.enclosingTypeDecl.get.addMember(outerMember, isStatic = false)
+    scope.pushMethodScope(method, ExpectedType.empty, isStatic = false)
+    scope.pushTypeDeclScope(innerTypeDecl, isStatic = false)
+
+    scope.lookupVariable("fooMember") shouldBe CapturedVariable(List(outerTypeDecl), ScopeMember(outerMember, false))
+  }
+
+  it should "find a capture chain for a captured variable" in {
+    val outerTypeDecl  = NewTypeDecl().name("FooDecl")
+    val method         = NewMethod().name("fooMethod")
+    val outerParameter = NewMethodParameterIn().name("fooParameter")
+    val innerTypeDecl  = NewTypeDecl().name("InnerDecl")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
+    scope.pushMethodScope(method, ExpectedType.empty, isStatic = false)
+    scope.enclosingMethod.get.addParameter(outerParameter)
+    scope.pushTypeDeclScope(innerTypeDecl, isStatic = false)
+
+    scope.lookupVariable("fooParameter") shouldBe CapturedVariable(Nil, ScopeParameter(outerParameter))
+  }
+
+  it should "find a capture chain for a captured variable in an outer-outer scope" in {
+    val outerOuterTypeDecl  = NewTypeDecl().name("OuterOuterTypeDecl")
+    val outerOuterMethod    = NewMethod().name("OuterOuterMethod")
+    val outerOuterParameter = NewMethodParameterIn().name("parameter")
+    val outerTypeDecl       = NewTypeDecl().name("OuterTypeDecl")
+    val outerMethod         = NewMethod().name("outerMethod")
+    val innerTypeDecl       = NewTypeDecl().name("InnerDecl")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(outerOuterTypeDecl, isStatic = false)
+    scope.pushMethodScope(outerOuterMethod, ExpectedType.empty, isStatic = false)
+    scope.enclosingMethod.get.addParameter(outerOuterParameter)
+    scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
+    scope.pushMethodScope(outerMethod, ExpectedType.empty, isStatic = false)
+    scope.pushTypeDeclScope(innerTypeDecl, isStatic = false)
+
+    scope.lookupVariable("parameter") shouldBe CapturedVariable(
+      List(outerTypeDecl),
+      ScopeParameter(outerOuterParameter)
+    )
+  }
+
+  it should "not find a capture chain for a captured variable in an outer-outer scope interrupted by a static scope" in {
+    val outerOuterTypeDecl  = NewTypeDecl().name("OuterOuterTypeDecl")
+    val outerOuterMethod    = NewMethod().name("OuterOuterMethod")
+    val outerOuterParameter = NewMethodParameterIn().name("parameter")
+    val outerTypeDecl       = NewTypeDecl().name("OuterTypeDecl")
+    val outerMethod         = NewMethod().name("outerMethod")
+    val innerTypeDecl       = NewTypeDecl().name("InnerDecl")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(outerOuterTypeDecl, isStatic = false)
+    scope.pushMethodScope(outerOuterMethod, ExpectedType.empty, isStatic = false)
+    scope.enclosingMethod.get.addParameter(outerOuterParameter)
+    scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
+    scope.pushMethodScope(outerMethod, ExpectedType.empty, isStatic = false)
+    scope.pushTypeDeclScope(innerTypeDecl, isStatic = true)
+
+    scope.lookupVariable("parameter") shouldBe NotInScope
+  }
+
+  it should "not find a capture chain for a member outside a static method scope" in {
+    val outerTypeDecl = NewTypeDecl().name("FooDecl")
+    val outerMember   = NewMember().name("fooMember")
+    val method        = NewMethod().name("fooMethod")
+    val innerTypeDecl = NewTypeDecl().name("InnerDecl")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
+    scope.enclosingTypeDecl.get.addMember(outerMember, isStatic = false)
+    scope.pushMethodScope(method, ExpectedType.empty, isStatic = true)
+    scope.pushTypeDeclScope(innerTypeDecl, isStatic = false)
+
+    scope.lookupVariable("fooMember") shouldBe NotInScope
+  }
+
+  it should "not find a capture chain for a member outside a static field scope" in {
+    val outerTypeDecl = NewTypeDecl().name("FooDecl")
+    val outerMember   = NewMember().name("fooMember")
+    val innerTypeDecl = NewTypeDecl().name("InnerDecl")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
+    scope.enclosingTypeDecl.get.addMember(outerMember, isStatic = false)
+    scope.pushFieldDeclScope(isStatic = true, "fooMember")
+    scope.pushTypeDeclScope(innerTypeDecl, isStatic = false)
+
+    scope.lookupVariable("fooMember") shouldBe NotInScope
+  }
+
+  it should "find a capture chain for a member outside an instance field scope" in {
+    val outerTypeDecl = NewTypeDecl().name("FooDecl")
+    val outerMember   = NewMember().name("fooMember")
+    val innerTypeDecl = NewTypeDecl().name("InnerDecl")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
+    scope.enclosingTypeDecl.get.addMember(outerMember, isStatic = false)
+    scope.pushFieldDeclScope(isStatic = false, "fooMember")
+    scope.pushTypeDeclScope(innerTypeDecl, isStatic = false)
+
+    scope.lookupVariable("fooMember") shouldBe CapturedVariable(
+      List(outerTypeDecl),
+      ScopeMember(outerMember, isStatic = false)
+    )
+  }
+
+  it should "return correct captured variables for single nesting level" in {
+    val outerTypeDecl = NewTypeDecl().name("FooDecl")
+    val outerMember   = NewMember().name("fooMember")
+    val method        = NewMethod().name("fooMethod")
+
+    val scope = new Scope()
+    scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
+    scope.enclosingTypeDecl.get.addMember(outerMember, isStatic = false)
+    scope.pushMethodScope(method, ExpectedType.empty, isStatic = false)
+
+    scope.getCapturesForNewScope(false) shouldEqual Map(
+      "fooMember" -> CapturedVariable(List(outerTypeDecl), ScopeMember(outerMember, isStatic = false))
+    )
+  }
+}


### PR DESCRIPTION
This PR adds capture logic to nested and inner classes that mimics javac logic. In short, captured variables are represented as members in the capturing class and are passed as extra constructor arguments. In addition, an `outerClass` member/parameter is created with `this` from the outer class passed in, which can then be used to access captured members and methods. For example,

```java
class Foo {
  int fooMember = 0;

  void foo(int x, int y) { ... }

  void definesClass(int capturedParameter) {
    class Bar {
      void bar() {
        foo(fooMember, capturedParameter);
      }
    }
    Bar b = new Bar();
    b.bar();
  }
```

is represented as

```java
class Foo {
  int fooMember = 0;

  void foo(int x, int y) { ... }

  void definesClass(int capturedParameter) {
    class Bar {
      int capturedParameter;
      Foo outerClass;

      public Bar(Foo outerClass, int capturedParameter) {
        this.outerClass = outerClass;
        this.capturedParameter = capturedParameter;
      }

      void bar() {
        this.outerClass.foo(this.outerClass.fooMember, this.capturedParameter);
      }
    }
    Bar b = new Bar(this, capturedParameter);
    b.bar();
  }
```

Some TODOs that would follow this PR are:
- To clean up the `BindingTableAdapters`. There are currently 3 (one for inner classes, one for regular classes and one for lambdas), but we probably only need one (a version of the inner class one). The best way to unify these would depend somewhat on the next point.
- Maybe use this representation for captures in lambdas as well. It would be nice to not have duplicate code paths, but I'm not sure how well the open source dataflow engine would deal with this, given this representation's reliance on member initializations and accesses. @DavidBakerEffendi do you have any thoughts on this?
- Clean up how javasrc deals with object creation expressions. The logic used currently is quite convoluted and it has been the single biggest issue while implementing this. It works in all the cases I've tested, but I would not be surprised if there is a case I missed.

This fixes dataflow tests in https://github.com/ShiftLeftSecurity/codescience/pull/7376