### PR TITLE
[ruby] Arrow Syntax for Lambda Expressions

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.astcreation
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{Unknown, *}
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{Unknown, Block as RubyBlock, *}
 import io.joern.rubysrc2cpg.datastructures.BlockScope
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.{RubyOperators, getBuiltInType}
@@ -670,7 +670,13 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     node match
       // Associations in method calls are keyword arguments
       case assoc: Association => astForKeywordArgument(assoc)
-      case _                  => astForExpression(node)
+      case block: RubyBlock =>
+        val Seq(methodDecl, typeDecl, _, methodRef) = astForDoBlock(block)
+        Ast.storeInDiffGraph(methodDecl, diffGraph)
+        Ast.storeInDiffGraph(typeDecl, diffGraph)
+
+        methodRef
+      case _ => astForExpression(node)
   }
 
   private def astForKeywordArgument(assoc: Association): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -205,8 +205,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
   protected def astForDoBlock(block: Block with RubyNode): Seq[Ast] = {
     // Create closure structures: [MethodDecl, TypeRef, MethodRef]
-    val methodName         = nextClosureName()
-    val methodAstsWithRefs = astForMethodDeclaration(block.toMethodDeclaration(methodName), isClosure = true)
+    val methodName = nextClosureName()
+
+    val methodAstsWithRefs = block.body match {
+      case x: Block => astForMethodDeclaration(x.toMethodDeclaration(methodName), isClosure = true)
+      case _        => astForMethodDeclaration(block.toMethodDeclaration(methodName), isClosure = true)
+    }
+
     // Set span contents
     methodAstsWithRefs.flatMap(_.nodes).foreach {
       case m: NewMethodRef => DummyNode(m.copy)(block.span.spanStart(m.code))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -516,6 +516,12 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     }
   }
 
+  override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): RubyNode = {
+    val parameters = Option(ctx.parameterList()).fold(List())(_.parameters).map(visit)
+    val body       = visit(ctx.block())
+    Block(parameters, body)(ctx.toTextSpan)
+  }
+
   override def visitMethodCallWithParenthesesExpression(
     ctx: RubyParser.MethodCallWithParenthesesExpressionContext
   ): RubyNode = {


### PR DESCRIPTION
This PR handles:
 * Arrow syntax for lambda expressions.

Resolves #4394 