### PR TITLE
[swiftsrc2cpg] Fixed node offset calculation 

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -10,6 +10,7 @@ import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
+import io.joern.x2cpg.utils.OffsetUtils
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
@@ -135,11 +136,16 @@ class AstCreator(val config: Config, val global: SwiftGlobal, val parserResult: 
   override protected def lineEnd(node: SwiftNode): Option[Integer]   = node.endLine.map(Integer.valueOf)
   override protected def columnEnd(node: SwiftNode): Option[Integer] = node.endColumn.map(Integer.valueOf)
 
+  private val lineOffsetTable = OffsetUtils.getLineOffsetTable(Option(parserResult.fileContent)) :+ 0
+
   private def nodeOffsets(node: SwiftNode): Option[(Int, Int)] = {
-    for {
-      startOffset <- node.startOffset
-      endOffset   <- node.endOffset
-    } yield (math.max(startOffset, 0), math.min(endOffset, parserResult.fileContent.length))
+    val offsets = for {
+      lineNr      <- line(node)
+      columnNr    <- column(node)
+      lineEndNr   <- lineEnd(node)
+      columnEndNr <- columnEnd(node)
+    } yield OffsetUtils.coordinatesToOffset(lineOffsetTable, lineNr - 1, columnNr - 1, lineEndNr - 1, columnEndNr - 1)
+    offsets.map { case (offset, offsetEnd) => (offset, offsetEnd - 1) }
   }
 
   override protected def offset(node: SwiftNode): Option[(Int, Int)] = {

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -136,7 +136,10 @@ class AstCreator(val config: Config, val global: SwiftGlobal, val parserResult: 
   override protected def lineEnd(node: SwiftNode): Option[Integer]   = node.endLine.map(Integer.valueOf)
   override protected def columnEnd(node: SwiftNode): Option[Integer] = node.endColumn.map(Integer.valueOf)
 
-  private val lineOffsetTable = OffsetUtils.getLineOffsetTable(Option(parserResult.fileContent)) :+ 0
+  private val lineOffsetTable =
+    OffsetUtils.getLineOffsetTable(Option(parserResult.fileContent))
+    // we add one last offset as the swift-syntax parser always expects one EOF newline
+      :+ 0
 
   private def nodeOffsets(node: SwiftNode): Option[(Int, Int)] = {
     val offsets = for {

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ClassExtensionTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ClassExtensionTests.scala
@@ -16,11 +16,13 @@ class ClassExtensionTests extends AbstractPassTest {
         |
         |class Foo: Bar { // implicitly internal (private)
         |  public var a = A()
+        |  // some comment ✅
         |  private var b = false
         |  var c = 0.0
         |  var d: String?
         |
         |  static var e = 1
+        |  // some comment ©
         |  static var f = true
         |
         |  var g: Double { return self * 1_000.0 }


### PR DESCRIPTION
The offsets returned by the swift-syntax parser generate actual offsets based on the strings byte length taking multi-byte characters into account. We do not handle that when using String.substring.
Hence, all code calculations solely based on the parser offsets were wrong if the code contained such multi-byte characters.

With this PR we calculate the offsets based on the node's line, lineEnd, column, and columnEnd which represent the node's true source locations.