### PR TITLE
[swiftsrc2cpg] Fix creation of unnecessary nested blocks

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -85,19 +85,11 @@ class AstCreator(val config: Config, val global: SwiftGlobal, val parserResult: 
       methodNode(ast, name, name, fullName, None, path, Option(NodeTypes.TYPE_DECL), Option(fullName))
     methodAstParentStack.push(fakeGlobalMethod)
     scope.pushNewMethodScope(fullName, name, fakeGlobalMethod, None)
-
-    val blockNode_ = blockNode(ast, "<empty>", Defines.Any)
-    scope.pushNewBlockScope(blockNode_)
-    localAstParentStack.push(blockNode_)
     val sourceFileAst = astForNode(ast)
-    localAstParentStack.pop()
-    scope.popScope()
-    val blockAst_ = blockAst(blockNode_, List(sourceFileAst))
-
-    val methodReturn = newMethodReturnNode(Defines.Any, None, line(ast), column(ast))
+    val methodReturn  = newMethodReturnNode(Defines.Any, None, line(ast), column(ast))
     val modifiers = Seq(newModifierNode(ModifierTypes.VIRTUAL).order(0), newModifierNode(ModifierTypes.MODULE).order(1))
     Ast(fakeGlobalTypeDecl).withChild(
-      methodAst(fakeGlobalMethod, Seq.empty, blockAst_, methodReturn, modifiers = modifiers)
+      methodAst(fakeGlobalMethod, Seq.empty, sourceFileAst, methodReturn, modifiers = modifiers)
     )
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -16,6 +16,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.NewCall
 import io.shiftleft.codepropertygraph.generated.nodes.NewMethod
 import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.nodes.File.PropertyDefaults
 
 import scala.jdk.CollectionConverters.*
 
@@ -804,7 +805,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     val codeString  = code(node)
     val methodNode_ = methodNode(node, methodName, codeString, methodFullName, Option(signature), filename)
-    val block       = blockNode(node, "<empty>", Defines.Any)
+    val block       = blockNode(node, PropertyDefaults.Code, Defines.Any)
     methodAstParentStack.push(methodNode_)
     scope.pushNewMethodScope(methodFullName, methodName, block, capturingRefNode)
     localAstParentStack.push(block)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -21,7 +21,6 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
         localAstParentStack.pop()
         scope.popScope()
         blockAst(blockNode_, childrenAsts)
-
     }
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -5,6 +5,7 @@ import io.joern.swiftsrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.datastructures.Stack.*
+import io.shiftleft.codepropertygraph.generated.nodes.File.PropertyDefaults
 
 trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMode) {
   this: AstCreator =>
@@ -14,7 +15,7 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
       case Nil         => Ast()
       case head :: Nil => astForNodeWithFunctionReference(head)
       case elements =>
-        val blockNode_ = blockNode(node, "<empty>", Defines.Any)
+        val blockNode_ = blockNode(node, PropertyDefaults.Code, Defines.Any)
         scope.pushNewBlockScope(blockNode_)
         localAstParentStack.push(blockNode_)
         val childrenAsts = astsForBlockElements(elements)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -16,6 +16,7 @@ import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.NewIdentifier
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.File.PropertyDefaults
 
 trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -360,10 +361,10 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   private def astForSourceFileSyntax(node: SourceFileSyntax): Ast = {
     node.statements.children.toList match {
       case Nil =>
-        val blockNode_ = blockNode(node, "<empty>", Defines.Any)
+        val blockNode_ = blockNode(node, PropertyDefaults.Code, Defines.Any)
         blockAst(blockNode_, List.empty)
       case head :: Nil =>
-        val blockNode_ = blockNode(node, "<empty>", Defines.Any)
+        val blockNode_ = blockNode(node, PropertyDefaults.Code, Defines.Any)
         scope.pushNewBlockScope(blockNode_)
         localAstParentStack.push(blockNode_)
         val childrenAst = astForNodeWithFunctionReference(head)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -356,9 +356,12 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   private def astForPrimaryAssociatedTypeSyntax(node: PrimaryAssociatedTypeSyntax): Ast = notHandledYet(node)
   private def astForReturnClauseSyntax(node: ReturnClauseSyntax): Ast                   = notHandledYet(node)
   private def astForSameTypeRequirementSyntax(node: SameTypeRequirementSyntax): Ast     = notHandledYet(node)
+
   private def astForSourceFileSyntax(node: SourceFileSyntax): Ast = {
     node.statements.children.toList match {
-      case Nil => Ast()
+      case Nil =>
+        val blockNode_ = blockNode(node, "<empty>", Defines.Any)
+        blockAst(blockNode_, List.empty)
       case head :: Nil =>
         val blockNode_ = blockNode(node, "<empty>", Defines.Any)
         scope.pushNewBlockScope(blockNode_)
@@ -370,6 +373,7 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
       case _ => astForNode(node.statements)
     }
   }
+
   private def astForSpecializeAvailabilityArgumentSyntax(node: SpecializeAvailabilityArgumentSyntax): Ast =
     notHandledYet(node)
   private def astForSpecializeTargetFunctionArgumentSyntax(node: SpecializeTargetFunctionArgumentSyntax): Ast =

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -52,11 +52,16 @@ class SimpleAstCreationPassTest extends AbstractPassTest {
         |var d: String? = ""
         |""".stripMargin) { cpg =>
       val List(method)     = cpg.method.nameExact("<global>").l
-      val List(a, b, c, d) = method.ast.isIdentifier.l
+      val List(a, b, c, d) = method.block.ast.isIdentifier.l
       a.typeFullName shouldBe Defines.Any
       b.typeFullName shouldBe Defines.Int
       c.typeFullName shouldBe Defines.String
       d.typeFullName shouldBe Defines.String
+      val List(localA, localB, localC, localD) = method.block.local.l
+      localA.typeFullName shouldBe Defines.Any
+      localB.typeFullName shouldBe Defines.Int
+      localC.typeFullName shouldBe Defines.String
+      localD.typeFullName shouldBe Defines.String
     }
 
     "have correct structure for tuple variable declarations" in AstFixture("""

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/dependency/DependenciesPassTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/dependency/DependenciesPassTests.scala
@@ -1,7 +1,8 @@
 package io.joern.swiftsrc2cpg.passes.dependency
 
 import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.File.PropertyDefaults
+import io.shiftleft.semanticcpg.language.*
 
 class DependenciesPassTests extends SwiftSrc2CpgSuite {
 
@@ -39,7 +40,7 @@ class DependenciesPassTests extends SwiftSrc2CpgSuite {
         debPackageDesc.dependencyGroupId shouldBe Some("PackageDescription")
 
         depA.name shouldBe "DepA"
-        depA.version shouldBe "<empty>"
+        depA.version shouldBe PropertyDefaults.Name
         depA.dependencyGroupId shouldBe Some("PathA")
 
         depB.name shouldBe "https://github.com/DepB"
@@ -67,7 +68,7 @@ class DependenciesPassTests extends SwiftSrc2CpgSuite {
         depG.dependencyGroupId shouldBe None
 
         depH.name shouldBe "../some/path/DepH"
-        depH.version shouldBe "<empty>"
+        depH.version shouldBe PropertyDefaults.Name
         depH.dependencyGroupId shouldBe None
       }
     }


### PR DESCRIPTION
Previously, we created a top level block if

1) a source file contained only one statement, and
2) a source file contained two or more statements

which resulted in two nested blocks in the second case where the statements are wrapped in a `CodeBlockItemListSyntax` node for which we always create a surrounding block.

With this PR we only create a block for 1 manually.