### PR TITLE
[javasrc2cpg] - add ability to cache JdkTypeSolver

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -20,7 +20,8 @@ final case class Config(
   jdkPath: Option[String] = None,
   showEnv: Boolean = false,
   skipTypeInfPass: Boolean = false,
-  dumpJavaparserAsts: Boolean = false
+  dumpJavaparserAsts: Boolean = false,
+  cacheJdkTypeSolver: Boolean = false
 ) extends X2CpgConfig[Config]
     with TypeRecoveryParserConfig[Config] {
   def withInferenceJarPaths(paths: Set[String]): Config = {
@@ -61,6 +62,10 @@ final case class Config(
 
   def withDumpJavaparserAsts(value: Boolean): Config = {
     copy(dumpJavaparserAsts = value).withInheritedFields(this)
+  }
+
+  def withCacheJdkTypeSolver(value: Boolean): Config = {
+    copy(cacheJdkTypeSolver = value).withInheritedFields(this)
   }
 }
 
@@ -111,7 +116,11 @@ private object Frontend {
       opt[Unit]("dump-javaparser-asts")
         .hidden()
         .action((_, c) => c.withDumpJavaparserAsts(true))
-        .text("Dump the javaparser asts for the given input files and terminate (for debugging).")
+        .text("Dump the javaparser asts for the given input files and terminate (for debugging)."),
+      opt[Unit]("cache-jdk-type-solver")
+        .hidden()
+        .action((_, c) => c.withCacheJdkTypeSolver(true))
+        .text("Re-use JDK type solver between scans.")
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -119,7 +119,9 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
         jdkPath
     }
 
-    combinedTypeSolver.addNonCachingTypeSolver(JdkJarTypeSolver.fromJdkPath(jdkPath))
+    combinedTypeSolver.addNonCachingTypeSolver(
+      JdkJarTypeSolver.fromJdkPath(jdkPath, useCache = config.cacheJdkTypeSolver)
+    )
 
     val relativeSourceFilenames =
       sourceFilenames.map(filename => Path.of(config.inputPath).relativize(Path.of(filename)).toString)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/JavaSrc2CpgTestContext.scala
@@ -17,6 +17,7 @@ class JavaSrc2CpgTestContext {
       val config = Config(inferenceJarPaths = inferenceJarPaths)
         .withInputPath(writeCodeToFile(code, "javasrc2cpgTest", ".java").getAbsolutePath)
         .withOutputPath("")
+        .withCacheJdkTypeSolver(true)
       val cpg = javaSrc2Cpg.createCpgWithOverlays(config)
       if (runDataflow) {
         val context = new LayerCreatorContext(cpg.get)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -17,7 +17,8 @@ trait JavaSrcFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".java"
 
   override def execute(sourceCodeFile: File): Cpg = {
-    val config = getConfig().map(_.asInstanceOf[Config]).getOrElse(JavaSrc2Cpg.DefaultConfig)
+    val config =
+      getConfig().map(_.asInstanceOf[Config]).getOrElse(JavaSrc2Cpg.DefaultConfig).withCacheJdkTypeSolver(true)
     new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath)(config).get
   }
 }


### PR DESCRIPTION
* `JdkJarTypeSolver` is now built using a builder pattern, cf. `JdkJarTypeSolverBuilder`. This comes after the realization that `JdkJarTypeSolver` is essentially comprised of just a `parent`, `classPool` and `knownPackagePrefixes`. And, if it were not for `setParent` (which comes from `TypeSolver`), it'd have no mutators. Since we throw a runtime exception if we attempt to invoke `setParent` twice, I chose to cache `JdkJarTypeSolverBuilder`s instead of `JdkJarTypeSolver`s. This allows us to cheaply create new `JdkJarTypeSolver`s from `JdkJarTypeSolverBuilder`s each time we require a new one without changing any of the former's logic.
* The companion object method `JdkJarTypeSolver.fromJdkPath` now takes an extra parameter (`useCache = false`), which  looks up the given JDK path in a cache for `JdkJarTypeSolverBuilder`s.
* This new `useCache` parameter is set in a new `Config` parameter
* Unit-tests make use of `useCache = true`. Requires much less memory and speeds things up, and I reckon it's safe to assume the JDK contents won't change in between.

Fixes #3953 