### PR TITLE
FieldAccessLinkerPass Use Same Name Check as `cpg.fieldAccess`

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/typerelations/FieldAccessLinkerPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/typerelations/FieldAccessLinkerPass.scala
@@ -6,7 +6,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Member, StoredNode}
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
+import io.shiftleft.semanticcpg.language.operatorextension.{OpNodes, allFieldAccessTypes}
 import io.shiftleft.semanticcpg.utils.MemberAccess
 import org.slf4j.LoggerFactory
 
@@ -33,7 +33,7 @@ class FieldAccessLinkerPass(cpg: Cpg) extends CpgPass(cpg) with LinkingUtil {
   }
 
   private def dstMemberFullNames(call: Call): Seq[String] = {
-    if (MemberAccess.isFieldAccess(call.name) && name != Operators.indexAccess) {
+    if (allFieldAccessTypes.contains(call.name)) {
       val fieldAccess = call.asInstanceOf[OpNodes.FieldAccess]
       fieldAccess.argumentOption(1) match
         case Some(baseNode) =>


### PR DESCRIPTION
This fixes the incompatible field access operations from entering the `FieldAccessLinkerPass.dstMemberFullNames` by using the same name set as `cpg.fieldAccess`.

Follows from #4026