### PR TITLE
[ruby] Qualified Base Names

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -114,7 +114,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
   // Member accesses are lowered as calls, i.e. `x.y` is the call of `y` of `x` without any arguments.
   protected def astForMemberAccess(node: MemberAccess): Ast = {
-    astForMemberCall(MemberCall(node.target, node.op, node.methodName, List.empty)(node.span))
+    astForMemberCall(MemberCall(node.target, node.op, node.memberName, List.empty)(node.span))
   }
 
   /** Attempts to extract a type from the base of a member call.
@@ -506,7 +506,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
   private def astForMemberCallWithoutBlock(node: SimpleCall, memberAccess: MemberAccess): Ast = {
     val receiverAst = astForFieldAccess(memberAccess)
-    val methodName  = memberAccess.methodName
+    val methodName  = memberAccess.memberName
     // TODO: Type recovery should potentially resolve this
     val methodFullName = typeFromCallTarget(memberAccess.target)
       .map(x => s"$x:$methodName")
@@ -566,9 +566,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   protected def astForFieldAccess(node: MemberAccess): Ast = {
-    val fieldIdentifierAst = Ast(fieldIdentifierNode(node, node.methodName, node.methodName))
+    val fieldIdentifierAst = Ast(fieldIdentifierNode(node, node.memberName, node.memberName))
     val targetAst          = astForExpression(node.target)
-    val code               = s"${node.target.text}${node.op}${node.methodName}"
+    val code               = s"${node.target.text}${node.op}${node.memberName}"
     val fieldAccess = callNode(node, code, Operators.fieldAccess, Operators.fieldAccess, DispatchTypes.STATIC_DISPATCH)
     callAst(fieldAccess, Seq(targetAst, fieldIdentifierAst))
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -68,7 +68,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     val classBody =
       node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
     val classBodyAsts = classBody.statements.flatMap(astsForStatement) match {
-      case bodyAsts if scope.shouldGenerateDefaultConstructor =>
+      case bodyAsts if scope.shouldGenerateDefaultConstructor && this.parseLevel == AstParseLevel.FULL_AST =>
         val bodyStart = classBody.span.spanStart()
         val initBody  = StatementList(List())(bodyStart)
         val methodDecl = astForMethodDeclaration(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -27,10 +27,15 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
           case Some(_) => Option(name) // in the case of singleton classes, we want to keep the variable name
           case None    => scope.tryResolveTypeReference(name).map(_.name).orElse(Option(name))
         }
-      case selfIdentifier: SelfIdentifier =>
+      case _: SelfIdentifier =>
         scope.surroundingTypeFullName
-      case _ =>
-        logger.warn(s"Qualified base class names are not supported yet: ${code(node)} ($relativeFileName), skipping")
+      case qualifiedBaseClass: MemberAccess =>
+        // TODO: May need massaging on the type resolution
+        scope.tryResolveTypeReference(qualifiedBaseClass.toString)
+          .map(_.name)
+          .orElse(Option(qualifiedBaseClass.toString))
+      case x =>
+        logger.warn(s"Base class names of type ${x.getClass} are not supported yet: ${code(node)} ($relativeFileName), skipping")
         None
   }
 
@@ -61,7 +66,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     val classBody =
       node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
     val classBodyAsts = classBody.statements.flatMap(astsForStatement) match {
-      case bodyAsts if scope.shouldGenerateDefaultConstructor && parseLevel == AstParseLevel.FULL_AST =>
+      case bodyAsts if scope.shouldGenerateDefaultConstructor =>
         val bodyStart = classBody.span.spanStart()
         val initBody  = StatementList(List())(bodyStart)
         val methodDecl = astForMethodDeclaration(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -30,12 +30,14 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       case _: SelfIdentifier =>
         scope.surroundingTypeFullName
       case qualifiedBaseClass: MemberAccess =>
-        // TODO: May need massaging on the type resolution
-        scope.tryResolveTypeReference(qualifiedBaseClass.toString)
+        scope
+          .tryResolveTypeReference(qualifiedBaseClass.toString)
           .map(_.name)
           .orElse(Option(qualifiedBaseClass.toString))
       case x =>
-        logger.warn(s"Base class names of type ${x.getClass} are not supported yet: ${code(node)} ($relativeFileName), skipping")
+        logger.warn(
+          s"Base class names of type ${x.getClass} are not supported yet: ${code(node)} ($relativeFileName), skipping"
+        )
         None
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -58,7 +58,6 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
       RubyType(m.fullName, m.method.map(toMethod).l, m.member.map(toField).l)
     }
 
-
     def handleNestedTypes(t: TypeDecl, parentScope: String): Seq[(String, Set[RubyType])] = {
       val typeFullName     = s"$parentScope.${t.name}"
       val childrenTypes    = t.astChildren.collectAll[TypeDecl].l
@@ -82,7 +81,10 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
         // Map module types
         val typeEntries = namespace.method.collectFirst {
           case m: Method if m.name == Defines.Program =>
-            (path, s"${namespace.fullName}:${m.name}") -> m.block.astChildren.collectAll[TypeDecl].map(toType).toSet
+            val childrenTypes = m.block.astChildren.collectAll[TypeDecl].l
+            val fullName      = s"${namespace.fullName}:${m.name}"
+            val nestedTypes   = childrenTypes.flatMap(handleNestedTypes(_, fullName))
+            (path, fullName) -> (childrenTypes.map(toType).toSet ++ nestedTypes.flatMap(_._2))
         }.toSeq
 
         moduleEntry +: typeEntries

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -53,6 +53,13 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
       RubyType(m.fullName, m.method.map(toMethod).l, m.member.map(toField).l)
     }
 
+    def handleNestedTypes(t: TypeDecl, parentScope: String): Seq[(String, Set[RubyType])] = {
+      val typeFullName     = s"$parentScope.${t.name}"
+      val childrenTypes    = t.astChildren.collectAll[TypeDecl].l
+      val typesOnThisLevel = childrenTypes.flatMap(handleNestedTypes(_, typeFullName))
+      Seq(typeFullName -> childrenTypes.map(toType).toSet) ++ typesOnThisLevel
+    }
+
     val mapping = cpg.namespaceBlock.flatMap { namespace =>
       // Map module functions/variables
       val moduleEntry = namespace.fullName -> namespace.method.map { module =>
@@ -65,9 +72,16 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
         moduleTypeMap
       }.toSet
       // Map module types
-      val typeEntries = namespace.method.collectFirst {
+      val typeEntries = namespace.method.flatMap {
         case m: Method if m.name == Defines.Program =>
-          s"${namespace.fullName}:${m.name}" -> m.block.astChildren.collectAll[TypeDecl].map(toType).toSet
+          val moduleFullName = s"${namespace.fullName}:${m.name}"
+          val nestedTypes    = m.block.astChildren.collectAll[TypeDecl].flatMap(handleNestedTypes(_, moduleFullName))
+          Seq(
+            moduleFullName -> (m.block.astChildren.collectAll[TypeDecl].map(toType).toSet ++
+              nestedTypes.flatMap(_._2)) // Approximate that nested types are imported into this namespace
+          )
+            ++ nestedTypes
+        case _ => Seq.empty
       }.toSeq
 
       moduleEntry +: typeEntries

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -298,7 +298,8 @@ object RubyIntermediateAst {
   final case class IndexAccess(target: RubyNode, indices: List[RubyNode])(span: TextSpan) extends RubyNode(span)
 
   // TODO: Might be replaced by MemberCall simply?
-  final case class MemberAccess(target: RubyNode, op: String, memberName: String)(span: TextSpan) extends RubyNode(span) {
+  final case class MemberAccess(target: RubyNode, op: String, memberName: String)(span: TextSpan)
+      extends RubyNode(span) {
     override def toString: String = s"${target.text}.$memberName"
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -298,7 +298,9 @@ object RubyIntermediateAst {
   final case class IndexAccess(target: RubyNode, indices: List[RubyNode])(span: TextSpan) extends RubyNode(span)
 
   // TODO: Might be replaced by MemberCall simply?
-  final case class MemberAccess(target: RubyNode, op: String, methodName: String)(span: TextSpan) extends RubyNode(span)
+  final case class MemberAccess(target: RubyNode, op: String, memberName: String)(span: TextSpan) extends RubyNode(span) {
+    override def toString: String = s"${target.text}.$memberName"
+  }
 
   /** A Ruby node that instantiates objects.
     */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -461,7 +461,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitSimpleCommand(ctx: RubyParser.SimpleCommandContext): RubyNode = {
-    if (!ctx.methodIdentifier().isAttrDeclaration) {
+    if (Option(ctx.commandArgument()).map(_.getText).exists(_.startsWith("::"))) {
+      val memberName = ctx.commandArgument().getText.stripPrefix("::")
+      MemberAccess(visit(ctx.methodIdentifier()), "::", memberName)(ctx.toTextSpan)
+    } else if (!ctx.methodIdentifier().isAttrDeclaration) {
       SimpleCall(visit(ctx.methodIdentifier()), ctx.commandArgument().arguments.map(visit))(ctx.toTextSpan)
     } else {
       FieldsDeclaration(ctx.commandArgument().arguments.map(visit))(ctx.toTextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -300,4 +300,40 @@ class ClassTests extends RubyCode2CpgFixture {
 
   }
 
+  "fully qualified references" should {
+
+    val cpg = code(
+      """require "rails/all"
+        |
+        |module Bar
+        | class Baz
+        | end
+        |end
+        |
+        |module Railsgoat
+        |  class Application < Rails::Application
+        |  end
+        |
+        |  class Foo < Bar::Baz
+        |  end
+        |end
+        |""".stripMargin)
+
+    "be interpreted as static member accesses" in {
+      inside(cpg.typeDecl("Application").headOption) {
+        case Some(app) =>
+          app.inheritsFromTypeFullName.head shouldBe "Rails.Application"
+        case None => fail("Expected a type decl for 'Application', instead got nothing")
+      }
+    }
+
+    "be interpreted as static member accesses (internal)" in {
+      inside(cpg.typeDecl("Foo").headOption) {
+        case Some(app) =>
+          app.inheritsFromTypeFullName.head shouldBe "Bar.Baz"
+        case None => fail("Expected a type decl for 'Foo', instead got nothing")
+      }
+    }
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -300,10 +300,9 @@ class ClassTests extends RubyCode2CpgFixture {
 
   }
 
-  "fully qualified references" should {
+  "fully qualified base types" should {
 
-    val cpg = code(
-      """require "rails/all"
+    val cpg = code("""require "rails/all"
         |
         |module Bar
         | class Baz
@@ -319,7 +318,7 @@ class ClassTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    "be interpreted as static member accesses" in {
+    "not confuse the internal `Application` with `Rails::Application` and leave the type unresolved" in {
       inside(cpg.typeDecl("Application").headOption) {
         case Some(app) =>
           app.inheritsFromTypeFullName.head shouldBe "Rails.Application"
@@ -327,10 +326,10 @@ class ClassTests extends RubyCode2CpgFixture {
       }
     }
 
-    "be interpreted as static member accesses (internal)" in {
+    "resolve the internal type being referenced" in {
       inside(cpg.typeDecl("Foo").headOption) {
         case Some(app) =>
-          app.inheritsFromTypeFullName.head shouldBe "Bar.Baz"
+          app.inheritsFromTypeFullName.head shouldBe "Test0.rb:<global>::program.Bar.Baz"
         case None => fail("Expected a type decl for 'Foo', instead got nothing")
       }
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
@@ -113,6 +113,7 @@ trait TypedScope[M <: MethodLike, F <: FieldLike, T <: TypeLike[M, F]](summary: 
     tag: ClassTag[M]
   ): Option[M] = typeFullName match {
     case None =>
+      // This function uses the `implicit tag` (IntelliJ incorrectly marks it as unused)
       def matchingM: PartialFunction[MemberLike, M] = { case m: M if m.name == callName => m }
       // TODO: The typesInScope part is to imprecisely solve the unimplemented polymorphism limitation
       membersInScope.collectFirst(matchingM).orElse { typesInScope.flatMap(_.methods).collectFirst(matchingM) }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/ProgramSummary.scala
@@ -89,10 +89,10 @@ trait TypedScope[M <: MethodLike, F <: FieldLike, T <: TypeLike[M, F]](summary: 
     *   the type meta-data if found.
     */
   def tryResolveTypeReference(typeName: String): Option[T] = {
-    // TODO: Handle partially qualified names
     typesInScope
       .collectFirst {
-        case typ if typ.name.split("[.]").lastOption == typeName.split("[.]").lastOption  => typ
+        // Handle partially qualified names
+        case typ if typ.name.split("[.]").endsWith(typeName.split("[.]"))                 => typ
         case typ if aliasedTypes.contains(typeName) && typ.name == aliasedTypes(typeName) => typ
       }
   }


### PR DESCRIPTION
This PR handles qualified base names in class declarations.

* Qualified base names are created as `MemberAccess` nodes for convenience
* These are resolves against the scope, so they may resolve fully if the type is within the program summary
* Added the ability for the program summary to visit nested types, and approximated that they share the namespace as their root parent
* Handle partially qualified names in `tryResolveTypeReference` to avoid collisions by checking whole suffixes

Resolves #4270 