### PR TITLE
[ruby] Bugfix - Handling explicit return statements in Control Structures

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -288,6 +288,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   private def returnLastNode(x: RubyNode): RubyNode = {
     def statementListReturningLastExpression(stmts: List[RubyNode]): List[RubyNode] = stmts match {
       case (head: ControlFlowClause) :: Nil => clauseReturningLastExpression(head) :: Nil
+      case (head: ReturnExpression) :: Nil  => head :: Nil
       case head :: Nil                      => ReturnExpression(head :: Nil)(head.span) :: Nil
       case Nil                              => List.empty
       case head :: tail                     => head :: statementListReturningLastExpression(tail)


### PR DESCRIPTION
This PR includes:
 * handling of explicit return statements in a control structure that is being handled as an implicit return.

Resolves #4273 