### PR TITLE
[ruby] Final Tweaks for Beta

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -98,6 +98,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       "%"   -> Operators.modulo,
       "**"  -> Operators.exponentiation,
       "=="  -> Operators.equals,
+      "===" -> Operators.equals,
       "!="  -> Operators.notEquals,
       "<"   -> Operators.lessThan,
       "<="  -> Operators.lessEqualsThan,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -129,7 +129,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
           // which is translated to `x.include? y` and `x.any?` conditions respectively
 
           val conditions = whenClause.matchExpressions.map { mExpr =>
-            expr.map(e => MemberCall(mExpr, ".", "===", List(e))(mExpr.span)).getOrElse(mExpr)
+            expr.map(e => BinaryExpression(mExpr, "===", e)(mExpr.span)).getOrElse(mExpr)
           } ++ (whenClause.matchSplatExpression.iterator.flatMap {
             case splat @ SplattingRubyNode(exprList) =>
               expr

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -102,27 +102,20 @@ class ArrayTests extends RubyCode2CpgFixture {
         |x = Array [1, 2, 3]
         |""".stripMargin)
 
-    inside(cpg.call.name(Operators.arrayInitializer).l) {
-      case arrayCall :: Nil =>
-        arrayCall.code shouldBe "Array [1, 2, 3]"
-        arrayCall.lineNumber shouldBe Some(2)
+    inside(cpg.call.nameExact("[]").l) {
+      case bracketCall :: Nil =>
+        bracketCall.name shouldBe "[]"
+        bracketCall.methodFullName shouldBe "__builtin.Array:[]"
+        bracketCall.typeFullName shouldBe "__builtin.Array"
 
-        inside(arrayCall.inCall.headOption) {
-          case Some(bracketCall) =>
-            bracketCall.name shouldBe "[]"
-            bracketCall.methodFullName shouldBe "__builtin.Array:[]"
-            bracketCall.typeFullName shouldBe "__builtin.Array"
-          case None => fail("Expected a call with the name []")
-        }
-
-        inside(arrayCall.argument.l) {
+        inside(bracketCall.argument.l) {
           case one :: two :: three :: Nil =>
             one.code shouldBe "1"
             two.code shouldBe "2"
             three.code shouldBe "3"
           case xs => fail(s"Expected 3 literals under the array initializer, instead got [${xs.code.mkString(", ")}]")
         }
-      case xs => fail(s"Expected a single array initializer call, instead got [${xs.code.mkString(", ")}]")
+      case xs => fail(s"Expected a single array initializer call ([]), instead got [${xs.code.mkString(", ")}]")
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -38,17 +38,22 @@ class CaseTests extends RubyCode2CpgFixture {
         .l
       orConds.map {
         case mExpr: Call if mExpr.name == "include?" =>
-          val List(lhs, rhs) = mExpr.argument.l
+          val List(lhs, rhs) = mExpr.astChildren.l
           rhs.code shouldBe "<tmp-0>"
           s"splat:${lhs.code}"
-        case mExpr: Call if mExpr.name == "===" =>
+        case mExpr: Call if mExpr.name == Operators.equals =>
           val List(lhs, rhs) = mExpr.argument.l
           rhs.code shouldBe "<tmp-0>"
           s"expr:${lhs.code}"
       }.l
     }.l
 
-    conds shouldBe List(List("expr:0"), List("expr:1", "expr:2"), List("expr:3", "splat:[4,5]"), List("splat:[6]"))
+    conds shouldBe List(
+      List("expr:0"),
+      List("expr:1", "expr:2"),
+      List("expr:3", "splat:[4,5].include?"),
+      List("splat:[6].include?")
+    )
     val matchResults = ifStmts.astChildren.order(2).astChildren ++ ifStmts.last.astChildren.order(3).astChildren
     matchResults.code.l shouldBe List("0", "1", "2", "3", "4")
 
@@ -80,7 +85,7 @@ class CaseTests extends RubyCode2CpgFixture {
         .l
       orConds.map {
         case c: Call if c.name == "any?" =>
-          val List(lhs) = c.argument.l
+          val List(lhs) = c.astChildren.l
           s"splat:${lhs.code}"
         case e: Expression =>
           s"expr:${e.code}"
@@ -89,8 +94,8 @@ class CaseTests extends RubyCode2CpgFixture {
     conds shouldBe List(
       List("expr:false", "expr:true"),
       List("expr:true"),
-      List("expr:false", "splat:[false,false]"),
-      List("splat:[false,true]")
+      List("expr:false", "splat:[false,false].any?"),
+      List("splat:[false,true].any?")
     )
 
     val matchResults = ifStmts.astChildren.order(2).astChildren.l

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -97,7 +97,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
     "specify the closure reference as an argument to the member call with block" in {
       inside(cpg.call("each").argument.l) {
-        case (_: Identifier) :: (lambdaRef: MethodRef) :: Nil =>
+        case (lambdaRef: MethodRef) :: Nil =>
           lambdaRef.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
@@ -157,7 +157,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
     "specify the closure reference as an argument to the member call with block" in {
       inside(cpg.call("each").argument.l) {
-        case (_: Identifier) :: (lambdaRef: MethodRef) :: Nil =>
+        case (lambdaRef: MethodRef) :: Nil =>
           lambdaRef.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -146,28 +146,20 @@ class HashTests extends RubyCode2CpgFixture {
         |x = Hash [1 => "a", 2 => "b", 3 => "c"]
         |""".stripMargin)
 
-    inside(cpg.call.name(RubyOperators.hashInitializer).l) {
+    inside(cpg.call.nameExact("[]").l) {
       case hashCall :: Nil =>
         hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
         hashCall.lineNumber shouldBe Some(2)
+        hashCall.methodFullName shouldBe "__builtin.Hash:[]"
+        hashCall.typeFullName shouldBe "__builtin.Hash"
 
-        inside(hashCall.parentBlock.astChildren.l) {
-          case _ :: _ :: (one: Call) :: (two: Call) :: (three: Call) :: (tmp: Identifier) :: Nil =>
-            one.code shouldBe "<tmp-0>[1] = \"a\""
-            two.code shouldBe "<tmp-0>[2] = \"b\""
-            three.code shouldBe "<tmp-0>[3] = \"c\""
-            tmp.code shouldBe "<tmp-0>"
-          case xs => fail(s"Expected 3 literals under the array initializer, instead got [${xs.code.mkString(", ")}]")
+        inside(hashCall.astChildren.l) {
+          case _ :: (one: Call) :: (two: Call) :: (three: Call) :: Nil =>
+            one.code shouldBe "1 => \"a\""
+            two.code shouldBe "2 => \"b\""
+            three.code shouldBe "3 => \"c\""
+          case xs => fail(s"Expected 3 literals under the hash initializer, instead got [${xs.code.mkString(", ")}]")
         }
-
-        inside(hashCall.parentBlock.inCall.headOption) {
-          case Some(bracketCall) =>
-            bracketCall.name shouldBe "[]"
-            bracketCall.methodFullName shouldBe "__builtin.Hash:[]"
-            bracketCall.typeFullName shouldBe "__builtin.Hash"
-          case None => fail("Expected a call with the name []")
-        }
-
       case xs => fail(s"Expected a single array initializer call, instead got [${xs.code.mkString(", ")}]")
     }
   }


### PR DESCRIPTION
* Rolled back some method receiver/base changes
* Corrected argument structure in `Array::[]` style calls
* Corrected oversight on array literals always being treated as `%i` style arrays instead of the `[1,2,p]` style array literals (which are created elsewhere too)
* Added some temporary receiver type fetching logic for call receivers
* Treat member calls with `::` as static dispatch
* Registered `===` as an `equals` binary op