### PR TITLE
Fix orphan identifiers in object creation expressions

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
@@ -11,7 +11,14 @@ import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 import io.joern.javasrc2cpg.util.NameConstants
 import io.joern.x2cpg.utils.AstPropertiesUtil.*
 import io.joern.x2cpg.Ast
-import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewFieldIdentifier, NewIdentifier, NewMember}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  AstNodeNew,
+  NewCall,
+  NewFieldIdentifier,
+  NewIdentifier,
+  NewMember,
+  NewUnknown
+}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import org.slf4j.LoggerFactory
 
@@ -184,8 +191,15 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
 
     val initializerAsts = initializer match {
       case objectCreationExpr: ObjectCreationExpr if isSimpleAssign && isVarOrFieldAssign =>
+        val initReceiver =
+          target.subTreeCopy(target.root.collect { case astNode: AstNodeNew => astNode }.getOrElse(NewUnknown()))
         val inlinedAsts =
-          inlinedAstsForObjectCreationExpr(objectCreationExpr, target, expectedType, resetAssignmentTargetType = false)
+          inlinedAstsForObjectCreationExpr(
+            objectCreationExpr,
+            initReceiver,
+            expectedType,
+            resetAssignmentTargetType = false
+          )
         inlinedAsts.allocAst :: inlinedAsts.initAst :: Nil
 
       case _ => astsForExpression(initializer, expectedType).toList

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ConstructorInvocationTests.scala
@@ -2,9 +2,11 @@ package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Local, Method}
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Block, Call, Identifier, Literal, Local, Method}
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
+
+import scala.util.Try
 
 class NewConstructorInvocationTests extends JavaSrcCode2CpgFixture {
   "inner class constructor invocations" when {
@@ -245,6 +247,14 @@ class ConstructorInvocationTests extends JavaSrcCode2CpgFixture {
       case res =>
         fail(s"Expected 2 Bar constructors, but got $res")
     }
+  }
+
+  "it should not leave any orphan identifiers" in {
+    cpg.identifier.filter(node => Try(node.astParent).isFailure).l shouldBe Nil
+  }
+
+  "it should not have any nodes with multiple parents" in {
+    cpg.all.collectAll[AstNode].filter(node => Try(node._astIn.size).toOption.exists(_ >= 2)).l shouldBe Nil
   }
 
   "it should create joint `alloc` and `init` calls for a constructor invocation in a vardecl" in {


### PR DESCRIPTION
A copy of the synthetic temporary variable used as the init receiver in object creation expressions was added to the graph via a ref edge, but was not added to the AST. This PR fixes that issue. I've added a unit test for this, but also ran `cpg2sp` locally on 2 of the failing sptests projects with no crashes.