### PR TITLE
[ruby] Multi-Assignment Statements (excl. Splatting)

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -25,6 +25,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case node: FieldsDeclaration          => astsForFieldDeclarations(node)
     case node: MethodDeclaration          => astForMethodDeclaration(node) :: Nil
     case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node) :: Nil
+    case node: MultipleAssignment         => node.assignments.map(astForExpression)
     case _                                => astForExpression(node) :: Nil
 
   private def astForWhileStatement(node: WhileExpression): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -75,6 +75,8 @@ object RubyIntermediateAst {
 
   final case class SingleAssignment(lhs: RubyNode, op: String, rhs: RubyNode)(span: TextSpan) extends RubyNode(span)
 
+  final case class MultipleAssignment(assignments: List[SingleAssignment])(span: TextSpan) extends RubyNode(span)
+
   final case class AttributeAssignment(target: RubyNode, op: String, attributeName: String, rhs: RubyNode)(
     span: TextSpan
   ) extends RubyNode(span)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -19,7 +19,10 @@ import io.joern.rubysrc2cpg.parser.RubyParser.MultipleRightHandSideContext
   */
 class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
 
-  override def defaultResult(): RubyNode = Unknown()(TextSpan(None, None, None, None, ""))
+  private def defaultTextSpan(code: String = ""): TextSpan = TextSpan(None, None, None, None, code)
+
+  override def defaultResult(): RubyNode = Unknown()(defaultTextSpan())
+
   override protected def shouldVisitNextChild(node: RuleNode, currentResult: RubyNode): Boolean =
     currentResult.isInstanceOf[Unknown]
 
@@ -338,7 +341,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     val op = ctx.EQ().toString()
     // TODO: Handle grouping/ungrouping with splatting
     val assignments = lhsNodes
-      .zipAll(rhsNodes, defaultResult(), defaultResult())
+      .zipAll(rhsNodes, defaultResult(), Unknown()(defaultTextSpan(Defines.Undefined)))
       .map { case (lhs, rhs) => SingleAssignment(lhs, op, rhs)(ctx.toTextSpan) }
       .toList
     MultipleAssignment(assignments)(ctx.toTextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -9,6 +9,11 @@ import org.antlr.v4.runtime.tree.{ErrorNode, ParseTree, TerminalNode}
 import scala.jdk.CollectionConverters.*
 import org.antlr.v4.runtime.tree.RuleNode
 import io.joern.rubysrc2cpg.parser.RubyParser.SplattingArgumentContext
+import io.joern.rubysrc2cpg.parser.RubyParser.MultipleAssignmentStatementStatementContext
+import io.joern.rubysrc2cpg.parser.RubyParser.MultipleAssignmentStatementContext
+import io.joern.rubysrc2cpg.parser.RubyParser.MultipleLeftHandSideContext
+import io.joern.rubysrc2cpg.parser.RubyParser.SplattingRightHandSideContext
+import io.joern.rubysrc2cpg.parser.RubyParser.MultipleRightHandSideContext
 
 /** Converts an ANTLR Ruby Parse Tree into the intermediate Ruby AST.
   */
@@ -318,6 +323,32 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     val rhs = visit(ctx.rhs)
     val op  = ctx.assignmentOperator().getText
     SingleAssignment(lhs, op, rhs)(ctx.toTextSpan)
+  }
+
+  override def visitMultipleAssignmentStatement(ctx: MultipleAssignmentStatementContext): RubyNode = {
+    val lhsNodes = Option(ctx.multipleLeftHandSide())
+      .map(_.multipleLeftHandSideItem().asScala)
+      .map(_.map(visit))
+      .getOrElse(List.empty)
+      .toList
+    val rhsNodes = Option(ctx.multipleRightHandSide()).map(visit).getOrElse(defaultResult()) match {
+      case x: StatementList => x.statements
+      case x                => List(x)
+    }
+    val op = ctx.EQ().toString()
+    // TODO: Handle grouping/ungrouping with splatting
+    val assignments = lhsNodes
+      .zipAll(rhsNodes, defaultResult(), defaultResult())
+      .map { case (lhs, rhs) => SingleAssignment(lhs, op, rhs)(ctx.toTextSpan) }
+      .toList
+    MultipleAssignment(assignments)(ctx.toTextSpan)
+  }
+
+  override def visitMultipleRightHandSide(ctx: MultipleRightHandSideContext): RubyNode = {
+    Option(ctx.operatorExpressionList2())
+      .map(x => StatementList(x.operatorExpression().asScala.map(visit).toList)(ctx.toTextSpan))
+      .orElse(Option(ctx.splattingRightHandSide()).map(_.splattingArgument()).map(visit))
+      .getOrElse(defaultResult())
   }
 
   override def visitAttributeAssignmentExpression(ctx: RubyParser.AttributeAssignmentExpressionContext): RubyNode = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -4,6 +4,7 @@ import io.joern.rubysrc2cpg.astcreation.GlobalTypes
 
 object Defines {
   val Any: String        = "ANY"
+  val Undefined: String  = "Undefined"
   val Object: String     = "Object"
   val NilClass: String   = "NilClass"
   val TrueClass: String  = "TrueClass"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language.*
 
 class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
 
-  "simple destructuring of assignments" should {
+  "destructuring of a paired multi-assignment" should {
 
     val cpg = code("""
                     |a, b, c = 1, 2, 3
@@ -27,6 +27,25 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
           val List(c: Identifier, three: Literal) = cAssignment.argumentOut.toList: @unchecked
           c.name shouldBe "c"
           three.code shouldBe "3"
+        case _ => fail("Unexpected number of assignments found")
+      }
+
+    }
+
+  }
+
+  "destructuring of an unpaired multi-assignment biased to LHS" should {
+
+    val cpg = code("""
+                    |a, b, c, d = 1, 2, 3
+                    |""".stripMargin)
+
+    "separate the assigments into 3 and leave `d` undefined" in {
+      inside(cpg.assignment.l) {
+        case a :: b :: c :: Nil =>
+          a.code shouldBe "a, b, c, d = 1, 2, 3"
+          b.code shouldBe "a, b, c, d = 1, 2, 3"
+          c.code shouldBe "a, b, c, d = 1, 2, 3"
         case _ => fail("Unexpected number of assignments found")
       }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -1,0 +1,39 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Literal, Identifier}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import io.shiftleft.semanticcpg.language.*
+
+class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
+
+  "simple destructuring of assignments" should {
+
+    val cpg = code("""
+                    |
+                    |a, b, c = 1, 2, 3
+                    |""".stripMargin)
+
+    "separate the assigments" in {
+
+      inside(cpg.assignment.l) {
+        case aAssignment :: bAssignment :: cAssignment :: Nil =>
+          val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
+          a.name shouldBe "a"
+          one.code shouldBe "1"
+
+          val List(b: Identifier, two: Literal) = bAssignment.argumentOut.toList: @unchecked
+          b.name shouldBe "b"
+          two.code shouldBe "2"
+
+          val List(c: Identifier, three: Literal) = cAssignment.argumentOut.toList: @unchecked
+          c.name shouldBe "c"
+          three.code shouldBe "3"
+        case _ => fail("Unexpected number of assignments found")
+      }
+
+    }
+
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -13,9 +13,13 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
                     |a, b, c = 1, 2, 3
                     |""".stripMargin)
 
-    "separate the assigments" in {
+    "separate the assigments into three separate assignment nodes" in {
       inside(cpg.assignment.l) {
         case aAssignment :: bAssignment :: cAssignment :: Nil =>
+          aAssignment.code shouldBe "a, b, c = 1, 2, 3"
+          bAssignment.code shouldBe "a, b, c = 1, 2, 3"
+          cAssignment.code shouldBe "a, b, c = 1, 2, 3"
+
           val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
           a.name shouldBe "a"
           one.code shouldBe "1"
@@ -42,10 +46,22 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
 
     "separate the assigments into 3 and leave `d` undefined" in {
       inside(cpg.assignment.l) {
-        case a :: b :: c :: Nil =>
-          a.code shouldBe "a, b, c, d = 1, 2, 3"
-          b.code shouldBe "a, b, c, d = 1, 2, 3"
-          c.code shouldBe "a, b, c, d = 1, 2, 3"
+        case aAssignment :: bAssignment :: cAssignment :: Nil =>
+          aAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
+          bAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
+          cAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
+
+          val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
+          a.name shouldBe "a"
+          one.code shouldBe "1"
+
+          val List(b: Identifier, two: Literal) = bAssignment.argumentOut.toList: @unchecked
+          b.name shouldBe "b"
+          two.code shouldBe "2"
+
+          val List(c: Identifier, three: Literal) = cAssignment.argumentOut.toList: @unchecked
+          c.name shouldBe "c"
+          three.code shouldBe "3"
         case _ => fail("Unexpected number of assignments found")
       }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -10,12 +10,10 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
   "simple destructuring of assignments" should {
 
     val cpg = code("""
-                    |
                     |a, b, c = 1, 2, 3
                     |""".stripMargin)
 
     "separate the assigments" in {
-
       inside(cpg.assignment.l) {
         case aAssignment :: bAssignment :: cAssignment :: Nil =>
           val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -13,6 +13,7 @@ import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
 import org.scalatest.Tag
 
 import java.io.File
+import org.scalatest.Inside
 
 trait RubyFrontend(useDeprecatedFrontend: Boolean) extends LanguageFrontend {
   override val fileSuffix: String = ".rb"
@@ -62,6 +63,7 @@ class RubyCode2CpgFixture(
         .withExtraFlows(extraFlows)
         .withPostProcessingPasses(withPostProcessing)
     )
+    with Inside
     with SemanticCpgTestFixture(extraFlows) {
 
   implicit val resolver: ICallResolver = NoResolve


### PR DESCRIPTION
* Handles desugaring a multi-assignment statement into pairs and eventually mapped to a list of single assignments
* Handles the case where there is an unpaired variable on the LHS, and simply leaves it undeclared as is the behaviour of the interpreter

Partially resolves #3931