### PR TITLE
Clean up unused created AST in class statements

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -670,7 +670,7 @@ class AstCreator(filename: String, phpAst: PhpFile)(implicit withSchemaValidatio
           val code         = s"static $$$name"
           val typeFullName = maybeDefaultValueAst.flatMap(_.rootType).getOrElse(TypeConstants.Any)
 
-          val local = localNode(stmt, name, code, maybeDefaultValueAst.flatMap(_.rootType).getOrElse(TypeConstants.Any))
+          val local = localNode(stmt, name, code, typeFullName)
           scope.addToScope(local.name, local)
 
           val assignmentAst = maybeDefaultValueAst.map { defaultValue =>
@@ -1647,7 +1647,6 @@ class AstCreator(filename: String, phpAst: PhpFile)(implicit withSchemaValidatio
   }
 
   private def astForMagicClassConstant(expr: PhpClassConstFetchExpr): Ast = {
-    val classAst = astForExpr(expr.className)
     val typeFullName = expr.className match {
       case nameExpr: PhpNameExpr =>
         scope
@@ -1656,10 +1655,11 @@ class AstCreator(filename: String, phpAst: PhpFile)(implicit withSchemaValidatio
           .getOrElse(nameExpr.name)
 
       case expr =>
-        classAst.rootType.orElse(classAst.rootName).getOrElse(UnresolvedNamespace)
+        logger.warn(s"Unexpected expression as class name in <class>::class expression: $filename")
+        NameConstants.Unknown
     }
 
-    Ast(typeRefNode(expr, classAst.rootCodeOrEmpty, typeFullName))
+    Ast(typeRefNode(expr, s"$typeFullName::class", typeFullName))
   }
 
   private def astForClassConstFetchExpr(expr: PhpClassConstFetchExpr): Ast = {


### PR DESCRIPTION
A follow up to https://github.com/joernio/joern/pull/4133 which cleans up another instance of usused AST elements being created.

The same issue exists for the condition ASTs in `astForSwitchCase` and `astForMatchArm`, but the correct fix for those would be a change to the lowering we do, so I'll do that separately.