### PR TITLE
[c#] Enum Handling

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.11
+version = 3.7.17
 runner.dialect = scala3
 preset = IntelliJ
 maxColumn = 120

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
@@ -62,6 +62,8 @@ class AstCreator(val relativeFileName: String, val parserResult: ParserResult, v
       case ClassDeclaration          => astForClassDeclaration(nodeInfo)
       case StructDeclaration         => astForClassDeclaration(nodeInfo)
       case RecordDeclaration         => astForRecordDeclaration(nodeInfo)
+      case EnumDeclaration           => astForEnumDeclaration(nodeInfo)
+      case EnumMemberDeclaration     => astForEnumMemberDeclaration(nodeInfo)
       case MethodDeclaration         => astForMethodDeclaration(nodeInfo)
       case FieldDeclaration          => astForFieldDeclaration(nodeInfo)
       case VariableDeclaration       => astForVariableDeclaration(nodeInfo)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -104,7 +104,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       case StringLiteralExpression                        => BuiltinTypes.DotNetTypeMap(BuiltinTypes.String)
       case TrueLiteralExpression | FalseLiteralExpression => BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool)
       case IdentifierName                                 => typeFromTypeString(nameFromNode(node))
-      case PredefinedType =>
+      case PredefinedType | SimpleBaseType =>
         BuiltinTypes.DotNetTypeMap.getOrElse(node.code, Defines.Any)
       case _ =>
         Try(createDotNetNodeInfo(node.json(ParserKeys.Type))) match

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -78,6 +78,31 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     Seq(typeDeclAst)
   }
 
