### PR TITLE
[javasrc2cpg] - add YAML files as configuration files

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
@@ -33,7 +33,10 @@ class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
     pathEndFilter("build.gradle"),
     pathEndFilter("build.gradle.kts"),
     // ANDROID
-    pathEndFilter("AndroidManifest.xml")
+    pathEndFilter("AndroidManifest.xml"),
+    // SPRING
+    extensionFilter(".yaml"),
+    extensionFilter(".yml")
   )
 
   private def mybatisFilter(file: File): Boolean = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.yaml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.yaml
@@ -1,0 +1,1 @@
+key: value

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.yml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/basic.yml
@@ -1,0 +1,1 @@
+key: value

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -36,7 +36,9 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
       Paths.get(absoluteConfigDir, "struts.xml").toString,
       Paths.get(absoluteConfigDir, "web.xml").toString,
       Paths.get(absoluteConfigDir, "build.gradle").toString,
-      Paths.get(absoluteConfigDir, "build.gradle.kts").toString
+      Paths.get(absoluteConfigDir, "build.gradle.kts").toString,
+      Paths.get(absoluteConfigDir, "basic.yaml").toString,
+      Paths.get(absoluteConfigDir, "basic.yml").toString
     )
   }
 


### PR DESCRIPTION
* Besides `*.properties`,  Spring also takes into account `*.{yaml,yml}` files, not necessarily named `application.yaml`, cf. https://docs.spring.io/spring-boot/docs/3.2.0/reference/html/features.html#features.external-config

Fixes #3943

