### PR TITLE
[c#] Avoid Downloading an Existing Summary & Improve Summary Merging

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 csharpsrc2cpg {
-    dotnetastgen_version: "0.26.0"
+    dotnetastgen_version: "0.27.0"
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -119,4 +119,10 @@ case class CSharpMethod(name: String, returnType: String, parameterTypes: List[(
     extends MethodLike derives ReadWriter
 
 case class CSharpType(name: String, methods: List[CSharpMethod], fields: List[CSharpField])
-    extends TypeLike[CSharpMethod, CSharpField] derives ReadWriter
+    extends TypeLike[CSharpMethod, CSharpField] derives ReadWriter {
+  @targetName("add")
+  override def +(o: TypeLike[CSharpMethod, CSharpField]): TypeLike[CSharpMethod, CSharpField] = {
+    this.copy(methods = mergeMethods(o), fields = mergeFields(o))
+  }
+
+}

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
@@ -54,7 +54,8 @@ class DependencyDownloader(
     *   true if the dependency is already in the given summary, false if otherwise.
     */
   private def isAlreadySummarized(dependency: Dependency): Boolean = {
-    // TODO: Check internalSummaries too
+    // TODO: `namespace` != `packageId`, so we may want to have summaries store the `packageId` in future
+    internalProgramSummary.namespaceToType.keySet.exists(_.startsWith(dependency.name)) ||
     internalPackages.contains(dependency.name)
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
@@ -55,8 +55,9 @@ class DependencyDownloader(
     */
   private def isAlreadySummarized(dependency: Dependency): Boolean = {
     // TODO: `namespace` != `packageId`, so we may want to have summaries store the `packageId` in future
-    internalProgramSummary.namespaceToType.keySet.exists(_.startsWith(dependency.name)) ||
-    internalPackages.contains(dependency.name)
+    internalProgramSummary.namespaceToType.keySet.exists(_.startsWith(dependency.name)) || internalPackages.contains(
+      dependency.name
+    )
   }
 
   private case class NuGetPackageVersions(versions: List[String]) derives ReadWriter

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/DependencyDownloadTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/DependencyDownloadTests.scala
@@ -42,8 +42,8 @@ class DependencyDownloadTests extends CSharpCode2CpgFixture {
       summary.typesUnderNamespace("CSharpx") should not be empty
     }
 
-    "not summarize NewtonsoftJson (as it publishes without PDB files)" in {
-      summary.typesUnderNamespace("Microsoft.AspNetCore.Mvc.NewtonsoftJson") shouldBe empty
+    "manage to summarize NewtonsoftJson (as it publishes without PDB files, but DotNetAstGen can generate these)" in {
+      summary.typesUnderNamespace("Microsoft.AspNetCore.Mvc.NewtonsoftJson") should not be empty
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -1,7 +1,8 @@
 package io.joern.rubysrc2cpg.datastructures
 
-import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, TypeLike}
 import io.joern.x2cpg.Defines as XDefines
+import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, TypeLike}
+
 import scala.annotation.targetName
 
 class RubyProgramSummary(
@@ -33,6 +34,12 @@ case class RubyField(name: String, typeName: String) extends FieldLike
 
 case class RubyType(name: String, methods: List[RubyMethod], fields: List[RubyField])
     extends TypeLike[RubyMethod, RubyField] {
+
+  @targetName("add")
+  override def +(o: TypeLike[RubyMethod, RubyField]): TypeLike[RubyMethod, RubyField] = {
+    this.copy(methods = mergeMethods(o), fields = mergeFields(o))
+  }
+
   def hasConstructor: Boolean = {
     methods.exists(_.name == XDefines.ConstructorMethodName)
   }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/datastructures/ProgramSummaryTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/datastructures/ProgramSummaryTests.scala
@@ -3,8 +3,11 @@ package io.joern.x2cpg.datastructures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import io.shiftleft.codepropertygraph.generated.nodes.DeclarationNew
+
 import scala.collection.mutable
 import org.scalatest.Inside
+
+import scala.annotation.targetName
 
 class ProgramSummaryTests extends AnyWordSpec with Matchers with Inside {
 
@@ -113,6 +116,11 @@ class ProgramSummaryTests extends AnyWordSpec with Matchers with Inside {
 
   case class Field(name: String, typeName: String) extends FieldLike
 
-  case class Typ(name: String, methods: List[Method], fields: List[Field]) extends TypeLike[Method, Field]
+  case class Typ(name: String, methods: List[Method], fields: List[Field]) extends TypeLike[Method, Field] {
+    @targetName("add")
+    override def +(o: TypeLike[Method, Field]): TypeLike[Method, Field] = {
+      this.copy(methods = mergeMethods(o), fields = mergeFields(o))
+    }
+  }
 
 }


### PR DESCRIPTION
* Adds a check to existing summaries if existing namespacing starting with the dependency name exists.
* Added `TypeLike` addition handler to handle member collisions.
* Upgraded DotNetAstGen version

Resolves #4368