### PR TITLE
[ruby] Nested ruby control flow structures in assign and return #4337 

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -255,7 +255,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
                       SingleAssignment(
                         node.lhs,
                         node.op,
-                        StaticLiteral(getBuiltInType(Defines.NilClass))(node.span.spanStart("nil"))
+                        StaticLiteral(getBuiltInType(Defines.NilClass))(span.spanStart("nil"))
                       )(span.spanStart(s"${node.lhs.span.text} ${node.op} nil")) :: Nil
                     )(span.spanStart(s"${node.lhs.span.text} ${node.op} nil"))
                   )(span.spanStart(s"else\n\t${node.lhs.span.text} ${node.op} nil\nend"))
@@ -305,7 +305,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case (head: ControlFlowClause) :: Nil     => clauseAssigningLastExpression(head) :: Nil
       case (head: ControlFlowExpression) :: Nil => transform(head) :: Nil
       case head :: Nil =>
-        SingleAssignment(lhs, op, head)(lhs.span.spanStart(s"${lhs.span.text} $op ${head.span.text}")) :: Nil
+        SingleAssignment(lhs, op, head)(rhs.span.spanStart(s"${lhs.span.text} $op ${head.span.text}")) :: Nil
       case Nil          => List.empty
       case head :: tail => head :: stmtListAssigningLastExpression(tail)
     }
@@ -326,7 +326,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case clause: ControlFlowClause   => clauseAssigningLastExpression(clause)
       case expr: ControlFlowExpression => transform(expr)
       case _ =>
-        SingleAssignment(lhs, op, rhs)(lhs.span.spanStart(s"${lhs.span.text} $op ${rhs.span.text}"))
+        SingleAssignment(lhs, op, rhs)(rhs.span.spanStart(s"${lhs.span.text} $op ${rhs.span.text}"))
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -31,6 +31,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: HashLiteral              => astForHashLiteral(node)
     case node: Association              => astForAssociation(node)
     case node: IfExpression             => astForIfExpression(node)
+    case node: UnlessExpression         => astForUnlessExpression(node)
     case node: RescueExpression         => astForRescueExpression(node)
     case node: MandatoryParameter       => astForMandatoryParameter(node)
     case node: SplattingRubyNode        => astForSplattingRubyNode(node)
@@ -533,6 +534,11 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       callAst(call, conditionAst :: thenAst :: elseAsts_)
     }
     foldIfExpression(builder)(node)
+  }
+
+  protected def astForUnlessExpression(node: UnlessExpression): Ast = {
+    val notConditionAst = UnaryExpression("!", node.condition)(node.condition.span)
+    astForExpression(IfExpression(notConditionAst, node.trueBranch, List(), node.falseBranch)(node.span))
   }
 
   protected def astForRescueExpression(node: RescueExpression): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -248,7 +248,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     node match
       case expr: ControlFlowExpression =>
-        def transform(e: RubyNode with ControlFlowExpression): RubyNode = 
+        def transform(e: RubyNode with ControlFlowExpression): RubyNode =
           transformLastRubyNodeInControlFlowExpressionBody(e, returnLastNode(_, transform), elseReturnNil)
         astsForStatement(transform(expr))
       case node: MemberCallWithBlock => returnAstForRubyCall(node)
@@ -310,14 +310,14 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     * @return
     *   the RubyNode with an explicit expression
     */
