### PR TITLE
[gosrc2cpg] - Ignore indirect dependencies

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 gosrc2cpg {
-    goastgen_version: "0.11.0"
+    goastgen_version: "0.12.0"
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
@@ -37,7 +37,7 @@ class GoSrc2Cpg extends X2CpgFrontend[Config] {
         )
         if (config.fetchDependencies) {
           goGlobal.processingDependencies = true
-          new DownloadDependenciesPass(goMod, goGlobal).process()
+          new DownloadDependenciesPass(goMod, goGlobal, config).process()
           goGlobal.processingDependencies = false
         }
         val astCreators =

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/Main.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/Main.scala
@@ -7,13 +7,19 @@ import scopt.OParser
 
 import java.nio.file.Paths
 
-final case class Config(fetchDependencies: Boolean = false) extends X2CpgConfig[Config] with AstGenConfig[Config] {
+final case class Config(fetchDependencies: Boolean = false, includeIndirectDependencies: Boolean = false)
+    extends X2CpgConfig[Config]
+    with AstGenConfig[Config] {
 
   override val astGenProgramName: String  = "goastgen"
   override val astGenConfigPrefix: String = "gosrc2cpg"
 
   def withFetchDependencies(value: Boolean): Config = {
     copy(fetchDependencies = value).withInheritedFields(this)
+  }
+
+  def withIncludeIndirectDependencies(value: Boolean): Config = {
+    copy(includeIndirectDependencies = value).withInheritedFields(this)
   }
 }
 
@@ -27,6 +33,9 @@ object Frontend {
       programName("gosrc2cpg"),
       opt[Unit]("fetch-dependencies")
         .text("attempt to fetch dependencies for extra type information")
+        .action((_, c) => c.withFetchDependencies(true)),
+      opt[Unit]("include-indirect-dependencies")
+        .text("try to fetch indirect dependencies as well, this flag works along with flag 'fetch-dependencies'")
         .action((_, c) => c.withFetchDependencies(true))
     )
   }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/model/GoMod.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/model/GoMod.scala
@@ -54,6 +54,7 @@ case class GoModModule(
 case class GoModDependency(
   module: String,
   version: String,
+  indirect: Boolean,
   lineNo: Option[Int] = None,
   colNo: Option[Int] = None,
   endLineNo: Option[Int] = None,
@@ -83,6 +84,7 @@ object CirceEnDe {
     override def apply(c: HCursor): Result[GoModDependency] = {
       val module    = c.downField("Module").as[String]
       val version   = c.downField("Version").as[String]
+      val indirect  = c.downField("Indirect").as[Boolean]
       val lineNo    = c.downField("node_line_no").as[Int]
       val endLineNo = c.downField("node_line_no_end").as[Int]
       val colNo     = c.downField("node_col_no").as[Int]
@@ -91,6 +93,7 @@ object CirceEnDe {
         GoModDependency(
           module = module.getOrElse(""),
           version = version.getOrElse(""),
+          indirect = indirect.getOrElse(false),
           lineNo = lineNo.toOption,
           colNo = colNo.toOption,
           endLineNo = endLineNo.toOption,


### PR DESCRIPTION
1. `go.mod` also contains indirect dependencies, as we were processing all the dependencies to cache type and method signature metadata. Even with few direct dependencies, it may end up having many indirect dependencies, which are generally not used in the main code. Hence for now ignoring these indirect dependencies so that it can reduce the time it takes to download and process those dependencies.
2. Introduced the `include-indirect-dependencies` flag in case someone wants to try downloading and processing indirect dependencies.