### PR TITLE
[ruby] Implicit Return Handling for Control Structures

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -292,7 +292,7 @@ primaryValue
         # methodDefinition
     |   DEF singletonObject op=(DOT | COLON2) definedMethodName methodParameterPart bodyStatement END
         # singletonMethodDefinition
-    |   DEF definedMethodName (LPAREN parameterList? RPAREN)? EQ NL* commandOrPrimaryValue
+    |   DEF definedMethodName (LPAREN parameterList? RPAREN)? EQ NL* statement
         # endlessMethodDefinition
     |   MINUSGT (LPAREN parameterList? RPAREN)? block
         # lambdaExpression

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -15,7 +15,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: DynamicLiteral           => astForDynamicLiteral(node)
     case node: UnaryExpression          => astForUnary(node)
     case node: BinaryExpression         => astForBinary(node)
-    case node: ConditionalExpression    => astForConditional(node)
     case node: MemberAccess             => astForMemberAccess(node)
     case node: MemberCall               => astForMemberCall(node)
     case node: ObjectInstantiation      => astForObjectInstantiation(node)
@@ -102,14 +101,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         val rhsAst = astForExpression(node.rhs)
         val call   = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
         callAst(call, Seq(lhsAst, rhsAst))
-  }
-
-  protected def astForConditional(node: ConditionalExpression): Ast = {
-    val conditionAst = astForExpression(node.condition)
-    val thenAst      = astForExpression(node.trueBranch)
-    val elseAst      = astForExpression(node.falseBranch)
-    val call = callNode(node, code(node), Operators.conditional, Operators.conditional, DispatchTypes.STATIC_DISPATCH)
-    callAst(call, Seq(conditionAst, thenAst, elseAst))
   }
 
   // Member accesses are lowered as calls, i.e. `x.y` is the call of `y` of `x` without any arguments.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -217,10 +217,11 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     blockAst(block, stmtAsts)
   }
 
