### PR TITLE
[kotlin2cpg] Kotlin frontend FieldAccess CALL node issue fixes.

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -73,7 +73,7 @@ class CallsToFieldAccessTests extends KotlinCode2CpgFixture(withOssDataflow = fa
     }
 
     "Create require field access nodes for members accessed outside the class properly" in {
-      val List(ctory, insidemainy) = cpg.call.methodFullName(Operators.fieldAccess).l
+      val List(ctory, insidemainy) = cpg.call.methodFullNameExact(Operators.fieldAccess).l
       ctory.code shouldBe "this.y"
       ctory.name shouldBe Operators.fieldAccess
       insidemainy.code shouldBe "a.y"
@@ -100,7 +100,7 @@ class CallsToFieldAccessTests extends KotlinCode2CpgFixture(withOssDataflow = fa
     }
 
     "2nd level Chained field access CALL node should have name <operator>.fieldAccess" in {
-      val List(ctora, ctorb, insidemainx, insidemainacls) = cpg.call.methodFullName(Operators.fieldAccess).l
+      val List(ctora, ctorb, insidemainx, insidemainacls) = cpg.call.methodFullNameExact(Operators.fieldAccess).l
       ctora.name shouldBe Operators.fieldAccess
       ctorb.name shouldBe Operators.fieldAccess
       insidemainacls.name shouldBe Operators.fieldAccess

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -3,24 +3,24 @@ package io.joern.kotlin2cpg.querying
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.{FieldIdentifier, Identifier}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 class CallsToFieldAccessTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
   "CPG for code with class method referencing member in a call" should {
     val cpg = code("""
-        |package mypkg
-        |
-        |class AClass(private val x: String) {
-        |    fun printX() {
-        |        println(x)
-        |    }
-        |}
-        |
-        |fun main() {
-        |    val a = AClass("A_MESSAGE")
-        |    a.printX()
-        |}
-        |""".stripMargin)
+                     |package mypkg
+                     |
+                     |class AClass(private val x: String) {
+                     |    fun printX() {
+                     |        println(x)
+                     |    }
+                     |}
+                     |
+                     |fun main() {
+                     |    val a = AClass("A_MESSAGE")
+                     |    a.printX()
+                     |}
+                     |""".stripMargin)
 
     "should contain a CALL node for the referenced member with the correct props set" in {
       val List(c) = cpg.call.codeExact("println(x)").argument.isCall.l
@@ -39,6 +39,104 @@ class CallsToFieldAccessTests extends KotlinCode2CpgFixture(withOssDataflow = fa
       secondArg.argumentIndex shouldBe 2
       secondArg.code shouldBe "x"
       secondArg.canonicalName shouldBe "x"
+    }
+
+    "Create only two fieldAccess AST Nodes" in {
+      cpg.call(Operators.fieldAccess).size shouldBe 2
+      val List(println, ctor) = cpg.call(Operators.fieldAccess).l
+      // The one created representing initialisation of member variable inside constructor
+      ctor.lineNumber shouldBe None
+      // The one created for member access inside println method
+      println.lineNumber shouldBe Some(6)
+    }
+  }
+
+  "Variable access outside class" should {
+    val cpg = code("""
+                     |package mypkg
+                     |class BClass(var y: String){
+                     |}
+                     |
+                     |fun main() {
+                     |    val a = BClass("A_MESSAGE")
+                     |    val m = a.y
+                     |}
+                     |""".stripMargin)
+
+    "Create two fieldAccess AST Node" in {
+      cpg.call(Operators.fieldAccess).size shouldBe 2
+      val List(ctor, insidemain) = cpg.call(Operators.fieldAccess).l
+      // The one created representing initialisation of member variable inside constructor
+      ctor.lineNumber shouldBe None
+      // The one created for member access inside println method
+      insidemain.lineNumber shouldBe Some(8)
+    }
+
+    "Create require field access nodes for members accessed outside the class properly" in {
+      val List(ctory, insidemainy) = cpg.call.methodFullName(Operators.fieldAccess).l
+      ctory.code shouldBe "this.y"
+      ctory.name shouldBe Operators.fieldAccess
+      insidemainy.code shouldBe "a.y"
+      insidemainy.name shouldBe Operators.fieldAccess
+    }
+  }
+
+  "Chained field access " should {
+    val cpg = code("""
+                     |package mypkg
+                     |class AClass(var x: String){
+                     |}
+                     |class BClass(var acls: AClass){
+                     |}
+                     |
+                     |fun main() {
+                     |    val a = AClass("A_MESSAGE")
+                     |    val b = BClass(a)
+                     |    val m = b.acls.x
+                     |}
+                     |""".stripMargin)
+    "Create four fieldAccess nodes" in {
+      cpg.call(Operators.fieldAccess).size shouldBe 4
+    }
+
+    "2nd level Chained field access CALL node should have name <operator>.fieldAccess" in {
+      val List(ctora, ctorb, insidemainx, insidemainacls) = cpg.call.methodFullName(Operators.fieldAccess).l
+      ctora.name shouldBe Operators.fieldAccess
+      ctorb.name shouldBe Operators.fieldAccess
+      insidemainacls.name shouldBe Operators.fieldAccess
+      insidemainx.name shouldBe Operators.fieldAccess
+    }
+  }
+
+  "Chained method call" should {
+    val cpg = code("""
+                     |package mypkg
+                     |class AClass(var x: String){
+                     |    fun printX() {
+                     |        println(x)
+                     |    }
+                     |}
+                     |class BClass(var acls: AClass){
+                     |}
+                     |
+                     |fun main() {
+                     |    val a = AClass("A_MESSAGE")
+                     |    val b = BClass(a)
+                     |    val m = b.acls.printX()
+                     |}
+                     |""".stripMargin)
+    "Create four fieldAccess nodes" in {
+      cpg.call(Operators.fieldAccess).size shouldBe 4
+      val List(one, two, three, four) = cpg.call(Operators.fieldAccess).l
+      one.code shouldBe "this.x"
+      two.code shouldBe "this.x"
+      three.code shouldBe "this.acls"
+      four.code shouldBe "b.acls"
+    }
+
+    "Create CALL nodes for printX" in {
+      val List(x) = cpg.call("printX").l
+      x.methodFullName shouldBe "mypkg.AClass.printX:void()"
     }
   }
 }


### PR DESCRIPTION
1. As part of the performance issue troubleshooting exercise came across the issue where the FieldAccess `CALL` Node was getting created for chained field access e.g. a.b.c. While creating the fieldAccess `CALL` node for `.c` it was creating CALL node with `methodFullName` set to `<operator>.fieldAccess` and the name was getting set as `c` instead of the same value as `methodFullName`. Because of this, it resulted in creating many `METHOD` node stubs. In turn in StaticCodeLinker pass it was linking all the FieldAccess `CALL` Nodes to all of these `METHOD` stubs as the look-up was done over `methodFullName`. Added respective unit tests for the same.
2. Made respective changes to fix this issue.