### PR TITLE
Replace typeNodePass regex with more efficient name extraction

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -68,6 +68,11 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         |}
         |""".stripMargin)
 
+    "create the correct type node for the lambda" in {
+      cpg.typ.name(".*lambda.*").name.l shouldBe List("<lambda>0")
+      cpg.typ.name(".*lambda.*").fullName.l shouldBe List("Foo.<lambda>0:java.lang.String(java.lang.String)")
+    }
+
     "create a method node for the lambda" in {
       cpg.typeDecl.name("Foo").method.name(".*lambda.*").isLambda.l match {
         case List(lambdaMethod) =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
@@ -65,12 +65,6 @@ class TypeNodePass protected (
 }
 
 object TypeNodePass {
-  // Lambda typeDecl type names fit the structure
-  // `a.b.c.d.ClassName.lambda$method$name:returnType(paramTypes)`
-  // so this regex works by greedily matching the package and class names
-  // at the start and cutting off the matched group before the signature.
-  private val lambdaTypeRegex = raw".*\.(.*):.*\(.*\)".r
-
   def withTypesFromCpg(cpg: Cpg, keyPool: Option[KeyPool] = None): TypeNodePass = {
     new TypeNodePass(Nil, cpg, keyPool, getTypesFromCpg = true)
   }
@@ -80,9 +74,6 @@ object TypeNodePass {
   }
 
   def fullToShortName(typeName: String): String = {
-    typeName match {
-      case lambdaTypeRegex(methodName) => methodName
-      case _                           => typeName.split('.').lastOption.getOrElse(typeName)
-    }
+    typeName.takeWhile(_ != ':').split('.').lastOption.getOrElse(typeName)
   }
 }


### PR DESCRIPTION
The regex just matched everything following the last `.` in the type name until the `:`, but this can easily be done without a regex.