### PR TITLE
[swiftsrc2cpg] Added handling of TypeSyntax

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -17,6 +17,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.NewMethod
 import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.nodes.File.PropertyDefaults
+import io.shiftleft.codepropertygraph.generated.nodes.NewIdentifier
 
 trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   this: AstCreator =>
@@ -40,7 +41,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     // - handle genericWhereClause
     val attributes = astForDeclAttributes(node)
     val modifiers  = modifiersForDecl(node)
-    val aliasName  = node.initializer.map(i => code(i.value))
+    val aliasName  = node.initializer.map(i => handleTypeAliasInitializer(i.value))
 
     val name                               = typeNameForDeclSyntax(node)
     val (astParentType, astParentFullName) = astParentInfo()
@@ -838,13 +839,20 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForSubscriptDeclSyntax(node: SubscriptDeclSyntax): Ast = notHandledYet(node)
 
+  private def handleTypeAliasInitializer(node: TypeSyntax): String = {
+    astForTypeSyntax(node).root match
+      case Some(id: NewIdentifier)     => id.name
+      case Some(typeDecl: NewTypeDecl) => typeDecl.fullName
+      case _                           => code(node)
+  }
+
   private def astForTypeAliasDeclSyntax(node: TypeAliasDeclSyntax): Ast = {
     // TODO:
     // - handle genericParameterClause
     // - handle genericWhereClause
     val attributes = astForDeclAttributes(node)
     val modifiers  = modifiersForDecl(node)
-    val aliasName  = code(node.initializer.value)
+    val aliasName  = handleTypeAliasInitializer(node.initializer.value)
 
     val name                     = typeNameForDeclSyntax(node)
     val (typeName, typeFullName) = calcTypeNameAndFullName(name)

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/TypealiasTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/TypealiasTests.scala
@@ -16,8 +16,13 @@ class TypealiasTests extends AbstractPassTest {
         |  var foo: String
         |}
         |""".stripMargin) { cpg =>
+      val expectedTypeAliasFullName = "code.swift:<global>:_anon_cdecl_0"
+      val List(tupleTypeDecl)       = cpg.typeDecl.fullNameExact(expectedTypeAliasFullName).l
+      tupleTypeDecl.name shouldBe "_anon_cdecl_0"
+      tupleTypeDecl.code shouldBe "(Int, Int)"
+
       val List(intPair) = cpg.typeDecl.nameExact("IntPair").l
-      intPair.aliasTypeFullName shouldBe Option("(Int, Int)")
+      intPair.aliasTypeFullName shouldBe Option(expectedTypeAliasFullName)
 
       val List(intPairExt) = cpg.typeDecl.nameExact("IntPair<extension>").l
       intPairExt.member.code.l shouldBe List("foo")
@@ -29,16 +34,26 @@ class TypealiasTests extends AbstractPassTest {
         |}
         |typealias IntPair = (Int, Int)
         |""".stripMargin) { cpg =>
+      val expectedTypeAliasFullName = "code.swift:<global>:_anon_cdecl_0"
+      val List(tupleTypeDecl)       = cpg.typeDecl.fullNameExact(expectedTypeAliasFullName).l
+      tupleTypeDecl.name shouldBe "_anon_cdecl_0"
+      tupleTypeDecl.code shouldBe "(Int, Int)"
+
       val List(intPair) = cpg.typeDecl.nameExact("IntPair").l
-      intPair.aliasTypeFullName shouldBe Option("(Int, Int)")
+      intPair.aliasTypeFullName shouldBe Option(expectedTypeAliasFullName)
 
       val List(intPairExt) = cpg.typeDecl.nameExact("IntPair<extension>").l
       intPairExt.member.code.l shouldBe List("foo")
     }
 
     "testTypealias2b" in AstFixture("typealias IntTriple = (Int, Int, Int)") { cpg =>
+      val expectedTypeAliasFullName = "code.swift:<global>:_anon_cdecl_0"
+      val List(tupleTypeDecl)       = cpg.typeDecl.fullNameExact(expectedTypeAliasFullName).l
+      tupleTypeDecl.name shouldBe "_anon_cdecl_0"
+      tupleTypeDecl.code shouldBe "(Int, Int, Int)"
+
       val List(intTriple) = cpg.typeDecl.nameExact("IntTriple").l
-      intTriple.aliasTypeFullName shouldBe Option("(Int, Int, Int)")
+      intTriple.aliasTypeFullName shouldBe Option(expectedTypeAliasFullName)
     }
 
     "testTypealias3a" in AstFixture("typealias Foo1 = Int") { cpg =>


### PR DESCRIPTION
For a type alias or an associated type we have to generate an anonymous type for initializer value which is a type or a type reference by itself to correctly create type alias edges later (see AliasLinkerPass).