### PR TITLE
[swiftsrc2cpg] Fix-up type names for optional types

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -33,6 +33,8 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
     if (!Defines.JsTypes.contains(name) && !seenAliasTypes.exists(_.name == name)) {
       val (typeName, typeFullName) = calcTypeNameAndFullName(alias, Option(name))
+      registerType(typeFullName)
+
       val typeDeclNode_ = typeDeclNode(
         alias,
         typeName,
@@ -43,7 +45,6 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         astParentFullName,
         alias = Option(aliasFullName)
       )
-      registerType(typeFullName)
       diffGraph.addEdge(methodAstParentStack.head, typeDeclNode_, EdgeTypes.AST)
     } else {
       seenAliasTypes.find(t => t.name == name).foreach(_.aliasTypeFullName(aliasFullName))
@@ -420,6 +421,8 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
   protected def astForModule(tsModuleDecl: BabelNodeInfo): Ast = {
     val (name, fullName) = calcTypeNameAndFullName(tsModuleDecl)
+    registerType(fullName)
+
     val namespaceNode = NewNamespaceBlock()
       .code(tsModuleDecl.code)
       .lineNumber(tsModuleDecl.lineNumber)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -156,8 +156,10 @@ class AstCreator(val config: Config, val global: SwiftGlobal, val parserResult: 
   }
 
   override protected def code(node: SwiftNode): String = {
-    nodeOffsets(node) match {
-      case Some((startOffset, endOffset)) =>
+    (nodeOffsets(node), node) match {
+      case (Some((startOffset, endOffset)), _: TypeSyntax) =>
+        parserResult.fileContent.substring(startOffset, endOffset).trim.stripSuffix("?").stripSuffix("!")
+      case (Some((startOffset, endOffset)), _) =>
         shortenCode(parserResult.fileContent.substring(startOffset, endOffset).trim)
       case _ =>
         PropertyDefaults.Code

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -1066,7 +1066,8 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
       names.map { name =>
         val typeFullName = binding.typeAnnotation.fold(Defines.Any)(t => code(t.`type`))
-        val nLocalNode   = localNode(binding, name, name, typeFullName).order(0)
+        registerType(typeFullName)
+        val nLocalNode = localNode(binding, name, name, typeFullName).order(0)
         scope.addVariable(name, nLocalNode, scopeType)
         diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -41,9 +41,10 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForArrowExprSyntax(node: ArrowExprSyntax): Ast = notHandledYet(node)
 
   private def astForAsExprSyntax(node: AsExprSyntax): Ast = {
-    val op        = Operators.cast
-    val typ       = code(node.`type`)
-    val lhsNode   = node.`type`
+    val op      = Operators.cast
+    val lhsNode = node.`type`
+    val typ     = code(lhsNode)
+    registerType(typ)
     val lhsAst    = Ast(literalNode(lhsNode, code(lhsNode), None).dynamicTypeHintFullName(Seq(typ)))
     val rhsAst    = astForNodeWithFunctionReference(node.expression)
     val callNode_ = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH).dynamicTypeHintFullName(Seq(typ))

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForPatternSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForPatternSyntaxCreator.scala
@@ -25,9 +25,10 @@ trait AstForPatternSyntaxCreator(implicit withSchemaValidation: ValidationMode) 
   }
 
   private def astForIsTypePatternSyntax(node: IsTypePatternSyntax): Ast = {
-    val op        = Operators.instanceOf
-    val typ       = code(node.`type`)
-    val lhsNode   = node.`type`
+    val op      = Operators.instanceOf
+    val lhsNode = node.`type`
+    val typ     = code(lhsNode)
+    registerType(typ)
     val lhsAst    = Ast(literalNode(lhsNode, code(lhsNode), None).dynamicTypeHintFullName(Seq(typ)))
     val callNode_ = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH).dynamicTypeHintFullName(Seq(typ))
     callAst(callNode_, Seq(lhsAst))
@@ -69,6 +70,7 @@ trait AstForPatternSyntaxCreator(implicit withSchemaValidation: ValidationMode) 
         (generateUnusedVariableName(usedVariableNames, "wildcard"), Defines.Any)
     }
     val nLocalNode = localNode(node, name, name, typeFullName).order(0)
+    registerType(typeFullName)
     scope.addVariable(name, nLocalNode, scopeType)
     diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
     Ast()

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -319,7 +319,8 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
         generateUnusedVariableName(usedVariableNames, "wildcard")
     }
     val typeFullName = node.typeAnnotation.fold(Defines.Any)(t => code(t.`type`))
-    val nLocalNode   = localNode(node, name, name, typeFullName).order(0)
+    registerType(typeFullName)
+    val nLocalNode = localNode(node, name, name, typeFullName).order(0)
     scope.addVariable(name, nLocalNode, scopeType)
     diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1,8 +1,9 @@
 package io.joern.swiftsrc2cpg.passes.ast
 
-import io.shiftleft.codepropertygraph.generated._
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.joern.swiftsrc2cpg.passes.Defines
+import io.shiftleft.codepropertygraph.generated.*
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 class SimpleAstCreationPassTest extends AbstractPassTest {
 
@@ -42,6 +43,20 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
       val List(assignX, assignY) = method.assignment.l
       assignX.code shouldBe "let x = 1"
       assignY.code shouldBe """var y: String = "2""""
+    }
+
+    "have correct types for simple variable declarations" in AstFixture("""
+        |let a = 1
+        |let b: Int = 1
+        |var c: String! = ""
+        |var d: String? = ""
+        |""".stripMargin) { cpg =>
+      val List(method)     = cpg.method.nameExact("<global>").l
+      val List(a, b, c, d) = method.ast.isIdentifier.l
+      a.typeFullName shouldBe Defines.Any
+      b.typeFullName shouldBe Defines.Int
+      c.typeFullName shouldBe Defines.String
+      d.typeFullName shouldBe Defines.String
     }
 
     "have correct structure for tuple variable declarations" in AstFixture("""


### PR DESCRIPTION
Type names from type annotation with ? (optional) or ! (implicitly unwrapped optional) are registered without ? or ! now as we do not process them as new types (we can't express such things in the CPG anyway).