### PR TITLE
[c2cpg] Fixed logging from ExternalCommand

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/ExternalCommand.scala
@@ -1,6 +1,9 @@
 package io.joern.c2cpg.utils
 
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.sys.process.{Process, ProcessLogger}
 import scala.util.{Failure, Success, Try}
+import scala.jdk.CollectionConverters.*
 
 object ExternalCommand extends io.joern.x2cpg.utils.ExternalCommand {
 
@@ -11,11 +14,21 @@ object ExternalCommand extends io.joern.x2cpg.utils.ExternalCommand {
       case Success(1) if IsWin && IncludeAutoDiscovery.gccAvailable() =>
         // the command to query the system header file locations within a Windows
         // environment always returns Success(1) for whatever reason...
-        Success(stdErr)
+        Success(stdOut)
       case _ =>
         val allOutput = stdOut ++ stdErr
         Failure(new RuntimeException(allOutput.mkString(System.lineSeparator())))
     }
+  }
+
+  override def run(command: String, cwd: String, extraEnv: Map[String, String] = Map.empty): Try[Seq[String]] = {
+    val stdOutOutput  = new ConcurrentLinkedQueue[String]
+    val processLogger = ProcessLogger(stdOutOutput.add, stdOutOutput.add)
+    val process = shellPrefix match {
+      case Nil => Process(command, new java.io.File(cwd), extraEnv.toList: _*)
+      case _   => Process(shellPrefix :+ command, new java.io.File(cwd), extraEnv.toList: _*)
+    }
+    handleRunResult(Try(process.!(processLogger)), stdOutOutput.asScala.toSeq, Nil)
   }
 
 }


### PR DESCRIPTION
With https://github.com/joernio/joern/pull/4068 c2cpg also got two different handlers for std err and out which messes up the handling/retrieval of system header file locations.