### PR TITLE
[ruby] Add visitor for `MethodOnlyIdentifier`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -570,6 +570,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     SimpleIdentifier()(ctx.toTextSpan)
   }
 
+  override def visitMethodOnlyIdentifier(ctx: RubyParser.MethodOnlyIdentifierContext): RubyNode = {
+    SimpleIdentifier()(ctx.toTextSpan)
+  }
+
   override def visitIsDefinedKeyword(ctx: RubyParser.IsDefinedKeywordContext): RubyNode = {
     SimpleIdentifier()(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -356,7 +356,30 @@ class MethodTests extends RubyCode2CpgFixture {
         case _ => fail("Expected one Method for :program")
       }
     }
+  }
 
+  "A Boolean method" should {
+    val cpg = code("""
+        |def exists?
+        |  true
+        |end
+        |""".stripMargin)
+
+    "be represented by a a METHOD node" in {
+      inside(cpg.method.name("exists\\?").l) {
+        case existsMethod :: Nil =>
+          existsMethod.fullName shouldBe "Test0.rb:<global>::program:exists?"
+          existsMethod.isExternal shouldBe false
+
+          inside(existsMethod.methodReturn.cfgIn.l) {
+            case existsMethodReturn :: Nil =>
+              existsMethodReturn.code shouldBe "true"
+            case _ => fail("Expected return for method")
+          }
+
+        case xs => fail(s"Expected one method, found ${xs.name.mkString(", ")}")
+      }
+    }
   }
 
 }


### PR DESCRIPTION
This PR handles:
 * Added visitor for `methodOnlyIdentifier` (methods ending with `=?!`

Resolves #4336 