### PR TITLE
[c#] Simple Lambda Expression Handling

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/build.sbt
+++ b/joern-cli/frontends/csharpsrc2cpg/build.sbt
@@ -33,12 +33,11 @@ Test / fork := false
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 
 lazy val AstgenWin      = "dotnetastgen-win.exe"
-lazy val AstgenWinArm   = "dotnetastgen-win-arm.exe"
 lazy val AstgenLinux    = "dotnetastgen-linux"
 lazy val AstgenLinuxArm = "dotnetastgen-linux-arm"
 lazy val AstgenMac      = "dotnetastgen-macos"
 
-lazy val AllPlatforms = Seq(AstgenWin, AstgenWinArm, AstgenLinux, AstgenLinuxArm, AstgenMac)
+lazy val AllPlatforms = Seq(AstgenWin, AstgenLinux, AstgenLinuxArm, AstgenMac)
 
 lazy val astGenDlUrl = settingKey[String]("astgen download url")
 astGenDlUrl := s"https://github.com/joernio/DotNetAstGen/releases/download/v${astGenVersion.value}/"
@@ -59,18 +58,12 @@ astGenBinaryNames := {
     AllPlatforms
   } else {
     Environment.operatingSystem match {
-      case Environment.OperatingSystemType.Windows =>
-        Environment.architecture match {
-          case Environment.ArchitectureType.X86 => Seq(AstgenWin)
-          case Environment.ArchitectureType.ARM => Seq(AstgenWinArm)
-        }
-        Seq(AstgenWin)
+      case Environment.OperatingSystemType.Windows => Seq(AstgenWin)
       case Environment.OperatingSystemType.Linux =>
         Environment.architecture match {
           case Environment.ArchitectureType.X86 => Seq(AstgenLinux)
           case Environment.ArchitectureType.ARM => Seq(AstgenLinuxArm)
         }
-        Seq(AstgenLinux)
       case Environment.OperatingSystemType.Mac => Seq(AstgenMac)
       case Environment.OperatingSystemType.Unknown =>
         AllPlatforms

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 csharpsrc2cpg {
-    dotnetastgen_version: "0.18.0"
+    dotnetastgen_version: "0.19.0"
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -185,6 +185,15 @@ object AstCreatorHelper {
     val lhs = nameFromNode(createDotNetNodeInfo(qualifiedName.json(ParserKeys.Left)))
     s"$lhs.$rhs"
   }
+
+  def elementTypesFromCollectionType(collType: String): Seq[String] = {
+    val genericRegex = "^\\w+<([\\w, ]+)>$".r
+    collType match {
+      case genericRegex(elementTypes) => elementTypes.split("[,]").map(_.trim).toSeq
+      case t if t.endsWith("[]")      => t.stripSuffix("[]") :: Nil
+      case t                          => t :: Nil
+    }
+  }
 }
 
 /** Contains all the C# builtin types, as well as `null` and `void`.

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -73,6 +73,8 @@ object DotNetJsonAst {
 
   object VariableDeclarator extends DeclarationExpr
 
+  object SimpleLambdaExpression extends BaseExpr
+
   sealed trait ClauseExpr extends BaseExpr
 
   object EqualsValueClause extends ClauseExpr
@@ -238,6 +240,7 @@ object ParserKeys {
   val ElementType      = "ElementType"
   val Else             = "Else"
   val Expression       = "Expression"
+  val ExpressionBody   = "ExpressionBody"
   val Finally          = "Finally"
   val FileName         = "FileName"
   val Identifier       = "Identifier"
@@ -255,6 +258,7 @@ object ParserKeys {
   val Name             = "Name"
   val Operand          = "Operand"
   val OperatorToken    = "OperatorToken"
+  val Parameter        = "Parameter"
   val Parameters       = "Parameters"
   val ParameterList    = "ParameterList"
   val Pattern          = "Pattern"

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
@@ -20,6 +20,7 @@ class DotNetAstGenRunner(config: Config) extends AstGenRunnerBase(config) {
 
   // The x86 variant seems to run well enough on MacOS M-family chips, whereas the ARM build crashes
   override val MacArm: String = MacX86
+  override val WinArm: String = WinX86
 
   override def fileFilter(file: String, out: File): Boolean = {
     file.stripSuffix(".json").replace(out.pathAsString, config.inputPath) match {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
@@ -1,0 +1,59 @@
+package io.joern.csharpsrc2cpg.querying.ast
+
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Method, MethodRef, TypeDecl}
+import io.shiftleft.semanticcpg.language.*
+import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes
+import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes.DotNetTypeMap
+
+class LambdaTests extends CSharpCode2CpgFixture {
+
+  "a simple lambda used and defined in a high-order function" should {
+
+    val cpg = code(basicBoilerplate("""
+        |int[] numbers = { 2, 3, 4, 5 };
+        |var squaredNumbers = numbers.Select(x => x * x);
+        |""".stripMargin))
+
+    "create an anonymous method declaration" in {
+      inside(cpg.method("Main").astChildren.collectAll[Method].l) {
+        case anon :: Nil =>
+          anon.name shouldBe "<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+
+          inside(anon.parameter.l) {
+            case x :: Nil =>
+              x.name shouldBe "x"
+              x.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
+              x.index shouldBe 1
+            case xs => fail(s"Expected a single parameter, got [${xs.code.mkString(",")}]")
+          }
+
+        case xs => fail(s"Expected a single anonymous method declaration, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "create an anonymous type declaration" in {
+      inside(cpg.method("Main").astChildren.collectAll[TypeDecl].l) {
+        case anon :: Nil =>
+          anon.name shouldBe "<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+        case xs => fail(s"Expected a single anonymous type declaration, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "pass a method reference to the anonymous function in the call `Select`" in {
+      inside(cpg.call("Select").argument.l) {
+        case (numbers: Identifier) :: (closure: MethodRef) :: Nil =>
+          numbers.name shouldBe "numbers"
+          numbers.typeFullName shouldBe s"${DotNetTypeMap(BuiltinTypes.Int)}[]"
+
+          closure.methodFullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+          closure.referencedMethod.name shouldBe "<lambda>0"
+        case xs => fail(s"Expected two `Select` call argument, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
* Added basic handling for simple lambda expressions, which includes making the related Method/Type decl and method ref
* Parsing param type hints down from receiver if the lambda is used as a call argument, otherwise parameter isn't typed.
* Created a helper to unpack the type hint, as a collection type will be given, and too much context is stripped away to do this much more gracefully
* Updated DotNetAstGen and made appropriate changes for no longer having win-arm

Concerns #4000

TODO: Lambdas with multiple parameters 
TODO: Statement lambdas
TODO: Capturing variables