### PR TITLE
[c#] Interface support

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/TypeMap.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/TypeMap.scala
@@ -6,6 +6,7 @@ import io.joern.csharpsrc2cpg.astcreation.AstCreatorHelper
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.{
   ClassDeclaration,
   FieldDeclaration,
+  InterfaceDeclaration,
   MethodDeclaration,
   NamespaceDeclaration,
   RecordDeclaration,
@@ -109,10 +110,11 @@ class TypeMap(astGenResult: AstGenRunnerResult, initialMappings: List[NamespaceT
       .map(AstCreatorHelper.createDotNetNodeInfo(_))
       .filter { x =>
         x.node match
-          case ClassDeclaration  => true
-          case StructDeclaration => true
-          case RecordDeclaration => true
-          case _                 => false
+          case ClassDeclaration     => true
+          case StructDeclaration    => true
+          case RecordDeclaration    => true
+          case InterfaceDeclaration => true
+          case _                    => false
       }
       .map(parseClassDeclaration)
       .toSet

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
@@ -60,6 +60,7 @@ class AstCreator(val relativeFileName: String, val parserResult: ParserResult, v
       case _: BaseStmt               => astForStatement(nodeInfo)
       case NamespaceDeclaration      => astForNamespaceDeclaration(nodeInfo)
       case ClassDeclaration          => astForClassDeclaration(nodeInfo)
+      case InterfaceDeclaration      => astForClassDeclaration(nodeInfo)
       case StructDeclaration         => astForClassDeclaration(nodeInfo)
       case RecordDeclaration         => astForRecordDeclaration(nodeInfo)
       case EnumDeclaration           => astForEnumDeclaration(nodeInfo)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -274,7 +274,12 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val fullName    = s"${astFullName(methodDecl)}:$signature"
     val methodNode_ = methodNode(methodDecl, name, code(methodDecl), fullName, Option(signature), relativeFileName)
     scope.pushNewScope(MethodScope(fullName))
-    val body = astForBlock(createDotNetNodeInfo(methodDecl.json(ParserKeys.Body)))
+
+    // In the case of interfaces, the method body may not be present
+    val jsonBody = methodDecl.json(ParserKeys.Body)
+    val body =
+      if (!jsonBody.isNull) astForBlock(createDotNetNodeInfo(jsonBody))
+      else Ast(blockNode(methodDecl)) // Creates an empty block
     scope.popScope()
     val modifiers = astForModifiers(methodDecl).flatMap(_.nodes).collect { case x: NewModifier => x }
     val thisNode =

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -56,6 +56,8 @@ object DotNetJsonAst {
 
   object EnumMemberDeclaration extends DeclarationExpr
 
+  object InterfaceDeclaration extends DeclarationExpr
+
   object MethodDeclaration extends DeclarationExpr
 
   object ConstructorDeclaration extends DeclarationExpr


### PR DESCRIPTION
 * Parses interfaces like class declarations
 * Handles methods with empty bodies
 * Excludes inheritance handling, which is related to #3992
 
Resolves  [#3998](https://github.com/joernio/joern/issues/3998)