### PR TITLE
[C#] Better type resolution for identifiers

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -22,6 +22,9 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { t
             // Check for implicit field reference
             case Some(field) if field.node.node != DotNetJsonAst.VariableDeclarator =>
               astForFieldIdentifier(typeFullName, identifierName, field)
+            case Some(field) if field.node.node == DotNetJsonAst.VariableDeclarator =>
+              /* This is so that if the type reference is not resolved, atleast the shorthand type will be populated instead of ANY */
+              Ast(identifierNode(ident, identifierName, ident.code, field.typeFullName))
             case _ =>
               // Check for static type reference
               scope.tryResolveTypeReference(identifierName) match {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberTests.scala
@@ -318,4 +318,27 @@ class MemberTests extends CSharpCode2CpgFixture {
       }
     }
   }
+
+  "a member with a external type" should {
+    val cpg = code("""
+        |using Microsoft.Extensions.Logging;
+        |
+        |namespace Foo {
+        | public class Bar {
+        |   private readonly ILogger<AcceptBookingRequestHandler> _logger;
+        |
+        |   public static void Main() {
+        |     _logger.LogInformation("Some info");
+        |   }
+        | }
+        |
+        |}
+        |""".stripMargin)
+
+    "link to it's reference, and propagate type" in {
+      inside(cpg.identifier.nameExact("_logger").l) { case logger :: Nil =>
+        logger.typeFullName shouldBe "ILogger" // TODO: Get the fullyQualifiedName.
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR aims to populate shorthand types for identiifers instead of ANY if the lookup returns a `VariableDeclarator` node; comes with a corresponding test.