### PR TITLE
Python 3.12 support.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/pythonGrammar.jj
+++ b/joern-cli/frontends/pysrc2cpg/pythonGrammar.jj
@@ -1311,6 +1311,10 @@ ArrayList<istmt> simpleStatement(): {
         Match matchStmt = matchStmt(name);
         stmts.add(matchStmt);
         return stmts;
+      } else if (name.id().equals("type")) {
+        TypeAlias typeAlias = typeAlias(name);
+        stmts.add(typeAlias);
+        return stmts;
       }
     } catch (ParseException printException) {
       // If something goes wrong trying to parse as python2 or match
@@ -1405,10 +1409,10 @@ iexpr starNamedExpression(): {
 }
 
 // "match" is a so called "soft" keyword introduced in Python 3.10.
-// Only in the specific pattern match statment constellation it is
+// Only in the specific pattern match statement constellation it is
 // considered a keyword and otherwise it is a regular NAME token
 // which means we cannot have something like a MATCH token.
-Match matchStmt(Name matchName): {
+Match matchStmt(Name matchKeyword): {
   ArrayList<iexpr> expressions = new ArrayList<>();
   iexpr subjectExpr;
   boolean isTuple = false;
@@ -1441,7 +1445,7 @@ Match matchStmt(Name matchName): {
   )+
   (<DEDENT> | <EOF>)
   {
-    return new Match(subjectExpr, cases, attributes(matchName, token));
+    return new Match(subjectExpr, cases, attributes(matchKeyword, token));
   }
 }
 
@@ -1825,6 +1829,56 @@ istmt smallStatement(): {
   }
 }
 
+// "type" is a so called "soft" keyword introduced in Python 3.12.
+// Only in the specific type alias statement constellation it is
+// considered a keyword and otherwise it is a regular NAME token
+// which means we cannot have something like a TYPE token.
+TypeAlias typeAlias(Name typeKeyword): {
+  Name name;
+  ArrayList<itypeParam> typeParams = new ArrayList<>();
+  iexpr value;
+} {
+    <NAME> { name = new Name(token.image, attributes(token, token)); }
+    (typeParams(typeParams))?
+    <ASSIGN> value = expression()
+    {
+      return new TypeAlias(name, typeParams, value, attributes(typeKeyword, token));
+    }
+}
+
+void typeParams(ArrayList<itypeParam> typeParams): {
+  itypeParam typeParam;
+} {
+  <SQUARE_OPEN>
+  typeParam = typeParam() { typeParams.add(typeParam); }
+  (LOOKAHEAD(2)
+    <COMMA> typeParam = typeParam() { typeParams.add(typeParam); }
+  )*
+  (<COMMA>)?
+  <SQUARE_CLOSE>
+}
+
+itypeParam typeParam(): {
+  Token startToken;
+  iexpr bound = null;
+  itypeParam typeParam;
+} {
+  (
+    (<NAME> { startToken = token; }
+     (<COLON> bound = expression())? { typeParam = new TypeVar(startToken.image, bound, attributes(startToken, token)); }
+    )
+  | (<STAR> { startToken = token; }
+     <NAME> { typeParam = new TypeVarTuple(token.image, attributes(startToken, token));}
+    )
+  | (<DOUBLE_STAR> { startToken = token; }
+     <NAME> { typeParam = new ParamSpec(token.image, attributes(startToken, token));}
+    )
+  )
+  {
+    return typeParam;
+  }
+}
+
 // We are little bit less restrictive than the python 3.9 grammar because
 // we allow logical expressions in star expressions to be returned.
 // E.g. "return * x and y" the python 3.9 grammar would require parenthesis:
@@ -2087,9 +2141,11 @@ istmt functionDef(ArrayList<iexpr> decorators, boolean isAsync, Token asyncToken
   Arguments parameters;
   iexpr returnExpr = null;
   ArrayList<istmt> blockStmts;
+  ArrayList<itypeParam> typeParams = new ArrayList<>();
 } {
   <DEF> { if (!isAsync) {startToken = token;} }
   <NAME> { name = token.image; }
+  (typeParams(typeParams))?
   <PAREN_OPEN>
   parameters = parameters()
   <PAREN_CLOSE>
@@ -2099,10 +2155,10 @@ istmt functionDef(ArrayList<iexpr> decorators, boolean isAsync, Token asyncToken
   {
     if (isAsync) {
       return new AsyncFunctionDef(name, parameters, blockStmts, decorators,
-        returnExpr, null, attributes(startToken, token));
+        returnExpr, null, typeParams, attributes(startToken, token));
     } else {
       return new FunctionDef(name, parameters, blockStmts, decorators,
-        returnExpr, null, attributes(startToken, token));
+        returnExpr, null, typeParams, attributes(startToken, token));
     }
   }
 }
