### PR TITLE
[ruby] Handle Keyword Arguments

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -51,11 +51,13 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   // TODO: remaining cases
   protected def astForParameter(node: RubyNode, index: Int): Ast = {
     node match
-      case node: MandatoryParameter =>
+      case node: (MandatoryParameter | OptionalParameter) =>
+        val _code = code(node)
+        val name  = "^(\\w)+".r.findFirstMatchIn(_code).map(_.toString()).getOrElse(_code)
         val parameterIn = parameterInNode(
           node = node,
-          name = code(node),
-          code = code(node),
+          name = name,
+          code = _code,
           index = index,
           isVariadic = false,
           evaluationStrategy = EvaluationStrategies.BY_REFERENCE,


### PR DESCRIPTION
Keyword arguments are picked up as associations. This PR handles call arguments in a special way where associations are treated differently to use the `key` as the `argumentName` for the node generated by the `value`.

Additionally, added handling for `OptionalParameter`s and used regex to isolate the parameter name from the span (which includes the default value).

This is pretty basic, so is there anything I'm missing on the RHS of the named calls?

Resolves #3932