### PR TITLE
[swiftsrc2cpg] Added support for PostfixIfConfigExpr

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -772,7 +772,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     astForFunctionLike(node).ast
   }
 
-  private def ifConfigDeclConditionIsSatisfied(node: IfConfigClauseSyntax): Boolean = {
+  protected def ifConfigDeclConditionIsSatisfied(node: IfConfigClauseSyntax): Boolean = {
     node.condition.isEmpty
     || definedSymbols.get(code(node.condition.get)).exists(_.toLowerCase == "true")
     || definedSymbols.get(code(node.condition.get)).contains("1")

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -116,8 +116,20 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     baseNode: NewNode,
     callName: String
   ): Ast = {
-    val args      = callExpr.arguments.children.map(astForNode)
-    val callNode_ = callNode(callExpr, code(callExpr), callName, DispatchTypes.DYNAMIC_DISPATCH)
+    val args         = callExpr.arguments.children.map(astForNode)
+    val callExprCode = code(callExpr)
+    val callCode = callExprCode match {
+      case c if c.startsWith(".") && codeOf(baseNode) != "this" => s"${codeOf(baseNode)}$callExprCode"
+      case c if c.contains("#if ") =>
+        val recCode = codeOf(receiverAst.nodes.head)
+        if (recCode.endsWith(callName)) {
+          s"${codeOf(receiverAst.nodes.head)}(${code(callExpr.arguments)})"
+        } else {
+          s"${codeOf(receiverAst.nodes.head)}$callName(${code(callExpr.arguments)})"
+        }
+      case _ => callExprCode
+    }
+    val callNode_ = callNode(callExpr, callCode, callName, DispatchTypes.DYNAMIC_DISPATCH)
     // If the callee is a function itself, e.g. closure, then resolve this locally, if possible
     if (callExpr.calledExpression.isInstanceOf[ClosureExprSyntax]) {
       functionNodeToNameAndFullName.get(callExpr.calledExpression).foreach { case (name, fullName) =>
@@ -159,7 +171,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
               val baseTmpNode = identifierNode(otherBase, tmpVarName)
               scope.addVariableReference(tmpVarName, baseTmpNode)
               val baseAst   = astForNodeWithFunctionReference(otherBase)
-              val codeField = s"(${codeOf(baseTmpNode)} = ${code(otherBase)})"
+              val codeField = s"(${codeOf(baseTmpNode)} = ${codeOf(baseAst.nodes.head)})"
               val tmpAssignmentAst =
                 createAssignmentCallAst(Ast(baseTmpNode), baseAst, codeField, line(otherBase), column(otherBase))
               val memberNode = createFieldIdentifierNode(code(member), line(member), column(member))
@@ -285,11 +297,53 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     Ast(literalNode(node, code(node), Option(Defines.Nil)))
   }
 
-  private def astForOptionalChainingExprSyntax(node: OptionalChainingExprSyntax): Ast       = notHandledYet(node)
-  private def astForPackElementExprSyntax(node: PackElementExprSyntax): Ast                 = notHandledYet(node)
-  private def astForPackExpansionExprSyntax(node: PackExpansionExprSyntax): Ast             = notHandledYet(node)
-  private def astForPatternExprSyntax(node: PatternExprSyntax): Ast                         = notHandledYet(node)
-  private def astForPostfixIfConfigExprSyntax(node: PostfixIfConfigExprSyntax): Ast         = notHandledYet(node)
+  private def astForOptionalChainingExprSyntax(node: OptionalChainingExprSyntax): Ast = notHandledYet(node)
+  private def astForPackElementExprSyntax(node: PackElementExprSyntax): Ast           = notHandledYet(node)
+  private def astForPackExpansionExprSyntax(node: PackExpansionExprSyntax): Ast       = notHandledYet(node)
+  private def astForPatternExprSyntax(node: PatternExprSyntax): Ast                   = notHandledYet(node)
+
+  private def astForPostfixIfConfigExprSyntax(node: PostfixIfConfigExprSyntax): Ast = {
+    val children              = node.config.clauses.children
+    val ifIfConfigClauses     = children.filter(c => code(c.poundKeyword) == "#if")
+    val elseIfIfConfigClauses = children.filter(c => code(c.poundKeyword) == "#elseif")
+    val elseIfConfigClauses   = children.filter(c => code(c.poundKeyword) == "#else")
+
+    node.base match {
+      case Some(base) =>
+        val maybeFunctionCallExpr = ifIfConfigClauses match {
+          case Nil => None
+          case ifIfConfigClause :: Nil if ifConfigDeclConditionIsSatisfied(ifIfConfigClause) =>
+            ifIfConfigClause.elements
+          case _ :: Nil =>
+            val firstElseIfSatisfied = elseIfIfConfigClauses.find(ifConfigDeclConditionIsSatisfied)
+            firstElseIfSatisfied match {
+              case Some(elseIfIfConfigClause) =>
+                elseIfIfConfigClause.elements
+              case None =>
+                elseIfConfigClauses match {
+                  case Nil                       => None
+                  case elseIfConfigClause :: Nil => elseIfConfigClause.elements
+                  case _                         => None
+                }
+            }
+          case _ => None
+        }
+        maybeFunctionCallExpr match {
+          case Some(functionCallExpr: FunctionCallExprSyntax) =>
+            functionCallExpr.calledExpression match
+              case MemberAccessExprSyntax(json) =>
+                val memberChildren = json("children").arr
+                memberChildren.addOne(base.json)
+                astForNode(functionCallExpr)
+              case _ =>
+                notHandledYet(node)
+          case _ => notHandledYet(node)
+        }
+      case None => astForNode(node.config)
+    }
+
+  }
+
   private def astForPostfixOperatorExprSyntax(node: PostfixOperatorExprSyntax): Ast         = notHandledYet(node)
   private def astForPrefixOperatorExprSyntax(node: PrefixOperatorExprSyntax): Ast           = notHandledYet(node)
   private def astForRegexLiteralExprSyntax(node: RegexLiteralExprSyntax): Ast               = notHandledYet(node)

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/DirectiveTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/DirectiveTests.scala
@@ -54,6 +54,42 @@ class DirectiveTests extends AbstractPassTest {
       cpg.call.code.l shouldBe List("foo()", "config1()", "config2()", "config4()", "bar()")
     }
 
+    "testConfigExpression6 (call behind define)" in AstFixture(
+      """
+        |foo
+        |#if CONFIG1
+        |.bar()
+        |#else
+        |.baz()
+        |#endif
+        |""".stripMargin,
+      defines = Set("CONFIG1")
+    ) { cpg =>
+      cpg.call.code.l shouldBe List("foo.bar()", "foo.bar")
+    }
+
+    "testConfigExpression7 (call behind define with trailing call)" in AstFixture(
+      """
+        |foo
+        |#if CONFIG1
+        |.bar()
+        |#else
+        |.baz()
+        |#endif
+        |.oneMore(x: 1)
+        |""".stripMargin,
+      defines = Set("CONFIG1")
+    ) { cpg =>
+      cpg.call.code.l shouldBe List(
+        "(_tmp_0 = foo.bar()).oneMore(x: 1)",
+        "(_tmp_0 = foo.bar()).oneMore",
+        "(_tmp_0 = foo.bar())",
+        "foo.bar()",
+        "foo.bar",
+        "x: 1"
+      )
+    }
+
     "testSourceLocation1" ignore AstFixture("#sourceLocation()") { cpg => ??? }
 
     "testSourceLocation2" ignore AstFixture("""#sourceLocation(file: "foo", line: 42)""") { cpg => ??? }


### PR DESCRIPTION
Swift allows `#if` config clauses in between calls (and only there). So we have to manually patch the base node into the resulting member access call.