### PR TITLE
3939 ruby import nodes require support

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import java.nio.file.{Files, Paths}
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try, Using}
+import io.joern.rubysrc2cpg.passes.ImportsPass
 
 class RubySrc2Cpg extends X2CpgFrontend[Config] {
 
@@ -61,6 +62,8 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
         .getOrElse(RubyProgramSummary())
       val astCreationPass = new AstCreationPass(cpg, astCreators.map(_.withSummary(programSummary)))
       astCreationPass.createAndApply()
+      val importsPass = new ImportsPass(cpg)
+      importsPass.createAndApply()
       TypeNodePass.withTypesFromCpg(cpg).createAndApply()
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -31,7 +31,7 @@ class AstCreator(
 
   /* Used to track variable names and their LOCAL nodes.
    */
-  protected val scope: RubyScope = new RubyScope(programSummary)
+  protected val scope: RubyScope = new RubyScope(programSummary, projectRoot)
 
   protected val logger: Logger = LoggerFactory.getLogger(getClass)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -23,6 +23,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: AttributeAssignment      => astForAttributeAssignment(node)
     case node: SimpleIdentifier         => astForSimpleIdentifier(node)
     case node: SimpleCall               => astForSimpleCall(node)
+    case node: RequireCall              => astForRequireCall(node)
+    case node: IncludeCall              => astForIncludeCall(node)
     case node: RangeExpression          => astForRange(node)
     case node: ArrayLiteral             => astForArrayLiteral(node)
     case node: HashLiteral              => astForHashLiteral(node)
@@ -222,6 +224,19 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case targetNode =>
         logger.warn(s"Unrecognized target of call: ${targetNode.text} ($relativeFileName), skipping")
         astForUnknown(targetNode)
+  }
+
+  protected def astForRequireCall(node: RequireCall): Ast = {
+    val pathOpt = node.argument match {
+      case arg: StaticLiteral if arg.isString => Option(arg.innerText)
+      case _ => None
+    }
+    pathOpt.foreach(path => scope.addRequire(path, node.isRelative))
+    astForSimpleCall(node.asSimpleCall)
+  }
+
+  protected def astForIncludeCall(node: IncludeCall): Ast = {
+    astForSimpleCall(node.asSimpleCall)
   }
 
   protected def astForRange(node: RangeExpression): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -49,26 +49,32 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
       RubyType(m.fullName, m.method.map(toMethod).l, m.member.map(toField).l)
     }
 
