### PR TITLE
Properly handle python sub module imports.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
@@ -16,7 +16,7 @@ class ImportsPass(cpg: Cpg) extends XImportsPass(cpg) {
     call.argument.code.l match {
       case List("", what)       => what.split('.')(0)
       case List(where, what)    => s"$where.$what"
-      case List("", what, _)    => what.split('.')(0)
+      case List("", what, _)    => what
       case List(where, what, _) => s"$where.$what"
       case _                    => ""
     }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ImportsPass.scala
@@ -14,9 +14,9 @@ class ImportsPass(cpg: Cpg) extends XImportsPass(cpg) {
 
   override def importedEntityFromCall(call: Call): String = {
     call.argument.code.l match {
-      case List("", what)       => what
+      case List("", what)       => what.split('.')(0)
       case List(where, what)    => s"$where.$what"
-      case List("", what, _)    => what
+      case List("", what, _)    => what.split('.')(0)
       case List(where, what, _) => s"$where.$what"
       case _                    => ""
     }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -61,8 +61,11 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
     val importAssignNodes =
       names.map { alias =>
         val importedAsIdentifierName = alias.asName.getOrElse(alias.name)
+
+        val nameParts = importedAsIdentifierName.split('.')
+
         val importAssignLhsIdentifierNode =
-          createIdentifierNode(importedAsIdentifierName, Store, lineAndCol)
+          createIdentifierNode(nameParts(0), Store, lineAndCol)
 
         val arguments = Seq(
           nodeBuilder.stringLiteralNode(from, lineAndCol),

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -67,10 +67,6 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
         val importAssignLhsIdentifierNode =
           createIdentifierNode(nameParts(0), Store, lineAndCol)
 
-        // To enable compatibility with the downstream import resolver, we set the full path to the
-        // `name` property of the identifier
-        importAssignLhsIdentifierNode.name(importedAsIdentifierName)
-
         val arguments = Seq(
           nodeBuilder.stringLiteralNode(from, lineAndCol),
           nodeBuilder.stringLiteralNode(alias.name, lineAndCol)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -67,6 +67,10 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
         val importAssignLhsIdentifierNode =
           createIdentifierNode(nameParts(0), Store, lineAndCol)
 
+        // To enable compatibility with the downstream import resolver, we set the full path to the
+        // `name` property of the identifier
+        importAssignLhsIdentifierNode.name(importedAsIdentifierName)
+
         val arguments = Seq(
           nodeBuilder.stringLiteralNode(from, lineAndCol),
           nodeBuilder.stringLiteralNode(alias.name, lineAndCol)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonImportResolverPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonImportResolverPass.scala
@@ -83,8 +83,7 @@ class PythonImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
       resolvedImports.foreach(x => evaluatedImportToTag(x, importCall, diffGraph))
     } else {
       // Here we use heuristics to guess the correct paths, and make the types look friendly for querying
-      createPseudoImports(importedEntity, importedAs)
-        .foreach(x => evaluatedImportToTag(x, importCall, diffGraph))
+      createPseudoImports(importedEntity, importedAs).map(x => evaluatedImportToTag(x, importCall, diffGraph)).l
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonImportResolverPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonImportResolverPass.scala
@@ -53,19 +53,13 @@ class PythonImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
   override protected def optionalResolveImport(
     fileName: String,
     importCall: Call,
-    _importedEntity: String,
-    _importedAs: String,
+    importedEntity: String,
+    importedAs: String,
     diffGraph: DiffGraphBuilder
   ): Unit = {
     val currDir = File(codeRootDir) / fileName match
       case x if x.isDirectory => x
       case x                  => x.parent
-
-    val importedEntity = importCall.argument.code.l match
-      case List("", what) => what
-      case _              => _importedEntity
-
-    val importedAs = importCall.inAssignment.target.isIdentifier.name.headOption.getOrElse(_importedAs)
 
     val importedEntityAsFullyQualifiedImport =
       // If the path/entity uses Python's `from .import x` syntax, we will need to remove these

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonImportResolverPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonImportResolverPass.scala
@@ -89,7 +89,8 @@ class PythonImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
       resolvedImports.foreach(x => evaluatedImportToTag(x, importCall, diffGraph))
     } else {
       // Here we use heuristics to guess the correct paths, and make the types look friendly for querying
-      createPseudoImports(importedEntity, importedAs).map(x => evaluatedImportToTag(x, importCall, diffGraph)).l
+      createPseudoImports(importedEntity, importedAs)
+        .foreach(x => evaluatedImportToTag(x, importCall, diffGraph))
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -46,9 +46,9 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     }
 
   override def visitImport(i: Import): Unit = {
-    i.importedAs.foreach { importedAs =>
-      val entityName = i.isCallForImportIn.inAssignment.target.isIdentifier.name.headOption.getOrElse(importedAs)
+    if (i.importedAs.isDefined && i.importedEntity.isDefined) {
 
+      val entityName = i.importedAs.get
       i.call.tag.flatMap(EvaluatedImport.tagToEvaluatedImport).foreach {
         case ResolvedMethod(fullName, alias, receiver, _) => symbolTable.put(CallAlias(alias, receiver), fullName)
         case ResolvedTypeDecl(fullName, _)                => symbolTable.put(LocalVar(entityName), fullName)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonTypeRecovery.scala
@@ -46,9 +46,9 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
     }
 
   override def visitImport(i: Import): Unit = {
-    if (i.importedAs.isDefined && i.importedEntity.isDefined) {
+    i.importedAs.foreach { importedAs =>
+      val entityName = i.isCallForImportIn.inAssignment.target.isIdentifier.name.headOption.getOrElse(importedAs)
 
-      val entityName = i.importedAs.get
       i.call.tag.flatMap(EvaluatedImport.tagToEvaluatedImport).foreach {
         case ResolvedMethod(fullName, alias, receiver, _) => symbolTable.put(CallAlias(alias, receiver), fullName)
         case ResolvedTypeDecl(fullName, _)                => symbolTable.put(LocalVar(entityName), fullName)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ImportCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ImportCpgTests.scala
@@ -36,4 +36,18 @@ class ImportCpgTests extends AnyFreeSpec with Matchers {
     importedEntity.code shouldBe "a.b"
   }
 
+  "test 'from ... import' statement with hierarchical name" in {
+    lazy val cpg = Py2CpgTestContext.buildCpg("""from a.b import c""".stripMargin)
+    val assignment = cpg.call.code(".*=.*import.*").l
+
+    val lhsIdentifier = assignment.argument(1).isIdentifier.head
+    lhsIdentifier.code shouldBe "c"
+
+    val fromLiteral = assignment.argument(2).isCall.argument(1).head
+    fromLiteral.code shouldBe "a.b"
+
+    val importedEntity = assignment.argument(2).isCall.argument(2).head
+    importedEntity.code shouldBe "c"
+  }
+
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ImportCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ImportCpgTests.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class ImportCpgTests extends AnyFreeSpec with Matchers {
 
   "test plain import statement" in {
-    lazy val cpg = Py2CpgTestContext.buildCpg("""import a""".stripMargin)
+    lazy val cpg   = Py2CpgTestContext.buildCpg("""import a""".stripMargin)
     val assignment = cpg.call.code(".*=.*import.*").l
 
     val lhsIdentifier = assignment.argument(1).isIdentifier.head
@@ -23,7 +23,7 @@ class ImportCpgTests extends AnyFreeSpec with Matchers {
   }
 
   "test plain import statement with hierarchical name" in {
-    lazy val cpg = Py2CpgTestContext.buildCpg("""import a.b""".stripMargin)
+    lazy val cpg   = Py2CpgTestContext.buildCpg("""import a.b""".stripMargin)
     val assignment = cpg.call.code(".*=.*import.*").l
 
     val lhsIdentifier = assignment.argument(1).isIdentifier.head
@@ -37,7 +37,7 @@ class ImportCpgTests extends AnyFreeSpec with Matchers {
   }
 
   "test 'from ... import' statement with hierarchical name" in {
-    lazy val cpg = Py2CpgTestContext.buildCpg("""from a.b import c""".stripMargin)
+    lazy val cpg   = Py2CpgTestContext.buildCpg("""from a.b import c""".stripMargin)
     val assignment = cpg.call.code(".*=.*import.*").l
 
     val lhsIdentifier = assignment.argument(1).isIdentifier.head

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ImportCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ImportCpgTests.scala
@@ -1,0 +1,39 @@
+package io.joern.pysrc2cpg.cpg
+
+import io.joern.pysrc2cpg.Py2CpgTestContext
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language.*
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ImportCpgTests extends AnyFreeSpec with Matchers {
+
+  "test plain import statement" in {
+    lazy val cpg = Py2CpgTestContext.buildCpg("""import a""".stripMargin)
+    val assignment = cpg.call.code(".*=.*import.*").l
+
+    val lhsIdentifier = assignment.argument(1).isIdentifier.head
+    lhsIdentifier.code shouldBe "a"
+
+    val fromLiteral = assignment.argument(2).isCall.argument(1).head
+    fromLiteral.code shouldBe ""
+
+    val importedEntity = assignment.argument(2).isCall.argument(2).head
+    importedEntity.code shouldBe "a"
+  }
+
+  "test plain import statement with hierarchical name" in {
+    lazy val cpg = Py2CpgTestContext.buildCpg("""import a.b""".stripMargin)
+    val assignment = cpg.call.code(".*=.*import.*").l
+
+    val lhsIdentifier = assignment.argument(1).isIdentifier.head
+    lhsIdentifier.code shouldBe "a"
+
+    val fromLiteral = assignment.argument(2).isCall.argument(1).head
+    fromLiteral.code shouldBe ""
+
+    val importedEntity = assignment.argument(2).isCall.argument(2).head
+    importedEntity.code shouldBe "a.b"
+  }
+
+}

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
@@ -1,0 +1,23 @@
+package io.joern.pysrc2cpg.cpg
+
+import io.joern.pysrc2cpg.Py2CpgTestContext
+import io.shiftleft.semanticcpg.language._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class MethodCpgTests extends AnyFreeSpec with Matchers {
+  "A method" - {
+
+    lazy val cpg = Py2CpgTestContext.buildCpg(
+      """
+        |def method():
+        |   pass
+        |""".stripMargin, "a/b.py")
+
+    "foo" in {
+      val method = cpg.method.name("method").head
+      method.fullName shouldBe "a/b.py:<module>.method"
+    }
+  }
+
+}

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
@@ -14,7 +14,7 @@ class MethodCpgTests extends AnyFreeSpec with Matchers {
         |   pass
         |""".stripMargin, "a/b.py")
 
-    "foo" in {
+    "test method full name" in {
       val method = cpg.method.name("method").head
       method.fullName shouldBe "a/b.py:<module>.method"
     }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
@@ -12,7 +12,9 @@ class MethodCpgTests extends AnyFreeSpec with Matchers {
       """
         |def method():
         |   pass
-        |""".stripMargin, "a/b.py")
+        |""".stripMargin,
+      "a/b.py"
+    )
 
     "test method full name" in {
       val method = cpg.method.name("method").head

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -399,15 +399,15 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     "resolve correct imports via tag nodes" in {
       val List(error: UnknownImport, request: UnknownImport) =
         cpg.call.where(_.referencedImports).tag._toEvaluatedImport.toList: @unchecked
-      error.path shouldBe "urllib.py:<module>.error"
-      request.path shouldBe "urllib.py:<module>.request"
+      error.path shouldBe "urllib.py:<module>"
+      request.path shouldBe "urllib.py:<module>"
     }
 
     "reasonably determine the constructor type" in {
       val Some(tmp0) = cpg.identifier("tmp0").headOption: @unchecked
-      tmp0.typeFullName shouldBe "urllib.py:<module>.request"
+      tmp0.typeFullName shouldBe "urllib.py:<module>.<member>(request)"
       val Some(requestCall) = cpg.call("Request").headOption: @unchecked
-      requestCall.methodFullName shouldBe "urllib.py:<module>.request.Request.__init__"
+      requestCall.methodFullName shouldBe "urllib.py:<module>.<member>(request).Request.__init__"
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -399,15 +399,15 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     "resolve correct imports via tag nodes" in {
       val List(error: UnknownImport, request: UnknownImport) =
         cpg.call.where(_.referencedImports).tag._toEvaluatedImport.toList: @unchecked
-      error.path shouldBe "urllib.py:<module>"
-      request.path shouldBe "urllib.py:<module>"
+      error.path shouldBe "urllib.py:<module>.error"
+      request.path shouldBe "urllib.py:<module>.request"
     }
 
     "reasonably determine the constructor type" in {
       val Some(tmp0) = cpg.identifier("tmp0").headOption: @unchecked
-      tmp0.typeFullName shouldBe "urllib.py:<module>.<member>(request)"
+      tmp0.typeFullName shouldBe "urllib.py:<module>.request"
       val Some(requestCall) = cpg.call("Request").headOption: @unchecked
-      requestCall.methodFullName shouldBe "urllib.py:<module>.<member>(request).Request.__init__"
+      requestCall.methodFullName shouldBe "urllib.py:<module>.request.Request.__init__"
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -637,7 +637,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "be sufficient to resolve method full names at calls" in {
       val List(call) = cpg.call("query").l
-      call.methodFullName shouldBe "sqlalchemy.py:<module>.Session.query"
+      call.methodFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session.query").mkString(File.separator)
     }
 
   }
@@ -721,15 +721,15 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "with the correct identifier and call types" in {
       val Some(postCallReceiver) = cpg.identifier("db").headOption: @unchecked
-      postCallReceiver.typeFullName shouldBe "sqlalchemy.py:<module>.Session"
+      postCallReceiver.typeFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session").mkString(File.separator)
       val Some(postCall) = cpg.call("query").headOption: @unchecked
-      postCall.methodFullName shouldBe "sqlalchemy.py:<module>.Session.query"
+      postCall.methodFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session.query").mkString(File.separator)
     }
 
     "reflect these types as under the type full name" in {
       val List(p1, p2) = cpg.method("get_user_by_email").parameter.l
       p1.typeFullName shouldBe "__builtin.str"
-      p2.typeFullName shouldBe "sqlalchemy.py:<module>.Session"
+      p2.typeFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session").mkString(File.separator)
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -399,15 +399,15 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     "resolve correct imports via tag nodes" in {
       val List(error: UnknownImport, request: UnknownImport) =
         cpg.call.where(_.referencedImports).tag._toEvaluatedImport.toList: @unchecked
-      error.path shouldBe "urllib.py:<module>.error"
-      request.path shouldBe "urllib.py:<module>.request"
+      error.path shouldBe "urllib.py:<module>"
+      request.path shouldBe "urllib.py:<module>"
     }
 
     "reasonably determine the constructor type" in {
       val Some(tmp0) = cpg.identifier("tmp0").headOption: @unchecked
-      tmp0.typeFullName shouldBe "urllib.py:<module>.request"
+      tmp0.typeFullName shouldBe "urllib.py:<module>.<member>(request)"
       val Some(requestCall) = cpg.call("Request").headOption: @unchecked
-      requestCall.methodFullName shouldBe "urllib.py:<module>.request.Request.__init__"
+      requestCall.methodFullName shouldBe "urllib.py:<module>.<member>(request).Request.__init__"
     }
   }
 
@@ -637,7 +637,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "be sufficient to resolve method full names at calls" in {
       val List(call) = cpg.call("query").l
-      call.methodFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session.query").mkString(File.separator)
+      call.methodFullName shouldBe "sqlalchemy.py:<module>.Session.query"
     }
 
   }
@@ -721,15 +721,15 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     "with the correct identifier and call types" in {
       val Some(postCallReceiver) = cpg.identifier("db").headOption: @unchecked
-      postCallReceiver.typeFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session").mkString(File.separator)
+      postCallReceiver.typeFullName shouldBe "sqlalchemy.py:<module>.Session"
       val Some(postCall) = cpg.call("query").headOption: @unchecked
-      postCall.methodFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session.query").mkString(File.separator)
+      postCall.methodFullName shouldBe "sqlalchemy.py:<module>.Session.query"
     }
 
     "reflect these types as under the type full name" in {
       val List(p1, p2) = cpg.method("get_user_by_email").parameter.l
       p1.typeFullName shouldBe "__builtin.str"
-      p2.typeFullName shouldBe Seq("sqlalchemy", "orm.py:<module>.Session").mkString(File.separator)
+      p2.typeFullName shouldBe "sqlalchemy.py:<module>.Session"
     }
   }
 


### PR DESCRIPTION
Hierarchical imports like 'import a.b' are now represented correctly.

Do not yet merge.