### PR TITLE
[javasrc2cpg] Fix inner class constructors

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
@@ -161,7 +161,7 @@ object JavaScopeElement {
     callAst: Ast,
     receiverAst: Ast,
     argsAsts: List[Ast],
-    capturedThis: Option[NewMethodParameterIn]
+    outerClassAst: Option[Ast]
   )
 
   extension (typeDeclScope: Option[TypeDeclScope]) {


### PR DESCRIPTION
In javasrc2cpg inner classes, we have an `outerClass` constructor parameter for the captured outer class. Before, a reference to the enclosing class was always provided as an argument for this, but this is incorrect for inner class constructors, e.g. `new Foo().new Bar()` where the `outerClass` argument for `Bar.<init>` should be the value of the scope expression `new Foo()`. This PR fixes this issue.