### PR TITLE
[ruby] Handle Multi-Assignment Splitting

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -84,6 +84,7 @@ multipleLeftHandSideExceptPacking
 
 packingLeftHandSide
     :   STAR leftHandSide?
+    |   STAR leftHandSide (COMMA multipleLeftHandSideItem)*
     ;
 
 groupedLeftHandSide
@@ -92,12 +93,11 @@ groupedLeftHandSide
 
 multipleLeftHandSideItem
     :   leftHandSide
-    |   packingLeftHandSide
     |   groupedLeftHandSide
     ;
 
 multipleRightHandSide
-    :   operatorExpressionList2 (COMMA splattingRightHandSide)?
+    :   operatorExpressionList (COMMA splattingRightHandSide)?
     |   splattingRightHandSide
     ;
      

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -30,6 +30,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: IfExpression          => astForIfExpression(node)
     case node: RescueExpression      => astForRescueExpression(node)
     case node: MandatoryParameter    => astForMandatoryParameter(node)
+    case node: SplattingRubyNode     => astForSplattingRubyNode(node)
     case _                           => astForUnknown(node)
 
   protected def astForStaticLiteral(node: StaticLiteral): Ast = {
@@ -336,6 +337,13 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val code               = s"${node.target.text}${node.op}${node.methodName}"
     val fieldAccess = callNode(node, code, Operators.fieldAccess, Operators.fieldAccess, DispatchTypes.STATIC_DISPATCH)
     callAst(fieldAccess, Seq(targetAst, fieldIdentifierAst))
+  }
+
+  protected def astForSplattingRubyNode(node: SplattingRubyNode): Ast = {
+    val splattingCall =
+      callNode(node, code(node), RubyOperators.splat, RubyOperators.splat, DispatchTypes.STATIC_DISPATCH)
+    val argumentAst = astsForStatement(node.name)
+    callAst(splattingCall, argumentAst)
   }
 
   private def getBinaryOperatorName(op: String): Option[String]     = BinaryOperatorNames.get(op)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -127,7 +127,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
             case u: Unknown => List(u)
             case e =>
               logger.warn("Splatting not implemented for `when` in ruby `case`")
-              List(Unknown()(e.span.spanStart(s"*${e.span.text}")))
+              List(Unknown()(e.span))
           })
           // There is always at least one match expression or a splat
           // a splat will become an unknown in condition at the end

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -331,13 +331,9 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
       *   how many more duplicates to create.
       */
     def slurp(nodes: List[RubyNode], expandSize: Int): List[RubyNode] = nodes match {
-      case (head: SplattingRubyNode) :: tail if expandSize > 0 && tail.exists(_.isInstanceOf[SplattingRubyNode]) =>
-        val newTail = slurp(tail, expandSize - 1)
-        head :: slurp(head :: newTail, expandSize - 2)
-      case (head: SplattingRubyNode) :: tail if expandSize > 0 =>
-        head :: slurp(head :: tail, expandSize - 1)
-      case head :: tail => head :: slurp(tail, expandSize)
-      case Nil          => List.empty
+      case (head: SplattingRubyNode) :: tail if expandSize > 0 => head :: slurp(head :: tail, expandSize - 1)
+      case head :: tail                                        => head :: slurp(tail, expandSize)
+      case Nil                                                 => List.empty
     }
 
     val lhsNodes = Option(ctx.multipleLeftHandSide())

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -24,5 +24,6 @@ object Defines {
   object RubyOperators {
     val hashInitializer = "<operator>.hashInitializer"
     val association     = "<operator>.association"
+    val splat           = "<operator>.splat"
   }
 }


### PR DESCRIPTION
* Handles the splat operator on an array on the RHS of a multi-assignment
* Rolls back change where we could expect two splats on LHS, but had to work around some other grammar restrictions for the splat operator being on other points in the multi-assignment, e.g., `*a, b, c = ...` and `a, *b, c = ...`

In the following example
```ruby
list = [2, 3]
a, b, c = 1, *list
```
We would get
```ruby
a => 1
b => 2
c => 3
```
But we may not always be able to see `list`, instead, this is approximated with an `<operator>.splat` call node to look like
```ruby
a => 1
b => *list
c => *list
```

Finally Resolves #3931