### PR TITLE
[ruby] Overapproximate Static Type References & Handle `self`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -26,7 +26,10 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def handleVariableOccurrence(node: RubyNode): Ast = {
     val name       = code(node)
     val identifier = identifierNode(node, name, name, Defines.Any)
+    val typeRef    = scope.tryResolveTypeReference(name)
     scope.lookupVariable(name) match {
+      case None if typeRef.isDefined =>
+        Ast(identifier.typeFullName(typeRef.get.name))
       case None =>
         val local = localNode(node, name, name, Defines.Any)
         scope.addToScope(name, local) match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -121,6 +121,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
   protected def astForMemberCall(node: MemberCall): Ast = {
     // Use the scope type recovery to attempt to obtain a receiver type for the call
+    // TODO: Type recovery should potentially resolve this
     val fullName = typeFromCallTarget(node.target)
       .map(x => s"$x:${node.methodName}")
       .getOrElse(node.methodName)
@@ -441,6 +442,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   private def astForMemberCallWithoutBlock(node: SimpleCall, memberAccess: MemberAccess): Ast = {
     val receiverAst = astForFieldAccess(memberAccess)
     val methodName  = memberAccess.methodName
+    // TODO: Type recovery should potentially resolve this
     val methodFullName = typeFromCallTarget(memberAccess.target)
       .map(x => s"$x:$methodName")
       .getOrElse(methodName)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -92,4 +92,18 @@ class RubyScope(summary: RubyProgramSummary)
       case _                           =>
     }
   }
+
+  override def tryResolveTypeReference(typeName: String): Option[RubyType] = {
+    // TODO: While we find better ways to understand how the implicit class loading works,
+    //  we can approximate that all types are in scope in the mean time.
+    super.tryResolveTypeReference(typeName) match {
+      case None =>
+        summary.namespaceToType.flatMap(_._2).collectFirst {
+          case x if x.name.split("[.]").lastOption.contains(typeName) =>
+            typesInScope.addOne(x)
+            x
+        }
+      case x => x
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -39,7 +39,7 @@ class CaseTests extends RubyCode2CpgFixture {
         case u: Unknown => "unknown"
         case mExpr =>
           val call @ List(_) = List(mExpr).isCall.l
-          call.methodFullName.l shouldBe List("===")
+          call.methodFullName.l shouldBe List("__builtin.Integer:===")
           val List(lhs, rhs) = call.argument.l
           rhs.code shouldBe "<tmp-0>"
           val List(code) = List(lhs).isCall.argument(1).code.l

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.semanticcpg.language.*
 
 class FieldAccessTests extends RubyCode2CpgFixture {
@@ -24,6 +24,38 @@ class FieldAccessTests extends RubyCode2CpgFixture {
     fieldAccessCall.code shouldBe "x.y"
     fieldAccessCall.name shouldBe "y"
     fieldAccessCall.receiver.l shouldBe List(fieldAccess)
+  }
+
+  "`self.x` should correctly create a `this` node field base" in {
+
+    // Example from railsgoat
+    val cpg = code("""
+        |class PaidTimeOff < ApplicationRecord
+        |  belongs_to :user
+        |  has_many :schedule, foreign_key: :user_id, primary_key: :user_id, dependent: :destroy
+        |
+        |  def sick_days_remaining
+        |    self.sick_days_earned - self.sick_days_taken
+        |  end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.fieldAccess.code("self.*").l) {
+      case sickDays :: _ =>
+        sickDays.code shouldBe "self.sick_days_earned"
+        sickDays.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+        inside(sickDays.argument.l) {
+          case (self: Identifier) :: sickDaysEarned :: Nil =>
+            self.name shouldBe "this"
+            self.code shouldBe "self"
+            self.typeFullName should endWith("PaidTimeOff")
+
+            sickDaysEarned.code shouldBe "sick_days_earned"
+          case xs => fail(s"Expected exactly two field access arguments, instead got [${xs.code.mkString(", ")}]")
+        }
+      case Nil => fail("Expected at least one field access with `self` base, but got none.")
+    }
   }
 
 }


### PR DESCRIPTION
Frameworks such as Ruby on Rails implicitly loads classes in a way that requires more careful analysis, which is the goal of [#3940](https://github.com/joernio/joern/issues/3940). For now, however, we can choose a layered approach of first looking at types in scope, then looking at the rest of the program. This is useful for instances such as `User.save`, where `User` doesn't have an associated `require`, nor is its definition in the same directory.

This PR does this, which allows `astForMemberCall` to resolve method calls, as well as adds simple handling for occurrences of the `self` identifier.