### PR TITLE
[jssrc2cpg] Fixed ObjectMethod naming and TypeNodePass performance

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -156,7 +156,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   }
 
   private def calcMethodName(func: BabelNodeInfo): String = func.node match {
-    case TSCallSignatureDeclaration      => nextClosureName()
+    case ObjectMethod if isMethodOrGetSet(func) && code(func.json("key")).startsWith("'") => nextClosureName()
+    case TSCallSignatureDeclaration                                                       => nextClosureName()
     case TSConstructSignatureDeclaration => io.joern.x2cpg.Defines.ConstructorMethodName
     case _ if isMethodOrGetSet(func) =>
       if (hasKey(func.json("key"), "name")) func.json("key")("name").str

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeNodePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeNodePass.scala
@@ -2,7 +2,7 @@ package io.joern.jssrc2cpg.passes
 
 import io.joern.x2cpg.passes.frontend.TypeNodePass
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.passes.KeyPool
 
 import scala.collection.mutable
@@ -12,14 +12,19 @@ object JavaScriptTypeNodePass {
   def withRegisteredTypes(registeredTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] = None): TypeNodePass = {
     new TypeNodePass(registeredTypes, cpg, keyPool, getTypesFromCpg = false) {
 
+      override def fullToShortName(typeName: String): String = {
+        typeName match {
+          case name if name.endsWith(":program") => ":program"
+          case name if name.contains("=>")       => name
+          case name if name.contains(":")        => name.split(':').lastOption.getOrElse(typeName)
+          case _                                 => typeName.split('.').lastOption.getOrElse(typeName)
+        }
+      }
+
       override protected def typeDeclTypes: mutable.Set[String] = {
         // The only difference to the default implementation in TypeNodePass.typeDeclTypes is the following:
         // We do not want to add types for types being inherited as this is already handled by the JavaScriptInheritanceNamePass.
-        val typeDeclTypes = mutable.Set[String]()
-        cpg.typeDecl.foreach { typeDecl =>
-          typeDeclTypes += typeDecl.fullName
-        }
-        typeDeclTypes
+        cpg.typeDecl.fullName.toSetMutable
       }
 
     }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -404,7 +404,8 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
     "have correct structure for 1 object with object function" in AstFixture("""
        |var x = {
        | key1: value(),
-       | foo() {}
+       | foo() {},
+       | 'bladad'() {}
        |}
        |""".stripMargin) { cpg =>
       val List(methodBlock) = cpg.method.nameExact(":program").astChildren.isBlock.l

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/SwiftTypeNodePass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/SwiftTypeNodePass.scala
@@ -2,8 +2,9 @@ package io.joern.swiftsrc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.joern.x2cpg.passes.frontend.TypeNodePass
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.passes.KeyPool
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 import scala.collection.mutable
 
@@ -12,14 +13,18 @@ object SwiftTypeNodePass {
   def withRegisteredTypes(registeredTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] = None): TypeNodePass = {
     new TypeNodePass(registeredTypes, cpg, keyPool, getTypesFromCpg = false) {
 
+      override def fullToShortName(typeName: String): String = {
+        typeName match {
+          case name if name.contains("=>")                                   => name
+          case name if name.endsWith(NamespaceTraversal.globalNamespaceName) => NamespaceTraversal.globalNamespaceName
+          case _ => typeName.split('.').lastOption.getOrElse(typeName)
+        }
+      }
+
       override protected def typeDeclTypes: mutable.Set[String] = {
         // The only difference to the default implementation in TypeNodePass.typeDeclTypes is the following:
         // We do not want to add types for types being inherited as this is already handled by the SwiftInheritanceNamePass.
-        val typeDeclTypes = mutable.Set[String]()
-        cpg.typeDecl.foreach { typeDecl =>
-          typeDeclTypes += typeDecl.fullName
-        }
-        typeDeclTypes
+        cpg.typeDecl.fullName.toSetMutable
       }
 
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
@@ -39,6 +39,8 @@ class TypeNodePass protected (
       .toSet
   }
 
+  protected def fullToShortName(typeName: String): String = TypeNodePass.fullToShortName(typeName)
+
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val typeFullNameValues =
       if (getTypesFromCpg)
@@ -79,11 +81,8 @@ object TypeNodePass {
 
   def fullToShortName(typeName: String): String = {
     typeName match {
-      case lambdaTypeRegex(methodName)                                   => methodName
-      case name if name.endsWith(":program")                             => ":program" // for JavaScript only atm.
-      case name if name.endsWith(NamespaceTraversal.globalNamespaceName) => NamespaceTraversal.globalNamespaceName
-      case name if name.contains(":") => name.split(':').lastOption.getOrElse(typeName)
-      case _                          => typeName.split('.').lastOption.getOrElse(typeName)
+      case lambdaTypeRegex(methodName) => methodName
+      case _                           => typeName.split('.').lastOption.getOrElse(typeName)
     }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/joernio/joern/issues/3901 (both the REF errors and the performance)

For whatever reason the `lambdaTypeRegex` in the TypeNodePass hangs when evaluating certain JS/TS types. So I have overridden the default there and this fixes it.