### PR TITLE
[Jimple2cpg] catch error caused by soot and asm

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
@@ -287,7 +287,7 @@ implicit class JvmStringOpts(s: String) {
     * <code>I</code> to <code>int</code>.
     * @return
     */
-  def parseAsJavaType: String = 
-    Try{ Type.getType(s).getClassName.replaceAll("/", ".") }.getOrElse("unknownType")
+  def parseAsJavaType: String =
+    Try { Type.getType(s).getClassName.replaceAll("/", ".") }.getOrElse("unknownType")
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
@@ -288,6 +288,6 @@ implicit class JvmStringOpts(s: String) {
     * @return
     */
   def parseAsJavaType: String =
-    Try { Type.getType(s).getClassName.replaceAll("/", ".") }.getOrElse("unknownType")
+    Try { Type.getType(s).getClassName.replaceAll("/", ".") }.getOrElse(Defines.Any)
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
@@ -6,7 +6,7 @@ import io.joern.jimple2cpg.astcreation.statements.AstForStatementsCreator
 import io.joern.x2cpg.Ast.storeInDiffGraph
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.utils.NodeBuilders
-import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, ValidationMode}
+import io.joern.x2cpg.*
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.objectweb.asm.Type

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
@@ -287,6 +287,7 @@ implicit class JvmStringOpts(s: String) {
     * <code>I</code> to <code>int</code>.
     * @return
     */
-  def parseAsJavaType: String = Type.getType(s).getClassName.replaceAll("/", ".")
+  def parseAsJavaType: String = 
+    Try{ Type.getType(s).getClassName.replaceAll("/", ".") }.getOrElse("unknownType")
 
 }


### PR DESCRIPTION
```
  protected def astsForAnnotations(annotationTag: AnnotationTag, host: AbstractHost): Ast = {
    val typeFullName = registerType(annotationTag.getType.parseAsJavaType)
    val name         = typeFullName.split('.').last
    val elementNodes = annotationTag.getElems.asScala.map(astForAnnotationElement(_, host)).toSeq
    val code = s"@$name(${elementNodes.flatMap(_.root).flatMap(_.properties.get(PropertyNames.CODE)).mkString(", ")})"

    val annotation = annotationNode(host, code, name, typeFullName)
    annotationAst(annotation, elementNodes)
  }
```
Some times the `annotationTag.getType` returns a `MethodRef` and  `Type.getType(s)`  will throw excpetions.
Just catch this for the moment.