### PR TITLE
[c#] Download & Summarise Dependencies

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 csharpsrc2cpg {
-    dotnetastgen_version: "0.20.0"
+    dotnetastgen_version: "0.24.0"
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
@@ -5,7 +5,7 @@ import io.joern.csharpsrc2cpg.astcreation.AstCreator
 import io.joern.csharpsrc2cpg.datastructures.CSharpProgramSummary
 import io.joern.csharpsrc2cpg.parser.DotNetJsonParser
 import io.joern.csharpsrc2cpg.passes.{AstCreationPass, DependencyPass}
-import io.joern.csharpsrc2cpg.utils.DotNetAstGenRunner
+import io.joern.csharpsrc2cpg.utils.{DependencyDownloader, DotNetAstGenRunner}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.astgen.AstGenRunner.AstGenRunnerResult
 import io.joern.x2cpg.astgen.ParserResult
@@ -35,7 +35,7 @@ class CSharpSrc2Cpg extends X2CpgFrontend[Config] {
         val astGenResult = new DotNetAstGenRunner(config).execute(tmpDir)
         val astCreators  = CSharpSrc2Cpg.processAstGenRunnerResults(astGenResult.parsedFiles, config)
         // Pre-parse the AST creators for high level structures
-        val programSummary = ConcurrentTaskUtil
+        val internalProgramSummary = ConcurrentTaskUtil
           .runUsingThreadPool(astCreators.map(x => () => x.summarize()).iterator)
           .flatMap {
             case Failure(exception) => logger.warn(s"Unable to pre-parse C# file, skipping - ", exception); None
@@ -46,7 +46,12 @@ class CSharpSrc2Cpg extends X2CpgFrontend[Config] {
         val hash = HashUtil.sha256(astCreators.map(_.parserResult).map(x => Paths.get(x.fullPath)))
         new MetaDataPass(cpg, Languages.CSHARPSRC, config.inputPath, Option(hash)).createAndApply()
         new DependencyPass(cpg, buildFiles(config)).createAndApply()
-        // TODO: Enable download dependencies option
+        // If "download dependencies" is enabled, then fetch dependencies and resolve their symbols for additional types
+        val programSummary = if (config.downloadDependencies) {
+          DependencyDownloader(cpg, internalProgramSummary).download()
+        } else {
+          internalProgramSummary
+        }
         new AstCreationPass(cpg, astCreators.map(_.withSummary(programSummary)), report).createAndApply()
         report.print()
       }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
@@ -48,7 +48,7 @@ class CSharpSrc2Cpg extends X2CpgFrontend[Config] {
         new DependencyPass(cpg, buildFiles(config)).createAndApply()
         // If "download dependencies" is enabled, then fetch dependencies and resolve their symbols for additional types
         val programSummary = if (config.downloadDependencies) {
-          DependencyDownloader(cpg, internalProgramSummary).download()
+          DependencyDownloader(cpg, config, internalProgramSummary).download()
         } else {
           internalProgramSummary
         }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -10,10 +10,17 @@ import scopt.OParser
 
 import java.nio.file.Paths
 
-final case class Config() extends X2CpgConfig[Config] with TypeRecoveryParserConfig[Config] with AstGenConfig[Config] {
+final case class Config(downloadDependencies: Boolean = false)
+    extends X2CpgConfig[Config]
+    with TypeRecoveryParserConfig[Config]
+    with AstGenConfig[Config] {
 
   override val astGenProgramName: String  = "dotnetastgen"
   override val astGenConfigPrefix: String = "csharpsrc2cpg"
+
+  def withDownloadDependencies(value: Boolean): Config = {
+    this.copy(downloadDependencies = value).withInheritedFields(this)
+  }
 
 }
 
@@ -23,7 +30,13 @@ object Frontend {
   val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
     import builder.*
-    OParser.sequence(programName("csharpsrc2cpg"), XTypeRecovery.parserOptions)
+    OParser.sequence(
+      programName("csharpsrc2cpg"),
+      opt[Unit]("download-dependencies")
+        .text("Download the dependencies of the target project and use their symbols to resolve types.")
+        .action((_, c) => c.withDownloadDependencies(true)),
+      XTypeRecovery.parserOptions
+    )
   }
 
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -6,14 +6,12 @@ import org.slf4j.LoggerFactory
 import upickle.core.LinkedHashMap
 import upickle.default.*
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, ObjectOutputStream}
-import scala.io.Source
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import java.io.{ByteArrayInputStream, InputStream}
 import scala.annotation.targetName
+import scala.collection.mutable.ListBuffer
+import scala.io.Source
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
-import better.files.File
-import io.joern.x2cpg.utils.Environment
 
 type NamespaceToTypeMap = Map[String, Set[CSharpType]]
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -10,7 +10,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, Object
 import scala.io.Source
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.annotation.targetName
-import scala.collection.JavaConverters.enumerationAsScalaIteratorConverter
+import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 import better.files.File
 import io.joern.x2cpg.utils.Environment

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/DependencyPass.scala
@@ -25,7 +25,7 @@ class DependencyPass(cpg: Cpg, buildFiles: List[String]) extends ForkJoinParalle
             case packageReference if packageReference.label == "PackageReference" =>
               Try {
                 val packageName    = packageReference.attribute("Include").map(_.toString()).get
-                val packageVersion = packageReference.attribute("Version").map(_.toString()).get
+                val packageVersion = packageReference.attribute("Version").map(_.toString()).getOrElse("")
                 val dependencyNode = NewDependency()
                   .name(packageName)
                   .version(packageVersion)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
@@ -1,0 +1,158 @@
+package io.joern.csharpsrc2cpg.utils
+
+import better.files.File
+import io.joern.csharpsrc2cpg.datastructures.CSharpProgramSummary
+import io.joern.semanticcpg.utils.SecureXmlParsing
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Dependency
+import io.shiftleft.semanticcpg.language.*
+import org.slf4j.LoggerFactory
+
+import java.io.{BufferedReader, FileOutputStream, InputStreamReader}
+import java.net.{HttpURLConnection, URI, URL, URLConnection}
+import java.util.zip.{GZIPInputStream, InflaterInputStream, ZipEntry}
+import scala.util.{Failure, Success, Try, Using}
+import scala.xml.Elem
+
+/** Queries NuGet for the artifacts of a programs' dependencies.
+  *
+  * @see
+  *   <a href="https://learn.microsoft.com/en-us/nuget/api/overview">NuGet API</a>
+  */
+class DependencyDownloader(
+  cpg: Cpg,
+  internalProgramSummary: CSharpProgramSummary,
+  nugetRepositoryBaseUrl: String = "www.nuget.org",
+  nugetApiVersion: String = "v2"
+) {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /** Downloads dependencies and summarises their symbol information.
+    * @return
+    *   the dependencies' summary combined with the given internal program summary.
+    */
+  def download(): CSharpProgramSummary = {
+    File.temporaryDirectory("joern-csharpsrc2cpg").apply { dir =>
+      cpg.dependency.filterNot(isAlreadySummarized).foreach(downloadDependency(dir, _))
+      unzipDependencies(dir)
+      summarizeDependencies(dir) ++ internalProgramSummary
+    }
+  }
+
+  /** Using the internal program summary (which may contain pre-defined type stubs), determines if the dependency is
+    * already summarized and does not need to be downloaded.
+    * @param dependency
+    *   the dependency to download.
+    * @return
+    *   true if the dependency is already in the given summary, false if otherwise.
+    */
+  private def isAlreadySummarized(dependency: Dependency): Boolean = {
+    // TODO: Implement
+    false
+  }
+
+  /** Downloads the dependency to a temporary directory. This will be a `nupkg` and `snupkg` file for each dependency
+    * respectively, which are compressed using the ZIP format.
+    *
+    * @param targetDir
+    *   the directory to download to.
+    * @param dependency
+    *   the dependency to download.
+    * @return
+    *   a disposable version of the directory where the dependencies live.
+    */
+  private def downloadDependency(targetDir: File, dependency: Dependency): Unit = {
+    Seq("package", "symbolpackage")
+      .map(packageType =>
+        URI(
+          s"https://$nugetRepositoryBaseUrl/api/$nugetApiVersion/$packageType/${dependency.name}/${dependency.version}"
+        ).toURL
+      )
+      .foreach { url =>
+        var connection: Option[HttpURLConnection] = None
+        try {
+          connection = Option(url.openConnection()).collect { case x: HttpURLConnection => x }
+          // allow both GZip and Deflate (ZLib) encodings
+          connection.foreach(_.setRequestProperty("Accept-Encoding", "gzip, deflate"))
+          connection match {
+            case Some(conn: HttpURLConnection) if conn.getResponseCode == HttpURLConnection.HTTP_OK =>
+              val ext      = if url.toString.contains("/package/") then "nupkg" else "snupkg"
+              val fileName = targetDir / s"${dependency.name}.$ext"
+
+              val inputStream = Option(conn.getContentEncoding) match {
+                case Some(encoding) if encoding.equalsIgnoreCase("gzip")    => GZIPInputStream(conn.getInputStream)
+                case Some(encoding) if encoding.equalsIgnoreCase("deflate") => InflaterInputStream(conn.getInputStream)
+                case _                                                      => conn.getInputStream
+              }
+
+              Try {
+                Using.resources(inputStream, new FileOutputStream(fileName.pathAsString)) { (is, fos) =>
+                  val buffer = new Array[Byte](4096)
+                  Iterator
+                    .continually(is.read(buffer))
+                    .takeWhile(_ != -1)
+                    .foreach(bytesRead => fos.write(buffer, 0, bytesRead))
+                }
+              } match {
+                case Failure(exception) =>
+                  logger.error(
+                    s"Exception occurred while downloading $fileName (${dependency.name}:${dependency.version})",
+                    exception
+                  )
+                case Success(_) =>
+                  logger.info(s"Successfully downloaded dependency ${dependency.name}:${dependency.version}")
+              }
+            case Some(conn: HttpURLConnection) =>
+              logger.error(s"Connection to $url responded with non-200 code ${conn.getResponseCode}")
+            case _ => logger.error(s"Unknown URL connection made, aborting")
+          }
+
+        } catch {
+          case exception: Throwable =>
+            logger.error(s"Unable to download dependency ${dependency.name}:${dependency.version}", exception)
+        } finally {
+          connection.foreach(_.disconnect())
+        }
+      }
+  }
+
+  /** Unzips all the `pkg` files and extracts the `DLL`, `XML`, and `PDB` files.
+    * @param targetDir
+    *   the temporary directory containing all of the successfully downloaded dependencies.
+    */
+  private def unzipDependencies(targetDir: File): Unit = {
+
+    def zipFilter(zipEntry: ZipEntry): Boolean = {
+      val isZipSlip = zipEntry.getName.contains("..")
+      !isZipSlip && (zipEntry.isDirectory || zipEntry.getName.matches(".*lib.*\\.(dll|xml|pdb)$"))
+    }
+
+    targetDir.list.foreach { pkg =>
+      // Will unzip to `targetDir/lib` and clean-up
+      pkg.unzipTo(targetDir, zipFilter)
+      pkg.delete(swallowIOExceptions = true)
+    }
+
+    // Move and merge files
+    val libDir = targetDir / "lib"
+    // Sometimes these dependencies will include DLLs for multiple version of dotnet, we only want one
+    libDir.listRecursively.filterNot(_.isDirectory).distinctBy(_.name).foreach { f =>
+      f.copyTo(targetDir / f.name)
+    }
+    // Clean-up lib dir
+    libDir.delete(swallowIOExceptions = true)
+  }
+
+  /** Given a directory of all the summaries, will produce a summary thereof.
+    * @param targetDir
+    *   the directory with all the dependencies.
+    * @return
+    *   a summary of all the dependencies.
+    */
+  private def summarizeDependencies(targetDir: File): CSharpProgramSummary = {
+    // TODO: Implement
+    CSharpProgramSummary()
+  }
+
+}

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
@@ -8,9 +8,10 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Dependency
 import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
+import upickle.default.*
 
 import java.io.FileOutputStream
-import java.net.{HttpURLConnection, URI, URLConnection}
+import java.net.{HttpURLConnection, URI, URL, URLConnection}
 import java.util.zip.{GZIPInputStream, InflaterInputStream, ZipEntry}
 import scala.util.{Failure, Success, Try, Using}
 
@@ -21,14 +22,12 @@ import scala.util.{Failure, Success, Try, Using}
   * @see
   *   <a href="https://learn.microsoft.com/en-us/nuget/api/overview">NuGet API</a>
   */
-class DependencyDownloader(
-  cpg: Cpg,
-  config: Config,
-  internalProgramSummary: CSharpProgramSummary,
-  nugetRepositoryApi: String = "www.nuget.org/api/v2"
-) {
+class DependencyDownloader(cpg: Cpg, config: Config, internalProgramSummary: CSharpProgramSummary) {
 
   private val logger = LoggerFactory.getLogger(getClass)
+
+  private val NUGET_BASE_API_V2 = "www.nuget.org/api/v2"
+  private val NUGET_BASE_API_V3 = "api.nuget.org/v3-flatcontainer"
 
   /** Downloads dependencies and summarises their symbol information.
     * @return
@@ -54,6 +53,8 @@ class DependencyDownloader(
     false
   }
 
+  private case class NuGetPackageVersions(versions: List[String]) derives ReadWriter
+
   /** Downloads the dependency to a temporary directory. This will be a `nupkg` and `snupkg` file for each dependency
     * respectively, which are compressed using the ZIP format.
     *
@@ -65,59 +66,91 @@ class DependencyDownloader(
     *   a disposable version of the directory where the dependencies live.
     */
   private def downloadDependency(targetDir: File, dependency: Dependency): Unit = {
-    Seq("package", "symbolpackage")
-      .map(packageType =>
-        URI(s"https://$nugetRepositoryApi/$packageType/${dependency.name}/${dependency.version}").toURL
-      )
-      .foreach { url =>
-        var connection: Option[HttpURLConnection] = None
-        try {
-          connection = Option(url.openConnection()).collect { case x: HttpURLConnection => x }
-          // allow both GZip and Deflate (ZLib) encodings
-          connection.foreach(_.setRequestProperty("Accept-Encoding", "gzip, deflate"))
-          connection match {
-            case Some(conn: HttpURLConnection) if conn.getResponseCode == HttpURLConnection.HTTP_OK =>
-              val ext      = if url.toString.contains("/package/") then "nupkg" else "snupkg"
-              val fileName = targetDir / s"${dependency.name}.$ext"
 
-              val inputStream = Option(conn.getContentEncoding) match {
-                case Some(encoding) if encoding.equalsIgnoreCase("gzip")    => GZIPInputStream(conn.getInputStream)
-                case Some(encoding) if encoding.equalsIgnoreCase("deflate") => InflaterInputStream(conn.getInputStream)
-                case _                                                      => conn.getInputStream
-              }
+    def getVersion(packageName: String): Option[String] = {
+      Using.resource(URI(s"https://$NUGET_BASE_API_V3/${packageName.toLowerCase}/index.json").toURL.openStream()) {
+        is =>
+          Try(read[NuGetPackageVersions](ujson.Readable.fromByteArray(is.readAllBytes()))).toOption
+            .flatMap(_.versions.lastOption)
+      }
+    }
 
-              Try {
-                Using.resources(inputStream, new FileOutputStream(fileName.pathAsString)) { (is, fos) =>
-                  val buffer = new Array[Byte](4096)
-                  Iterator
-                    .continually(is.read(buffer))
-                    .takeWhile(_ != -1)
-                    .foreach(bytesRead => fos.write(buffer, 0, bytesRead))
-                }
-              } match {
-                case Failure(exception) =>
-                  logger.error(
-                    s"Exception occurred while downloading $fileName (${dependency.name}:${dependency.version})",
-                    exception
-                  )
-                case Success(_) =>
-                  logger.info(s"Successfully downloaded dependency ${dependency.name}:${dependency.version}")
-              }
-            case Some(conn: HttpURLConnection) =>
-              logger.error(s"Connection to $url responded with non-200 code ${conn.getResponseCode}")
-            case _ => logger.error(s"Unknown URL connection made, aborting")
+    def createUrl(packageType: String, version: String): URL = {
+      URI(s"https://$NUGET_BASE_API_V2/$packageType/${dependency.name}/$version").toURL
+    }
+
+    // If dependency version is not specified, latest is returned
+    val versionOpt = if dependency.version.isBlank then getVersion(dependency.name) else Option(dependency.version)
+
+    versionOpt match {
+      case Some(version) =>
+        downloadPackage(targetDir, dependency, createUrl("package", version))
+        downloadPackage(targetDir, dependency, createUrl("symbolpackage", version))
+      case None =>
+        logger.error(s"Unable to determine package version for ${dependency.name}, skipping")
+    }
+  }
+
+  /** Downloads the package and unpacks the contents to the target directory.
+    * @param targetDir
+    *   the directory to download and unpack to.
+    * @param dependency
+    *   the dependency information.
+    * @param url
+    *   the download URL.
+    * @return
+    *   the package version.
+    */
+  private def downloadPackage(targetDir: File, dependency: Dependency, url: URL): Unit = {
+    var connection: Option[HttpURLConnection] = None
+    try {
+      connection = Option(url.openConnection()).collect { case x: HttpURLConnection => x }
+      // allow both GZip and Deflate (ZLib) encodings
+      connection.foreach(_.setRequestProperty("Accept-Encoding", "gzip, deflate"))
+      connection match {
+        case Some(conn: HttpURLConnection) if conn.getResponseCode == HttpURLConnection.HTTP_OK =>
+          val ext      = if url.toString.contains("/package/") then "nupkg" else "snupkg"
+          val fileName = targetDir / s"${dependency.name}.$ext"
+
+          val inputStream = Option(conn.getContentEncoding) match {
+            case Some(encoding) if encoding.equalsIgnoreCase("gzip")    => GZIPInputStream(conn.getInputStream)
+            case Some(encoding) if encoding.equalsIgnoreCase("deflate") => InflaterInputStream(conn.getInputStream)
+            case _                                                      => conn.getInputStream
           }
 
-        } catch {
-          case exception: Throwable =>
-            logger.error(s"Unable to download dependency ${dependency.name}:${dependency.version}", exception)
-        } finally {
-          connection.foreach(_.disconnect())
-        }
+          Try {
+            Using.resources(inputStream, new FileOutputStream(fileName.pathAsString)) { (is, fos) =>
+              val buffer = new Array[Byte](4096)
+              Iterator
+                .continually(is.read(buffer))
+                .takeWhile(_ != -1)
+                .foreach(bytesRead => fos.write(buffer, 0, bytesRead))
+            }
+          } match {
+            case Failure(exception) =>
+              logger.error(
+                s"Exception occurred while downloading $fileName (${dependency.name}:${dependency.version})",
+                exception
+              )
+              None
+            case Success(_) =>
+              logger.info(s"Successfully downloaded dependency ${dependency.name}:${dependency.version}")
+          }
+        case Some(conn: HttpURLConnection) =>
+          logger.error(s"Connection to $url responded with non-200 code ${conn.getResponseCode}")
+        case _ =>
+          logger.error(s"Unknown URL connection made, aborting")
       }
+    } catch {
+      case exception: Throwable =>
+        logger.error(s"Unable to download dependency ${dependency.name}:${dependency.version}", exception)
+    } finally {
+      connection.foreach(_.disconnect())
+    }
   }
 
   /** Unzips all the `pkg` files and extracts the `DLL`, `XML`, and `PDB` files.
+    *
     * @param targetDir
     *   the temporary directory containing all of the successfully downloaded dependencies.
     */
@@ -151,24 +184,8 @@ class DependencyDownloader(
     *   a summary of all the dependencies.
     */
   private def summarizeDependencies(targetDir: File): CSharpProgramSummary = {
-    val astGenRunner = new DotNetAstGenRunner(config)
-    val astGenRunnerResult = targetDir.list
-      // Dependencies may result in files with multiple dots, so we remove the last one (the extension)
-      .groupBy(_.name.split("[.]").dropRight(1).mkString("."))
-      .collect {
-        // We need both PDB and DLL files present
-        case (name, files)
-            if files.exists(_.`extension`.contains(".pdb")) && files.exists(_.`extension`.contains(".dll")) =>
-          name -> files.filter(_.`extension`.contains(".dll")).head
-      }
-      .map { case (name, ddlFile) => astGenRunner.executeForDependencies(ddlFile, targetDir / s"$name.json") }
-      .reduceOption((a, b) =>
-        DefaultAstGenRunnerResult(
-          (a.parsedFiles ++ b.parsedFiles).distinct,
-          (a.skippedFiles ++ b.skippedFiles).distinct
-        )
-      )
-      .getOrElse(DefaultAstGenRunnerResult())
+    val astGenRunner       = new DotNetAstGenRunner(config.withInputPath(targetDir.pathAsString))
+    val astGenRunnerResult = astGenRunner.execute(targetDir)
     val mappings = astGenRunnerResult.parsedFiles.map(x => File(x)).flatMap { f =>
       Using.resource(f.newFileInputStream) { fis =>
         CSharpProgramSummary.jsonToInitialMapping(fis) match {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/DependencyDownloadTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/DependencyDownloadTests.scala
@@ -1,0 +1,38 @@
+package io.joern.csharpsrc2cpg.io
+
+import io.joern.csharpsrc2cpg.Config
+import io.joern.csharpsrc2cpg.datastructures.CSharpProgramSummary
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.joern.csharpsrc2cpg.utils.DependencyDownloader
+
+class DependencyDownloadTests extends CSharpCode2CpgFixture {
+
+  "parsing and downloading dependencies" should {
+
+    val cpg = code(
+      """
+        |<Project Sdk="Microsoft.NET.Sdk">
+        |
+        |    <ItemGroup>
+        |      <PackageReference Include="CommandLineParser" Version="2.9.1" />
+        |      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+        |    </ItemGroup>
+        |
+        |    <ItemGroup>
+        |      <Folder Include="release\" />
+        |    </ItemGroup>
+        |
+        |</Project>
+        |
+        |""".stripMargin,
+      "DotNetAstGen.csproj"
+    )
+
+    "result in downloading and summarizing the dependencies" in {
+      val dd      = new DependencyDownloader(cpg, CSharpProgramSummary())
+      val summary = dd.download()
+    }
+
+  }
+
+}

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/DependencyDownloadTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/DependencyDownloadTests.scala
@@ -28,9 +28,22 @@ class DependencyDownloadTests extends CSharpCode2CpgFixture {
       "DotNetAstGen.csproj"
     )
 
-    "result in downloading and summarizing the dependencies" in {
-      val dd      = new DependencyDownloader(cpg, CSharpProgramSummary())
-      val summary = dd.download()
+    val dd      = new DependencyDownloader(cpg, Config(), CSharpProgramSummary())
+    val summary = dd.download()
+
+    "summarize CommandLineParser (as it publishes with PDB files)" in {
+      summary.typesUnderNamespace("CommandLine.Core") should not be empty
+      summary.typesUnderNamespace("CommandLine.Infrastructure") should not be empty
+      summary.typesUnderNamespace("CommandLine.Text") should not be empty
+    }
+
+    "summarize CommandLineParser's transient dependencies" in {
+      summary.typesUnderNamespace("RailwaySharp.ErrorHandling") should not be empty
+      summary.typesUnderNamespace("CSharpx") should not be empty
+    }
+
+    "not summarize NewtonsoftJson (as it publishes without PDB files)" in {
+      summary.typesUnderNamespace("Microsoft.AspNetCore.Mvc.NewtonsoftJson") shouldBe empty
     }
 
   }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/DependencyDownloadTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/DependencyDownloadTests.scala
@@ -14,7 +14,7 @@ class DependencyDownloadTests extends CSharpCode2CpgFixture {
         |<Project Sdk="Microsoft.NET.Sdk">
         |
         |    <ItemGroup>
-        |      <PackageReference Include="CommandLineParser" Version="2.9.1" />
+        |      <PackageReference Include="CommandLineParser" />
         |      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
         |    </ItemGroup>
         |
@@ -25,13 +25,13 @@ class DependencyDownloadTests extends CSharpCode2CpgFixture {
         |</Project>
         |
         |""".stripMargin,
-      "DotNetAstGen.csproj"
+      "dotnetastgen-macos.csproj"
     )
 
     val dd      = new DependencyDownloader(cpg, Config(), CSharpProgramSummary())
     val summary = dd.download()
 
-    "summarize CommandLineParser (as it publishes with PDB files)" in {
+    "summarize the latest version of CommandLineParser (as it publishes with PDB files)" in {
       summary.typesUnderNamespace("CommandLine.Core") should not be empty
       summary.typesUnderNamespace("CommandLine.Infrastructure") should not be empty
       summary.typesUnderNamespace("CommandLine.Text") should not be empty


### PR DESCRIPTION
* Added download dependencies CLI argument
* If downloading of dependencies is enabled, then these packages are downloaded and unzipped from NuGet
* Calling DotNetAstGen to summarize results and merges these with internal summaries

TODO: Choose the version of DLL to summarize more intelligently. If a package publishes binaries with more than one dot net version, the first is taken.
TODO: Extend `DotNetAstGen` to parse DLLs even when PDB files are not present. Right now dependencies without PDB files are skipped.

Resolves [#4188](https://github.com/joernio/joern/issues/4188)