### PR TITLE
[php2cpg] Fix orphan identifier issue

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -667,7 +667,7 @@ class AstCreator(filename: String, phpAst: PhpFile)(implicit withSchemaValidatio
         case PhpVariable(PhpNameExpr(name, _), _) =>
           val maybeDefaultValueAst = staticVarDecl.defaultValue.map(astForExpr)
 
-          val code         = s"static $name"
+          val code         = s"static $$$name"
           val typeFullName = maybeDefaultValueAst.flatMap(_.rootType).getOrElse(TypeConstants.Any)
 
           val local = localNode(stmt, name, code, maybeDefaultValueAst.flatMap(_.rootType).getOrElse(TypeConstants.Any))
@@ -677,7 +677,7 @@ class AstCreator(filename: String, phpAst: PhpFile)(implicit withSchemaValidatio
             val variableNode = identifierNode(stmt, name, s"$$$name", typeFullName)
             val variableAst  = Ast(variableNode).withRefEdge(variableNode, local)
 
-            val assignCode = s"static $code = ${defaultValue.rootCodeOrEmpty}"
+            val assignCode = s"$code = ${defaultValue.rootCodeOrEmpty}"
             val assignNode = newOperatorCallNode(Operators.assignment, assignCode, line = line(stmt))
 
             callAst(assignNode, variableAst :: defaultValue :: Nil)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
@@ -1052,6 +1052,36 @@ class ControlStructureTests extends PhpCode2CpgFixture {
     cpg.all.collectAll[Identifier].filter(node => Try(node.astParent).isFailure).toList shouldBe Nil
   }
 
+  "foreach statements referencing parameters in methods should not create parentless identifiers" in {
+    val cpg = code("""<?php
+                     |class Test {
+                     |  function test() {
+                     |    foreach($this as $x) {}
+                     |  }
+                     |}
+                     |""".stripMargin)
+    cpg.all.collectAll[Identifier].filter(node => Try(node.astParent).isFailure).toList shouldBe Nil
+  }
+
+  "foreach statements referencing regular parameters should not create parentless identifiers" in {
+    val cpg = code("""<?php
+                     |function test($values) {
+                     |  foreach($values as $x) {}
+                     |}
+                     |""".stripMargin)
+    cpg.all.collectAll[Identifier].filter(node => Try(node.astParent).isFailure).toList shouldBe Nil
+  }
+
+  "foreach statements referencing locals should not create parentless identifiers" in {
+    val cpg = code("""<?php
+                     |function test() {
+                     |  $values = 2;
+                     |  foreach($values as $x) {}
+                     |}
+                     |""".stripMargin)
+    cpg.all.collectAll[Identifier].filter(node => Try(node.astParent).isFailure).toList shouldBe Nil
+  }
+
   "foreach statements with only simple values should be represented as a for" in {
     val cpg = code("""<?php
      |function foo($arr) {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -4,7 +4,9 @@ import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, Local}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
+
+import scala.util.Try
 
 class MethodTests extends PhpCode2CpgFixture {
 
@@ -32,22 +34,29 @@ class MethodTests extends PhpCode2CpgFixture {
     }
   }
 
-  "static variables without default values should be represented as the correct local nodes" in {
+  "static variables without default values" should {
     val cpg = code("""<?php
         |function foo() {
         |  static $x, $y;
         |}
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").body.astChildren.l) { case List(xLocal: Local, yLocal: Local) =>
-      xLocal.name shouldBe "x"
-      xLocal.code shouldBe "static $x"
-      xLocal.lineNumber shouldBe Some(3)
-
-      yLocal.name shouldBe "y"
-      yLocal.code shouldBe "static $y"
-      yLocal.lineNumber shouldBe Some(3)
+    "not leave orphan identifiers" in {
+      cpg.identifier.filter(identifier => Try(identifier.astParent.isEmpty).getOrElse(true)).toList shouldBe Nil
     }
+
+    "be represented as the correct local nodes" in {
+      inside(cpg.method.name("foo").body.astChildren.l) { case List(xLocal: Local, yLocal: Local) =>
+        xLocal.name shouldBe "x"
+        xLocal.code shouldBe "static $x"
+        xLocal.lineNumber shouldBe Some(3)
+
+        yLocal.name shouldBe "y"
+        yLocal.code shouldBe "static $y"
+        yLocal.lineNumber shouldBe Some(3)
+      }
+    }
+
   }
 
   "static variables with default values should have the correct initialisers" in {


### PR DESCRIPTION
There's a pattern in `php2cpg` where ASTs are sometimes created, but not added to the graph (doing it this way seemed sensible at the time, but now I'm doubting that). Regardless, this was causing an issue with `astForNameExpression` which added ref edges from the newly created node to the declaring node directly to the graph, even if that AST was not added, resulting in orphan identifier nodes. These orphan nodes, in turn, caused issues with some backend passes.

This PR cleans up a few of the cases where the AST is created but not added, but also changed `astForNameExpr` to return the ref edges in the identifier AST instead of adding them to the graph directly, which fixes the orphan issue even if created ASTs are discarded.

This should also fix https://shiftleftinc.atlassian.net/browse/SEN-2172