### PR TITLE
[swiftsrc2cpg] Added support for dependencies

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
@@ -31,7 +31,7 @@ class SwiftSrc2Cpg extends X2CpgFrontend[Config] {
         SwiftTypeNodePass.withRegisteredTypes(astCreationPass.typesSeen(), cpg).createAndApply()
         new SwiftMetaDataPass(cpg, hash, config.inputPath).createAndApply()
         new BuiltinTypesPass(cpg).createAndApply()
-        new DependenciesPass(cpg, config).createAndApply()
+        new DependenciesPass(cpg).createAndApply()
         new ImportsPass(cpg).createAndApply()
 
         report.print()

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -1,16 +1,38 @@
 package io.joern.swiftsrc2cpg.astcreation
 
 import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.*
+import io.joern.swiftsrc2cpg.passes.Defines
+import io.joern.swiftsrc2cpg.passes.GlobalBuiltins
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 
 trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   this: AstCreator =>
 
-  private def astForArrayExprSyntax(node: ArrayExprSyntax): Ast                   = notHandledYet(node)
+  private def astForArrayExprSyntax(node: ArrayExprSyntax): Ast = {
+    val op           = Operators.arrayInitializer
+    val initCallNode = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
+
+    val MAX_INITIALIZERS = 1000
+    val children         = node.elements.children
+    val clauses          = children.slice(0, MAX_INITIALIZERS)
+
+    val args = clauses.map(x => astForNode(x))
+
+    val ast = callAst(initCallNode, args)
+    if (children.length > MAX_INITIALIZERS) {
+      val placeholder =
+        literalNode(node, "<too-many-initializers>", Defines.Any).argumentIndex(MAX_INITIALIZERS)
+      ast.withChild(Ast(placeholder)).withArgEdge(initCallNode, placeholder)
+    } else {
+      ast
+    }
+  }
+
   private def astForArrowExprSyntax(node: ArrowExprSyntax): Ast                   = notHandledYet(node)
   private def astForAsExprSyntax(node: AsExprSyntax): Ast                         = notHandledYet(node)
   private def astForAssignmentExprSyntax(node: AssignmentExprSyntax): Ast         = notHandledYet(node)
@@ -33,13 +55,92 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     scope.addVariableReference(name, identNode)
     Ast(identNode)
   }
