### PR TITLE
[javasrc2cpg] Clean up assignment creation code

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -168,7 +168,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
     fieldDeclarations.flatMap { fieldDeclaration =>
       fieldDeclaration.getVariables.asScala.filter(_.getInitializer.isPresent).toList.flatMap { variableDeclaration =>
         scope.pushFieldDeclScope(fieldDeclaration.isStatic, variableDeclaration.getNameAsString)
-        val assignmentAsts = assignmentsForVarDecl(variableDeclaration :: Nil)
+        val assignmentAsts = astsForVariableDeclarator(variableDeclaration, fieldDeclaration)
         scope.popFieldDeclScope()
         assignmentAsts
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -462,7 +462,7 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     staticFields.flatMap { field =>
       field.getVariables.asScala.toList.flatMap { variable =>
         scope.pushFieldDeclScope(isStatic = true, name = variable.getNameAsString)
-        val assignment = assignmentsForVarDecl(variable :: Nil)
+        val assignment = astsForVariableDeclarator(variable, field)
         scope.popFieldDeclScope()
         assignment
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -210,8 +210,14 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     val blockAst =
       blockAstForConstructorInvocation(line(expr), column(expr), allocNode, initCall, argumentAsts, isInnerType)
 
+    val parentIsSimpleAssign = expr.getParentNode.toScala
+      .collect { case assignExpr: AssignExpr =>
+        assignExpr.getTarget.isInstanceOf[NameExpr]
+      }
+      .getOrElse(false)
+
     expr.getParentNode.toScala match {
-      case Some(parent) if parent.isInstanceOf[VariableDeclarator] || parent.isInstanceOf[AssignExpr] =>
+      case Some(parent) if parent.isInstanceOf[VariableDeclarator] || parentIsSimpleAssign =>
         val partialConstructor = PartialConstructor(typeFullName, initCall, argumentAsts, blockAst)
         partialConstructorQueue.append(partialConstructor)
         Ast(allocNode)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForExpressionsCreator.scala
@@ -61,7 +61,7 @@ trait AstForExpressionsCreator
       case x: SuperExpr               => Seq(astForSuperExpr(x, expectedType))
       case x: ThisExpr                => Seq(astForThisExpr(x, expectedType))
       case x: UnaryExpr               => Seq(astForUnaryExpr(x, expectedType))
-      case x: VariableDeclarationExpr => astsForVariableDecl(x)
+      case x: VariableDeclarationExpr => astsForVariableDeclarationExpr(x)
       case x                          => Seq(unknownAst(x))
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
@@ -14,7 +14,6 @@ import io.joern.javasrc2cpg.scope.Scope.{
   NotInScope,
   ScopeMember,
   ScopeParameter,
-  ScopeStaticImport,
   ScopeVariable,
   SimpleVariable
 }
@@ -50,11 +49,6 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
           line(nameExpr),
           column(nameExpr)
         )
-
-      case SimpleVariable(variable: ScopeStaticImport) =>
-        val targetName   = variable.typeFullName.stripSuffix(s".${variable.name}")
-        val typeFullName = expressionReturnTypeFullName(nameExpr).map(typeInfoCalc.registerType)
-        fieldAccessAst(targetName, Some(targetName), variable.name, typeFullName, line(nameExpr), column(nameExpr))
 
       case SimpleVariable(variable) =>
         val identifier = identifierNode(nameExpr, name, name, typeFullName.getOrElse(TypeConstants.Any))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
@@ -75,10 +75,6 @@ object JavaScopeElement {
 
   class NamespaceScope(val namespace: NewNamespaceBlock) extends JavaScopeElement with TypeDeclContainer {
     val isStatic = false
-
-    def addStaticImport(staticImport: NewImport): Unit = {
-      addVariableToScope(ScopeStaticImport(staticImport))
-    }
   }
 
   class BlockScope extends JavaScopeElement {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BooleanOperationsTests.scala
@@ -42,6 +42,7 @@ class BooleanOperationsTests extends JavaSrcCode2CpgFixture {
   "should contain call nodes with <operation>.assignment for all variables" in {
     val assignments = cpg.assignment.map(x => (x.target.code, x.typeFullName)).l
     assignments.size shouldBe vars.size
+    assignments.toSet shouldBe (vars.toSet)
     vars.foreach(x => {
       withClue(s"Assignment to `${x._1}`:") {
         assignments contains x shouldBe true

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -72,6 +72,8 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
         |}
       |""".stripMargin)
 
+    val x = cpg.call.head
+    x.method
     cpg.call.name("foo").methodFullName.toList shouldBe List("Test.foo:void(java.lang.String[])")
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -72,8 +72,6 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
         |}
       |""".stripMargin)
 
-    val x = cpg.call.head
-    x.method
     cpg.call.name("foo").methodFullName.toList shouldBe List("Test.foo:void(java.lang.String[])")
   }
 


### PR DESCRIPTION
The main purpose of this PR is to deduplicate assignment code paths that were handled separately for variable declaration expressions and assignment expressions, which in turn will help clean up code for object creation expressions. 

It also removes unused code for handling static imports (cases to handle static imports from the scope were added, but static imports weren't added to the scope since representing these properly is problematic). Static imports as `NewVariableType`s was causing some trouble since they don't really fit the pattern for the others.