### PR TITLE
[ruby] Proc Expressions & Captured Variables

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -32,6 +32,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: MandatoryParameter       => astForMandatoryParameter(node)
     case node: SplattingRubyNode        => astForSplattingRubyNode(node)
     case node: AnonymousTypeDeclaration => astForAnonymousTypeDeclaration(node)
+    case node: ProcOrLambdaExpr         => astForProcOrLambdaExpr(node)
     case node: DummyNode                => Ast(node.node)
     case _                              => astForUnknown(node)
 
@@ -438,6 +439,15 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val argumentAst = node.arguments.map(astForMethodCallArgument)
     val call        = callNode(node, code(node), methodName, methodFullName, DispatchTypes.STATIC_DISPATCH)
     callAst(call, argumentAst, None, None)
+  }
+
+  private def astForProcOrLambdaExpr(node: ProcOrLambdaExpr): Ast = {
+    val Seq(methodDecl, typeDecl, _, methodRef) = astForDoBlock(node.block): @unchecked
+
+    Ast.storeInDiffGraph(methodDecl, diffGraph)
+    Ast.storeInDiffGraph(typeDecl, diffGraph)
+
+    methodRef
   }
 
   private def astForMethodCallArgument(node: RubyNode): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -3,10 +3,17 @@ package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.datastructures.{ConstructorScope, MethodScope}
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.x2cpg.utils.NodeBuilders.{newModifierNode, newThisParameterNode}
-import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
-import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, ModifierTypes, NodeTypes}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewLocal, NewMethodParameterIn, NewTypeDecl}
+import io.joern.x2cpg.utils.NodeBuilders.{newClosureBindingNode, newLocalNode, newModifierNode, newThisParameterNode}
+import io.joern.x2cpg.{Ast, AstEdge, ValidationMode, Defines as XDefines}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, ModifierTypes, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  DeclarationNew,
+  NewIdentifier,
+  NewLocal,
+  NewMethodParameterIn,
+  NewMethodRef,
+  NewTypeDecl
+}
 
 trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -46,9 +53,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val optionalStatementList = statementListForOptionalParams(node.parameters)
 
-    val stmtBlockAst = astForMethodBody(node.body, optionalStatementList)
-    scope.popScope()
-
     val methodReturn = methodReturnNode(node, Defines.Any)
     val refs = if (isClosure) {
       List(
@@ -71,10 +75,62 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       Nil
     }
 
+    // Consider which variables are captured from the outer scope
+    val stmtBlockAst = if (isClosure) {
+      val baseStmtBlockAst = astForMethodBody(node.body, optionalStatementList)
+      transformAsClosureBody(refs, baseStmtBlockAst)
+    } else {
+      astForMethodBody(node.body, optionalStatementList)
+    }
+
+    scope.popScope()
+
     val modifiers =
       ModifierTypes.VIRTUAL :: (if isClosure then ModifierTypes.LAMBDA :: Nil else Nil) map newModifierNode
 
     methodAst(method, parameterAsts, stmtBlockAst, methodReturn, modifiers) :: refs
+  }
+
+  private def transformAsClosureBody(refs: List[Ast], baseStmtBlockAst: Ast) = {
+    // Determine which locals are captured
+    val capturedLocalNodes = baseStmtBlockAst.nodes
+      .collect { case x: NewIdentifier => x }
+      .distinctBy(_.name)
+      .flatMap(i => scope.lookupVariable(i.name))
+      .toSet
+    val capturedIdentifiers = baseStmtBlockAst.nodes.collect {
+      case i: NewIdentifier if capturedLocalNodes.map(_.name).contains(i.name) => i
+    }
+    // Copy AST block detaching the REF nodes between parent locals/params and identifiers, with the closures' one
+    val capturedBlockAst = baseStmtBlockAst.copy(refEdges = baseStmtBlockAst.refEdges.filterNot {
+      case AstEdge(_: NewIdentifier, dst: DeclarationNew) => capturedLocalNodes.contains(dst)
+      case _                                              => false
+    })
+
+    val methodRefOption = refs.flatMap(_.nodes).collectFirst { case x: NewMethodRef => x }
+
+    capturedLocalNodes
+      .collect {
+        case local: NewLocal =>
+          val closureBindingId = scope.surroundingScopeFullName.map(x => s"$x:${local.name}")
+          (local, local.name, local.code, closureBindingId)
+        case param: NewMethodParameterIn =>
+          val closureBindingId = scope.surroundingScopeFullName.map(x => s"$x:${param.name}")
+          (param, param.name, param.code, closureBindingId)
+      }
+      .collect { case (decl, name, code, Some(closureBindingId)) =>
+        val local          = newLocalNode(name, code, Option(closureBindingId))
+        val closureBinding = newClosureBindingNode(closureBindingId, name, EvaluationStrategies.BY_REFERENCE)
+
+        // Create new local node for lambda, with corresponding REF edges to identifiers and closure binding
+        capturedBlockAst.withChild(Ast(local))
+        capturedIdentifiers.filter(_.name == name).foreach(i => capturedBlockAst.withRefEdge(i, local))
+        diffGraph.addEdge(closureBinding, decl, EdgeTypes.REF)
+
+        methodRefOption.foreach(methodRef => diffGraph.addEdge(methodRef, closureBinding, EdgeTypes.CAPTURE))
+      }
+
+    capturedBlockAst
   }
 
   // TODO: remaining cases

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -34,7 +34,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       fullName = fullName,
       code = code(node),
       signature = None,
