### PR TITLE
[C#] Ast for `switch` and `label` statements

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 csharpsrc2cpg {
-    dotnetastgen_version: "0.16.0"
+    dotnetastgen_version: "0.18.0"
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -27,6 +27,10 @@ object DotNetJsonAst {
   sealed trait BaseExpr extends DotNetParserNode
   sealed trait BaseStmt extends DotNetParserNode
 
+  sealed trait BasePattern extends DotNetParserNode
+
+  sealed trait BaseLabel extends DotNetParserNode
+
   object GlobalStatement     extends BaseStmt
   object ExpressionStatement extends BaseStmt
 
@@ -156,6 +160,20 @@ object DotNetJsonAst {
 
   object WhileStatement extends BaseStmt
 
+  object SwitchStatement extends BaseStmt
+
+  object SwitchSection extends BaseExpr
+
+  object RelationalPattern extends BasePattern
+
+  object ConstantPattern extends BasePattern
+
+  object CaseSwitchLabel extends BaseLabel
+
+  object CasePatternSwitchLabel extends BaseLabel
+
+  object DefaultSwitchLabel extends BaseLabel
+
   object Unknown extends DotNetParserNode
 
 }
@@ -185,6 +203,7 @@ object ParserKeys {
   val Initializer   = "Initializer"
   val Keyword       = "Keyword"
   val Kind          = "Kind"
+  val Labels        = "Labels"
   val Left          = "Left"
   val LineStart     = "LineStart"
   val LineEnd       = "LineEnd"
@@ -196,6 +215,8 @@ object ParserKeys {
   val OperatorToken = "OperatorToken"
   val Parameters    = "Parameters"
   val ParameterList = "ParameterList"
+  val Pattern       = "Pattern"
+  val Sections      = "Sections"
   val Statement     = "Statement"
   val Statements    = "Statements"
   val ReturnType    = "ReturnType"

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ControlStructureTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ControlStructureTests.scala
@@ -3,7 +3,7 @@ package io.joern.csharpsrc2cpg.querying.ast
 import io.joern.csharpsrc2cpg.CSharpOperators
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Local}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, JumpTarget, Local}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes}
 import io.shiftleft.semanticcpg.language.*
 
@@ -101,6 +101,83 @@ class ControlStructureTests extends CSharpCode2CpgFixture {
             case _ => fail("No call node found!")
           }
         case None => fail("No `finally` block found!")
+      }
+    }
+
+  }
+
+  "the swtich statement" should {
+    val cpg = code(basicBoilerplate("""
+        |switch (i) {
+        | case > 0:
+        |   i++;
+        |   break;
+        | case < 0:
+        |   i--;
+        |   break;
+        | default:
+        |  i += 10;
+        |  break;
+        |}
+        |""".stripMargin))
+
+    "create a control structure node and contain correct astChildren" in {
+      inside(cpg.method("Main").controlStructure.controlStructureTypeExact(ControlStructureTypes.SWITCH).l) {
+        case switchNode :: Nil =>
+          switchNode.code shouldBe "switch (i)";
+          switchNode.controlStructureType shouldBe ControlStructureTypes.SWITCH
+
+          inside(switchNode.astChildren.isBlock.l) { case case1 :: case2 :: case3 :: Nil =>
+            val List(incCall) = case1.astChildren.isCall.l;
+            incCall.code shouldBe "i++"
+
+            val List(decCall) = case2.astChildren.isCall.l;
+            decCall.code shouldBe "i--"
+
+            val List(plusEqualsCall) = case3.astChildren.isCall.l;
+            plusEqualsCall.code shouldBe "i += 10"
+          }
+
+          inside(switchNode.astChildren.collect { case j: JumpTarget => j }.l) {
+            case case1 :: case2 :: defaultCase :: Nil =>
+              case1.code shouldBe "case > 0:"
+              case2.code shouldBe "case < 0:"
+              defaultCase.code shouldBe "default:"
+          }
+      }
+    }
+  }
+
+  "switch statement with multiple labels" should {
+    val cpg = code(basicBoilerplate("""
+        |switch (i) {
+        | case > 0:
+        | case < 10:
+        |   i++;
+        |   break;
+        | case 10:
+        |   i--;
+        |   break;
+        | default:
+        |  i += 10;
+        |  break;
+        |}
+        |""".stripMargin))
+
+    "create a control structure node with correct label and case clauses" in {
+
+      inside(cpg.method("Main").controlStructure.controlStructureTypeExact(ControlStructureTypes.SWITCH).l) {
+        case switchNode :: Nil =>
+          switchNode.code shouldBe "switch (i)";
+          switchNode.controlStructureType shouldBe ControlStructureTypes.SWITCH
+
+          inside(switchNode.astChildren.collect { case j: JumpTarget => j }.l) {
+            case case1 :: case1_1 :: case2 :: defaultCase :: Nil =>
+              case1.code shouldBe "case > 0:"
+              case2.code shouldBe "case 10:"
+              case1_1.code shouldBe "case < 10:"
+              defaultCase.code shouldBe "default:"
+          }
       }
     }
 


### PR DESCRIPTION
This PR includes, 
1. AST Creation for `Switch` statements.
2. Corresponding tests. 
3. Upgrading the `DotNetAstGen` version to allow new properties.

Resolves [#3984](https://github.com/joernio/joern/issues/3984)