### PR TITLE
[ruby] Download & Summarize Dependencies

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -10,7 +10,7 @@ import scopt.OParser
 
 import java.nio.file.Paths
 
-final case class Config()
+final case class Config(downloadDependencies: Boolean = false)
     extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config]
@@ -18,6 +18,10 @@ final case class Config()
 
   override val astGenProgramName: String  = "dotnetastgen"
   override val astGenConfigPrefix: String = "csharpsrc2cpg"
+
+  override def withDownloadDependencies(value: Boolean): Config = {
+    copy(downloadDependencies = value).withInheritedFields(this)
+  }
 
 }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -10,7 +10,7 @@ import scopt.OParser
 
 import java.nio.file.Paths
 
-final case class Config(downloadDependencies: Boolean = false)
+final case class Config()
     extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config]

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -4,7 +4,7 @@ import io.joern.csharpsrc2cpg.Frontend.{cmdLineParser, defaultConfig}
 import io.joern.x2cpg.astgen.AstGenConfig
 import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
 import io.joern.x2cpg.utils.Environment
-import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
+import io.joern.x2cpg.{DependencyDownloadConfig, X2CpgConfig, X2CpgMain}
 import org.slf4j.LoggerFactory
 import scopt.OParser
 
@@ -12,15 +12,12 @@ import java.nio.file.Paths
 
 final case class Config(downloadDependencies: Boolean = false)
     extends X2CpgConfig[Config]
+    with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config]
     with AstGenConfig[Config] {
 
   override val astGenProgramName: String  = "dotnetastgen"
   override val astGenConfigPrefix: String = "csharpsrc2cpg"
-
-  def withDownloadDependencies(value: Boolean): Config = {
-    this.copy(downloadDependencies = value).withInheritedFields(this)
-  }
 
 }
 
@@ -30,13 +27,7 @@ object Frontend {
   val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
     import builder.*
-    OParser.sequence(
-      programName("csharpsrc2cpg"),
-      opt[Unit]("download-dependencies")
-        .text("Download the dependencies of the target project and use their symbols to resolve types.")
-        .action((_, c) => c.withDownloadDependencies(true)),
-      XTypeRecovery.parserOptions
-    )
+    OParser.sequence(programName("csharpsrc2cpg"), DependencyDownloadConfig.parserOptions, XTypeRecovery.parserOptions)
   }
 
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
@@ -132,7 +132,6 @@ class DependencyDownloader(cpg: Cpg, config: Config, internalProgramSummary: CSh
                 s"Exception occurred while downloading $fileName (${dependency.name}:${dependency.version})",
                 exception
               )
-              None
             case Success(_) =>
               logger.info(s"Successfully downloaded dependency ${dependency.name}:${dependency.version}")
           }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
