### PR TITLE
[Kotlin2Cpg] - Handle when without argument and without else block

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -403,7 +403,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     assert(expr.getSubjectExpression == null)
 
     val typeFullName = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
-    var elseAst: Ast = null
+    var elseAst: Ast = Ast() // Initialize this as `Ast()` instead of `null`, as there is no guarantee of else block
 
     // In reverse order than expr.getEntries since that is the order
     // we need for nested Operators.conditional construction.
@@ -424,8 +424,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
           elseAst = newElseAst
         case None =>
           // This is the 'else' branch of 'when'.
-          // No argument 'when' always have an 'else branch which comes last
-          // and thus first in reverse order.
+          // and thus first in reverse order, if exists
           elseAst = astsForExpression(entry.getExpression, None).head
       }
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/WhenExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/WhenExpressionTests.scala
@@ -91,6 +91,28 @@ class WhenExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = false)
     }
   }
 
+  "CPG for code with `when` without `argument` and without `else` block" should {
+    "be able to generate cpg" in {
+      val cpg = code("""
+          |package mypkg
+          |
+          |fun main() {
+          |    val number = 5
+          |
+          |    when {
+          |        number == 1 -> println("Number is 1")
+          |        number == 2 -> println("Number is 2")
+          |        number == 3 -> println("Number is 3")
+          |    }
+          |}
+          |
+          |""".stripMargin)
+
+      cpg.identifier("number").nonEmpty shouldBe true
+      cpg.literal("\"Number is 1\"").nonEmpty shouldBe true
+    }
+  }
+
   "smoke test for 'is'-pattern in 'when' statement" in {
     val cpg = code("""
         |package mypkg


### PR DESCRIPTION
This PR handles
- The assumption of having an `Else` block for when without argument 
- Initializes elseAst as `empty AST` instead of `null`, which results in runtime error while creation