### PR TITLE
Fix issue that resulted in error messages being used as namespace names

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -285,7 +285,7 @@ class AstCreator(
               case callExpr: MethodCallExpr =>
                 callExpr.getScope.toScala match {
                   case Some(_: Expression) => None
-                  case _                   => scope.lookupType(symbolException.getName)
+                  case _                   => scope.lookupType(symbolException.getName, includeWildcards = false)
                 }
               case _ => None
             }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -12,6 +12,22 @@ import overflowdb.traversal.toNodeTraversal
 
 class NewCallTests extends JavaSrcCode2CpgFixture {
 
+  "calls with unresolved receivers should have the correct fullnames" in {
+    val cpg = code("""
+        |import a.*;
+        |
+        |class Test {
+        |
+        |  void test() {
+        |    foo().bar();
+        |  }
+        |}
+        |""".stripMargin)
+
+    cpg.call.name("foo").typeFullName.l shouldBe List("ANY")
+    cpg.call.name("foo").methodFullName.l shouldBe List("Test.foo:<unresolvedSignature>(0)")
+    cpg.call.name("bar").methodFullName.l shouldBe List("<unresolvedNamespace>.bar:<unresolvedSignature>(0)")
+  }
   "calls to imported nested classes should be resolved" in {
     lazy val cpg = code("""
       |import foo.Foo.Bar;


### PR DESCRIPTION
This PR fixes an issue that was introduced in https://github.com/joernio/joern/pull/2831, where an error message in the unsolved symbol exception name would sometimes be appended to a wildcard.