### PR TITLE
[c#] fix code extraction for attribute node

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -174,9 +174,12 @@ object AstCreatorHelper {
     val cn       = metaData(ParserKeys.ColumnStart).numOpt.map(_.toInt.asInstanceOf[Integer])
     val lnEnd    = metaData(ParserKeys.LineEnd).numOpt.map(_.toInt.asInstanceOf[Integer])
     val cnEnd    = metaData(ParserKeys.ColumnEnd).numOpt.map(_.toInt.asInstanceOf[Integer])
-    val c =
-      metaData(ParserKeys.Code).strOpt.map(x => x.takeWhile(x => x != '\n' && x != '{')).getOrElse("<empty>").strip()
-    val node = nodeType(metaData, relativeFileName)
+    val node     = nodeType(metaData, relativeFileName)
+    val c = node.toString match
+      case "Attribute" =>
+        metaData(ParserKeys.Code).strOpt.map(x => x.takeWhile(x => x != '\n')).getOrElse("<empty>").strip()
+      case _ =>
+        metaData(ParserKeys.Code).strOpt.map(x => x.takeWhile(x => x != '\n' && x != '{')).getOrElse("<empty>").strip()
     DotNetNodeInfo(node, json, c, ln, cn, lnEnd, cnEnd)
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/AnnotationTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/AnnotationTests.scala
@@ -48,6 +48,26 @@ class AnnotationTests extends CSharpCode2CpgFixture {
         obsolete.fullName shouldBe "System.ObsoleteAttribute"
       }
     }
+
+    "have correct code for Route attribute" in {
+      val cpg = code("""
+          |using System;
+          |
+          |namespace Foo {
+          | [Route("api/v{version:number}/some/[controller]")]
+          | public class Controller {
+          |   public static void Main() {}
+          | }
+          |}
+          |""".stripMargin)
+
+      inside(cpg.typeDecl("Controller").annotation.l) { case route :: Nil =>
+        route.code shouldBe "Route(\"api/v{version:number}/some/[controller]\")"
+        route.name shouldBe "Route"
+        route.fullName shouldBe "RouteAttribute"
+      }
+
+    }
   }
 
   "annotations for members" should {


### PR DESCRIPTION
The Attribute nodes were not getting proper `code` extracted rom them since default truncation was at `{`. This skips it while not disturbing code extraction for other nodes. Test also added. 