### PR TITLE
[c#] minor dependency resolution fix

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/DependencyPass.scala
@@ -25,7 +25,7 @@ class DependencyPass(cpg: Cpg, buildFiles: List[String]) extends ForkJoinParalle
             case packageReference if packageReference.label == "PackageReference" =>
               Try {
                 val packageName    = packageReference.attribute("Include").map(_.toString()).get
-                val packageVersion = packageReference.attribute("Version").map(_.toString()).get
+                val packageVersion = packageReference.attribute("Version").map(_.toString()).getOrElse("")
                 val dependencyNode = NewDependency()
                   .name(packageName)
                   .version(packageVersion)


### PR DESCRIPTION
Allows deps with no version number to still populate