### PR TITLE
[ruby] Block Constructors

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -173,7 +173,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
    * foo(<args>, <method_ref>)
    * ```
    */
-  private def astsForCallWithBlock[C <: RubyCall](node: RubyNode with RubyCallWithBlock[C]): Seq[Ast] = {
+  protected def astsForCallWithBlock[C <: RubyCall](node: RubyNode with RubyCallWithBlock[C]): Seq[Ast] = {
     val Seq(methodDecl, typeDecl, _, methodRef) = astForDoBlock(node.block): @unchecked
     val methodRefDummyNode                      = methodRef.root.map(DummyNode(_)(node.span)).toList
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.astcreation
 
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.ObjectInstantiation
 import io.joern.rubysrc2cpg.passes.Defines
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 
@@ -299,8 +300,21 @@ object RubyIntermediateAst {
   // TODO: Might be replaced by MemberCall simply?
   final case class MemberAccess(target: RubyNode, op: String, methodName: String)(span: TextSpan) extends RubyNode(span)
 
-  final case class ObjectInstantiation(clazz: RubyNode, arguments: List[RubyNode])(span: TextSpan)
+  /** A Ruby node that instantiates objects.
+    */
+  sealed trait ObjectInstantiation extends RubyCall
+
+  final case class SimpleObjectInstantiation(target: RubyNode, arguments: List[RubyNode])(span: TextSpan)
       extends RubyNode(span)
+      with ObjectInstantiation
+
+  final case class ObjectInstantiationWithBlock(target: RubyNode, arguments: List[RubyNode], block: Block)(
+    span: TextSpan
+  ) extends RubyNode(span)
+      with ObjectInstantiation
+      with RubyCallWithBlock[SimpleObjectInstantiation] {
+    def withoutBlock: SimpleObjectInstantiation = SimpleObjectInstantiation(target, arguments)(span)
+  }
 
   /** Represents a `do` or `{ .. }` (braces) block. */
   final case class Block(parameters: List[RubyNode], body: RubyNode)(span: TextSpan) extends RubyNode(span) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -97,6 +97,9 @@ class RubyScope(summary: RubyProgramSummary)
     // TODO: While we find better ways to understand how the implicit class loading works,
     //  we can approximate that all types are in scope in the mean time.
     super.tryResolveTypeReference(typeName) match {
+      case None if GlobalTypes.builtinFunctions.contains(typeName) =>
+        // TODO: Create a builtin.json for the program summary to load
+        Option(RubyType(s"${GlobalTypes.builtinPrefix}.$typeName", List.empty, List.empty))
       case None =>
         summary.namespaceToType.flatMap(_._2).collectFirst {
           case x if x.name.split("[.]").lastOption.contains(typeName) =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
@@ -89,7 +89,7 @@ trait TypedScope[M <: MethodLike, F <: FieldLike, T <: TypeLike[M, F]](summary: 
     *   the type meta-data if found.
     */
   def tryResolveTypeReference(typeName: String): Option[T] = {
-    // TODO: Handle partially quaified names
+    // TODO: Handle partially qualified names
     typesInScope
       .collectFirst {
         case typ if typ.name.split("[.]").lastOption == typeName.split("[.]").lastOption  => typ


### PR DESCRIPTION
* Restructured `ObjectInstantiation` `RubyNode` as a trait, and the calls into `SimpleObjectInstantiation` and `ObjectInstantiationWithBlock` to leverage existing call handling
* Testing that object instantiations with blocks do the usual lowering, but also handle the block closure situation

Resolves #4274