@@ -2493,13 +2549,16 @@ ClassDef classDef(ArrayList<iexpr> decorators): {
   String name;
   ArrayList<iexpr> bases = new ArrayList<iexpr>();
   ArrayList<Keyword> keywords = new ArrayList<Keyword>();
+  ArrayList<itypeParam> typeParams = new ArrayList<>();
   ArrayList<istmt> blockStmts;
 } {
-  <CLASS> { startToken = token; } <NAME> { name = token.image; }
+  <CLASS> { startToken = token; }
+  <NAME> { name = token.image; }
+  (typeParams(typeParams))?
   (<PAREN_OPEN> arguments(bases, keywords) <PAREN_CLOSE>)?
   <COLON>
   blockStmts = block()
-  { return new ClassDef(name, bases, keywords, blockStmts, decorators,
+  { return new ClassDef(name, bases, keywords, blockStmts, decorators, typeParams,
      attributes(startToken, token)); }
 }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -184,6 +184,7 @@ class PythonAstVisitor(relFileName: String, protected val nodeToCode: NodeToCode
       case node: ast.Return           => convert(node)
       case node: ast.Delete           => convert(node)
       case node: ast.Assign           => convert(node)
+      case node: ast.TypeAlias        => unhandled(node)
       case node: ast.AnnAssign        => convert(node)
       case node: ast.AugAssign        => convert(node)
       case node: ast.For              => convert(node)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/MemoryOperationCalculator.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/MemoryOperationCalculator.scala
@@ -12,7 +12,11 @@ import io.joern.pythonparser.ast.{
   MatchSequence,
   MatchSingleton,
   MatchStar,
-  MatchValue
+  MatchValue,
+  ParamSpec,
+  TypeAlias,
+  TypeVar,
+  TypeVarTuple
 }
 import io.joern.pythonparser.{AstVisitor, ast}
 
@@ -96,6 +100,8 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     accept(assign.value)
     pop()
   }
+
+  override def visit(typeAlias: TypeAlias): Unit = {}
 
   override def visit(annAssign: ast.AnnAssign): Unit = {
     push(Store)
@@ -538,4 +544,10 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
   }
 
   override def visit(typeIgnore: ast.TypeIgnore): Unit = {}
+
+  override def visit(typeVar: TypeVar): Unit = {}
+
+  override def visit(paramSpec: ParamSpec): Unit = {}
+
+  override def visit(typeVarTuple: TypeVarTuple): Unit = {}
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/AstPrinter.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/AstPrinter.scala
@@ -15,6 +15,14 @@ class AstPrinter(indentStr: String) extends AstVisitor[String] {
     indentStr + printStr.replaceAll(ls, ls + indentStr)
   }
 
+  private def printTypeParams(typeParams: CollType[itypeParam]): String = {
+    if (typeParams.nonEmpty) {
+      "[" + typeParams.map(print).mkString(", ") + "]"
+    } else {
+      ""
+    }
+  }
+
   override def visit(ast: iast): String = ???
 
   override def visit(mod: imod): String = ???
@@ -27,7 +35,7 @@ class AstPrinter(indentStr: String) extends AstVisitor[String] {
 
   override def visit(functionDef: FunctionDef): String = {
     functionDef.decorator_list.map(d => "@" + print(d) + ls).mkString("") +
-      "def " + functionDef.name + "(" + print(functionDef.args) + ")" +
+      "def " + functionDef.name + printTypeParams(functionDef.type_params) + "(" + print(functionDef.args) + ")" +
       functionDef.returns.map(r => " -> " + print(r)).getOrElse("") +
       ":" + functionDef.body.map(printIndented).mkString(ls, ls, "")
 
@@ -35,7 +43,7 @@ class AstPrinter(indentStr: String) extends AstVisitor[String] {
 
   override def visit(functionDef: AsyncFunctionDef): String = {
     functionDef.decorator_list.map(d => "@" + print(d) + ls).mkString("") +
-      "async def " + functionDef.name + "(" + print(functionDef.args) + ")" +
+      "async def " + functionDef.name + printTypeParams(functionDef.type_params) + "(" + print(functionDef.args) + ")" +
       functionDef.returns.map(r => " -> " + print(r)).getOrElse("") +
       ":" + functionDef.body.map(printIndented).mkString(ls, ls, "")
 
@@ -45,7 +53,7 @@ class AstPrinter(indentStr: String) extends AstVisitor[String] {
     val optionArgEndComma = if (classDef.bases.nonEmpty && classDef.keywords.nonEmpty) ", " else ""
 
     classDef.decorator_list.map(d => "@" + print(d) + ls).mkString("") +
-      "class " + classDef.name +
+      "class " + classDef.name + printTypeParams(classDef.type_params) +
       "(" +
       classDef.bases.map(print).mkString(", ") +
       optionArgEndComma +
@@ -64,6 +72,10 @@ class AstPrinter(indentStr: String) extends AstVisitor[String] {
 
   override def visit(assign: Assign): String = {
     assign.targets.map(print).mkString("", " = ", " = ") + print(assign.value)
+  }
+
+  override def visit(typeAlias: TypeAlias): String = {
+    "type " + print(typeAlias.name) + printTypeParams(typeAlias.type_params) + " = " + print(typeAlias.value)
   }
 
   override def visit(annAssign: AnnAssign): String = {
@@ -753,5 +765,17 @@ class AstPrinter(indentStr: String) extends AstVisitor[String] {
 
   override def visit(typeIgnore: TypeIgnore): String = {
     typeIgnore.tag
+  }
+
+  override def visit(typeVar: TypeVar): String = {
+    typeVar.name + typeVar.bound.map(b => ": " + print(b)).getOrElse("")
+  }
+
+  override def visit(paramSpec: ParamSpec): String = {
+    "**" + paramSpec.name
+  }
+
+  override def visit(typeVarTuple: TypeVarTuple): String = {
+    "*" + typeVarTuple.name
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/AstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/AstVisitor.scala
@@ -15,6 +15,7 @@ trait AstVisitor[T] {
   def visit(ret: Return): T
   def visit(delete: Delete): T
   def visit(assign: Assign): T
+  def visit(typeAlias: TypeAlias): T
   def visit(annAssign: AnnAssign): T
   def visit(augAssign: AugAssign): T
   def visit(forStmt: For): T
@@ -148,4 +149,10 @@ trait AstVisitor[T] {
   def visit(matchOr: MatchOr): T
 
   def visit(typeIgnore: TypeIgnore): T
+
+  def visit(typeVar: TypeVar): T
+
+  def visit(paramSpec: ParamSpec): T
+
+  def visit(typeVarTyple: TypeVarTuple): T
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/ast/Ast.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/ast/Ast.scala
@@ -68,6 +68,7 @@ case class FunctionDef(
   decorator_list: CollType[iexpr],
   returns: Option[iexpr],
   type_comment: Option[String],
+  type_params: CollType[itypeParam],
   attributeProvider: AttributeProvider
 ) extends istmt {
   def this(
@@ -77,9 +78,19 @@ case class FunctionDef(
     decorator_list: util.ArrayList[iexpr],
     returns: iexpr,
     type_comment: String,
+    type_params: util.ArrayList[itypeParam],
     attributeProvider: AttributeProvider
   ) = {
-    this(name, args, body.asScala, decorator_list.asScala, Option(returns), Option(type_comment), attributeProvider)
+    this(
+      name,
+      args,
+      body.asScala,
+      decorator_list.asScala,
+      Option(returns),
+      Option(type_comment),
+      type_params.asScala,
+      attributeProvider
+    )
   }
   override def accept[T](visitor: AstVisitor[T]): T = {
     visitor.visit(this)
@@ -93,6 +104,7 @@ case class AsyncFunctionDef(
   decorator_list: CollType[iexpr],
   returns: Option[iexpr],
   type_comment: Option[String],
+  type_params: CollType[itypeParam],
   attributeProvider: AttributeProvider
 ) extends istmt {
   def this(
@@ -102,9 +114,19 @@ case class AsyncFunctionDef(
     decorator_list: util.ArrayList[iexpr],
     returns: iexpr,
     type_comment: String,
+    type_params: util.ArrayList[itypeParam],
     attributeProvider: AttributeProvider
   ) = {
-    this(name, args, body.asScala, decorator_list.asScala, Option(returns), Option(type_comment), attributeProvider)
+    this(
+      name,
+      args,
+      body.asScala,
+      decorator_list.asScala,
+      Option(returns),
+      Option(type_comment),
+      type_params.asScala,
+      attributeProvider
+    )
   }
   override def accept[T](visitor: AstVisitor[T]): T = {
     visitor.visit(this)
@@ -117,6 +139,7 @@ case class ClassDef(
   keywords: CollType[Keyword],
   body: CollType[istmt],
   decorator_list: CollType[iexpr],
+  type_params: CollType[itypeParam],
   attributeProvider: AttributeProvider
 ) extends istmt {
   def this(
@@ -125,9 +148,18 @@ case class ClassDef(
     keywords: util.ArrayList[Keyword],
     body: util.ArrayList[istmt],
     decorator_list: util.ArrayList[iexpr],
+    type_params: util.ArrayList[itypeParam],
     attributeProvider: AttributeProvider
   ) = {
-    this(name, bases.asScala, keywords.asScala, body.asScala, decorator_list.asScala, attributeProvider)
+    this(
+      name,
+      bases.asScala,
+      keywords.asScala,
+      body.asScala,
+      decorator_list.asScala,
+      type_params.asScala,
+      attributeProvider
+    )
   }
   override def accept[T](visitor: AstVisitor[T]): T = {
     visitor.visit(this)
@@ -160,6 +192,16 @@ case class Assign(
 ) extends istmt {
   def this(targets: util.ArrayList[iexpr], value: iexpr, attributeProvider: AttributeProvider) = {
     this(targets.asScala, value, None, attributeProvider)
+  }
+  override def accept[T](visitor: AstVisitor[T]): T = {
+    visitor.visit(this)
+  }
+}
+
+case class TypeAlias(name: iexpr, type_params: CollType[itypeParam], value: iexpr, attributeProvider: AttributeProvider)
+    extends istmt {
+  def this(name: iexpr, typeParams: util.ArrayList[itypeParam], value: iexpr, attributeProvider: AttributeProvider) = {
+    this(name, typeParams.asScala, value, attributeProvider)
   }
   override def accept[T](visitor: AstVisitor[T]): T = {
     visitor.visit(this)
@@ -1133,6 +1175,32 @@ case class MatchOr(patterns: CollType[ipattern], attributeProvider: AttributePro
 // AST type_ignore classes
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 case class TypeIgnore(lineno: Int, tag: String) extends iast {
+  override def accept[T](visitor: AstVisitor[T]): T = {
+    visitor.visit(this)
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// AST type_param classes
+///////////////////////////////////////////////////////////////////////////////////////////////////
+trait itypeParam extends iast with iattributes
+
+case class TypeVar(name: String, bound: Option[iexpr], attributeProvider: AttributeProvider) extends itypeParam {
+  def this(name: String, bound: iexpr, attributeProvider: AttributeProvider) = {
+    this(name, Option(bound), attributeProvider)
+  }
+  override def accept[T](visitor: AstVisitor[T]): T = {
+    visitor.visit(this)
+  }
+}
+
+case class ParamSpec(name: String, attributeProvider: AttributeProvider) extends itypeParam {
+  override def accept[T](visitor: AstVisitor[T]): T = {
+    visitor.visit(this)
+  }
+}
+
+case class TypeVarTuple(name: String, attributeProvider: AttributeProvider) extends itypeParam {
   override def accept[T](visitor: AstVisitor[T]): T = {
     visitor.visit(this)
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pythonparser/ParserTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pythonparser/ParserTests.scala
@@ -151,6 +151,8 @@ class ParserTests extends AnyFreeSpec with Matchers {
 
       testT("async def func():\n\tpass")
       testT("@x\nasync def func():\n\tpass")
+
+      testT("def func[T]():\n\tpass")
     }
 
     "if statement tests" in {
@@ -169,6 +171,7 @@ class ParserTests extends AnyFreeSpec with Matchers {
       testT("class x(y, z = a):\n\tpass")
       testT("@x\nclass y():\n\tpass")
       testT("@x\n@y\nclass z():\n\tpass")
+      testT("class x[A]():\n\tpass")
     }
 
     "try statement tests" in {
@@ -1093,6 +1096,22 @@ class ParserTests extends AnyFreeSpec with Matchers {
   "test non keyword 'match' usages" in {
     testT("match[1] = 0")
     testT("match * 2")
+  }
+
+  "test type keyword" in {
+    testT("type x = a")
+    testT("type x[T] = a")
+    testT("type x[A, B] = a")
+    testT("type x[A, B, ] = a", "type x[A, B] = a")
+    testT("type x[*A] = a")
+    testT("type x[*A, *B] = a")
+    testT("type x[A, *B] = a")
+    testT("type x[**A] = a")
+    testT("type x[A, **B] = a")
+  }
+
+  "test non keyword 'type' usages" in {
+    testT("x = type")
   }
 
   "non-latin identifier name tests" in {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pythonparser/ParserTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pythonparser/ParserTests.scala
@@ -688,6 +688,9 @@ class ParserTests extends AnyFreeSpec with Matchers {
     testT("f\"\"\"a\"\"\"")
     testT("f'''{a}'''")
     testT("f'''a'''")
+
+    testT("""f"{"x"}"""")
+    testT("""f"{f"{f"{x}"}"}"""")
   }
 
   "format string tests with context" in {


### PR DESCRIPTION
- Add support for new generic type syntax introduced in python 3.12.
- Add tests for quote reuse in python 3.12 format strings.
- Create unknown node for new type alias statement of python 3.12.