### PR TITLE
[ruby] Do-Block Arguments (with or without params)

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -12,6 +12,10 @@ final case class Config(
 ) extends X2CpgConfig[Config]
     with TypeRecoveryParserConfig[Config] {
 
+  this.defaultIgnoredFilesRegex = List("spec", "test").flatMap { directory =>
+    List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|/)$directory($$|/)".r.unanchored)
+  }
+
   def withEnableDependencyDownload(value: Boolean): Config = {
     copy(enableDependencyDownload = value).withInheritedFields(this)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -21,6 +21,7 @@ import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Paths}
+import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try, Using}
 
 class RubySrc2Cpg extends X2CpgFrontend[Config] {
@@ -73,6 +74,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
       .determine(
         config.inputPath,
         RubySourceFileExtensions,
+        ignoredDefaultRegex = Option(config.defaultIgnoredFilesRegex),
         ignoredFilesRegex = Option(config.ignoredFilesRegex),
         ignoredFilesPath = Option(config.ignoredFiles)
       )
@@ -83,18 +85,6 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
         }
       }
       .iterator
-  }
-
-  private def parseFile(
-    fileName: String,
-    resourceManagedParser: parser.ResourceManagedParser
-  ): Option[RubyParser.ProgramContext] = {
-    resourceManagedParser.parse(fileName) match {
-      case Success(programCtx) => Option(programCtx)
-      case Failure(exception) =>
-        logger.warn(s"Could not parse file: $fileName, skipping - ", exception)
-        None
-    }
   }
 
   private def deprecatedCreateCpgAction(cpg: Cpg, config: Config): Unit = try {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -33,6 +33,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: MandatoryParameter       => astForMandatoryParameter(node)
     case node: SplattingRubyNode        => astForSplattingRubyNode(node)
     case node: AnonymousTypeDeclaration => astForAnonymousTypeDeclaration(node)
+    case node: DummyNode                => Ast(node.node)
     case _                              => astForUnknown(node)
 
   protected def astForStaticLiteral(node: StaticLiteral): Ast = {
@@ -282,6 +283,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   protected def astForAssociationHash(node: Association, tmp: String): List[Ast] = {
+    val tmpAst = astForSimpleIdentifier(SimpleIdentifier()(node.span.spanStart(tmp)))
     node.key match {
       case rangeExpr: RangeExpression =>
         val expandedList = generateStaticLiteralsForRange(rangeExpr).map { x =>
@@ -289,12 +291,12 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         }
 
         if (expandedList.nonEmpty) {
-          expandedList
+          expandedList :+ tmpAst
         } else {
-          astForSingleKeyValue(node.key, node.value, tmp) :: Nil
+          astForSingleKeyValue(node.key, node.value, tmp) :: tmpAst :: Nil
         }
 
-      case _ => astForSingleKeyValue(node.key, node.value, tmp) :: Nil
+      case _ => astForSingleKeyValue(node.key, node.value, tmp) :: tmpAst :: Nil
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -4,12 +4,20 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.datastructures.{ConstructorScope, MethodScope}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
-import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewLocal, NewMethodParameterIn, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes}
 
 trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  protected def astForMethodDeclaration(node: MethodDeclaration): Ast = {
+  /** Creates method declaration related structures.
+    * @param node
+    *   the node to create the AST structure from.
+    * @param withRefsAndTypes
+    *   if true, will generate a type decl, type ref, and method ref. This is useful for lambda methods.
+    * @return
+    *   a method declaration with additional refs and types if specified.
+    */
+  protected def astForMethodDeclaration(node: MethodDeclaration, withRefsAndTypes: Boolean = false): Seq[Ast] = {
 
     // Special case constructor methods
     val isInTypeDecl = scope.surroundingAstLabel.contains(NodeTypes.TYPE_DECL)
@@ -63,7 +71,19 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           astForUnknown(body)
     }
     scope.popScope()
-    methodAst(method, parameterAsts, stmtBlockAst, methodReturnNode(node, Defines.Any))
+
+    val methodReturn = methodReturnNode(node, Defines.Any)
+    val refs = if (withRefsAndTypes) {
+      List(
+        typeDeclNode(node, methodName, fullName, relativeFileName, code(node)),
+        typeRefNode(node, methodName, fullName),
+        methodRefNode(node, methodName, fullName, methodReturn.typeFullName)
+      ).map(Ast.apply)
+    } else {
+      Nil
+    }
+
+    methodAst(method, parameterAsts, stmtBlockAst, methodReturn) :: refs
   }
 
   // TODO: remaining cases

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -65,7 +65,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         val methodDecl = astForMethodDeclaration(
           MethodDeclaration(XDefines.ConstructorMethodName, List(), initBody)(bodyStart)
         )
-        methodDecl :: bodyAsts
+        methodDecl ++ bodyAsts
       case bodyAsts => bodyAsts
     }
     scope.popScope()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -182,8 +182,10 @@ object AntlrContextHelpers {
         val splatting           = Option(ctx.splattingArgument()).toList
         val block               = Option(ctx.blockArgument()).toList
         operatorExpressions ++ associations ++ splatting ++ block
+      case ctx: AssociationsArgumentListContext =>
+        Option(ctx.associationList()).map(_.associations).getOrElse(List.empty)
       case ctx =>
-        logger.warn(s"Unsupported element type ${ctx.getClass}")
+        logger.warn(s"Unsupported element type ${ctx.getClass.getSimpleName}")
         List()
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -4,10 +4,13 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.TextSpan
 import io.joern.rubysrc2cpg.parser.RubyParser.*
 import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.misc.Interval
+import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.*
 
 object AntlrContextHelpers {
+
+  private val logger = LoggerFactory.getLogger(getClass)
 
   sealed implicit class ParserRuleContextHelper(ctx: ParserRuleContext) {
     def toTextSpan: TextSpan = {
@@ -93,14 +96,20 @@ object AntlrContextHelpers {
   sealed implicit class BlockParameterListContextHelper(ctx: BlockParameterListContext) {
     def parameters: List[ParserRuleContext] = ctx match
       case ctx: SingleElementBlockParameterListContext => ctx.leftHandSide() :: Nil
-      case ctx                                         => List() // TODO: N-ary parameter blocks are not supported yet
+      case ctx: MultipleElementBlockParameterListContext =>
+        Option(ctx.multipleLeftHandSide()).map(_.multipleLeftHandSideItem()).map(_.asScala.toList).getOrElse(List.empty)
+      case ctx =>
+        logger.warn(s"Unsupported parameter type ${ctx.getClass}")
+        List()
   }
 
   sealed implicit class CommandArgumentContextHelper(ctx: CommandArgumentContext) {
     def arguments: List[ParserRuleContext] = ctx match
       case ctx: CommandCommandArgumentListContext         => ctx.command() :: Nil
       case ctx: CommandArgumentCommandArgumentListContext => ctx.commandArgumentList().elements
-      case ctx                                            => List() // TODO
+      case ctx =>
+        logger.warn(s"Unsupported argument type ${ctx.getClass}")
+        List()
   }
 
   sealed implicit class CommandArgumentListContextHelper(ctx: CommandArgumentListContext) {
@@ -151,14 +160,18 @@ object AntlrContextHelpers {
       case ctx: CommandIndexingArgumentListContext => List(ctx.command())
       case ctx: OperatorExpressionListIndexingArgumentListContext =>
         ctx.operatorExpressionList().operatorExpression().asScala.toList
-      case ctx => List() // TODO
+      case ctx =>
+        logger.warn(s"Unsupported argument type ${ctx.getClass}")
+        List()
   }
 
   sealed implicit class ArgumentWithParenthesesContextHelper(ctx: ArgumentWithParenthesesContext) {
     def arguments: List[ParserRuleContext] = ctx match
       case _: EmptyArgumentWithParenthesesContext          => List()
       case ctx: ArgumentListArgumentWithParenthesesContext => ctx.argumentList().elements
-      case ctx                                             => List() // TODO
+      case ctx =>
+        logger.warn(s"Unsupported argument type ${ctx.getClass}")
+        List()
   }
 
   sealed implicit class ArgumentListContextHelper(ctx: ArgumentListContext) {
@@ -169,6 +182,8 @@ object AntlrContextHelpers {
         val splatting           = Option(ctx.splattingArgument()).toList
         val block               = Option(ctx.blockArgument()).toList
         operatorExpressions ++ associations ++ splatting ++ block
-      case ctx => List() // TODO
+      case ctx =>
+        logger.warn(s"Unsupported element type ${ctx.getClass}")
+        List()
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -322,7 +322,6 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     val body       = visit(ctx.bodyStatement())
     Block(parameters, body)(ctx.toTextSpan)
   }
-
   override def visitLocalVariableAssignmentExpression(
     ctx: RubyParser.LocalVariableAssignmentExpressionContext
   ): RubyNode = {
@@ -477,7 +476,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitMethodCallWithBlockExpression(ctx: RubyParser.MethodCallWithBlockExpressionContext): RubyNode = {
-    SimpleCallWithBlock(visit(ctx.methodIdentifier()), List(), visit(ctx.block()))(ctx.toTextSpan)
+    SimpleCallWithBlock(visit(ctx.methodIdentifier()), List(), visit(ctx.block()).asInstanceOf[Block])(ctx.toTextSpan)
   }
 
   override def visitMethodCallWithParenthesesExpression(
@@ -487,7 +486,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
       SimpleCallWithBlock(
         visit(ctx.methodIdentifier()),
         ctx.argumentWithParentheses().arguments.map(visit),
-        visit(ctx.block())
+        visit(ctx.block()).asInstanceOf[Block]
       )(ctx.toTextSpan)
     } else {
       SimpleCall(visit(ctx.methodIdentifier()), ctx.argumentWithParentheses().arguments.map(visit))(ctx.toTextSpan)
@@ -578,7 +577,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
         ctx.op.getText,
         ctx.methodName().getText,
         Option(ctx.argumentWithParentheses()).map(_.arguments).getOrElse(List()).map(visit),
-        visit(ctx.block())
+        visit(ctx.block()).asInstanceOf[Block]
       )(ctx.toTextSpan)
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -1,0 +1,66 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+
+class DoBlockTests extends RubyCode2CpgFixture {
+
+  "a basic parameterized do-block with braces" should {
+    val cpg = code(
+      """
+        |my_array = [1, 2, 3]
+        |my_array.each { |item|
+        |    puts item
+        |}
+        |""".stripMargin)
+
+    "create an anonymous method with associated type declaration" in {
+
+    }
+
+    "have specify the `item` parameter in the method" in {
+
+    }
+  }
+
+  "a basic parameterized do-block with pipes" should {
+
+    val cpg = code(
+      """
+        |my_array = [:uno, :dos, :tres]
+        |my_array.each do |item|
+        |    puts item
+        |end
+        |""".stripMargin)
+
+    "create an anonymous method with associated type declaration" in {
+
+    }
+
+    "have specify the `item` parameter in the method" in {
+
+    }
+
+  }
+
+  "a do block iterating over a hash" should {
+
+    val cpg = code(
+      """
+        |hash = { "a" => 1, "b" => 2 }
+        |hash.each do |key, value|
+        |  puts "#{key}-----"
+        |  puts value
+        |end
+        |""".stripMargin)
+
+    "create an anonymous method with associated type declaration" in {
+
+    }
+
+    "have specify the `key` and `value` parameters in the method" in {
+
+    }
+
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -6,6 +6,58 @@ import io.shiftleft.semanticcpg.language.*
 
 class DoBlockTests extends RubyCode2CpgFixture {
 
+  "a basic unparameterized do block off a simple call" should {
+
+    val cpg = code("""
+        |def foo &block
+        | puts block.call
+        |end
+        |
+        |foo do
+        | "world!"
+        |end
+        |
+        |""".stripMargin)
+
+    "create an anonymous method with associated type declaration" in {
+      inside(cpg.method.nameExact(":program").l) {
+        case program :: Nil =>
+          inside(program.block.astChildren.collectAll[Method].l) {
+            case foo :: closureMethod :: Nil =>
+              foo.name shouldBe "foo"
+
+              closureMethod.name shouldBe "<lambda>0"
+              closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+            case xs => fail(s"Expected a two method nodes, instead got [${xs.code.mkString(", ")}]")
+          }
+
+          inside(program.block.astChildren.collectAll[TypeDecl].l) {
+            case closureType :: Nil =>
+              closureType.name shouldBe "<lambda>0"
+              closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+            case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
+          }
+        case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
+      }
+    }
+
+    "have no parameters in the closure declaration" in {
+      inside(cpg.method("<lambda>0").parameter.l) {
+        case Nil => // pass
+        case xs  => fail(s"Expected the closure to have no parameters, instead got [${xs.code.mkString(", ")}]")
+      }
+    }
+
+    "have the return node under the closure (returning the literal)" in {
+      inside(cpg.method("<lambda>0").block.astChildren.l) {
+        case ret :: Nil =>
+          ret.code shouldBe "\"world!\""
+        case xs => fail(s"Expected the closure to have a single call, instead got [${xs.code.mkString(", ")}]")
+      }
+    }
+
+  }
+
   "a basic parameterized do-block with braces" should {
     val cpg = code("""
         |my_array = [1, 2, 3]
@@ -17,14 +69,18 @@ class DoBlockTests extends RubyCode2CpgFixture {
     "create an anonymous method with associated type declaration" in {
       inside(cpg.method.nameExact(":program").l) {
         case program :: Nil =>
-          inside(program.block.astChildren.collectAll[Method].l) { case closureMethod :: Nil =>
-            closureMethod.name shouldBe "<lambda>0"
-            closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+          inside(program.block.astChildren.collectAll[Method].l) {
+            case closureMethod :: Nil =>
+              closureMethod.name shouldBe "<lambda>0"
+              closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+            case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
-          inside(program.block.astChildren.collectAll[TypeDecl].l) { case closureType :: Nil =>
-            closureType.name shouldBe "<lambda>0"
-            closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+          inside(program.block.astChildren.collectAll[TypeDecl].l) {
+            case closureType :: Nil =>
+              closureType.name shouldBe "<lambda>0"
+              closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+            case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
         case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
       }
@@ -52,7 +108,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
         case puts :: Nil =>
           puts.name shouldBe "puts"
           puts.code shouldBe "puts item"
-        case xs => fail(s"Expected the closure to have a single parameter, instead got [${xs.code.mkString(", ")}]")
+        case xs => fail(s"Expected the closure to have a single call, instead got [${xs.code.mkString(", ")}]")
       }
     }
   }
@@ -70,14 +126,18 @@ class DoBlockTests extends RubyCode2CpgFixture {
     "create an anonymous method with associated type declaration" in {
       inside(cpg.method.nameExact(":program").l) {
         case program :: Nil =>
-          inside(program.block.astChildren.collectAll[Method].l) { case closureMethod :: Nil =>
-            closureMethod.name shouldBe "<lambda>0"
-            closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+          inside(program.block.astChildren.collectAll[Method].l) {
+            case closureMethod :: Nil =>
+              closureMethod.name shouldBe "<lambda>0"
+              closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+            case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
-          inside(program.block.astChildren.collectAll[TypeDecl].l) { case closureType :: Nil =>
-            closureType.name shouldBe "<lambda>0"
-            closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+          inside(program.block.astChildren.collectAll[TypeDecl].l) {
+            case closureType :: Nil =>
+              closureType.name shouldBe "<lambda>0"
+              closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+            case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
         case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
       }
@@ -88,7 +148,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
         case keyParam :: valParam :: Nil =>
           keyParam.name shouldBe "key"
           valParam.name shouldBe "value"
-        case xs => fail(s"Expected the closure to have a single parameter, instead got [${xs.code.mkString(", ")}]")
+        case xs => fail(s"Expected the closure to have two calls, instead got [${xs.code.mkString(", ")}]")
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language.*
 
 class HashTests extends RubyCode2CpgFixture {
@@ -98,14 +98,13 @@ class HashTests extends RubyCode2CpgFixture {
                      |{1...3:"abc"}
                      |""".stripMargin)
 
-    val List(hashCall) = cpg.call.name(RubyOperators.hashInitializer).l
-
     inside(cpg.call.name(RubyOperators.hashInitializer).l) {
       case hashInitializer :: Nil =>
         inside(hashInitializer.argument.l) {
-          case firstCall :: secondCall :: Nil =>
+          case (firstCall: Call) :: (secondCall: Call) :: (tmp: Identifier) :: Nil =>
             firstCall.code shouldBe "<tmp-0>[1] = \"abc\""
             secondCall.code shouldBe "<tmp-0>[2] = \"abc\""
+            tmp.name shouldBe "<tmp-0>"
           case _ => fail("Expected 2 calls (one per item in range)")
         }
       case _ => fail("Expected one hash initializer function")


### PR DESCRIPTION
* Added default ignore regex for test suites
* Added warnings to unhandled cases in `AntlrContextHelpers`
* Created common `RubyCall` traits
* Created the `DummyNode` to inject new nodes into `RubyNode` operations
* Made hashes return the `tmp` variable that is lowered
* Made all block arguments behave like lambdas so that they can be resolved to some function interprocedurally with an associated type and method decl

As per the comment on `astsForCallWithBlock`
```
  /* `foo(<args>) do <params> <stmts> end` is lowered as a METHOD node shaped like so:
   * ```
   * <method_ref> = def <lambda>0(<params>)
   *   <stmts>
   * end
   * foo(<args>, <method_ref>)
   * ```
   */
 ```  

Resolves #4232