### PR TITLE
simplify staged frontend starter scripts

### DIFF
--- a/joern-cli/frontends/c2cpg/c2cpg.sh
+++ b/joern-cli/frontends/c2cpg/c2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/c2cpg -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -J-XX:+UseStringDeduplication $@
+$SCRIPT_ABS_DIR/target/universal/stage/bin/c2cpg.sh $@

--- a/joern-cli/frontends/csharpsrc2cpg/src/universal/bin/csharpsrc2cpg.sh
+++ b/joern-cli/frontends/csharpsrc2cpg/src/universal/bin/csharpsrc2cpg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH="$0"
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+
+SCRIPT_ABS_DIR=$(dirname "$0")
+SCRIPT="$SCRIPT_ABS_DIR"/csharpsrc2cpg
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/ghidra2cpg/ghidra2cpg.sh
+++ b/joern-cli/frontends/ghidra2cpg/ghidra2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/csharpsrc2cpg $@
+$SCRIPT_ABS_DIR/target/universal/stage/bin/ghidra2cpg.sh $@

--- a/joern-cli/frontends/ghidra2cpg/src/universal/bin/ghidra2cpg.sh
+++ b/joern-cli/frontends/ghidra2cpg/src/universal/bin/ghidra2cpg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH="$0"
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+
+SCRIPT_ABS_DIR=$(dirname "$0")
+SCRIPT="$SCRIPT_ABS_DIR"/ghidra2cpg
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/gosrc2cpg/gosrc2cpg.sh
+++ b/joern-cli/frontends/gosrc2cpg/gosrc2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/gosrc2cpg -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -J-XX:+UseStringDeduplication $@
+$SCRIPT_ABS_DIR/target/universal/stage/bin/gosrc2cpg $@

--- a/joern-cli/frontends/javasrc2cpg/javasrc2cpg.sh
+++ b/joern-cli/frontends/javasrc2cpg/javasrc2cpg.sh
@@ -1,1 +1,6 @@
-javasrc2cpg
+#!/usr/bin/env sh
+
+SCRIPT_ABS_PATH=$(readlink -f "$0")
+SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
+
+$SCRIPT_ABS_DIR/target/universal/stage/bin/javasrc2cpg.sh $@

--- a/joern-cli/frontends/javasrc2cpg/src/universal/bin/javasrc2cpg.sh
+++ b/joern-cli/frontends/javasrc2cpg/src/universal/bin/javasrc2cpg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH="$0"
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+
+SCRIPT_ABS_DIR=$(dirname "$0")
+SCRIPT="$SCRIPT_ABS_DIR"/javasrc2cpg
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/jimple2cpg/jimple2cpg.sh
+++ b/joern-cli/frontends/jimple2cpg/jimple2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/csharpsrc2cpg $@
+$SCRIPT_ABS_DIR/target/universal/stage/bin/jimple2cpg.sh $@

--- a/joern-cli/frontends/jimple2cpg/src/universal/bin/jimple2cpg.sh
+++ b/joern-cli/frontends/jimple2cpg/src/universal/bin/jimple2cpg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH="$0"
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+
+SCRIPT_ABS_DIR=$(dirname "$0")
+SCRIPT="$SCRIPT_ABS_DIR"/jimple2cpg
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/jssrc2cpg/jssrc2cpg.sh
+++ b/joern-cli/frontends/jssrc2cpg/jssrc2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/jssrc2cpg -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -J-XX:+UseStringDeduplication $@
+$SCRIPT_ABS_DIR/target/universal/stage/bin/jssrc2cpg.sh $@

--- a/joern-cli/frontends/php2cpg/php2cpg.sh
+++ b/joern-cli/frontends/php2cpg/php2cpg.sh
@@ -1,1 +1,6 @@
-php2cpg
+#!/usr/bin/env sh
+
+SCRIPT_ABS_PATH=$(readlink -f "$0")
+SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
+
+$SCRIPT_ABS_DIR/target/universal/stage/bin/php2cpg.sh $@

--- a/joern-cli/frontends/php2cpg/src/universal/bin/php2cpg.sh
+++ b/joern-cli/frontends/php2cpg/src/universal/bin/php2cpg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH="$0"
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+
+SCRIPT_ABS_DIR=$(dirname "$0")
+SCRIPT="$SCRIPT_ABS_DIR"/php2cpg
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/rubysrc2cpg/rubysrc2cpg.sh
+++ b/joern-cli/frontends/rubysrc2cpg/rubysrc2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/rubysrc2cpg -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -J-XX:+UseStringDeduplication "$@"
+$SCRIPT_ABS_DIR/target/universal/stage/bin/rubysrc2cpg "$@"

--- a/joern-cli/frontends/swiftsrc2cpg/swiftsrc2cpg.sh
+++ b/joern-cli/frontends/swiftsrc2cpg/swiftsrc2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/swiftsrc2cpg -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -J-XX:+UseStringDeduplication $@
+$SCRIPT_ABS_DIR/target/universal/stage/bin/swiftsrc2cpg $@


### PR DESCRIPTION
Simply invoke the staged x2cpg.sh script without defining additional
JVM properties. If we want to define those by default, it should
rather be done in `src/universal/x2cpg.sh`

N.b. we can't just symlink to the `target/universal/stage/bin/x2cpg.sh`
because of the `SCRIPT_ABS_PATH` handling - we wouldn't be able to
invoke the frontend from different directories any longer.

For now only c2cpg to gather feedback, if it's to your liking I'll
apply the same to all frontends.