### PR TITLE
[ruby] Call & Receiver Tweaks

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
@@ -1,19 +1,39 @@
 package io.joern.rubysrc2cpg.passes
 
-import io.joern.rubysrc2cpg.Config
 import io.joern.rubysrc2cpg.astcreation.AstCreator
-import io.joern.rubysrc2cpg.parser.ResourceManagedParser
-import io.joern.x2cpg.SourceFiles
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
 import io.shiftleft.passes.ConcurrentWriterCpgPass
-import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
+import overflowdb.BatchedUpdate
 
 class AstCreationPass(cpg: Cpg, astCreators: List[AstCreator]) extends ConcurrentWriterCpgPass[AstCreator](cpg) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
   override def generateParts(): Array[AstCreator] = astCreators.toArray
+
+  override def init(): Unit = {
+    // The first entry will be the <empty> type, which is often found on fieldAccess nodes
+    //   (which may be receivers to calls)
+    val diffGraph = new DiffGraphBuilder
+    val emptyType =
+      NewTypeDecl()
+        .astParentType(NodeTypes.NAMESPACE_BLOCK)
+        .astParentFullName(NamespaceTraversal.globalNamespaceName)
+        .isExternal(true)
+    val anyType =
+      NewTypeDecl()
+        .name(Defines.Any)
+        .fullName(Defines.Any)
+        .astParentType(NodeTypes.NAMESPACE_BLOCK)
+        .astParentFullName(NamespaceTraversal.globalNamespaceName)
+        .isExternal(true)
+    diffGraph.addNode(emptyType).addNode(anyType)
+    BatchedUpdate.applyDiff(cpg.graph, diffGraph)
+  }
 
   override def runOnPart(diffGraph: DiffGraphBuilder, astCreator: AstCreator): Unit = {
     try {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ControlStructureTests.scala
@@ -117,7 +117,12 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("t = 100", 2), ("t + 1", 4)), List(("t = 100", 2), ("t + 2", 6)))
+      Set(
+        List(("t = 100", 2), ("t + 1", 4), ("puts t + 1", 4)),
+        List(("t = 100", 2), ("t + 2", 6), ("puts t + 2", 6)),
+        List(("t = 100", 2), ("t + 2", 6)),
+        List(("t = 100", 2), ("t + 1", 4))
+      )
   }
 
   "flow through an `unless-end` statement" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
@@ -16,11 +16,13 @@ class SingleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val source = cpg.literal.l
     val sink   = cpg.method.name("puts").callIn.argument.l
     val flows  = sink.reachableByFlows(source).map(flowToResultPairs).distinct.sortBy(_.length).l
-    flows.size shouldBe 4
-    val List(flow1, flow2, flow3, flow4) = flows
+    flows.size shouldBe 6
+    val List(flow1, flow2, flow3, flow4, flow5, flow6) = flows
     flow1 shouldBe List(("y = 1", 2), ("puts y", 3))
     flow2 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("puts x", 4))
     flow3 shouldBe List(("y = 1", 2), ("z = x = y = 1", 2), ("puts z", 5))
