### PR TITLE
[gosrc2cpg] - fix for package-level global variables from dependencies.

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
@@ -36,7 +36,9 @@ class GoSrc2Cpg extends X2CpgFrontend[Config] {
           astGenResult.parsedModFile.flatMap(modFile => GoAstJsonParser.readModFile(Paths.get(modFile)).map(x => x))
         )
         if (config.fetchDependencies) {
+          goGlobal.processingDependencies = true
           new DownloadDependenciesPass(goMod, goGlobal).process()
+          goGlobal.processingDependencies = false
         }
         val astCreators =
           new MethodAndTypeCacheBuilderPass(Some(cpg), astGenResult.parsedFiles, config, goMod, goGlobal).process()

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -74,7 +74,7 @@ trait AstCreatorHelper { this: AstCreator =>
     // If the first letter of the node (function, typeDecl, etc) is uppercase, then it is exported.
     // Else, it is un-exported
     // The scope of the node is the package it is defined in.
-    if (name(0).isUpper) {
+    if (name.headOption.exists(_.isUpper)) {
       newModifierNode(ModifierTypes.PUBLIC)
     } else {
       newModifierNode(ModifierTypes.PRIVATE)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForGenDeclarationCreator.scala
@@ -76,8 +76,8 @@ trait AstForGenDeclarationCreator(implicit withSchemaValidation: ValidationMode)
                   s"$fullyQualifiedPackage${Defines.dot}$variableName",
                   typeFullName.getOrElse(Defines.anyTypeName)
                 )
+                astForGlobalVarAndConstants(typeFullName.getOrElse(Defines.anyTypeName), localParserNode)
               }
-              astForGlobalVarAndConstants(typeFullName.getOrElse(Defines.anyTypeName), localParserNode)
               Seq.empty
             } else {
               Seq(astForLocalNode(localParserNode, typeFullName)) ++: astForNode(localParserNode)
@@ -104,8 +104,8 @@ trait AstForGenDeclarationCreator(implicit withSchemaValidation: ValidationMode)
         // While processing the dependencies code ignoring package level global variables starting with lower case letter
         // as these variables are only accessible within package. So those will not be referred from main source code.
         goGlobal.recordStructTypeMemberType(s"$fullyQualifiedPackage${Defines.dot}$variableName", rhsTypeFullName)
+        astForGlobalVarAndConstants(rhsTypeFullName, lhsParserNode, Some(rhsAst))
       }
