### PR TITLE
[ruby] Begin, Rescue, Ensure (Try-Catch Statements) for intermediate ast #3927

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -22,6 +22,12 @@ object RubyIntermediateAst {
     def text: String = span.text
   }
 
+  implicit class RubyNodeHelper(node: RubyNode) {
+    def asStatementList = node match
+      case stmtList: StatementList => stmtList
+      case _                       => StatementList(List(node))(node.span)
+  }
+
   final case class Unknown()(span: TextSpan) extends RubyNode(span)
 
   final case class StatementList(statements: List[RubyNode])(span: TextSpan) extends RubyNode(span) {
@@ -69,6 +75,23 @@ object RubyIntermediateAst {
   final case class AttributeAssignment(target: RubyNode, op: String, attributeName: String, rhs: RubyNode)(
     span: TextSpan
   ) extends RubyNode(span)
+
+  final case class RescueExpression(
+    body: RubyNode,
+    rescueClauses: List[RubyNode],
+    elseClause: Option[RubyNode],
+    ensureClause: Option[RubyNode]
+  )(span: TextSpan)
+      extends RubyNode(span)
+
+  final case class RescueClause(
+    exceptionClassList: Option[RubyNode],
+    assignment: Option[RubyNode],
+    thenClause: RubyNode
+  )(span: TextSpan)
+      extends RubyNode(span)
+
+  final case class EnsureClause(thenClause: RubyNode)(span: TextSpan) extends RubyNode(span)
 
   final case class WhileExpression(condition: RubyNode, body: RubyNode)(span: TextSpan) extends RubyNode(span)
 


### PR DESCRIPTION
The related issue assumes the RubyNode intermediate AST is complete for Begin, Rescue, Ensure, but this is not the case. The scope of this issue has crept to include handling the ANTLR-to-RubyNode AST feature for these expressions, as well as the AstCreator CPG building. This appears to be the case for a few of the other Ruby issues, which will influence their ETA accordingly.

Additionally, Rescue clauses in Ruby can contain splats which isn't handled yet in parsing. For now the exception list is will be an unknown block and posted as a medium-priority issue. I am unsure if adding a RubyNode for multipleRightHandSide affects anything else.

The scope of this PR is reduced to just the intermediate AST and the AST creator changes will be in a follow up. 