### PR TITLE
[javasrc2cpg] Don't create 2 ASTs for init calls

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -25,7 +25,6 @@ import com.github.javaparser.resolution.types.ResolvedType
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
 import io.joern.javasrc2cpg.astcreation.declarations.AstForDeclarationsCreator
-import io.joern.javasrc2cpg.astcreation.expressions.AstForCallExpressionsCreator.PartialConstructor
 import io.joern.javasrc2cpg.astcreation.expressions.AstForExpressionsCreator
 import io.joern.javasrc2cpg.astcreation.statements.AstForStatementsCreator
 import io.joern.javasrc2cpg.scope.Scope
@@ -98,9 +97,7 @@ class AstCreator(
   private[astcreation] val scope = Scope()
 
   private[astcreation] val typeInfoCalc: TypeInfoCalculator = TypeInfoCalculator(global, symbolSolver)
-  // TODO Move to scope or get rid of it.
-  private[astcreation] val partialConstructorQueue: mutable.ArrayBuffer[PartialConstructor] = mutable.ArrayBuffer.empty
-  private[astcreation] val bindingTableCache = mutable.HashMap.empty[String, BindingTable]
+  private[astcreation] val bindingTableCache                = mutable.HashMap.empty[String, BindingTable]
 
   /** Entry point of AST creation. Translates a compilation unit created by JavaParser into a DiffGraph containing the
     * corresponding CPG AST.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg.astcreation.expressions
 
 import com.github.javaparser.ast.body.VariableDeclarator
+import com.github.javaparser.ast.expr.AssignExpr.Operator
 import com.github.javaparser.ast.expr.{
   AssignExpr,
   Expression,
@@ -15,8 +16,9 @@ import com.github.javaparser.ast.expr.{
 import com.github.javaparser.ast.{Node, NodeList}
 import com.github.javaparser.resolution.declarations.{ResolvedMethodDeclaration, ResolvedMethodLikeDeclaration}
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
-import io.joern.javasrc2cpg.astcreation.expressions.AstForCallExpressionsCreator.PartialConstructor
+import io.joern.javasrc2cpg.astcreation.expressions.AstForCallExpressionsCreator.AllocAndInitCallAsts
 import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
+import io.joern.javasrc2cpg.scope.Scope.typeFullName
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 import io.joern.javasrc2cpg.util.NameConstants
 import io.joern.javasrc2cpg.util.Util.{composeMethodFullName, composeMethodLikeSignature, composeUnresolvedSignature}
@@ -24,23 +26,31 @@ import io.joern.x2cpg.utils.AstPropertiesUtil.*
 import io.joern.x2cpg.utils.NodeBuilders.{newIdentifierNode, newOperatorCallNode}
 import io.joern.x2cpg.{Ast, Defines}
 import io.shiftleft.codepropertygraph.generated.nodes.Call.PropertyDefaults
-import io.shiftleft.codepropertygraph.generated.nodes.{ExpressionNew, NewBlock, NewCall, NewIdentifier}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  AstNodeNew,
+  ExpressionNew,
+  NewBlock,
+  NewCall,
+  NewIdentifier,
+  NewMember
+}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.{Success, Try}
 import javassist.compiler.ast.CallExpr
-import io.joern.javasrc2cpg.scope.Scope.ScopeInnerType
-import io.joern.javasrc2cpg.scope.Scope.SimpleVariable
-import io.joern.javasrc2cpg.scope.Scope.ScopeParameter
+import io.joern.javasrc2cpg.scope.Scope.{NewVariableNode, ScopeInnerType, ScopeParameter, SimpleVariable}
 import io.joern.javasrc2cpg.scope.JavaScopeElement.PartialInit
+import org.slf4j.LoggerFactory
 
 object AstForCallExpressionsCreator {
-  case class PartialConstructor(typeFullName: Option[String], initNode: NewCall, initArgs: Seq[Ast], blockAst: Ast)
+  private[expressions] final case class AllocAndInitCallAsts(allocAst: Ast, initAst: Ast)
 }
 
 trait AstForCallExpressionsCreator { this: AstCreator =>
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   private var tempConstCount = 0
 
@@ -132,32 +142,51 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     }
   }
 
-  /** The below representation for constructor invocations and object creations was chosen for the sake of consistency
-    * with the Java frontend. It follows the bytecode approach of splitting a constructor call into separate `alloc` and
-    * `init` calls.
-    *
-    * There are two cases to consider. The first is a constructor invocation in an assignment, for example:
-    *
-    * Foo f = new Foo(42);
-    *
-    * is represented as
-    *
-    * Foo f = <operator>.alloc() f.init(42);
-    *
-    * The second case is a constructor invocation not in an assignment, for example as an argument to a method call. In
-    * this case, the representation does not stay as close to Java as in case
-    *   1. In particular, a new BLOCK is introduced to contain the constructor invocation. For example:
-    *
-    * foo(new Foo(42));
-    *
-    * is represented as
-    *
-    * foo({ Foo temp = alloc(); temp.init(42); temp })
-    *
-    * This is not valid Java code, but this representation is a decent compromise between staying faithful to Java and
-    * being consistent with the Java bytecode frontend.
-    */
-  private[expressions] def astForObjectCreationExpr(expr: ObjectCreationExpr, expectedType: ExpectedType): Ast = {
+  private[expressions] def blockAstForObjectCreationExpr(expr: ObjectCreationExpr, expectedType: ExpectedType): Ast = {
+    val tmpName = "$obj" ++ tempConstCount.toString
+    tempConstCount += 1
+
+    // Use an untyped identifier for receiver here, create the alloc and init ASTs,
+    // then use the types of those to fix the local type.
+    val tmpIdentifier = identifierNode(expr, tmpName, tmpName, TypeConstants.Any)
+    val allocAndInitAst =
+      inlinedAstsForObjectCreationExpr(expr, Ast(tmpIdentifier), expectedType, resetAssignmentTargetType = true)
+
+    tmpIdentifier.typeFullName(allocAndInitAst.allocAst.rootType.getOrElse(TypeConstants.Any))
+    val tmpLocal = localNode(expr, tmpName, tmpName, tmpIdentifier.typeFullName)
+
+    val allocAssignCode = s"$tmpName = ${allocAndInitAst.allocAst.rootCodeOrEmpty}"
+    val allocAssignCall =
+      callNode(
+        expr,
+        allocAssignCode,
+        Operators.assignment,
+        Operators.assignment,
+        DispatchTypes.STATIC_DISPATCH,
+        signature = None,
+        typeFullName = Option(tmpLocal.typeFullName)
+      )
+
+    val allocAssignTargetNode = tmpIdentifier.copy
+    val allocAssignTargetAst  = Ast(allocAssignTargetNode).withRefEdge(allocAssignTargetNode, tmpLocal)
+    val allocAssignAst        = callAst(allocAssignCall, allocAssignTargetAst :: allocAndInitAst.allocAst :: Nil)
+
+    val returnedIdentifier    = tmpIdentifier.copy
+    val returnedIdentifierAst = Ast(returnedIdentifier).withRefEdge(returnedIdentifier, tmpLocal)
+
+    Ast(blockNode(expr))
+      .withChild(Ast(tmpLocal).withRefEdge(tmpIdentifier, tmpLocal))
+      .withChild(allocAssignAst)
+      .withChild(allocAndInitAst.initAst)
+      .withChild(returnedIdentifierAst)
+  }
+
+  private[expressions] def inlinedAstsForObjectCreationExpr(
+    expr: ObjectCreationExpr,
+    assignmentTarget: Ast,
+    expectedType: ExpectedType,
+    resetAssignmentTargetType: Boolean
+  ): AllocAndInitCallAsts = {
     val maybeResolvedExpr = tryWithSafeStackOverflow(expr.resolve())
     val argumentAsts      = argAstsForCall(expr, maybeResolvedExpr, expr.getArguments)
 
@@ -179,6 +208,18 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
       else {
         scope.scopeFullName().map(enclosingScopeName => s"$enclosingScopeName.$typeName")
       }
+
+    if (resetAssignmentTargetType) {
+      typeFullName.foreach { typeFullName =>
+        assignmentTarget.root.collect { case identifier: NewIdentifier => identifier.typeFullName(typeFullName) }
+      }
+    }
+    val initReceiverType = assignmentTarget.rootType match {
+      case Some(TypeConstants.Any)             => typeFullName
+      case Some(PropertyDefaults.TypeFullName) => typeFullName
+      case Some(typ)                           => Option(typ)
+      case None                                => TypeConstants.Any
+    }
 
     anonymousClassBody.foreach { bodyStmts =>
       val anonymousClassDecl = astForAnonymousClassDecl(expr, bodyStmts, typeName, typeFullName, baseTypeFullName)
@@ -205,26 +246,33 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
 
     val isInnerType = anonymousClassBody.isDefined || baseTypeFromScope.exists(_.isInstanceOf[ScopeInnerType])
 
-    // Assume that a block ast is required, since there isn't enough information to decide otherwise.
-    // This simplifies logic elsewhere, and unnecessary blocks will be garbage collected soon.
-    val blockAst =
-      blockAstForConstructorInvocation(line(expr), column(expr), allocNode, initCall, argumentAsts, isInnerType)
-
-    val parentIsSimpleAssign = expr.getParentNode.toScala
-      .collect { case assignExpr: AssignExpr =>
-        assignExpr.getTarget.isInstanceOf[NameExpr]
+    lazy val thisParameter = scope.lookupVariable(NameConstants.This).variableNode
+    val initReceiverAst =
+      assignmentTarget.root.collect { case root: AstNodeNew => assignmentTarget.subTreeCopy(root) }.getOrElse {
+        logger.warn(s"Assignment target ast with no root at $filename:${line(expr)}:${column(expr)}")
+        unknownAst(expr)
       }
-      .getOrElse(false)
 
-    expr.getParentNode.toScala match {
-      case Some(parent) if parent.isInstanceOf[VariableDeclarator] || parentIsSimpleAssign =>
-        val partialConstructor = PartialConstructor(typeFullName, initCall, argumentAsts, blockAst)
-        partialConstructorQueue.append(partialConstructor)
-        Ast(allocNode)
-
-      case _ =>
-        blockAst
+    // TODO: This is wrong for chained constructors where the `captured this` is the object created by the previous
+    //  constructor in the chain
+    val capturedThis = scope.lookupVariable(NameConstants.This) match {
+      case SimpleVariable(param: ScopeParameter) => Some(param.node)
+      case _                                     => None
     }
+
+    val initAst = if (isInnerType) {
+      val initCallAst = Ast(initCall)
+      scope.enclosingTypeDecl.foreach(
+        _.registerInitToComplete(
+          PartialInit(allocNode.typeFullName, initCallAst, initReceiverAst, argumentAsts.toList, capturedThis)
+        )
+      )
+      initCallAst
+    } else {
+      callAst(initCall, argumentAsts, Option(initReceiverAst))
+    }
+
+    AllocAndInitCallAsts(callAst(allocNode, Nil), initAst)
   }
 
   def argAstsForCall(

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -174,7 +174,7 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     val returnedIdentifier    = tmpIdentifier.copy
     val returnedIdentifierAst = Ast(returnedIdentifier).withRefEdge(returnedIdentifier, tmpLocal)
 
-    Ast(blockNode(expr))
+    Ast(blockNode(expr).typeFullName(returnedIdentifier.typeFullName))
       .withChild(Ast(tmpLocal).withRefEdge(tmpIdentifier, tmpLocal))
       .withChild(allocAssignAst)
       .withChild(allocAndInitAst.initAst)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForExpressionsCreator.scala
@@ -57,7 +57,7 @@ trait AstForExpressionsCreator
       case x: LiteralExpr             => Seq(astForLiteralExpr(x))
       case x: MethodCallExpr          => Seq(astForMethodCall(x, expectedType))
       case x: NameExpr                => Seq(astForNameExpr(x, expectedType))
-      case x: ObjectCreationExpr      => Seq(astForObjectCreationExpr(x, expectedType))
+      case x: ObjectCreationExpr      => Seq(blockAstForObjectCreationExpr(x, expectedType))
       case x: SuperExpr               => Seq(astForSuperExpr(x, expectedType))
       case x: ThisExpr                => Seq(astForThisExpr(x, expectedType))
       case x: UnaryExpr               => Seq(astForUnaryExpr(x, expectedType))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -285,8 +285,8 @@ object Scope {
   type NewScopeNode    = NewBlock | NewMethod | NewTypeDecl | NewNamespaceBlock
   type NewVariableNode = NewLocal | NewMethodParameterIn | NewMember
 
-  def newVariableNodeType(variableNode: NewVariableNode): String = {
-    variableNode match {
+  extension (variableNode: NewVariableNode) {
+    def typeFullName: String = variableNode match {
       case node: NewLocal             => node.typeFullName
       case node: NewMethodParameterIn => node.typeFullName
       case node: NewMember            => node.typeFullName

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -233,9 +233,13 @@ class ConstructorInvocationTests extends JavaSrcCode2CpgFixture {
   "it should create `alloc` and `init` calls in a block for constructor invocations not in assignments" in {
     cpg.typeDecl.name("Bar").method.name("bar").l match {
       case List(method) =>
-        val idCall                                          = method.call.name("id").head
-        val consBlock                                       = idCall.argument(1).asInstanceOf[Block]
-        val List(assign: Call, init: Call, ret: Identifier) = consBlock.astChildren.l: @unchecked
+        val idCall                                                        = method.call.name("id").head
+        val consBlock                                                     = idCall.argument(1).asInstanceOf[Block]
+        val List(local: Local, assign: Call, init: Call, ret: Identifier) = consBlock.astChildren.l: @unchecked
+
+        local.name shouldBe "$obj0"
+        local.typeFullName shouldBe "Bar"
+        local.code shouldBe "$obj0"
 
         val List(temp: Identifier, alloc: Call) = assign.argument.l: @unchecked
         temp.name shouldBe "$obj0"
@@ -278,16 +282,20 @@ class ConstructorInvocationTests extends JavaSrcCode2CpgFixture {
   "it should create `alloc` and `init` calls in a block for complex assignments" in {
     cpg.typeDecl.name("Bar").method.name("test3").l match {
       case List(method) =>
-        val assignCall                                      = method.call.nameExact("<operator>.assignment").head
-        val consBlock                                       = assignCall.argument(2).asInstanceOf[Block]
-        val List(assign: Call, init: Call, ret: Identifier) = consBlock.astChildren.l: @unchecked
+        val assignCall = method.call.nameExact("<operator>.assignment").head
+        val consBlock  = assignCall.argument(2).asInstanceOf[Block]
+        val List(local: Local, assign: Call, init: Call, ret: Identifier) = consBlock.astChildren.l: @unchecked
+
+        local.name shouldBe "$obj1"
+        local.typeFullName shouldBe "Bar"
+        local.code shouldBe "$obj1"
 
         val List(temp: Identifier, alloc: Call) = assign.argument.l: @unchecked
-        temp.name shouldBe "$obj3"
+        temp.name shouldBe "$obj1"
         temp.typeFullName shouldBe "Bar"
         temp.order shouldBe 1
         temp.argumentIndex shouldBe 1
-        temp.code shouldBe "$obj3"
+        temp.code shouldBe "$obj1"
 
         alloc.name shouldBe "<operator>.alloc"
         alloc.methodFullName shouldBe "<operator>.alloc"
@@ -309,7 +317,7 @@ class ConstructorInvocationTests extends JavaSrcCode2CpgFixture {
         val List(obj: Identifier, initArg1: Literal) = init.argument.l: @unchecked
         obj.order shouldBe 1
         obj.argumentIndex shouldBe 0
-        obj.name shouldBe "$obj3"
+        obj.name shouldBe "$obj1"
         obj.typeFullName shouldBe "Bar"
 
         initArg1.code shouldBe "42"


### PR DESCRIPTION
Before this PR, 2 ASTs were created to handle the different cases for our constructor invocation lowering: one for the inlined version
```
Foo f = Foo.<alloc>()
f.<init>(...)
```
and one for the block version
```
bar({
  Foo tmp = Foo.<alloc>()
  tmp.<init>(...)
  tmp
})
```

Both of these representations were passed back up in the AST creator (one as the return value for `astForObjCreationExpr` and one in a queue in the scope). Only the "correct" representation was then added to the graph.

With this new change, the representation is chosen before creating the `<init>` AST, so the correct representation is created directly.