### PR TITLE
[swiftsrc2cpg] Added support for IfConfigDecls

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/README.md
+++ b/joern-cli/frontends/swiftsrc2cpg/README.md
@@ -31,10 +31,18 @@ swift build
 
 ## Running
 
-To produce a code property graph  issue the command:
+To produce a code property graph issue the command:
 ```shell script
 ./swiftsrc2cpg.sh <path/to/sourceCodeDirectory> --output <path/to/outputCpg>
 `````
+
+Additional options are available:
+```shell script
+./swiftsrc2cpg.sh <path/to/sourceCodeDirectory> \
+                --output <path/to/outputCpg> \
+                --define DEF
+                --define DEF_VAL=2
+```
 
 Run the following to see a complete list of available options:
 ```shell script

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
@@ -8,7 +8,13 @@ import scopt.OParser
 
 import java.nio.file.Paths
 
-final case class Config() extends X2CpgConfig[Config] with TypeRecoveryParserConfig[Config]
+final case class Config(defines: Set[String] = Set.empty)
+    extends X2CpgConfig[Config]
+    with TypeRecoveryParserConfig[Config] {
+  def withDefines(defines: Set[String]): Config = {
+    this.copy(defines = defines).withInheritedFields(this)
+  }
+}
 
 object Frontend {
   implicit val defaultConfig: Config = Config()
@@ -16,7 +22,14 @@ object Frontend {
   val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
     import builder.*
-    OParser.sequence(programName("swiftsrc2cpg"), XTypeRecovery.parserOptions)
+    OParser.sequence(
+      programName("swiftsrc2cpg"),
+      XTypeRecovery.parserOptions,
+      opt[String]("define")
+        .unbounded()
+        .text("define a name")
+        .action((d, c) => c.withDefines(c.defines + d))
+    )
   }
 
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -52,6 +52,15 @@ class AstCreator(val config: Config, val global: SwiftGlobal, val parserResult: 
   protected val seenAliasTypes                = mutable.HashSet.empty[NewTypeDecl]
   protected val functionFullNames             = mutable.HashSet.empty[String]
 
+  protected lazy val definedSymbols: Map[String, String] = {
+    config.defines.map {
+      case define if define.contains("=") =>
+        val s = define.split("=")
+        s.head -> s(1)
+      case define => define -> "true"
+    }.toMap
+  }
+
   override def createAst(): DiffGraphBuilder = {
     val fileNode       = NewFile().name(parserResult.filename).order(1)
     val namespaceBlock = globalNamespaceBlock()

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/AbstractPassTest.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/AbstractPassTest.scala
@@ -19,12 +19,12 @@ abstract class AbstractPassTest extends AnyWordSpec with Matchers with Inside {
   private implicit val schemaValidationMode: ValidationMode = ValidationMode.Enabled
 
   protected object AstFixture extends Fixture {
-    def apply(code: String, filename: String = "code.swift")(f: Cpg => Unit): Unit = {
+    def apply(code: String, filename: String = "code.swift", defines: Set[String] = Set.empty)(f: Cpg => Unit): Unit = {
       File.usingTemporaryDirectory("swiftsrc2cpgTests") { dir =>
         val cpg  = newEmptyCpg()
         val file = dir / filename
         file.write(code)
-        val config          = Config().withInputPath(dir.toString).withOutputPath(dir.toString)
+        val config          = Config().withInputPath(dir.toString).withOutputPath(dir.toString).withDefines(defines)
         val astGenResult    = new AstGenRunner(config).execute(dir)
         val astCreationPass = new AstCreationPass(cpg, astGenResult, config)
         astCreationPass.createAndApply()


### PR DESCRIPTION
We can't statically evaluate the conditions for these #if defs (they work pretty much the same is in C/C++). (plus, we do not want to re-implement the Swift pre-processor)

So we now provide a `--define` flag (same as in c2cpg) to set the desired config and generate all the sub ASTs accordingly. Obviously, this will only work for simple identifiers whereas Swift allows for arbitrary expression as `#if` condition.