### PR TITLE
Allow multiple colon-separated inference jar paths

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -78,9 +78,9 @@ private object Frontend {
     import builder._
     OParser.sequence(
       programName("javasrc2cpg"),
-      opt[String]("inference-jar-paths")
-        .text(s"extra jars used only for type information")
-        .action((path, c) => c.withInferenceJarPaths(c.inferenceJarPaths + path)),
+      opt[Seq[String]]("inference-jar-paths")
+        .text(s"extra jars used only for type information (comma-separated list of paths)")
+        .action((paths, c) => c.withInferenceJarPaths(c.inferenceJarPaths ++ paths)),
       opt[Unit]("fetch-dependencies")
         .text("attempt to fetch dependencies jars for extra type information")
         .action((_, c) => c.withFetchDependencies(true)),

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -133,6 +133,13 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
 
     // Add solvers for inference jars
     val jarsList = config.inferenceJarPaths.flatMap(recursiveJarsFromPath).toList
+    if (config.inferenceJarPaths.isEmpty) {
+      logger.debug("No inference jar paths given")
+    } else if (jarsList.isEmpty) {
+      logger.warn(s"Could not find any inference jars at provided paths: ${config.inferenceJarPaths.mkString(",")}")
+    } else {
+      logger.debug(s"Using inference jars: ${jarsList.mkString(":")}")
+    }
     (jarsList ++ dependencies)
       .flatMap { path =>
         Try(new JarTypeSolver(path)).toOption


### PR DESCRIPTION
Allow users to specify multiple inference jar paths with a `:` separated list. I chose `:` since it's the path separator on Linux and not a valid path character in Windows.