+  protected def astForEnumDeclaration(enumDecl: DotNetNodeInfo): Seq[Ast] = {
+    val name     = nameFromNode(enumDecl)
+    val fullName = astFullName(enumDecl)
+    val typeDecl = typeDeclNode(enumDecl, name, fullName, relativeFileName, code(enumDecl))
+    scope.pushNewScope(TypeScope(fullName))
+    val modifiers = astForModifiers(enumDecl)
+
+    val members = astForMembers(enumDecl.json(ParserKeys.Members).arr.map(createDotNetNodeInfo).toSeq)
+    scope.popScope()
+    val typeDeclAst = Ast(typeDecl)
+      .withChildren(modifiers)
+      .withChildren(members)
+    Seq(typeDeclAst)
+  }
+
+  protected def astForEnumMemberDeclaration(enumMemberDecl: DotNetNodeInfo): Seq[Ast] = {
+    val name         = nameFromNode(enumMemberDecl)
+    val typeFullName = scope.surroundingTypeDeclFullName.getOrElse(Defines.Any)
+    val member       = memberNode(enumMemberDecl, name, code(enumMemberDecl), typeFullName)
+    val modifiers    = astForModifiers(enumMemberDecl)
+
+    val memberAst = Ast(member).withChildren(modifiers)
+    Seq(memberAst)
+  }
+
   protected def astForFieldDeclaration(fieldDecl: DotNetNodeInfo): Seq[Ast] = {
     val declarationNode = createDotNetNodeInfo(fieldDecl.json(ParserKeys.Declaration))
     val declAsts        = astForVariableDeclaration(declarationNode)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
@@ -13,8 +13,9 @@ class CSharpScope(typeMap: TypeMap) extends Scope[String, DeclarationNew, ScopeT
   /** @return
     *   the surrounding type declaration if one exists.
     */
-  def surroundingTypeDeclFullName: Option[String] = stack.collectFirst { case ScopeElement(TypeScope(fullName), _) =>
-    fullName
+  def surroundingTypeDeclFullName: Option[String] = stack.collectFirst {
+    case ScopeElement(typeLike: TypeLikeScope, _) =>
+      typeLike.fullName
   }
 
   /** @return
@@ -23,7 +24,7 @@ class CSharpScope(typeMap: TypeMap) extends Scope[String, DeclarationNew, ScopeT
   def surroundingScopeFullName: Option[String] = stack.collectFirst {
     case ScopeElement(NamespaceScope(fullName), _) => fullName
     case ScopeElement(MethodScope(fullName), _)    => fullName
-    case ScopeElement(TypeScope(fullName), _)      => fullName
+    case ScopeElement(typeLike: TypeLikeScope, _)  => typeLike.fullName
   }
 
   /** @return
@@ -31,7 +32,7 @@ class CSharpScope(typeMap: TypeMap) extends Scope[String, DeclarationNew, ScopeT
     */
   def isTopLevel: Boolean = stack
     .filterNot(x => x.scopeNode.isInstanceOf[NamespaceScope])
-    .exists(x => x.scopeNode.isInstanceOf[MethodScope] || x.scopeNode.isInstanceOf[TypeScope])
+    .exists(x => x.scopeNode.isInstanceOf[MethodScope] || x.scopeNode.isInstanceOf[TypeLikeScope])
 
   def tryResolveTypeReference(typeName: String): Option[String] = {
     typesInScope.find(_.name.endsWith(typeName)).flatMap(typeMap.namespaceFor).map(n => s"$n.$typeName")

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
@@ -71,4 +71,14 @@ class CSharpScope(typeMap: TypeMap) extends Scope[String, DeclarationNew, ScopeT
       case x => x
   }
 
+  /** Returns the top of the scope, without removing it from the stack.
+    */
+  def peekScope(): Option[ScopeType] = {
+    super.popScope() match
+      case None => None
+      case Some(top) =>
+        super.pushNewScope(top)
+        Option(top)
+  }
+
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/ScopeType.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/ScopeType.scala
@@ -1,11 +1,49 @@
 package io.joern.csharpsrc2cpg.datastructures
 
+import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes
+import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes.DotNetTypeMap
+
+/** The unifying scope type trait.
+  */
 sealed trait ScopeType
 
+/** Represents scope objects mapping to namespace nodes. Likened to `namespace` or `package` declarations.
+  *
+  * @param fullName
+  */
 case class NamespaceScope(fullName: String) extends ScopeType
 
-case class TypeScope(fullName: String) extends ScopeType
+/** Represents scope objects that map to a type declaration node.
+  */
+sealed trait TypeLikeScope {
+  def fullName: String
+}
 
+/** A class or interface.
+  *
+  * @param fullName
+  *   the type full name.
+  */
+case class TypeScope(fullName: String) extends ScopeType with TypeLikeScope
+
+/** An enumeration type.
+  *
+  * @param fullName
+  *   the enum full name
+  * @param aliasFor
+  *   the integer equivalent type that this represents
+  */
+case class EnumScope(fullName: String, aliasFor: String = DotNetTypeMap(BuiltinTypes.Int))
+    extends ScopeType
+    with TypeLikeScope
+
+/** Represents scope objects that map to a method node.
+  *
+  * @param fullName
+  *   the method full name.
+  */
 case class MethodScope(fullName: String) extends ScopeType
 
+/** Represents scope objects that map to a block node.
+  */
 object BlockScope extends ScopeType

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -1,6 +1,7 @@
 package io.joern.csharpsrc2cpg.parser
 
 import org.slf4j.LoggerFactory
+import io.joern.csharpsrc2cpg.parser.ParserKeys.Type
 
 object DotNetJsonAst {
 
@@ -85,6 +86,8 @@ object DotNetJsonAst {
   object ArrayType extends TypeExpr
 
   object PredefinedType extends TypeExpr
+
+  object SimpleBaseType extends TypeExpr
 
   object Block extends BaseExpr
 
@@ -200,6 +203,7 @@ object ParserKeys {
   val AstRoot       = "AstRoot"
   val Arguments     = "Arguments"
   val ArgumentList  = "ArgumentList"
+  val BaseList      = "BaseList"
   val Body          = "Body"
   val Block         = "Block"
   val Catches       = "Catches"
@@ -237,6 +241,7 @@ object ParserKeys {
   val ReturnType    = "ReturnType"
   val Right         = "Right"
   val Type          = "Type"
+  val Types         = "Types"
   val Usings        = "Usings"
   val Value         = "Value"
   val Variables     = "Variables"

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -51,6 +51,10 @@ object DotNetJsonAst {
 
   object RecordDeclaration extends DeclarationExpr
 
+  object EnumDeclaration extends DeclarationExpr
+
+  object EnumMemberDeclaration extends DeclarationExpr
+
   object MethodDeclaration extends DeclarationExpr
 
   object FieldDeclaration extends DeclarationExpr

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
@@ -3,6 +3,9 @@ package io.joern.csharpsrc2cpg.querying.ast
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
+import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes
+import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes.DotNetTypeMap
+import io.joern.x2cpg.Defines
 
 class TypeDeclTests extends CSharpCode2CpgFixture {
 
@@ -120,44 +123,104 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
 
     val cpg = code(
       """
-                    |enum Season
-                    |{
-                    |    Spring,
-                    |    Summer,
-                    |    Autumn,
-                    |    Winter
-                    |}
-                    |""".stripMargin,
+        |enum Season
+        |{
+        |    Spring,
+        |    Summer,
+        |    Autumn,
+        |    Winter
+        |}
+        |""".stripMargin,
       "Season.cs"
     )
 
     "generate a type declaration enum members" in {
       inside(cpg.typeDecl.nameExact("Season").headOption) {
-        case Some(rec) =>
-          rec.fullName shouldBe "Season"
-          inside(rec.member.l) {
+        case Some(season) =>
+          season.fullName shouldBe "Season"
+          inside(season.member.l) {
             case xs if xs.isEmpty => fail("No enum members found!")
             case spring :: summer :: autumn :: winter :: Nil =>
               spring.name shouldBe "Spring"
               spring.code shouldBe "Spring"
-              spring.typeFullName shouldBe "Season"
+              spring.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
 
               summer.name shouldBe "Summer"
               summer.code shouldBe "Summer"
-              summer.typeFullName shouldBe "Season"
+              summer.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
 
               autumn.name shouldBe "Autumn"
               autumn.code shouldBe "Autumn"
-              autumn.typeFullName shouldBe "Season"
+              autumn.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
 
               winter.name shouldBe "Winter"
               winter.code shouldBe "Winter"
-              winter.typeFullName shouldBe "Season"
+              winter.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
             case _ => fail("Unexpected number of enum members!")
           }
         case None => fail("Unable to find `Season` type decl node")
       }
     }
+  }
+
+  "enum types cast as an integer type" should {
+
+    val cpg = code("""
+                    |enum ErrorCode : ushort
+                    |{
+                    |    None = 0,
+                    |    Unknown = 1,
+                    |    ConnectionLost = 100,
+                    |    OutlierReading = 200
+                    |}
+                    |
+                    |""".stripMargin)
+
+    "generate a type declaration enum members" in {
+      inside(cpg.typeDecl.nameExact("ErrorCode").headOption) {
+        case Some(errCode) =>
+          errCode.fullName shouldBe "ErrorCode"
+          inside(errCode.member.l) {
+            case xs if xs.isEmpty => fail("No enum members found!")
+            case none :: unknown :: connectionLost :: outlierReading :: Nil =>
+              none.name shouldBe "None"
+              none.code shouldBe "None = 0"
+              none.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.UShort)
+
+              unknown.name shouldBe "Unknown"
+              unknown.code shouldBe "Unknown = 1"
+              unknown.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.UShort)
+
+              connectionLost.name shouldBe "ConnectionLost"
+              connectionLost.code shouldBe "ConnectionLost = 100"
+              connectionLost.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.UShort)
+
+              outlierReading.name shouldBe "OutlierReading"
+              outlierReading.code shouldBe "OutlierReading = 200"
+              outlierReading.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.UShort)
+            case _ => fail("Unexpected number of enum members!")
+          }
+        case None => fail("Unable to find `ErrorCode` type decl node")
+      }
+    }
+
+    // TODO: Requires <clinit> issue to be done
+    "initialize the members in a <clinit> class" ignore {
+      inside(cpg.typeDecl.nameExact("ErrorCode").method.nameExact(Defines.StaticInitMethodName).l) {
+        case m :: Nil =>
+          m.fullName shouldBe s"ErrorCode.${Defines.StaticInitMethodName}"
+          inside(m.assignment.l) {
+            case none :: unknown :: connectionLost :: outlierReading :: Nil =>
+              none.code shouldBe "None = 0"
+              unknown.code shouldBe "Unknown = 1"
+              connectionLost.code shouldBe "ConnectionLost = 100"
+              outlierReading.code shouldBe "OutlierReading = 200"
+            case _ => fail("Exactly 4 assignments expected")
+          }
+        case _ => fail("`ErrorCode` has no static initializer method!")
+      }
+    }
+
   }
 
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
@@ -115,4 +115,49 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
       }
     }
   }
+
+  "basic enum types" should {
+
+    val cpg = code(
+      """
+                    |enum Season
+                    |{
+                    |    Spring,
+                    |    Summer,
+                    |    Autumn,
+                    |    Winter
+                    |}
+                    |""".stripMargin,
+      "Season.cs"
+    )
+
+    "generate a type declaration enum members" in {
+      inside(cpg.typeDecl.nameExact("Season").headOption) {
+        case Some(rec) =>
+          rec.fullName shouldBe "Season"
+          inside(rec.member.l) {
+            case xs if xs.isEmpty => fail("No enum members found!")
+            case spring :: summer :: autumn :: winter :: Nil =>
+              spring.name shouldBe "Spring"
+              spring.code shouldBe "Spring"
+              spring.typeFullName shouldBe "Season"
+
+              summer.name shouldBe "Summer"
+              summer.code shouldBe "Summer"
+              summer.typeFullName shouldBe "Season"
+
+              autumn.name shouldBe "Autumn"
+              autumn.code shouldBe "Autumn"
+              autumn.typeFullName shouldBe "Season"
+
+              winter.name shouldBe "Winter"
+              winter.code shouldBe "Winter"
+              winter.typeFullName shouldBe "Season"
+            case _ => fail("Unexpected number of enum members!")
+          }
+        case None => fail("Unable to find `Season` type decl node")
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
* Handling `enum` types as type declarations
* As defined by the docs, these are numerical types and are asserted as such
* Handle alternative numerical definitions of types, e.g., `uint16`
* Introduced `EnumScope` unified by the `TypeLikeScope` trait