### PR TITLE
Add <init> naming for ruby constructors

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -18,10 +18,14 @@ trait AstCreatorHelper { this: AstCreator =>
    * */
   protected val methodAstParentStack: Stack[NewNode] = new Stack()
 
-  /* Use to if any constructors of classes are present to know if a default constructor should be generated
+  /* Used if any constructors of classes are present to know if a default constructor should be generated
    * TODO: this seems too specific to add another stack, perhaps there is a better way in checking the class body. There are some possible
    * nesting edge cases which this handles better unless you recursively traverse the result of astsFor* on the class body. How common it would be in actual Ruby code is uncertain */
-  protected val hasInitializeStack: Stack[Boolean] = new Stack()
+  protected val shouldGenerateDefaultConstructorStack: Stack[Boolean] = new Stack()
+  protected def setNoDefaultConstructorForEnclosingTypeDecl : Unit = {
+    shouldGenerateDefaultConstructorStack.pop()
+    shouldGenerateDefaultConstructorStack.push(false)
+  }
 
   protected def getEnclosingAstType: String     = methodAstParentStack.head.label()
   protected def getEnclosingAstFullName: String = methodAstParentStack.head.properties(PropertyNames.FULL_NAME).toString

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -18,6 +18,11 @@ trait AstCreatorHelper { this: AstCreator =>
    * */
   protected val methodAstParentStack: Stack[NewNode] = new Stack()
 
+  /* Use to if any constructors of classes are present to know if a default constructor should be generated
+   * TODO: this seems too specific to add another stack, perhaps there is a better way in checking the class body. There are some possible
+   * nesting edge cases which this handles better unless you recursively traverse the result of astsFor* on the class body. How common it would be in actual Ruby code is uncertain */
+  protected val hasInitializeStack: Stack[Boolean] = new Stack()
+
   protected def getEnclosingAstType: String     = methodAstParentStack.head.label()
   protected def getEnclosingAstFullName: String = methodAstParentStack.head.properties(PropertyNames.FULL_NAME).toString
   protected def computeClassFullName(name: String): String  = s"$getEnclosingAstFullName.$name"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -22,7 +22,7 @@ trait AstCreatorHelper { this: AstCreator =>
    * TODO: this seems too specific to add another stack, perhaps there is a better way in checking the class body. There are some possible
    * nesting edge cases which this handles better unless you recursively traverse the result of astsFor* on the class body. How common it would be in actual Ruby code is uncertain */
   protected val shouldGenerateDefaultConstructorStack: Stack[Boolean] = new Stack()
-  protected def setNoDefaultConstructorForEnclosingTypeDecl : Unit = {
+  protected def setNoDefaultConstructorForEnclosingTypeDecl: Unit = {
     shouldGenerateDefaultConstructorStack.pop()
     shouldGenerateDefaultConstructorStack.push(false)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -9,11 +9,21 @@ import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForMethodDeclaration(node: MethodDeclaration): Ast = {
+
+    // Special case constructor methods
+    val isInTypeDecl = getEnclosingAstType == "TYPE_DECL"
+    val methodName = node.methodName match {
+      case "initialize" if isInTypeDecl =>
+        hasInitializeStack.pop()
+        hasInitializeStack.push(true)
+        "<init>"
+      case name => name
+    }
     // TODO: body could be a try
     val method = methodNode(
       node = node,
-      name = node.methodName,
-      fullName = computeMethodFullName(node.methodName),
+      name = methodName,
+      fullName = computeMethodFullName(methodName),
       code = code(node),
       signature = None,
       fileName = relativeFileName

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -14,8 +14,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val isInTypeDecl = getEnclosingAstType == "TYPE_DECL"
     val methodName = node.methodName match {
       case "initialize" if isInTypeDecl =>
-        hasInitializeStack.pop()
-        hasInitializeStack.push(true)
+        setNoDefaultConstructorForEnclosingTypeDecl
         "<init>"
       case name => name
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -13,12 +13,12 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   protected def astForModuleDeclaration(node: ModuleDeclaration): Ast = {
     // TODO: Might be wrong here (hence this placeholder), but I'm assuming modules ~= abstract classes.
     val classDecl = ClassDeclaration(node.moduleName, None, node.body)(node.span)
-    astForClassDeclaration(classDecl)
+    astForClassDeclaration(classDecl, defaultCtor = false)
   }
 
-  protected def astForClassDeclaration(node: ClassDeclaration): Ast = {
+  protected def astForClassDeclaration(node: ClassDeclaration, defaultCtor: Boolean = true): Ast = {
     node.className match
-      case name: SimpleIdentifier => astForSimpleNamedClassDeclaration(node, name)
+      case name: SimpleIdentifier => astForSimpleNamedClassDeclaration(node, name, defaultCtor)
       case name =>
         logger.warn(s"Qualified class names are not supported yet: ${name.text} ($relativeFileName), skipping")
         astForUnknown(node)
@@ -32,7 +32,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         None
   }
 
-  private def astForSimpleNamedClassDeclaration(node: ClassDeclaration, nameIdentifier: SimpleIdentifier): Ast = {
+  private def astForSimpleNamedClassDeclaration(node: ClassDeclaration, nameIdentifier: SimpleIdentifier, defaultCtor: Boolean): Ast = {
     val className    = nameIdentifier.text
     val inheritsFrom = node.baseClass.flatMap(getBaseClassName).toList
     val typeDecl = typeDeclNode(
@@ -48,18 +48,18 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     )
     methodAstParentStack.push(typeDecl)
     scope.pushNewScope(typeDecl)
-    hasInitializeStack.push(false)
+    shouldGenerateDefaultConstructorStack.push(defaultCtor)
     val classBody =
       node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
     val classBodyAsts = classBody.statements.flatMap(astsForStatement) match {
-      case bodyAsts if hasInitializeStack.head => bodyAsts
-      case bodyAsts =>
+      case bodyAsts if shouldGenerateDefaultConstructorStack.head =>
         val bodyStart  = classBody.span.spanStart
         val initBody   = StatementList(List())(bodyStart)
         val methodDecl = astForMethodDeclaration(MethodDeclaration("<init>", List(), initBody)(bodyStart))
         methodDecl :: bodyAsts
+      case bodyAsts  => bodyAsts
     }
-    hasInitializeStack.pop()
+    shouldGenerateDefaultConstructorStack.pop()
     scope.popScope()
     methodAstParentStack.pop()
     Ast(typeDecl).withChildren(classBodyAsts)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -32,7 +32,11 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         None
   }
 
-  private def astForSimpleNamedClassDeclaration(node: ClassDeclaration, nameIdentifier: SimpleIdentifier, defaultCtor: Boolean): Ast = {
+  private def astForSimpleNamedClassDeclaration(
+    node: ClassDeclaration,
+    nameIdentifier: SimpleIdentifier,
+    defaultCtor: Boolean
+  ): Ast = {
     val className    = nameIdentifier.text
     val inheritsFrom = node.baseClass.flatMap(getBaseClassName).toList
     val typeDecl = typeDeclNode(
@@ -57,7 +61,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         val initBody   = StatementList(List())(bodyStart)
         val methodDecl = astForMethodDeclaration(MethodDeclaration("<init>", List(), initBody)(bodyStart))
         methodDecl :: bodyAsts
-      case bodyAsts  => bodyAsts
+      case bodyAsts => bodyAsts
     }
     shouldGenerateDefaultConstructorStack.pop()
     scope.popScope()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -8,7 +8,9 @@ object RubyIntermediateAst {
     lineEnd: Option[Integer],
     columnEnd: Option[Integer],
     text: String
-  )
+  ) {
+    def spanStart: TextSpan = TextSpan(line, column, line, column, "")
+  }
 
   sealed class RubyNode(val span: TextSpan) {
     def line: Option[Integer] = span.line

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -171,4 +171,54 @@ class ClassTests extends RubyCode2CpgFixture {
     methodF.fullName shouldBe "Test0.rb:<global>::program.C:f"
   }
 
+  "`def initialize() ... end` directly inside a class has method name `<init>`" in {
+    val cpg = code("""
+                     |class C
+                     | def initialize()
+                     | end
+                     |end
+                     |""".stripMargin)
+
+    val List(classC)     = cpg.typeDecl.name("C").l
+    val List(methodInit) = classC.method.name("<init>").l
+
+    methodInit.fullName shouldBe "Test0.rb:<global>::program.C:<init>"
+  }
+
+  "`class C end` has default constructor" in {
+    val cpg = code("""
+                     |class C
+                     |end
+                     |""".stripMargin)
+
+    val List(classC)     = cpg.typeDecl.name("C").l
+    val List(methodInit) = classC.method.name("<init>").l
+
+    methodInit.fullName shouldBe "Test0.rb:<global>::program.C:<init>"
+  }
+
+  "`def initialize() ... end` not directly under class has method name `initialize`" in {
+    val cpg = code("""
+                     |def initialize()
+                     |  1
+                     |end
+                     |
+                     |class C
+                     | def f()
+                     |   2
+                     | end
+                     |end
+                     |
+                     |class D
+                     | def f()
+                     |   def initialize()
+                     |     3
+                     |   end
+                     | end
+                     |end
+                     |""".stripMargin)
+
+    cpg.method.name("<init>").literal.code.l should be(empty)
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -18,7 +18,7 @@ class ClassTests extends RubyCode2CpgFixture {
     classC.lineNumber shouldBe Some(2)
     classC.baseType.l shouldBe List()
     classC.member.l shouldBe List()
-    classC.method.l shouldBe List()
+    classC.method.name.l shouldBe List("<init>")
   }
 
   "`class C < D` is represented by a TYPE_DECL node inheriting from `D`" in {
@@ -34,7 +34,7 @@ class ClassTests extends RubyCode2CpgFixture {
     classC.fullName shouldBe "Test0.rb:<global>::program.C"
     classC.lineNumber shouldBe Some(2)
     classC.member.l shouldBe List()
-    classC.method.l shouldBe List()
+    classC.method.name.l shouldBe List("<init>")
 
     val List(typeD) = classC.baseType.l
     typeD.name shouldBe "D"


### PR DESCRIPTION
- Set the name of method nodes of ruby initialize methods whose parent method ast is a TYPE_DECL to be `<init>`.
- Also set the full name AST accordingly
- Create a default `<init>` if no constructor is present
  This is done pretty jankily, as I have added a stack  of boolean flags of whether the immediate TypeDecl contains a constructor. I'd love to know if there is a better way.