### PR TITLE
correctly handle <empty> in .content steps

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -26,16 +26,11 @@ class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLoca
       case expr: Expression if expr.argumentIndex == index => expr
     }
 
-  def macroExpansion: Iterator[Expression] =
-    Iterator
-      .single(node)
-      .dispatchTypeExact(DispatchTypes.INLINED)
-      .astChildren
-      .sortBy(_.order)
-      .reverseIterator
-      .isBlock
-      .astChildren
-      .isExpression
+  def macroExpansion: Iterator[Expression] = {
+    if (node.dispatchType != DispatchTypes.INLINED) return Iterator.empty
+
+    node.astChildren.isBlock.maxByOption(_.order).iterator.expressionDown
+  }
 
   override def location: NewLocation = {
     LocationCreator(node, node.code, node.label, node.lineNumber, node.method)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -66,14 +66,11 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
   }
 
   def content: Option[String] = {
-    val contentOption   = method.file.content.headOption
-    val offsetOption    = method.offset
-    val offsetEndOption = method.offsetEnd
-
-    if (contentOption.isDefined && offsetOption.isDefined && offsetEndOption.isDefined) {
-      contentOption.map(_.substring(offsetOption.get, offsetEndOption.get))
-    } else {
-      None
-    }
+    for {
+      content <- method.file.content.headOption
+      if content != File.PropertyDefaults.Content
+      offset    <- method.offset
+      offsetEnd <- method.offsetEnd
+    } yield content.slice(offset, offsetEnd)
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -116,14 +116,11 @@ object TypeDeclTraversal {
   private val maxAliasExpansions = 100
 
   private def contentOnSingle(typeDecl: TypeDecl): Option[String] = {
-    val contentOption   = typeDecl.file.content.headOption
-    val offsetOption    = typeDecl.offset
-    val offsetEndOption = typeDecl.offsetEnd
-
-    if (contentOption.isDefined && offsetOption.isDefined && offsetEndOption.isDefined) {
-      contentOption.map(_.substring(offsetOption.get, offsetEndOption.get))
-    } else {
-      None
-    }
+    for {
+      content <- typeDecl.file.content.headOption
+      if content != File.PropertyDefaults.Content
+      offset    <- typeDecl.offset
+      offsetEnd <- typeDecl.offsetEnd
+    } yield content.slice(offset, offsetEnd)
   }
 }


### PR DESCRIPTION
also use `.slice()` in order to avoid crashing in `.substring()` when the offsets are out of bounds. This just papers over issues with invalid offsets though, so it's arguable whether we actually want to do this?


Also contains a random refactor of the `.macroExpansion` step.