### PR TITLE
[ruby] Object Invocation & Identifier vs. Call Check

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -142,6 +142,11 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val argumentAsts    = node.arguments.map(astForMethodCallArgument)
     val constructorCall = callNode(node, code(node), methodName, fullName, DispatchTypes.STATIC_DISPATCH)
     val receiverAst     = Ast(identifierNode(node, className, className, receiverTypeFullName))
+    // TODO: We may want to lower this with an `alloc` wrapped in a block, e.g.
+    /*
+      `return Bar.new`, lowered to
+      `return {Bar tmp = Bar.<alloc>(); tmp.<init>(); tmp}`
+     */
     callAst(constructorCall, argumentAsts, Option(receiverAst))
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -6,6 +6,7 @@ import io.joern.rubysrc2cpg.passes.Defines.{RubyOperators, getBuiltInType}
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
+import io.joern.x2cpg.Defines as XDefines
 
 trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -17,6 +18,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: ConditionalExpression    => astForConditional(node)
     case node: MemberAccess             => astForMemberAccess(node)
     case node: MemberCall               => astForMemberCall(node)
+    case node: ObjectInstantiation      => astForObjectInstantiation(node)
     case node: IndexAccess              => astForIndexAccess(node)
     case node: SingleAssignment         => astForSingleAssignment(node)
     case node: AttributeAssignment      => astForAttributeAssignment(node)
@@ -129,33 +131,36 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     callAst(call, indexAsts, Some(targetAst))
   }
 
+  protected def astForObjectInstantiation(node: ObjectInstantiation): Ast = {
+    val className  = node.clazz.text
+    val methodName = XDefines.ConstructorMethodName
+    val (receiverTypeFullName, fullName) = scope.tryResolveTypeReference(className) match {
+      case Some(typeMetaData) => typeMetaData.name -> s"${typeMetaData.name}:$methodName"
+      case None =>
+        s"${XDefines.UnresolvedNamespace}.$className" -> s"${XDefines.UnresolvedNamespace}.$className:$methodName"
+    }
+    val argumentAsts    = node.arguments.map(astForMethodCallArgument)
+    val constructorCall = callNode(node, code(node), methodName, fullName, DispatchTypes.STATIC_DISPATCH)
+    val receiverAst     = Ast(identifierNode(node, className, className, receiverTypeFullName))
+    callAst(constructorCall, argumentAsts, Option(receiverAst))
+  }
+
   protected def astForSingleAssignment(node: SingleAssignment): Ast = {
     node.rhs match {
       case x: Unknown if x.span.text == Defines.Undefined =>
         // If the RHS is undefined, then this variable is not defined/placed in the variable table/registry
         Ast()
-      case _ => {
-        getAssignmentOperatorName(node.op) match
+      case _ =>
+        getAssignmentOperatorName(node.op) match {
           case None =>
             logger.warn(s"Unrecognized assignment operator: ${code(node)} ($relativeFileName), skipping")
             astForUnknown(node)
           case Some(op) =>
-            val lhsAst        = astForExpression(node.lhs)
-            val rhsAst        = astForExpression(node.rhs)
-            val call          = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
-            val assignmentAst = callAst(call, Seq(lhsAst, rhsAst))
-            scope.lookupVariable(node.lhs.text) match
-              case None =>
-                // We are introducing a new variable. Thus, also create a LOCAL.
-                // TODO: Add the newly created LOCAL to the current METHOD.
-                val lhsNode = node.lhs
-                val local   = localNode(lhsNode, lhsNode.text, lhsNode.text, Defines.Any)
-                scope.addToScope(lhsNode.text, local)
-                assignmentAst
-              case Some(_) =>
-                // This variable is already in scope, so just emit the assignment.
-                assignmentAst
-      }
+            val lhsAst = astForExpression(node.lhs)
+            val rhsAst = astForExpression(node.rhs)
+            val call   = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
+            callAst(call, Seq(lhsAst, rhsAst))
+        }
     }
 
   }
