### PR TITLE
Find lombok uses by scanning source code instead of fetched dependencies

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jpastprinter/JavaParserAstPrinter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jpastprinter/JavaParserAstPrinter.scala
@@ -11,8 +11,7 @@ import java.nio.file.Path
 
 object JavaParserAstPrinter {
   def printJpAsts(config: Config): Unit = {
-
-    val sourceParser = SourceParser(config, false, None)
+    val sourceParser = SourceParser(config, None)
     val printer      = new YamlPrinter(true)
 
     SourceFiles

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -60,7 +60,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
 
   private def initParserAndUtils(config: Config): (SourceParser, JavaSymbolSolver) = {
     val dependencies = getDependencyList(config.inputPath)
-    val sourceParser = SourceParser(config, dependencies.exists(_.contains("lombok")), sourcesOverride)
+    val sourceParser = SourceParser(config, sourcesOverride)
     val symbolSolver = createSymbolSolver(config, dependencies, sourceParser)
     (sourceParser, symbolSolver)
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -76,7 +76,11 @@ object Delombok {
     }
   }
 
-  def run(inputPath: Path, relativeFilenames: List[Path], analysisJavaHome: Option[String]): DelombokRunResult = {
+  def run(
+    inputPath: Path,
+    fileInfo: List[SourceParser.FileInfo],
+    analysisJavaHome: Option[String]
+  ): DelombokRunResult = {
     Try(File.newTemporaryDirectory(prefix = "delombok").deleteOnExit()) match {
       case Failure(_) =>
         logger.warn(s"Could not create temporary directory for delombok output. Scanning original sources instead")
@@ -84,7 +88,7 @@ object Delombok {
 
       case Success(tempDir) =>
         PackageRootFinder
-          .packageRootsFromFiles(inputPath, relativeFilenames)
+          .packageRootsFromFiles(inputPath, fileInfo)
           .foreach(delombokPackageRoot(inputPath, _, tempDir, analysisJavaHome))
         DelombokRunResult(tempDir.path, true)
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/PackageRootFinder.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/PackageRootFinder.scala
@@ -8,50 +8,43 @@ import scala.util.matching.Regex
 
 object PackageRootFinder {
 
-  private val PackageNameRegex: Regex = raw"package\s+([a-zA-Z$$_.]+)\s*;".r
-
-  def packageRootsFromFiles(inputPath: Path, relativeFilenames: List[Path]): List[Path] = {
+  def packageRootsFromFiles(inputPath: Path, fileInfos: List[SourceParser.FileInfo]): List[Path] = {
     // Files are sorted by path length to efficiently handle the non-standard package structure case described
     // below. If the `parentDirectory` in that case is closest to the input path, then the largest number of
     // files will be removed from the `filesToCheck` list.
-    var filesToCheck                              = mutable.ListBuffer.from(relativeFilenames).sortBy(_.getNameCount)
+    var filesToCheck = mutable.ListBuffer.from(fileInfos).sortBy(_.relativePath.getNameCount)
     val discoveredRoots: mutable.ListBuffer[Path] = mutable.ListBuffer.empty
 
     while (filesToCheck.nonEmpty) {
-      val filePath = filesToCheck.remove(0)
+      val fileInfo = filesToCheck.remove(0)
       // If filePath.getParent is null, then parent is actually the inputPath, but in this case
       // we don't want to "break out" of the specified input directory, so just use the relative
       // path `.`, which is equivalent to the inputPath since it is relative to the input path
       val dotPath         = Path.of(".")
-      val parentDirectory = Option(filePath.getParent).getOrElse(dotPath)
+      val parentDirectory = Option(fileInfo.relativePath.getParent).getOrElse(dotPath)
 
-      SourceParser.fileIfExists(inputPath.resolve(filePath)).foreach { file =>
-        val discoveredRoot = packageNameForFile(file) match {
-          case Some(packageName) =>
-            val packageDirs = Path.of(packageName.replaceAll(raw"\.", "/"))
+      val discoveredRoot = fileInfo.packageName match {
+        case Some(packageName) =>
+          val packageDirs = Path.of(packageName.replaceAll(raw"\.", "/"))
 
-            if (parentDirectory.endsWith(packageDirs))
-              parentDirectory.subpath(0, parentDirectory.getNameCount - packageDirs.getNameCount)
-            else
-              // In this case, the package name doesn't match the given directory structure, either
-              // because the project doesn't follow convention or because the given inputPath is
-              // already a subdirectory of the package tree (for example, `projectRoot/src/main/java/com/`)
-              filePath
+          if (parentDirectory.endsWith(packageDirs))
+            parentDirectory.subpath(0, parentDirectory.getNameCount - packageDirs.getNameCount)
+          else
+            // In this case, the package name doesn't match the given directory structure, either
+            // because the project doesn't follow convention or because the given inputPath is
+            // already a subdirectory of the package tree (for example, `projectRoot/src/main/java/com/`)
+            fileInfo.relativePath
 
-          case None => filePath
-        }
+        case None => fileInfo.relativePath
+      }
 
-        discoveredRoots.addOne(discoveredRoot)
-        if (discoveredRoot != dotPath) {
-          filesToCheck = filesToCheck.filterNot(path => path.startsWith(discoveredRoot))
-        }
+      discoveredRoots.addOne(discoveredRoot)
+      if (discoveredRoot != dotPath) {
+        filesToCheck = filesToCheck.filterNot(info => info.relativePath.startsWith(discoveredRoot))
       }
     }
 
     discoveredRoots.toList
   }
 
-  private def packageNameForFile(file: File): Option[String] = {
-    PackageNameRegex.findFirstMatchIn(file.contentAsString).map(_.group(1))
-  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.semanticcpg.language._
 import io.joern.javasrc2cpg.Config
 
 class LombokTests extends JavaSrcCode2CpgFixture {
-  val config = Config().withDelombokMode("run-delombok")
+  private val config = Config().withDelombokMode("default")
 
   "source in a mixed directory structure" should {
     val cpg = code(

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -16,8 +16,10 @@ trait JavaSrcFrontend extends LanguageFrontend {
   override val fileSuffix: String = ".java"
 
   override def execute(sourceCodeFile: File): Cpg = {
-    val config =
-      getConfig().map(_.asInstanceOf[Config]).getOrElse(JavaSrc2Cpg.DefaultConfig).withCacheJdkTypeSolver(true)
+    val config = getConfig()
+      .map(_.asInstanceOf[Config])
+      .getOrElse(JavaSrc2Cpg.DefaultConfig.withDelombokMode("no-delombok"))
+      .withCacheJdkTypeSolver(true)
     new JavaSrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath)(config).get
   }
 }


### PR DESCRIPTION
Before, the default `Delombok` behaviour was to check if `lombok` was found in the list of fetched dependencies and to run `delombok` if it was. With this PR, we check if `lombok` appears in code instead. This eliminates the dependence on successful dependency fetching.

I chose to just check for the substring `lombok` in any of the source files since this is a very simple check to do while also accounting for using lombok with fully qualified types instead of imports and it's not a common enough string to appear in natural non-lombok code in most cases. The cost for a false positive is also quite small. We would unnecessarily delombok the code, but since lombok wasn't used, we'd effectively still be scanning the original source files with only a bit of time wasted.

The bulk of the changes in this PR are just me moving things around to avoid having to read the file contents twice (to figure out if delombok needs to be run and again when finding package roots)