### PR TITLE
[ruby] when Statements (Switch Statements) #3926

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -22,6 +22,7 @@ class AstCreator(protected val filename: String, parser: ResourceManagedParser, 
     with AstForExpressionsCreator
     with AstForFunctionsCreator
     with AstForTypesCreator
+    with FreshVariableCreator
     with AstNodeBuilder[RubyNode, AstCreator] {
 
   protected val logger: Logger = LoggerFactory.getLogger(getClass)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -7,6 +7,8 @@ import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewLiteral, NewControlStructure}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, ControlStructureTypes}
 import io.shiftleft.semanticcpg.language.NodeOrdering.nodeList
+import scala.collection.mutable
+import io.joern.rubysrc2cpg.parser.RubyParser
 
 trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -109,7 +109,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         (whenClause: WhenClause, restClause: Option[RubyNode]) =>
           // We translate multiple match expressions into an or expression.
           // There may be a splat as the last match expression, which is currently parsed as unknown
-          // A single match expression is compared using `.===` to case target expression if it is present
+          // A single match expression is compared using `.===` to the case target expression if it is present
           // otherwise it is treated as a conditional.
           val conditions = whenClause.matchExpressions.map { mExpr =>
             expr.map(e => MemberCall(mExpr, ".", "===", List(e))(mExpr.span)).getOrElse(mExpr)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -104,35 +104,42 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   protected def astsForCaseExpression(node: CaseExpression): Seq[Ast] = {
     def goCase(expr: Option[SimpleIdentifier]): List[RubyNode] = {
       val elseThenClause: Option[RubyNode] = node.elseClause.map(_.asInstanceOf[ElseClause].thenClause)
-      val whenClauses = node.whenClauses.map(_.asInstanceOf[WhenClause])
-      val ifElseChain = whenClauses.foldRight[Option[RubyNode]](elseThenClause) { (whenClause: WhenClause, restClause: Option[RubyNode]) =>
-        // We translate multiple match expressions into an or expression.
-        // There may be a splat as the last match expression, which is currently parsed as unknown
-        // A single match expression is compared using `.===` to case target expression if it is present
-        // otherwise it is treated as a conditional.
-        val conditions = whenClause.matchExpressions.map { 
-          case u: Unknown => u
-          case mExpr => expr.map(e => MemberCall(e, ".", "===", List(mExpr))(mExpr.span)).getOrElse(mExpr)
-        }
-        // There is always at least one match expression
-        val condition = conditions.init.foldRight(conditions.last) { (cond, condAcc) => BinaryExpression(cond, "||", condAcc)(whenClause.span) }
-        val conditional = IfExpression(condition, 
-          whenClause.thenClause.map(_.asStatementList).getOrElse(StatementList(List())(whenClause.span)), 
-          List(),
-          restClause.map { els => ElseClause(els.asStatementList)(els.span) })(node.span)
-        Some(conditional)
+      val whenClauses                      = node.whenClauses.map(_.asInstanceOf[WhenClause])
+      val ifElseChain = whenClauses.foldRight[Option[RubyNode]](elseThenClause) {
+        (whenClause: WhenClause, restClause: Option[RubyNode]) =>
+          // We translate multiple match expressions into an or expression.
+          // There may be a splat as the last match expression, which is currently parsed as unknown
+          // A single match expression is compared using `.===` to case target expression if it is present
+          // otherwise it is treated as a conditional.
+          val conditions = whenClause.matchExpressions.map {
+            case u: Unknown => u
+            case mExpr      => expr.map(e => MemberCall(e, ".", "===", List(mExpr))(mExpr.span)).getOrElse(mExpr)
+          }
+          // There is always at least one match expression
+          val condition = conditions.init.foldRight(conditions.last) { (cond, condAcc) =>
+            BinaryExpression(cond, "||", condAcc)(whenClause.span)
+          }
+          val conditional = IfExpression(
+            condition,
+            whenClause.thenClause.map(_.asStatementList).getOrElse(StatementList(List())(whenClause.span)),
+            List(),
+            restClause.map { els => ElseClause(els.asStatementList)(els.span) }
+          )(node.span)
+          Some(conditional)
       }
       ifElseChain.iterator.toList
     }
-    def generatedNode: StatementList = node.expression.map { e =>
-      val tmp = SimpleIdentifier(None)(e.span.spanStart(freshName))
-      StatementList(List(SingleAssignment(e, "=", tmp)(e.span)) ++
-        goCase(Some(tmp))
-      )(node.span)
-      }.getOrElse(StatementList(goCase(None))(node.span))
+    def generatedNode: StatementList = node.expression
+      .map { e =>
+        val tmp = SimpleIdentifier(None)(e.span.spanStart(freshName))
+        StatementList(
+          List(SingleAssignment(e, "=", tmp)(e.span)) ++
+            goCase(Some(tmp))
+        )(node.span)
+      }
+      .getOrElse(StatementList(goCase(None))(node.span))
     astsForStatement(generatedNode)
   }
-
 
   protected def astForStatementList(node: StatementList): Ast = {
     val block = blockNode(node)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -57,7 +57,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
     val classBodyAsts = classBody.statements.flatMap(astsForStatement) match {
       case bodyAsts if shouldGenerateDefaultConstructorStack.head =>
-        val bodyStart  = classBody.span.spanStart
+        val bodyStart  = classBody.span.spanStart()
         val initBody   = StatementList(List())(bodyStart)
         val methodDecl = astForMethodDeclaration(MethodDeclaration("<init>", List(), initBody)(bodyStart))
         methodDecl :: bodyAsts

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/FreshVariableCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/FreshVariableCreator.scala
@@ -5,7 +5,7 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 
 trait FreshVariableCreator { this: AstCreator =>
   // This is in a single-threaded context.
-  var tmpCounter: Int = 0
+  var tmpCounter: Int                      = 0
   private def tmpTemplate(id: Int): String = s"<tmp-${id}>"
   protected def freshName: String = {
     val name = tmpTemplate(tmpCounter)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/FreshVariableCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/FreshVariableCreator.scala
@@ -1,0 +1,15 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.rubysrc2cpg.astcreation.AstCreator
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
+
+trait FreshVariableCreator { this: AstCreator =>
+  // This is in a single-threaded context.
+  var tmpCounter: Int = 0
+  private def tmpTemplate(id: Int): String = s"<tmp-${id}>"
+  protected def freshName: String = {
+    val name = tmpTemplate(tmpCounter)
+    tmpCounter += 1
+    name
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -9,7 +9,7 @@ object RubyIntermediateAst {
     columnEnd: Option[Integer],
     text: String
   ) {
-    def spanStart: TextSpan = TextSpan(line, column, line, column, "")
+    def spanStart(newText: String = ""): TextSpan = TextSpan(line, column, line, column, newText)
   }
 
   sealed class RubyNode(val span: TextSpan) {
@@ -118,6 +118,15 @@ object RubyIntermediateAst {
   final case class ConditionalExpression(condition: RubyNode, trueBranch: RubyNode, falseBranch: RubyNode)(
     span: TextSpan
   ) extends RubyNode(span)
+
+  final case class CaseExpression(expression: Option[RubyNode], whenClauses: List[RubyNode], elseClause: Option[RubyNode])(
+    span: TextSpan
+  ) extends RubyNode(span)
+
+  final case class WhenClause(matchExpressions: List[RubyNode], thenClause: Option[RubyNode])(
+    span: TextSpan
+  ) extends RubyNode(span)
+
 
   final case class ReturnExpression(expressions: List[RubyNode])(span: TextSpan) extends RubyNode(span)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -119,14 +119,15 @@ object RubyIntermediateAst {
     span: TextSpan
   ) extends RubyNode(span)
 
-  final case class CaseExpression(expression: Option[RubyNode], whenClauses: List[RubyNode], elseClause: Option[RubyNode])(
-    span: TextSpan
-  ) extends RubyNode(span)
+  final case class CaseExpression(
+    expression: Option[RubyNode],
+    whenClauses: List[RubyNode],
+    elseClause: Option[RubyNode]
+  )(span: TextSpan)
+      extends RubyNode(span)
 
-  final case class WhenClause(matchExpressions: List[RubyNode], thenClause: Option[RubyNode])(
-    span: TextSpan
-  ) extends RubyNode(span)
-
+  final case class WhenClause(matchExpressions: List[RubyNode], thenClause: Option[RubyNode])(span: TextSpan)
+      extends RubyNode(span)
 
   final case class ReturnExpression(expressions: List[RubyNode])(span: TextSpan) extends RubyNode(span)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -28,6 +28,7 @@ object RubyIntermediateAst {
     def asStatementList = node match
       case stmtList: StatementList => stmtList
       case _                       => StatementList(List(node))(node.span)
+
   }
 
   final case class Unknown()(span: TextSpan) extends RubyNode(span)
@@ -126,7 +127,11 @@ object RubyIntermediateAst {
   )(span: TextSpan)
       extends RubyNode(span)
 
-  final case class WhenClause(matchExpressions: List[RubyNode], thenClause: Option[RubyNode])(span: TextSpan)
+  final case class WhenClause(
+    matchExpressions: List[RubyNode],
+    matchSplatExpression: Option[RubyNode],
+    thenClause: RubyNode
+  )(span: TextSpan)
       extends RubyNode(span)
 
   final case class ReturnExpression(expressions: List[RubyNode])(span: TextSpan) extends RubyNode(span)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -569,24 +569,26 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitCaseWithExpression(ctx: RubyParser.CaseWithExpressionContext): RubyNode = {
-    val expression = Option(ctx.commandOrPrimaryValue()).map(visit)
+    val expression  = Option(ctx.commandOrPrimaryValue()).map(visit)
     val whenClauses = Option(ctx.whenClause().asScala).fold(List())(_.map(visit).toList)
-    val elseClause = Option(ctx.elseClause()).map(visit)
+    val elseClause  = Option(ctx.elseClause()).map(visit)
     CaseExpression(expression, whenClauses, elseClause)(ctx.toTextSpan)
   }
 
   override def visitCaseWithoutExpression(ctx: RubyParser.CaseWithoutExpressionContext): RubyNode = {
-    val expression = None
+    val expression  = None
     val whenClauses = Option(ctx.whenClause().asScala).fold(List())(_.map(visit).toList)
-    val elseClause = Option(ctx.elseClause()).map(visit)
+    val elseClause  = Option(ctx.elseClause()).map(visit)
     CaseExpression(expression, whenClauses, elseClause)(ctx.toTextSpan)
   }
 
   override def visitWhenClause(ctx: RubyParser.WhenClauseContext): RubyNode = {
-    val matchArgs = Option(ctx.whenArgument()).iterator.flatMap(arg => 
-        Option(arg.operatorExpressionList()).iterator.flatMap(_.operatorExpression().asScala).map(visit) ++ 
-        Option(arg.splattingArgument()).map(visit).iterator
-    ).toList
+    val matchArgs = Option(ctx.whenArgument()).iterator
+      .flatMap(arg =>
+        Option(arg.operatorExpressionList()).iterator.flatMap(_.operatorExpression().asScala).map(visit) ++
+          Option(arg.splattingArgument()).map(visit).iterator
+      )
+      .toList
     val thenClause = Option(ctx.thenClause()).map(visit)
     WhenClause(matchArgs, thenClause)(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -7,9 +7,6 @@ import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import org.antlr.v4.runtime.tree.{ErrorNode, ParseTree, TerminalNode}
 
 import scala.jdk.CollectionConverters.*
-import io.joern.rubysrc2cpg.parser.RubyParser.RescueClauseContext
-import io.joern.rubysrc2cpg.parser.RubyParser.EnsureClauseContext
-import io.joern.rubysrc2cpg.parser.RubyParser.ExceptionClassListContext
 import org.antlr.v4.runtime.tree.RuleNode
 
 /** Converts an ANTLR Ruby Parse Tree into the intermediate Ruby AST.
@@ -555,20 +552,43 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     }
   }
 
-  override def visitExceptionClassList(ctx: ExceptionClassListContext): RubyNode = {
+  override def visitExceptionClassList(ctx: RubyParser.ExceptionClassListContext): RubyNode = {
     // Requires implementing multiple rhs with splatting
     Unknown()(ctx.toTextSpan)
   }
 
-  override def visitRescueClause(ctx: RescueClauseContext): RubyNode = {
+  override def visitRescueClause(ctx: RubyParser.RescueClauseContext): RubyNode = {
     val exceptionClassList = Option(ctx.exceptionClassList).map(visit)
     val elseClause         = Option(ctx.exceptionVariableAssignment).map(visit)
     val thenClause         = visit(ctx.thenClause)
     RescueClause(exceptionClassList, elseClause, thenClause)(ctx.toTextSpan)
   }
 
-  override def visitEnsureClause(ctx: EnsureClauseContext): RubyNode = {
+  override def visitEnsureClause(ctx: RubyParser.EnsureClauseContext): RubyNode = {
     EnsureClause(visit(ctx.compoundStatement()))(ctx.toTextSpan)
+  }
+
+  override def visitCaseWithExpression(ctx: RubyParser.CaseWithExpressionContext): RubyNode = {
+    val expression = Option(ctx.commandOrPrimaryValue()).map(visit)
+    val whenClauses = Option(ctx.whenClause().asScala).fold(List())(_.map(visit).toList)
+    val elseClause = Option(ctx.elseClause()).map(visit)
+    CaseExpression(expression, whenClauses, elseClause)(ctx.toTextSpan)
+  }
+
+  override def visitCaseWithoutExpression(ctx: RubyParser.CaseWithoutExpressionContext): RubyNode = {
+    val expression = None
+    val whenClauses = Option(ctx.whenClause().asScala).fold(List())(_.map(visit).toList)
+    val elseClause = Option(ctx.elseClause()).map(visit)
+    CaseExpression(expression, whenClauses, elseClause)(ctx.toTextSpan)
+  }
+
+  override def visitWhenClause(ctx: RubyParser.WhenClauseContext): RubyNode = {
+    val matchArgs = Option(ctx.whenArgument()).iterator.flatMap(arg => 
+        Option(arg.operatorExpressionList()).iterator.flatMap(_.operatorExpression().asScala).map(visit) ++ 
+        Option(arg.splattingArgument()).map(visit).iterator
+    ).toList
+    val thenClause = Option(ctx.thenClause()).map(visit)
+    WhenClause(matchArgs, thenClause)(ctx.toTextSpan)
   }
 
   override def visitAssociationKey(ctx: RubyParser.AssociationKeyContext): RubyNode = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -1,0 +1,37 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class CaseTests extends RubyCode2CpgFixture {
+  "`case x ... end` should be represented with" in {
+    val cpg = code("""
+      |case 0
+      |  when 0 
+      |    0
+      |  when 1 then 1
+      |end
+      |""".stripMargin)
+
+    cpg.method(":program").dotAst.foreach(println)
+  }
+
+  "`case ... end` without expression" in {
+    val cpg = code("""
+      |case
+      |  when true then 1
+      |end
+      |""".stripMargin)
+
+  }
+
+  "case with else" in {
+    val cpg = code("""
+      |case 0
+      |  when 1 then 1
+      |  else 0
+      |end
+      |""".stripMargin)
+
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -2,36 +2,75 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.codepropertygraph.generated.nodes.*
 
 class CaseTests extends RubyCode2CpgFixture {
-  "`case x ... end` should be represented with" in {
+  "`case x ... end` should be represented with if-else chain" in {
     val cpg = code("""
       |case 0
       |  when 0 
       |    0
-      |  when 1 then 1
+      |  when 1,2 then 1
+      |  when 3, *[4,5] then 2
+      |  when *[6] then 3
+      |  else 4
       |end
       |""".stripMargin)
 
-    cpg.method(":program").dotAst.foreach(println)
+    val block@List(_) = cpg.method(":program").block.astChildren.isBlock.l
+
+    val List(assign) = block.astChildren.assignment.l;
+    val List(lhs, rhs) = assign.argument.l
+
+    List(lhs).isCall.name.l shouldBe List("<tmp-0>")
+    List(rhs).isLiteral.code.l shouldBe List("0")
+
+    val headIf@List(_) = block.astChildren.isControlStructure.l
+    val ifStmts@List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
+    val conds: List[List[String]] = ifStmts.condition.map { cond =>
+      val orConds = List(cond).repeat(_.isCall.where(_.name("<operator>.logicalOr")).argument)(_.emit(_.whereNot(_.isCall.name("<operator>.logicalOr")))).l
+      orConds.map { 
+        case u: Unknown => "unknown"
+        case mExpr =>
+          val call@List(_) = List(mExpr).isCall.l
+          call.methodFullName.l shouldBe List("===")
+          val List(lhs, rhs) = call.argument.l
+          rhs.code shouldBe "<tmp-0>"
+          val List(code) = List(lhs).isCall.argument(1).code.l
+          code
+      }.l
+    }.l
+    conds shouldBe List(List("0"), List("1", "2"), List("3", "unknown"), List("unknown"))
+    val matchResults = ifStmts.astChildren.order(2).astChildren ++ ifStmts.last.astChildren.order(3).astChildren
+    matchResults.code.l shouldBe List("0", "1", "2", "3", "4")
   }
 
   "`case ... end` without expression" in {
     val cpg = code("""
       |case
+      |  when false, true then 0
       |  when true then 1
+      |  when false, *[false,false] then 2
+      |  when *[false, true] then 3
       |end
       |""".stripMargin)
 
-  }
+    val block@List(_) = cpg.method(":program").block.astChildren.isBlock.l
 
-  "case with else" in {
-    val cpg = code("""
-      |case 0
-      |  when 1 then 1
-      |  else 0
-      |end
-      |""".stripMargin)
+    val headIf@List(_) = block.astChildren.isControlStructure.l
+    val ifStmts@List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
+    val conds: List[List[String]] = ifStmts.condition.map { cond =>
+      val orConds = List(cond).repeat(_.isCall.where(_.name("<operator>.logicalOr")).argument)(_.emit(_.whereNot(_.isCall.name("<operator>.logicalOr")))).l
+      orConds.map {
+        case u: Unknown => "unknown"
+        case c => c.code
+      }
+    }.l
+    conds shouldBe List(List("false", "true"), List("true"), List("false", "unknown"), List("unknown")) 
 
+    val matchResults = ifStmts.astChildren.order(2).astChildren.l
+    matchResults.code.l shouldBe List("0", "1", "2", "3")
+
+    ifStmts.last.astChildren.order(3).l shouldBe List()
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -30,8 +30,8 @@ class CaseTests extends RubyCode2CpgFixture {
     val ifStmts @ List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
     val conds: List[List[String]] = ifStmts.condition.map { cond =>
       val orConds = List(cond)
-        .repeat(_.isCall.where(_.name("<operator>.logicalOr")).argument)(
-          _.emit(_.whereNot(_.isCall.name("<operator>.logicalOr")))
+        .repeat(_.isCall.where(_.name(Operators.logicalOr)).argument)(
+          _.emit(_.whereNot(_.isCall.name(Operators.logicalOr)))
         )
         .l
       orConds.map {
@@ -72,8 +72,8 @@ class CaseTests extends RubyCode2CpgFixture {
     val ifStmts @ List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
     val conds: List[List[String]] = ifStmts.condition.map { cond =>
       val orConds = List(cond)
-        .repeat(_.isCall.where(_.name("<operator>.logicalOr")).argument)(
-          _.emit(_.whereNot(_.isCall.name("<operator>.logicalOr")))
+        .repeat(_.isCall.where(_.name(Operators.logicalOr)).argument)(
+          _.emit(_.whereNot(_.isCall.name(Operators.logicalOr)))
         )
         .l
       orConds.map {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 
 class CaseTests extends RubyCode2CpgFixture {
-  "`case x ... end` should be represented with if-else chain" in {
+  "`case x ... end` should be represented with if-else chain and multiple match expressions should be or-ed together" in {
     val cpg = code("""
       |case 0
       |  when 0 
@@ -17,22 +17,26 @@ class CaseTests extends RubyCode2CpgFixture {
       |end
       |""".stripMargin)
 
-    val block@List(_) = cpg.method(":program").block.astChildren.isBlock.l
+    val block @ List(_) = cpg.method(":program").block.astChildren.isBlock.l
 
-    val List(assign) = block.astChildren.assignment.l;
+    val List(assign)   = block.astChildren.assignment.l;
     val List(lhs, rhs) = assign.argument.l
 
     List(lhs).isCall.name.l shouldBe List("<tmp-0>")
     List(rhs).isLiteral.code.l shouldBe List("0")
 
-    val headIf@List(_) = block.astChildren.isControlStructure.l
-    val ifStmts@List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
+    val headIf @ List(_)           = block.astChildren.isControlStructure.l
+    val ifStmts @ List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
     val conds: List[List[String]] = ifStmts.condition.map { cond =>
-      val orConds = List(cond).repeat(_.isCall.where(_.name("<operator>.logicalOr")).argument)(_.emit(_.whereNot(_.isCall.name("<operator>.logicalOr")))).l
-      orConds.map { 
+      val orConds = List(cond)
+        .repeat(_.isCall.where(_.name("<operator>.logicalOr")).argument)(
+          _.emit(_.whereNot(_.isCall.name("<operator>.logicalOr")))
+        )
+        .l
+      orConds.map {
         case u: Unknown => "unknown"
         case mExpr =>
-          val call@List(_) = List(mExpr).isCall.l
+          val call @ List(_) = List(mExpr).isCall.l
           call.methodFullName.l shouldBe List("===")
           val List(lhs, rhs) = call.argument.l
           rhs.code shouldBe "<tmp-0>"
@@ -55,18 +59,22 @@ class CaseTests extends RubyCode2CpgFixture {
       |end
       |""".stripMargin)
 
-    val block@List(_) = cpg.method(":program").block.astChildren.isBlock.l
+    val block @ List(_) = cpg.method(":program").block.astChildren.isBlock.l
 
-    val headIf@List(_) = block.astChildren.isControlStructure.l
-    val ifStmts@List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
+    val headIf @ List(_)           = block.astChildren.isControlStructure.l
+    val ifStmts @ List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
     val conds: List[List[String]] = ifStmts.condition.map { cond =>
-      val orConds = List(cond).repeat(_.isCall.where(_.name("<operator>.logicalOr")).argument)(_.emit(_.whereNot(_.isCall.name("<operator>.logicalOr")))).l
+      val orConds = List(cond)
+        .repeat(_.isCall.where(_.name("<operator>.logicalOr")).argument)(
+          _.emit(_.whereNot(_.isCall.name("<operator>.logicalOr")))
+        )
+        .l
       orConds.map {
         case u: Unknown => "unknown"
-        case c => c.code
+        case c          => c.code
       }
     }.l
-    conds shouldBe List(List("false", "true"), List("true"), List("false", "unknown"), List("unknown")) 
+    conds shouldBe List(List("false", "true"), List("true"), List("false", "unknown"), List("unknown"))
 
     val matchResults = ifStmts.astChildren.order(2).astChildren.l
     matchResults.code.l shouldBe List("0", "1", "2", "3")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.Operators
 
 class CaseTests extends RubyCode2CpgFixture {
   "`case x ... end` should be represented with if-else chain and multiple match expressions should be or-ed together" in {


### PR DESCRIPTION
This draft translates ruby `case` expressions into `if-elif-...-else-end` chains. 

The expression matched against is assigned a temporary variable `<tmp-#>` where # is a number. I was not sure on the convention but I wanted to be sure the variable is always fresh.

A single when can contain a list of expressions to match against, which I translate into an `or-expression` if there is more than one. When matching against an expression `mExpr`, it is turned into a condition with `mExpr.=== <tmp-#>`.

This list of expressions can contain a splat at the end, which we aren't handling yet.

It also remains maybe to special case to a switch ast if all match expressions are literals.

TextSpans for the generated intermediate ast are not sane and will need to be considered more carefully.

Sanity checking, unit tests and more documentation remain to be done.