### PR TITLE
[ruby] Handling of break statements, `RescueExpression` as method body, and explicit `ReturnStatement`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -363,6 +363,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           astForStatementListReturningLastExpression(
             StatementList(optionalStatementList.statements ++ stmtList.statements)(stmtList.span)
           )
+        case rescueExpr: RescueExpression =>
+          astForRescueExpression(rescueExpr)
         case _: (StaticLiteral | BinaryExpression | SingleAssignment | SimpleIdentifier | ArrayLiteral | HashLiteral |
               SimpleCall | MemberAccess | MemberCall) =>
           astForStatementListReturningLastExpression(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -6,7 +6,7 @@ import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{NewMethod, NewMethodRef, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewMethod, NewMethodRef, NewTypeDecl, NewControlStructure}
 
 trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -27,6 +27,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case node: MethodDeclaration          => astForMethodDeclaration(node)
     case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node) :: Nil
     case node: MultipleAssignment         => node.assignments.map(astForExpression)
+    case node: BreakStatement             => astForBreakStatement(node) :: Nil
     case _                                => astForExpression(node) :: Nil
 
   private def astForWhileStatement(node: WhileExpression): Ast = {
@@ -304,6 +305,15 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     returnAst(returnNode(node, code(node)), List(astForMemberCall(node)))
   }
 
+  private def astForBreakStatement(node: BreakStatement): Ast = {
+    val _node = NewControlStructure()
+      .controlStructureType(ControlStructureTypes.BREAK)
+      .lineNumber(line(node))
+      .columnNumber(column(node))
+      .code(code(node))
+    Ast(_node)
+  }
+
   /** Wraps the last RubyNode with a ReturnExpression.
     * @param x
     *   the node to wrap a return around. If a StatementList is given, then the ReturnExpression will wrap around the
@@ -335,6 +345,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case StatementList(statements)   => StatementList(statementListReturningLastExpression(statements))(x.span)
       case clause: ControlFlowClause   => clauseReturningLastExpression(clause)
       case node: ControlFlowExpression => transform(node)
+      case node: BreakStatement        => node
       case _                           => ReturnExpression(x :: Nil)(x.span)
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -346,6 +346,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case clause: ControlFlowClause   => clauseReturningLastExpression(clause)
       case node: ControlFlowExpression => transform(node)
       case node: BreakStatement        => node
+      case node: ReturnExpression      => node
       case _                           => ReturnExpression(x :: Nil)(x.span)
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -383,4 +383,5 @@ object RubyIntermediateAst {
 
   final case class AliasStatement(oldName: String, newName: String)(span: TextSpan) extends RubyNode(span)
 
+  final case class BreakStatement()(span: TextSpan) extends RubyNode(span)
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1035,4 +1035,8 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     AliasStatement(ctx.oldName.getText, ctx.newName.getText)(ctx.toTextSpan)
   }
 
+  override def visitBreakWithoutArguments(ctx: RubyParser.BreakWithoutArgumentsContext): RubyNode = {
+    BreakStatement()(ctx.toTextSpan)
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -570,6 +570,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     SimpleIdentifier()(ctx.toTextSpan)
   }
 
+  override def visitMethodOnlyIdentifier(ctx: RubyParser.MethodOnlyIdentifierContext): RubyNode = {
+    SimpleIdentifier()(ctx.toTextSpan)
+  }
+
   override def visitIsDefinedKeyword(ctx: RubyParser.IsDefinedKeywordContext): RubyNode = {
     SimpleIdentifier()(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -356,7 +356,30 @@ class MethodTests extends RubyCode2CpgFixture {
         case _ => fail("Expected one Method for :program")
       }
     }
+  }
 
+  "A Boolean method" should {
+    val cpg = code("""
+        |def exists?
+        |  true
+        |end
+        |""".stripMargin)
+
+    "be represented by a a METHOD node" in {
+      inside(cpg.method.name("exists\\?").l) {
+        case existsMethod :: Nil =>
+          existsMethod.fullName shouldBe "Test0.rb:<global>::program:exists?"
+          existsMethod.isExternal shouldBe false
+
+          inside(existsMethod.methodReturn.cfgIn.l) {
+            case existsMethodReturn :: Nil =>
+              existsMethodReturn.code shouldBe "true"
+            case _ => fail("Expected return for method")
+          }
+
+        case xs => fail(s"Expected one method, found ${xs.name.mkString(", ")}")
+      }
+    }
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -382,4 +382,43 @@ class MethodTests extends RubyCode2CpgFixture {
     }
   }
 
+  "return true if statement" should {
+    val cpg = code("""
+        |  def is_valid?(token)
+        |    if token =~ /(?<user>\d+)-(?<email_hash>[A-Z0-9]{32})/i
+        |
+        |      # Fetch the user by their id, and hash their email address
+        |      @user = User.find_by(id: $~[:user])
+        |      email = Digest::MD5.hexdigest(@user.email)
+        |
+        |      # Compare and validate our hashes
+        |      return true if email == $~[:email_hash]
+        |    end
+        |  end
+        |""".stripMargin)
+
+    "do something" in {
+      cpg.method.name("is_valid\\?").l.foreach(println)
+    }
+  }
+
+  "break unless statement" should {
+    val cpg = code("""
+        |  def generate_token(column)
+        |    loop do
+        |      self[column] = Encryption.encrypt_sensitive_value(self.id)
+        |      # puts "hi" unless User.exists?(column => self[column])
+        |      break unless User.exists?(column => self[column])
+        |    end
+        |
+        |    self.save!
+        |  end
+        |
+        |""".stripMargin)
+
+    "be" in {
+      cpg.method.name("generate_token").dotAst.l.foreach(println)
+    }
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -365,7 +365,7 @@ class MethodTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    "be represented by a a METHOD node" in {
+    "be represented by a METHOD node" in {
       inside(cpg.method.name("exists\\?").l) {
         case existsMethod :: Nil =>
           existsMethod.fullName shouldBe "Test0.rb:<global>::program:exists?"
@@ -382,14 +382,14 @@ class MethodTests extends RubyCode2CpgFixture {
     }
   }
 
-  "return true if statement" should {
+  "Explicit ReturnExpression as last statement" should {
     val cpg = code("""
         |  def foo
         |    return true if 1 < 2
         |  end
         |""".stripMargin)
 
-    "Generate return for explicit return expression as last statement" in {
+    "Represented by Return Node" in {
       inside(cpg.method.name("foo").l) {
         case fooMethod :: Nil =>
           inside(fooMethod.methodReturn.toReturn.l) {
@@ -467,4 +467,25 @@ class MethodTests extends RubyCode2CpgFixture {
     }
   }
 
+  "RescueExpression as Statement body" should {
+    val cpg = code("""
+        |  def self.silence_streams(*streams)
+        |    on_hold = streams.collect { |stream| stream.dup }
+        |    streams.each do |stream|
+        |      stream.reopen(RUBY_PLATFORM =~ /mswin/ ? "NUL:" : "/dev/null")
+        |      stream.sync = true
+        |    end
+        |    yield
+        |  ensure
+        |    streams.each_with_index do |stream, i|
+        |      stream.reopen(on_hold[i])
+        |    end
+        |  end
+        |""".stripMargin)
+
+    "" ignore {
+      // TODO: Implement tests once impl is ready
+      cpg.method.name("self.silence_streams").l.foreach(println)
+    }
+  }
 }


### PR DESCRIPTION
This PR Handles:
 * Added node and handling for `BreakStatement`
 * Added handling for `RescueExpression` as a method body
 * Added handling for explicit `ReturnExpression` as final statement in statement list
