### PR TITLE
[ruby] Object Instantiation Type Hint

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -38,6 +38,10 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         }
         Ast(identifier).withRefEdge(identifier, local)
       case Some(local) =>
+        local match {
+          case x: NewLocal             => identifier.dynamicTypeHintFullName(x.dynamicTypeHintFullName)
+          case x: NewMethodParameterIn => identifier.dynamicTypeHintFullName(x.dynamicTypeHintFullName)
+        }
         Ast(identifier).withRefEdge(identifier, local)
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -153,8 +153,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val methodName = XDefines.ConstructorMethodName
     val (receiverTypeFullName, fullName) = scope.tryResolveTypeReference(className) match {
       case Some(typeMetaData) => typeMetaData.name -> s"${typeMetaData.name}:$methodName"
-      case None =>
-        s"${XDefines.UnresolvedNamespace}.$className" -> s"${XDefines.UnresolvedNamespace}.$className:$methodName"
+      case None               => XDefines.Any      -> XDefines.DynamicCallUnknownFullName
     }
     /*
       Similarly to some other frontends, we lower the constructor into two operations, e.g.,
@@ -237,6 +236,22 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
               case _ =>
                 val lhsAst = astForExpression(node.lhs)
                 val rhsAst = astForExpression(node.rhs)
+
+                // If this is a simple object instantiation assignment, we can give the LHS variable a type hint
+                if (node.rhs.isInstanceOf[ObjectInstantiation] && lhsAst.root.exists(_.isInstanceOf[NewIdentifier])) {
+                  rhsAst.nodes.collectFirst {
+                    case tmp: NewIdentifier if tmp.name.startsWith("<tmp") =>
+                      lhsAst.root.collectFirst { case i: NewIdentifier =>
+                        scope.lookupVariable(i.name).foreach {
+                          case x: NewLocal =>
+                            x.dynamicTypeHintFullName(x.dynamicTypeHintFullName :+ tmp.typeFullName)
+                          case x: NewMethodParameterIn =>
+                            x.dynamicTypeHintFullName(x.dynamicTypeHintFullName :+ tmp.typeFullName)
+                        }
+                        i.dynamicTypeHintFullName(i.dynamicTypeHintFullName :+ tmp.typeFullName)
+                      }
+                  }
+                }
 
                 val call = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
                 callAst(call, Seq(lhsAst, rhsAst))

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -103,6 +103,7 @@ class CallTests extends RubyCode2CpgFixture {
           inside(assignment.argument.l) {
             case (a: Identifier) :: (_: Block) :: Nil =>
               a.name shouldBe "a"
+              a.dynamicTypeHintFullName should contain("Test0.rb:<global>::program.A")
             case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected a single assignment, got [${xs.code.mkString(",")}]")


### PR DESCRIPTION
Add a type hint to the LHS identifier of an object instantiation assignment to be hinted that the type would be that of the created object.

Question @max-leuthaeuser, is this a good place to use `dynamicTypeHintFullName`? Or should I stick to `possibleTypes`?