### PR TITLE
[js] Defensive Import Resolution

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptImportResolverPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptImportResolverPass.scala
@@ -1,11 +1,11 @@
 package io.joern.jssrc2cpg.passes
 
 import io.joern.x2cpg.Defines as XDefines
-import io.shiftleft.semanticcpg.language.importresolver.*
 import io.joern.x2cpg.passes.frontend.XImportResolverPass
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Method, MethodRef}
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.importresolver.*
 
 import java.io.File as JFile
 import java.util.regex.{Matcher, Pattern}
@@ -35,10 +35,12 @@ class JavaScriptImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
     // TODO: At times there is an operation inside of a require, e.g. path.resolve(__dirname + "/../config/env/all.js")
     //  this tries to recover the string but does not perform string constant propagation
     val entity = if (matcher.find()) matcher.group(1) else rawEntity
-    val resolvedPath = better.files
-      .File(currentFile.stripSuffix(currentFile.split(sep).last), entity.split(pathSep).head)
-      .pathAsString
-      .stripPrefix(root)
+    val resolvedPath = Try(
+      better.files
+        .File(currentFile.stripSuffix(currentFile.split(sep).last), entity.split(pathSep).head)
+        .pathAsString
+        .stripPrefix(root)
+    ).getOrElse(entity)
 
     val isImportingModule = !entity.contains(pathSep)
 


### PR DESCRIPTION
Local imports in JavaScript are file paths, but can sometimes be string concatenations.

These are currently not simulated, and are given directly to a path resolution. This, however, will throw an exception.

This commit wraps this resolution in a try-catch and gives a sensible default for the CPG to attempt to look-up against.

Resolves #3903