### PR TITLE
Add content steps for METHOD and TYPE_DECL nodes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.3.1"
 
-val cpgVersion = "1.4.33"
+val cpgVersion = "1.4.34"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -64,4 +64,16 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
   override def location: NewLocation = {
     LocationCreator(method, method.name, method.label, method.lineNumber, method)
   }
+
+  def content: Option[String] = {
+    val contentOption   = method.file.content.headOption
+    val offsetOption    = method.offset
+    val offsetEndOption = method.offsetEnd
+
+    if (contentOption.isDefined && offsetOption.isDefined && offsetEndOption.isDefined) {
+      contentOption.map(_.substring(offsetOption.get, offsetEndOption.get))
+    } else {
+      None
+    }
+  }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -171,4 +171,9 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
 
   def numberOfLines: Iterator[Int] = traversal.map(_.numberOfLines)
 
+  @Doc(info = "File content section belonging to method definition")
+  def content: Iterator[String] = {
+    traversal.flatMap(_.content)
+  }
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -107,8 +107,23 @@ class TypeDeclTraversal(val traversal: Iterator[TypeDecl]) extends AnyVal {
   def aliasTypeDeclTransitive: Iterator[TypeDecl] =
     traversal.repeat(_.aliasTypeDecl)(_.emitAllButFirst)
 
+  def content: Iterator[String] = {
+    traversal.flatMap(contentOnSingle)
+  }
 }
 
 object TypeDeclTraversal {
   private val maxAliasExpansions = 100
+
+  private def contentOnSingle(typeDecl: TypeDecl): Option[String] = {
+    val contentOption   = typeDecl.file.content.headOption
+    val offsetOption    = typeDecl.offset
+    val offsetEndOption = typeDecl.offsetEnd
+
+    if (contentOption.isDefined && offsetOption.isDefined && offsetEndOption.isDefined) {
+      contentOption.map(_.substring(offsetOption.get, offsetEndOption.get))
+    } else {
+      None
+    }
+  }
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTests.scala
@@ -11,8 +11,16 @@ class MethodTests extends AnyWordSpec with Matchers {
 
   val cpg = MockCpg()
     .withNamespace("namespace")
+    .withFile("someFile", Some("aaaCONTENTbbb"))
     .withTypeDecl("TypeDecl", inNamespace = Some("namespace"))
-    .withMethod("foo", inTypeDecl = Some("TypeDecl"), external = false)
+    .withMethod(
+      "foo",
+      inTypeDecl = Some("TypeDecl"),
+      external = false,
+      fileName = "someFile",
+      offset = Some(3),
+      offsetEnd = Some(10)
+    )
     .withMethod("bar", inTypeDecl = Some("TypeDecl"), external = true)
     .withCallInMethod("foo", "call")
     .withCallInMethod("foo", "call2")
@@ -144,6 +152,11 @@ class MethodTests extends AnyWordSpec with Matchers {
       val internalMethod: List[Method] =
         cpg.method.name("foo").hasModifier("modifiertype").toList
       internalMethod.size shouldBe 1
+    }
+
+    "get content" in {
+      cpg.method.name("foo").content.head shouldBe "CONTENT"
+      cpg.method.name("bar").content.headOption shouldBe empty
     }
   }
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -163,5 +163,23 @@ class TypeTests extends AnyWordSpec with Matchers {
       queryResult.map(_.name).toSet shouldBe Set("Derived", "Base")
     }
 
+  }
+
+  "Class content test" should {
+    val cpg = MockCpg()
+      .withNamespace("namespace")
+      .withFile("someFile", Some("aaaCONTENTbbb"))
+      .withTypeDecl(
+        "foo",
+        inNamespace = Some("namespace"),
+        inFile = Some("someFile"),
+        offset = Some(3),
+        offsetEnd = Some(10)
+      )
+      .cpg
+
+    "have correct content for class" in {
+      cpg.typeDecl.name("foo").content.head shouldBe "CONTENT"
+    }
   }
 }


### PR DESCRIPTION
With these new steps the parts of FILE content belonging to a TYPE_DECL
or METHOD can be easily accessed.