### PR TITLE
[ruby] implement splatting for when in case statements (#4318)

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -140,7 +140,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
                   List(MemberCall(exprList, ".", "any?", List())(splat.span))
                 }
             case e =>
-              logger.warn("Unrecognised RubyNode in case match splat expression")
+              logger.warn(s"Unrecognised RubyNode (${e.getClass}) in case match splat expression")
               List(Unknown()(e.span))
           })
           // There is always at least one match expression or a splat

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -131,13 +131,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
           val conditions = whenClause.matchExpressions.map { mExpr =>
             expr.map(e => MemberCall(mExpr, ".", "===", List(e))(mExpr.span)).getOrElse(mExpr)
           } ++ (whenClause.matchSplatExpression.iterator.flatMap {
-            case SplattingRubyNode(exprList) =>
+            case splat @ SplattingRubyNode(exprList) =>
               expr
                 .map { e =>
-                  List(MemberCall(exprList, ".", "include?", List(e))(exprList.span))
+                  List(MemberCall(exprList, ".", "include?", List(e))(splat.span))
                 }
                 .getOrElse {
-                  List(MemberCall(exprList, ".", "any?", List())(exprList.span))
+                  List(MemberCall(exprList, ".", "any?", List())(splat.span))
                 }
             case e =>
               logger.warn("Unrecognised RubyNode in case match splat expression")

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -119,15 +119,28 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       val ifElseChain = whenClauses.foldRight[Option[RubyNode]](elseThenClause) {
         (whenClause: WhenClause, restClause: Option[RubyNode]) =>
           // We translate multiple match expressions into an or expression.
-          // There may be a splat as the last match expression, which is currently parsed as unknown
+          //
           // A single match expression is compared using `.===` to the case target expression if it is present
           // otherwise it is treated as a conditional.
+          //
+          // There may be a splat as the last match expression,
+          // `case y when *x then c end` or
+          // `case when *x then c end`
+          // which is translated to `x.include? y` and `x.any?` conditions respectively
+
           val conditions = whenClause.matchExpressions.map { mExpr =>
             expr.map(e => MemberCall(mExpr, ".", "===", List(e))(mExpr.span)).getOrElse(mExpr)
           } ++ (whenClause.matchSplatExpression.iterator.flatMap {
-            case u: Unknown => List(u)
+            case SplattingRubyNode(exprList) =>
+              expr
+                .map { e =>
+                  List(MemberCall(exprList, ".", "include?", List(e))(exprList.span))
+                }
+                .getOrElse {
+                  List(MemberCall(exprList, ".", "any?", List())(exprList.span))
+                }
             case e =>
-              logger.warn("Splatting not implemented for `when` in ruby `case`")
+              logger.warn("Unrecognised RubyNode in case match splat expression")
               List(Unknown()(e.span))
           })
           // There is always at least one match expression or a splat

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -64,7 +64,7 @@ class CaseTests extends RubyCode2CpgFixture {
       |  when false, true then 0
       |  when true then 1
       |  when false, *[false,false] then 2
-      |  when *[false, true] then 3
+      |  when *[false,true] then 3
       |end
       |""".stripMargin)
 
@@ -89,8 +89,8 @@ class CaseTests extends RubyCode2CpgFixture {
     conds shouldBe List(
       List("expr:false", "expr:true"),
       List("expr:true"),
-      List("expr:false", "splat:[false, false]"),
-      List("splat:[false, true]")
+      List("expr:false", "splat:[false,false]"),
+      List("splat:[false,true]")
     )
 
     val matchResults = ifStmts.astChildren.order(2).astChildren.l

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -37,17 +37,18 @@ class CaseTests extends RubyCode2CpgFixture {
         )
         .l
       orConds.map {
-        case _: Unknown => "unknown"
-        case mExpr =>
-          val call @ List(_) = List(mExpr).isCall.l
-          call.methodFullName.l shouldBe List("__builtin.Integer:===")
-          val List(lhs, rhs) = call.argument.l
+        case mExpr: Call if mExpr.name == "include?" =>
+          val List(lhs, rhs) = mExpr.argument.l
           rhs.code shouldBe "<tmp-0>"
-          lhs.code
+          s"splat:${lhs.code}"
+        case mExpr: Call if mExpr.name == "===" =>
+          val List(lhs, rhs) = mExpr.argument.l
+          rhs.code shouldBe "<tmp-0>"
+          s"expr:${lhs.code}"
       }.l
     }.l
 
-    conds shouldBe List(List("0"), List("1", "2"), List("3", "unknown"), List("unknown"))
+    conds shouldBe List(List("expr:0"), List("expr:1", "expr:2"), List("expr:3", "splat:[4,5]"), List("splat:[6]"))
     val matchResults = ifStmts.astChildren.order(2).astChildren ++ ifStmts.last.astChildren.order(3).astChildren
     matchResults.code.l shouldBe List("0", "1", "2", "3", "4")
 
@@ -78,11 +79,14 @@ class CaseTests extends RubyCode2CpgFixture {
         )
         .l
       orConds.map {
-        case u: Unknown => "unknown"
-        case c          => c.code
+        case c: Call if c.name == "any?" => 
+          val List(lhs) = c.argument.l
+          s"splat:${lhs.code}"
+        case e: Expression => 
+          s"expr:${e.code}"
       }
     }.l
-    conds shouldBe List(List("false", "true"), List("true"), List("false", "unknown"), List("unknown"))
+    conds shouldBe List(List("expr:false", "expr:true"), List("expr:true"), List("expr:false", "splat:[false, false]"), List("splat:[false, true]"))
 
     val matchResults = ifStmts.astChildren.order(2).astChildren.l
     matchResults.code.l shouldBe List("0", "1", "2", "3")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -79,14 +79,19 @@ class CaseTests extends RubyCode2CpgFixture {
         )
         .l
       orConds.map {
-        case c: Call if c.name == "any?" => 
+        case c: Call if c.name == "any?" =>
           val List(lhs) = c.argument.l
           s"splat:${lhs.code}"
-        case e: Expression => 
+        case e: Expression =>
           s"expr:${e.code}"
       }
     }.l
-    conds shouldBe List(List("expr:false", "expr:true"), List("expr:true"), List("expr:false", "splat:[false, false]"), List("splat:[false, true]"))
+    conds shouldBe List(
+      List("expr:false", "expr:true"),
+      List("expr:true"),
+      List("expr:false", "splat:[false, false]"),
+      List("splat:[false, true]")
+    )
 
     val matchResults = ifStmts.astChildren.order(2).astChildren.l
     matchResults.code.l shouldBe List("0", "1", "2", "3")


### PR DESCRIPTION
For cases not matching against an expression  use `.any?` and with it we use `.include? expr`. This is not entirely faithful to ruby semantics, as matching is done with `.===` but doing so would be uglier with not much upside.