### PR TITLE
[C#] Ast for ParenthesizedLambdaExpression

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -30,7 +30,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case SimpleMemberAccessExpression => astForSimpleMemberAccessExpression(expr)
       case _: IdentifierNode            => astForIdentifier(expr) :: Nil
       case ThisExpression               => astForThisReceiver(expr) :: Nil
-      case SimpleLambdaExpression       => astForSimpleLambdaExpression(expr)
+      case _: BaseLambdaExpression      => astForSimpleLambdaExpression(expr)
       case _                            => notHandledYet(expr)
   }
 
@@ -346,8 +346,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       .flatMap(x =>
         val argExpression = createDotNetNodeInfo(x.json(ParserKeys.Expression))
         argExpression.node match {
-          case SimpleLambdaExpression => astForSimpleLambdaExpression(argExpression, baseTypeHint)
-          case _                      => astForExpressionStatement(x)
+          case _: BaseLambdaExpression =>
+            astForSimpleLambdaExpression(argExpression, baseTypeHint)
+          case _ => astForExpressionStatement(x)
         }
       )
       .toSeq

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -33,6 +33,8 @@ object DotNetJsonAst {
 
   sealed trait JumpStatement extends BaseStmt
 
+  sealed trait BaseLambdaExpression extends BaseExpr
+
   object GlobalStatement extends BaseStmt
 
   object ExpressionStatement extends BaseStmt
@@ -73,7 +75,9 @@ object DotNetJsonAst {
 
   object VariableDeclarator extends DeclarationExpr
 
-  object SimpleLambdaExpression extends BaseExpr
+  object SimpleLambdaExpression extends BaseLambdaExpression
+
+  object ParenthesizedLambdaExpression extends BaseLambdaExpression
 
   sealed trait ClauseExpr extends BaseExpr
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
@@ -1,7 +1,7 @@
 package io.joern.csharpsrc2cpg.querying.ast
 
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Method, MethodRef, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Method, MethodRef, TypeDecl}
 import io.shiftleft.semanticcpg.language.*
 import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes
 import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes.DotNetTypeMap
@@ -54,6 +54,67 @@ class LambdaTests extends CSharpCode2CpgFixture {
       }
     }
 
+  }
+
+  "a paranthesized lambda expression" should {
+    val cpg = code(basicBoilerplate("""
+        |int[] numbers = { 2, 3, 4, 5 };
+        |var squaredNumbers = numbers.Select((x,y) => {
+        |   Console.WriteLine(x);
+        |   x * x;
+        |});
+        |""".stripMargin))
+
+    "create an anonymous method declaration" in {
+      inside(cpg.method("Main").astChildren.collectAll[Method].l) {
+        case anon :: Nil =>
+          anon.name shouldBe "<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+
+          inside(anon.parameter.l) {
+            case x :: y :: Nil =>
+              x.name shouldBe "x"
+              x.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
+              x.index shouldBe 1
+
+              y.name shouldBe "y"
+              y.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
+              y.index shouldBe 2
+            case xs => fail(s"Expected two parameters, got [${xs.code.mkString(",")}]")
+          }
+
+        case xs => fail(s"Expected a single anonymous method declaration, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "create an anonymous type declaration" in {
+      inside(cpg.method("Main").astChildren.collectAll[TypeDecl].l) {
+        case anon :: Nil =>
+          anon.name shouldBe "<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+        case xs => fail(s"Expected a single anonymous type declaration, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "pass a method reference to the anonymous function in the call `Select`" in {
+      inside(cpg.call("Select").argument.l) {
+        case (numbers: Identifier) :: (closure: MethodRef) :: Nil =>
+          numbers.name shouldBe "numbers"
+          numbers.typeFullName shouldBe s"${DotNetTypeMap(BuiltinTypes.Int)}[]"
+
+          closure.methodFullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+          closure.referencedMethod.name shouldBe "<lambda>0"
+        case xs => fail(s"Expected two `Select` call argument, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "have correct attributes for it's body" in {
+      inside(cpg.method("Main").astChildren.collectAll[Method].l) { case anon :: Nil =>
+        inside(anon.ast.collectAll[Call].nameExact("WriteLine").l) { case callNode :: Nil =>
+          callNode.methodFullName shouldBe "System.Console.WriteLine:System.Void(System.Int32)"
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
This PR includes AST generation for the currently missing `ParenthesizedLambdaExpression`. Achieved this as a refactor to the existing `SimpleLambdaExpression` function.

Resolves #4276 