### PR TITLE
Revert "[CI/CD] GitHub Actions to Ignore `**.md` Edits"

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [master, main]
     tags: ["*"]
-    paths-ignore: ['**.md']
-
 jobs:
   test:
     concurrency: master

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,5 @@
 name: pr
-on:
-  pull_request:
-    paths-ignore: ['**.md']
-
+on: pull_request
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Reverts joernio/joern#3807

I believe we didn't think this through back in the days... the result is that PRs like https://github.com/joernio/joern/pull/4182 can't get merged because CI doesn't run, while it's mandatory for CI to run in order to merge...

I guess we could perform the same check before running `sbt test`, but in order to unblock the linked PR, I'd like to revert this now. 