### PR TITLE
[swiftsrc2cpg] Added support for missing operators and expressions

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -252,7 +252,9 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       case "<"                   => Operators.lessThan
       case ">"                   => Operators.greaterThan
       case "=="                  => Operators.equals
+      case "!="                  => Operators.notEquals
       case "==="                 => Operators.equals
+      case "!=="                 => Operators.notEquals
       case "&+"                  => Operators.plus
       case "+"                   => Operators.plus
       case "&+="                 => Operators.assignmentPlus
@@ -268,7 +270,6 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       case "..<" | ">.." | "..." => Operators.range
       case "%"                   => Operators.modulo
       case "!"                   => Operators.logicalNot
-      case "!="                  => Operators.notEquals
       case "^"                   => Operators.xor
       case "??"                  => Operators.elvis
       case _ =>
@@ -408,11 +409,12 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForPostfixOperatorExprSyntax(node: PostfixOperatorExprSyntax): Ast = {
     val operatorMethod = code(node.operator) match {
-      case "++" => Operators.postIncrement
-      case "--" => Operators.postDecrement
-      case "^"  => Operators.xor
-      case "<"  => Operators.lessThan
-      case ">"  => Operators.greaterThan
+      case "++"  => Operators.postIncrement
+      case "--"  => Operators.postDecrement
+      case "^"   => Operators.xor
+      case "<"   => Operators.lessThan
+      case ">"   => Operators.greaterThan
+      case "..." => "<operator>.splat"
       case _ =>
         notHandledYet(node.operator)
         "<operator>.unknown"

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -288,6 +288,8 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
     }
 
     val name = node.pattern match {
+      case expr: ExpressionPatternSyntax if expr.expression.isInstanceOf[DiscardAssignmentExprSyntax] =>
+        generateUnusedVariableName(usedVariableNames, "discard")
       case expr: ExpressionPatternSyntax =>
         notHandledYet(expr)
         code(expr)


### PR DESCRIPTION
Discovered during testing with https://github.com/OWASP/iGoat-Swift