-  private def astForDictionaryExprSyntax(node: DictionaryExprSyntax): Ast                       = notHandledYet(node)
-  private def astForDiscardAssignmentExprSyntax(node: DiscardAssignmentExprSyntax): Ast         = notHandledYet(node)
-  private def astForDoExprSyntax(node: DoExprSyntax): Ast                                       = notHandledYet(node)
-  private def astForEditorPlaceholderExprSyntax(node: EditorPlaceholderExprSyntax): Ast         = notHandledYet(node)
-  private def astForFloatLiteralExprSyntax(node: FloatLiteralExprSyntax): Ast                   = notHandledYet(node)
-  private def astForForceUnwrapExprSyntax(node: ForceUnwrapExprSyntax): Ast                     = notHandledYet(node)
-  private def astForFunctionCallExprSyntax(node: FunctionCallExprSyntax): Ast                   = notHandledYet(node)
+  private def astForDictionaryExprSyntax(node: DictionaryExprSyntax): Ast               = notHandledYet(node)
+  private def astForDiscardAssignmentExprSyntax(node: DiscardAssignmentExprSyntax): Ast = notHandledYet(node)
+  private def astForDoExprSyntax(node: DoExprSyntax): Ast                               = notHandledYet(node)
+  private def astForEditorPlaceholderExprSyntax(node: EditorPlaceholderExprSyntax): Ast = notHandledYet(node)
+  private def astForFloatLiteralExprSyntax(node: FloatLiteralExprSyntax): Ast           = notHandledYet(node)
+  private def astForForceUnwrapExprSyntax(node: ForceUnwrapExprSyntax): Ast             = notHandledYet(node)
+
+  private def createBuiltinStaticCall(callExpr: FunctionCallExprSyntax, callee: ExprSyntax, fullName: String): Ast = {
+    val callName = callee match {
+      case m: MemberAccessExprSyntax => code(m.declName)
+      case _                         => code(callee)
+    }
+    val callNode =
+      createStaticCallNode(code(callExpr), callName, fullName, line(callee), column(callee))
+    val argAsts = callExpr.arguments.children.map(astForNode)
+    callAst(callNode, argAsts)
+  }
+
+  private def handleCallNodeArgs(
+    callExpr: FunctionCallExprSyntax,
+    receiverAst: Ast,
+    baseNode: NewNode,
+    callName: String
+  ): Ast = {
+    val args      = callExpr.arguments.children.map(astForNode)
+    val callNode_ = callNode(callExpr, code(callExpr), callName, DispatchTypes.DYNAMIC_DISPATCH)
+    // If the callee is a function itself, e.g. closure, then resolve this locally, if possible
+    if (callExpr.calledExpression.isInstanceOf[ClosureExprSyntax]) {
+      functionNodeToNameAndFullName.get(callExpr.calledExpression).foreach { case (name, fullName) =>
+        callNode_.name(name).methodFullName(fullName)
+      }
+    }
+    callAst(callNode_, args, receiver = Option(receiverAst), base = Option(Ast(baseNode)))
+  }
+
+  private def astForFunctionCallExprSyntax(node: FunctionCallExprSyntax): Ast = {
+    val callee     = node.calledExpression
+    val calleeCode = code(callee)
+    if (GlobalBuiltins.builtins.contains(calleeCode)) {
+      createBuiltinStaticCall(node, callee, calleeCode)
+    } else {
+      val (receiverAst, baseNode, callName) = callee match {
+        case m: MemberAccessExprSyntax =>
+          val base   = m.base
+          val member = m.declName
+          base match {
+            case None =>
+              // referencing implicit this
+              val receiverAst = astForNodeWithFunctionReference(callee)
+              val baseNode    = identifierNode(m, "this")
+              scope.addVariableReference("this", baseNode)
+              (receiverAst, baseNode, code(member))
+            case Some(d: DeclReferenceExprSyntax) if code(d) == "this" || code(d) == "self" =>
+              val receiverAst = astForNodeWithFunctionReference(callee)
+              val baseNode    = identifierNode(d, code(d))
+              scope.addVariableReference(code(d), baseNode)
+              (receiverAst, baseNode, code(member))
+            case Some(d: DeclReferenceExprSyntax) =>
+              val receiverAst = astForNodeWithFunctionReference(callee)
+              val baseNode    = identifierNode(d, code(d))
+              scope.addVariableReference(code(d), baseNode)
+              (receiverAst, baseNode, code(member))
+            case Some(otherBase) =>
+              val tmpVarName  = generateUnusedVariableName(usedVariableNames, "_tmp")
+              val baseTmpNode = identifierNode(otherBase, tmpVarName)
+              scope.addVariableReference(tmpVarName, baseTmpNode)
+              val baseAst   = astForNodeWithFunctionReference(otherBase)
+              val codeField = s"(${codeOf(baseTmpNode)} = ${code(otherBase)})"
+              val tmpAssignmentAst =
+                createAssignmentCallAst(Ast(baseTmpNode), baseAst, codeField, line(otherBase), column(otherBase))
+              val memberNode = createFieldIdentifierNode(code(member), line(member), column(member))
+              val fieldAccessAst =
+                createFieldAccessCallAst(tmpAssignmentAst, memberNode, line(callee), column(callee))
+              val thisTmpNode = identifierNode(callee, tmpVarName)
+              (fieldAccessAst, thisTmpNode, code(member))
+          }
+        case _ =>
+          val receiverAst = astForNodeWithFunctionReference(callee)
+          val thisNode    = identifierNode(callee, "this").dynamicTypeHintFullName(typeHintForThisExpression())
+          scope.addVariableReference(thisNode.name, thisNode)
+          (receiverAst, thisNode, calleeCode)
+      }
+      handleCallNodeArgs(node, receiverAst, baseNode, callName)
+    }
+  }
+
   private def astForGenericSpecializationExprSyntax(node: GenericSpecializationExprSyntax): Ast = notHandledYet(node)
 
   private def astForIfExprSyntax(node: IfExprSyntax): Ast = {
@@ -57,31 +158,32 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForInOutExprSyntax(node: InOutExprSyntax): Ast = notHandledYet(node)
   private def astForInfixOperatorExprSyntax(node: InfixOperatorExprSyntax): Ast = {
     val op = code(node.operator) match {
-      case "="    => Operators.assignment
-      case "+="   => Operators.assignmentPlus
-      case "-="   => Operators.assignmentMinus
-      case "*="   => Operators.assignmentMultiplication
-      case "/="   => Operators.assignmentDivision
-      case "%="   => Operators.assignmentModulo
-      case "**="  => Operators.assignmentExponentiation
-      case "&="   => Operators.assignmentAnd
-      case "&&="  => Operators.assignmentAnd
-      case "|="   => Operators.assignmentOr
-      case "||="  => Operators.assignmentOr
-      case "^="   => Operators.assignmentXor
-      case "<<="  => Operators.assignmentShiftLeft
-      case ">>="  => Operators.assignmentArithmeticShiftRight
-      case ">>>=" => Operators.assignmentLogicalShiftRight
-      case "??="  => Operators.notNullAssert
-      case "<="   => Operators.lessEqualsThan
-      case ">="   => Operators.greaterEqualsThan
-      case "<"    => Operators.lessThan
-      case ">"    => Operators.greaterThan
-      case "=="   => Operators.equals
-      case "+"    => Operators.plus
-      case "-"    => Operators.minus
-      case "/"    => Operators.division
-      case "*"    => Operators.multiplication
+      case "="                   => Operators.assignment
+      case "+="                  => Operators.assignmentPlus
+      case "-="                  => Operators.assignmentMinus
+      case "*="                  => Operators.assignmentMultiplication
+      case "/="                  => Operators.assignmentDivision
+      case "%="                  => Operators.assignmentModulo
+      case "**="                 => Operators.assignmentExponentiation
+      case "&="                  => Operators.assignmentAnd
+      case "&&="                 => Operators.assignmentAnd
+      case "|="                  => Operators.assignmentOr
+      case "||="                 => Operators.assignmentOr
+      case "^="                  => Operators.assignmentXor
+      case "<<="                 => Operators.assignmentShiftLeft
+      case ">>="                 => Operators.assignmentArithmeticShiftRight
+      case ">>>="                => Operators.assignmentLogicalShiftRight
+      case "??="                 => Operators.notNullAssert
+      case "<="                  => Operators.lessEqualsThan
+      case ">="                  => Operators.greaterEqualsThan
+      case "<"                   => Operators.lessThan
+      case ">"                   => Operators.greaterThan
+      case "=="                  => Operators.equals
+      case "+"                   => Operators.plus
+      case "-"                   => Operators.minus
+      case "/"                   => Operators.division
+      case "*"                   => Operators.multiplication
+      case "..<" | ">.." | "..." => Operators.range
       case other =>
         logger.warn(s"Unknown assignment operator: '$other'")
         Operators.assignment
@@ -98,10 +200,30 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     astForNode(node.literal)
   }
 
-  private def astForIsExprSyntax(node: IsExprSyntax): Ast                                   = notHandledYet(node)
-  private def astForKeyPathExprSyntax(node: KeyPathExprSyntax): Ast                         = notHandledYet(node)
-  private def astForMacroExpansionExprSyntax(node: MacroExpansionExprSyntax): Ast           = notHandledYet(node)
-  private def astForMemberAccessExprSyntax(node: MemberAccessExprSyntax): Ast               = notHandledYet(node)
+  private def astForIsExprSyntax(node: IsExprSyntax): Ast                         = notHandledYet(node)
+  private def astForKeyPathExprSyntax(node: KeyPathExprSyntax): Ast               = notHandledYet(node)
+  private def astForMacroExpansionExprSyntax(node: MacroExpansionExprSyntax): Ast = notHandledYet(node)
+
+  private def astForMemberAccessExprSyntax(node: MemberAccessExprSyntax): Ast = {
+    val base   = node.base
+    val member = node.declName
+    val baseAst = base match {
+      case None =>
+        // referencing implicit this
+        val baseNode = identifierNode(node, "this")
+        scope.addVariableReference("this", baseNode)
+        Ast(baseNode)
+      case Some(d: DeclReferenceExprSyntax) if code(d) == "this" || code(d) == "self" =>
+        val baseNode = identifierNode(d, code(d))
+        scope.addVariableReference(code(d), baseNode)
+        Ast(baseNode)
+      case Some(otherBase) =>
+        astForNodeWithFunctionReference(otherBase)
+    }
+    val memberNode = createFieldIdentifierNode(code(member), line(member), column(member))
+    createFieldAccessCallAst(baseAst, memberNode, line(node), column(node))
+  }
+
   private def astForMissingExprSyntax(node: MissingExprSyntax): Ast                         = notHandledYet(node)
   private def astForNilLiteralExprSyntax(node: NilLiteralExprSyntax): Ast                   = notHandledYet(node)
   private def astForOptionalChainingExprSyntax(node: OptionalChainingExprSyntax): Ast       = notHandledYet(node)
@@ -114,10 +236,14 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForRegexLiteralExprSyntax(node: RegexLiteralExprSyntax): Ast               = notHandledYet(node)
   private def astForSequenceExprSyntax(node: SequenceExprSyntax): Ast                       = notHandledYet(node)
   private def astForSimpleStringLiteralExprSyntax(node: SimpleStringLiteralExprSyntax): Ast = notHandledYet(node)
-  private def astForStringLiteralExprSyntax(node: StringLiteralExprSyntax): Ast             = notHandledYet(node)
-  private def astForSubscriptCallExprSyntax(node: SubscriptCallExprSyntax): Ast             = notHandledYet(node)
-  private def astForSuperExprSyntax(node: SuperExprSyntax): Ast                             = notHandledYet(node)
-  private def astForSwitchExprSyntax(node: SwitchExprSyntax): Ast                           = notHandledYet(node)
+
+  private def astForStringLiteralExprSyntax(node: StringLiteralExprSyntax): Ast = {
+    astForNode(node.segments)
+  }
+
+  private def astForSubscriptCallExprSyntax(node: SubscriptCallExprSyntax): Ast = notHandledYet(node)
+  private def astForSuperExprSyntax(node: SuperExprSyntax): Ast                 = notHandledYet(node)
+  private def astForSwitchExprSyntax(node: SwitchExprSyntax): Ast               = notHandledYet(node)
 
   private def astForTernaryExprSyntax(node: TernaryExprSyntax): Ast = {
     val name = Operators.conditional

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -91,14 +91,18 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
     notHandledYet(node)
   private def astForSpecializeAttributeArgumentListSyntax(node: SpecializeAttributeArgumentListSyntax): Ast =
     notHandledYet(node)
-  private def astForStringLiteralSegmentListSyntax(node: StringLiteralSegmentListSyntax): Ast = notHandledYet(node)
-  private def astForSwitchCaseItemListSyntax(node: SwitchCaseItemListSyntax): Ast             = notHandledYet(node)
-  private def astForSwitchCaseListSyntax(node: SwitchCaseListSyntax): Ast                     = notHandledYet(node)
-  private def astForTuplePatternElementListSyntax(node: TuplePatternElementListSyntax): Ast   = notHandledYet(node)
-  private def astForTupleTypeElementListSyntax(node: TupleTypeElementListSyntax): Ast         = notHandledYet(node)
-  private def astForUnexpectedNodesSyntax(node: UnexpectedNodesSyntax): Ast                   = notHandledYet(node)
-  private def astForVersionComponentListSyntax(node: VersionComponentListSyntax): Ast         = notHandledYet(node)
-  private def astForYieldedExpressionListSyntax(node: YieldedExpressionListSyntax): Ast       = notHandledYet(node)
+
+  private def astForStringLiteralSegmentListSyntax(node: StringLiteralSegmentListSyntax): Ast = {
+    astForListSyntaxChildren(node, node.children)
+  }
+
+  private def astForSwitchCaseItemListSyntax(node: SwitchCaseItemListSyntax): Ast           = notHandledYet(node)
+  private def astForSwitchCaseListSyntax(node: SwitchCaseListSyntax): Ast                   = notHandledYet(node)
+  private def astForTuplePatternElementListSyntax(node: TuplePatternElementListSyntax): Ast = notHandledYet(node)
+  private def astForTupleTypeElementListSyntax(node: TupleTypeElementListSyntax): Ast       = notHandledYet(node)
+  private def astForUnexpectedNodesSyntax(node: UnexpectedNodesSyntax): Ast                 = notHandledYet(node)
+  private def astForVersionComponentListSyntax(node: VersionComponentListSyntax): Ast       = notHandledYet(node)
+  private def astForYieldedExpressionListSyntax(node: YieldedExpressionListSyntax): Ast     = notHandledYet(node)
 
   protected def astForSyntaxCollection(syntaxCollection: SyntaxCollection): Ast = syntaxCollection match {
     case node: AccessorDeclListSyntax                   => astForAccessorDeclListSyntax(node)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
@@ -5,11 +5,9 @@ import io.joern.swiftsrc2cpg.passes.Defines
 import io.joern.x2cpg
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.ValidationMode
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
-import org.apache.commons.lang.StringUtils
 
 trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -90,19 +88,6 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     callAst(callNode, arguments)
   }
 
-  protected def createTernaryCallAst(
-    testAst: Ast,
-    trueAst: Ast,
-    falseAst: Ast,
-    line: Option[Integer],
-    column: Option[Integer]
-  ): Ast = {
-    val code      = s"${codeOf(testAst.nodes.head)} ? ${codeOf(trueAst.nodes.head)} : ${codeOf(falseAst.nodes.head)}"
-    val callNode  = createCallNode(code, Operators.conditional, DispatchTypes.STATIC_DISPATCH, line, column)
-    val arguments = List(testAst, trueAst, falseAst)
-    callAst(callNode, arguments)
-  }
-
   def callNode(node: SwiftNode, code: String, name: String, dispatchType: String): NewCall = {
     val fullName =
       if (dispatchType == DispatchTypes.STATIC_DISPATCH) name
@@ -146,13 +131,6 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
       case _                                                 => Defines.Any
     }
     literalNode(node, code, typeFullName, dynamicTypeOption.toList)
-  }
-
-  protected def createEqualsCallAst(dest: Ast, source: Ast, line: Option[Integer], column: Option[Integer]): Ast = {
-    val code      = s"${codeOf(dest.nodes.head)} === ${codeOf(source.nodes.head)}"
-    val callNode  = createCallNode(code, Operators.equals, DispatchTypes.STATIC_DISPATCH, line, column)
-    val arguments = List(dest, source)
-    callAst(callNode, arguments)
   }
 
   protected def createAssignmentCallAst(

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/DependenciesPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/DependenciesPass.scala
@@ -1,22 +1,48 @@
 package io.joern.swiftsrc2cpg.passes
 
-import io.joern.swiftsrc2cpg.Config
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.codepropertygraph.generated.nodes.NewDependency
 import io.shiftleft.passes.CpgPass
+import io.shiftleft.semanticcpg.language.*
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /** Creation of DEPENDENCY nodes from "Package.swift" files.
   */
-class DependenciesPass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
+class DependenciesPass(cpg: Cpg) extends CpgPass(cpg) {
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
+
+  private val versionIds = Set("from", "branch", "revision", "exact")
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
-    // TODO: gather the actual dependencies from the Package.swift file
-    val dependencies: List[(String, String)] = List()
-    dependencies.foreach { case (name, version) =>
-      val dep = NewDependency()
-        .name(name)
-        .version(version)
-      diffGraph.addNode(dep)
+    cpg.file("Package.swift").ast.isCall.nameExact("package").foreach { call =>
+      call.argument.l match
+        case Nil => // Do nothing
+        case _ :: (pathArg: Call) :: Nil if pathArg.argument(1).code == "path" =>
+          val name = pathArg.argument(2).code
+          val dep  = NewDependency().name(name)
+          diffGraph.addNode(dep)
+        case _ :: (nameArg: Call) :: (pathArg: Call) :: Nil
+            if nameArg.argument(1).code == "name" && pathArg.argument(1).code == "path" =>
+          val name = nameArg.argument(2).code
+          val path = pathArg.argument(2).code
+          val dep  = NewDependency().name(name).dependencyGroupId(path)
+          diffGraph.addNode(dep)
+        case _ :: (urlArg: Call) :: (versionArg: Call) :: Nil
+            if urlArg.argument(1).code == "url" && versionIds.contains(versionArg.argument(1).code) =>
+          val name    = urlArg.argument(2).code
+          val version = versionArg.argument(2).code
+          val dep     = NewDependency().name(name).version(version)
+          diffGraph.addNode(dep)
+        case _ :: (urlArg: Call) :: (versionRange: Call) :: Nil if urlArg.argument(1).code == "url" =>
+          val name    = urlArg.argument(2).code
+          val version = versionRange.code
+          val dep     = NewDependency().name(name).version(version)
+          diffGraph.addNode(dep)
+        case call =>
+          logger.warn(s"Unknown dependency specification: '${call.mkString(", ")}'")
     }
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/GlobalBuiltins.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/GlobalBuiltins.scala
@@ -1,0 +1,7 @@
+package io.joern.swiftsrc2cpg.passes
+
+object GlobalBuiltins {
+
+  val builtins: Set[String] = Set() // TODO: fill this
+
+}

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -93,7 +93,7 @@ class AstGenRunner(config: Config) {
 
   import io.joern.swiftsrc2cpg.utils.AstGenRunner._
 
-  private def skippedFiles(in: File, astGenOut: List[String]): List[String] = {
+  private def skippedFiles(astGenOut: List[String]): List[String] = {
     val skipped = astGenOut.collect {
       case out if !out.startsWith("Generated") =>
         val filename = out.substring(out.indexOf(": `") + 3, out.indexOf("swift`") + 5)
@@ -139,7 +139,7 @@ class AstGenRunner(config: Config) {
     runAstGenNative(in, out) match {
       case Success(result) =>
         val parsed  = filterFiles(SourceFiles.determine(out.toString(), Set(".json")), out)
-        val skipped = skippedFiles(in, result.toList)
+        val skipped = skippedFiles(result.toList)
         AstGenRunnerResult(parsed.map((in.toString(), _)), skipped.map((in.toString(), _)))
       case Failure(f) =>
         logger.error("\t- running SwiftAstGen failed!", f)

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/dependency/DependenciesPassTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/dependency/DependenciesPassTests.scala
@@ -1,0 +1,73 @@
+package io.joern.swiftsrc2cpg.passes.dependency
+
+import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
+import io.shiftleft.semanticcpg.language._
+
+class DependenciesPassTests extends SwiftSrc2CpgSuite {
+
+  private val codeString = """
+     |// swift-tools-version: 5.9
+     |
+     |import PackageDescription
+     |
+     |let package = Package(
+     |  name: "TestApp",
+     |  platforms: [],
+     |  products: [],
+     |  dependencies: [
+     |    .package(name: "DepA", path: "PathA"),
+     |    .package(url: "https://github.com/DepB", from: "1.0.0"),
+     |    .package(url: "https://github.com/DepC", "1.2.3"..<"1.2.6"),
+     |    .package(url: "https://github.com/DepD", "1.2.3"..."1.2.6"),
+     |    .package(url: "https://github.com/DepE", branch: "main"),
+     |    .package(url: "https://github.com/DepF", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
+     |    .package(url: "https://github.com/DepG", exact: "1.2.3"),
+     |    .package(path: "../some/path/DepH")
+     |  ],
+     |  targets: []
+     |)
+     |}""".stripMargin
+
+  private val cpg = code(codeString, "Package.swift")
+
+  "DependenciesPass" should {
+
+    "generate dependency nodes correctly" in {
+      inside(cpg.dependency.l) { case List(depA, depB, depC, depD, depE, depF, depG, depH) =>
+        depA.name shouldBe "DepA"
+        depA.version shouldBe "<empty>"
+        depA.dependencyGroupId shouldBe Some("PathA")
+
+        depB.name shouldBe "https://github.com/DepB"
+        depB.version shouldBe "1.0.0"
+        depB.dependencyGroupId shouldBe None
+
+        depC.name shouldBe "https://github.com/DepC"
+        depC.version shouldBe """"1.2.3"..<"1.2.6""""
+        depC.dependencyGroupId shouldBe None
+
+        depD.name shouldBe "https://github.com/DepD"
+        depD.version shouldBe """"1.2.3"..."1.2.6""""
+        depD.dependencyGroupId shouldBe None
+
+        depE.name shouldBe "https://github.com/DepE"
+        depE.version shouldBe "main"
+        depE.dependencyGroupId shouldBe None
+
+        depF.name shouldBe "https://github.com/DepF"
+        depF.version shouldBe "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"
+        depF.dependencyGroupId shouldBe None
+
+        depG.name shouldBe "https://github.com/DepG"
+        depG.version shouldBe "1.2.3"
+        depG.dependencyGroupId shouldBe None
+
+        depH.name shouldBe "../some/path/DepH"
+        depH.version shouldBe "<empty>"
+        depH.dependencyGroupId shouldBe None
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Generated directly from the Swift AST withing the Package.swift file. That allows for dependency retrieval without manually parsing the actual dependency specification syntax.

To do that, this PR adds support for calls and array lists.