### PR TITLE
[ruby] Import Nodes & Require Support #3939

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import java.nio.file.{Files, Paths}
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try, Using}
+import io.joern.rubysrc2cpg.passes.ImportsPass
 
 class RubySrc2Cpg extends X2CpgFrontend[Config] {
 
@@ -61,6 +62,8 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
         .getOrElse(RubyProgramSummary())
       val astCreationPass = new AstCreationPass(cpg, astCreators.map(_.withSummary(programSummary)))
       astCreationPass.createAndApply()
+      val importsPass = new ImportsPass(cpg)
+      importsPass.createAndApply()
       TypeNodePass.withTypesFromCpg(cpg).createAndApply()
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportsPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportsPass.scala
@@ -7,8 +7,6 @@ import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.joern.x2cpg.X2Cpg.stripQuotes
 
-/** Derived from XImportsPass TODO: maybe make XImportsPass more generic
-  */
 class ImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
   protected val importCallName: String = "require"
   override def generateParts(): Array[Call] = cpg
@@ -20,7 +18,6 @@ class ImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
       case s :: _ => s
       case _      => ""
     })
-    val importedAs = ""
-    createImportNodeAndLink(importedEntity, importedAs, Some(call), diffGraph)
+    createImportNodeAndLink(importedEntity, importedEntity, Some(call), diffGraph)
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportsPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportsPass.scala
@@ -1,0 +1,26 @@
+package io.joern.rubysrc2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.joern.x2cpg.Imports.createImportNodeAndLink
+import io.joern.x2cpg.X2Cpg.stripQuotes
+
+/** Derived from XImportsPass TODO: maybe make XImportsPass more generic
+  */
+class ImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
+  protected val importCallName: String = "require"
+  override def generateParts(): Array[Call] = cpg
+    .call(importCallName)
+    .toArray
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, call: Call): Unit = {
+    val importedEntity = stripQuotes(call.argument.isLiteral.code.l match {
+      case s :: _ => s
+      case _      => ""
+    })
+    val importedAs = ""
+    createImportNodeAndLink(importedEntity, importedAs, Some(call), diffGraph)
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -4,15 +4,32 @@ import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 
 class ImportTests extends RubyCode2CpgFixture {
+
   "`require 'test'` is a CALL node with an IMPORT node pointing to it" in {
     val cpg = code("""
                      |require 'test'
                      |""".stripMargin)
     val List(importNode) = cpg.imports.l
     importNode.importedEntity shouldBe Some("test")
-    importNode.importedAs shouldBe Some("") // TODO: change X2Cpg import utility to allow optionals for importAs
+    importNode.importedAs shouldBe Some("test")
     val List(call) = importNode.call.l
     call.callee.name.l shouldBe List("require")
     call.argument.code.l shouldBe List("'test'")
   }
+
+  "`begin require 'test' rescue LoadError end` has a CALL node with an IMPORT node pointing to it" in {
+    val cpg = code("""
+                     |begin 
+                     |  require 'test'
+                     |rescue LoadError
+                     |end
+                     |""".stripMargin)
+    val List(importNode) = cpg.imports.l
+    importNode.importedEntity shouldBe Some("test")
+    importNode.importedAs shouldBe Some("test")
+    val List(call) = importNode.call.l
+    call.callee.name.l shouldBe List("require")
+    call.argument.code.l shouldBe List("'test'")
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -1,0 +1,18 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class ImportTests extends RubyCode2CpgFixture {
+  "`require 'test'` is a CALL node with an IMPORT node pointing to it" in {
+    val cpg = code("""
+                     |require 'test'
+                     |""".stripMargin)
+    val List(importNode) = cpg.imports.l
+    importNode.importedEntity shouldBe Some("test")
+    importNode.importedAs shouldBe Some("") // TODO: change X2Cpg import utility to allow optionals for importAs
+    val List(call) = importNode.call.l
+    call.callee.name.l shouldBe List("require")
+    call.argument.code.l shouldBe List("'test'")
+  }
+}


### PR DESCRIPTION
Add the import nodes in a new pass. The X2Cpg generic pass requires an assignment node for the importAs, but this doesn't fit the Ruby import mechanics which behave more like c `#includes` with dedup.