### PR TITLE
Add String/Regexp operator =~

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -73,7 +73,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       "|"   -> Operators.or,
       "^"   -> Operators.xor,
       "<<"  -> Operators.shiftLeft,
-      ">>"  -> Operators.logicalShiftRight
+      ">>"  -> Operators.logicalShiftRight,
+      "=~" -> "=~"
     )
 
   protected val AssignmentOperatorNames: Map[String, String] = Map(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -105,6 +105,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case None =>
         logger.warn(s"Unrecognized binary operator: ${code(node)} ($relativeFileName), skipping")
         astForUnknown(node)
+      case Some("=~") =>
+        astForMemberCall(MemberCall(node.lhs, ".", "=~", List(node.rhs))(node.span))
       case Some(op) =>
         val lhsAst = astForExpression(node.lhs)
         val rhsAst = astForExpression(node.rhs)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -1,0 +1,23 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import scala.reflect.ClassTag
+
+class RegexTests extends RubyCode2CpgFixture {
+  "`'x' =~ y` is a member call `'x'.=~ /y/" in {
+    val cpg = code(
+    """|'x' =~ /y/
+       |0
+       |""".stripMargin)
+    cpg.call("=~").methodFullName.l shouldBe List("__builtin.String:=~")
+  }
+  "`/x/ =~ 'y'` is a member call `/x/.=~ 'y'" in {
+    val cpg = code(
+    """|/x/ =~ 'y'
+       |0
+       |""".stripMargin)
+    cpg.call("=~").methodFullName.l shouldBe List("__builtin.Regexp:=~")
+  }
+}


### PR DESCRIPTION
- Treat `=~` as a member call.
- I'm a bit uncomfortable with not having a constant for "=~", but not sure where to put it.
- Unit tests are a bit bare, but not sure what else needs to be checked that is not done for member calls in general.