### PR TITLE
[ruby] Program Summary & Typed Scope

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -12,9 +12,13 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.BatchedUpdate
 
-class AstCreator(val fileName: String, programCtx: RubyParser.ProgramContext, projectRoot: Option[String] = None)(
-  implicit withSchemaValidation: ValidationMode
-) extends AstCreatorBase(fileName)
+class AstCreator(
+  val fileName: String,
+  protected val programCtx: RubyParser.ProgramContext,
+  protected val projectRoot: Option[String] = None,
+  protected val programSummary: RubyProgramSummary = RubyProgramSummary()
+)(implicit withSchemaValidation: ValidationMode)
+    extends AstCreatorBase(fileName)
     with AstCreatorHelper
     with AstForStatementsCreator
     with AstForExpressionsCreator
@@ -73,7 +77,7 @@ class AstCreator(val fileName: String, programCtx: RubyParser.ProgramContext, pr
     )
     val methodReturn = methodReturnNode(rootNode, Defines.Any)
 
-    scope.newModuleScope
+    scope.newProgramScope
       .map { moduleScope =>
         scope.pushNewScope(moduleScope)
         val statementAsts = rootNode.statements.flatMap(astsForStatement)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
+import io.joern.rubysrc2cpg.datastructures.{NamespaceScope, MethodScope}
 import io.joern.rubysrc2cpg.parser.{ResourceManagedParser, RubyNodeCreator}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.datastructures.Stack.*
@@ -48,16 +49,16 @@ class AstCreator(protected val filename: String, parser: ResourceManagedParser, 
    */
   private def astForRubyFile(rootStatements: StatementList): Ast = {
     val fileNode = NewFile().name(relativeFileName)
+    val fullName = s"$relativeFileName:${NamespaceTraversal.globalNamespaceName}"
     val namespaceBlock = NewNamespaceBlock()
       .filename(relativeFileName)
       .name(NamespaceTraversal.globalNamespaceName)
-      .fullName(s"$relativeFileName:${NamespaceTraversal.globalNamespaceName}")
+      .fullName(fullName)
 
-    methodAstParentStack.push(namespaceBlock)
-    scope.pushNewScope(namespaceBlock)
+    scope.pushNewScope(NamespaceScope(fullName))
     val rubyFileMethod = astInFakeMethod(rootStatements)
     scope.popScope()
-    methodAstParentStack.pop()
+
     Ast(fileNode).withChild(Ast(namespaceBlock).withChild(rubyFileMethod))
   }
 
@@ -75,12 +76,10 @@ class AstCreator(protected val filename: String, parser: ResourceManagedParser, 
     )
     val methodReturn = methodReturnNode(rootNode, Defines.Any)
 
-    methodAstParentStack.push(methodNode_)
-    scope.pushNewScope(methodNode_)
+    scope.pushNewScope(MethodScope(fullName))
     val statementAsts = rootNode.statements.flatMap(astsForStatement)
     val bodyAst       = blockAst(blockNode(rootNode), statementAsts)
     scope.popScope()
-    methodAstParentStack.pop()
 
     methodAst(methodNode_, Seq.empty, bodyAst, methodReturn, newModifierNode(ModifierTypes.MODULE) :: Nil)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -2,27 +2,12 @@ package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.astcreation.GlobalTypes.{builtinFunctions, builtinPrefix}
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.RubyNode
 import io.joern.rubysrc2cpg.datastructures.{RubyProgramSummary, RubyScope}
-import io.joern.x2cpg.{Ast, Defines, ValidationMode}
-import io.joern.x2cpg.datastructures.Scope
 import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.{Ast, Defines, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 
 trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
-
-  /* Used to track variable names and their LOCAL nodes.
-   * TODO: Pre-populate program summary
-   */
-  protected val scope: RubyScope = new RubyScope(RubyProgramSummary(Map.empty))
-
-  /* Used if any constructors of classes are present to know if a default constructor should be generated
-   * TODO: this seems too specific to add another stack, perhaps there is a better way in checking the class body. There are some possible
-   * nesting edge cases which this handles better unless you recursively traverse the result of astsFor* on the class body. How common it would be in actual Ruby code is uncertain */
-  protected val shouldGenerateDefaultConstructorStack: Stack[Boolean] = new Stack()
-  protected def setNoDefaultConstructorForEnclosingTypeDecl: Unit = {
-    shouldGenerateDefaultConstructorStack.pop()
-    shouldGenerateDefaultConstructorStack.push(false)
-  }
 
   protected def computeClassFullName(name: String): String  = s"${scope.surroundingScopeFullName.head}.$name"
   protected def computeMethodFullName(name: String): String = s"${scope.surroundingScopeFullName.head}:$name"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.astcreation.GlobalTypes.{builtinFunctions, builtinPrefix}
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.RubyNode
+import io.joern.rubysrc2cpg.datastructures.{RubyProgramSummary, RubyScope}
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.joern.x2cpg.datastructures.Scope
 import io.joern.x2cpg.datastructures.Stack.*
@@ -10,14 +11,9 @@ import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   /* Used to track variable names and their LOCAL nodes.
-   * TODO: Perhaps move this feature into a new Pass?
+   * TODO: Pre-populate program summary
    */
-  protected val scope: Scope[String, NewNode, NewNode] = new Scope()
-
-  /* Used to compute a method's full name and parent.
-   * TODO: port RubyScope from the deprecated frontend here?
-   * */
-  protected val methodAstParentStack: Stack[NewNode] = new Stack()
+  protected val scope: RubyScope = new RubyScope(RubyProgramSummary(Map.empty))
 
   /* Used if any constructors of classes are present to know if a default constructor should be generated
    * TODO: this seems too specific to add another stack, perhaps there is a better way in checking the class body. There are some possible
@@ -28,10 +24,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     shouldGenerateDefaultConstructorStack.push(false)
   }
 
-  protected def getEnclosingAstType: String     = methodAstParentStack.head.label()
-  protected def getEnclosingAstFullName: String = methodAstParentStack.head.properties(PropertyNames.FULL_NAME).toString
-  protected def computeClassFullName(name: String): String  = s"$getEnclosingAstFullName.$name"
-  protected def computeMethodFullName(name: String): String = s"$getEnclosingAstFullName:$name"
+  protected def computeClassFullName(name: String): String  = s"${scope.surroundingScopeFullName.head}.$name"
+  protected def computeMethodFullName(name: String): String = s"${scope.surroundingScopeFullName.head}:$name"
 
   override def column(node: RubyNode): Option[Integer]    = node.column
   override def columnEnd(node: RubyNode): Option[Integer] = node.columnEnd

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -21,8 +21,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case node: SimpleCallWithBlock        => astForSimpleCallWithBlock(node) :: Nil
     case node: MemberCallWithBlock        => astForMemberCallWithBlock(node) :: Nil
     case node: ReturnExpression           => astForReturnStatement(node) :: Nil
-    case node: ModuleDeclaration          => astForModuleDeclaration(node) :: Nil
-    case node: ClassDeclaration           => astForClassDeclaration(node) :: Nil
+    case node: TypeDeclaration            => astForClassDeclaration(node) :: Nil
     case node: FieldsDeclaration          => astsForFieldDeclarations(node)
     case node: MethodDeclaration          => astForMethodDeclaration(node) :: Nil
     case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node) :: Nil

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -1,25 +1,26 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
-import io.joern.rubysrc2cpg.datastructures.TypeScope
+import io.joern.rubysrc2cpg.datastructures.{BlockScope, ConstructorScope, MethodScope, TypeScope}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, Operators}
 
 import scala.collection.immutable.List
+import io.joern.x2cpg.Defines as XDefines
 
 trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForModuleDeclaration(node: ModuleDeclaration): Ast = {
     // TODO: Might be wrong here (hence this placeholder), but I'm assuming modules ~= abstract classes.
     val classDecl = ClassDeclaration(node.moduleName, None, node.body)(node.span)
-    astForClassDeclaration(classDecl, defaultCtor = false)
+    astForClassDeclaration(classDecl)
   }
 
-  protected def astForClassDeclaration(node: ClassDeclaration, defaultCtor: Boolean = true): Ast = {
+  protected def astForClassDeclaration(node: ClassDeclaration): Ast = {
     node.className match
-      case name: SimpleIdentifier => astForSimpleNamedClassDeclaration(node, name, defaultCtor)
+      case name: SimpleIdentifier => astForSimpleNamedClassDeclaration(node, name)
       case name =>
         logger.warn(s"Qualified class names are not supported yet: ${name.text} ($relativeFileName), skipping")
         astForUnknown(node)
@@ -33,11 +34,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         None
   }
 
-  private def astForSimpleNamedClassDeclaration(
-    node: ClassDeclaration,
-    nameIdentifier: SimpleIdentifier,
-    defaultCtor: Boolean
-  ): Ast = {
+  private def astForSimpleNamedClassDeclaration(node: ClassDeclaration, nameIdentifier: SimpleIdentifier): Ast = {
     val className     = nameIdentifier.text
     val inheritsFrom  = node.baseClass.flatMap(getBaseClassName).toList
     val classFullName = computeClassFullName(className)
@@ -54,18 +51,18 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     )
 
     scope.pushNewScope(TypeScope(classFullName))
-    shouldGenerateDefaultConstructorStack.push(defaultCtor)
     val classBody =
       node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
     val classBodyAsts = classBody.statements.flatMap(astsForStatement) match {
-      case bodyAsts if shouldGenerateDefaultConstructorStack.head =>
-        val bodyStart  = classBody.span.spanStart()
-        val initBody   = StatementList(List())(bodyStart)
-        val methodDecl = astForMethodDeclaration(MethodDeclaration("<init>", List(), initBody)(bodyStart))
+      case bodyAsts if scope.shouldGenerateDefaultConstructor =>
+        val bodyStart = classBody.span.spanStart()
+        val initBody  = StatementList(List())(bodyStart)
+        val methodDecl = astForMethodDeclaration(
+          MethodDeclaration(XDefines.ConstructorMethodName, List(), initBody)(bodyStart)
+        )
         methodDecl :: bodyAsts
       case bodyAsts => bodyAsts
     }
-    shouldGenerateDefaultConstructorStack.pop()
     scope.popScope()
 
     Ast(typeDecl).withChildren(classBodyAsts)
@@ -91,10 +88,11 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
   // creates a `def <name>() { return <fieldName> }` METHOD, for <fieldName> = @<name>.
   private def astForGetterMethod(node: FieldsDeclaration, fieldName: String): Ast = {
-    val name = fieldName.drop(1)
+    val name     = fieldName.drop(1)
+    val fullName = computeMethodFullName(name)
     val method = methodNode(
       node = node,
-      name = name,
+      name = fullName,
       fullName = computeMethodFullName(name),
       code = s"def $name (...)",
       signature = None,
@@ -102,7 +100,8 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       astParentType = scope.surroundingAstLabel,
       astParentFullName = scope.surroundingScopeFullName
     )
-
+    scope.pushNewScope(MethodScope(fullName))
+    scope.pushNewScope(BlockScope)
     // TODO: Should it be `return this.@abc`?
     val returnAst_ = {
       val returnNode_         = returnNode(node, s"return $fieldName")
@@ -112,26 +111,29 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
     val block_     = blockNode(node)
     val methodBody = blockAst(block_, List(returnAst_))
-
+    scope.popScope()
+    scope.popScope()
     methodAst(method, Seq(), methodBody, methodReturnNode(node, Defines.Any))
   }
 
   // creates a `def <name>=(x) { <fieldName> = x }` METHOD, for <fieldName> = @<name>
   private def astForSetterMethod(node: FieldsDeclaration, fieldName: String): Ast = {
-    val name = fieldName.drop(1) + "="
+    val name     = fieldName.drop(1) + "="
+    val fullName = computeMethodFullName(name)
     val method = methodNode(
       node = node,
       name = name,
-      fullName = computeMethodFullName(name),
+      fullName = fullName,
       code = s"def $name (...)",
       signature = None,
       fileName = relativeFileName,
       astParentType = scope.surroundingAstLabel,
       astParentFullName = scope.surroundingScopeFullName
     )
-
+    scope.pushNewScope(MethodScope(fullName))
     val parameter = parameterInNode(node, "x", "x", 1, false, EvaluationStrategies.BY_REFERENCE)
     val methodBody = {
+      scope.pushNewScope(BlockScope)
       val lhs = identifierNode(node, fieldName, fieldName, Defines.Any)
       val rhs = identifierNode(node, parameter.name, parameter.name, Defines.Any)
       val assignmentCall = callNode(
@@ -142,9 +144,10 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         DispatchTypes.STATIC_DISPATCH
       )
       val assignmentAst = callAst(assignmentCall, Seq(Ast(lhs), Ast(rhs)))
+      scope.popScope()
       blockAst(blockNode(node), List(assignmentAst))
     }
-
+    scope.popScope()
     methodAst(method, Seq(Ast(parameter)), methodBody, methodReturnNode(node, Defines.Any))
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -1,0 +1,19 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.rubysrc2cpg.datastructures.RubyProgramSummary
+
+trait AstSummaryVisitor { this: AstCreator =>
+
+  protected var programSummary: RubyProgramSummary = RubyProgramSummary()
+
+  def summarize(): RubyProgramSummary = {
+    programSummary = RubyProgramSummary()
+    programSummary
+  }
+
+  def withSummary(newSummary: RubyProgramSummary): AstCreator = {
+    programSummary = newSummary
+    this
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -1,19 +1,100 @@
 package io.joern.rubysrc2cpg.astcreation
 
-import io.joern.rubysrc2cpg.datastructures.RubyProgramSummary
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
+  ClassDeclaration,
+  FieldsDeclaration,
+  MandatoryParameter,
+  MethodDeclaration,
+  ModuleDeclaration,
+  OptionalParameter,
+  RubyNode,
+  SimpleIdentifier,
+  StatementList,
+  TypeDeclaration
+}
+import io.joern.rubysrc2cpg.datastructures.{
+  NamespaceScope,
+  RubyField,
+  RubyMethod,
+  RubyProgramSummary,
+  RubyType,
+  TypeScope
+}
+import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.rubysrc2cpg.parser.RubyNodeCreator
+import io.joern.x2cpg.datastructures.ProgramSummary
+import io.joern.x2cpg.{ValidationMode, Defines as XDefines}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewMember, NewMethod, NewMethodParameterIn}
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
-trait AstSummaryVisitor { this: AstCreator =>
+trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  protected var programSummary: RubyProgramSummary = RubyProgramSummary()
+  private def baseNamespace: String = s"$relativeFileName:${NamespaceTraversal.globalNamespaceName}"
 
   def summarize(): RubyProgramSummary = {
-    programSummary = RubyProgramSummary()
-    programSummary
+    val rootNode = new RubyNodeCreator().visit(this.programCtx).asInstanceOf[StatementList]
+    val fullName = baseNamespace
+    scope.pushNewScope(NamespaceScope(fullName))
+
+    val newMap = scope.newProgramScope
+      .map { moduleScope =>
+        scope.pushNewScope(moduleScope)
+        val m = rootNode.statements
+          .map(visitStatement)
+          .reduceOption((a, b) => ProgramSummary.combine(a, b))
+          .getOrElse(Map.empty)
+        scope.popScope()
+        m
+      }
+      .getOrElse(Map.empty)
+
+    scope.popScope()
+    RubyProgramSummary(newMap)
   }
 
   def withSummary(newSummary: RubyProgramSummary): AstCreator = {
-    programSummary = newSummary
-    this
+    AstCreator(fileName, programCtx, projectRoot, newSummary)
+  }
+
+  private def visitStatement(stmt: RubyNode): Map[String, Set[RubyType]] = stmt match {
+    case node: TypeDeclaration => visitTypeDeclaration(node)
+    case _                     => Map.empty
+  }
+
+  private def visitTypeDeclaration(classDecl: TypeDeclaration): Map[String, Set[RubyType]] = {
+    classDecl.name match {
+      case name: SimpleIdentifier =>
+        val fullName = computeClassFullName(name.text)
+        Map(
+          scope.surroundingScopeFullName
+            .getOrElse(baseNamespace) -> Set(visitTypeLikeDeclaration(fullName, classDecl.body))
+        )
+      case _ => Map.empty
+    }
+  }
+
+  private def visitTypeLikeDeclaration(fullName: String, body: RubyNode): RubyType = {
+    scope.pushNewScope(TypeScope(fullName))
+    val classBody = body.asInstanceOf[StatementList]
+    val bodyMap =
+      classBody.statements.flatMap {
+        case MethodDeclaration(methodName, parameters, _) =>
+          RubyMethod(methodName, visitParameters(parameters), XDefines.Any) :: Nil
+        case node: FieldsDeclaration =>
+          astsForFieldDeclarations(node).flatMap(_.nodes).collect {
+            case x: NewMember => RubyField(x.name, x.typeFullName)
+            case x: NewMethod => RubyMethod(x.name, List.empty, XDefines.Any) // These are getters/setters
+          }
+        case _ => Seq.empty
+      }
+    scope.popScope()
+    RubyType(fullName, bodyMap.collect { case x: RubyMethod => x }, bodyMap.collect { case x: RubyField => x })
+  }
+
+  private def visitParameters(parameters: List[RubyNode]): List[(String, String)] = {
+    parameters.map(astForParameter(_, -1)).flatMap(_.root).collect { case x: NewMethodParameterIn =>
+      (x.name, x.typeFullName)
+    }
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -41,10 +41,21 @@ object RubyIntermediateAst {
     def size: Int = statements.size
   }
 
-  final case class ModuleDeclaration(moduleName: RubyNode, body: RubyNode)(span: TextSpan) extends RubyNode(span)
+  sealed trait TypeDeclaration {
+    def name: RubyNode
+    def baseClass: Option[RubyNode]
+    def body: RubyNode
+  }
 
-  final case class ClassDeclaration(className: RubyNode, baseClass: Option[RubyNode], body: RubyNode)(span: TextSpan)
+  final case class ModuleDeclaration(name: RubyNode, body: RubyNode)(span: TextSpan)
       extends RubyNode(span)
+      with TypeDeclaration {
+    def baseClass: Option[RubyNode] = None
+  }
+
+  final case class ClassDeclaration(name: RubyNode, baseClass: Option[RubyNode], body: RubyNode)(span: TextSpan)
+      extends RubyNode(span)
+      with TypeDeclaration
 
   final case class FieldsDeclaration(fieldNames: List[RubyNode])(span: TextSpan) extends RubyNode(span) {
     def hasGetter: Boolean = text.startsWith("attr_reader") || text.startsWith("attr_accessor")

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -2,9 +2,16 @@ package io.joern.rubysrc2cpg.datastructures
 
 import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, TypeLike}
 
-class RubyProgramSummary(initialMap: Map[String, Set[RubyType]]) extends ProgramSummary[RubyType] {
+import scala.annotation.targetName
+
+class RubyProgramSummary(initialMap: Map[String, Set[RubyType]] = Map.empty) extends ProgramSummary[RubyType] {
 
   override val namespaceToType: Map[String, Set[RubyType]] = initialMap
+
+  @targetName("add")
+  def ++(other: RubyProgramSummary): RubyProgramSummary = {
+    RubyProgramSummary(ProgramSummary.combine(this.namespaceToType, other.namespaceToType))
+  }
 
 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -1,0 +1,16 @@
+package io.joern.rubysrc2cpg.datastructures
+
+import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, TypeLike}
+
+class RubyProgramSummary(initialMap: Map[String, Set[RubyType]]) extends ProgramSummary[RubyType] {
+
+  override val namespaceToType: Map[String, Set[RubyType]] = initialMap
+
+}
+
+case class RubyMethod(name: String, parameterTypes: List[(String, String)], returnType: String) extends MethodLike
+
+case class RubyField(name: String, typeName: String) extends FieldLike
+
+case class RubyType(name: String, methods: List[RubyMethod], fields: List[RubyField])
+    extends TypeLike[RubyMethod, RubyField]

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -1,9 +1,30 @@
 package io.joern.rubysrc2cpg.datastructures
 
-import io.joern.rubysrc2cpg.datastructures.{RubyField, RubyMethod, RubyProgramSummary, RubyType}
-import io.joern.x2cpg.datastructures.{Scope, TypedScope, TypedScopeElement}
+import io.joern.x2cpg.datastructures.*
+import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 
 class RubyScope(summary: RubyProgramSummary)
     extends Scope[String, NewNode, TypedScopeElement]
-    with TypedScope[RubyMethod, RubyField, RubyType](summary)
+    with TypedScope[RubyMethod, RubyField, RubyType](summary) {
+
+  /** @return
+    *   the full name of the surrounding scope.
+    */
+  def surroundingScopeFullName: Option[String] = stack.collectFirst {
+    case ScopeElement(x: NamespaceLikeScope, _) => x.fullName
+    case ScopeElement(x: TypeLikeScope, _)      => x.fullName
+    case ScopeElement(MethodScope(fullName), _) => fullName
+  }
+
+  /** @return
+    *   the corresponding node label according to the scope element.
+    */
+  def surroundingAstLabel: Option[String] = stack.collectFirst {
+    case ScopeElement(_: NamespaceLikeScope, _) => NodeTypes.NAMESPACE_BLOCK
+    case ScopeElement(_: TypeLikeScope, _)      => NodeTypes.TYPE_DECL
+    case ScopeElement(MethodScope(_), _)        => NodeTypes.METHOD
+    case ScopeElement(BlockScope, _)            => NodeTypes.BLOCK
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -1,0 +1,9 @@
+package io.joern.rubysrc2cpg.datastructures
+
+import io.joern.rubysrc2cpg.datastructures.{RubyField, RubyMethod, RubyProgramSummary, RubyType}
+import io.joern.x2cpg.datastructures.{Scope, TypedScope, TypedScopeElement}
+import io.shiftleft.codepropertygraph.generated.nodes.NewNode
+
+class RubyScope(summary: RubyProgramSummary)
+    extends Scope[String, NewNode, TypedScopeElement]
+    with TypedScope[RubyMethod, RubyField, RubyType](summary)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -12,7 +12,16 @@ case class NamespaceScope(fullName: String) extends NamespaceLikeScope
 /** A type-like scope with a full name.
   */
 trait TypeLikeScope extends TypedScopeElement {
+
+  /** @return
+    *   the full name of the type-like.
+    */
   def fullName: String
+
+  /** @return
+    *   true if a default constructor is required.
+    */
+  def needsDefaultConstructor: Boolean
 }
 
 /** A module.
@@ -22,6 +31,8 @@ trait TypeLikeScope extends TypedScopeElement {
   */
 case class ModuleScope(fileName: String) extends TypeLikeScope {
   override def fullName: String = s"$fileName:${Defines.Program}"
+
+  override def needsDefaultConstructor: Boolean = false
 }
 
 /** A class or interface.
@@ -29,14 +40,17 @@ case class ModuleScope(fileName: String) extends TypeLikeScope {
   * @param fullName
   *   the type full name.
   */
-case class TypeScope(fullName: String) extends TypeLikeScope
+case class TypeScope(fullName: String, needsDefaultConstructor: Boolean = false) extends TypeLikeScope
 
 /** Represents scope objects that map to a method node.
-  *
-  * @param fullName
-  *   the method full name.
   */
-case class MethodScope(fullName: String) extends TypedScopeElement
+trait MethodLikeScope extends TypedScopeElement {
+  def fullName: String
+}
+
+case class MethodScope(fullName: String) extends MethodLikeScope
+
+case class ConstructorScope(fullName: String) extends MethodLikeScope
 
 /** Represents scope objects that map to a block node.
   */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -1,0 +1,37 @@
+package io.joern.rubysrc2cpg.datastructures
+
+import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.x2cpg.datastructures.{NamespaceLikeScope, TypedScopeElement}
+
+/** The namespace.
+  * @param fullName
+  *   the namespace path.
+  */
+case class NamespaceScope(fullName: String) extends NamespaceLikeScope
+
+/** A module.
+  *
+  * @param fileName
+  *   the relative file name.
+  */
+case class ModuleScope(fileName: String) extends TypedScopeElement {
+  override def toString: String = s"$fileName:${Defines.Program}"
+}
+
+/** A class or interface.
+  *
+  * @param fullName
+  *   the type full name.
+  */
+case class TypeScope(fullName: String) extends TypedScopeElement
+
+/** Represents scope objects that map to a method node.
+  *
+  * @param fullName
+  *   the method full name.
+  */
+case class MethodScope(fullName: String) extends TypedScopeElement
+
+/** Represents scope objects that map to a block node.
+  */
+object BlockScope extends TypedScopeElement

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -24,14 +24,22 @@ trait TypeLikeScope extends TypedScopeElement {
   def needsDefaultConstructor: Boolean
 }
 
-/** A module.
+/** A file-level module.
   *
   * @param fileName
   *   the relative file name.
   */
-case class ModuleScope(fileName: String) extends TypeLikeScope {
+case class ProgramScope(fileName: String) extends TypeLikeScope {
   override def fullName: String = s"$fileName:${Defines.Program}"
 
+  override def needsDefaultConstructor: Boolean = false
+}
+
+/** A Ruby module/abstract class.
+  * @param fullName
+  *   the type full name.
+  */
+case class ModuleScope(fullName: String) extends TypeLikeScope {
   override def needsDefaultConstructor: Boolean = false
 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -9,13 +9,19 @@ import io.joern.x2cpg.datastructures.{NamespaceLikeScope, TypedScopeElement}
   */
 case class NamespaceScope(fullName: String) extends NamespaceLikeScope
 
+/** A type-like scope with a full name.
+  */
+trait TypeLikeScope extends TypedScopeElement {
+  def fullName: String
+}
+
 /** A module.
   *
   * @param fileName
   *   the relative file name.
   */
-case class ModuleScope(fileName: String) extends TypedScopeElement {
-  override def toString: String = s"$fileName:${Defines.Program}"
+case class ModuleScope(fileName: String) extends TypeLikeScope {
+  override def fullName: String = s"$fileName:${Defines.Program}"
 }
 
 /** A class or interface.
@@ -23,7 +29,7 @@ case class ModuleScope(fileName: String) extends TypedScopeElement {
   * @param fullName
   *   the type full name.
   */
-case class TypeScope(fullName: String) extends TypedScopeElement
+case class TypeScope(fullName: String) extends TypeLikeScope
 
 /** Represents scope objects that map to a method node.
   *

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -20,7 +20,7 @@ object Defines {
   val Encoding: String   = "Encoding"
   val Regexp: String     = "Regexp"
 
-  val Program: String = "program"
+  val Program: String = ":program"
 
   def getBuiltInType(typeInString: String) = s"${GlobalTypes.builtinPrefix}.$typeInString"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.passes
 import io.joern.rubysrc2cpg.astcreation.GlobalTypes
 
 object Defines {
+
   val Any: String        = "ANY"
   val Undefined: String  = "Undefined"
   val Object: String     = "Object"
@@ -18,6 +19,8 @@ object Defines {
   val Hash: String       = "Hash"
   val Encoding: String   = "Encoding"
   val Regexp: String     = "Regexp"
+
+  val Program: String = "program"
 
   def getBuiltInType(typeInString: String) = s"${GlobalTypes.builtinPrefix}.$typeInString"
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
@@ -8,10 +8,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.DeclarationNew
   *
   * The utility of this object is in assisting resolving shorthand types during AST creation.
   *
-  * @tparam M
-  *   the method/function meta data class.
-  * @tparam F
-  *   the field/object property meta data class.
   * @tparam T
   *   the type/class meta data class.
   */
@@ -48,12 +44,9 @@ trait ProgramSummary[T <: TypeLike[_, _]] {
   *   the field/object property meta data class.
   * @tparam T
   *   the type/class meta data class.
-  * @tparam S
-  *   the scope type.
   */
-trait TypedScope[M <: MethodLike, F <: FieldLike, T <: TypeLike[M, F], S <: TypedScopeElement](
-  summary: ProgramSummary[T]
-) { this: Scope[_, _, S] =>
+trait TypedScope[M <: MethodLike, F <: FieldLike, T <: TypeLike[M, F]](summary: ProgramSummary[T]) {
+  this: Scope[_, _, TypedScopeElement] =>
 
   /** Tracks the types that are visible to this scope.
     */
@@ -81,7 +74,6 @@ trait TypedScope[M <: MethodLike, F <: FieldLike, T <: TypeLike[M, F], S <: Type
         case typ if typ.name.endsWith(typeName)                                           => typ
         case typ if aliasedTypes.contains(typeName) && typ.name == aliasedTypes(typeName) => typ
       }
-      .flatMap(typ => summary.namespaceFor(typ).map(namespace => typ))
   }
 
   /** Given the type full name and call name, will attempt to find the matching entry.
@@ -194,7 +186,7 @@ trait TypedScope[M <: MethodLike, F <: FieldLike, T <: TypeLike[M, F], S <: Type
   */
 class DefaultTypedScope[M <: MethodLike, F <: FieldLike, T <: TypeLike[M, F]](summary: ProgramSummary[T])
     extends Scope[String, DeclarationNew, TypedScopeElement]
-    with TypedScope[M, F, T, TypedScopeElement](summary) {
+    with TypedScope[M, F, T](summary) {
 
   /** Pops the scope, adding types from the scope if necessary.
     */

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
@@ -1,7 +1,9 @@
 package io.joern.x2cpg.datastructures
 
-import scala.collection.mutable
 import io.shiftleft.codepropertygraph.generated.nodes.DeclarationNew
+
+import scala.collection.immutable.Map
+import scala.collection.mutable
 
 /** A hierarchical data-structure that stores the result of types and their respective members. These types can be
   * sourced from pre-parsing the application, or pre-computed stubs of common libraries.
@@ -32,6 +34,25 @@ trait ProgramSummary[T <: TypeLike[_, _]] {
     */
   def matchingTypes(typeName: String): List[T] = {
     namespaceToType.values.flatten.filter(_.name.endsWith(typeName)).toList
+  }
+
+}
+
+object ProgramSummary {
+
+  /** Combines two namespace-to-type maps.
+    */
+  def combine[T <: TypeLike[_, _]](a: Map[String, Set[T]], b: Map[String, Set[T]]): Map[String, Set[T]] = {
+    val accumulator = mutable.HashMap.from(a)
+    val allKeys     = accumulator.keySet ++ b.keySet
+
+    allKeys.foreach(k =>
+      accumulator.updateWith(k) {
+        case Some(existing) => Option(a.getOrElse(k, Set.empty) ++ b.getOrElse(k, Set.empty) ++ existing)
+        case None           => Option(a.getOrElse(k, Set.empty) ++ b.getOrElse(k, Set.empty))
+      }
+    )
+    accumulator.toMap
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
@@ -44,9 +44,8 @@ object ProgramSummary {
     */
   def combine[T <: TypeLike[_, _]](a: Map[String, Set[T]], b: Map[String, Set[T]]): Map[String, Set[T]] = {
     val accumulator = mutable.HashMap.from(a)
-    val allKeys     = accumulator.keySet ++ b.keySet
 
-    allKeys.foreach(k =>
+    b.keySet.foreach(k =>
       accumulator.updateWith(k) {
         case Some(existing) => Option(a.getOrElse(k, Set.empty) ++ b.getOrElse(k, Set.empty) ++ existing)
         case None           => Option(a.getOrElse(k, Set.empty) ++ b.getOrElse(k, Set.empty))


### PR DESCRIPTION
This is a big one, but here we go

* Created basic implementation classes for `ProgramSummary` and `TypedScopeElement` in Ruby
* Added program summary hooks with implementation in `AstSummaryVisitor` that re-uses some `AstCreator` processes.
* Implemented pre-parse of high-level structures 
* Used this to fix implicit constructor bugs (and other bugs that were lurking around due to having 3 stacks)
* Differentiated modules/types to make sure implicit constructor wasn't created for modules
* Removed other stacks, only using `scope` now

Now we should be able to figure out if an `identifier` is a call or not with the lookahead that `RubyScope` and `RubyProgramSummary` provides us with.

Resolves #4128