### PR TITLE
[c2cpg] Use direct CDT dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ null
 **/SwiftAstGen-mac
 **/SwiftAstGen-linux
 **/php2cpg/bin
+**/c2cpg/lib
 /foo.c
 /woo.c
 /cpg_*.bin.zip

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -59,7 +59,7 @@ lazy val signingFiles = List("META-INF/ECLIPSE_.RSA", "META-INF/ECLIPSE_.SF")
  */
 lazy val removeSigningInfo = taskKey[Unit](s"Remove signing info from jar file")
 removeSigningInfo := {
-  if (!(baseDirectory.value / "lib" / s"$cdtCoreDepName.jar").exists)
+  if (!(unmanagedBase.value / s"$cdtCoreDepName.jar").exists)
     (Compile / managedClasspath).value.find(_.data.name.contains(cdtCoreDepName)) match {
       case Some(path) =>
         val jarPath    = path.data.absolutePath
@@ -82,7 +82,7 @@ removeSigningInfo := {
           jarInputStream.close()
           jarOutputStream.close()
 
-          val lib = baseDirectory.value / "lib"
+          val lib = unmanagedBase.value
           if (!lib.exists) IO.createDirectory(lib)
           IO.move(outputFile, lib / outputFile.name)
         } catch {

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -47,12 +47,18 @@ Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc
 compile / javacOptions ++= Seq("-Xlint:all", "-Xlint:-cast", "-g")
 Test / fork := true
 
+
+
 lazy val signingFiles   = List("META-INF/ECLIPSE_.RSA", "META-INF/ECLIPSE_.SF")
 lazy val cdtCoreDepName = "org.eclipse.cdt.core"
 
+/* Dirty hack: we access cdt-internal types which are package-private. In order to do so, 
+ * `MacroArgumentExtractor` from this repo is in the `org.eclipse.cdt.internal.core.parser.scanner` package.
+ * The cdt jar is signed to ensure that doesn't happen, but because we're stubborn and yolo we simply remove the signing files. 
+ */
 lazy val removeSigningInfo = taskKey[Unit](s"Remove signing info from jar file")
 removeSigningInfo := {
-  (Test / managedClasspath).value.find(v => v.data.name.contains(cdtCoreDepName)) match {
+  (Test / managedClasspath).value.find(_.data.name.contains(cdtCoreDepName)) match {
     case Some(path) =>
       val jarPath    = path.data.absolutePath
       val inputFile  = new File(jarPath)

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -95,7 +95,15 @@ removeSigningInfo := {
   }
 }
 
-Compile/compile := (Compile/compile).dependsOn(removeSigningInfo).value
+lazy val removeSigningInfoStartup: State => State = { s: State =>
+  "removeSigningInfo" :: s
+}
+Global / onLoad := {
+  val old = (Global / onLoad).value
+  removeSigningInfoStartup compose old
+}
+// removeSigningInfo := removeSigningInfo.triggeredBy(Global/onLoad).value
+// Compile/compile := (Compile/compile).dependsOn(removeSigningInfo).value
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
   "org.eclipse.platform"    % "org.eclipse.core.resources" % "3.20.0",
   "org.eclipse.platform"    % "org.eclipse.text"           % "3.13.100",
-  "org.eclipse.platform"    % "org.eclipse.cdt.core"       % cdtCoreDepVersion from cdtCodeDepUrl,
+  "org.eclipse.platform"    % "org.eclipse.cdt.core"       % cdtCoreDepVersion % Provided from cdtCodeDepUrl,
   "org.scalatest"          %% "scalatest"                  % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -1,11 +1,18 @@
 name := "c2cpg"
 
-dependsOn(Projects.semanticcpg, Projects.dataflowengineoss % "compile->compile;test->test", Projects.x2cpg % "compile->compile;test->test")
+dependsOn(
+  Projects.semanticcpg,
+  Projects.dataflowengineoss % "compile->compile;test->test",
+  Projects.x2cpg             % "compile->compile;test->test"
+)
 
 libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
-  "com.diffplug.spotless"   % "spotless-eclipse-cdt"       % "10.5.0",
-  "org.scalatest"          %% "scalatest"                  % Versions.scalatest % Test
+  "org.eclipse.platform"    % "org.eclipse.core.resources" % "3.20.0",
+  "org.eclipse.platform"    % "org.eclipse.text"           % "3.13.100",
+  "org.eclipse.platform"    % "org.eclipse.cdt.core"       % "8.4.0.202401051815"
+    from "https://ci.eclipse.org/cdt/job/cdt/job/main/lastSuccessfulBuild/artifact/releng/org.eclipse.cdt.repo/target/repository/plugins/org.eclipse.cdt.core_8.4.0.202401051815.jar",
+  "org.scalatest" %% "scalatest" % Versions.scalatest % Test
 )
 
 dependencyOverrides ++= Seq(

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -47,14 +47,12 @@ Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc
 compile / javacOptions ++= Seq("-Xlint:all", "-Xlint:-cast", "-g")
 Test / fork := true
 
-
-
 lazy val signingFiles   = List("META-INF/ECLIPSE_.RSA", "META-INF/ECLIPSE_.SF")
 lazy val cdtCoreDepName = "org.eclipse.cdt.core"
 
-/* Dirty hack: we access cdt-internal types which are package-private. In order to do so, 
+/* Dirty hack: we access cdt-internal types which are package-private. In order to do so,
  * `MacroArgumentExtractor` from this repo is in the `org.eclipse.cdt.internal.core.parser.scanner` package.
- * The cdt jar is signed to ensure that doesn't happen, but because we're stubborn and yolo we simply remove the signing files. 
+ * The cdt jar is signed to ensure that doesn't happen, but because we're stubborn and yolo we simply remove the signing files.
  */
 lazy val removeSigningInfo = taskKey[Unit](s"Remove signing info from jar file")
 removeSigningInfo := {


### PR DESCRIPTION
The currently used CDT dependency is > 3 years old and won't get any updates (the spotless project repacked CDT as standalone release because CDT itself isn't published via Maven).

We now use the packaged jar artifact from CDT's build server instead and unsign it.