### PR TITLE
[javasrc] Fix JavaParser -> standard name conversion for nested classes

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -11,6 +11,86 @@ import overflowdb.traversal.jIteratortoTraversal
 import overflowdb.traversal.toNodeTraversal
 
 class NewCallTests extends JavaSrcCode2CpgFixture {
+  "calls to imported methods" when {
+    "they are static methods imported from java.lang.* should be resolved" in {
+      val cpg = code("""
+                       |class Test {
+                       |  public void test() {
+                       |    String.valueOf(true);
+                       |  }
+                       |}
+                       |
+                       |""".stripMargin)
+
+      cpg.call.name("valueOf").methodFullName.l shouldBe List("java.lang.String.valueOf:java.lang.String(boolean)")
+    }
+
+    "they are instance methods imported from java.lang.* should be resolved" in {
+      val cpg = code("""
+                       |class Test {
+                       |  public void test(String s) {
+                         |  s.length();
+                       |  }
+                       |}
+                       |
+                       |""".stripMargin)
+
+      cpg.call.name("length").methodFullName.l shouldBe List("java.lang.String.length:int()")
+    }
+
+    "they are calls to instance methods from java imports should be resolved" in {
+      val cpg = code("""
+                       |import java.util.Base64;
+                       |
+                       |class Test {
+                       |  public void test(Base64.Decoder decoder, String src) {
+                       |    decoder.decode(src);
+                       |  }
+                       |}
+                       |
+                       |""".stripMargin)
+      cpg.call.name("decode").methodFullName.l shouldBe List("java.util.Base64$Decoder.decode:byte[](java.lang.String)")
+    }
+
+    "they are calls to static methods from java imports should be resolved" in {
+      val cpg = code("""
+                       |import java.util.Base64;
+                       |
+                       |class Foo {
+                       |  void test() {
+                       |    Base64.getDecoder();
+                       |  }
+                       |}
+                       |""".stripMargin)
+
+      cpg.call.name("getDecoder").methodFullName.l shouldBe List("java.util.Base64.getDecoder:java.util.Base64$Decoder()")
+    }
+  }
+
+  "calls to static methods in other files should be resolved" in {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |  public static String foo() {
+        |    return "FOO";
+        |  }
+        |}
+        |""".stripMargin)
+      .moreCode("""
+        |package bar;
+        |
+        |import foo.Foo;
+        |
+        |class Bar {
+        |  void test() {
+        |    Foo.foo();
+        |  }
+        |}
+        |""".stripMargin)
+
+    cpg.call.name("foo").methodFullName.l shouldBe List("foo.Foo.foo:java.lang.String()")
+  }
 
   "calls with unresolved receivers should have the correct fullnames" in {
     val cpg = code("""

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -63,7 +63,9 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
                        |}
                        |""".stripMargin)
 
-      cpg.call.name("getDecoder").methodFullName.l shouldBe List("java.util.Base64.getDecoder:java.util.Base64$Decoder()")
+      cpg.call.name("getDecoder").methodFullName.l shouldBe List(
+        "java.util.Base64.getDecoder:java.util.Base64$Decoder()"
+      )
     }
   }
 


### PR DESCRIPTION
JavaParser represents "standard" nested class names `a.b.Foo$Bar` as `a.b.Foo.Bar`. Therefore, when looking up nested class names in the classpool, we need to convert the JavaParser name to the standard representation. This was done incorrectly, leading to type resolution failures for types we know about.

This PR changes the approach to try all possible combinations of `.` and `$` before returning an unsolved symbol (short-circuiting if a match is found), so for the example above we'd try:
- `a.b.Foo.Bar`
- `a.b.Foo$Bar` -- (found, so stop here but in theory also try the below if this was not resolved)
- `a.b$Foo$Bar`
- `a$b$Foo$Bar`