### PR TITLE
[kotlin] Null-safe Handling of `.get` and `Option`

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
@@ -443,7 +443,7 @@ class DefaultTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeIn
 
   def typeFullName(expr: KtAnnotationEntry, defaultValue: String): String = {
     Option(bindingsForEntity(bindingContext, expr))
-      .map(_ => bindingContext.get(BindingContext.ANNOTATION, expr))
+      .flatMap(_ => Option(bindingContext.get(BindingContext.ANNOTATION, expr)))
       .map { desc => TypeRenderer.render(desc.getType) }
       .getOrElse(defaultValue)
   }
@@ -748,10 +748,8 @@ class DefaultTypeInfoProvider(environment: KotlinCoreEnvironment) extends TypeIn
       parameterType(parameter, explicitTypeFullName)
     }
     val paramListSignature = s"(${paramTypeNames.mkString(",")})"
-    val methodName = Option(fnDesc)
-      .map { desc =>
-        s"${TypeRenderer.renderFqNameForDesc(desc.get)}${TypeConstants.initPrefix}"
-      }
+    val methodName = fnDesc
+      .map(desc => s"${TypeRenderer.renderFqNameForDesc(desc)}${TypeConstants.initPrefix}")
       .getOrElse(s"${Defines.UnresolvedNamespace}.${TypeConstants.initPrefix}")
     val signature = s"${TypeConstants.void}$paramListSignature"
     val fullname  = s"$methodName:$signature"


### PR DESCRIPTION
* Wrapped `bindingContext.get(BindingContext.ANNOTATION, expr)` in `Option` to filter out instances where the return is `null`.
* Fixed bug where `fnDesc` was treated as a raw type, however it was already an `Option` type.

Resolves #3949