-    flow4 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("z = x = y = 1", 2), ("puts z", 5))
+    flow4 shouldBe List(("y = 1", 2), ("puts y", 3), ("puts x", 4))
+    flow5 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("puts x", 4), ("puts z", 5))
+    flow6 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("z = x = y = 1", 2), ("puts z", 5))
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -109,7 +109,7 @@ class ArrayTests extends RubyCode2CpgFixture {
         bracketCall.typeFullName shouldBe "__builtin.Array"
 
         inside(bracketCall.argument.l) {
-          case one :: two :: three :: Nil =>
+          case _ :: one :: two :: three :: Nil =>
             one.code shouldBe "1"
             two.code shouldBe "2"
             three.code shouldBe "3"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -17,7 +17,11 @@ class CallTests extends RubyCode2CpgFixture {
     puts.lineNumber shouldBe Some(2)
     puts.code shouldBe "puts 'hello'"
 
-    val List(hello) = puts.argument.l
+    val List(rec: Identifier, hello: Literal) = puts.argument.l: @unchecked
+    rec.argumentIndex shouldBe 0
+    rec.name shouldBe "puts"
+
+    hello.argumentIndex shouldBe 1
     hello.code shouldBe "'hello'"
     hello.lineNumber shouldBe Some(2)
   }
@@ -75,7 +79,10 @@ class CallTests extends RubyCode2CpgFixture {
 
     "contain they keyword in the argumentName property" in {
       inside(cpg.call.nameExact("foo").argument.l) {
-        case (hello: Literal) :: (baz: Literal) :: Nil =>
+        case (foo: Identifier) :: (hello: Literal) :: (baz: Literal) :: Nil =>
+          foo.name shouldBe "foo"
+          foo.argumentIndex shouldBe 0
+
           hello.code shouldBe "\"hello\""
           hello.argumentIndex shouldBe 1
           hello.argumentName shouldBe None

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -48,12 +48,7 @@ class CaseTests extends RubyCode2CpgFixture {
       }.l
     }.l
 
-    conds shouldBe List(
-      List("expr:0"),
-      List("expr:1", "expr:2"),
-      List("expr:3", "splat:[4,5].include?"),
-      List("splat:[6].include?")
-    )
+    conds shouldBe List(List("expr:0"), List("expr:1", "expr:2"), List("expr:3", "splat:[4,5]"), List("splat:[6]"))
     val matchResults = ifStmts.astChildren.order(2).astChildren ++ ifStmts.last.astChildren.order(3).astChildren
     matchResults.code.l shouldBe List("0", "1", "2", "3", "4")
 
@@ -94,8 +89,8 @@ class CaseTests extends RubyCode2CpgFixture {
     conds shouldBe List(
       List("expr:false", "expr:true"),
       List("expr:true"),
-      List("expr:false", "splat:[false,false].any?"),
-      List("splat:[false,true].any?")
+      List("expr:false", "splat:[false,false]"),
+      List("splat:[false,true]")
     )
 
     val matchResults = ifStmts.astChildren.order(2).astChildren.l

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -318,13 +318,13 @@ class ClassTests extends RubyCode2CpgFixture {
           val List(validateCall: Call) = userType.astChildren.isCall.l: @unchecked
 
           inside(validateCall.argument.l) {
-            case (passwordArg: Literal) :: (presenceArg: Literal) :: (confirmationArg: Literal) :: (lengthArg: Block) :: (onArg: Literal) :: (ifArg: Literal) :: Nil =>
+            case _ :: (passwordArg: Literal) :: (presenceArg: Literal) :: (confirmationArg: Literal) :: (lengthArg: Block) :: (onArg: Literal) :: (ifArg: Literal) :: Nil =>
               passwordArg.code shouldBe ":password"
               presenceArg.code shouldBe "true"
               confirmationArg.code shouldBe "true"
               onArg.code shouldBe ":create"
               ifArg.code shouldBe ":password"
-            case xs => fail(s"Expected 6 arguments, got ${xs.code.mkString(", ")} instead")
+            case xs => fail(s"Expected 7 arguments, got ${xs.code.mkString(", ")} instead")
           }
         case _ => fail("Expected typeDecl for user, none found instead")
       }
@@ -344,11 +344,11 @@ class ClassTests extends RubyCode2CpgFixture {
           inside(adminTypeDecl.astChildren.isCall.l) {
             case beforeActionCall :: skipBeforeActionCall :: layoutCall :: Nil =>
               inside(beforeActionCall.argument.l) {
-                case adminArg :: ifArg :: exceptArg :: Nil =>
+                case _ :: adminArg :: ifArg :: exceptArg :: Nil =>
                   adminArg.code shouldBe ":administrative"
                   ifArg.code shouldBe ":admin_param"
                   exceptArg.code shouldBe "[:get_user]"
-                case xs => fail(s"Expected 3 args, instead found ${xs.code.mkString(", ")}")
+                case xs => fail(s"Expected 4 args, instead found ${xs.code.mkString(", ")}")
               }
             case xs => fail(s"Expected 3 calls, instead found ${xs.code.mkString(", ")}")
           }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -97,7 +97,11 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
     "specify the closure reference as an argument to the member call with block" in {
       inside(cpg.call("each").argument.l) {
-        case (lambdaRef: MethodRef) :: Nil =>
+        case (myArray: Identifier) :: (lambdaRef: MethodRef) :: Nil =>
+          myArray.argumentIndex shouldBe 0
+          myArray.name shouldBe "my_array"
+
+          lambdaRef.argumentIndex shouldBe 1
           lambdaRef.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
@@ -157,7 +161,11 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
     "specify the closure reference as an argument to the member call with block" in {
       inside(cpg.call("each").argument.l) {
-        case (lambdaRef: MethodRef) :: Nil =>
+        case (hash: Identifier) :: (lambdaRef: MethodRef) :: Nil =>
+          hash.argumentIndex shouldBe 0
+          hash.name shouldBe "hash"
+
+          lambdaRef.argumentIndex shouldBe 1
           lambdaRef.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -18,7 +18,7 @@ class ImportTests extends RubyCode2CpgFixture with Inspectors {
     importNode.importedAs shouldBe Some("test")
     val List(call) = importNode.call.l
     call.callee.name.l shouldBe List("require")
-    call.argument.code.l shouldBe List("'test'")
+    call.argument.where(_.argumentIndexGt(0)).code.l shouldBe List("'test'")
   }
 
   "`begin require 'test' rescue LoadError end` has a CALL node with an IMPORT node pointing to it" in {
@@ -33,7 +33,7 @@ class ImportTests extends RubyCode2CpgFixture with Inspectors {
     importNode.importedAs shouldBe Some("test")
     val List(call) = importNode.call.l
     call.callee.name.l shouldBe List("require")
-    call.argument.code.l shouldBe List("'test'")
+    call.argument.where(_.argumentIndexGt(0)).code.l shouldBe List("'test'")
   }
 
   "Ambiguous class resolves to required method" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -391,7 +391,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
 
                   returnCall.name shouldBe "foo"
 
-                  val List(arg: MethodRef) = returnCall.argument.l: @unchecked
+                  val List(_, arg: MethodRef) = returnCall.argument.l: @unchecked
                   arg.methodFullName shouldBe "Test0.rb:<global>::program:bar:<lambda>0"
                 case xs => fail(s"Expected one call for return, but found ${xs.code.mkString(", ")} instead")
               }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.Return
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, Return}
 import io.shiftleft.semanticcpg.language.*
 
 class MethodTests extends RubyCode2CpgFixture {
@@ -293,7 +293,13 @@ class MethodTests extends RubyCode2CpgFixture {
               // bar forwards parameters to a call to the aliased method
               inside(bar.call.name("x=").l) {
                 case barCall :: Nil =>
-                  barCall.argument.isIdentifier.name.head shouldBe "z"
+                  inside(barCall.argument.l) {
+                    case _ :: (z: Identifier) :: Nil =>
+                      z.name shouldBe "z"
+                      z.argumentIndex shouldBe 1
+                    case xs =>
+                      fail(s"Expected a two arguments for the call `x=`,  instead got [${xs.code.mkString(",")}]")
+                  }
                   barCall.code shouldBe "x=(z)"
                 case xs => fail(s"Expected a single call to `bar=`,  instead got [${xs.code.mkString(",")}]")
               }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
@@ -54,7 +54,7 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
         "replace the yield with a call to the block parameter with arguments" in {
           val List(call) = cpg.call.codeExact("yield(x)").astChildren.isCall.codeExact("yield(x)").l
           call.name shouldBe "<proc-param-0>"
-          call.argument.code.l shouldBe List("x")
+          call.argument.code.l shouldBe List("<proc-param-0>", "x")
         }
 
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SetterTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SetterTests.scala
@@ -21,7 +21,7 @@ class SetterTests extends RubyCode2CpgFixture {
     fieldAccess.lineNumber shouldBe Some(2)
     fieldAccess.fieldIdentifier.code.l shouldBe List("y=")
 
-    val List(one) = setter.argument.l
+    val List(_, one) = setter.argument.l
     one.code shouldBe "1"
     one.lineNumber shouldBe Some(2)
   }


### PR DESCRIPTION
* No longer making call receivers field accesses, this is the source of many bugs
* Included `<empty>` and `ANY` type creation for the linker as these are explicitly ignored otherwise and have `null` implications for nodes that evaluate to those types
* Adjusted tests accordingly