### PR TITLE
[ruby] Handle Method with Array/Hash Init Arg

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -171,7 +171,10 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
               if node.indices.exists(_.isInstanceOf[Association]) then HashLiteral(node.indices)(node.span) :: Nil
               else ArrayLiteral(node.indices)(node.span) :: Nil
             val expr = astForExpression(SimpleCall(arrayMethodName, args)(node.span))
-            expr.root.collect { case x: NewCall => x.methodFullName(s"$typeReference:${m.name}") }
+            expr.root.collect { case x: NewCall =>
+              x.methodFullName(s"$typeReference:${m.name}")
+              scope.tryResolveTypeReference(m.returnType).map(_.name).foreach(x.typeFullName(_))
+            }
             expr
           }
           .getOrElse(defaultBehaviour)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -1,10 +1,10 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{Unknown, *}
-import io.joern.rubysrc2cpg.datastructures.{BlockScope, FieldDecl}
-import io.joern.rubysrc2cpg.passes.Defines.{RubyOperators, getBuiltInType}
-import io.joern.x2cpg.{Ast, Defines as XDefines, ValidationMode}
+import io.joern.rubysrc2cpg.datastructures.BlockScope
 import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.rubysrc2cpg.passes.Defines.{RubyOperators, getBuiltInType}
+import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators, PropertyNames}
 
