### PR TITLE
[ruby] Bug-Fix: Safe casting for body of MethodDecl to StatementList

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -694,12 +694,16 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     )(ctx.toTextSpan)
   }
 
-  private def findFieldsInmethodDecls(methodDecls: List[MethodDeclaration]): List[RubyNode with RubyFieldIdentifier] = {
+  private def findFieldsInMethodDecls(methodDecls: List[MethodDeclaration]): List[RubyNode with RubyFieldIdentifier] = {
     // TODO: Handle case where body of method is not a StatementList
     methodDecls
-      .flatMap {
-        _.body.asInstanceOf[StatementList].statements.collect { case x: SingleAssignment =>
-          x.lhs
+      .flatMap { x =>
+        x.body match {
+          case stmtList: StatementList =>
+            stmtList.statements.collect { case x: SingleAssignment =>
+              x.lhs
+            }
+          case _ => List.empty
         }
       }
       .collect { case x: RubyNode with RubyFieldIdentifier =>
@@ -752,7 +756,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
           x
         }
 
-        val fieldsInMethodDecls = findFieldsInmethodDecls(methodDecls)
+        val fieldsInMethodDecls = findFieldsInMethodDecls(methodDecls)
 
         val (instanceFieldsInMethodDecls, classFieldsInMethodDecls) = partitionRubyFields(fieldsInMethodDecls)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -549,22 +549,7 @@ class ClassTests extends RubyCode2CpgFixture {
 
   "Bodies that aren't StatementList" should {
     val cpg = code("""
-        |require 'base64'
-        |require 'digest'
-        |require 'openssl'
-        |
-        |module SendGrid
-        |  # This class allows you to use the Event Webhook feature. Read the docs for
-        |  # more details: https://sendgrid.com/docs/for-developers/tracking-events/event
         |  class EventWebhook
-        |    # * *Args* :
-        |    #   - +public_key+ -> verification key under Mail Settings
-        |    #
-        |    def convert_public_key_to_ecdsa(public_key)
-        |      verify_engine
-        |      OpenSSL::PKey::EC.new(Base64.decode64(public_key))
-        |    end
-        |
         |    # * *Args* :
         |    #   - +public_key+ -> elliptic curve public key
         |    #   - +payload+ -> event payload in the request body
@@ -579,26 +564,7 @@ class ClassTests extends RubyCode2CpgFixture {
         |    rescue StandardError
         |      false
         |    end
-        |
-        |    def verify_engine
-        |      # JRuby does not fully support ECDSA: https://github.com/jruby/jruby-openssl/issues/193
-        |      raise NotSupportedError, "Event Webhook verification is not supported by JRuby" if RUBY_PLATFORM == "java"
-        |    end
-        |
-        |    class Error < ::RuntimeError
-        |    end
-        |
-        |    class NotSupportedError < Error
-        |    end
         |  end
-        |
-        |  # This class lists headers that get posted to the webhook. Read the docs for
-        |  # more details: https://sendgrid.com/docs/for-developers/tracking-events/event
-        |  class EventWebhookHeader
-        |    SIGNATURE = "HTTP_X_TWILIO_EMAIL_EVENT_WEBHOOK_SIGNATURE".freeze
-        |    TIMESTAMP = "HTTP_X_TWILIO_EMAIL_EVENT_WEBHOOK_TIMESTAMP".freeze
-        |  end
-        |end
         |""".stripMargin)
     "not throw an execption" in {
       inside(cpg.method.name("verify_signature").l) {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -546,4 +546,65 @@ class ClassTests extends RubyCode2CpgFixture {
       }
     }
   }
+
+  "Bodies that aren't StatementList" should {
+    val cpg = code("""
+        |require 'base64'
+        |require 'digest'
+        |require 'openssl'
+        |
+        |module SendGrid
+        |  # This class allows you to use the Event Webhook feature. Read the docs for
+        |  # more details: https://sendgrid.com/docs/for-developers/tracking-events/event
+        |  class EventWebhook
+        |    # * *Args* :
+        |    #   - +public_key+ -> verification key under Mail Settings
+        |    #
+        |    def convert_public_key_to_ecdsa(public_key)
+        |      verify_engine
+        |      OpenSSL::PKey::EC.new(Base64.decode64(public_key))
+        |    end
+        |
+        |    # * *Args* :
+        |    #   - +public_key+ -> elliptic curve public key
+        |    #   - +payload+ -> event payload in the request body
+        |    #   - +signature+ -> signature value obtained from the 'X-Twilio-Email-Event-Webhook-Signature' header
+        |    #   - +timestamp+ -> timestamp value obtained from the 'X-Twilio-Email-Event-Webhook-Timestamp' header
+        |    def verify_signature(public_key, payload, signature, timestamp)
+        |      verify_engine
+        |      timestamped_playload = "#{timestamp}#{payload}"
+        |      payload_digest = Digest::SHA256.digest(timestamped_playload)
+        |      decoded_signature = Base64.decode64(signature)
+        |      public_key.dsa_verify_asn1(payload_digest, decoded_signature)
+        |    rescue StandardError
+        |      false
+        |    end
+        |
+        |    def verify_engine
+        |      # JRuby does not fully support ECDSA: https://github.com/jruby/jruby-openssl/issues/193
+        |      raise NotSupportedError, "Event Webhook verification is not supported by JRuby" if RUBY_PLATFORM == "java"
+        |    end
+        |
+        |    class Error < ::RuntimeError
+        |    end
+        |
+        |    class NotSupportedError < Error
+        |    end
+        |  end
+        |
+        |  # This class lists headers that get posted to the webhook. Read the docs for
+        |  # more details: https://sendgrid.com/docs/for-developers/tracking-events/event
+        |  class EventWebhookHeader
+        |    SIGNATURE = "HTTP_X_TWILIO_EMAIL_EVENT_WEBHOOK_SIGNATURE".freeze
+        |    TIMESTAMP = "HTTP_X_TWILIO_EMAIL_EVENT_WEBHOOK_TIMESTAMP".freeze
+        |  end
+        |end
+        |""".stripMargin)
+    "not throw an execption" in {
+      inside(cpg.method.name("verify_signature").l) {
+        case verifySigMethod :: Nil => // Passing case
+        case _                      => fail("Expected method for verify_sginature")
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR Handles
 * Changed casting of body for MethodDecl to handle case for body where it isn't StatementList. Defaulted to `List.empty` until proper implementation is done at a later stage.