### PR TITLE
cdt: download from official releases rather than jenkins

### DIFF
--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -13,6 +13,7 @@ dependsOn(
 )
 
 // download cdt from the official eclipse download section: https://download.eclipse.org/tools/cdt/releases/11.4/cdt-11.4.0/plugins/
+// note: as soon as 8.4.x is released we should upgrade, since we can then drop our custom jar fiddling below, i.e. `signingFiles`, `removeSigningInfo` and `removeSigningInfoStartup`
 lazy val cdtCoreVersion = "8.3.100.202309251502"
 lazy val eclipseDlMirror = "https://ftp.fau.de/eclipse" // alternative: "https://eclipse.mirror.garr.it"
 lazy val cdtCoreUrl     = s"$eclipseDlMirror/tools/cdt/releases/11.4/cdt-11.4.0/plugins/org.eclipse.cdt.core_$cdtCoreVersion.jar"
@@ -50,6 +51,64 @@ Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc
 
 compile / javacOptions ++= Seq("-Xlint:all", "-Xlint:-cast", "-g")
 Test / fork := true
+
+lazy val signingFiles = List("META-INF/ECLIPSE_.RSA", "META-INF/ECLIPSE_.SF")
+
+/* Dirty hack: we access cdt-internal types which are package-private. In order to do so,
+ * `MacroArgumentExtractor` from this repo is in the `org.eclipse.cdt.internal.core.parser.scanner` package.
+ * The cdt jar is signed to ensure that doesn't happen, but because we're stubborn and yolo we simply remove the signing files.
+ */
+lazy val removeSigningInfo = taskKey[Unit]("Remove signing info from Eclipse CDT jar file")
+removeSigningInfo := {
+  import java.nio.file.Files
+  val log = streams.value.log
+  val managedClasspathValue = (Compile / managedClasspath).value
+  val lib = unmanagedBase.value
+  if (!lib.exists) IO.createDirectory(lib)
+  val outputFile = lib / s"$cdtCoreDepNameAndVersion.custom.jar"
+  if (!outputFile.exists) {
+    managedClasspathValue.find(_.data.name.contains(cdtCoreDepName)) match {
+      case Some(path) =>
+        val jarPath    = path.data.absolutePath
+        val inputFile  = new File(jarPath)
+
+        try {
+          val jarInputStream  = new JarInputStream(new FileInputStream(inputFile))
+          val jarOutputStream = new JarOutputStream(new FileOutputStream(outputFile))
+
+          Iterator.continually(jarInputStream.getNextJarEntry).takeWhile(_ != null).foreach { entry =>
+            val entryName = entry.getName
+            if (!signingFiles.contains(entryName)) {
+              jarOutputStream.putNextEntry(new JarEntry(entryName))
+              Iterator.continually(jarInputStream.read()).takeWhile(_ != -1).foreach(jarOutputStream.write)
+            }
+            jarOutputStream.closeEntry()
+          }
+
+          jarInputStream.close()
+          jarOutputStream.close()
+
+          log.info("Removed signing info from Eclipse CDT jar file")
+
+          // cleanup other versions of the Eclipse CDT jar file, if any
+          lib.listFiles.foreach { file =>
+            if (!file.name.contains(cdtCoreDepNameAndVersion) && file.name.contains(cdtCoreDepName)) {
+              file.delete()
+            }
+          }
+        } catch {
+          case e: Exception => log.error(s"Error removing signing info from '$jarPath': ${e.getMessage}")
+        }
+      case _ => // do nothing
+    }
+  }
+}
+
+lazy val removeSigningInfoStartup: State => State = { s: State => "removeSigningInfo" :: s }
+Global / onLoad := {
+  val old = (Global / onLoad).value
+  removeSigningInfoStartup compose old
+}
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -13,10 +13,10 @@ dependsOn(
 )
 
 // download cdt from the official eclipse download section: https://download.eclipse.org/tools/cdt/releases/11.4/cdt-11.4.0/plugins/