-  private def astsForImplicitReturnStatement(node: RubyNode): List[Ast] = {
+  private def astsForImplicitReturnStatement(node: RubyNode): Seq[Ast] = {
     node match
+      case expr: ControlFlowExpression => astsForStatement(rubyNodeForExplicitReturnControlFlowExpression(expr))
       case _: (ArrayLiteral | HashLiteral | StaticLiteral | BinaryExpression | UnaryExpression | SimpleIdentifier |
-            IfExpression | RescueExpression | SimpleCall | IndexAccess) =>
+            SimpleCall | IndexAccess) =>
         astForReturnStatement(ReturnExpression(List(node))(node.span)) :: Nil
       case node: SingleAssignment =>
         astForSingleAssignment(node) :: List(astForReturnStatement(ReturnExpression(List(node.lhs))(node.span)))
@@ -254,5 +255,63 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
   private def astForReturnMemberCall(node: MemberAccess): Ast = {
     returnAst(returnNode(node, code(node)), List(astForMemberAccess(node)))
+  }
+
+  /** Wraps the last RubyNode with a ReturnExpression.
+    * @param x
+    *   the node to wrap a return around. If a StatementList is given, then the ReturnExpression will wrap around the
+    *   final element.
+    * @return
+    *   the RubyNode with an explicit ReturnExpression.
+    */
+  private def returnLastNode(x: RubyNode): RubyNode = {
+
+    def statementListReturningLastExpression(stmts: List[RubyNode]): List[RubyNode] = stmts match {
+      case (head: ControlFlowClause) :: Nil => clauseReturningLastExpression(head) :: Nil
+      case head :: Nil                      => ReturnExpression(head :: Nil)(head.span) :: Nil
+      case Nil                              => List.empty
+      case head :: tail                     => head :: statementListReturningLastExpression(tail)
+    }
+
+    def clauseReturningLastExpression(x: RubyNode with ControlFlowClause): RubyNode = x match {
+      case RescueClause(exceptionClassList, assignment, thenClause) =>
+        RescueClause(exceptionClassList, assignment, returnLastNode(thenClause))(x.span)
+      case EnsureClause(thenClause)           => EnsureClause(returnLastNode(thenClause))(x.span)
+      case ElsIfClause(condition, thenClause) => ElsIfClause(condition, returnLastNode(thenClause))(x.span)
+      case ElseClause(thenClause)             => ElseClause(returnLastNode(thenClause))(x.span)
+      case WhenClause(matchExpressions, matchSplatExpression, thenClause) =>
+        WhenClause(matchExpressions, matchSplatExpression, returnLastNode(thenClause))(x.span)
+    }
+
+    x match {
+      case StatementList(statements) => StatementList(statementListReturningLastExpression(statements))(x.span)
+      case clause: ControlFlowClause => clauseReturningLastExpression(clause)
+      case _                         => ReturnExpression(x :: Nil)(x.span)
+    }
+  }
+
+  private def rubyNodeForExplicitReturnControlFlowExpression(node: RubyNode with ControlFlowExpression): RubyNode = {
+    node match {
+      case RescueExpression(body, rescueClauses, elseClause, ensureClause) =>
+        // TODO: Check this one
+        RescueExpression(body, rescueClauses.map(returnLastNode), elseClause, ensureClause)(node.span)
+      case WhileExpression(condition, body) => WhileExpression(condition, returnLastNode(body))(node.span)
+      case UntilExpression(condition, body) => UntilExpression(condition, returnLastNode(body))(node.span)
+      case IfExpression(condition, thenClause, elsifClauses, elseClause) =>
+        IfExpression(
+          condition,
+          returnLastNode(thenClause),
+          elsifClauses.map(returnLastNode),
+          elseClause.map(returnLastNode)
+        )(node.span)
+      case UnlessExpression(condition, trueBranch, falseBranch) =>
+        UnlessExpression(condition, returnLastNode(trueBranch), falseBranch.map(returnLastNode))(node.span)
+      case ForExpression(forVariable, iterableVariable, doBlock) =>
+        ForExpression(forVariable, iterableVariable, returnLastNode(doBlock))(node.span)
+      case ConditionalExpression(condition, trueBranch, falseBranch) =>
+        ConditionalExpression(condition, returnLastNode(trueBranch), returnLastNode(falseBranch))(node.span)
+      case CaseExpression(expression, whenClauses, elseClause) =>
+        CaseExpression(expression, whenClauses.map(returnLastNode), elseClause.map(returnLastNode))(node.span)
+    }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -114,6 +114,14 @@ object RubyIntermediateAst {
     span: TextSpan
   ) extends RubyNode(span)
 
+  /** Any structure that conditionally modifies the control flow of the program.
+    */
+  sealed trait ControlFlowExpression
+
+  /** A control structure's clause, which may contain an additional control structures.
+    */
+  sealed trait ControlFlowClause
+
   final case class RescueExpression(
     body: RubyNode,
     rescueClauses: List[RubyNode],
@@ -121,6 +129,7 @@ object RubyIntermediateAst {
     ensureClause: Option[RubyNode]
   )(span: TextSpan)
       extends RubyNode(span)
+      with ControlFlowExpression
 
   final case class RescueClause(
     exceptionClassList: Option[RubyNode],
@@ -128,12 +137,17 @@ object RubyIntermediateAst {
     thenClause: RubyNode
   )(span: TextSpan)
       extends RubyNode(span)
+      with ControlFlowClause
 
-  final case class EnsureClause(thenClause: RubyNode)(span: TextSpan) extends RubyNode(span)
+  final case class EnsureClause(thenClause: RubyNode)(span: TextSpan) extends RubyNode(span) with ControlFlowClause
 
-  final case class WhileExpression(condition: RubyNode, body: RubyNode)(span: TextSpan) extends RubyNode(span)
+  final case class WhileExpression(condition: RubyNode, body: RubyNode)(span: TextSpan)
+      extends RubyNode(span)
+      with ControlFlowExpression
 
-  final case class UntilExpression(condition: RubyNode, body: RubyNode)(span: TextSpan) extends RubyNode(span)
+  final case class UntilExpression(condition: RubyNode, body: RubyNode)(span: TextSpan)
+      extends RubyNode(span)
+      with ControlFlowExpression
 
   final case class IfExpression(
     condition: RubyNode,
@@ -142,21 +156,27 @@ object RubyIntermediateAst {
     elseClause: Option[RubyNode]
   )(span: TextSpan)
       extends RubyNode(span)
+      with ControlFlowExpression
 
-  final case class ElsIfClause(condition: RubyNode, thenClause: RubyNode)(span: TextSpan) extends RubyNode(span)
+  final case class ElsIfClause(condition: RubyNode, thenClause: RubyNode)(span: TextSpan)
+      extends RubyNode(span)
+      with ControlFlowClause
 
-  final case class ElseClause(thenClause: RubyNode)(span: TextSpan) extends RubyNode(span)
+  final case class ElseClause(thenClause: RubyNode)(span: TextSpan) extends RubyNode(span) with ControlFlowClause
 
   final case class UnlessExpression(condition: RubyNode, trueBranch: RubyNode, falseBranch: Option[RubyNode])(
     span: TextSpan
   ) extends RubyNode(span)
+      with ControlFlowExpression
 
   final case class ForExpression(forVariable: RubyNode, iterableVariable: RubyNode, doBlock: RubyNode)(span: TextSpan)
       extends RubyNode(span)
+      with ControlFlowExpression
 
   final case class ConditionalExpression(condition: RubyNode, trueBranch: RubyNode, falseBranch: RubyNode)(
     span: TextSpan
   ) extends RubyNode(span)
+      with ControlFlowExpression
 
   final case class CaseExpression(
     expression: Option[RubyNode],
@@ -164,6 +184,7 @@ object RubyIntermediateAst {
     elseClause: Option[RubyNode]
   )(span: TextSpan)
       extends RubyNode(span)
+      with ControlFlowExpression
 
   final case class WhenClause(
     matchExpressions: List[RubyNode],
@@ -171,6 +192,7 @@ object RubyIntermediateAst {
     thenClause: RubyNode
   )(span: TextSpan)
       extends RubyNode(span)
+      with ControlFlowClause
 
   final case class ReturnExpression(expressions: List[RubyNode])(span: TextSpan) extends RubyNode(span)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -173,11 +173,6 @@ object RubyIntermediateAst {
       extends RubyNode(span)
       with ControlFlowExpression
 
-  final case class ConditionalExpression(condition: RubyNode, trueBranch: RubyNode, falseBranch: RubyNode)(
-    span: TextSpan
-  ) extends RubyNode(span)
-      with ControlFlowExpression
-
   final case class CaseExpression(
     expression: Option[RubyNode],
     whenClauses: List[RubyNode],

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -6,7 +6,7 @@ import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Return}
 import io.shiftleft.semanticcpg.language.*
 
-class MethodReturnTests extends RubyCode2CpgFixture {
+class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
 
   "implicit RETURN node for `x * x` exists" in {
     val cpg = code("""
@@ -215,29 +215,55 @@ class MethodReturnTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    val List(f)         = cpg.method.name("f").l
-    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
-    val List(c: Call)   = r.astChildren.isCall.l
+    inside(cpg.method.name("f").l) {
+      case f :: Nil =>
+        // Check the two return statements
+        inside(f.methodReturn.toReturn.l) {
+          case return20 :: return40 :: Nil =>
+            return20.code shouldBe "20"
+            return20.lineNumber shouldBe Some(4)
+            val List(twenty: Literal) = return20.astChildren.l: @unchecked
+            twenty.code shouldBe "20"
+            twenty.lineNumber shouldBe Some(4)
+            twenty.typeFullName shouldBe "__builtin.Integer"
 
-    c.methodFullName shouldBe Operators.conditional
-    val test      = c.argument(1)
-    val blockThen = c.argument(2)
-    val blockElse = c.argument(3)
+            return40.code shouldBe "40"
+            return40.lineNumber shouldBe Some(6)
+            val List(forty: Literal) = return40.astChildren.l: @unchecked
+            forty.code shouldBe "40"
+            forty.lineNumber shouldBe Some(6)
+          case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
+        }
+      case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
+    }
+  }
 
-    test.code shouldBe "true"
-    test.lineNumber shouldBe Some(3)
-    blockThen.isBlock shouldBe true
-    blockElse.isBlock shouldBe true
+  "implicit RETURN node for ternary expression" in {
+    val cpg = code("""
+        |def f(x) = x ? 20 : 40
+        |""".stripMargin)
 
-    val List(twenty: Literal) = blockThen.astChildren.l: @unchecked
-    twenty.code shouldBe "20"
-    twenty.lineNumber shouldBe Some(4)
-    twenty.typeFullName shouldBe "__builtin.Integer"
+    inside(cpg.method.name("f").l) {
+      case f :: Nil =>
+        // Check the two return statements
+        inside(f.methodReturn.toReturn.l) {
+          case return20 :: return40 :: Nil =>
+            return20.code shouldBe "20"
+            return20.lineNumber shouldBe Some(2)
+            val List(twenty: Literal) = return20.astChildren.l: @unchecked
+            twenty.code shouldBe "20"
+            twenty.lineNumber shouldBe Some(2)
+            twenty.typeFullName shouldBe "__builtin.Integer"
 
-    val List(forty: Literal) = blockElse.astChildren.l: @unchecked
-    forty.code shouldBe "40"
-    forty.lineNumber shouldBe Some(6)
-    forty.typeFullName shouldBe "__builtin.Integer"
+            return40.code shouldBe "40"
+            return40.lineNumber shouldBe Some(2)
+            val List(forty: Literal) = return40.astChildren.l: @unchecked
+            forty.code shouldBe "40"
+            forty.lineNumber shouldBe Some(2)
+          case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
+        }
+      case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
+    }
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -179,29 +179,30 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
         | end
         |end""".stripMargin)
 
-    // Lowered as `def f; return true ? 20 : nil; end`
-    val List(f)         = cpg.method.name("f").l
-    val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
-    val List(c: Call)   = r.astChildren.isCall.l
+    // Lowered as `def f; if true then return 20 else return nil end`
 
-    c.methodFullName shouldBe Operators.conditional
-    val test      = c.argument(1)
-    val blockThen = c.argument(2)
-    val blockElse = c.argument(3)
+    inside(cpg.method.name("f").l) {
+      case f :: Nil =>
+        // Check the two return statements
+        inside(f.methodReturn.toReturn.l) {
+          case return20 :: returnNil :: Nil =>
+            return20.code shouldBe "20"
+            return20.lineNumber shouldBe Some(4)
+            val List(twenty: Literal) = return20.astChildren.l: @unchecked
+            twenty.code shouldBe "20"
+            twenty.lineNumber shouldBe Some(4)
+            twenty.typeFullName shouldBe "__builtin.Integer"
 
-    test.code shouldBe "true"
-    test.lineNumber shouldBe Some(3)
-    blockThen.isBlock shouldBe true
-    blockElse.isBlock shouldBe true
-
-    val List(twenty: Literal) = blockThen.astChildren.l: @unchecked
-    twenty.code shouldBe "20"
-    twenty.lineNumber shouldBe Some(4)
-    twenty.typeFullName shouldBe "__builtin.Integer"
-
-    val List(nil: Literal) = blockElse.astChildren.l: @unchecked
-    nil.code shouldBe "nil"
-    nil.typeFullName shouldBe "__builtin.NilClass"
+            returnNil.code shouldBe "return nil"
+            returnNil.lineNumber shouldBe Some(3)
+            val List(nil: Literal) = returnNil.astChildren.l: @unchecked
+            nil.code shouldBe "nil"
+            nil.lineNumber shouldBe Some(3)
+            nil.typeFullName shouldBe "__builtin.NilClass"
+          case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
+        }
+      case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
+    }
   }
 
   "implicit RETURN node for `if-else-end` expression" in {
@@ -232,6 +233,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(6)
+            forty.typeFullName shouldBe "__builtin.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -260,6 +262,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(2)
+            forty.typeFullName shouldBe "__builtin.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")


### PR DESCRIPTION
* Added conditional related `RubyNode` traits to group control structure nodes
* Added `rubyNodeForExplicitReturnControlFlowExpression` to add a return node around the last statements in the correct places depending on the control structure as play
* Changed `endlessMethod` grammar rule to allow for a statement on the RHS as it wasn't detecting control structures such as ternary operators
* Removed the notion of a `ConditionalExpression` and simply mapped ternary operators to `if-else` statements to match the semantics
* If the control structure is an implicitly returned one, but lacks an else clause, then a default one is supplied as `return nil`
* Adjusted all tests accordingly

Resolves #4233 