@@ -169,14 +174,14 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
   protected def astForSimpleIdentifier(node: SimpleIdentifier): Ast = {
     val name = code(node)
-    // TODO: This treats identifiers as parenthesis-less calls by default, we would benefit from a pre-pass to validate
-    //  all defined method name in the application to check against
-    scope.lookupVariable(name) match
-      case None    => astForSimpleCall(SimpleCall(node, List())(node.span))
-      case Some(_) => handleNewVariableOccurrence(node)
+    scope.lookupVariable(name) match {
+      case None if scope.tryResolveMethodInvocation(node.text, List.empty).isDefined =>
+        astForSimpleCall(SimpleCall(node, List())(node.span))
+      case _ => handleVariableOccurrence(node)
+    }
   }
 
-  protected def astForMandatoryParameter(node: RubyNode): Ast = handleNewVariableOccurrence(node)
+  protected def astForMandatoryParameter(node: RubyNode): Ast = handleVariableOccurrence(node)
 
   protected def astForSimpleCall(node: SimpleCall): Ast = {
     node.target match
@@ -322,7 +327,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   private def astForKeywordArgument(assoc: Association): Ast = {
     val value = astForExpression(assoc.value)
     astForExpression(assoc.key).root match
-      case Some(keyNode: NewCall) =>
+      case Some(keyNode: NewIdentifier) =>
         value.root.collectFirst { case x: ExpressionNew =>
           x.argumentName_=(Option(keyNode.name))
           x.argumentIndex_=(-1)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -106,7 +106,8 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       astParentFullName = scope.surroundingScopeFullName
     )
     scope.pushNewScope(MethodScope(fullName))
-    scope.pushNewScope(BlockScope)
+    val block_ = blockNode(node)
+    scope.pushNewScope(BlockScope(block_))
     // TODO: Should it be `return this.@abc`?
     val returnAst_ = {
       val returnNode_         = returnNode(node, s"return $fieldName")
@@ -114,7 +115,6 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       returnAst(returnNode_, Seq(Ast(fieldNameIdentifier)))
     }
 
-    val block_     = blockNode(node)
     val methodBody = blockAst(block_, List(returnAst_))
     scope.popScope()
     scope.popScope()
@@ -138,7 +138,8 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     scope.pushNewScope(MethodScope(fullName))
     val parameter = parameterInNode(node, "x", "x", 1, false, EvaluationStrategies.BY_REFERENCE)
     val methodBody = {
-      scope.pushNewScope(BlockScope)
+      val block_ = blockNode(node)
+      scope.pushNewScope(BlockScope(block_))
       val lhs = identifierNode(node, fieldName, fieldName, Defines.Any)
       val rhs = identifierNode(node, parameter.name, parameter.name, Defines.Any)
       val assignmentCall = callNode(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -233,6 +233,9 @@ object RubyIntermediateAst {
   // TODO: Might be replaced by MemberCall simply?
   final case class MemberAccess(target: RubyNode, op: String, methodName: String)(span: TextSpan) extends RubyNode(span)
 
+  final case class ObjectInstantiation(clazz: RubyNode, arguments: List[RubyNode])(span: TextSpan)
+      extends RubyNode(span)
+
   /** Represents a `do` or `{ .. }` (braces) block. */
   final case class Block(parameters: List[RubyNode], body: RubyNode)(span: TextSpan) extends RubyNode(span)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -31,8 +31,15 @@ class RubyScope(summary: RubyProgramSummary)
             .flatMap(_.methods)
             .exists(_.name == "initialize") =>
         TypeScope(fullName, true)
+      case n: NamespaceLikeScope =>
+        typesInScope.addAll(summary.typesUnderNamespace(n.fullName))
+        n
+      case n: ProgramScope =>
+        typesInScope.addAll(summary.typesUnderNamespace(n.fullName))
+        n
       case _ => scopeNode
     }
+
     super.pushNewScope(mappedScopeNode)
   }
 
@@ -53,7 +60,6 @@ class RubyScope(summary: RubyProgramSummary)
     case ScopeElement(_: ProgramScope, _)       => NodeTypes.METHOD
     case ScopeElement(_: TypeLikeScope, _)      => NodeTypes.TYPE_DECL
     case ScopeElement(_: MethodLikeScope, _)    => NodeTypes.METHOD
-    case ScopeElement(BlockScope, _)            => NodeTypes.BLOCK
   }
 
   /** @return

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.datastructures
 
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.datastructures.{NamespaceLikeScope, TypedScopeElement}
+import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
 
 /** The namespace.
   * @param fullName
@@ -62,4 +63,4 @@ case class ConstructorScope(fullName: String) extends MethodLikeScope
 
 /** Represents scope objects that map to a block node.
   */
-object BlockScope extends TypedScopeElement
+case class BlockScope(block: NewBlock) extends TypedScopeElement

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ConditionalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ConditionalTests.scala
@@ -16,10 +16,10 @@ class ConditionalTests extends RubyCode2CpgFixture(withPostProcessing = true, wi
     val source = cpg.literal
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
-    flows.map(flowToResultPairs).toSet shouldBe
+    flows.map(flowToResultPairs).sortBy(_.headOption.map(_._1)).toSet shouldBe
       Set(
-        List(("x = 1", 2), ("x", 2), ("foo ? x : y", 4), ("z", 4), ("puts z", 5)),
-        List(("y = 2", 3), ("y", 3), ("foo ? x : y", 4), ("z", 4), ("puts z", 5))
+        List(("x = 1", 2), ("foo ? x : y", 4), ("z = foo ? x : y", 4), ("puts z", 5)),
+        List(("y = 2", 3), ("foo ? x : y", 4), ("z = foo ? x : y", 4), ("puts z", 5))
       )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ControlStructureTests.scala
@@ -8,52 +8,58 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
 
   "flow through body of a `while-end` statement" in {
     val cpg = code("""
-        |x = 10
-        |while x > 0 do
-        |  x = x - 1
+        |x = 1
+        |y = 10
+        |while y > 0 do
+        |  y = y - x
         |end
         |puts x
         |""".stripMargin)
-    val source = cpg.literal("10")
+
+    val source = cpg.literal("1")
     val sink   = cpg.method.name("puts").callIn.argument
-    val flows  = sink.reachableByFlows(source)
+    val flows  = sink.reachableByFlows(source).l
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("x = 10", 2), ("x", 2), ("x - 1", 4), ("x = x - 1", 4), ("x > 0", 3), ("puts x", 6)))
+      Set(List(("x = 1", 2), ("y - x", 5), ("puts x", 7)))
   }
 
   "flow through body of a `... while ...` statement" in {
     val cpg = code("""
-        |x = 0
-        |x = x + 1 while x < 10
+        |x = 1
+        |y = 10
+        |y = y - x while y > 0
         |puts x
         |""".stripMargin)
-    val source = cpg.literal("0")
+
+    val source = cpg.literal("1")
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("x = 0", 2), ("x", 2), ("x + 1", 3), ("x = x + 1", 3), ("x < 10", 3), ("puts x", 4)))
+      Set(List(("x = 1", 2), ("y - x", 4), ("puts x", 5)))
   }
 
   "flow through body of an `until-end` statement" in {
     val cpg = code("""
-        |x = 10
-        |until x <= 0 do
-        |  x = x - 1
+        |x = 1
+        |y = 10
+        |until y <= 0 do
+        |  y = y - x
         |end
         |puts x
         |""".stripMargin)
-    val source = cpg.literal("10")
+    val source = cpg.literal("1")
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("x = 10", 2), ("x", 2), ("x - 1", 4), ("x = x - 1", 4), ("x <= 0", 3), ("puts x", 6)))
+      Set(List(("x = 1", 2), ("y - x", 5), ("puts x", 7)))
   }
 
   "flow through the 1st branch of an `if-end` statement" in {
     val cpg = code("""
         |t = 100
+        |y = 1
         |if true
-        | t = t + 1
+        | y = y - t
         |end
         |puts t
         |""".stripMargin)
@@ -61,7 +67,7 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("t = 100", 2), ("t", 2), ("t + 1", 4), ("t = t + 1", 4), ("puts t", 6)))
+      Set(List(("t = 100", 2), ("y - t", 5), ("puts t", 7)))
   }
 
   "flow through the 2nd branch of an `if-else-end` statement" in {
@@ -78,7 +84,7 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("t = 100", 2), ("t", 2), ("t - 1", 6), ("t = t - 1", 6), ("puts t", 8)))
+      Set(List(("t = 100", 2), ("t - 1", 6), ("t = t - 1", 6), ("puts t", 8)))
   }
 
   "flow through the 2nd branch of an `if-elsif-end` statement" in {
@@ -95,7 +101,7 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("t = 100", 2), ("t", 2), ("t * 2", 6), ("t = t * 2", 6), ("puts t", 8)))
+      Set(List(("t = 100", 2), ("t * 2", 6), ("t = t * 2", 6), ("puts t", 8)))
   }
 
   "flow through both branches of an `if-else-end` statement" in {
@@ -111,7 +117,7 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("t = 100", 2), ("t", 2), ("t + 2", 6)), List(("t = 100", 2), ("t", 2), ("t + 1", 4)))
+      Set(List(("t = 100", 2), ("t + 1", 4)), List(("t = 100", 2), ("t + 2", 6)))
   }
 
   "flow through an `unless-end` statement" in {
@@ -126,7 +132,7 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("x = 1", 2), ("x", 2), ("x * 2", 4), ("x = x * 2", 4), ("puts x", 6)))
+      Set(List(("x = 1", 2), ("x * 2", 4), ("x = x * 2", 4), ("puts x", 6)))
   }
 
   "flow through a `begin-rescue-end` expression" ignore {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodReturnTests.scala
@@ -53,7 +53,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
     val sink   = cpg.method.name("f").methodReturn
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("f(x)", 2), ("y = x", 3), ("y", 3), ("y = x", 3), ("RET", 2)))
+      Set(List(("f(x)", 2), ("y = x", 3), ("RET", 2)))
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
@@ -15,14 +15,12 @@ class SingleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
         |""".stripMargin)
     val source = cpg.literal.l
     val sink   = cpg.method.name("puts").callIn.argument.l
-    val flows  = sink.reachableByFlows(source).l
-    flows.size shouldBe 6
-    val List(flow1, flow2, flow3, flow4, flow5, flow6) = flows.map(flowToResultPairs).distinct.sortBy(_.length).toList
-    flow1 shouldBe List(("y = 1", 2), ("y", 2), ("puts y", 3))
-    flow2 shouldBe List(("y = 1", 2), ("x", 2), ("puts x", 4))
-    flow3 shouldBe List(("y = 1", 2), ("z", 2), ("puts z", 5))
-    flow4 shouldBe List(("y = 1", 2), ("y", 2), ("y = 1", 2), ("x", 2), ("puts x", 4))
-    flow5 shouldBe List(("y = 1", 2), ("x", 2), ("x = y = 1", 2), ("z", 2), ("puts z", 5))
-    flow6 shouldBe List(("y = 1", 2), ("y", 2), ("y = 1", 2), ("x", 2), ("x = y = 1", 2), ("z", 2), ("puts z", 5))
+    val flows  = sink.reachableByFlows(source).map(flowToResultPairs).distinct.sortBy(_.length).l
+    flows.size shouldBe 4
+    val List(flow1, flow2, flow3, flow4) = flows
+    flow1 shouldBe List(("y = 1", 2), ("puts y", 3))
+    flow2 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("puts x", 4))
+    flow3 shouldBe List(("y = 1", 2), ("z = x = y = 1", 2), ("puts z", 5))
+    flow4 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("z = x = y = 1", 2), ("puts z", 5))
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -24,7 +24,7 @@ class CaseTests extends RubyCode2CpgFixture {
     val List(assign)   = block.astChildren.assignment.l;
     val List(lhs, rhs) = assign.argument.l
 
-    List(lhs).isCall.name.l shouldBe List("<tmp-0>")
+    List(lhs).isIdentifier.name.l shouldBe List("<tmp-0>")
     List(rhs).isLiteral.code.l shouldBe List("0")
 
     val headIf @ List(_)           = block.astChildren.isControlStructure.l


### PR DESCRIPTION
* Now checking the `Class` token of `Class.new` for anonymous types
* Created an `ObjectInstantiation` entry for `RubyNode` when a `new` call is parsed without a block body
* `AstCreator` creates an `<init>` call when a constructor is encountered, using the scope to attempt to resolve the full name. This is constructed as a lowered block following some other frontend examples
* When an identifier is encountered in the `AstCreator`, a scope look-up on the members in scope is run to determine if the identifier is a call or not
* Made sure local nodes are persisted.
* Modified code and tests that expected an identifier to always be a parenthesis-less call. This also had a weird effect on data-flows. The operators in the tests are changed due to the bug in [https://github.com/joernio/joern/issues/4213](https://github.com/joernio/joern/issues/4213).

Resolves #4168 
