### PR TITLE
Disable caching for actions/setup-go

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
+          cache: false
           go-version: 1.18
       - name: Set up Swift
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
They enabled caching since v4. We do not need it.