### PR TITLE
cdt artifact: update url - this is a short term fix only...

### DIFF
--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -12,10 +12,10 @@ dependsOn(
   Projects.x2cpg             % "compile->compile;test->test"
 )
 
-lazy val cdtCoreDepVersion        = "8.4.0.202401182322"
+lazy val cdtCoreDepVersion        = "8.4.0.202401242025"
 lazy val cdtCoreDepNameAndVersion = s"org.eclipse.cdt.core_$cdtCoreDepVersion"
 lazy val cdtCodeDepUrl =
-  s"https://ci.eclipse.org/cdt/job/cdt/job/main/348/artifact/releng/org.eclipse.cdt.repo/target/repository/plugins/$cdtCoreDepNameAndVersion.jar"
+  s"https://ci.eclipse.org/cdt/job/cdt/job/main/353/artifact/releng/org.eclipse.cdt.repo/target/repository/plugins/$cdtCoreDepNameAndVersion.jar"
 
 libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",


### PR DESCRIPTION
I only just realised that we're downloading this from their jenkins.
That's not a good idea since it's only available for a short time.
Will figure out a more permanent solution via DM.

Fixes the release build: https://github.com/joernio/joern/actions/runs/7707446583/job/21004658263