### PR TITLE
[C#] Resolve correct types for fixed type operators

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -5,7 +5,7 @@ import io.joern.csharpsrc2cpg.parser.{DotNetJsonAst, DotNetNodeInfo, ParserKeys}
 import io.joern.csharpsrc2cpg.{Constants, astcreation}
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, PropertyNames}
 import ujson.Value
 
 import scala.annotation.tailrec
@@ -81,6 +81,17 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         logger.warn(s"Unhandled declaration type '${x.label()}' for ${x.name}")
         identifierNode(dotNetNode.orNull, x.name, x.name, Defines.Any)
   }
+
+  protected val fixedTypeOperators: Map[String, String] = Map(
+    Operators.equals            -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool),
+    Operators.notEquals         -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool),
+    Operators.logicalAnd        -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool),
+    Operators.logicalOr         -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool),
+    Operators.greaterThan       -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool),
+    Operators.greaterEqualsThan -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool),
+    Operators.lessThan          -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool),
+    Operators.lessEqualsThan    -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool)
+  )
 
   protected def nodeTypeFullName(node: DotNetNodeInfo): String = {
     node.node match {

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -124,7 +124,11 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     )
 
     val cNode =
-      createCallNodeForOperator(binaryExpr, operatorName, typeFullName = Some(getTypeFullNameFromAstNode(args)))
+      createCallNodeForOperator(
+        binaryExpr,
+        operatorName,
+        typeFullName = Some(fixedTypeOperators.getOrElse(operatorName, getTypeFullNameFromAstNode(args)))
+      )
     Seq(callAst(cNode, args))
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeTests.scala
@@ -1,6 +1,8 @@
 package io.joern.csharpsrc2cpg.querying.ast
 
+import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.*
 
 class TypeTests extends CSharpCode2CpgFixture {
@@ -50,6 +52,20 @@ class TypeTests extends CSharpCode2CpgFixture {
         case _ => fail("Identifier named `iBar` not found")
       }
     }
+  }
 
+  "resolve types for operators and propagate to others" in {
+    val cpg = code(basicBoilerplate("""
+        |int a = 10;
+        |var b = a > 1;
+        |""".stripMargin))
+
+    inside(cpg.local.nameExact("b").l) { case b :: Nil =>
+      b.typeFullName shouldBe BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool)
+    }
+
+    inside(cpg.call.nameExact(Operators.greaterThan).l) { case opCall :: Nil =>
+      opCall.typeFullName shouldBe BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool)
+    }
   }
 }


### PR DESCRIPTION
This PR is an attempt to resolve correct types for operators that have a fixed type. Currently, we try to resolve types from operand nodes, which might propagate types incorrectly. 