### PR TITLE
javasrc2cpg - workaround for failing to resolve a method's external return type when it contains external type arguments

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
@@ -103,3 +103,75 @@ class MethodTests3 extends JavaSrcCode2CpgFixture {
     cpg.method("virtualMethod").isVirtual.fullName.head shouldBe "Foo.virtualMethod:void(java.lang.Integer)"
   }
 }
+
+class MethodTests4 extends JavaSrcCode2CpgFixture {
+
+  "List<String> in the method return type" should {
+    val cpg = code("""
+        |import java.util.*;
+        |class Foo {
+        | List<String> run() {
+        |   return null;
+        | }
+        |}
+        |""".stripMargin)
+
+    "have correct signature and full name" in {
+      val List(method) = cpg.method("run").l
+      method.signature shouldBe "java.util.List()"
+      method.fullName shouldBe "Foo.run:java.util.List()"
+    }
+  }
+
+  "Baz<String> in the method return type" should {
+    val cpg = code("""
+        |import foo.bar.Baz;
+        |class Foo {
+        | Baz<String> run() {
+        |   return null;
+        | }
+        |}
+        |""".stripMargin)
+
+    "have correct signature and full name" in {
+      val List(method) = cpg.method("run").l
+      method.signature shouldBe "foo.bar.Baz()"
+      method.fullName shouldBe "Foo.run:foo.bar.Baz()"
+    }
+  }
+
+  "Identity method for Baz<String>" should {
+    val cpg = code("""
+        |import foo.bar.Baz;
+        |class Foo {
+        | Baz<String> run(Baz<String> x) {
+        |   return x;
+        | }
+        |}
+        |""".stripMargin)
+
+    "have correct signature and full name" in {
+      val List(method) = cpg.method("run").l
+      method.signature shouldBe "foo.bar.Baz(foo.bar.Baz)"
+      method.fullName shouldBe "Foo.run:foo.bar.Baz(foo.bar.Baz)"
+    }
+  }
+
+  "Generic identity method for Baz<T>" should {
+    val cpg = code("""
+        |import foo.bar.Baz;
+        |class Foo {
+        | <T> Baz<T> run(Baz<T> x) {
+        |   return x;
+        | }
+        |}
+        |""".stripMargin)
+
+    "have correct signature and full name" in {
+      val List(method) = cpg.method("run").l
+      method.signature shouldBe "foo.bar.Baz(foo.bar.Baz)"
+      method.fullName shouldBe "Foo.run:foo.bar.Baz(foo.bar.Baz)"
+    }
+  }
+
+}


### PR DESCRIPTION
This is a continuation of #4037, but this time relative to a method's return type - the same discrepancy is observed.

Missing from that same PR was the handling of method parameters from a `ResolvedMethodLikeDeclaration` in `calcParameterTypes`. 

I'm not proud of applying the same fix twice, but I don't see a good way around the handling of ordinary parameters and parameters from a `ResolvedMethodLikeDeclaration` without uncomfortable drastic changes, so I even reused the comment. Let me know if you can think of a better way.