### PR TITLE
Kotlin fixes and debug logging.

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -51,6 +51,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
   protected val relativizedPath: String = fileWithMeta.relativizedPath
 
   protected val scope: Scope[String, DeclarationNew, NewNode] = new Scope()
+  protected val debugScope                                    = mutable.Stack.empty[KtDeclaration]
 
   def createAst(): DiffGraphBuilder = {
     implicit val typeInfoProvider: TypeInfoProvider = xTypeInfoProvider
@@ -172,6 +173,21 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     }
   }
 
+  private def logDebugWithTestAndStackTrace(message: String): Unit = {
+    val declString = debugScope.headOption.map(_.getText).getOrElse("Declaration scope empty")
+    logger.debug(message + "\nIn declaration:\n" + declString + "\nStack trace to from declaration:" + getStackTrace)
+  }
+
+  private def getStackTrace: String = {
+    val stackTrace = Thread.currentThread().getStackTrace
+    var endIndex   = stackTrace.indexWhere(_.toString.contains("astsForDeclaration"))
+    if (endIndex == -1) {
+      endIndex = stackTrace.length
+    }
+    val partialStackTrace = stackTrace.slice(2, endIndex + 1)
+    partialStackTrace.mkString("\n\t", "\n\t", "")
+  }
+
   @tailrec
   final def astsForExpression(
     expr: KtExpression,
@@ -245,7 +261,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
         )
         Seq(astForUnknown(typedExpr, argIdxMaybe, argNameMaybe, annotations))
       case null =>
-        logger.warn("Received null expression! Skipping...")
+        logDebugWithTestAndStackTrace("Received null expression! Skipping...")
         Seq()
       // TODO: handle `KtCallableReferenceExpression` like `this::baseTerrain`
       case unknownExpr =>
@@ -313,21 +329,25 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
   }
 
   def astsForDeclaration(decl: KtDeclaration)(implicit typeInfoProvider: TypeInfoProvider): Seq[Ast] = {
-    decl match {
-      case c: KtClass             => astsForClassOrObject(c)
-      case o: KtObjectDeclaration => astsForClassOrObject(o)
-      case n: KtNamedFunction =>
-        val isExtensionFn = typeInfoProvider.isExtensionFn(n)
-        astsForMethod(n, isExtensionFn)
-      case t: KtTypeAlias            => Seq(astForTypeAlias(t))
-      case s: KtSecondaryConstructor => Seq(astForUnknown(s, None, None))
-      case p: KtProperty             => astsForProperty(p)
-      case unhandled =>
-        logger.error(
-          s"Unknown declaration type encountered with text `${unhandled.getText}` and class `${unhandled.getClass}`!"
-        )
-        Seq()
-    }
+    debugScope.push(decl)
+    val result =
+      decl match {
+        case c: KtClass             => astsForClassOrObject(c)
+        case o: KtObjectDeclaration => astsForClassOrObject(o)
+        case n: KtNamedFunction =>
+          val isExtensionFn = typeInfoProvider.isExtensionFn(n)
+          astsForMethod(n, isExtensionFn)
+        case t: KtTypeAlias            => Seq(astForTypeAlias(t))
+        case s: KtSecondaryConstructor => Seq(astForUnknown(s, None, None))
+        case p: KtProperty             => astsForProperty(p)
+        case unhandled =>
+          logger.error(
+            s"Unknown declaration type encountered with text `${unhandled.getText}` and class `${unhandled.getClass}`!"
+          )
+          Seq()
+      }
+    debugScope.pop()
+    result
   }
 
   def astForUnknown(

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -245,7 +245,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
         )
         Seq(astForUnknown(typedExpr, argIdxMaybe, argNameMaybe, annotations))
       case null =>
-        logger.trace("Received null expression! Skipping...")
+        logger.warn("Received null expression! Skipping...")
         Seq()
       // TODO: handle `KtCallableReferenceExpression` like `this::baseTerrain`
       case unknownExpr =>

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -340,7 +340,12 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   def astForReturnExpression(expr: KtReturnExpression)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val children = astsForExpression(expr.getReturnedExpression, None)
-    returnAst(returnNode(expr, expr.getText), children.toList)
+    val returnedExpr =
+      if (expr.getReturnedExpression != null) {
+        astsForExpression(expr.getReturnedExpression, None)
+      } else {
+        Nil
+      }
+    returnAst(returnNode(expr, expr.getText), returnedExpr)
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -4,7 +4,7 @@ import io.joern.kotlin2cpg.Constants
 import io.joern.kotlin2cpg.ast.Nodes.operatorCallNode
 import io.joern.kotlin2cpg.types.{TypeConstants, TypeInfoProvider}
 import io.joern.x2cpg.{Ast, AstNodeBuilder, ValidationMode}
