### PR TITLE
[ruby]Hash parameter in do-block

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -431,14 +431,7 @@ doBlock
 
 blockParameter
     :   BAR NL* BAR
-    |   BAR NL* blockParameterList NL* BAR
-    ;
-
-blockParameterList
-    :   leftHandSide
-        # singleElementBlockParameterList
-    |   multipleLeftHandSide
-        # multipleElementBlockParameterList
+    |   BAR NL* parameterList NL* BAR
     ;
 
 thenClause

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -90,17 +90,7 @@ object AntlrContextHelpers {
   }
 
   sealed implicit class BlockParameterContextHelper(ctx: BlockParameterContext) {
-    def parameters: List[ParserRuleContext] = Option(ctx.blockParameterList()).map(_.parameters).getOrElse(List())
-  }
-
-  sealed implicit class BlockParameterListContextHelper(ctx: BlockParameterListContext) {
-    def parameters: List[ParserRuleContext] = ctx match
-      case ctx: SingleElementBlockParameterListContext => ctx.leftHandSide() :: Nil
-      case ctx: MultipleElementBlockParameterListContext =>
-        Option(ctx.multipleLeftHandSide()).map(_.multipleLeftHandSideItem()).map(_.asScala.toList).getOrElse(List.empty)
-      case ctx =>
-        logger.warn(s"Unsupported parameter type ${ctx.getClass}")
-        List()
+    def parameters: List[ParserRuleContext] = Option(ctx.parameterList()).map(_.parameters).getOrElse(List())
   }
 
   sealed implicit class CommandArgumentContextHelper(ctx: CommandArgumentContext) {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -258,7 +258,23 @@ class DoBlockTests extends RubyCode2CpgFixture {
         case xs => fail(s"Unexpected `foo` assignment children [${xs.code.mkString(",")}]")
       }
     }
+  }
 
+  "Hash parameter for Do-block" should {
+    val cpg = code("""
+        |  define_method(name) do |**args| # <--- Parser error on this line
+        |          setting_type.fetch(sendgrid_client: sendgrid_client, name: name, query_params: args)
+        |        end
+        |""".stripMargin)
+
+    "Create correct parameter for args" in {
+      inside(cpg.parameter.name("args").l) {
+        case argParam :: Nil =>
+          argParam.name shouldBe "args"
+          argParam.code shouldBe "**args"
+        case _ => fail("Expected parameter `**args` to exist")
+      }
+    }
   }
 
 }


### PR DESCRIPTION
This PR handles:
 * Fixing parser crashing on `HashParameter`.
 * Modified `blockParameter` in grammar to use `parameterList` instead of `blockParameterList`