-      fileName = relativeFileName
+      fileName = relativeFileName,
+      astParentType = scope.surroundingAstLabel,
+      astParentFullName = scope.surroundingScopeFullName
     )
 
     if (methodName == XDefines.ConstructorMethodName) scope.pushNewScope(ConstructorScope(fullName))
@@ -50,7 +52,15 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val methodReturn = methodReturnNode(node, Defines.Any)
     val refs = if (withRefsAndTypes) {
       List(
-        typeDeclNode(node, methodName, fullName, relativeFileName, code(node)),
+        typeDeclNode(
+          node,
+          methodName,
+          fullName,
+          relativeFileName,
+          code(node),
+          astParentType = scope.surroundingAstLabel.getOrElse("<empty>"),
+          astParentFullName = scope.surroundingScopeFullName.getOrElse("<empty>")
+        ),
         typeRefNode(node, methodName, fullName),
         methodRefNode(node, methodName, fullName, methodReturn.typeFullName)
       ).map(Ast.apply)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -192,7 +192,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   protected def astForDoBlock(block: Block with RubyNode): Seq[Ast] = {
     // Create closure structures: [MethodDecl, TypeRef, MethodRef]
     val methodName         = nextClosureName()
-    val methodAstsWithRefs = astForMethodDeclaration(block.toMethodDeclaration(methodName), withRefsAndTypes = true)
+    val methodAstsWithRefs = astForMethodDeclaration(block.toMethodDeclaration(methodName), isClosure = true)
     // Set span contents
     methodAstsWithRefs.flatMap(_.nodes).foreach {
       case m: NewMethodRef => DummyNode(m.copy)(block.span.spanStart(m.code))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -225,8 +225,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   private def astsForImplicitReturnStatement(node: RubyNode): Seq[Ast] = {
     node match
       case expr: ControlFlowExpression => astsForStatement(rubyNodeForExplicitReturnControlFlowExpression(expr))
-      case _: (ArrayLiteral | HashLiteral | StaticLiteral | BinaryExpression | UnaryExpression | SimpleIdentifier |
-            SimpleCall | IndexAccess | Association) =>
+      case _: (LiteralExpr | BinaryExpression | UnaryExpression | SimpleIdentifier | SimpleCall | IndexAccess |
+            Association) =>
         astForReturnStatement(ReturnExpression(List(node))(node.span)) :: Nil
       case node: SingleAssignment =>
         astForSingleAssignment(node) :: List(astForReturnStatement(ReturnExpression(List(node.lhs))(node.span)))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -174,27 +174,32 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
    * ```
    */
   private def astsForCallWithBlock[C <: RubyCall](node: RubyNode with RubyCallWithBlock[C]): Seq[Ast] = {
-    // Create closure structures: [MethodDecl, TypeRef, MethodRef]
-    val block              = node.block
-    val methodName         = nextClosureName()
-    val methodAstsWithRefs = astForMethodDeclaration(block.toMethodDeclaration(methodName), withRefsAndTypes = true)
-    val methodRefArgs =
-      methodAstsWithRefs.flatMap(_.nodes).collect { case m: NewMethodRef =>
-        DummyNode(m.copy)(node.span.spanStart(m.code))
-      }
-    // Isolate method and type declaration AST (all we need here)
-    val declarationAsts = methodAstsWithRefs.filter(_.root.exists(_.isInstanceOf[NewMethod | NewTypeDecl]))
+    val Seq(methodDecl, typeDecl, _, methodRef) = astForDoBlock(node.block): @unchecked
+    val methodRefDummyNode                      = methodRef.root.map(DummyNode(_)(node.span)).toList
 
     // Create call with argument referencing the MethodRef
     val callWithLambdaArg = node.withoutBlock match {
-      case x: SimpleCall => astForSimpleCall(x.copy(arguments = x.arguments ++ methodRefArgs)(x.span))
-      case x: MemberCall => astForMemberCall(x.copy(arguments = x.arguments ++ methodRefArgs)(x.span))
+      case x: SimpleCall => astForSimpleCall(x.copy(arguments = x.arguments ++ methodRefDummyNode)(x.span))
+      case x: MemberCall => astForMemberCall(x.copy(arguments = x.arguments ++ methodRefDummyNode)(x.span))
       case x =>
         logger.warn(s"Unhandled call-with-block type ${code(x)}, creating anonymous method structures only")
         Ast()
     }
 
-    declarationAsts :+ callWithLambdaArg
+    methodDecl :: typeDecl :: methodRef :: callWithLambdaArg :: Nil
+  }
+
+  protected def astForDoBlock(block: Block with RubyNode): Seq[Ast] = {
+    // Create closure structures: [MethodDecl, TypeRef, MethodRef]
+    val methodName         = nextClosureName()
+    val methodAstsWithRefs = astForMethodDeclaration(block.toMethodDeclaration(methodName), withRefsAndTypes = true)
+    // Set span contents
+    methodAstsWithRefs.flatMap(_.nodes).foreach {
+      case m: NewMethodRef => DummyNode(m.copy)(block.span.spanStart(m.code))
+      case _               =>
+    }
+
+    methodAstsWithRefs
   }
 
   protected def astForReturnStatement(node: ReturnExpression): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -4,6 +4,7 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.StatementList
 import io.joern.rubysrc2cpg.datastructures.{RubyField, RubyMethod, RubyProgramSummary, RubyType}
 import io.joern.rubysrc2cpg.parser.RubyNodeCreator
 import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Local, Member, Method, TypeDecl}
@@ -22,6 +23,9 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
       val ast      = astForRubyFile(rootNode)
       Ast.storeInDiffGraph(ast, diffGraph)
       BatchedUpdate.applyDiff(cpg.graph, diffGraph)
+
+      // Link basic AST elements
+      AstLinkerPass(cpg).createAndApply()
 
       // Summarize findings
       summarize(cpg)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.astcreation
 
+import io.joern.rubysrc2cpg.passes.Defines
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 
 object RubyIntermediateAst {
@@ -196,8 +197,15 @@ object RubyIntermediateAst {
 
   final case class SelfIdentifier()(span: TextSpan) extends RubyNode(span)
 
+  /**
+   * Represents some kind of literal expression.
+   */
+  sealed trait LiteralExpr {
+    def typeFullName: String
+  }
+
   /** Represents a non-interpolated literal. */
-  final case class StaticLiteral(typeFullName: String)(span: TextSpan) extends RubyNode(span) {
+  final case class StaticLiteral(typeFullName: String)(span: TextSpan) extends RubyNode(span) with LiteralExpr {
     def isSymbol: Boolean = text.startsWith(":")
 
     def isString: Boolean = text.startsWith("\"")
@@ -210,7 +218,7 @@ object RubyIntermediateAst {
   }
 
   final case class DynamicLiteral(typeFullName: String, expressions: List[RubyNode])(span: TextSpan)
-      extends RubyNode(span)
+      extends RubyNode(span) with LiteralExpr
 
   final case class RangeExpression(lowerBound: RubyNode, upperBound: RubyNode, rangeOperator: RangeOperator)(
     span: TextSpan
@@ -218,7 +226,7 @@ object RubyIntermediateAst {
 
   final case class RangeOperator(exclusive: Boolean)(span: TextSpan) extends RubyNode(span)
 
-  final case class ArrayLiteral(elements: List[RubyNode])(span: TextSpan) extends RubyNode(span) {
+  final case class ArrayLiteral(elements: List[RubyNode])(span: TextSpan) extends RubyNode(span) with LiteralExpr {
     def isSymbolArray: Boolean = text.take(2).toLowerCase.startsWith("%i")
 
     def isStringArray: Boolean = text.take(2).toLowerCase.startsWith("%w")
@@ -226,9 +234,13 @@ object RubyIntermediateAst {
     def isDynamic: Boolean = text.take(2).startsWith("%I") || text.take(2).startsWith("%W")
 
     def isStatic: Boolean = !isDynamic
+    
+    def typeFullName: String = Defines.getBuiltInType(Defines.Array)
   }
 
-  final case class HashLiteral(elements: List[RubyNode])(span: TextSpan) extends RubyNode(span)
+  final case class HashLiteral(elements: List[RubyNode])(span: TextSpan) extends RubyNode(span) with LiteralExpr {
+    def typeFullName: String = Defines.getBuiltInType(Defines.Hash)
+  }
 
   final case class Association(key: RubyNode, value: RubyNode)(span: TextSpan) extends RubyNode(span)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -244,6 +244,10 @@ object RubyIntermediateAst {
       extends RubyNode(span)
       with RubyCall
 
+  /** Represents standalone `proc { ... }` or `lambda { ... }` expressions
+    */
+  final case class ProcOrLambdaExpr(block: Block)(span: TextSpan) extends RubyNode(span)
+
   /** Represents a call with a block argument.
     */
   sealed trait RubyCallWithBlock[C <: RubyCall] extends RubyCall {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -197,9 +197,8 @@ object RubyIntermediateAst {
 
   final case class SelfIdentifier()(span: TextSpan) extends RubyNode(span)
 
-  /**
-   * Represents some kind of literal expression.
-   */
+  /** Represents some kind of literal expression.
+    */
   sealed trait LiteralExpr {
     def typeFullName: String
   }
@@ -218,7 +217,8 @@ object RubyIntermediateAst {
   }
 
   final case class DynamicLiteral(typeFullName: String, expressions: List[RubyNode])(span: TextSpan)
-      extends RubyNode(span) with LiteralExpr
+      extends RubyNode(span)
+      with LiteralExpr
 
   final case class RangeExpression(lowerBound: RubyNode, upperBound: RubyNode, rangeOperator: RangeOperator)(
     span: TextSpan
@@ -234,7 +234,7 @@ object RubyIntermediateAst {
     def isDynamic: Boolean = text.take(2).startsWith("%I") || text.take(2).startsWith("%W")
 
     def isStatic: Boolean = !isDynamic
-    
+
     def typeFullName: String = Defines.getBuiltInType(Defines.Array)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -481,7 +481,13 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitMethodCallWithBlockExpression(ctx: RubyParser.MethodCallWithBlockExpressionContext): RubyNode = {
-    SimpleCallWithBlock(visit(ctx.methodIdentifier()), List(), visit(ctx.block()).asInstanceOf[Block])(ctx.toTextSpan)
+    ctx.methodIdentifier().getText match {
+      case Defines.Proc | Defines.Lambda => ProcOrLambdaExpr(visit(ctx.block()).asInstanceOf[Block])(ctx.toTextSpan)
+      case _ =>
+        SimpleCallWithBlock(visit(ctx.methodIdentifier()), List(), visit(ctx.block()).asInstanceOf[Block])(
+          ctx.toTextSpan
+        )
+    }
   }
 
   override def visitMethodCallWithParenthesesExpression(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -19,6 +19,8 @@ object Defines {
   val Hash: String       = "Hash"
   val Encoding: String   = "Encoding"
   val Regexp: String     = "Regexp"
+  val Lambda: String     = "lambda"
+  val Proc: String       = "proc"
 
   val Program: String = ":program"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, MethodRef, TypeDecl}
 import io.shiftleft.semanticcpg.language.*
 
@@ -130,6 +131,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
               closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+              closureMethod.isLambda.nonEmpty shouldBe true
             case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
@@ -137,6 +139,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
               closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+              closureType.isLambda.nonEmpty shouldBe true
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
         case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
@@ -189,7 +192,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           m.name should startWith("<lambda>")
         case xs => fail(s"Expected exactly one closure method decl, instead got [${xs.code.mkString(",")}]")
       }
-      
+
       inside(cpg.typeDecl("<lambda>.*").l) {
         case m :: Nil =>
           m.name should startWith("<lambda>")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -175,4 +175,30 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
   }
 
+  "a do block referencing variables from the surrounding scope" should {
+
+    val cpg = code("""var = "Jack"
+        |
+        |x = proc { "Hello #{var}" }
+        |""".stripMargin)
+
+    // Basic assertions for expected behaviour
+    "create the declarations for the closure" in {
+      inside(cpg.method("<lambda>.*").l) {
+        case m :: Nil =>
+          m.name should startWith("<lambda>")
+        case xs => fail(s"Expected exactly one closure method decl, instead got [${xs.code.mkString(",")}]")
+      }
+      
+      inside(cpg.typeDecl("<lambda>.*").l) {
+        case m :: Nil =>
+          m.name should startWith("<lambda>")
+        case xs => fail(s"Expected exactly one closure type decl, instead got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "annotate the nodes via CAPTURE bindings" in {}
+
+  }
+
 }


### PR DESCRIPTION
* Handling `proc { ... }` or `lambda { ... }` expressions
* Made sure closure method/type decl's can attach to parent scope automatically by defining `AST_PARENT_FULL_NAME` and `AST_PARENT_TYPE` properties
* Using `AstLinkerPass` on summary to ensure the above is emulated
* Made a trait `LiteralExpr` to bind all literals, and added support for them in implicit returns
* Added `LAMBDA` modifier to closure method and type decls
* Implemented closure bindings and variable capturing

Resolves [#4248](https://github.com/joernio/joern/issues/4248)