-   private def returnLastNode(x: RubyNode, transform: (RubyNode with ControlFlowExpression) => RubyNode): RubyNode = {
+  private def returnLastNode(x: RubyNode, transform: (RubyNode with ControlFlowExpression) => RubyNode): RubyNode = {
     def statementListReturningLastExpression(stmts: List[RubyNode]): List[RubyNode] = stmts match {
-      case (head: ControlFlowClause) :: Nil => clauseReturningLastExpression(head) :: Nil
+      case (head: ControlFlowClause) :: Nil     => clauseReturningLastExpression(head) :: Nil
       case (head: ControlFlowExpression) :: Nil => transform(head) :: Nil
-      case (head: ReturnExpression) :: Nil  => head :: Nil
-      case head :: Nil                      => ReturnExpression(head :: Nil)(head.span) :: Nil
-      case Nil                              => List.empty
-      case head :: tail                     => head :: statementListReturningLastExpression(tail)
+      case (head: ReturnExpression) :: Nil      => head :: Nil
+      case head :: Nil                          => ReturnExpression(head :: Nil)(head.span) :: Nil
+      case Nil                                  => List.empty
+      case head :: tail                         => head :: statementListReturningLastExpression(tail)
     }
 
     def clauseReturningLastExpression(x: RubyNode with ControlFlowClause): RubyNode = x match {
@@ -331,15 +331,15 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     }
 
     x match {
-      case StatementList(statements) => StatementList(statementListReturningLastExpression(statements))(x.span)
-      case clause: ControlFlowClause => clauseReturningLastExpression(clause)
+      case StatementList(statements)   => StatementList(statementListReturningLastExpression(statements))(x.span)
+      case clause: ControlFlowClause   => clauseReturningLastExpression(clause)
       case node: ControlFlowExpression => transform(node)
-      case _                         => ReturnExpression(x :: Nil)(x.span)
+      case _                           => ReturnExpression(x :: Nil)(x.span)
     }
   }
 
-  /** @param node // TODO update
-    *   \- Control Flow Expression RubyNode
+  /** @param node
+    *   // TODO update \- Control Flow Expression RubyNode
     * @param transform
     *   \- RubyNode => RubyNode function for transformation on the clauses of the ControlFlowExpression
     * @return
@@ -369,15 +369,19 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
           elseClause.map(transform).orElse(defaultElseBranch(node.span))
         )(node.span)
       case UnlessExpression(condition, trueBranch, falseBranch) =>
-        UnlessExpression(condition, transform(trueBranch), falseBranch.map(transform).orElse(defaultElseBranch(node.span)))(
-          node.span
-        )
+        UnlessExpression(
+          condition,
+          transform(trueBranch),
+          falseBranch.map(transform).orElse(defaultElseBranch(node.span))
+        )(node.span)
       case ForExpression(forVariable, iterableVariable, doBlock) =>
         ForExpression(forVariable, iterableVariable, transform(doBlock))(node.span)
       case CaseExpression(expression, whenClauses, elseClause) =>
-        CaseExpression(expression, whenClauses.map(transform), elseClause.map(transform).orElse(defaultElseBranch(node.span)))(
-          node.span
-        )
+        CaseExpression(
+          expression,
+          whenClauses.map(transform),
+          elseClause.map(transform).orElse(defaultElseBranch(node.span))
+        )(node.span)
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -236,19 +236,21 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   private def astsForImplicitReturnStatement(node: RubyNode): Seq[Ast] = {
-    def elseReturnNil = Option {
+    def elseReturnNil(span: TextSpan) = Option {
       ElseClause(
         StatementList(
-          ReturnExpression(StaticLiteral(getBuiltInType(Defines.NilClass))(node.span.spanStart("nil")) :: Nil)(
-            node.span.spanStart("return nil")
+          ReturnExpression(StaticLiteral(getBuiltInType(Defines.NilClass))(span.spanStart("nil")) :: Nil)(
+            span.spanStart("return nil")
           ) :: Nil
-        )(node.span.spanStart("return nil"))
-      )(node.span.spanStart("else\n\treturn nil\nend"))
+        )(span.spanStart("return nil"))
+      )(span.spanStart("else\n\treturn nil\nend"))
     }
 
     node match
       case expr: ControlFlowExpression =>
-        astsForStatement(transformLastRubyNodeInControlFlowExpressionBody(expr, returnLastNode, elseReturnNil))
+        def transform(e: RubyNode with ControlFlowExpression): RubyNode = 
+          transformLastRubyNodeInControlFlowExpressionBody(e, returnLastNode(_, transform), elseReturnNil)
+        astsForStatement(transform(expr))
       case node: MemberCallWithBlock => returnAstForRubyCall(node)
       case node: SimpleCallWithBlock => returnAstForRubyCall(node)
       case _: (LiteralExpr | BinaryExpression | UnaryExpression | SimpleIdentifier | IndexAccess | Association |
@@ -308,9 +310,10 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     * @return
     *   the RubyNode with an explicit expression
     */
-  private def returnLastNode(x: RubyNode): RubyNode = {
+   private def returnLastNode(x: RubyNode, transform: (RubyNode with ControlFlowExpression) => RubyNode): RubyNode = {
     def statementListReturningLastExpression(stmts: List[RubyNode]): List[RubyNode] = stmts match {
       case (head: ControlFlowClause) :: Nil => clauseReturningLastExpression(head) :: Nil
+      case (head: ControlFlowExpression) :: Nil => transform(head) :: Nil
       case (head: ReturnExpression) :: Nil  => head :: Nil
       case head :: Nil                      => ReturnExpression(head :: Nil)(head.span) :: Nil
       case Nil                              => List.empty
@@ -319,32 +322,33 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     def clauseReturningLastExpression(x: RubyNode with ControlFlowClause): RubyNode = x match {
       case RescueClause(exceptionClassList, assignment, thenClause) =>
-        RescueClause(exceptionClassList, assignment, returnLastNode(thenClause))(x.span)
-      case EnsureClause(thenClause)           => EnsureClause(returnLastNode(thenClause))(x.span)
-      case ElsIfClause(condition, thenClause) => ElsIfClause(condition, returnLastNode(thenClause))(x.span)
-      case ElseClause(thenClause)             => ElseClause(returnLastNode(thenClause))(x.span)
+        RescueClause(exceptionClassList, assignment, returnLastNode(thenClause, transform))(x.span)
+      case EnsureClause(thenClause)           => EnsureClause(returnLastNode(thenClause, transform))(x.span)
+      case ElsIfClause(condition, thenClause) => ElsIfClause(condition, returnLastNode(thenClause, transform))(x.span)
+      case ElseClause(thenClause)             => ElseClause(returnLastNode(thenClause, transform))(x.span)
       case WhenClause(matchExpressions, matchSplatExpression, thenClause) =>
-        WhenClause(matchExpressions, matchSplatExpression, returnLastNode(thenClause))(x.span)
+        WhenClause(matchExpressions, matchSplatExpression, returnLastNode(thenClause, transform))(x.span)
     }
 
     x match {
       case StatementList(statements) => StatementList(statementListReturningLastExpression(statements))(x.span)
       case clause: ControlFlowClause => clauseReturningLastExpression(clause)
+      case node: ControlFlowExpression => transform(node)
       case _                         => ReturnExpression(x :: Nil)(x.span)
     }
   }
 
-  /** @param node
+  /** @param node // TODO update
     *   \- Control Flow Expression RubyNode
     * @param transform
-    *   \- RubyNode => RubyNode function for transformation on last ruby node
+    *   \- RubyNode => RubyNode function for transformation on the clauses of the ControlFlowExpression
     * @return
     *   RubyNode with transform function applied
     */
   protected def transformLastRubyNodeInControlFlowExpressionBody(
     node: RubyNode with ControlFlowExpression,
     transform: RubyNode => RubyNode,
-    defaultElseBranch: Option[ElseClause]
+    defaultElseBranch: TextSpan => Option[ElseClause]
   ): RubyNode = {
     node match {
       case RescueExpression(body, rescueClauses, elseClause, ensureClause) =>
@@ -352,7 +356,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         RescueExpression(
           transform(body),
           rescueClauses.map(transform),
-          elseClause.map(transform).orElse(defaultElseBranch),
+          elseClause.map(transform).orElse(defaultElseBranch(node.span)),
           ensureClause
         )(node.span)
       case WhileExpression(condition, body) => WhileExpression(condition, transform(body))(node.span)
@@ -362,16 +366,16 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
           condition,
           transform(thenClause),
           elsifClauses.map(transform),
-          elseClause.map(transform).orElse(defaultElseBranch)
+          elseClause.map(transform).orElse(defaultElseBranch(node.span))
         )(node.span)
       case UnlessExpression(condition, trueBranch, falseBranch) =>
-        UnlessExpression(condition, transform(trueBranch), falseBranch.map(transform).orElse(defaultElseBranch))(
+        UnlessExpression(condition, transform(trueBranch), falseBranch.map(transform).orElse(defaultElseBranch(node.span)))(
           node.span
         )
       case ForExpression(forVariable, iterableVariable, doBlock) =>
         ForExpression(forVariable, iterableVariable, transform(doBlock))(node.span)
       case CaseExpression(expression, whenClauses, elseClause) =>
-        CaseExpression(expression, whenClauses.map(transform), elseClause.map(transform).orElse(defaultElseBranch))(
+        CaseExpression(expression, whenClauses.map(transform), elseClause.map(transform).orElse(defaultElseBranch(node.span)))(
           node.span
         )
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -339,7 +339,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   /** @param node
-    *   // TODO update \- Control Flow Expression RubyNode
+    *   \- Control Flow Expression RubyNode
     * @param transform
     *   \- RubyNode => RubyNode function for transformation on the clauses of the ControlFlowExpression
     * @return

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ConditionalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ConditionalTests.scala
@@ -43,20 +43,20 @@ class ConditionalTests extends RubyCode2CpgFixture {
     val cpg = code("""
                      |f(x ? y : z)
                      |""".stripMargin)
-    val List(cond) = cpg.call(Operators.conditional).l
-    val List(x,y,z) = cond.argument.l
+    val List(cond)    = cpg.call(Operators.conditional).l
+    val List(x, y, z) = cond.argument.l
     x.code shouldBe "x"
-    List(y,z).isBlock.astChildren.isIdentifier.code.l shouldBe List("y","z")
+    List(y, z).isBlock.astChildren.isIdentifier.code.l shouldBe List("y", "z")
   }
 
   "`f(unless x then y else z end)` is lowered into conditional operator" in {
     val cpg = code("""
                      |f(unless x then y else z end)
                      |""".stripMargin)
-    val List(cond) = cpg.call(Operators.conditional).l
-    val List(x,y,z) = cond.argument.l
+    val List(cond)    = cpg.call(Operators.conditional).l
+    val List(x, y, z) = cond.argument.l
     List(x).isCall.name(Operators.logicalNot).argument.code.l shouldBe List("x")
-    List(y,z).isBlock.astChildren.isIdentifier.code.l shouldBe List("y","z")
+    List(y, z).isBlock.astChildren.isIdentifier.code.l shouldBe List("y", "z")
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ConditionalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ConditionalTests.scala
@@ -39,4 +39,24 @@ class ConditionalTests extends RubyCode2CpgFixture {
     }
   }
 
+  "`f(x ? y : z)` is lowered into conditional operator" in {
+    val cpg = code("""
+                     |f(x ? y : z)
+                     |""".stripMargin)
+    val List(cond) = cpg.call(Operators.conditional).l
+    val List(x,y,z) = cond.argument.l
+    x.code shouldBe "x"
+    List(y,z).isBlock.astChildren.isIdentifier.code.l shouldBe List("y","z")
+  }
+
+  "`f(unless x then y else z end)` is lowered into conditional operator" in {
+    val cpg = code("""
+                     |f(unless x then y else z end)
+                     |""".stripMargin)
+    val List(cond) = cpg.call(Operators.conditional).l
+    val List(x,y,z) = cond.argument.l
+    List(x).isCall.name(Operators.logicalNot).argument.code.l shouldBe List("x")
+    List(y,z).isBlock.astChildren.isIdentifier.code.l shouldBe List("y","z")
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -259,14 +259,12 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
       | end
       |""".stripMargin)
 
-    inside(cpg.method.name("foo").l) {
-      case f :: Nil =>
-        val returns = f.methodReturn.toReturn.l
-        returns.code.l shouldBe List("1","2","3","4")
-        returns.map(_.lineNumber).l shouldBe List(Some(5), Some(7), Some(11), Some(13))
+    inside(cpg.method.name("foo").l) { case f :: Nil =>
+      val returns = f.methodReturn.toReturn.l
+      returns.code.l shouldBe List("1", "2", "3", "4")
+      returns.map(_.lineNumber).l shouldBe List(Some(5), Some(7), Some(11), Some(13))
     }
   }
-
 
   "implicit RETURN node for ternary expression" in {
     val cpg = code("""

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -242,7 +242,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
 
   "implicit return of nested control flow" in {
     val cpg = code("""
-      | def foo
+      | def f
       |  if true
       |   if true
       |    1
@@ -259,10 +259,25 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
       | end
       |""".stripMargin)
 
-    inside(cpg.method.name("foo").l) { case f :: Nil =>
-      val returns = f.methodReturn.toReturn.l
-      returns.code.l shouldBe List("1", "2", "3", "4")
-      returns.map(_.lineNumber).l shouldBe List(Some(5), Some(7), Some(11), Some(13))
+    inside(cpg.method.name("f").l) {
+      case f :: Nil =>
+        inside(cpg.methodReturn.toReturn.l) {
+          case return1 :: return2 :: return3 :: return4 :: Nil =>
+            return1.code shouldBe "1"
+            return1.lineNumber shouldBe Some(5)
+
+            return2.code shouldBe "2"
+            return2.lineNumber shouldBe Some(7)
+
+            return3.code shouldBe "3"
+            return3.lineNumber shouldBe Some(11)
+
+            return4.code shouldBe "4"
+            return4.lineNumber shouldBe Some(13)
+
+          case xs => fail(s"Expected 4 returns, instead got [${xs.code.mkString(",")}]")
+        }
+      case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -142,7 +142,6 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
     rhsElseBranchValue.code shouldBe "40"
   }
 
-
   "nested if-else-end on the RHS of an assignment" in {
     val cpg = code("""
       |x = if true
@@ -161,11 +160,11 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       |
       |""".stripMargin)
 
-      cpg.method(":program").dotAst.foreach(println)
-      val assigns = cpg.assignment.l
-      assigns.argument(1).code.l shouldBe List("x","x","x","x")
-      assigns.argument(2).code.l shouldBe List("1","2","3","4")
-      assigns.argument(2).map(_.lineNumber).l shouldBe List(Some(4), Some(6), Some(10), Some(12))
+    cpg.method(":program").dotAst.foreach(println)
+    val assigns = cpg.assignment.l
+    assigns.argument(1).code.l shouldBe List("x", "x", "x", "x")
+    assigns.argument(2).code.l shouldBe List("1", "2", "3", "4")
+    assigns.argument(2).map(_.lineNumber).l shouldBe List(Some(4), Some(6), Some(10), Some(12))
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -120,7 +120,7 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
     two.code shouldBe "2"
   }
 
-  "`if-else-end` on the RHS of an assignment is represented by a `conditional` operator call" in {
+  "`if-else-end` on the RHS of an assignment" in {
     val cpg = code("""
         |x = if true then 20 else 40 end
         |""".stripMargin)
@@ -140,6 +140,32 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
     assignmentElseBranch.methodFullName shouldBe Operators.assignment
     rhsElseBranchIdentifier.code shouldBe "x"
     rhsElseBranchValue.code shouldBe "40"
+  }
+
+
+  "nested if-else-end on the RHS of an assignment" in {
+    val cpg = code("""
+      |x = if true
+      |  if true
+      |    1
+      |  else
+      |    2
+      |  end
+      |else
+      |  if true
+      |    3
+      |  else
+      |    4
+      |  end
+      |end
+      |
+      |""".stripMargin)
+
+      cpg.method(":program").dotAst.foreach(println)
+      val assigns = cpg.assignment.l
+      assigns.argument(1).code.l shouldBe List("x","x","x","x")
+      assigns.argument(2).code.l shouldBe List("1","2","3","4")
+      assigns.argument(2).map(_.lineNumber).l shouldBe List(Some(4), Some(6), Some(10), Some(12))
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -160,11 +160,26 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       |
       |""".stripMargin)
 
-    cpg.method(":program").dotAst.foreach(println)
     val assigns = cpg.assignment.l
     assigns.argument(1).code.l shouldBe List("x", "x", "x", "x")
     assigns.argument(2).code.l shouldBe List("1", "2", "3", "4")
+    assigns.map(_.lineNumber).l shouldBe List(Some(4), Some(5), Some(10), Some(11))
     assigns.argument(2).map(_.lineNumber).l shouldBe List(Some(4), Some(6), Some(10), Some(12))
+  }
+
+  "nested if-end should have implicit elses" in {
+    val cpg = code("""
+      |x = if true
+      | if true
+      |  1
+      | end
+      |end
+      |""".stripMargin)
+
+    val assigns = cpg.assignment.l
+    assigns.argument(1).code.l shouldBe List("x", "x", "x")
+    assigns.argument(2).code.l shouldBe List("1", "nil", "nil")
+    assigns.map(_.lineNumber).l shouldBe List(Some(4), Some(3), Some(2))
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -160,11 +160,30 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       |
       |""".stripMargin)
 
-    val assigns = cpg.assignment.l
-    assigns.argument(1).code.l shouldBe List("x", "x", "x", "x")
-    assigns.argument(2).code.l shouldBe List("1", "2", "3", "4")
-    assigns.map(_.lineNumber).l shouldBe List(Some(4), Some(5), Some(10), Some(11))
-    assigns.argument(2).map(_.lineNumber).l shouldBe List(Some(4), Some(6), Some(10), Some(12))
+    inside(cpg.assignment.l) {
+      case assign1 :: assign2 :: assign3 :: assign4 :: Nil =>
+        assign1.lineNumber shouldBe Some(4)
+        assign1.argument(1).code shouldBe "x"
+        assign1.argument(2).code shouldBe "1"
+        assign1.argument(2).lineNumber shouldBe Some(4)
+
+        assign2.lineNumber shouldBe Some(5)
+        assign2.argument(1).code shouldBe "x"
+        assign2.argument(2).code shouldBe "2"
+        assign2.argument(2).lineNumber shouldBe Some(6)
+
+        assign3.lineNumber shouldBe Some(10)
+        assign3.argument(1).code shouldBe "x"
+        assign3.argument(2).code shouldBe "3"
+        assign3.argument(2).lineNumber shouldBe Some(10)
+
+        assign4.lineNumber shouldBe Some(11)
+        assign4.argument(1).code shouldBe "x"
+        assign4.argument(2).code shouldBe "4"
+        assign4.argument(2).lineNumber shouldBe Some(12)
+      case xs => fail(s"Expected 4 assignments, instead got [${xs.code.mkString(",")}]")
+    }
+
   }
 
   "nested if-end should have implicit elses" in {
@@ -177,9 +196,21 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       |""".stripMargin)
 
     val assigns = cpg.assignment.l
-    assigns.argument(1).code.l shouldBe List("x", "x", "x")
-    assigns.argument(2).code.l shouldBe List("1", "nil", "nil")
-    assigns.map(_.lineNumber).l shouldBe List(Some(4), Some(3), Some(2))
+    inside(cpg.assignment.l) {
+      case assign1 :: assignNil1 :: assignNil2 :: Nil =>
+        assign1.argument(1).code shouldBe "x"
+        assign1.argument(2).code shouldBe "1"
+        assign1.lineNumber shouldBe Some(4)
+
+        assignNil1.argument(1).code shouldBe "x"
+        assignNil1.argument(2).code shouldBe "nil"
+        assignNil1.lineNumber shouldBe Some(3)
+
+        assignNil2.argument(1).code shouldBe "x"
+        assignNil2.argument(2).code shouldBe "nil"
+        assignNil2.lineNumber shouldBe Some(2)
+      case xs => fail(s"Expected 3 assignments, instead got [${xs.code.mkString(",")}]")
+    }
   }
 
 }


### PR DESCRIPTION
- Make return and assignment transformation for control flow expressions recursive
- Make `else return nil` or `else x = nil` TextSpan more localized
- Make a conditional operator when `unless` appears as an expression.