-      astForGlobalVarAndConstants(rhsTypeFullName, lhsParserNode, Some(rhsAst))
       (Ast(), Ast())
     } else {
       val localAst  = astForLocalNode(lhsParserNode, Some(rhsTypeFullName))

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/CacheBuilder.scala
@@ -1,7 +1,6 @@
 package io.joern.gosrc2cpg.astcreation
 
-import io.joern.gosrc2cpg.datastructures.GoGlobal
-import io.joern.gosrc2cpg.parser.ParserAst.{FuncType, GenDecl, InterfaceType, StructType, ValueSpec}
+import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.gosrc2cpg.utils.UtilityConstants.fileSeparateorPattern
 import io.joern.x2cpg.{Ast, ValidationMode}
@@ -120,19 +119,25 @@ trait CacheBuilder(implicit withSchemaValidation: ValidationMode) { this: AstCre
   }
 
   protected def processTypeSepc(typeSepc: Value): (String, String, Seq[Ast]) = {
-    val name     = typeSepc(ParserKeys.Name)(ParserKeys.Name).str
-    val fullName = fullyQualifiedPackage + Defines.dot + name
-    val typeNode = createParserNodeInfo(typeSepc(ParserKeys.Type))
-    val ast = typeNode.node match {
-      // As of don't see any use case where InterfaceType needs to be handled.
-      case InterfaceType => Seq.empty
-      // astForStructType() function will record the member types
-      case StructType => astForStructType(typeNode, fullName)
-      // Process lambda function types to record lambda function signature mapped to TypeFullName
-      case FuncType => processFuncType(typeNode, fullName)
-      case _        => Seq.empty
-    }
-    (name, fullName, ast)
+    val name = typeSepc(ParserKeys.Name)(ParserKeys.Name).str
+    if (!goGlobal.processingDependencies || goGlobal.processingDependencies && name.headOption.exists(_.isUpper)) {
+      // Ignoring recording the Type details when we are processing dependencies code with Type name starting with lower case letter
+      // As the Types starting with lower case letters will only be accessible within that package. Which means
+      // these Types are not going to get referred from main source code.
+      val fullName = fullyQualifiedPackage + Defines.dot + name
+      val typeNode = createParserNodeInfo(typeSepc(ParserKeys.Type))
+      val ast = typeNode.node match {
+        // As of don't see any use case where InterfaceType needs to be handled.
+        case InterfaceType => Seq.empty
+        // astForStructType() function will record the member types
+        case StructType => astForStructType(typeNode, fullName)
+        // Process lambda function types to record lambda function signature mapped to TypeFullName
+        case FuncType => processFuncType(typeNode, fullName)
+        case _        => Seq.empty
+      }
+      (name, fullName, ast)
+    } else
+      ("", "", Seq.empty)
   }
 
   protected def processImports(importDecl: Value): (String, String) = {
@@ -148,22 +153,28 @@ trait CacheBuilder(implicit withSchemaValidation: ValidationMode) { this: AstCre
   protected def processFuncDecl(
     funcDeclVal: Value
   ): (String, String, String, Value, Option[(String, String, String, ParserNodeInfo)], Map[String, List[String]]) = {
-    val name         = funcDeclVal(ParserKeys.Name).obj(ParserKeys.Name).str
-    val receiverInfo = getReceiverInfo(Try(funcDeclVal(ParserKeys.Recv)))
-    val methodFullname = receiverInfo match
-      case Some(_, typeFullName, _, _) =>
-        s"$typeFullName.$name"
-      case _ =>
-        s"$fullyQualifiedPackage.$name"
-    // TODO: handle multiple return type or tuple (int, int)
-    val genericTypeMethodMap = processTypeParams(funcDeclVal(ParserKeys.Type))
-    val (returnTypeStr, _) =
-      getReturnType(funcDeclVal(ParserKeys.Type), genericTypeMethodMap).headOption
-        .getOrElse(("", null))
-    val params = funcDeclVal(ParserKeys.Type)(ParserKeys.Params)(ParserKeys.List)
-    val signature =
-      s"$methodFullname(${parameterSignature(params, genericTypeMethodMap)})$returnTypeStr"
-    goGlobal.recordFullNameToReturnType(methodFullname, returnTypeStr, signature)
-    (name, methodFullname, signature, params, receiverInfo, genericTypeMethodMap)
+    val name = funcDeclVal(ParserKeys.Name).obj(ParserKeys.Name).str
+    if (!goGlobal.processingDependencies || goGlobal.processingDependencies && name.headOption.exists(_.isUpper)) {
+      // Ignoring recording the method details when we are processing dependencies code with functions name starting with lower case letter
+      // As the functions starting with lower case letters will only be accessible within that package. Which means
+      // these methods / functions are not going to get referred from main source code.
+      val receiverInfo = getReceiverInfo(Try(funcDeclVal(ParserKeys.Recv)))
+      val methodFullname = receiverInfo match
+        case Some(_, typeFullName, _, _) =>
+          s"$typeFullName.$name"
+        case _ =>
+          s"$fullyQualifiedPackage.$name"
+      // TODO: handle multiple return type or tuple (int, int)
+      val genericTypeMethodMap = processTypeParams(funcDeclVal(ParserKeys.Type))
+      val (returnTypeStr, _) =
+        getReturnType(funcDeclVal(ParserKeys.Type), genericTypeMethodMap).headOption
+          .getOrElse(("", null))
+      val params = funcDeclVal(ParserKeys.Type)(ParserKeys.Params)(ParserKeys.List)
+      val signature =
+        s"$methodFullname(${parameterSignature(params, genericTypeMethodMap)})$returnTypeStr"
+      goGlobal.recordFullNameToReturnType(methodFullname, returnTypeStr, signature)
+      (name, methodFullname, signature, params, receiverInfo, genericTypeMethodMap)
+    } else
+      ("", "", "", Value("{}"), None, Map())
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/datastructures/GoGlobal.scala
@@ -6,6 +6,8 @@ import java.util.concurrent.ConcurrentHashMap
 
 class GoGlobal {
 
+  var processingDependencies = false
+
   /** This map will only contain the mapping for those packages whose package name is different from the enclosing
     * folder name
     *

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/DownloadDependencyTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/DownloadDependencyTest.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language.*
 class DownloadDependencyTest extends GoCodeToCpgSuite {
   // NOTE: With respect to conversation on this PR - https://github.com/joernio/joern/pull/3753
   // ignoring the below uni tests, which tries to download the dependencies.
-  "Simple use case of third-party dependency download" ignore {
+  "Simple use case of third-party dependency download" should {
     val config = Config().withFetchDependencies(true)
     val cpg = code(
       """
@@ -34,7 +34,7 @@ class DownloadDependencyTest extends GoCodeToCpgSuite {
     }
   }
 
-  // NOTE: This test is ignored because of high memory usage on windows
+  // TODO: These tests were working, something has broken. Will fix it in next PR.
   "Download dependency example with different package and namespace name" ignore {
     val config = Config().withFetchDependencies(true)
     val cpg = code(
@@ -51,6 +51,7 @@ class DownloadDependencyTest extends GoCodeToCpgSuite {
           |import "github.com/aerospike/aerospike-client-go/v6"
           |func main()  {
           |  client, err := aerospike.NewClient("localhost", 3000)
+          |  var test = aerospike.UserAdmin
           |}
           |""".stripMargin)
       .withConfig(config)
@@ -58,6 +59,11 @@ class DownloadDependencyTest extends GoCodeToCpgSuite {
     "Check CALL Node" in {
       val List(x) = cpg.call("NewClient").l
       x.typeFullName shouldBe "*github.com/aerospike/aerospike-client-go/v6.Client"
+    }
+
+    "Check if we are able to identify the type of constants accessible out side dependencies code" in {
+      val List(t) = cpg.local("test").l
+      t.typeFullName shouldBe "string"
     }
   }
 


### PR DESCRIPTION
1. It's been observed that the AST nodes were getting created for package-level global variables and constants from the dependencies code. As it was getting processed through the same ASTCreators code. Made changes to handle this situation.
2. Also identified that the variables, constants, types and functions from dependencies which starts with lower case letter will not be referred from the main source code. Hence, I ignored the processing for those. This will also reduce the memory footprint as we are not storing that metadata in the cache. This will also speed up the processing
3. With a lesser memory footprint, unit tests with download dependencies should work. Hence enabled those unit tests. These tests will be helpful in identifying some breaking changes. Like the other ignore test in the same file, was working before. With some recent changes, it has started breaking that flow.