-    val mapping = cpg.namespaceBlock.flatMap { namespace =>
-      // Map module functions/variables
-      val moduleEntry = namespace.fullName -> namespace.method.map { module =>
-        val moduleTypeMap =
-          RubyType(
-            module.fullName,
-            module.block.astChildren.collectAll[Method].map(toMethod).l,
-            module.local.map(toModuleVariable).l
-          )
-        moduleTypeMap
-      }.toSet
-      // Map module types
-      val typeEntries = namespace.method.collectFirst {
-        case m: Method if m.name == Defines.Program =>
-          s"${namespace.fullName}:${m.name}" -> m.block.astChildren.collectAll[TypeDecl].map(toType).toSet
-      }.toSeq
+    val mappings = 
+      cpg.namespaceBlock.flatMap { namespace =>
+        val path = namespace.filename.stripSuffix(".rb")
+        // Map module functions/variables
+        val moduleEntry = (path, namespace.name) -> namespace.method.map { module =>
+          val moduleTypeMap =
+            RubyType(
+              module.fullName,
+              module.block.astChildren.collectAll[Method].map(toMethod).l,
+              module.local.map(toModuleVariable).l
+            )
+          moduleTypeMap
+        }.toSet
+        // Map module types
+        val typeEntries = namespace.method.collectFirst {
+          case m: Method if m.name == Defines.Program =>
+            (path, s"${namespace.name}:${m.name}") -> m.block.astChildren.collectAll[TypeDecl].map(toType).toSet
+        }.toSeq
 
-      moduleEntry +: typeEntries
-    }.toMap
-    RubyProgramSummary(mapping)
+        moduleEntry +: typeEntries
+      }.toList
+
+    val namespaceMappings = mappings.map { case (_, ns) -> entry => ns -> entry }.toMap
+    val pathMappings = mappings.map { case (path, _) -> entry => path -> entry }.toMap
+
+    RubyProgramSummary(namespaceMappings, pathMappings)
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -200,7 +200,7 @@ object RubyIntermediateAst {
   final case class StaticLiteral(typeFullName: String)(span: TextSpan) extends RubyNode(span) {
     def isSymbol: Boolean = text.startsWith(":")
 
-    def isString: Boolean = text.startsWith("\"")
+    def isString: Boolean = text.startsWith("\"") || text.startsWith("'")
 
     def innerText: String = text match
       case s":'$content'" => content
@@ -243,6 +243,24 @@ object RubyIntermediateAst {
   final case class SimpleCall(target: RubyNode, arguments: List[RubyNode])(span: TextSpan)
       extends RubyNode(span)
       with RubyCall
+
+  final case class RequireCall(target: RubyNode, argument: RubyNode, isRelative: Boolean)(span: TextSpan)
+      extends RubyNode(span)
+      with RubyCall {
+    def arguments: List[RubyNode] = List(argument)
+    def asSimpleCall: SimpleCall = SimpleCall(target, arguments)(span)
+  }
+
+  final case class IncludeCall(target: RubyNode, argument: RubyNode)(span: TextSpan)
+      extends RubyNode(span)
+      with RubyCall {
+    def arguments: List[RubyNode] = List(argument)
+    def asSimpleCall: SimpleCall = SimpleCall(target, arguments)(span)
+  }
+
+  /** Represents standalone `proc { ... }` or `lambda { ... }` expressions
+    */
+  final case class ProcOrLambdaExpr(block: Block)(span: TextSpan) extends RubyNode(span)
 
   /** Represents a call with a block argument.
     */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -4,18 +4,26 @@ import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, Typ
 import io.joern.x2cpg.Defines as XDefines
 import scala.annotation.targetName
 
-class RubyProgramSummary(initialMap: Map[String, Set[RubyType]] = Map.empty) extends ProgramSummary[RubyType] {
+class RubyProgramSummary(
+  initialNamespaceMap: Map[String, Set[RubyType]] = Map.empty,
+  initialPathMap: Map[String, Set[RubyType]] = Map.empty
+) extends ProgramSummary[RubyType] {
 
-  override val namespaceToType: Map[String, Set[RubyType]] = initialMap
+  override val namespaceToType: Map[String, Set[RubyType]] = initialNamespaceMap
+  val pathToType: Map[String, Set[RubyType]] = initialPathMap
 
   @targetName("add")
   def ++(other: RubyProgramSummary): RubyProgramSummary = {
-    RubyProgramSummary(ProgramSummary.combine(this.namespaceToType, other.namespaceToType))
+    RubyProgramSummary(
+      ProgramSummary.combine(this.namespaceToType, other.namespaceToType),
+      ProgramSummary.combine(this.pathToType, other.pathToType)
+    )
   }
 
 }
 
-case class RubyMethod(name: String, parameterTypes: List[(String, String)], returnType: String) extends MethodLike
+case class RubyMethod(name: String, parameterTypes: List[(String, String)], returnType: String) extends MethodLike {
+}
 
 case class RubyField(name: String, typeName: String) extends FieldLike
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -5,19 +5,27 @@ import io.joern.x2cpg.Defines
 import io.joern.x2cpg.datastructures.*
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{DeclarationNew, NewLocal, NewMethodParameterIn}
+import better.files.File
 
 import scala.collection.mutable
+import scala.reflect.ClassTag
+import io.joern.x2cpg.datastructures.TypedScopeElement
 
-class RubyScope(summary: RubyProgramSummary)
+final case class RubyRequire(path: String, isRelative: Boolean)
+
+class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     extends Scope[String, DeclarationNew, TypedScopeElement]
     with TypedScope[RubyMethod, RubyField, RubyType](summary) {
 
   private val builtinMethods = GlobalTypes.builtinFunctions.map(m => RubyMethod(m, List.empty, Defines.Any)).toList
 
+
   override val typesInScope: mutable.Set[RubyType] =
     mutable.Set(RubyType(GlobalTypes.builtinPrefix, builtinMethods, List.empty))
 
   override val membersInScope: mutable.Set[MemberLike] = mutable.Set(builtinMethods*)
+
+  val requiredPaths: mutable.Set[RubyRequire] = mutable.Set()
 
   // Ruby does not have overloading, so this can be set to true
   override protected def isOverloadedBy(method: RubyMethod, argTypes: List[String]): Boolean = true
@@ -42,6 +50,26 @@ class RubyScope(summary: RubyProgramSummary)
     super.pushNewScope(mappedScopeNode)
   }
 
+  def addRequire(path: String, isRelative: Boolean): Unit = {
+    // We assume the project root is the sole LOAD_PATH of the project sources for now
+    val relativizedPath =
+      if(isRelative) {
+        val parentDir = File(surrounding[ProgramScope].get.fileName).parentOption.get
+        val absPath = (parentDir / path).path.toAbsolutePath
+        projectRoot.map(File(_).path.toAbsolutePath.relativize(absPath).toString)
+      } else {
+        Some(path)
+      }
+
+    relativizedPath.iterator.flatMap(summary.pathToType.getOrElse(_, Set())).foreach { ty => 
+      addImportedMember(ty.name) 
+    }
+  }
+
+  def addInclude(typeOrModule: String): Unit = {
+    addImportedMember(typeOrModule)
+  }
+
   /** @return
     *   the full name of the surrounding scope.
     */
@@ -63,6 +91,10 @@ class RubyScope(summary: RubyProgramSummary)
     case ScopeElement(_: ProgramScope, _)       => NodeTypes.METHOD
     case ScopeElement(_: TypeLikeScope, _)      => NodeTypes.TYPE_DECL
     case ScopeElement(_: MethodLikeScope, _)    => NodeTypes.METHOD
+  }
+
+  def surrounding[T <: TypedScopeElement](implicit tag: ClassTag[T]): Option[T] = stack.collectFirst {
+    case ScopeElement(elem: T, _) => elem
   }
 
   /** @return

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -462,7 +462,18 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
 
   override def visitSimpleCommand(ctx: RubyParser.SimpleCommandContext): RubyNode = {
     if (!ctx.methodIdentifier().isAttrDeclaration) {
-      SimpleCall(visit(ctx.methodIdentifier()), ctx.commandArgument().arguments.map(visit))(ctx.toTextSpan)
+      val identifierCtx = ctx.methodIdentifier()
+      val arguments = ctx.commandArgument().arguments.map(visit)
+      (identifierCtx.getText, arguments) match {
+        case ("require", List(argument)) => 
+          RequireCall(visit(identifierCtx), argument, false)(ctx.toTextSpan)
+        case ("require_relative", List(argument)) => 
+          RequireCall(visit(identifierCtx), argument, true)(ctx.toTextSpan)
+        case ("include", List(argument)) => 
+          IncludeCall(visit(identifierCtx), argument)(ctx.toTextSpan)
+        case _ => 
+          SimpleCall(visit(identifierCtx), arguments)(ctx.toTextSpan)
+      }
     } else {
       FieldsDeclaration(ctx.commandArgument().arguments.map(visit))(ctx.toTextSpan)
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportsPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportsPass.scala
@@ -7,8 +7,6 @@ import io.shiftleft.passes.ConcurrentWriterCpgPass
 import io.joern.x2cpg.Imports.createImportNodeAndLink
 import io.joern.x2cpg.X2Cpg.stripQuotes
 
-/** Derived from XImportsPass TODO: maybe make XImportsPass more generic
-  */
 class ImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
   protected val importCallName: String = "require"
   override def generateParts(): Array[Call] = cpg
@@ -20,7 +18,6 @@ class ImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
       case s :: _ => s
       case _      => ""
     })
-    val importedAs = ""
-    createImportNodeAndLink(importedEntity, importedAs, Some(call), diffGraph)
+    createImportNodeAndLink(importedEntity, importedEntity, Some(call), diffGraph)
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportsPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImportsPass.scala
@@ -1,0 +1,26 @@
+package io.joern.rubysrc2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.joern.x2cpg.Imports.createImportNodeAndLink
+import io.joern.x2cpg.X2Cpg.stripQuotes
+
+/** Derived from XImportsPass TODO: maybe make XImportsPass more generic
+  */
+class ImportsPass(cpg: Cpg) extends ConcurrentWriterCpgPass[Call](cpg) {
+  protected val importCallName: String = "require"
+  override def generateParts(): Array[Call] = cpg
+    .call(importCallName)
+    .toArray
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, call: Call): Unit = {
+    val importedEntity = stripQuotes(call.argument.isLiteral.code.l match {
+      case s :: _ => s
+      case _      => ""
+    })
+    val importedAs = ""
+    createImportNodeAndLink(importedEntity, importedAs, Some(call), diffGraph)
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -4,15 +4,32 @@ import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 
 class ImportTests extends RubyCode2CpgFixture {
+
   "`require 'test'` is a CALL node with an IMPORT node pointing to it" in {
     val cpg = code("""
                      |require 'test'
                      |""".stripMargin)
     val List(importNode) = cpg.imports.l
     importNode.importedEntity shouldBe Some("test")
-    importNode.importedAs shouldBe Some("") // TODO: change X2Cpg import utility to allow optionals for importAs
+    importNode.importedAs shouldBe Some("test")
     val List(call) = importNode.call.l
     call.callee.name.l shouldBe List("require")
     call.argument.code.l shouldBe List("'test'")
   }
+
+  "`begin require 'test' rescue LoadError end` has a CALL node with an IMPORT node pointing to it" in {
+    val cpg = code("""
+                     |begin 
+                     |  require 'test'
+                     |rescue LoadError
+                     |end
+                     |""".stripMargin)
+    val List(importNode) = cpg.imports.l
+    importNode.importedEntity shouldBe Some("test")
+    importNode.importedAs shouldBe Some("test")
+    val List(call) = importNode.call.l
+    call.callee.name.l shouldBe List("require")
+    call.argument.code.l shouldBe List("'test'")
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -1,0 +1,18 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class ImportTests extends RubyCode2CpgFixture {
+  "`require 'test'` is a CALL node with an IMPORT node pointing to it" in {
+    val cpg = code("""
+                     |require 'test'
+                     |""".stripMargin)
+    val List(importNode) = cpg.imports.l
+    importNode.importedEntity shouldBe Some("test")
+    importNode.importedAs shouldBe Some("") // TODO: change X2Cpg import utility to allow optionals for importAs
+    val List(call) = importNode.call.l
+    call.callee.name.l shouldBe List("require")
+    call.argument.code.l shouldBe List("'test'")
+  }
+}


### PR DESCRIPTION
- Adds new RequireCall and ImportCall nodes
- Adds pathToTypes to RubyProgramSummary that map require paths
- Handles require_relative, require and include with `addImported*` methods.

What has yet to be done
- tryResolveTypeReference should be changed to use the new information. Unit tests written now mostly pass trivially unless some ambiguous resolution needs to be made. They will mostly act as regression.
- Nested modules are not handled (either in the summary or both the summary and the main pass, not sure)  
- Unit tests require multi-file cpgs to processed together so that program summary has all information, which appears not be the the case
  - as a workaround, I can directly invoke the frontend on a test folder in a unit test for now, but not ideal 

TODO accidentally committed ImportsPass, or not rebased properly, will fix