-// note: as soon as 8.4.x is released we should upgrade, since we can then drop our custom jar fiddling below, i.e. `signingFiles`, `removeSigningInfo` and `removeSigningInfoStartup`
+// TODO: as soon as 8.4.x is released we should upgrade, since we can then drop our custom jar fiddling below, i.e. `signingFiles`, `removeSigningInfo`, `removeSigningInfoStartup` and `cdtCoreNameAndVersion`
 lazy val cdtCoreVersion = "8.3.100.202309251502"
 lazy val eclipseDlMirror = "https://ftp.fau.de/eclipse" // alternative: "https://eclipse.mirror.garr.it"
-lazy val cdtCoreUrl     = s"$eclipseDlMirror/tools/cdt/releases/11.4/cdt-11.4.0/plugins/org.eclipse.cdt.core_$cdtCoreVersion.jar"
+lazy val cdtCoreUrl = s"$eclipseDlMirror/tools/cdt/releases/11.4/cdt-11.4.0/plugins/org.eclipse.cdt.core_$cdtCoreVersion.jar"
 
 libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
@@ -57,7 +57,12 @@ lazy val signingFiles = List("META-INF/ECLIPSE_.RSA", "META-INF/ECLIPSE_.SF")
 /* Dirty hack: we access cdt-internal types which are package-private. In order to do so,
  * `MacroArgumentExtractor` from this repo is in the `org.eclipse.cdt.internal.core.parser.scanner` package.
  * The cdt jar is signed to ensure that doesn't happen, but because we're stubborn and yolo we simply remove the signing files.
+ * TODO upgrade to 8.4.x and remove this
  */
