### PR TITLE
[C#] Type handling for null literal

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -94,6 +94,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         BuiltinTypes.DotNetTypeMap(BuiltinTypes.Decimal)
       case StringLiteralExpression                        => BuiltinTypes.DotNetTypeMap(BuiltinTypes.String)
       case TrueLiteralExpression | FalseLiteralExpression => BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool)
+      case NullLiteralExpression                          => BuiltinTypes.DotNetTypeMap(BuiltinTypes.Null)
       case ObjectCreationExpression =>
         val typeName = nameFromNode(createDotNetNodeInfo(node.json(ParserKeys.Type)))
         scope

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -89,6 +89,7 @@ object DotNetJsonAst {
   object StringLiteralExpression  extends LiteralExpr
   object TrueLiteralExpression    extends LiteralExpr
   object FalseLiteralExpression   extends LiteralExpr
+  object NullLiteralExpression    extends LiteralExpr
 
   object UsingDirective extends BaseExpr
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeTests.scala
@@ -10,6 +10,7 @@ class TypeTests extends CSharpCode2CpgFixture {
       val cpg = code(basicBoilerplate("""
           |int? a = 10;
           |string? b = "Foo";
+          |var c = null;
           |""".stripMargin))
 
       inside(cpg.identifier.nameExact("a").l) {
@@ -22,6 +23,12 @@ class TypeTests extends CSharpCode2CpgFixture {
         case a :: Nil =>
           a.typeFullName shouldBe "System.String"
         case _ => fail("Identifier named `b` not found")
+      }
+
+      inside(cpg.identifier.nameExact("c").l) {
+        case a :: Nil =>
+          a.typeFullName shouldBe "null"
+        case _ => fail("Identifier named `c` not found")
       }
     }
 


### PR DESCRIPTION
Handles types for `null` literals.
Resolves #4302 