### PR TITLE
[ruby] Handling nodes directly under typedecl

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -76,7 +76,11 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       val baseStmtBlockAst = astForMethodBody(node.body, optionalStatementList)
       transformAsClosureBody(refs, baseStmtBlockAst)
     } else {
-      astForMethodBody(node.body, optionalStatementList)
+      if (methodName != XDefines.ConstructorMethodName && node.methodName != XDefines.StaticInitMethodName) {
+        astForMethodBody(node.body, optionalStatementList)
+      } else {
+        astForConstructorMethodBody(node.body, optionalStatementList)
+      }
     }
 
     val anonProcParam = scope.anonProcParam.map { param =>
@@ -368,6 +372,24 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           astForStatementListReturningLastExpression(
             StatementList(optionalStatementList.statements ++ List(body))(body.span)
           )
+        case body =>
+          logger.warn(
+            s"Non-linear method bodies are not supported yet: ${body.text} (${body.getClass.getSimpleName}) ($relativeFileName), skipping"
+          )
+          astForUnknown(body)
+    }
+  }
+
+  private def astForConstructorMethodBody(body: RubyNode, optionalStatementList: StatementList): Ast = {
+    if (this.parseLevel == AstParseLevel.SIGNATURES) {
+      Ast()
+    } else {
+      body match
+        case stmtList: StatementList =>
+          astForStatementList(StatementList(optionalStatementList.statements ++ stmtList.statements)(stmtList.span))
+        case _: (StaticLiteral | BinaryExpression | SingleAssignment | SimpleIdentifier | ArrayLiteral | HashLiteral |
+              SimpleCall | MemberAccess | MemberCall) =>
+          astForStatementList(StatementList(optionalStatementList.statements ++ List(body))(body.span))
         case body =>
           logger.warn(
             s"Non-linear method bodies are not supported yet: ${body.text} (${body.getClass.getSimpleName}) ($relativeFileName), skipping"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -44,7 +44,9 @@ object RubyIntermediateAst {
     def size: Int = statements.size
   }
 
-  sealed trait TypeDeclaration {
+  sealed trait AllowedTypeDeclarationChild
+
+  sealed trait TypeDeclaration extends AllowedTypeDeclarationChild {
     def name: RubyNode
     def baseClass: Option[RubyNode]
     def body: RubyNode
@@ -85,6 +87,7 @@ object RubyIntermediateAst {
 
   final case class MethodDeclaration(methodName: String, parameters: List[RubyNode], body: RubyNode)(span: TextSpan)
       extends RubyNode(span)
+      with AllowedTypeDeclarationChild
 
   final case class SingletonMethodDeclaration(
     target: RubyNode,
@@ -93,6 +96,7 @@ object RubyIntermediateAst {
     body: RubyNode
   )(span: TextSpan)
       extends RubyNode(span)
+      with AllowedTypeDeclarationChild
 
   sealed trait MethodParameter {
     def name: String

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -79,7 +79,9 @@ object RubyIntermediateAst {
   ) extends RubyNode(span)
       with AnonymousTypeDeclaration
 
-  final case class FieldsDeclaration(fieldNames: List[RubyNode])(span: TextSpan) extends RubyNode(span) {
+  final case class FieldsDeclaration(fieldNames: List[RubyNode])(span: TextSpan)
+      extends RubyNode(span)
+      with AllowedTypeDeclarationChild {
     def hasGetter: Boolean = text.startsWith("attr_reader") || text.startsWith("attr_accessor")
 
     def hasSetter: Boolean = text.startsWith("attr_writer") || text.startsWith("attr_accessor")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -315,16 +315,24 @@ class ClassTests extends RubyCode2CpgFixture {
           |""".stripMargin)
       inside(cpg.typeDecl.name("User").l) {
         case userType :: Nil =>
-          val List(validateCall: Call) = userType.astChildren.isCall.l: @unchecked
+          inside(userType.method.name(Defines.ConstructorMethodName).l) {
+            case constructor :: Nil =>
+              inside(constructor.astChildren.isBlock.l) {
+                case methodBlock :: Nil =>
+                  val List(validateCall: Call) = methodBlock.astChildren.isCall.l: @unchecked
 
-          inside(validateCall.argument.l) {
-            case _ :: (passwordArg: Literal) :: (presenceArg: Literal) :: (confirmationArg: Literal) :: (lengthArg: Block) :: (onArg: Literal) :: (ifArg: Literal) :: Nil =>
-              passwordArg.code shouldBe ":password"
-              presenceArg.code shouldBe "true"
-              confirmationArg.code shouldBe "true"
-              onArg.code shouldBe ":create"
-              ifArg.code shouldBe ":password"
-            case xs => fail(s"Expected 7 arguments, got ${xs.code.mkString(", ")} instead")
+                  inside(validateCall.argument.l) {
+                    case (identArg: Identifier) :: (passwordArg: Literal) :: (presenceArg: Literal) :: (confirmationArg: Literal) :: (lengthArg: Block) :: (onArg: Literal) :: (ifArg: Literal) :: Nil =>
+                      passwordArg.code shouldBe ":password"
+                      presenceArg.code shouldBe "true"
+                      confirmationArg.code shouldBe "true"
+                      onArg.code shouldBe ":create"
+                      ifArg.code shouldBe ":password"
+                    case xs => fail(s"Expected 7 arguments, got ${xs.code.mkString(", ")} instead")
+                  }
+                case xs => fail(s"Expected one block for method body, got ${xs.code.mkString(", ")} instead")
+              }
+            case xs => fail(s"Expected one constructor method, got ${xs.name.mkString(", ")} instead")
           }
         case _ => fail("Expected typeDecl for user, none found instead")
       }
@@ -341,17 +349,26 @@ class ClassTests extends RubyCode2CpgFixture {
 
       inside(cpg.typeDecl.name("AdminController").l) {
         case adminTypeDecl :: Nil =>
-          inside(adminTypeDecl.astChildren.isCall.l) {
-            case beforeActionCall :: skipBeforeActionCall :: layoutCall :: Nil =>
-              inside(beforeActionCall.argument.l) {
-                case _ :: adminArg :: ifArg :: exceptArg :: Nil =>
-                  adminArg.code shouldBe ":administrative"
-                  ifArg.code shouldBe ":admin_param"
-                  exceptArg.code shouldBe "[:get_user]"
-                case xs => fail(s"Expected 4 args, instead found ${xs.code.mkString(", ")}")
+          inside(adminTypeDecl.method.name(Defines.ConstructorMethodName).l) {
+            case constructor :: Nil =>
+              inside(constructor.astChildren.isBlock.l) {
+                case methodBlock :: Nil =>
+                  inside(methodBlock.astChildren.isCall.l) {
+                    case beforeActionCall :: skipBeforeActionCall :: layoutCall :: Nil =>
+                      inside(beforeActionCall.argument.l) {
+                        case identArg :: adminArg :: ifArg :: exceptArg :: Nil =>
+                          adminArg.code shouldBe ":administrative"
+                          ifArg.code shouldBe ":admin_param"
+                          exceptArg.code shouldBe "[:get_user]"
+                        case xs => fail(s"Expected 4 args, instead found ${xs.code.mkString(", ")}")
+                      }
+                    case xs => fail(s"Expected 3 calls, instead found ${xs.code.mkString(", ")}")
+                  }
+                case xs => fail(s"Expected one block for method body, got ${xs.code.mkString(", ")} instead")
               }
-            case xs => fail(s"Expected 3 calls, instead found ${xs.code.mkString(", ")}")
+            case xs => fail(s"Expected one constructor method, got ${xs.name.mkString(", ")} instead")
           }
+
         case _ => fail("Expected one typeDecl for AdminController")
       }
     }
@@ -593,9 +610,10 @@ class ClassTests extends RubyCode2CpgFixture {
                   scopeCall.code shouldBe "scope :published, -> { where(status: \"Published\") }"
 
                   inside(scopeCall.argument.l) {
-                    case (literalArg: Literal) :: unknownArg :: Nil =>
+                    case (scopeIdent: Identifier) :: (literalArg: Literal) :: unknownArg :: Nil =>
+                      scopeIdent.code shouldBe "scope"
                       literalArg.code shouldBe ":published"
-                    case xs => fail(s"Expected two arguments, got ${xs.code.mkString(", ")} instead")
+                    case xs => fail(s"Expected three arguments, got ${xs.code.mkString(", ")} instead")
                   }
                 case xs => fail(s"Expected one call under constructor, got ${xs.code.mkString(", ")} instead")
               }


### PR DESCRIPTION
This PR Handles:
 * Added new trait `AllowedTypeDeclerationChild` for all nodes that are allowed to be directly under `TypeDecl`. 
 * Moved all nodes at start of class definition not allowed under `TypeDecl` into the `<init>` method.
 * `astForConstructorMethodBody` parses method body for constructor without the implicit return.

Resolves #4395 