+
+lazy val cdtCoreName           = s"org.eclipse.cdt.core"
+lazy val cdtCoreNameAndVersion = s"${cdtCoreName}_$cdtCoreVersion"
+
 lazy val removeSigningInfo = taskKey[Unit]("Remove signing info from Eclipse CDT jar file")
 removeSigningInfo := {
   import java.nio.file.Files
@@ -65,9 +70,9 @@ removeSigningInfo := {
   val managedClasspathValue = (Compile / managedClasspath).value
   val lib = unmanagedBase.value
   if (!lib.exists) IO.createDirectory(lib)
-  val outputFile = lib / s"$cdtCoreDepNameAndVersion.custom.jar"
+  val outputFile = lib / s"$cdtCoreNameAndVersion.custom.jar"
   if (!outputFile.exists) {
-    managedClasspathValue.find(_.data.name.contains(cdtCoreDepName)) match {
+    managedClasspathValue.find(_.data.name.contains(cdtCoreName)) match {
       case Some(path) =>
         val jarPath    = path.data.absolutePath
         val inputFile  = new File(jarPath)
@@ -92,7 +97,7 @@ removeSigningInfo := {
 
           // cleanup other versions of the Eclipse CDT jar file, if any
           lib.listFiles.foreach { file =>
-            if (!file.name.contains(cdtCoreDepNameAndVersion) && file.name.contains(cdtCoreDepName)) {
+            if (!file.name.contains(cdtCoreNameAndVersion) && file.name.contains(cdtCoreName)) {
               file.delete()
             }
           }

--- a/joern-cli/frontends/c2cpg/build.sbt
+++ b/joern-cli/frontends/c2cpg/build.sbt
@@ -12,16 +12,16 @@ dependsOn(
   Projects.x2cpg             % "compile->compile;test->test"
 )
 
-lazy val cdtCoreDepVersion        = "8.4.0.202401242025"
-lazy val cdtCoreDepNameAndVersion = s"org.eclipse.cdt.core_$cdtCoreDepVersion"
-lazy val cdtCodeDepUrl =
-  s"https://ci.eclipse.org/cdt/job/cdt/job/main/353/artifact/releng/org.eclipse.cdt.repo/target/repository/plugins/$cdtCoreDepNameAndVersion.jar"
+// download cdt from the official eclipse download section: https://download.eclipse.org/tools/cdt/releases/11.4/cdt-11.4.0/plugins/
+lazy val cdtCoreVersion = "8.3.100.202309251502"
+lazy val eclipseDlMirror = "https://ftp.fau.de/eclipse" // alternative: "https://eclipse.mirror.garr.it"
+lazy val cdtCoreUrl     = s"$eclipseDlMirror/tools/cdt/releases/11.4/cdt-11.4.0/plugins/org.eclipse.cdt.core_$cdtCoreVersion.jar"
 
 libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
   "org.eclipse.platform"    % "org.eclipse.core.resources" % "3.20.0",
   "org.eclipse.platform"    % "org.eclipse.text"           % "3.13.100",
-  "org.eclipse.platform"    % "org.eclipse.cdt.core"       % cdtCoreDepVersion from cdtCodeDepUrl,
+  "org.eclipse.platform"    % "org.eclipse.cdt.core"       % cdtCoreVersion from cdtCoreUrl,
   "org.scalatest"          %% "scalatest"                  % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -15,6 +15,7 @@ import org.apache.commons.lang.StringUtils
 import org.eclipse.cdt.core.dom.ast.{IASTMacroExpansionLocation, IASTNode, IASTPreprocessorMacroDefinition}
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
+import org.eclipse.cdt.internal.core.parser.scanner.MacroArgumentExtractor
 
 import scala.annotation.nowarn
 import scala.collection.mutable

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/ExternalCommand.scala
@@ -16,8 +16,7 @@ object ExternalCommand extends io.joern.x2cpg.utils.ExternalCommand {
         // environment always returns Success(1) for whatever reason...
         Success(stdOut)
       case _ =>
-        val allOutput = stdOut ++ stdErr
-        Failure(new RuntimeException(allOutput.mkString(System.lineSeparator())))
+        Failure(new RuntimeException(stdOut.mkString(System.lineSeparator())))
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
@@ -1,20 +1,16 @@
-package io.joern.c2cpg.astcreation
+package org.eclipse.cdt.internal.core.parser.scanner
 
-import org.eclipse.cdt.core.dom.ast.IASTFileLocation
-import org.eclipse.cdt.core.dom.ast.IASTName
-import org.eclipse.cdt.core.dom.ast.IASTPreprocessorElifStatement
-import org.eclipse.cdt.core.dom.ast.IASTPreprocessorIfStatement
-import org.eclipse.cdt.core.dom.ast.IASTPreprocessorMacroExpansion
-import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit
+import org.eclipse.cdt.core.dom.ast.{
+  IASTFileLocation,
+  IASTName,
+  IASTPreprocessorElifStatement,
+  IASTPreprocessorIfStatement,
+  IASTPreprocessorMacroExpansion,
+  IASTTranslationUnit
+}
 import org.eclipse.cdt.core.parser.IToken
 import org.eclipse.cdt.core.parser.util.CharArrayMap
-import org.eclipse.cdt.internal.core.parser.scanner.ILexerLog
-import org.eclipse.cdt.internal.core.parser.scanner.ILocationResolver
 import org.eclipse.cdt.internal.core.parser.scanner.Lexer.LexerOptions
-import org.eclipse.cdt.internal.core.parser.scanner.MacroExpander
-import org.eclipse.cdt.internal.core.parser.scanner.MacroExpansionTracker
-import org.eclipse.cdt.internal.core.parser.scanner.PreprocessorMacro
-import org.eclipse.cdt.internal.core.parser.scanner.TokenList
 
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -29,6 +25,8 @@ import scala.collection.mutable
   * `setExpandedMacroArgument`, we can intercept arguments and store them in a list for later retrieval. We wrap this
   * rather complicated way of accessing the macro arguments in the single public method `getArguments` of the
   * `MacroArgumentExtractor`.
+  *
+  * This class must be in this package in order to have access to `PreprocessorMacro`.
   */
 class MacroArgumentExtractor(tu: IASTTranslationUnit, loc: IASTFileLocation) {
 


### PR DESCRIPTION
https://download.eclipse.org/tools/cdt/releases/11.4/cdt-11.4.0/plugins/

While we're waiting for 8.4 to get officially released, we need the old jar fiddling hack. 
That's unfortunate, but better than having commits in master that won't work in the future (e.g. if we need to bisect anything) because the jars disappeared from their CI (which they do after a week). 