### PR TITLE
[ruby] Added implicit assignment for control structures

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -182,13 +182,63 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
             logger.warn(s"Unrecognized assignment operator: ${code(node)} ($relativeFileName), skipping")
             astForUnknown(node)
           case Some(op) =>
-            val lhsAst = astForExpression(node.lhs)
-            val rhsAst = astForExpression(node.rhs)
-            val call   = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
-            callAst(call, Seq(lhsAst, rhsAst))
+            node.rhs match {
+              case cfNode: ControlFlowExpression =>
+                def elseAssignNil = Option {
+                  ElseClause(
+                    StatementList(
+                      SingleAssignment(
+                        node.lhs,
+                        node.op,
+                        StaticLiteral(getBuiltInType(Defines.NilClass))(node.span.spanStart("nil"))
+                      )(node.span.spanStart(s"${node.lhs.span.text} ${node.op} nil")) :: Nil
+                    )(node.span.spanStart(s"${node.lhs.span.text} ${node.op} nil"))
+                  )(node.span.spanStart(s"else\n\t${node.lhs.span.text} ${node.op} nil\nend"))
+                }
+
+                astForExpression(
+                  transformLastRubyNodeInControlFlowExpressionBody(
+                    cfNode,
+                    x => reassign(node.lhs, node.op, x),
+                    elseAssignNil
+                  )
+                )
+              case _ =>
+                val lhsAst = astForExpression(node.lhs)
+                val rhsAst = astForExpression(node.rhs)
+
+                val call = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
+                callAst(call, Seq(lhsAst, rhsAst))
+            }
         }
     }
+  }
 
+  private def reassign(lhs: RubyNode, op: String, rhs: RubyNode): RubyNode = {
+    def stmtListAssigningLastExpression(stmts: List[RubyNode]): List[RubyNode] = stmts match {
+      case (head: ControlFlowClause) :: Nil => clauseAssigningLastExpression(head) :: Nil
+      case head :: Nil =>
+        SingleAssignment(lhs, op, head)(lhs.span.spanStart(s"${lhs.span.text} $op ${head.span.text}")) :: Nil
+      case Nil          => List.empty
+      case head :: tail => head :: stmtListAssigningLastExpression(tail)
+    }
+
+    def clauseAssigningLastExpression(x: RubyNode with ControlFlowClause): RubyNode = x match {
+      case RescueClause(exceptionClassList, assignment, thenClause) =>
+        RescueClause(exceptionClassList, assignment, reassign(lhs, op, thenClause))(x.span)
+      case EnsureClause(thenClause)           => EnsureClause(reassign(lhs, op, thenClause))(x.span)
+      case ElsIfClause(condition, thenClause) => ElsIfClause(condition, reassign(lhs, op, thenClause))(x.span)
+      case ElseClause(thenClause)             => ElseClause(reassign(lhs, op, thenClause))(x.span)
+      case WhenClause(matchExpressions, matchSplatExpression, thenClause) =>
+        WhenClause(matchExpressions, matchSplatExpression, reassign(lhs, op, thenClause))(x.span)
+    }
+
+    rhs match {
+      case StatementList(statements) => StatementList(stmtListAssigningLastExpression(statements))(rhs.span)
+      case clause: ControlFlowClause => clauseAssigningLastExpression(clause)
+      case _ =>
+        SingleAssignment(lhs, op, rhs)(lhs.span.spanStart(s"${lhs.span.text} $op ${rhs.span.text}"))
+    }
   }
 
   // `x.y = 1` is lowered as `x.y=(1)`, i.e. as calling `y=` on `x` with argument `1`

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ConditionalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ConditionalTests.scala
@@ -17,9 +17,6 @@ class ConditionalTests extends RubyCode2CpgFixture(withPostProcessing = true, wi
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).sortBy(_.headOption.map(_._1)).toSet shouldBe
-      Set(
-        List(("x = 1", 2), ("foo ? x : y", 4), ("z = foo ? x : y", 4), ("puts z", 5)),
-        List(("y = 2", 3), ("foo ? x : y", 4), ("z = foo ? x : y", 4), ("puts z", 5))
-      )
+      Set(List(("x = 1", 2), ("z = x", 4), ("puts z", 5)), List(("y = 2", 3), ("z = y", 4), ("puts z", 5)))
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -387,4 +387,36 @@ class ControlStructureTests extends RubyCode2CpgFixture {
       }
     }
   }
