### PR TITLE
use correct (non-milestone) circe version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,6 +92,7 @@ jobs:
           ./joern --src /tmp/foo --run scan
           ./joern-scan /tmp/foo
           ./joern-scan --dump
+          ./joern-slice data-flow -o target/slice
       - run: |
           cd joern-cli/target/universal/stage
           ./schema-extender/test.sh

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -4,7 +4,7 @@ enablePlugins(JavaAppPackaging)
 
 val ScoptVersion          = "4.1.0"
 val CaskVersion           = "0.9.1"
-val CirceVersion          = "0.14.5"
+val CirceVersion          = "0.14.6"
 val ZeroturnaroundVersion = "1.15"
 
 dependsOn(

--- a/joern-cli/frontends/php2cpg/build.sbt
+++ b/joern-cli/frontends/php2cpg/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "com.lihaoyi"   %% "ujson"             % Versions.upickle,
   "io.shiftleft"  %% "codepropertygraph" % Versions.cpg,
   "org.scalatest" %% "scalatest"         % Versions.scalatest % Test,
-  "io.circe"      %% "circe-core"        % "0.15.0-M1"
+  "io.circe"      %% "circe-core"        % Versions.circe
 )
 
 lazy val phpParseInstallTask = taskKey[Unit]("Install PHP-Parse using PHP Composer")


### PR DESCRIPTION
Without this, the milestone version of circe overrides the final release
that we really want to use.

fixes https://github.com/joernio/joern/issues/3924