### PR TITLE
[c#] Safe Download Dependency Handling & Cleanups

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/DependencyTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/DependencyTests.scala
@@ -1,6 +1,7 @@
 package io.joern.csharpsrc2cpg.querying.ast
 
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.joern.csharpsrc2cpg.Config
 import io.shiftleft.semanticcpg.language.*
 
 class DependencyTests extends CSharpCode2CpgFixture {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/testfixtures/CSharpCode2CpgFixture.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/testfixtures/CSharpCode2CpgFixture.scala
@@ -63,7 +63,9 @@ class DefaultTestCpgWithCSharp extends DefaultTestCpg with CSharpFrontend with S
   }
 
   override def applyPostProcessingPasses(): Unit = {
-    CSharpSrc2Cpg.postProcessingPasses(this, config).foreach(_.createAndApply())
+    CSharpSrc2Cpg
+      .postProcessingPasses(this, getConfig().map(_.asInstanceOf[Config]).getOrElse(defaultConfig))
+      .foreach(_.createAndApply())
     super.applyPostProcessingPasses()
   }
 
@@ -73,7 +75,7 @@ trait CSharpFrontend extends LanguageFrontend {
 
   override val fileSuffix: String = ".cs"
 
-  implicit val config: Config =
+  implicit lazy val defaultConfig: Config =
     getConfig()
       .map(_.asInstanceOf[Config])
       .getOrElse(Config().withSchemaValidation(ValidationMode.Enabled))


### PR DESCRIPTION
* Fixed non-exhaustive matching on string interpolation handling
* Wrapped the package version check in a try-catch
* Ignore looking to nuget for packages that are internal to a potential c# monolith
* Fixed test config loading in fixture

Resolves https://github.com/joernio/DotNetAstGen/issues/23
Resolves https://github.com/joernio/DotNetAstGen/issues/24