+
+  "implicit if-elsif-else assignment" should {
+    val cpg = code("""
+        |   a = if (y > 3) then 123 elsif(y < 6) then 2003 elsif(y < 10) then 982 else 456 end
+        |""".stripMargin)
+
+    "Create assignment operators for each branch" in {
+      inside(cpg.call.name(Operators.assignment).l) {
+        case ifAssignment :: elsifOneAssignment :: elsifTwoAssignment :: elseAssignment :: Nil =>
+          ifAssignment.code shouldBe "a = 123"
+          elsifOneAssignment.code shouldBe "a = 2003"
+          elsifTwoAssignment.code shouldBe "a = 982"
+          elseAssignment.code shouldBe "a = 456"
+        case xs => fail(s"Expected four assignments, instead found ${xs.code.mkString(", ")}")
+      }
+    }
+  }
+
+  "implicit if assignment" should {
+    val cpg = code("""
+        | a = if(x > 4) then 123 end
+        |""".stripMargin)
+
+    "create assignment operators for if and default else branch" in {
+      inside(cpg.call.name(Operators.assignment).l) {
+        case ifAssignment :: defaultElseAssignment :: Nil =>
+          ifAssignment.code shouldBe "a = 123"
+          defaultElseAssignment.code shouldBe "a = nil"
+        case xs => fail(s"Expected two assignments, instead found ${xs.code.mkString(", ")}")
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 
@@ -125,27 +125,21 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |x = if true then 20 else 40 end
         |""".stripMargin)
 
-    val List(assignment) = cpg.assignment.l
-    val rhs              = assignment.argument(2).asInstanceOf[Call]
+    val List(assignmentIfBranch, assignmentElseBranch) = cpg.assignment.l
 
-    rhs.code shouldBe "if true then 20 else 40 end"
-    rhs.methodFullName shouldBe Operators.conditional
+    val rhsIfBranchIdentifier = assignmentIfBranch.argument(1).asInstanceOf[Identifier]
+    val rhsIfBranchValue      = assignmentIfBranch.argument(2).asInstanceOf[Literal]
 
-    val test      = rhs.argument(1)
-    val thenBlock = rhs.argument(2).asInstanceOf[Block]
-    val elseBlock = rhs.argument(3).asInstanceOf[Block]
+    val rhsElseBranchIdentifier = assignmentElseBranch.argument(1).asInstanceOf[Identifier]
+    val rhsElseBranchValue      = assignmentElseBranch.argument(2).asInstanceOf[Literal]
 
-    test.code shouldBe "true"
-    test.lineNumber shouldBe Some(2)
+    assignmentIfBranch.methodFullName shouldBe Operators.assignment
+    rhsIfBranchIdentifier.code shouldBe "x"
+    rhsIfBranchValue.code shouldBe "20"
 
-    val List(twenty: Literal) = thenBlock.astChildren.l: @unchecked
-    val List(forty: Literal)  = elseBlock.astChildren.l: @unchecked
-
-    twenty.code shouldBe "20"
-    twenty.lineNumber shouldBe Some(2)
-
-    forty.code shouldBe "40"
-    forty.lineNumber shouldBe Some(2)
+    assignmentElseBranch.methodFullName shouldBe Operators.assignment
+    rhsElseBranchIdentifier.code shouldBe "x"
+    rhsElseBranchValue.code shouldBe "40"
   }
 
 }


### PR DESCRIPTION
This PR handles:
 * implicit assignment of control structures to variables
 * Adds `nil` assignment for `if` statements without `else` branches

Resolves #4245 