### PR TITLE
[ruby] Fix Flaky Pre-Parse Test & Handle Class Look-Ahead

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/ParseInternalStructures.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/ParseInternalStructures.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.deprecated
 import io.joern.rubysrc2cpg.RubySrc2Cpg
 import io.joern.rubysrc2cpg.deprecated.parser.DeprecatedRubyParser
 import io.joern.rubysrc2cpg.deprecated.parser.DeprecatedRubyParser.*
+import io.joern.rubysrc2cpg.deprecated.passes.Defines
 import io.joern.rubysrc2cpg.deprecated.utils.PackageTable
 import io.joern.x2cpg.utils.ConcurrentTaskUtil
 import org.antlr.v4.runtime.ParserRuleContext
@@ -63,7 +64,32 @@ class ParseInternalStructures(
 
   private def parsePrimaryContext(ctx: PrimaryContext)(implicit classStack: mutable.Stack[String]): Unit = ctx match {
     case ctx: MethodDefinitionPrimaryContext => parseMethodDefinitionContext(ctx.methodDefinition())
+    case ctx: ModuleDefinitionPrimaryContext => parseModuleDefinitionContext(ctx.moduleDefinition())
+    case ctx: ClassDefinitionPrimaryContext  => parseClassDefinition(ctx.classDefinition())
     case _                                   =>
+  }
+
+  private def parseModuleDefinitionContext(
+    moduleDefinitionContext: ModuleDefinitionContext
+  )(implicit classStack: mutable.Stack[String]): Unit = {
+    val className = moduleDefinitionContext.classOrModuleReference().CONSTANT_IDENTIFIER().getText
+    classStack.push(className)
+    parseClassBody(moduleDefinitionContext.bodyStatement())
+  }
+
+  private def parseClassDefinition(
+    classDef: ClassDefinitionContext
+  )(implicit classStack: mutable.Stack[String]): Unit = {
+    Option(classDef).foreach { ctx =>
+      Option(ctx.classOrModuleReference()).map(_.CONSTANT_IDENTIFIER().getText).foreach { className =>
+        classStack.push(className)
+        parseClassBody(ctx.bodyStatement())
+      }
+    }
+  }
+
+  private def parseClassBody(ctx: BodyStatementContext)(implicit classStack: mutable.Stack[String]): Unit = {
+    Option(ctx).map(_.compoundStatement()).map(_.statements()).foreach(_.statement().asScala.foreach(parseStatement))
   }
 
   private def parseMethodDefinitionContext(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/ParseInternalStructures.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/ParseInternalStructures.scala
@@ -19,21 +19,12 @@ class ParseInternalStructures(
   projectRoot: Option[String] = None
 ) {
 
-  private val logger = LoggerFactory.getLogger(getClass)
-
   def populatePackageTable(): Unit = {
-    val tasks = parsedFiles.map { case (fileName, programCtx) =>
-      () => {
-        val relativeFilename: String =
-          projectRoot.map(fileName.stripPrefix).map(_.stripPrefix(JFile.separator)).getOrElse(fileName)
-        implicit val classStack: mutable.Stack[String] = mutable.Stack[String]()
-        parseForStructures(relativeFilename, programCtx)
-      }
-    }.iterator
-    ConcurrentTaskUtil.runUsingThreadPool(tasks).foreach {
-      case Failure(exception) =>
-        logger.warn("Exception encountered while scanning for internal structures", exception)
-      case _ => // do nothing
+    parsedFiles.foreach { case (fileName, programCtx) =>
+      val relativeFilename: String =
+        projectRoot.map(fileName.stripPrefix).map(_.stripPrefix(JFile.separator)).getOrElse(fileName)
+      implicit val classStack: mutable.Stack[String] = mutable.Stack[String]()
+      parseForStructures(relativeFilename, programCtx)
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/CallCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/CallCpgTests.scala
@@ -219,8 +219,7 @@ class CallCpgTests extends RubyCode2CpgFixture(withPostProcessing = true, useDep
         "foo.rb"
       )
 
-    // TODO: Flaky test
-    "have its call node correctly identified and created" ignore {
+    "have its call node correctly identified and created" in {
       val List(deviceParams) = cpg.call.nameExact("device_params").l: @unchecked
       deviceParams.name shouldBe "device_params"
       deviceParams.code shouldBe "device_params"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/CallCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/CallCpgTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.deprecated.passes.ast
 
 import io.joern.rubysrc2cpg.deprecated.passes.Defines
 import io.joern.rubysrc2cpg.testfixtures.{RubyCode2CpgFixture, SameInNewFrontend}
-import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, MethodRef}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, MethodRef}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, nodes}
 import io.shiftleft.semanticcpg.language.*
 
@@ -228,6 +228,53 @@ class CallCpgTests extends RubyCode2CpgFixture(withPostProcessing = true, useDep
       deviceParams.lineNumber shouldBe Option(5)
       deviceParams.columnNumber shouldBe Option(22)
       deviceParams.argumentIndex shouldBe 0
+    }
+  }
+
+  "a parenthesis-less call (defined later in the module) in a call's argument" should {
+    val cpg = code("""
+        |module Pay
+        |  module Webhooks
+        |    class BraintreeController < Pay::ApplicationController
+        |      if Rails.application.config.action_controller.default_protect_from_forgery
+        |        skip_before_action :verify_authenticity_token
+        |      end
+        |
+        |      def create
+        |        queue_event(verified_event) # <------ verified event is a call here
+        |        head :ok
+        |      rescue ::Braintree::InvalidSignature
+        |        head :bad_request
+        |      end
+        |
+        |      private
+        |
+        |      def queue_event(event)
+        |        return unless Pay::Webhooks.delegator.listening?("braintree.#{event.kind}")
+        |
+        |        record = Pay::Webhook.create!(
+        |          processor: :braintree,
+        |          event_type: event.kind,
+        |          event: {bt_signature: params[:bt_signature], bt_payload: params[:bt_payload]}
+        |        )
+        |        Pay::Webhooks::ProcessJob.perform_later(record)
+        |      end
+        |
+        |      def verified_event
+        |        Pay.braintree_gateway.webhook_notification.parse(params[:bt_signature], params[:bt_payload])
+        |      end
+        |    end
+        |  end
+        |end
+        |""".stripMargin)
+
+    "be a call node instead of an identifier" in {
+      inside(cpg.call("queue_event").argument.l) {
+        case (verifiedEvent: Call) :: Nil =>
+          verifiedEvent.name shouldBe "verified_event"
+        case xs =>
+          fail(s"Expected a single call argument, received [${xs.map(x => x.label -> x.code).mkString(", ")}] instead!")
+      }
     }
   }
 }


### PR DESCRIPTION
Following up on https://github.com/joernio/joern/pull/4145, this removes the mulithreaded pre-parsing.

The issue was that the underlying data structures in `packageTable` were not thread-safe, and thus resulted in race-conditions. As this is the deprecated frontend, I will leave the pre-parsing as serial for now.

Used this as an opportunity to add an additional test case, visiting modules & classes for methods in the look-ahead.

Resolves  #4057