### PR TITLE
Fix `release` Action: Specify Ruby Bundler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           ruby-version: 2.7
       - name: Install Bundler
-        run: gem install bundler
+        run: gem install bundler -v 2.4.22
       - name: Delete `.rustup` directory
         run: rm -rf /home/runner/.rustup # to save disk space
         if: runner.os == 'Linux'


### PR DESCRIPTION
A completion following the fix done here: https://github.com/joernio/joern/commit/73243dd31d860c212c8d0a856cd7a95f30e9d11e