### PR TITLE
javasrc2cpg - allow `persistence.xml` and `*.cfg.xml` files as ConfigFiles

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPass.scala
@@ -36,7 +36,11 @@ class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
     pathEndFilter("AndroidManifest.xml"),
     // SPRING
     extensionFilter(".yaml"),
-    extensionFilter(".yml")
+    extensionFilter(".yml"),
+    // JPA
+    pathEndFilter("persistence.xml"),
+    // HIBERNATE
+    pathEndFilter("cfg.xml")
   )
 
   private def mybatisFilter(file: File): Boolean = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/hibernate.cfg.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/hibernate.cfg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 5.3//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-5.3.dtd">
+<hibernate-configuration>
+</hibernate-configuration>

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/persistence.xml
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/persistence.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
+ http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
+
+</persistence>

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -38,7 +38,9 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
       Paths.get(absoluteConfigDir, "build.gradle").toString,
       Paths.get(absoluteConfigDir, "build.gradle.kts").toString,
       Paths.get(absoluteConfigDir, "basic.yaml").toString,
-      Paths.get(absoluteConfigDir, "basic.yml").toString
+      Paths.get(absoluteConfigDir, "basic.yml").toString,
+      Paths.get(absoluteConfigDir, "hibernate.cfg.xml").toString,
+      Paths.get(absoluteConfigDir, "persistence.xml").toString
     )
   }
 


### PR DESCRIPTION
Often JPA/Hibernate settings are stored in `persistence.xml` and `*.cfg.xml` files. In fact, they could be stored in any XML file and be referenced programatically. However, including all XML files in the CPG is probably a bit too much for some, so I chose a more conservative approach here. (If it would be ok to include all XML files, I'd happily propose a PR for that.)