### PR TITLE
[swiftsrc2cpg] more type calculation and registration fixes

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/Defines.scala
@@ -14,5 +14,5 @@ object Defines {
   val GlobalNamespace: String = NamespaceTraversal.globalNamespaceName
 
   val SwiftTypes: List[String] =
-    List(Any, Character, String, Int, Float, Double, Bool)
+    List(Any, Nil, Character, String, Int, Float, Double, Bool)
 }


### PR DESCRIPTION
- only calculate a type fullname if we have not seen that type already (extension types)
- re-use the typedecls fullname as return type fullname for its constructor instead of calculating a new one
- register types from inherits clauses