### PR TITLE
[ruby] For-In Loop Support

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -44,15 +44,14 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def pathSep                            = "."
 
   protected def handleNewVariableOccurrence(node: RubyNode): Ast = {
-    val name = code(node)
+    val name       = code(node)
+    val identifier = identifierNode(node, name, name, Defines.Any)
     scope.lookupVariable(name) match
       case None =>
-        val local      = localNode(node, name, name, Defines.Any)
-        val identifier = identifierNode(node, name, name, Defines.Any)
+        val local = localNode(node, name, name, Defines.Any)
         scope.addToScope(name, local)
-        Ast(identifierNode(node, name, name, Defines.Any)).withRefEdge(identifier, local)
+        Ast(identifier).withRefEdge(identifier, local)
       case Some(local) =>
-        val identifier = identifierNode(node, name, name, Defines.Any)
         Ast(identifier).withRefEdge(identifier, local)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,12 +1,13 @@
 package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.astcreation.GlobalTypes.{builtinFunctions, builtinPrefix}
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.RubyNode
+import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.joern.x2cpg.datastructures.Scope
 import io.joern.x2cpg.datastructures.Stack.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 
-trait AstCreatorHelper { this: AstCreator =>
+trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   /* Used to track variable names and their LOCAL nodes.
    * TODO: Perhaps move this feature into a new Pass?
@@ -41,6 +42,19 @@ trait AstCreatorHelper { this: AstCreator =>
   protected def isBuiltin(x: String): Boolean      = builtinFunctions.contains(x)
   protected def prefixAsBuiltin(x: String): String = s"$builtinPrefix$pathSep$x"
   protected def pathSep                            = "."
+
+  protected def handleNewVariableOccurrence(node: RubyNode): Ast = {
+    val name = code(node)
+    scope.lookupVariable(name) match
+      case None =>
+        val local      = localNode(node, name, name, Defines.Any)
+        val identifier = identifierNode(node, name, name, Defines.Any)
+        scope.addToScope(name, local)
+        Ast(identifierNode(node, name, name, Defines.Any)).withRefEdge(identifier, local)
+      case Some(local) =>
+        val identifier = identifierNode(node, name, name, Defines.Any)
+        Ast(identifier).withRefEdge(identifier, local)
+  }
 
   protected val UnaryOperatorNames: Map[String, String] = Map(
     "!"   -> Operators.logicalNot,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -14,6 +14,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case node: UntilExpression            => astForUntilStatement(node) :: Nil
     case node: IfExpression               => astForIfStatement(node) :: Nil
     case node: UnlessExpression           => astForUnlessStatement(node) :: Nil
+    case node: ForExpression              => astForForExpression(node) :: Nil
     case node: CaseExpression             => astsForCaseExpression(node)
     case node: StatementList              => astForStatementList(node) :: Nil
     case node: SimpleCallWithBlock        => astForSimpleCallWithBlock(node) :: Nil
@@ -99,6 +100,14 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val elseAsts = node.falseBranch.map(astForElseClause).toList
     val ifNode   = controlStructureNode(node, ControlStructureTypes.IF, code(node))
     controlStructureAst(ifNode, Some(notConditionAst), thenAst :: elseAsts)
+  }
+
+  private def astForForExpression(node: ForExpression): Ast = {
+    val forEachNode  = controlStructureNode(node, ControlStructureTypes.FOR, code(node))
+    val doBodyAst    = astsForStatement(node.doBlock)
+    val iteratorNode = astForExpression(node.forVariable)
+    val iterableNode = astForExpression(node.iterableVariable)
+    Ast(forEachNode).withChild(iteratorNode).withChild(iterableNode).withChildren(doBodyAst)
   }
 
   protected def astsForCaseExpression(node: CaseExpression): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -116,6 +116,9 @@ object RubyIntermediateAst {
     span: TextSpan
   ) extends RubyNode(span)
 
+  final case class ForExpression(forVariable: RubyNode, iterableVariable: RubyNode, doBlock: RubyNode)(span: TextSpan)
+      extends RubyNode(span)
+
   final case class ConditionalExpression(condition: RubyNode, trueBranch: RubyNode, falseBranch: RubyNode)(
     span: TextSpan
   ) extends RubyNode(span)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -79,6 +79,18 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     UnlessExpression(condition, thenBody, elseBody)(ctx.toTextSpan)
   }
 
+  override def visitForExpression(ctx: RubyParser.ForExpressionContext): RubyNode = {
+    val forVariable      = visit(ctx.forVariable())
+    val iterableVariable = visit(ctx.commandOrPrimaryValue())
+    val doBlock          = visit(ctx.doClause())
+    ForExpression(forVariable, iterableVariable, doBlock)(ctx.toTextSpan)
+  }
+
+  override def visitForVariable(ctx: RubyParser.ForVariableContext): RubyNode = {
+    if (ctx.leftHandSide() != null) visit(ctx.leftHandSide())
+    else visit(ctx.multipleLeftHandSide())
+  }
+
   override def visitModifierStatement(ctx: RubyParser.ModifierStatementContext): RubyNode = {
     ctx.statementModifier().getText match
       case "if" =>


### PR DESCRIPTION
* Added basic for-in loop support, mostly handling off each component to other visitors
* Added handling for `MandatoryParameter` as a basic identifier
* Added `handleNewVariableOccurrence` as a re-usable feature for handling new and existing identifier occurrences
* Removed debugging code in ControlStructureTests
* Added package heading to ControlStructureTests

Resolves #3936