### PR TITLE
[ruby] Class Variables

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,6 +1,13 @@
 package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.astcreation.GlobalTypes.{builtinFunctions, builtinPrefix}
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{DummyNode, InstanceFieldIdentifier, MemberAccess, RubyNode}
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
+  ClassFieldIdentifier,
+  DummyNode,
+  InstanceFieldIdentifier,
+  MemberAccess,
+  RubyFieldIdentifier,
+  RubyNode
+}
 import io.joern.rubysrc2cpg.datastructures.{BlockScope, FieldDecl}
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators}
@@ -23,36 +30,35 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def prefixAsBuiltin(x: String): String = s"$builtinPrefix$pathSep$x"
   protected def pathSep                            = "."
 
+  private def astForFieldInstance(name: String, node: RubyNode with RubyFieldIdentifier): Ast = {
+    val identName = node match {
+      case _: InstanceFieldIdentifier => Defines.This
+      case _: ClassFieldIdentifier    => scope.surroundingTypeFullName.getOrElse(Defines.Any)
+    }
+
+    astForFieldAccess(
+      MemberAccess(
+        DummyNode(identifierNode(node, identName, identName, Defines.Any))(node.span.spanStart(identName)),
+        ".",
+        name
+      )(node.span)
+    )
+  }
+
   protected def handleVariableOccurrence(node: RubyNode): Ast = {
     val name       = code(node)
     val identifier = identifierNode(node, name, name, Defines.Any)
     val typeRef    = scope.tryResolveTypeReference(name)
 
     node match {
-      case instanceField: InstanceFieldIdentifier =>
+      case fieldVariable: InstanceFieldIdentifier =>
         scope.findFieldInScope(name) match {
           case None =>
-            scope.pushField(FieldDecl(name, Defines.Any, false, false, node))
-            astForFieldAccess(
-              MemberAccess(
-                DummyNode(identifierNode(instanceField, Defines.This, Defines.This, Defines.Any))(
-                  instanceField.span.spanStart(Defines.This)
-                ),
-                ".",
-                name
-              )(instanceField.span)
-            )
+            scope.pushField(FieldDecl(name, Defines.Any, false, false, fieldVariable))
+            astForFieldInstance(name, fieldVariable)
           case Some(field) =>
             val fieldNode = field.node
-            astForFieldAccess(
-              MemberAccess(
-                DummyNode(identifierNode(fieldNode, Defines.This, Defines.This, Defines.Any))(
-                  instanceField.span.spanStart(Defines.This)
-                ),
-                ".",
-                name
-              )(fieldNode.span)
-            )
+            astForFieldInstance(name, fieldNode)
         }
       case _ =>
         scope.lookupVariable(name) match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -33,7 +33,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   private def astForFieldInstance(name: String, node: RubyNode with RubyFieldIdentifier): Ast = {
     val identName = node match {
       case _: InstanceFieldIdentifier => Defines.This
-      case _: ClassFieldIdentifier    => scope.surroundingTypeFullName.getOrElse(Defines.Any)
+      case _: ClassFieldIdentifier    => scope.surroundingTypeFullName.map(_.split("[.]").last).getOrElse(Defines.Any)
     }
 
     astForFieldAccess(
@@ -51,7 +51,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     val typeRef    = scope.tryResolveTypeReference(name)
 
     node match {
-      case fieldVariable: InstanceFieldIdentifier =>
+      case fieldVariable: RubyFieldIdentifier =>
         scope.findFieldInScope(name) match {
           case None =>
             scope.pushField(FieldDecl(name, Defines.Any, false, false, fieldVariable))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -57,8 +57,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
             scope.pushField(FieldDecl(name, Defines.Any, false, false, fieldVariable))
             astForFieldInstance(name, fieldVariable)
           case Some(field) =>
-            val fieldNode = field.node
-            astForFieldInstance(name, fieldNode)
+            astForFieldInstance(name, field.node)
         }
       case _ =>
         scope.lookupVariable(name) match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -309,12 +309,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   protected def astForSimpleIdentifier(node: RubyNode with RubyIdentifier): Ast = {
     val name = code(node)
 
-    if (name.startsWith("@@")) {
-      logger.warn(
-        s"Class (@@) are not handled as members yet, but are instead handled as simple identifier declarations. Found: $name"
-      )
-    }
-
     scope.lookupVariable(name) match {
       case None if scope.tryResolveMethodInvocation(node.text, List.empty).isDefined =>
         astForSimpleCall(SimpleCall(node, List())(node.span))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -60,7 +60,7 @@ object RubyIntermediateAst {
     name: RubyNode,
     baseClass: Option[RubyNode],
     body: RubyNode,
-    fields: List[InstanceFieldIdentifier]
+    fields: List[RubyNode with RubyFieldIdentifier]
   )(span: TextSpan)
       extends RubyNode(span)
       with TypeDeclaration
@@ -132,7 +132,13 @@ object RubyIntermediateAst {
     */
   sealed trait ControlFlowClause
 
+  /** Any structure that is an Identifier, except self. e.g. `a`, `@a`, `@@a`
+    */
   sealed trait RubyIdentifier
+
+  /** Ruby Instance or Class Variable Identifiers: `@a`, `@@a`
+    */
+  sealed trait RubyFieldIdentifier extends RubyIdentifier
 
   final case class RescueExpression(
     body: RubyNode,
@@ -209,7 +215,10 @@ object RubyIntermediateAst {
       with RubyIdentifier
 
   /** Represents a InstanceFieldIdentifier e.g `@x` */
-  final case class InstanceFieldIdentifier()(span: TextSpan) extends RubyNode(span) with RubyIdentifier
+  final case class InstanceFieldIdentifier()(span: TextSpan) extends RubyNode(span) with RubyFieldIdentifier
+
+  /** Represents a ClassFieldIdentifier e.g `@@x` */
+  final case class ClassFieldIdentifier()(span: TextSpan) extends RubyNode(span) with RubyFieldIdentifier
 
   final case class SelfIdentifier()(span: TextSpan) extends RubyNode(span)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.datastructures
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.RubyNode
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{RubyFieldIdentifier, RubyNode}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.datastructures.{NamespaceLikeScope, TypedScopeElement}
 import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
@@ -11,8 +11,13 @@ import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
   */
 case class NamespaceScope(fullName: String) extends NamespaceLikeScope
 
-case class FieldDecl(name: String, typeFullName: String, isStatic: Boolean, isInitialized: Boolean, node: RubyNode)
-    extends TypedScopeElement
+case class FieldDecl(
+  name: String,
+  typeFullName: String,
+  isStatic: Boolean,
+  isInitialized: Boolean,
+  node: RubyNode with RubyFieldIdentifier
+) extends TypedScopeElement
 
 /** A type-like scope with a full name.
   */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -714,6 +714,11 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   ): (RubyNode, List[RubyNode with RubyFieldIdentifier]) = {
     val loweredClassDecls = lowerSingletonClassDeclarations(ctxBodyStatement)
 
+    /** Generates SingleAssignment RubyNodes for list of fields and fields found in method decls
+      * @param fields
+      * @param fieldsInMethodDecls
+      * @return
+      */
     def genSingleAssignmentStmtList(
       fields: List[RubyNode],
       fieldsInMethodDecls: List[RubyNode]
@@ -769,7 +774,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
               //   <instanceField> = nil; <instanceField> = ...;
               case stmtList: StatementList =>
                 val initializers = initStmtListStatements :+ clinitMethod
-                StatementList(initializers ++ stmtList.statements)(stmtList.span)
+                StatementList(initializers ++ rest)(stmtList.span)
               case x => x
             }
           case None =>
@@ -778,7 +783,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
                 stmtList.span
               )
             val initializers = newInitMethod :: clinitMethod :: Nil
-            StatementList(newInitMethod +: stmtList.statements)(stmtList.span)
+            StatementList(initializers ++ rest)(stmtList.span)
         }
 
         val combinedFields = rubyFieldIdentifiers ++ instanceFieldsInMethodDecls ++ classFieldsInMethodDecls

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -415,6 +415,7 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create respective member nodes" in {
+      cpg.typeDecl.nameExact("Foo").dotAst.l.foreach(println)
       inside(cpg.typeDecl.name("Foo").l) {
         case fooType :: Nil =>
           inside(fooType.member.l) {
@@ -435,8 +436,8 @@ class ClassTests extends RubyCode2CpgFixture {
       inside(cpg.typeDecl.name("Foo").l) {
         case fooType :: Nil =>
           inside(fooType.method.name(Defines.ConstructorMethodName).l) {
-            case clinitMethod :: Nil =>
-              inside(clinitMethod.block.astChildren.isCall.name(Operators.assignment).l) {
+            case initMethod :: Nil =>
+              inside(initMethod.block.astChildren.isCall.name(Operators.assignment).l) {
                 case aAssignment :: bAssignment :: cAssignment :: dAssignment :: oAssignment :: Nil =>
                   aAssignment.code shouldBe "@a = nil"
 
@@ -454,6 +455,83 @@ class ClassTests extends RubyCode2CpgFixture {
                         case (identifier: Identifier) :: (fieldIdentifier: FieldIdentifier) :: Nil =>
                           identifier.code shouldBe RubyDefines.This
                           fieldIdentifier.code shouldBe "@a"
+                        case _ => fail("Expected identifier and fieldIdentifier for fieldAccess")
+                      }
+
+                      rhs.code shouldBe "nil"
+                    case _ => fail("Expected only LHS and RHS for assignment call")
+                  }
+                case _ => fail("")
+              }
+            case xs => fail(s"Expected one method for init, instead got ${xs.name.mkString(", ")}")
+          }
+        case xs => fail(s"Expected TypeDecl for Foo, instead got ${xs.name.mkString(", ")}")
+      }
+    }
+  }
+
+  "Class Variables in Class and Methods" should {
+    val cpg = code("""
+        |class Foo
+        | @@a
+        |
+        | def foo
+        |   @@b = 10
+        | end
+        |
+        | def foobar
+        |   @@c = 20
+        |   @@d = 40
+        | end
+        |
+        | def barfoo
+        |   puts @@a
+        |   puts @@c
+        |   @@o = "a"
+        | end
+        |end
+        |""".stripMargin)
+
+    "create respective member nodes" in {
+      inside(cpg.typeDecl.name("Foo").l) {
+        case fooType :: Nil =>
+          inside(fooType.member.l) {
+            case aMember :: bMember :: cMember :: dMember :: oMember :: Nil =>
+              // Test that all members in class are present
+              aMember.code shouldBe "@@a"
+              bMember.code shouldBe "@@b"
+              cMember.code shouldBe "@@c"
+              dMember.code shouldBe "@@d"
+              oMember.code shouldBe "@@o"
+            case _ => fail("Expected 5 members")
+          }
+        case xs => fail(s"Expected TypeDecl for Foo, instead got ${xs.name.mkString(", ")}")
+      }
+    }
+
+    "create nil assignments under the class initializer" in {
+      inside(cpg.typeDecl.name("Foo").l) {
+        case fooType :: Nil =>
+          inside(fooType.method.name(Defines.StaticInitMethodName).l) {
+            case clinitMethod :: Nil =>
+              inside(clinitMethod.block.astChildren.isCall.name(Operators.assignment).l) {
+                case aAssignment :: bAssignment :: cAssignment :: dAssignment :: oAssignment :: Nil =>
+                  aAssignment.code shouldBe "@@a = nil"
+
+                  bAssignment.code shouldBe "@@b = nil"
+                  cAssignment.code shouldBe "@@c = nil"
+                  dAssignment.code shouldBe "@@d = nil"
+                  oAssignment.code shouldBe "@@o = nil"
+
+                  inside(aAssignment.argument.l) {
+                    case (lhs: Call) :: (rhs: Literal) :: Nil =>
+                      lhs.code shouldBe "Foo.@@a"
+                      lhs.methodFullName shouldBe Operators.fieldAccess
+
+                      inside(lhs.argument.l) {
+                        case (identifier: Identifier) :: (fieldIdentifier: FieldIdentifier) :: Nil =>
+                          identifier.code shouldBe "Foo"
+                          fieldIdentifier.code shouldBe "@@a"
                         case _ => fail("Expected identifier and fieldIdentifier for fieldAccess")
                       }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -21,7 +21,7 @@ class ClassTests extends RubyCode2CpgFixture {
     classC.lineNumber shouldBe Some(2)
     classC.baseType.l shouldBe List()
     classC.member.l shouldBe List()
-    classC.method.name.l shouldBe List("<init>")
+    classC.method.name.l shouldBe List("<init>", "<clinit>")
   }
 
   "`class C < D` is represented by a TYPE_DECL node inheriting from `D`" in {
@@ -37,7 +37,7 @@ class ClassTests extends RubyCode2CpgFixture {
     classC.fullName shouldBe "Test0.rb:<global>::program.C"
     classC.lineNumber shouldBe Some(2)
     classC.member.l shouldBe List()
-    classC.method.name.l shouldBe List("<init>")
+    classC.method.name.l shouldBe List("<init>", "<clinit>")
 
     val List(typeD) = classC.baseType.l
     typeD.name shouldBe "D"


### PR DESCRIPTION
This PR handles:
 * Class Variables - used a similar structure to the instance variables where all class variables found are added as `Member` nodes under the `TypeDecl`, and initialized to `nil` under the `<clinit>` method

TODO:
 * Need to filter out `var = nil` in the `<clinit>` method if the var is already assigned a default value when created (similar issue to instance variables).

Resolves #4246 