### PR TITLE
[c2cpg] Emit Catch ControlStructures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.3.1"
 
-val cpgVersion = "1.6.6"
+val cpgVersion = "1.6.8"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/cfg/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/cfg/CfgCreationPassTests.scala
@@ -1,10 +1,9 @@
 package io.joern.c2cpg.passes.cfg
 
 import io.joern.c2cpg.parser.FileDefaults
-import io.joern.c2cpg.testfixtures.C2CpgFrontend
 import io.joern.c2cpg.testfixtures.CCfgTestCpg
 import io.joern.x2cpg.passes.controlflow.cfgcreation.Cfg.*
-import io.joern.x2cpg.testfixtures.{CfgTestCpg, CfgTestFixture}
+import io.joern.x2cpg.testfixtures.CfgTestFixture
 import io.shiftleft.codepropertygraph.Cpg
 
 class CfgCreationPassTests extends CfgTestFixture(() => new CCfgTestCpg) {
@@ -524,16 +523,16 @@ class CppCfgCreationPassTests extends CfgTestFixture(() => new CCfgTestCpg(FileD
 
     "be correct for try with multiple catches" in {
       implicit val cpg: Cpg = code("""
-                               |try {
-                               |  a;
-                               |} catch (short x) {
-                               |  b;
-                               |} catch (int y) {
-                               |  c;
-                               |} catch (long z) {
-                               |  d;
-                               |}
-                               |""".stripMargin)
+       |try {
+       |  a;
+       |} catch (short x) {
+       |  b;
+       |} catch (int y) {
+       |  c;
+       |} catch (long z) {
+       |  d;
+       |}
+       |""".stripMargin)
       succOf("func") shouldBe expected(("a", AlwaysEdge))
       // Try should have an edge to all catches and return
       succOf("a") shouldBe expected(("b", AlwaysEdge), ("c", AlwaysEdge), ("d", AlwaysEdge), ("RET", AlwaysEdge))

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -497,33 +497,31 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
 
     val tryBodyCfg: Cfg = maybeTryBlock.map(cfgFor).getOrElse(Cfg.empty)
 
-    val catchBodyCfgsByCatch: List[Cfg] =
-      node.astChildren.isControlStructure.isCatch.toList match {
-        case Nil  => List(Cfg.empty)
-        case asts => asts.map(cfgFor)
-      }
-    val catchBodyCfgs = if (catchBodyCfgsByCatch.isEmpty) {
+    val catchControlStructures = node.astChildren.isControlStructure.isCatch.toList
+    val catchBodyCfgs = if (catchControlStructures.isEmpty) {
       node.astChildren.order(2).toList match {
         case Nil  => List(Cfg.empty)
         case asts => asts.map(cfgFor)
       }
     } else {
-      catchBodyCfgsByCatch
+      catchControlStructures match {
+        case Nil  => List(Cfg.empty)
+        case asts => asts.map(cfgFor)
+      }
     }
 
-    val maybeFinallyBodyCfgByFinally: List[Cfg] =
-      node.astChildren.isControlStructure.isFinally
-        .map(cfgFor)
-        .headOption // Assume there can only be one
-        .toList
-    val maybeFinallyBodyCfg = if (catchBodyCfgsByCatch.isEmpty && maybeFinallyBodyCfgByFinally.isEmpty) {
+    val finallyControlStructures = node.astChildren.isControlStructure.isFinally.toList
+    val maybeFinallyBodyCfg = if (catchControlStructures.isEmpty && finallyControlStructures.isEmpty) {
       node.astChildren
         .order(3)
         .map(cfgFor)
         .headOption // Assume there can only be one
         .toList
     } else {
-      maybeFinallyBodyCfgByFinally
+      finallyControlStructures
+        .map(cfgFor)
+        .headOption // Assume there can only be one
+        .toList
     }
 
     val tryToCatchEdges = catchBodyCfgs.flatMap { catchBodyCfg =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -502,13 +502,11 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
         case Nil  => List(Cfg.empty)
         case asts => asts.map(cfgFor)
       }
-    val catchBodyCfgsByOrder: List[Cfg] =
+    val catchBodyCfgs = if (catchBodyCfgsByCatch.isEmpty) {
       node.astChildren.order(2).toList match {
         case Nil  => List(Cfg.empty)
         case asts => asts.map(cfgFor)
       }
-    val catchBodyCfgs = if (catchBodyCfgsByCatch.isEmpty) {
-      catchBodyCfgsByOrder
     } else {
       catchBodyCfgsByCatch
     }
@@ -518,14 +516,12 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
         .map(cfgFor)
         .headOption // Assume there can only be one
         .toList
-    val maybeFinallyBodyCfgByOrder: List[Cfg] =
+    val maybeFinallyBodyCfg = if (catchBodyCfgsByCatch.isEmpty && maybeFinallyBodyCfgByFinally.isEmpty) {
       node.astChildren
         .order(3)
         .map(cfgFor)
         .headOption // Assume there can only be one
         .toList
-    val maybeFinallyBodyCfg = if (catchBodyCfgsByCatch.isEmpty && maybeFinallyBodyCfgByFinally.isEmpty) {
-      maybeFinallyBodyCfgByOrder
     } else {
       maybeFinallyBodyCfgByFinally
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -33,6 +33,14 @@ class ControlStructureTraversal(val traversal: Iterator[ControlStructure]) exten
   def isTry: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.TRY)
 
+  @Doc(info = "Only `Catch` control structures")
+  def isCatch: Iterator[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.CATCH)
+
+  @Doc(info = "Only `Finally` control structures")
+  def isFinally: Iterator[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.FINALLY)
+
   @Doc(info = "Only `If` control structures")
   def isIf: Iterator[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.IF)


### PR DESCRIPTION
With this change catches do not have to have order 2 for correct control flow generation. Multiple siblings with the same order are invalid.

The change in CfgCreator allows for backwards compatibility.
We fall back to order(2) for catch and order(3) for finally if no ControlStructure CATCH or ControlStructure FINALLY is found.
