### PR TITLE
[swiftsrc2cpg] Update SwiftAstGen

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.2.2"
+    astgen_version: "0.2.3"
 }


### PR DESCRIPTION
This version of SwiftAstGen was built on Ubuntu 20.04 which ships with an older version of lib6-dev and libgcc9-dev. Hopefully, this unblocks our CS integration tests.