@@ -153,11 +153,30 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   protected def astForIndexAccess(node: IndexAccess): Ast = {
-    val indexAsts = node.indices.map(astForExpression)
-    val targetAst = astForExpression(node.target)
-    val call = callNode(node, code(node), Operators.indexAccess, Operators.indexAccess, DispatchTypes.STATIC_DISPATCH)
-
-    callAst(call, targetAst +: indexAsts)
+    // Array::[] and Hash::[] looks like an index access to the parser, some other methods may have this name too
+    lazy val arrayMethodName = SimpleIdentifier(None)(node.span.spanStart("[]"))
+    lazy val defaultBehaviour = {
+      val indexAsts = node.indices.map(astForExpression)
+      val targetAst = astForExpression(node.target)
+      val call =
+        callNode(node, code(node), Operators.indexAccess, Operators.indexAccess, DispatchTypes.STATIC_DISPATCH)
+      callAst(call, targetAst +: indexAsts)
+    }
+    scope.tryResolveTypeReference(node.target.text).map(_.name) match {
+      case Some(typeReference) =>
+        scope
+          .tryResolveMethodInvocation("[]", List.empty, Option(typeReference))
+          .map { m =>
+            val args =
+              if node.indices.exists(_.isInstanceOf[Association]) then HashLiteral(node.indices)(node.span) :: Nil
+              else ArrayLiteral(node.indices)(node.span) :: Nil
+            val expr = astForExpression(SimpleCall(arrayMethodName, args)(node.span))
+            expr.root.collect { case x: NewCall => x.methodFullName(s"$typeReference:${m.name}") }
+            expr
+          }
+          .getOrElse(defaultBehaviour)
+      case None => defaultBehaviour
+    }
   }
 
   protected def astForObjectInstantiation(node: RubyNode with ObjectInstantiation): Ast = {
@@ -376,10 +395,14 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   protected def astForHashLiteral(node: HashLiteral): Ast = {
+    val tmp = freshVariableName
+
+    def tmpAst(tmpNode: Option[RubyNode] = None) = astForSimpleIdentifier(
+      SimpleIdentifier()(tmpNode.map(_.span).getOrElse(node.span).spanStart(tmp))
+    )
+
     val block = blockNode(node)
     scope.pushNewScope(BlockScope(block))
-
-    val tmp = freshVariableName
 
     val argumentAsts = node.elements.flatMap(elem =>
       elem match
@@ -388,19 +411,24 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
           logger.warn(s"Could not represent element: ${code(node)} ($relativeFileName), skipping")
           astForUnknown(node) :: Nil
     )
-    val call = callNode(
+
+    val hashInitCall = callNode(
       node,
       code(node),
       RubyOperators.hashInitializer,
       RubyOperators.hashInitializer,
       DispatchTypes.STATIC_DISPATCH
     )
+
+    val assignment =
+      callNode(node, code(node), Operators.assignment, Operators.assignment, DispatchTypes.STATIC_DISPATCH)
+    val tmpAssignment = callAst(assignment, tmpAst() :: Ast(hashInitCall) :: Nil)
+
     scope.popScope()
-    blockAst(block, List(callAst(call, argumentAsts)))
+    blockAst(block, tmpAssignment +: argumentAsts :+ tmpAst(node.elements.lastOption))
   }
 
   protected def astForAssociationHash(node: Association, tmp: String): List[Ast] = {
-    val tmpAst = astForSimpleIdentifier(SimpleIdentifier()(node.span.spanStart(tmp)))
     node.key match {
       case rangeExpr: RangeExpression =>
         val expandedList = generateStaticLiteralsForRange(rangeExpr).map { x =>
@@ -408,12 +436,12 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         }
 
         if (expandedList.nonEmpty) {
-          expandedList :+ tmpAst
+          expandedList
         } else {
-          astForSingleKeyValue(node.key, node.value, tmp) :: tmpAst :: Nil
+          astForSingleKeyValue(node.key, node.value, tmp) :: Nil
         }
 
-      case _ => astForSingleKeyValue(node.key, node.value, tmp) :: tmpAst :: Nil
+      case _ => astForSingleKeyValue(node.key, node.value, tmp) :: Nil
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.datastructures
 
 import better.files.File
 import io.joern.rubysrc2cpg.astcreation.GlobalTypes
+import io.joern.rubysrc2cpg.astcreation.GlobalTypes.builtinPrefix
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.datastructures.*
 import io.shiftleft.codepropertygraph.generated.NodeTypes
@@ -21,6 +22,23 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
 
   override val typesInScope: mutable.Set[RubyType] =
     mutable.Set(RubyType(GlobalTypes.builtinPrefix, builtinMethods, List.empty))
+
+  // Add some built-in methods that are significant
+  // TODO: Perhaps create an offline pre-built list of methods
+  typesInScope.addAll(
+    Seq(
+      RubyType(
+        s"$builtinPrefix.Array",
+        List(RubyMethod("[]", List.empty, s"$builtinPrefix.Array", Option(s"$builtinPrefix.Array"))),
+        List.empty
+      ),
+      RubyType(
+        s"$builtinPrefix.Hash",
+        List(RubyMethod("[]", List.empty, s"$builtinPrefix.Hash", Option(s"$builtinPrefix.Hash"))),
+        List.empty
+      )
+    )
+  )
 
   override val membersInScope: mutable.Set[MemberLike] = mutable.Set(builtinMethods*)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -160,6 +160,7 @@ object AntlrContextHelpers {
       case ctx: CommandIndexingArgumentListContext => List(ctx.command())
       case ctx: OperatorExpressionListIndexingArgumentListContext =>
         ctx.operatorExpressionList().operatorExpression().asScala.toList
+      case ctx: AssociationListIndexingArgumentListContext => ctx.associationList().associations
       case ctx =>
         logger.warn(s"Unsupported argument type ${ctx.getClass}")
         List()

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/CallCpgTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/passes/ast/CallCpgTests.scala
@@ -147,7 +147,6 @@ class CallCpgTests extends RubyCode2CpgFixture(withPostProcessing = true, useDep
         |""".stripMargin)
 
     "take note of the here doc locations and construct the literals respectively from the following statements" in {
-      cpg.method(":program").dotAst.foreach(println)
       val List(one, two) = cpg.call.nameExact("puts").argument.isLiteral.l: @unchecked
       one.code shouldBe "content for heredoc one"
       one.lineNumber shouldBe Option(1)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -96,4 +96,34 @@ class ArrayTests extends RubyCode2CpgFixture {
     y.code shouldBe "y"
     y.typeFullName shouldBe "__builtin.Symbol"
   }
+
+  "an implicit array constructor (Array::[]) should be lowered to an array initializer" in {
+    val cpg = code("""
+        |x = Array [1, 2, 3]
+        |""".stripMargin)
+
+    inside(cpg.call.name(Operators.arrayInitializer).l) {
+      case arrayCall :: Nil =>
+        arrayCall.code shouldBe "Array [1, 2, 3]"
+        arrayCall.lineNumber shouldBe Some(2)
+
+        inside(arrayCall.inCall.headOption) {
+          case Some(bracketCall) =>
+            bracketCall.name shouldBe "[]"
+            bracketCall.methodFullName shouldBe "__builtin.Array:[]"
+          case None => fail("Expected a call with the name []")
+        }
+
+        inside(arrayCall.argument.l) {
+          case one :: two :: three :: Nil =>
+            one.code shouldBe "1"
+            two.code shouldBe "2"
+            three.code shouldBe "3"
+          case xs => fail(s"Expected 3 literals under the array initializer, instead got [${xs.code.mkString(", ")}]")
+        }
+      case xs => fail(s"Expected a single array initializer call, instead got [${xs.code.mkString(", ")}]")
+    }
+
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -111,6 +111,7 @@ class ArrayTests extends RubyCode2CpgFixture {
           case Some(bracketCall) =>
             bracketCall.name shouldBe "[]"
             bracketCall.methodFullName shouldBe "__builtin.Array:[]"
+            bracketCall.typeFullName shouldBe "__builtin.Array"
           case None => fail("Expected a call with the name []")
         }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -415,7 +415,6 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create respective member nodes" in {
-      cpg.typeDecl.nameExact("Foo").dotAst.l.foreach(println)
       inside(cpg.typeDecl.name("Foo").l) {
         case fooType :: Nil =>
           inside(fooType.member.l) {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -13,9 +13,8 @@ class HashTests extends RubyCode2CpgFixture {
                      |{}
                      |""".stripMargin)
 
-    val List(hashCall) = cpg.call.l
+    val List(hashCall) = cpg.call.name(RubyOperators.hashInitializer).l
 
-    hashCall.methodFullName shouldBe RubyOperators.hashInitializer
     hashCall.code shouldBe "{}"
     hashCall.lineNumber shouldBe Some(2)
   }
@@ -29,7 +28,7 @@ class HashTests extends RubyCode2CpgFixture {
     hashCall.code shouldBe "{x:1}"
     hashCall.lineNumber shouldBe Some(2)
 
-    val List(assocCall) = hashCall.argument.isCall.l
+    val List(assocCall) = hashCall.inCall.astSiblings.assignment.l
     val List(x, one)    = assocCall.argument.l
     x.code shouldBe "<tmp-0>[x]"
     one.code shouldBe "1"
@@ -43,7 +42,7 @@ class HashTests extends RubyCode2CpgFixture {
 
     inside(cpg.call.name(RubyOperators.hashInitializer).l) {
       case hashInitializerInt :: hashInitializerString :: Nil =>
-        inside(hashInitializerInt.argument.isCall.l) {
+        inside(hashInitializerInt.inCall.astSiblings.assignment.l) {
           case firstCall :: secondCall :: thirdCall :: fourthCall :: fifthCall :: Nil =>
             firstCall.code shouldBe "<tmp-0>[1] = \"abc\""
             secondCall.code shouldBe "<tmp-0>[2] = \"abc\""
@@ -71,7 +70,7 @@ class HashTests extends RubyCode2CpgFixture {
           case _ => fail("Expected 5 calls (one per item in range)")
         }
 
-        inside(hashInitializerString.argument.isCall.l) {
+        inside(hashInitializerString.inCall.astSiblings.assignment.l) {
           case firstCall :: secondCall :: thirdCall :: Nil =>
             firstCall.code shouldBe "<tmp-1>['a'] = \"abc\""
             secondCall.code shouldBe "<tmp-1>['b'] = \"abc\""
@@ -100,8 +99,8 @@ class HashTests extends RubyCode2CpgFixture {
 
     inside(cpg.call.name(RubyOperators.hashInitializer).l) {
       case hashInitializer :: Nil =>
-        inside(hashInitializer.argument.l) {
-          case (firstCall: Call) :: (secondCall: Call) :: (tmp: Identifier) :: Nil =>
+        inside(hashInitializer.inCall.astSiblings.l) {
+          case _ :: (firstCall: Call) :: (secondCall: Call) :: (tmp: Identifier) :: Nil =>
             firstCall.code shouldBe "<tmp-0>[1] = \"abc\""
             secondCall.code shouldBe "<tmp-0>[2] = \"abc\""
             tmp.name shouldBe "<tmp-0>"
@@ -118,7 +117,7 @@ class HashTests extends RubyCode2CpgFixture {
 
     inside(cpg.call.name(RubyOperators.hashInitializer).l) {
       case hashInitializer :: Nil =>
-        inside(hashInitializer.argument.isCall.l) {
+        inside(hashInitializer.inCall.astSiblings.assignment.l) {
           case rangeExprArg :: Nil =>
             inside(rangeExprArg.argument.l) {
               case (lhs: Call) :: (rhs: Literal) :: Nil =>
@@ -139,6 +138,36 @@ class HashTests extends RubyCode2CpgFixture {
           case _ => fail("Expected one argument for range expression")
         }
       case _ => fail("Expected one hash initializer function")
+    }
+  }
+
+  "an implicit hash constructor (Hash::[]) should be lowered to a hash initializer" in {
+    val cpg = code("""
+        |x = Hash [1 => "a", 2 => "b", 3 => "c"]
+        |""".stripMargin)
+
+    inside(cpg.call.name(RubyOperators.hashInitializer).l) {
+      case hashCall :: Nil =>
+        hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
+        hashCall.lineNumber shouldBe Some(2)
+
+        inside(hashCall.parentBlock.astChildren.l) {
+          case _ :: _ :: (one: Call) :: (two: Call) :: (three: Call) :: (tmp: Identifier) :: Nil =>
+            one.code shouldBe "<tmp-0>[1] = \"a\""
+            two.code shouldBe "<tmp-0>[2] = \"b\""
+            three.code shouldBe "<tmp-0>[3] = \"c\""
+            tmp.code shouldBe "<tmp-0>"
+          case xs => fail(s"Expected 3 literals under the array initializer, instead got [${xs.code.mkString(", ")}]")
+        }
+
+        inside(hashCall.parentBlock.inCall.headOption) {
+          case Some(bracketCall) =>
+            bracketCall.name shouldBe "[]"
+            bracketCall.methodFullName shouldBe "__builtin.Hash:[]"
+          case None => fail("Expected a call with the name []")
+        }
+
+      case xs => fail(s"Expected a single array initializer call, instead got [${xs.code.mkString(", ")}]")
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -164,6 +164,7 @@ class HashTests extends RubyCode2CpgFixture {
           case Some(bracketCall) =>
             bracketCall.name shouldBe "[]"
             bracketCall.methodFullName shouldBe "__builtin.Hash:[]"
+            bracketCall.typeFullName shouldBe "__builtin.Hash"
           case None => fail("Expected a call with the name []")
         }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -138,7 +138,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
     r.code shouldBe "{x:0}"
     r.lineNumber shouldBe Some(2)
 
-    val List(c: Call) = r.astChildren.isBlock.astChildren.isCall.l
+    val List(c: Call) = r.astChildren.isBlock.astChildren.assignment.source.isCall.l
     c.methodFullName shouldBe RubyOperators.hashInitializer
   }
 


### PR DESCRIPTION
`Array::[]` and `Hash::[]` may look like index accesses to the parser, this change adds a check that, if the name on the LHS is a known method, then treat it as such.

This also fixes the hash initializer structure where the lowering happened under the hash initializer call, this change makes this align closer to what Python has for dict literals.

Resolves #4357