### PR TITLE
[ruby] Bug Fix - Generate Implicit Return for IndexAccess

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -128,7 +128,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val indexAsts = node.indices.map(astForExpression)
     val targetAst = astForExpression(node.target)
     val call = callNode(node, code(node), Operators.indexAccess, Operators.indexAccess, DispatchTypes.STATIC_DISPATCH)
-    callAst(call, indexAsts, Some(targetAst))
+
+    callAst(call, targetAst +: indexAsts)
   }
 
   protected def astForObjectInstantiation(node: ObjectInstantiation): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -242,7 +242,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   private def astsForImplicitReturnStatement(node: RubyNode): List[Ast] = {
     node match
       case _: (ArrayLiteral | HashLiteral | StaticLiteral | BinaryExpression | UnaryExpression | SimpleIdentifier |
-            IfExpression | RescueExpression | SimpleCall) =>
+            IfExpression | RescueExpression | SimpleCall | IndexAccess) =>
         astForReturnStatement(ReturnExpression(List(node))(node.span)) :: Nil
       case node: SingleAssignment =>
         astForSingleAssignment(node) :: List(astForReturnStatement(ReturnExpression(List(node.lhs))(node.span)))

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -106,6 +106,24 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     c.methodFullName shouldBe Operators.arrayInitializer
   }
 
+  "implicit RETURN node for index access exists" in {
+    val cpg = code("""
+                     |def f
+                     | l = [1, 2, 3]
+                     | l[1]
+                     |end
+                     |""".stripMargin)
+
+    val List(f)         = cpg.method.name("f").l
+    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
+
+    r.code shouldBe "l[1]"
+    r.lineNumber shouldBe Some(4)
+
+    val List(c: Call) = r.astChildren.isCall.l
+    c.methodFullName shouldBe Operators.indexAccess
+  }
+
   "implicit RETURN node for `{x:0}` exists" in {
     val cpg = code("""
         |def f = {x:0}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -122,6 +122,9 @@ class MethodReturnTests extends RubyCode2CpgFixture {
 
     val List(c: Call) = r.astChildren.isCall.l
     c.methodFullName shouldBe Operators.indexAccess
+    val List(arg1, arg2) = c.argument.l
+    arg1.argumentIndex shouldBe 1
+    arg2.argumentIndex shouldBe 2
   }
 
   "implicit RETURN node for `{x:0}` exists" in {


### PR DESCRIPTION
This PR includes:
 * generate implicit return for index access

Resolves #4230 