@@ -13,7 +13,8 @@ final case class Config(
   gradleConfigurationName: Option[String] = None,
   jar4importServiceUrl: Option[String] = None,
   includeJavaSourceFiles: Boolean = false,
-  generateNodesForDependencies: Boolean = false
+  generateNodesForDependencies: Boolean = false,
+  downloadDependencies: Boolean = false
 ) extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config] {
 
@@ -43,6 +44,10 @@ final case class Config(
 
   def withGenerateNodesForDependencies(value: Boolean): Config = {
     this.copy(generateNodesForDependencies = value).withInheritedFields(this)
+  }
+
+  override def withDownloadDependencies(value: Boolean): Config = {
+    this.copy(downloadDependencies = value).withInheritedFields(this)
   }
 }
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
@@ -1,7 +1,7 @@
 package io.joern.kotlin2cpg
 
-import io.joern.kotlin2cpg.Frontend._
-import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
+import io.joern.kotlin2cpg.Frontend.*
+import io.joern.x2cpg.{DependencyDownloadConfig, X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
 case class DefaultContentRootJarPath(path: String, isResource: Boolean)
@@ -9,13 +9,13 @@ case class DefaultContentRootJarPath(path: String, isResource: Boolean)
 final case class Config(
   classpath: Set[String] = Set.empty,
   withStdlibJarsInClassPath: Boolean = true,
-  downloadDependencies: Boolean = false,
   gradleProjectName: Option[String] = None,
   gradleConfigurationName: Option[String] = None,
   jar4importServiceUrl: Option[String] = None,
   includeJavaSourceFiles: Boolean = false,
   generateNodesForDependencies: Boolean = false
-) extends X2CpgConfig[Config] {
+) extends X2CpgConfig[Config]
+    with DependencyDownloadConfig[Config] {
 
   def withClasspath(classpath: Set[String]): Config = {
     this.copy(classpath = classpath).withInheritedFields(this)
@@ -23,10 +23,6 @@ final case class Config(
 
   def withStdLibJars(value: Boolean): Config = {
     this.copy(withStdlibJarsInClassPath = value).withInheritedFields(this)
-  }
-
-  def withDownloadDependencies(value: Boolean): Config = {
-    this.copy(downloadDependencies = value).withInheritedFields(this)
   }
 
   def withGradleProjectName(name: String): Config = {
@@ -69,9 +65,6 @@ private object Frontend {
       opt[String]("jar4import-url")
         .text("Set URL of service which fetches necessary dependency jars for import names found in the project")
         .action((value, c) => c.withJar4ImportServiceUrl(value)),
-      opt[Unit]("download-dependencies")
-        .text("Download the dependencies of the target project and add them to the classpath")
-        .action((_, c) => c.withDownloadDependencies(true)),
       opt[String]("gradle-project-name")
         .text("Name of the Gradle project used to download dependencies")
         .action((value, c) => c.withGradleProjectName(value)),
@@ -83,7 +76,8 @@ private object Frontend {
         .action((_, c) => c.withIncludeJavaSourceFiles(true)),
       opt[Unit]("generate-nodes-for-dependencies")
         .text("Generate nodes for the dependencies of the target project")
-        .action((_, c) => c.withGenerateNodesForDependencies(true))
+        .action((_, c) => c.withGenerateNodesForDependencies(true)),
+      DependencyDownloadConfig.parserOptions
     )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -4,6 +4,7 @@ dependsOn(Projects.dataflowengineoss % "compile->compile;test->test", Projects.x
 
 libraryDependencies ++= Seq(
   "io.shiftleft"  %% "codepropertygraph" % Versions.cpg,
+  "org.apache.commons" % "commons-compress" % "1.26.1", // For unpacking Gems with `--download-dependencies`
   "org.scalatest" %% "scalatest"         % Versions.scalatest % Test,
   "org.antlr"      % "antlr4-runtime"    % Versions.antlr
 )

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -5,8 +5,11 @@ import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
 import io.joern.x2cpg.{DependencyDownloadConfig, X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
-final case class Config(antlrCacheMemLimit: Double = 0.6d, useDeprecatedFrontend: Boolean = false)
-    extends X2CpgConfig[Config]
+final case class Config(
+  antlrCacheMemLimit: Double = 0.6d,
+  useDeprecatedFrontend: Boolean = false,
+  downloadDependencies: Boolean = false
+) extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config] {
 
@@ -20,6 +23,10 @@ final case class Config(antlrCacheMemLimit: Double = 0.6d, useDeprecatedFrontend
 
   def withUseDeprecatedFrontend(value: Boolean): Config = {
     copy(useDeprecatedFrontend = value).withInheritedFields(this)
+  }
+
+  override def withDownloadDependencies(value: Boolean): Config = {
+    copy(downloadDependencies = value).withInheritedFields(this)
   }
 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -2,22 +2,16 @@ package io.joern.rubysrc2cpg
 
 import io.joern.rubysrc2cpg.Frontend.*
 import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
-import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
+import io.joern.x2cpg.{DependencyDownloadConfig, X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
-final case class Config(
-  enableDependencyDownload: Boolean = false,
-  antlrCacheMemLimit: Double = 0.6d,
-  useDeprecatedFrontend: Boolean = false
-) extends X2CpgConfig[Config]
+final case class Config(antlrCacheMemLimit: Double = 0.6d, useDeprecatedFrontend: Boolean = false)
+    extends X2CpgConfig[Config]
+    with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config] {
 
   this.defaultIgnoredFilesRegex = List("spec", "test").flatMap { directory =>
     List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|/)$directory($$|/)".r.unanchored)
-  }
-
-  def withEnableDependencyDownload(value: Boolean): Config = {
-    copy(enableDependencyDownload = value).withInheritedFields(this)
   }
 
   def withAntlrCacheMemoryLimit(value: Double): Config = {
@@ -38,10 +32,6 @@ private object Frontend {
     import builder.*
     OParser.sequence(
       programName("rubysrc2cpg"),
-      opt[Unit]("enableDependencyDownload")
-        .hidden()
-        .action((_, c) => c.withEnableDependencyDownload(true))
-        .text("enable dependency download for Unix System only"),
       opt[Double]("antlrCacheMemLimit")
         .hidden()
         .action((x, c) => c.withAntlrCacheMemoryLimit(x))
@@ -57,6 +47,7 @@ private object Frontend {
       opt[Unit]("useDeprecatedFrontend")
         .action((_, c) => c.withUseDeprecatedFrontend(true))
         .text("uses the original (but deprecated) Ruby frontend (default false)"),
+      DependencyDownloadConfig.parserOptions,
       XTypeRecovery.parserOptions
     )
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -13,6 +13,8 @@ import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.BatchedUpdate
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
+import java.util.regex.Matcher
+
 class AstCreator(
   val fileName: String,
   protected val programCtx: RubyParser.ProgramContext,
@@ -36,9 +38,17 @@ class AstCreator(
   protected val logger: Logger = LoggerFactory.getLogger(getClass)
 
   protected var parseLevel: AstParseLevel = AstParseLevel.FULL_AST
-
+  
   protected val relativeFileName: String =
-    projectRoot.map(fileName.stripPrefix).map(_.stripPrefix(java.io.File.separator)).getOrElse(fileName)
+    projectRoot
+      .map(fileName.stripPrefix)
+      .map(_.stripPrefix(java.io.File.separator))
+      .getOrElse(fileName)
+
+  /** The relative file name, in a unix path delimited format.
+   */
+  private def relativeUnixStyleFileName =
+    relativeFileName.replaceAll(Matcher.quoteReplacement(java.io.File.separator), "/")
 
   override def createAst(): BatchedUpdate.DiffGraphBuilder = {
     val rootNode = new RubyNodeCreator().visit(programCtx).asInstanceOf[StatementList]
@@ -53,7 +63,7 @@ class AstCreator(
    */
   protected def astForRubyFile(rootStatements: StatementList): Ast = {
     val fileNode = NewFile().name(relativeFileName)
-    val fullName = s"$relativeFileName:${NamespaceTraversal.globalNamespaceName}"
+    val fullName = s"$relativeUnixStyleFileName:${NamespaceTraversal.globalNamespaceName}"
     val namespaceBlock = NewNamespaceBlock()
       .filename(relativeFileName)
       .name(NamespaceTraversal.globalNamespaceName)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -38,7 +38,7 @@ class AstCreator(
   protected val logger: Logger = LoggerFactory.getLogger(getClass)
 
   protected var parseLevel: AstParseLevel = AstParseLevel.FULL_AST
-  
+
   protected val relativeFileName: String =
     projectRoot
       .map(fileName.stripPrefix)
@@ -46,7 +46,7 @@ class AstCreator(
       .getOrElse(fileName)
 
   /** The relative file name, in a unix path delimited format.
-   */
+    */
   private def relativeUnixStyleFileName =
     relativeFileName.replaceAll(Matcher.quoteReplacement(java.io.File.separator), "/")
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -253,7 +253,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
                 // If this is a simple object instantiation assignment, we can give the LHS variable a type hint
                 if (node.rhs.isInstanceOf[ObjectInstantiation] && lhsAst.root.exists(_.isInstanceOf[NewIdentifier])) {
                   rhsAst.nodes.collectFirst {
-                    case tmp: NewIdentifier if tmp.name.startsWith("<tmp") =>
+                    case tmp: NewIdentifier if tmp.name.startsWith("<tmp") && tmp.typeFullName != Defines.Any =>
                       lhsAst.root.collectFirst { case i: NewIdentifier =>
                         scope.lookupVariable(i.name).foreach {
                           case x: NewLocal =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -11,6 +11,8 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Local, Member, Method, Ty
 import io.shiftleft.semanticcpg.language.*
 import overflowdb.{BatchedUpdate, Config}
 
+import java.io.File as JavaFile
+import java.util.regex.Matcher
 import scala.util.Using
 
 trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
@@ -67,7 +69,9 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
 
     val mappings =
       cpg.namespaceBlock.flatMap { namespace =>
-        val path = namespace.filename.stripSuffix(".rb")
+        val path = namespace.filename
+          .replaceAll(Matcher.quoteReplacement(JavaFile.separator), "/") // handle Windows paths
+          .stripSuffix(".rb")
         // Map module functions/variables
         val moduleEntry = (path, namespace.fullName) -> namespace.method.map { module =>
           val moduleTypeMap =

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -213,11 +213,15 @@ object RubyIntermediateAst {
 
     def isString: Boolean = text.startsWith("\"") || text.startsWith("'")
 
-    def innerText: String = text match
-      case s":'$content'" => content
-      case s":$symbol"    => symbol
-      case s"'$content'"  => content
-      case s              => s
+    def innerText: String = {
+      val strRegex = ":?['\"]([\\w\\d_-]+)['\"]".r
+      text match {
+        case s":'$content'"                       => content
+        case s":$symbol"                          => symbol
+        case strRegex(content) if content != null => content
+        case s                                    => s
+      }
+    }
   }
 
   final case class DynamicLiteral(typeFullName: String, expressions: List[RubyNode])(span: TextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -24,6 +24,8 @@ object Defines {
 
   val Program: String = ":program"
 
+  val Resolver: String = "<dependency-resolver>"
+
   def getBuiltInType(typeInString: String) = s"${GlobalTypes.builtinPrefix}.$typeInString"
 
   object RubyOperators {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/DependencyPass.scala
@@ -1,0 +1,47 @@
+package io.joern.rubysrc2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{ConfigFile, NewDependency}
+import io.shiftleft.passes.ForkJoinParallelCpgPass
+import io.shiftleft.semanticcpg.language.*
+
+/** Parses the dependencies from the `Gemfile.lock` file. TODO: Approximate dependencies from Gemfile alone.
+  * @param cpg
+  *   the graph.
+  */
+class DependencyPass(cpg: Cpg) extends ForkJoinParallelCpgPass[ConfigFile](cpg) {
+
+  override def generateParts(): Array[ConfigFile] = cpg.configFile.name(".*Gemfile\\.lock").toArray
+
+  override def runOnPart(builder: DiffGraphBuilder, configFile: ConfigFile): Unit = {
+    var inGem       = false
+    var inSpecs     = false
+    var specTabSize = 0
+    val specRegex   = " *([\\w_]+) \\(([\\d.]+)\\)".r
+    configFile.content.linesIterator.foreach {
+      // Check if we're under the GEM header
+      case "GEM" => inGem = true
+      // Check if we've left the GEM header
+      case "" if inGem => inGem = false
+      // Check if we're under a new header
+      case line if !line.isBlank && !line.charAt(0).isWhitespace => inGem = false
+      // If we're under the GEM header, process line
+      case gemLine if inGem =>
+        val currentTabSize = gemLine.takeWhile(_.isWhitespace).length
+        gemLine match {
+          case remote if remote.trim.startsWith("remote:") => // do nothing
+          case specs if specs.trim.startsWith("specs:") =>
+            inSpecs = true
+          case specRegex(dep, version) if inSpecs && (specTabSize == currentTabSize || specTabSize == 0) =>
+            specTabSize = currentTabSize
+            val depNode = NewDependency()
+              .name(dep)
+              .version(version)
+            builder.addNode(depNode)
+          case _ => // do nothing
+        }
+      case _ => // do nothing
+    }
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/DependencyDownloader.scala
@@ -1,0 +1,176 @@
+package io.joern.rubysrc2cpg.utils
+
+import better.files.File
+import io.joern.rubysrc2cpg.Config
+import io.joern.rubysrc2cpg.datastructures.RubyProgramSummary
+import io.joern.x2cpg.astgen.AstGenRunner.DefaultAstGenRunnerResult
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Dependency
+import io.shiftleft.semanticcpg.language.*
+import org.slf4j.LoggerFactory
+import upickle.default.*
+
+import java.io.FileOutputStream
+import java.net.{HttpURLConnection, URI, URL, URLConnection}
+import java.util.zip.{GZIPInputStream, InflaterInputStream, ZipEntry}
+import scala.util.{Failure, Success, Try, Using}
+
+/** Queries NuGet for the artifacts of a programs' dependencies, according to the V2 API.
+  *
+  * TODO: Note that NuGet has API throttling, so beware of that if this is to be processed concurrently.
+  *
+  * @see
+  *   <a href="https://learn.microsoft.com/en-us/nuget/api/overview">NuGet API</a>
+  */
+class DependencyDownloader(cpg: Cpg, config: Config, internalProgramSummary: RubyProgramSummary) {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val NUGET_BASE_API_V2 = "www.nuget.org/api/v2"
+  private val NUGET_BASE_API_V3 = "api.nuget.org/v3-flatcontainer"
+
+  /** Downloads dependencies and summarises their symbol information.
+    * @return
+    *   the dependencies' summary combined with the given internal program summary.
+    */
+  def download(): RubyProgramSummary = {
+//    File.temporaryDirectory("joern-rubysrc2cpg").apply { dir =>
+//      cpg.dependency.filterNot(isAlreadySummarized).foreach(downloadDependency(dir, _))
+//      unzipDependencies(dir)
+//      summarizeDependencies(dir) ++ internalProgramSummary
+//    }
+    internalProgramSummary
+  }
+
+  /** Using the internal program summary (which may contain pre-defined type stubs), determines if the dependency is
+    * already summarized and does not need to be downloaded.
+    * @param dependency
+    *   the dependency to download.
+    * @return
+    *   true if the dependency is already in the given summary, false if otherwise.
+    */
+  private def isAlreadySummarized(dependency: Dependency): Boolean = {
+    // TODO: Implement
+    false
+  }
+
+  private case class NuGetPackageVersions(versions: List[String]) derives ReadWriter
+
+  /** Downloads the dependency to a temporary directory. This will be a `nupkg` and `snupkg` file for each dependency
+    * respectively, which are compressed using the ZIP format.
+    *
+    * @param targetDir
+    *   the directory to download to.
+    * @param dependency
+    *   the dependency to download.
+    * @return
+    *   a disposable version of the directory where the dependencies live.
+    */
+  private def downloadDependency(targetDir: File, dependency: Dependency): Unit = {
+
+    def getVersion(packageName: String): Option[String] = {
+      Using.resource(URI(s"https://$NUGET_BASE_API_V3/${packageName.toLowerCase}/index.json").toURL.openStream()) {
+        is =>
+          Try(read[NuGetPackageVersions](ujson.Readable.fromByteArray(is.readAllBytes()))).toOption
+            .flatMap(_.versions.lastOption)
+      }
+    }
+
+    def createUrl(packageType: String, version: String): URL = {
+      URI(s"https://$NUGET_BASE_API_V2/$packageType/${dependency.name}/$version").toURL
+    }
+
+    // If dependency version is not specified, latest is returned
+    val versionOpt = if dependency.version.isBlank then getVersion(dependency.name) else Option(dependency.version)
+
+    versionOpt match {
+      case Some(version) =>
+        downloadPackage(targetDir, dependency, createUrl("package", version))
+        downloadPackage(targetDir, dependency, createUrl("symbolpackage", version))
+      case None =>
+        logger.error(s"Unable to determine package version for ${dependency.name}, skipping")
+    }
+  }
+
+  /** Downloads the package and unpacks the contents to the target directory.
+    * @param targetDir
+    *   the directory to download and unpack to.
+    * @param dependency
+    *   the dependency information.
+    * @param url
+    *   the download URL.
+    * @return
+    *   the package version.
+    */
+  private def downloadPackage(targetDir: File, dependency: Dependency, url: URL): Unit = {
+    var connection: Option[HttpURLConnection] = None
+    try {
+      connection = Option(url.openConnection()).collect { case x: HttpURLConnection => x }
+      // allow both GZip and Deflate (ZLib) encodings
+      connection.foreach(_.setRequestProperty("Accept-Encoding", "gzip, deflate"))
+      connection match {
+        case Some(conn: HttpURLConnection) if conn.getResponseCode == HttpURLConnection.HTTP_OK =>
+          val ext      = if url.toString.contains("/package/") then "nupkg" else "snupkg"
+          val fileName = targetDir / s"${dependency.name}.$ext"
+
+          val inputStream = Option(conn.getContentEncoding) match {
+            case Some(encoding) if encoding.equalsIgnoreCase("gzip")    => GZIPInputStream(conn.getInputStream)
+            case Some(encoding) if encoding.equalsIgnoreCase("deflate") => InflaterInputStream(conn.getInputStream)
+            case _                                                      => conn.getInputStream
+          }
+
+          Try {
+            Using.resources(inputStream, new FileOutputStream(fileName.pathAsString)) { (is, fos) =>
+              val buffer = new Array[Byte](4096)
+              Iterator
+                .continually(is.read(buffer))
+                .takeWhile(_ != -1)
+                .foreach(bytesRead => fos.write(buffer, 0, bytesRead))
+            }
+          } match {
+            case Failure(exception) =>
+              logger.error(
+                s"Exception occurred while downloading $fileName (${dependency.name}:${dependency.version})",
+                exception
+              )
+              None
+            case Success(_) =>
+              logger.info(s"Successfully downloaded dependency ${dependency.name}:${dependency.version}")
+          }
+        case Some(conn: HttpURLConnection) =>
+          logger.error(s"Connection to $url responded with non-200 code ${conn.getResponseCode}")
+        case _ =>
+          logger.error(s"Unknown URL connection made, aborting")
+      }
+    } catch {
+      case exception: Throwable =>
+        logger.error(s"Unable to download dependency ${dependency.name}:${dependency.version}", exception)
+    } finally {
+      connection.foreach(_.disconnect())
+    }
+  }
+
+  /** Given a directory of all the summaries, will produce a summary thereof.
+    * @param targetDir
+    *   the directory with all the dependencies.
+    * @return
+    *   a summary of all the dependencies.
+    */
+  private def summarizeDependencies(targetDir: File): RubyProgramSummary = {
+//    val astGenRunner       = new DotNetAstGenRunner(config.withInputPath(targetDir.pathAsString))
+//    val astGenRunnerResult = astGenRunner.execute(targetDir)
+//    val mappings = astGenRunnerResult.parsedFiles.map(x => File(x)).flatMap { f =>
+//      Using.resource(f.newFileInputStream) { fis =>
+//        CSharpProgramSummary.jsonToInitialMapping(fis) match {
+//          case Failure(exception) =>
+//            logger.error(s"Unable to parse JSON program summary at $f", exception)
+//            None
+//          case Success(parsedJson) =>
+//            Option(parsedJson)
+//        }
+//      }
+//    }
+    RubyProgramSummary()
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/querying/RubyMethodFullNameTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/querying/RubyMethodFullNameTests.scala
@@ -7,7 +7,7 @@ import org.scalatest.BeforeAndAfterAll
 
 class RubyMethodFullNameTests extends RubyCode2CpgFixture(useDeprecatedFrontend = true) with BeforeAndAfterAll {
 
-  private val config = Config().withEnableDependencyDownload(true)
+  private val config = Config().withDownloadDependencies(true)
 
   "Code for method full name when method present in module" should {
     val cpg = code(

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
@@ -1,8 +1,8 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.Config
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
+import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Identifier}
 import io.shiftleft.semanticcpg.language.*
 
@@ -13,7 +13,7 @@ class DependencyTests extends RubyCode2CpgFixture {
     val cpg = code(DependencyTests.GEMFILELOCK, "Gemfile.lock")
 
     "result in dependency nodes of the set packages" in {
-      inside(cpg.dependency.l) {
+      inside(cpg.dependency.nameNot(RubyDefines.Resolver).l) {
         case aruba :: bcrypt :: betterErrors :: Nil =>
           aruba.name shouldBe "aruba"
           aruba.version shouldBe "0.14.12"
@@ -35,7 +35,7 @@ class DependencyTests extends RubyCode2CpgFixture {
     val cpg = code(DependencyTests.GEMFILE, "Gemfile")
 
     "result in dependency nodes of the set packages" in {
-      inside(cpg.dependency.l) {
+      inside(cpg.dependency.nameNot(RubyDefines.Resolver).l) {
         case aruba :: bcrypt :: coffeeRails :: Nil =>
           aruba.name shouldBe "aruba"
           aruba.version shouldBe "2.5.1"
@@ -58,7 +58,7 @@ class DependencyTests extends RubyCode2CpgFixture {
 
     "be preferred over a normal Gemfile" in {
       // Our Gemfile.lock specifies exact versions whereas the Gemfile does not
-      cpg.dependency.forall(d => !d.version.isBlank) shouldBe true
+      cpg.dependency.nameNot(RubyDefines.Resolver).forall(d => !d.version.isBlank) shouldBe true
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
@@ -1,0 +1,64 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class DependencyTests extends RubyCode2CpgFixture {
+
+  "parsing a Ruby Gems lock file" should {
+
+    val cpg = code(
+      """
+        |GEM
+        |  remote: https://rubygems.org/
+        |  specs:
+        |    aruba (0.14.12)
+        |      childprocess (>= 0.6.3, < 4.0.0)
+        |      contracts (~> 0.9)
+        |      cucumber (>= 1.3.19)
+        |      ffi (~> 1.9)
+        |      rspec-expectations (>= 2.99)
+        |      thor (~> 0.19)
+        |    bcrypt (3.1.13)
+        |    better_errors (2.5.1)
+        |      coderay (>= 1.0.0)
+        |      erubi (>= 1.0.0)
+        |      rack (>= 0.9.0)
+        |
+        |PLATFORMS
+        |  ruby
+        |
+        |DEPENDENCIES
+        |  aruba
+        |  bcrypt
+        |  better_errors
+        |
+        |RUBY VERSION
+        |   ruby 2.6.5p114
+        |
+        |BUNDLED WITH
+        |   1.17.3
+        |
+        |""".stripMargin,
+      "Gemfile.lock"
+    )
+
+    "result in dependency nodes of the set packages" in {
+      inside(cpg.dependency.l) {
+        case aruba :: bcrypt :: betterErrors :: Nil =>
+          aruba.name shouldBe "aruba"
+          aruba.version shouldBe "0.14.12"
+
+          bcrypt.name shouldBe "bcrypt"
+          bcrypt.version shouldBe "3.1.13"
+
+          betterErrors.name shouldBe "better_errors"
+          betterErrors.version shouldBe "2.5.1"
+
+        case xs => fail(s"Expected exactly three dependencies, instead got [${xs.name.mkString(",")}]")
+      }
+    }
+
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
@@ -7,41 +7,7 @@ class DependencyTests extends RubyCode2CpgFixture {
 
   "parsing a Ruby Gems lock file" should {
 
-    val cpg = code(
-      """
-        |GEM
-        |  remote: https://rubygems.org/
-        |  specs:
-        |    aruba (0.14.12)
-        |      childprocess (>= 0.6.3, < 4.0.0)
-        |      contracts (~> 0.9)
-        |      cucumber (>= 1.3.19)
-        |      ffi (~> 1.9)
-        |      rspec-expectations (>= 2.99)
-        |      thor (~> 0.19)
-        |    bcrypt (3.1.13)
-        |    better_errors (2.5.1)
-        |      coderay (>= 1.0.0)
-        |      erubi (>= 1.0.0)
-        |      rack (>= 0.9.0)
-        |
-        |PLATFORMS
-        |  ruby
-        |
-        |DEPENDENCIES
-        |  aruba
-        |  bcrypt
-        |  better_errors
-        |
-        |RUBY VERSION
-        |   ruby 2.6.5p114
-        |
-        |BUNDLED WITH
-        |   1.17.3
-        |
-        |""".stripMargin,
-      "Gemfile.lock"
-    )
+    val cpg = code(DependencyTests.GEMFILELOCK, "Gemfile.lock")
 
     "result in dependency nodes of the set packages" in {
       inside(cpg.dependency.l) {
@@ -61,4 +27,85 @@ class DependencyTests extends RubyCode2CpgFixture {
 
   }
 
+  "parsing a Ruby Gems file" should {
+
+    val cpg = code(DependencyTests.GEMFILE, "Gemfile")
+
+    "result in dependency nodes of the set packages" in {
+      inside(cpg.dependency.l) {
+        case aruba :: bcrypt :: coffeeRails :: Nil =>
+          aruba.name shouldBe "aruba"
+          aruba.version shouldBe "2.5.1"
+
+          bcrypt.name shouldBe "bcrypt"
+          bcrypt.version shouldBe ""
+
+          coffeeRails.name shouldBe "coffee-rails"
+          coffeeRails.version shouldBe ""
+
+        case xs => fail(s"Expected exactly three dependencies, instead got [${xs.name.mkString(",")}]")
+      }
+    }
+
+  }
+
+  "a Gems lock file" should {
+
+    val cpg = code(DependencyTests.GEMFILE, "Gemfile").moreCode(DependencyTests.GEMFILELOCK, "Gemfile.lock")
+
+    "be preferred over a normal Gemfile" in {
+      // Our Gemfile.lock specifies exact versions whereas the Gemfile does not
+      cpg.dependency.forall(d => !d.version.isBlank) shouldBe true
+    }
+
+  }
+
+}
+
+object DependencyTests {
+  private val GEMFILELOCK =
+    """
+      |GEM
+      |  remote: https://rubygems.org/
+      |  specs:
+      |    aruba (0.14.12)
+      |      childprocess (>= 0.6.3, < 4.0.0)
+      |      contracts (~> 0.9)
+      |      cucumber (>= 1.3.19)
+      |      ffi (~> 1.9)
+      |      rspec-expectations (>= 2.99)
+      |      thor (~> 0.19)
+      |    bcrypt (3.1.13)
+      |    better_errors (2.5.1)
+      |      coderay (>= 1.0.0)
+      |      erubi (>= 1.0.0)
+      |      rack (>= 0.9.0)
+      |
+      |PLATFORMS
+      |  ruby
+      |
+      |DEPENDENCIES
+      |  aruba
+      |  bcrypt
+      |  better_errors
+      |
+      |RUBY VERSION
+      |   ruby 2.6.5p114
+      |
+      |BUNDLED WITH
+      |   1.17.3
+      |
+      |""".stripMargin
+
+  private val GEMFILE =
+    """
+        |# frozen_string_literal: true
+        |source "https://rubygems.org"
+        |
+        |ruby "2.6.5"
+        |
+        |gem "aruba", '2.5.1'
+        |gem "bcrypt"
+        |gem "coffee-rails"
+        |""".stripMargin
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -15,7 +15,7 @@ import org.scalatest.Tag
 import java.io.File
 import org.scalatest.Inside
 
-trait RubyFrontend(useDeprecatedFrontend: Boolean) extends LanguageFrontend {
+trait RubyFrontend(useDeprecatedFrontend: Boolean, withDownloadDependencies: Boolean) extends LanguageFrontend {
   override val fileSuffix: String = ".rb"
 
   implicit val config: Config =
@@ -23,6 +23,7 @@ trait RubyFrontend(useDeprecatedFrontend: Boolean) extends LanguageFrontend {
       .map(_.asInstanceOf[Config])
       .getOrElse(Config().withSchemaValidation(ValidationMode.Enabled))
       .withUseDeprecatedFrontend(useDeprecatedFrontend)
+      .withDownloadDependencies(withDownloadDependencies)
 
   override def execute(sourceCodeFile: File): Cpg = {
     new RubySrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
@@ -30,9 +31,12 @@ trait RubyFrontend(useDeprecatedFrontend: Boolean) extends LanguageFrontend {
 
 }
 
-class DefaultTestCpgWithRuby(packageTable: Option[PackageTable], useDeprecatedFrontend: Boolean)
-    extends DefaultTestCpg
-    with RubyFrontend(useDeprecatedFrontend)
+class DefaultTestCpgWithRuby(
+  packageTable: Option[PackageTable],
+  useDeprecatedFrontend: Boolean,
+  downloadDependencies: Boolean = false
+) extends DefaultTestCpg
+    with RubyFrontend(useDeprecatedFrontend, downloadDependencies)
     with SemanticTestCpg {
 
   override protected def applyPasses(): Unit = {
@@ -54,11 +58,12 @@ class DefaultTestCpgWithRuby(packageTable: Option[PackageTable], useDeprecatedFr
 class RubyCode2CpgFixture(
   withPostProcessing: Boolean = false,
   withDataFlow: Boolean = false,
+  downloadDependencies: Boolean = false,
   extraFlows: List[FlowSemantic] = List.empty,
   packageTable: Option[PackageTable] = None,
   useDeprecatedFrontend: Boolean = false
 ) extends Code2CpgFixture(() =>
-      new DefaultTestCpgWithRuby(packageTable, useDeprecatedFrontend)
+      new DefaultTestCpgWithRuby(packageTable, useDeprecatedFrontend, downloadDependencies)
         .withOssDataflow(withDataFlow)
         .withExtraFlows(extraFlows)
         .withPostProcessingPasses(withPostProcessing)
@@ -74,9 +79,9 @@ class RubyCode2CpgFixture(
     }
 }
 
-class RubyCfgTestCpg(useDeprecatedFrontend: Boolean = true)
+class RubyCfgTestCpg(useDeprecatedFrontend: Boolean = true, downloadDependencies: Boolean = false)
     extends CfgTestCpg
-    with RubyFrontend(useDeprecatedFrontend) {
+    with RubyFrontend(useDeprecatedFrontend, downloadDependencies) {
   override val fileSuffix: String = ".rb"
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -86,12 +86,7 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
   */
 trait DependencyDownloadConfig[R <: X2CpgConfig[R]] { this: R =>
 
-  var downloadDependencies: Boolean = false
-
-  def withDownloadDependencies(value: Boolean): R = {
-    this.downloadDependencies = value
-    this
-  }
+  def withDownloadDependencies(value: Boolean): R
 
 }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -1,7 +1,6 @@
 package io.joern.x2cpg
 
 import better.files.File
-import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, withErrorsToConsole}
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
 import io.shiftleft.codepropertygraph.Cpg
@@ -80,6 +79,31 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
     this.ignoredFiles = config.ignoredFiles
     this.disableFileContent = config.disableFileContent
     this.asInstanceOf[R]
+  }
+}
+
+/** Enables the configuration to specify if dependencies should be downloaded for additional symbol information.
+  */
+trait DependencyDownloadConfig[R <: X2CpgConfig[R]] { this: R =>
+
+  var downloadDependencies: Boolean = false
+
+  def withDownloadDependencies(value: Boolean): R = {
+    this.downloadDependencies = value
+    this
+  }
+
+}
+
+object DependencyDownloadConfig {
+  def parserOptions[R <: X2CpgConfig[R] with DependencyDownloadConfig[R]]: OParser[_, R] = {
+    val builder = OParser.builder[R]
+    import builder.*
+    OParser.sequence(
+      opt[Unit]("download-dependencies")
+        .text("Download the dependencies of the target project and use their symbols to resolve types.")
+        .action((_, c) => c.withDownloadDependencies(true))
+    )
   }
 }
 


### PR DESCRIPTION
* Unified the download dependency option as a trait under `X2Cpg` to be readily added to configurations
* Dependencies are parsed from  `Gemfile` and `Gemfile.lock`
* Downloads, unarchives, and parses dependencies for symbol information
* Library symbols successfully resolved against `RubyScope` and the `RubyPorgramSummary` classes
* Made sure all relative paths in `fullName` properties are Unix delimited

One advantage of this version of dependency downloading and parsing against the deprecated frontend is that this is OS independent and reduces the need for `gems` being installed.

cc @pandurangpatil 

Resolves #4314 