### PR TITLE
[XTypeRecovery] Fix type recovery function pointer bug

### DIFF
--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -8,6 +8,18 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.semanticcpg.language._
 
 class CallTests extends PhpCode2CpgFixture {
+  "variable call arguments with names matching methods should not have a methodref" in {
+    val cpg = code("""<?php
+      |$a = file("ABC");
+      |$file = $a.contents();
+      |foo($file);
+      |""".stripMargin)
+
+    inside(cpg.call.name("foo").argument.l) { case List(fileArg: Identifier) =>
+      fileArg.name shouldBe "file"
+    }
+  }
+
   "halt_compiler calls should be created correctly" in {
     val cpg = code("""<?php
         |__halt_compiler();

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -1129,8 +1129,10 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
       storeNodeTypeInfo(x, filteredTypes.toSeq)
       x match {
         case i: Identifier if symbolTable.contains(i) =>
-          if (isField(i)) persistMemberType(i, filteredTypes)
-          handlePotentialFunctionPointer(i, filteredTypes, i.name)
+          if (isField(i)) {
+            persistMemberType(i, filteredTypes)
+            handlePotentialFunctionPointer(i, filteredTypes, i.name)
+          }
         case _ =>
       }
     }


### PR DESCRIPTION
This PR partially fixes an issue that came up in https://github.com/joernio/joern/issues/4172.

In this case, the `file` identifier matches the `file` method name, so in `XTypeRecovery` the `handlePotentialFunctionPointer` confuses them and creates a `METHOD_REF` in any case. The `handlePontentialFunctionPointer` function comment 
```
  /** In the case this field access is a function pointer, we would want to make sure this has a method ref.
    */
```
suggests that change in this PR is the intended behaviour, but I'm not sure about that and this isn't a proper fix for php either. Even if the `file` identifier were referring to a field, we'd still not want to enable this behaviour. A better fix could be to move `handlePotentialFunctionPointer` into the `XTypeRecovery` class to make it possible to adjust this behaviour per language.

I haven't looked at the type recovery code in quite a while though, so please let me know if I'm missing something.