### PR TITLE
[ruby] Implement RubySummary with CPG Lookahead

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg
 
 import better.files.File
 import io.joern.rubysrc2cpg.astcreation.AstCreator
+import io.joern.rubysrc2cpg.astcreation.GlobalTypes
 import io.joern.rubysrc2cpg.datastructures.RubyProgramSummary
 import io.joern.rubysrc2cpg.deprecated.parser.DeprecatedRubyParser
 import io.joern.rubysrc2cpg.deprecated.parser.DeprecatedRubyParser.*

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -35,6 +35,8 @@ class AstCreator(
 
   protected val logger: Logger = LoggerFactory.getLogger(getClass)
 
+  protected var parseLevel: AstParseLevel = AstParseLevel.FULL_AST
+
   protected val relativeFileName: String =
     projectRoot.map(fileName.stripPrefix).map(_.stripPrefix(java.io.File.separator)).getOrElse(fileName)
 
@@ -49,7 +51,7 @@ class AstCreator(
    * The (parsed) contents of the file are put under that fictitious METHOD node, thus
    * allowing for a straightforward representation of out-of-method statements.
    */
-  private def astForRubyFile(rootStatements: StatementList): Ast = {
+  protected def astForRubyFile(rootStatements: StatementList): Ast = {
     val fileNode = NewFile().name(relativeFileName)
     val fullName = s"$relativeFileName:${NamespaceTraversal.globalNamespaceName}"
     val namespaceBlock = NewNamespaceBlock()
@@ -91,4 +93,17 @@ class AstCreator(
       }
       .getOrElse(Ast())
   }
+}
+
+/** Determines till what depth the AST creator will parse until.
+  */
+enum AstParseLevel {
+
+  /** This level will parse all types and methods signatures, but exclude method bodies.
+    */
+  case SIGNATURES
+
+  /** This level will parse the full AST.
+    */
+  case FULL_AST
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -59,7 +59,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     val classBody =
       node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
     val classBodyAsts = classBody.statements.flatMap(astsForStatement) match {
-      case bodyAsts if scope.shouldGenerateDefaultConstructor =>
+      case bodyAsts if scope.shouldGenerateDefaultConstructor && parseLevel == AstParseLevel.FULL_AST =>
         val bodyStart = classBody.span.spanStart()
         val initBody  = StatementList(List())(bodyStart)
         val methodDecl = astForMethodDeclaration(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -1,100 +1,74 @@
 package io.joern.rubysrc2cpg.astcreation
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
-  ClassDeclaration,
-  FieldsDeclaration,
-  MandatoryParameter,
-  MethodDeclaration,
-  ModuleDeclaration,
-  OptionalParameter,
-  RubyNode,
-  SimpleIdentifier,
-  StatementList,
-  TypeDeclaration
-}
-import io.joern.rubysrc2cpg.datastructures.{
-  NamespaceScope,
-  RubyField,
-  RubyMethod,
-  RubyProgramSummary,
-  RubyType,
-  TypeScope
-}
-import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.StatementList
+import io.joern.rubysrc2cpg.datastructures.{RubyField, RubyMethod, RubyProgramSummary, RubyType}
 import io.joern.rubysrc2cpg.parser.RubyNodeCreator
-import io.joern.x2cpg.datastructures.ProgramSummary
-import io.joern.x2cpg.{ValidationMode, Defines as XDefines}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewMember, NewMethod, NewMethodParameterIn}
-import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Local, Member, Method, TypeDecl}
+import io.shiftleft.semanticcpg.language.*
+import overflowdb.{BatchedUpdate, Config}
+
+import scala.util.Using
 
 trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  private def baseNamespace: String = s"$relativeFileName:${NamespaceTraversal.globalNamespaceName}"
-
   def summarize(): RubyProgramSummary = {
-    val rootNode = new RubyNodeCreator().visit(this.programCtx).asInstanceOf[StatementList]
-    val fullName = baseNamespace
-    scope.pushNewScope(NamespaceScope(fullName))
+    this.parseLevel = AstParseLevel.SIGNATURES
+    Using.resource(Cpg.withConfig(Config.withoutOverflow())) { cpg =>
+      // Build and store compilation unit AST
+      val rootNode = new RubyNodeCreator().visit(programCtx).asInstanceOf[StatementList]
+      val ast      = astForRubyFile(rootNode)
+      Ast.storeInDiffGraph(ast, diffGraph)
+      BatchedUpdate.applyDiff(cpg.graph, diffGraph)
 
-    val newMap = scope.newProgramScope
-      .map { moduleScope =>
-        scope.pushNewScope(moduleScope)
-        val m = rootNode.statements
-          .map(visitStatement)
-          .reduceOption((a, b) => ProgramSummary.combine(a, b))
-          .getOrElse(Map.empty)
-        scope.popScope()
-        m
-      }
-      .getOrElse(Map.empty)
-
-    scope.popScope()
-    RubyProgramSummary(newMap)
+      // Summarize findings
+      summarize(cpg)
+    }
   }
 
   def withSummary(newSummary: RubyProgramSummary): AstCreator = {
     AstCreator(fileName, programCtx, projectRoot, newSummary)
   }
 
-  private def visitStatement(stmt: RubyNode): Map[String, Set[RubyType]] = stmt match {
-    case node: TypeDeclaration => visitTypeDeclaration(node)
-    case _                     => Map.empty
-  }
-
-  private def visitTypeDeclaration(classDecl: TypeDeclaration): Map[String, Set[RubyType]] = {
-    classDecl.name match {
-      case name: SimpleIdentifier =>
-        val fullName = computeClassFullName(name.text)
-        Map(
-          scope.surroundingScopeFullName
-            .getOrElse(baseNamespace) -> Set(visitTypeLikeDeclaration(fullName, classDecl.body))
-        )
-      case _ => Map.empty
+  private def summarize(cpg: Cpg): RubyProgramSummary = {
+    def toMethod(m: Method): RubyMethod = {
+      RubyMethod(m.name, m.parameter.map(x => x.name -> x.typeFullName).l, m.methodReturn.typeFullName)
     }
-  }
 
-  private def visitTypeLikeDeclaration(fullName: String, body: RubyNode): RubyType = {
-    scope.pushNewScope(TypeScope(fullName))
-    val classBody = body.asInstanceOf[StatementList]
-    val bodyMap =
-      classBody.statements.flatMap {
-        case MethodDeclaration(methodName, parameters, _) =>
-          RubyMethod(methodName, visitParameters(parameters), XDefines.Any) :: Nil
-        case node: FieldsDeclaration =>
-          astsForFieldDeclarations(node).flatMap(_.nodes).collect {
-            case x: NewMember => RubyField(x.name, x.typeFullName)
-            case x: NewMethod => RubyMethod(x.name, List.empty, XDefines.Any) // These are getters/setters
-          }
-        case _ => Seq.empty
-      }
-    scope.popScope()
-    RubyType(fullName, bodyMap.collect { case x: RubyMethod => x }, bodyMap.collect { case x: RubyField => x })
-  }
-
-  private def visitParameters(parameters: List[RubyNode]): List[(String, String)] = {
-    parameters.map(astForParameter(_, -1)).flatMap(_.root).collect { case x: NewMethodParameterIn =>
-      (x.name, x.typeFullName)
+    def toField(f: Member): RubyField = {
+      RubyField(f.name, f.typeFullName)
     }
+
+    def toModuleVariable(v: Local): RubyField = {
+      RubyField(v.name, v.typeFullName)
+    }
+
+    def toType(m: TypeDecl): RubyType = {
+      RubyType(m.fullName, m.method.map(toMethod).l, m.member.map(toField).l)
+    }
+
+    val mapping = cpg.namespaceBlock.flatMap { namespace =>
+      // Map module functions/variables
+      val moduleEntry = namespace.fullName -> namespace.method.map { module =>
+        val moduleTypeMap =
+          RubyType(
+            module.fullName,
+            module.block.astChildren.collectAll[Method].map(toMethod).l,
+            module.local.map(toModuleVariable).l
+          )
+        moduleTypeMap
+      }.toSet
+      // Map module types
+      val typeEntries = namespace.method.collectFirst {
+        case m: Method if m.name == Defines.Program =>
+          s"${namespace.fullName}:${m.name}" -> m.block.astChildren.collectAll[TypeDecl].map(toType).toSet
+      }.toSeq
+
+      moduleEntry +: typeEntries
+    }.toMap
+    RubyProgramSummary(mapping)
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.datastructures
 
 import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, TypeLike}
-
+import io.joern.x2cpg.Defines as XDefines
 import scala.annotation.targetName
 
 class RubyProgramSummary(initialMap: Map[String, Set[RubyType]] = Map.empty) extends ProgramSummary[RubyType] {
@@ -20,4 +20,8 @@ case class RubyMethod(name: String, parameterTypes: List[(String, String)], retu
 case class RubyField(name: String, typeName: String) extends FieldLike
 
 case class RubyType(name: String, methods: List[RubyMethod], fields: List[RubyField])
-    extends TypeLike[RubyMethod, RubyField]
+    extends TypeLike[RubyMethod, RubyField] {
+  def hasConstructor: Boolean = {
+    methods.exists(_.name == XDefines.ConstructorMethodName)
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -18,11 +18,6 @@ trait TypeLikeScope extends TypedScopeElement {
     *   the full name of the type-like.
     */
   def fullName: String
-
-  /** @return
-    *   true if a default constructor is required.
-    */
-  def needsDefaultConstructor: Boolean
 }
 
 /** A file-level module.
@@ -32,24 +27,20 @@ trait TypeLikeScope extends TypedScopeElement {
   */
 case class ProgramScope(fileName: String) extends TypeLikeScope {
   override def fullName: String = s"$fileName:${Defines.Program}"
-
-  override def needsDefaultConstructor: Boolean = false
 }
 
 /** A Ruby module/abstract class.
   * @param fullName
   *   the type full name.
   */
-case class ModuleScope(fullName: String) extends TypeLikeScope {
-  override def needsDefaultConstructor: Boolean = false
-}
+case class ModuleScope(fullName: String) extends TypeLikeScope
 
 /** A class or interface.
   *
   * @param fullName
   *   the type full name.
   */
-case class TypeScope(fullName: String, needsDefaultConstructor: Boolean = false) extends TypeLikeScope
+case class TypeScope(fullName: String) extends TypeLikeScope
 
 /** Represents scope objects that map to a method node.
   */

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -140,4 +140,23 @@ class CallTests extends RubyCode2CpgFixture {
     }
   }
 
+  "a parenthesis-less call" should {
+    val cpg = code("""
+        |def src = 1
+        |def f(p)
+        | p += src
+        | p
+        |end
+        |""".stripMargin)
+
+    "correctly create a `src` call instead of identifier" in {
+      inside(cpg.call("src").l) {
+        case src :: Nil =>
+          src.name shouldBe "src"
+          src.methodFullName shouldBe "src"
+        case xs => fail(s"Expected exactly one `src` call, instead got [${xs.code.mkString(",")}]")
+      }
+    }
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -153,7 +153,7 @@ class CallTests extends RubyCode2CpgFixture {
       inside(cpg.call("src").l) {
         case src :: Nil =>
           src.name shouldBe "src"
-          src.methodFullName shouldBe "src"
+          src.methodFullName shouldBe "Test0.rb:<global>::program:src"
         case xs => fail(s"Expected exactly one `src` call, instead got [${xs.code.mkString(",")}]")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -249,7 +249,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     whileCond.code shouldBe "true"
     whileCond.lineNumber shouldBe Some(2)
 
-    putsHi.methodFullName shouldBe "puts"
+    putsHi.methodFullName shouldBe "__builtin:puts"
     putsHi.code shouldBe "puts 'hi'"
     putsHi.lineNumber shouldBe Some(2)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -71,7 +71,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     r.lineNumber shouldBe Some(3)
 
     val List(c: Call) = r.astChildren.isCall.l
-    c.methodFullName shouldBe "puts"
+    c.methodFullName shouldBe "__builtin:puts"
     c.lineNumber shouldBe Some(3)
     c.code shouldBe "puts x"
   }


### PR DESCRIPTION
* Following [#4196](https://github.com/joernio/joern/pull/4196), similarly implemented a look-ahead and summary using an in-memory CPG
* Testing that a parenthesis-less call is correctly created as a call instead of identifier
* Resolving direct function calls if possible using the scope object
* Fixed scope around new pre-parse & loaded builtins