### PR TITLE
[swiftsrc2cpg] Added ExtensionInheritancePass

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
@@ -29,8 +29,10 @@ class SwiftSrc2Cpg extends X2CpgFrontend[Config] {
         astCreationPass.createAndApply()
 
         SwiftTypeNodePass.withRegisteredTypes(astCreationPass.typesSeen(), cpg).createAndApply()
-        new SwiftMetaDataPass(cpg, hash, config.inputPath).createAndApply()
         new BuiltinTypesPass(cpg).createAndApply()
+
+        new ExtensionInheritancePass(cpg).createAndApply()
+        new SwiftMetaDataPass(cpg, hash, config.inputPath).createAndApply()
         new DependenciesPass(cpg).createAndApply()
         new ImportsPass(cpg).createAndApply()
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/ExtensionInheritancePass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/ExtensionInheritancePass.scala
@@ -1,0 +1,47 @@
+package io.joern.swiftsrc2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.passes.ConcurrentWriterCpgPass
+import io.shiftleft.semanticcpg.language.*
+
+import java.io.File
+
+class ExtensionInheritancePass(cpg: Cpg) extends ConcurrentWriterCpgPass[TypeDecl](cpg) {
+
+  private val SourceFolder: String = "/Source/"
+
+  override def generateParts(): Array[TypeDecl] = cpg.typeDecl.filterNot(_.fullName.endsWith("<extension>")).toArray
+
+  private def setInheritsFromFullNames(
+    builder: DiffGraphBuilder,
+    part: TypeDecl,
+    fromExtensions: Iterator[TypeDecl]
+  ): Unit = {
+    val fullNames = (part.inheritsFromTypeFullName ++ fromExtensions.map(_.fullName)).toSet.toSeq
+    builder.setNodeProperty(part, PropertyNames.INHERITS_FROM_TYPE_FULL_NAME, fullNames)
+    cpg.typ.fullNameExact(fullNames: _*).foreach(tgt => builder.addEdge(part, tgt, EdgeTypes.INHERITS_FROM))
+  }
+
+  override def runOnPart(builder: DiffGraphBuilder, part: TypeDecl): Unit = {
+    val folderOption = Option(new File(part.filename).getParent)
+    if (folderOption.isEmpty) {
+      val extensions = cpg.typeDecl.filter(_.fullName.endsWith(s":${part.name}<extension>"))
+      setInheritsFromFullNames(builder, part, extensions)
+    } else {
+      val folder = s"${folderOption.get}/".replaceAll("\\\\", "/")
+      val folderPrefix = if (folder.contains(SourceFolder)) {
+        folder.substring(0, folder.indexOf(SourceFolder))
+      } else {
+        ""
+      }
+      val extensions = cpg.typeDecl.filter(t =>
+        t.fullName.startsWith(folderPrefix) && t.fullName.endsWith(s":${part.name}<extension>")
+      )
+      setInheritsFromFullNames(builder, part, extensions)
+    }
+  }
+
+}

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ClassExtensionTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ClassExtensionTests.scala
@@ -1,5 +1,6 @@
 package io.joern.swiftsrc2cpg.passes.ast
 
+import io.joern.swiftsrc2cpg.passes.ExtensionInheritancePass
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
@@ -90,7 +91,7 @@ class ClassExtensionTests extends AbstractPassTest {
       "someMethod",
       "square"
     )
-    typeDeclFoo.inheritsFromTypeFullName.l shouldBe List("Bar")
+    typeDeclFoo.inheritsFromTypeFullName.sorted.l shouldBe List("Bar", "code.swift:<global>:Foo<extension>")
     typeDeclFoo.modifier.modifierType.l shouldBe List(ModifierTypes.PRIVATE)
 
     val List(fooConstructor) = typeDeclFoo.method.isConstructor.l
@@ -130,6 +131,7 @@ class ClassExtensionTests extends AbstractPassTest {
         |$classFooCode
         |$classFooExtensionCode
         |""".stripMargin) { cpg =>
+      new ExtensionInheritancePass(cpg).createAndApply()
       testClassExtension(cpg)
     }
 
@@ -139,6 +141,7 @@ class ClassExtensionTests extends AbstractPassTest {
         |$classFooExtensionCode
         |$classFooCode
         |""".stripMargin) { cpg =>
+      new ExtensionInheritancePass(cpg).createAndApply()
       testClassExtension(cpg)
     }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/inheritance/ExtensionInheritancePassTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/inheritance/ExtensionInheritancePassTests.scala
@@ -1,0 +1,80 @@
+package io.joern.swiftsrc2cpg.passes.inheritance
+
+import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
+import io.shiftleft.codepropertygraph.generated.nodes.File.PropertyDefaults
+import io.shiftleft.semanticcpg.language.*
+
+class ExtensionInheritancePassTests extends SwiftSrc2CpgSuite {
+
+  private val classBarCode =
+    """
+      |class Bar {
+      |}""".stripMargin
+
+  private val extensionBarCode =
+    """
+      |extension Bar {
+      |}""".stripMargin
+
+  private val classFooCode = """
+     |class Foo : Bar {
+     |}""".stripMargin
+
+  private val extension1FooCode =
+    """
+      |extension Foo {
+      |  var name = "1"
+      |}""".stripMargin
+
+  private val extension2FooCode =
+    """
+      |extension Foo {
+      |  var name = "2"
+      |}""".stripMargin
+
+  private val extensionStringCode =
+    """
+      |extension String {
+      |  func toUpperCase -> String {
+      |    // ...
+      |  }
+      |}""".stripMargin
+
+  private val cpg =
+    code(classFooCode, "projectA/Source/Foo.swift")
+      .moreCode(classBarCode, "main/Bar.swift")
+      .moreCode(extensionBarCode, "extensions/Bar+Ext.swift")
+      .moreCode(classFooCode, "projectB/Source/Foo.swift")
+      .moreCode(extension1FooCode, "projectA/Source/Foo+Ext1.swift")
+      .moreCode(extension2FooCode, "projectA/Source/Foo+Ext2.swift")
+      .moreCode(extension1FooCode, "projectB/Source/Foo+Ext1.swift")
+      .moreCode(extensionStringCode, "String+Ext.swift")
+
+  "ExtensionInheritancePass" should {
+
+    "generate inheritance for extensions correctly" in {
+      val List(fooTypeDeclInProjectA) = cpg.typeDecl.fullNameExact("projectA/Source/Foo.swift:<global>:Foo").l
+      fooTypeDeclInProjectA.inheritsFromTypeFullName.sorted.l shouldBe List(
+        "Bar",
+        "projectA/Source/Foo+Ext1.swift:<global>:Foo<extension>",
+        "projectA/Source/Foo+Ext2.swift:<global>:Foo<extension>"
+      )
+
+      val List(fooTypeDeclInProjectB) = cpg.typeDecl.fullNameExact("projectB/Source/Foo.swift:<global>:Foo").l
+      fooTypeDeclInProjectB.inheritsFromTypeFullName.sorted.l shouldBe List(
+        "Bar",
+        "projectB/Source/Foo+Ext1.swift:<global>:Foo<extension>"
+      )
+
+      val List(stringTypeDecl) = cpg.typeDecl("String").l
+      stringTypeDecl.inheritsFromTypeFullName.l shouldBe List("String+Ext.swift:<global>:String<extension>")
+
+      val List(barTypeDeclInMain) = cpg.typeDecl.fullNameExact("main/Bar.swift:<global>:Bar").l
+      barTypeDeclInMain.inheritsFromTypeFullName.sorted.l shouldBe List(
+        "extensions/Bar+Ext.swift:<global>:Bar<extension>"
+      )
+    }
+
+  }
+
+}


### PR DESCRIPTION
This pass adds the inheritance relation between base types and their extensions. Although, that is semantically not quite correct in the way Swift extensions work its still the closest lowering in our CPG world.