-import io.joern.x2cpg.utils.NodeBuilders.{newIdentifierNode}
+import io.joern.x2cpg.utils.NodeBuilders.newIdentifierNode
 import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import org.jetbrains.kotlin.psi.{
@@ -22,12 +22,14 @@ import org.jetbrains.kotlin.psi.{
   KtProperty,
   KtPsiUtil,
   KtTryExpression,
+  KtWhenConditionWithExpression,
   KtWhenEntry,
   KtWhenExpression,
   KtWhileExpression
 }
 
 import scala.jdk.CollectionConverters.*
+import scala.collection.mutable
 import io.shiftleft.semanticcpg.language.*
 
 trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
@@ -339,6 +341,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   def astForWhenAsStatement(expr: KtWhenExpression, argIdx: Option[Int])(implicit
     typeInfoProvider: TypeInfoProvider
   ): Ast = {
+    assert(expr.getSubjectExpression != null)
+
     val astForSubject = astsForExpression(expr.getSubjectExpression, Some(1)).headOption.getOrElse(Ast())
     val finalAstForSubject = expr.getSubjectExpression match {
       case p: KtProperty =>
@@ -370,6 +374,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   def astForWhenAsExpression(expr: KtWhenExpression, argIdx: Option[Int], argNameMaybe: Option[String])(implicit
     typeInfoProvider: TypeInfoProvider
   ): Ast = {
+    assert(expr.getSubjectExpression != null)
+
     val callNode =
       withArgumentIndex(operatorCallNode("<operator>.when", "<operator>.when", None), argIdx)
         .argumentName(argNameMaybe)
@@ -393,6 +399,39 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     callAst(callNode, List(subjectBlockAst) ++ argAsts)
   }
 
+  private def astForNoArgWhen(expr: KtWhenExpression)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
+    assert(expr.getSubjectExpression == null)
+
+    val typeFullName = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
+    var elseAst: Ast = null
+
+    // In reverse order than expr.getEntries since that is the order
+    // we need for nested Operators.conditional construction.
+    expr.getEntries.asScala.reverse.foreach { entry =>
+      entry.getConditions.headOption match {
+        // The other KtWhenCondition implementations are not generated
+        // we have smoke tests for those.
+        case Some(cond: KtWhenConditionWithExpression) =>
+          val condAst = astsForExpression(cond.getExpression, None).head
+
+          val entryExpr    = entry.getExpression
+          val entryExprAst = astsForExpression(entryExpr, None).head
+
+          val callNode =
+            operatorCallNode(Operators.conditional, Operators.conditional, Some(typeFullName), line(cond), column(cond))
+
+          val newElseAst = callAst(callNode, Seq(condAst, entryExprAst, elseAst))
+          elseAst = newElseAst
+        case None =>
+          // This is the 'else' branch of 'when'.
+          // No argument 'when' always have an 'else branch which comes last
+          // and thus first in reverse order.
+          elseAst = astsForExpression(entry.getExpression, None).head
+      }
+    }
+    elseAst
+  }
+
   def astForWhen(
     expr: KtWhenExpression,
     argIdx: Option[Int],
@@ -400,9 +439,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     annotations: Seq[KtAnnotationEntry] = Seq()
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
     val outAst =
-      typeInfoProvider.usedAsExpression(expr) match {
-        case Some(true) => astForWhenAsExpression(expr, argIdx, argNameMaybe)
-        case _          => astForWhenAsStatement(expr, argIdx)
+      if (expr.getSubjectExpression != null) {
+        typeInfoProvider.usedAsExpression(expr) match {
+          case Some(true) => astForWhenAsExpression(expr, argIdx, argNameMaybe)
+          case _          => astForWhenAsStatement(expr, argIdx)
+        }
+      } else {
+        astForNoArgWhen(expr)
       }
     outAst.withChildren(annotations.map(astForAnnotationEntry))
   }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -280,7 +280,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   ): Ast = {
     val conditionAst = astsForExpression(expr.getCondition, None).headOption
     val thenAsts     = astsForExpression(expr.getThen, None)
-    val elseAsts     = astsForExpression(expr.getElse, None)
+    val elseAsts     = Option(expr.getElse).toSeq.flatMap(astsForExpression(_, None))
 
     val node = controlStructureNode(expr, ControlStructureTypes.IF, expr.getText)
     controlStructureAst(node, conditionAst, List(thenAsts ++ elseAsts).flatten)
@@ -295,7 +295,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   )(implicit typeInfoProvider: TypeInfoProvider): Ast = {
     val conditionAsts = astsForExpression(expr.getCondition, None)
     val thenAsts      = astsForExpression(expr.getThen, None)
-    val elseAsts      = astsForExpression(expr.getElse, None)
+    val elseAsts      = Option(expr.getElse).toSeq.flatMap(astsForExpression(_, None))
 
     val allAsts = (conditionAsts ++ thenAsts ++ elseAsts).toList
     if (allAsts.nonEmpty) {


### PR DESCRIPTION
- Avoid null expression warning for Unit/void return statements.
   We achieve this by not calling astForExpression on null.

 - Avoid calling astsForExpression for null else branch.

 - Properly handle 'when' statement/expression without argument.

 - Add debug logging facility with declaration text and stack trace.