### PR TITLE
[c#] Fix RHS of EqualsValueClause

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -47,7 +47,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
          |  Line: ${node.lineNumber.getOrElse(-1)}
          |  Column: ${node.columnNumber.getOrElse(-1)}
          |  """.stripMargin
-    logger.info(text)
+    logger.warn(text)
     Seq(Ast(unknownNode(node, node.code)))
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -64,11 +64,11 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       .json(ParserKeys.Variables)
       .arr
       .map(createDotNetNodeInfo)
-      .flatMap { astForVariableDeclarator(_, typeFullName) }
+      .flatMap(astForVariableDeclarator(_, typeFullName))
       .toSeq
   }
 
-  protected def astForVariableDeclarator(varDecl: DotNetNodeInfo, typeFullName: String): List[Ast] = {
+  protected def astForVariableDeclarator(varDecl: DotNetNodeInfo, typeFullName: String): Seq[Ast] = {
     val name          = nameFromNode(varDecl)
     val identifierAst = astForIdentifier(varDecl, typeFullName)
     val _localNode    = localNode(varDecl, name, name, typeFullName)
@@ -86,13 +86,13 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val initializerJson = varDecl.json(ParserKeys.Initializer)
     if (initializerJson.isNull) {
       // Implicitly assigned to `null`
-      List(
+      Seq(
         callAst(assignmentNode, Seq(identifierAst, Ast(literalNode(varDecl, BuiltinTypes.Null, BuiltinTypes.Null)))),
         localNodeAst
       )
     } else {
       val rhs = astForNode(createDotNetNodeInfo(initializerJson))
-      List(callAst(assignmentNode, identifierAst +: rhs), localNodeAst)
+      Seq(callAst(assignmentNode, identifierAst +: rhs), localNodeAst)
     }
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -89,11 +89,11 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     Seq(callAst(cNode, args))
   }
 
+  /** Handles the `= ...` part of the equals value clause, thus this only contains an RHS.
+    */
   protected def astForEqualsValueClause(clause: DotNetNodeInfo): Seq[Ast] = {
     val rhsNode = createDotNetNodeInfo(clause.json(ParserKeys.Value))
-    rhsNode.node match
-      case _: LiteralExpr => astForLiteralExpression(rhsNode)
-      case _              => notHandledYet(rhsNode)
+    astForNode(rhsNode)
   }
 
   private def astForInvocationExpression(invocationExpr: DotNetNodeInfo): Seq[Ast] = {

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -34,7 +34,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val conditionAst  = astForNode(conditionNode).headOption.getOrElse(Ast())
 
     val thenNode     = createDotNetNodeInfo(ifStmt.json(ParserKeys.Statement))
-    val thenAst: Ast = Option(astForBlock(createDotNetNodeInfo(ifStmt.json(ParserKeys.Statement)))).getOrElse(Ast())
+    val thenAst: Ast = astForBlock(thenNode)
     val ifNode =
       controlStructureNode(ifStmt, ControlStructureTypes.IF, s"if (${conditionNode.code})")
     val elseAst = ifStmt.json(ParserKeys.Else) match

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/dataflow/SimpleDataflowTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/dataflow/SimpleDataflowTests.scala
@@ -1,0 +1,26 @@
+package io.joern.csharpsrc2cpg.querying.dataflow
+
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+import io.joern.dataflowengineoss.language.*
+
+class SimpleDataflowTests extends CSharpCode2CpgFixture(withDataFlow = true) {
+
+  "a source with a simple re-assignment" should {
+
+    val cpg = code(basicBoilerplate("""
+        |int i = 0;
+        |int a = i + 1;
+        |Console.WriteLine(a);
+        |""".stripMargin))
+
+    "still propagate to the sink" in {
+      cpg.method("Main").dotAst.foreach(println)
+      val src  = cpg.assignment.target.isIdentifier.nameExact("i").l
+      val sink = cpg.call.nameExact("WriteLine").l
+      sink.reachableBy(src).p.foreach(println)
+    }
+
+  }
+
+}

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/dataflow/SimpleDataflowTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/dataflow/SimpleDataflowTests.scala
@@ -15,10 +15,9 @@ class SimpleDataflowTests extends CSharpCode2CpgFixture(withDataFlow = true) {
         |""".stripMargin))
 
     "still propagate to the sink" in {
-      cpg.method("Main").dotAst.foreach(println)
       val src  = cpg.assignment.target.isIdentifier.nameExact("i").l
       val sink = cpg.call.nameExact("WriteLine").l
-      sink.reachableBy(src).p.foreach(println)
+      sink.reachableBy(src).size shouldBe 1
     }
 
   }


### PR DESCRIPTION
Simple data-flows were not being propagated after some re-assignment. This was found to be caused by only a limited class of RHS nodes being handled on the EqualsValueClause. This has now been fixed and tested.

Other style-related changes added.

Resolves #4078