### PR TITLE
[ruby] Call Restructuring

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -133,11 +133,22 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     // TODO: Type recovery should potentially resolve this
     val fullName = typeFromCallTarget(node.target)
       .map(x => s"$x:${node.methodName}")
-      .getOrElse(node.methodName)
+      .getOrElse(XDefines.DynamicCallUnknownFullName)
+
+    val fieldAccessBase = astForExpression(node.target)
     val fieldAccessAst  = astForFieldAccess(MemberAccess(node.target, node.op, node.methodName)(node.span))
     val argumentAsts    = node.arguments.map(astForMethodCallArgument)
+
+    // This is consistent with `pysrc` calls
+    fieldAccessAst.root.collect { case x: AstNodeNew => x.order = 0 }
+    fieldAccessBase.root.collect { case x: AstNodeNew => x.order = 1 }
+    argumentAsts.zipWithIndex.foreach { case (arg, idx) =>
+      arg.root.collect { case x: AstNodeNew => x.order = idx + 2 }
+    }
+
     val fieldAccessCall = callNode(node, code(node), node.methodName, fullName, DispatchTypes.DYNAMIC_DISPATCH)
-    callAst(fieldAccessCall, argumentAsts, Some(fieldAccessAst))
+
+    callAst(fieldAccessCall, argumentAsts, Option(fieldAccessBase), Option(fieldAccessAst))
   }
 
   protected def astForIndexAccess(node: IndexAccess): Ast = {
@@ -535,15 +546,23 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   private def astForMethodCallWithoutBlock(node: SimpleCall, methodIdentifier: SimpleIdentifier): Ast = {
-    val methodName           = methodIdentifier.text
-    lazy val defaultFullName = s"${XDefines.UnresolvedNamespace}:$methodName"
-    val methodFullName = scope.tryResolveMethodInvocation(methodName, List.empty) match {
-      case Some(m) => scope.typeForMethod(m).map(t => s"${t.name}:${m.name}").getOrElse(defaultFullName)
-      case None    => defaultFullName
+    val methodName = methodIdentifier.text
+
+    lazy val defaultResult = Defines.Any -> XDefines.DynamicCallUnknownFullName
+    val (receiverType, methodFullName) = scope.tryResolveMethodInvocation(methodName, List.empty) match {
+      case Some(m) =>
+        scope.typeForMethod(m).map(t => t.name -> s"${t.name}:${m.name}").getOrElse(defaultResult)
+      case None => defaultResult
     }
-    val argumentAst = node.arguments.map(astForMethodCallArgument)
-    val call        = callNode(node, code(node), methodName, methodFullName, DispatchTypes.STATIC_DISPATCH)
-    callAst(call, argumentAst, None, None)
+    val argumentAst      = node.arguments.map(astForMethodCallArgument)
+    val call             = callNode(node, code(node), methodName, methodFullName, DispatchTypes.STATIC_DISPATCH)
+    val receiverCallName = identifierNode(node, call.name, call.name, receiverType)
+
+    // Consistent with `pysrc`
+    receiverCallName.order(0)
+    argumentAst.zipWithIndex.foreach { case (arg, idx) => arg.root.collect { case x: AstNodeNew => x.order = idx + 1 } }
+
+    callAst(call, argumentAst, None, Option(Ast(receiverCallName)))
   }
 
   private def astForProcOrLambdaExpr(node: ProcOrLambdaExpr): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -6,6 +6,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.Operators
 
 class CaseTests extends RubyCode2CpgFixture {
+
   "`case x ... end` should be represented with if-else chain and multiple match expressions should be or-ed together" in {
     val caseCode = """
       |case 0
@@ -36,14 +37,13 @@ class CaseTests extends RubyCode2CpgFixture {
         )
         .l
       orConds.map {
-        case u: Unknown => "unknown"
+        case _: Unknown => "unknown"
         case mExpr =>
           val call @ List(_) = List(mExpr).isCall.l
           call.methodFullName.l shouldBe List("__builtin.Integer:===")
           val List(lhs, rhs) = call.argument.l
           rhs.code shouldBe "<tmp-0>"
-          val List(code) = List(lhs).isCall.argument(1).code.l
-          code
+          lhs.code
       }.l
     }.l
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -97,7 +97,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
     "specify the closure reference as an argument to the member call with block" in {
       inside(cpg.call("each").argument.l) {
-        case (_: Call) :: (lambdaRef: MethodRef) :: Nil =>
+        case (_: Identifier) :: (lambdaRef: MethodRef) :: Nil =>
           lambdaRef.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
@@ -157,7 +157,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
     "specify the closure reference as an argument to the member call with block" in {
       inside(cpg.call("each").argument.l) {
-        case (_: Call) :: (lambdaRef: MethodRef) :: Nil =>
+        case (_: Identifier) :: (lambdaRef: MethodRef) :: Nil =>
           lambdaRef.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -271,11 +271,15 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
 
   "implicit RETURN node for MEMBER CALL" in {
     val cpg = code("""
-                     |def f(x)
-                     | puts(x)
+                     |class F
+                     |  def self.x(y)
+                     |   puts(y)
+                     |  end
                      |end
+                     |
                      |def j()
-                     | f.x(1)
+                     |  f = F.new
+                     |  f.x(1)
                      |end
                      |""".stripMargin)
 
@@ -286,7 +290,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             retMemAccess.code shouldBe "f.x(1)"
 
             val List(call: Call) = retMemAccess.astChildren.l: @unchecked
-            call.methodFullName shouldBe "x"
+            call.name shouldBe "x"
           case xs => fail(s"Expected exactly one return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case _ => fail("Only one method expected")


### PR DESCRIPTION
The Ruby calls were somewhat a bastard child in terms of structure. This PR aligns the structure closer to `pysrc2cpg` in that there is always some kind of base/receiver. e.g.

```ruby
x.foo(a, b)
# x.foo (FieldIdentifier @ 0)
# x (Identifier @ 1)
# a @ 2
# b @ 3
```
and
```ruby
foo(a, b)
# foo (Identifier @ 0)
# a @ 1
# b @ 2
```