### PR TITLE
javasrc2cpg - workaround for failing to resolve a method parameter's type

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -219,6 +219,12 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
       typeInfoCalc
         .fullName(parameter.getType)
         .orElse(scope.lookupType(parameter.getTypeAsString))
+        // In a scenario where we have an import of an external type e.g. `import foo.bar.Baz` and
+        // this parameter's type is e.g. `Baz<String>`, the lookup will fail. However, if we lookup
+        // for `Baz` instead (i.e. without type arguments), then the lookup will succeed.
+        .orElse(
+          Try(parameter.getType.asClassOrInterfaceType).toOption.flatMap(t => scope.lookupType(t.getNameAsString))
+        )
         .map(_ ++ maybeArraySuffix)
         .getOrElse(s"${Defines.UnresolvedNamespace}.${parameter.getTypeAsString}")
     val evalStrat =

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
@@ -135,4 +135,46 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
       }
     }
   }
+
+  "imported method parameter's external, non-generic type" should {
+    val cpg = code("""
+        |import foo.bar.Baz;
+        |class Main {
+        | void run(Baz p1) {}
+        |}
+        |""".stripMargin)
+
+    "have correct type for parameter p1" in {
+      val List(param) = cpg.method.name("run").parameter.name("p1").l
+      param.typeFullName shouldBe "foo.bar.Baz"
+    }
+  }
+
+  "imported method parameter's internal, generic type" should {
+    val cpg = code("""
+        |import java.util.*;
+        |class Main {
+        | void run(List<String> p1) {}
+        |}
+        |""".stripMargin)
+
+    "have correct type for parameter p1" in {
+      val List(param) = cpg.method.name("run").parameter.name("p1").l
+      param.typeFullName shouldBe "java.util.List"
+    }
+  }
+
+  "imported method parameter's external, generic type" should {
+    val cpg = code("""
+        |import foo.bar.Baz;
+        |class Main {
+        |  void run(Baz<String> p1) {}
+        |}
+        |""".stripMargin)
+
+    "have correct type for parameter p1" in {
+      val List(param) = cpg.method.name("run").parameter.name("p1").l
+      param.typeFullName shouldBe "foo.bar.Baz"
+    }
+  }
 }


### PR DESCRIPTION
Noticed the following discrepancy w.r.t. a method parameter's type.

If a method's parameter type is (e.g.):

1. `List`, and we have no appropriate import, it resolves to `<unresolvedNamespace>.List`
2. `List`, and we have some kind of import (e.g. `import foo.List`), it resolves to `foo.List`
3. `List<String>`, and we have no appropriate import, it resolves to `<unresolvedNamespace>.List<String>` 
4. `List<String>`, and we have some kind of import (e.g. `import foo.List`), it resolves to `<unresolvedNamespace>.List<String>`

Comparing 1-2 vs 3-4, we see that when a type has type arguments, it may fail to resolve in a situation where it wouldn't fail if it had none. This PR makes it so that 4. resolves to `foo.List`.

There might be some valid reason we shouldn't do this that I'm not aware of. In the unit-tests provided, only the last one (lines 167-179) would originally fail.
