### PR TITLE
data flow table: use shorter column name for line number

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
@@ -26,7 +26,7 @@ object Path {
     availableWidthProvider: AvailableWidthProvider = semanticcpg.defaultAvailableWidthProvider
   ): Show[Path] = { path =>
     val table = Table(
-      columnNames = Array("nodeType", "tracked", "lineNumber", "method", "file"),
+      columnNames = Array("nodeType", "tracked", "line", "method", "file"),
       rows = path.elements.map { astNode =>
         val nodeType   = astNode.getClass.getSimpleName
         val lineNumber = astNode.lineNumber.getOrElse("N/A").toString


### PR DESCRIPTION
so that the whole column uses less space