### PR TITLE
[javasrc2cpg] - introduce JavaSummaryTypeSolver

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -21,7 +21,8 @@ final case class Config(
   showEnv: Boolean = false,
   skipTypeInfPass: Boolean = false,
   dumpJavaparserAsts: Boolean = false,
-  cacheJdkTypeSolver: Boolean = false
+  cacheJdkTypeSolver: Boolean = false,
+  typeSummariesPath: Option[String] = None
 ) extends X2CpgConfig[Config]
     with TypeRecoveryParserConfig[Config] {
   def withInferenceJarPaths(paths: Set[String]): Config = {
@@ -66,6 +67,10 @@ final case class Config(
 
   def withCacheJdkTypeSolver(value: Boolean): Config = {
     copy(cacheJdkTypeSolver = value).withInheritedFields(this)
+  }
+
+  def withTypeSummariesPath(path: String): Config = {
+    copy(typeSummariesPath = Some(path)).withInheritedFields(this)
   }
 }
 
@@ -120,7 +125,11 @@ private object Frontend {
       opt[Unit]("cache-jdk-type-solver")
         .hidden()
         .action((_, c) => c.withCacheJdkTypeSolver(true))
-        .text("Re-use JDK type solver between scans.")
+        .text("Re-use JDK type solver between scans."),
+      opt[String]("type-summaries-path")
+        .hidden()
+        .action((path, c) => c.withTypeSummariesPath(path))
+        .text("Type summaries path used for resolving external types.")
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JavaSummaryTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JavaSummaryTypeSolver.scala
@@ -1,0 +1,182 @@
+package io.joern.javasrc2cpg.typesolvers
+
+import better.files.File
+import com.github.javaparser.ParserConfiguration.LanguageLevel
+import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ast.Node.Parsedness
+import com.github.javaparser.ast.body.TypeDeclaration
+import com.github.javaparser.resolution.TypeSolver
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
+import com.github.javaparser.resolution.model.SymbolReference
+import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade
+import com.github.javaparser.{JavaParser, ParserConfiguration}
+import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, TypeLike}
+import org.slf4j.LoggerFactory
+import upickle.default.*
+
+import java.io.{ByteArrayInputStream, FileInputStream, InputStream, StringReader}
+import scala.annotation.targetName
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.RichOptional
+import scala.util.{Failure, Success, Try}
+
+/** A type solver built out of a [[JavaProgramSummary]].
+  *
+  * Proceeds similarly to [[EagerSourceTypeSolver]], by first transforming type summaries into equivalent Java
+  * declarations to be then parsed.
+  */
+class JavaSummaryTypeSolver(
+  summary: JavaProgramSummary,
+  combinedTypeSolver: SimpleCombinedTypeSolver,
+  symbolSolver: JavaSymbolSolver
+) extends TypeSolver {
+
+  private val logger             = LoggerFactory.getLogger(getClass)
+  private var parent: TypeSolver = _
+  private val javaParser: JavaParser = new JavaParser(
+    new ParserConfiguration()
+      .setLanguageLevel(LanguageLevel.BLEEDING_EDGE)
+      .setStoreTokens(false)
+  )
+
+  private def parseSummary(javaCode: String): Option[CompilationUnit] = {
+    val parseResult = javaParser.parse(StringReader(javaCode))
+    parseResult.getResult.toScala match {
+      case Some(result) if result.getParsed == Parsedness.PARSED => Some(result)
+      case _ =>
+        logger.warn(s"Encountered problems while parsing a Java type summary:")
+        parseResult.getProblems.asScala.foreach(problem => logger.warn(s"- ${problem.getMessage}"))
+        None
+    }
+  }
+
+  private def resolveSymbols(cu: CompilationUnit): List[(String, SymbolReference[ResolvedReferenceTypeDeclaration])] = {
+    symbolSolver.inject(cu)
+    cu.findAll(classOf[TypeDeclaration[_]])
+      .asScala
+      .map { typeDeclaration =>
+        val name = typeDeclaration.getFullyQualifiedName.toScala.getOrElse(typeDeclaration.getNameAsString)
+        val resolvedSymbol = Try(
+          SymbolReference.solved(
+            JavaParserFacade.get(combinedTypeSolver).getTypeDeclaration(typeDeclaration)
+          ): SymbolReference[ResolvedReferenceTypeDeclaration]
+        ).getOrElse(SymbolReference.unsolved())
+        name -> resolvedSymbol
+      }
+      .toList
+  }
+
+  private val foundTypes: Map[String, SymbolReference[ResolvedReferenceTypeDeclaration]] =
+    summary.asJavaCode.flatMap(parseSummary).flatMap(resolveSymbols).toMap
+
+  override def tryToSolveType(name: String): SymbolReference[ResolvedReferenceTypeDeclaration] =
+    foundTypes.getOrElse(name, SymbolReference.unsolved())
+
+  override def getParent: TypeSolver = parent
+
+  override def setParent(parent: TypeSolver): Unit = {
+    if (parent == null) {
+      logger.warn(s"Cannot set parent of type solver to null. setParent will be ignored.")
+    } else if (this.parent != null) {
+      logger.warn(s"Attempting to re-set type solver parent. setParent will be ignored.")
+    } else if (parent == this) {
+      logger.warn(s"Parent of TypeSolver cannot be itself. setParent will be ignored.")
+    } else {
+      this.parent = parent
+    }
+  }
+}
+
+case class JavaFieldSummary(name: String, typeName: String) extends FieldLike derives ReadWriter {
+  def asJavaCode: List[String] = s"public $typeName $name;" :: Nil
+}
+
+case class JavaMethodSummary(
+  name: String,
+  returnType: String,
+  parameterTypes: List[(String, String)],
+  isStatic: Boolean
+) extends MethodLike
+    derives ReadWriter {
+
+  def asJavaCode: List[String] =
+    s"""
+       |public${if (isStatic) " static" else ""} $returnType $name($parametersAsJavaCode){}
+       |""".stripMargin :: Nil
+
+  private def parametersAsJavaCode: String = parameterTypes.map { p => s"${p._2} ${p._1}" }.mkString(", ")
+}
+
+case class JavaTypeSummary(
+  name: String,
+  methods: List[JavaMethodSummary],
+  fields: List[JavaFieldSummary],
+  isStatic: Boolean,
+  innerClasses: List[JavaTypeSummary]
+) extends TypeLike[JavaMethodSummary, JavaFieldSummary]
+    derives ReadWriter {
+
+  @targetName("add")
+  override def +(other: TypeLike[JavaMethodSummary, JavaFieldSummary]): TypeLike[JavaMethodSummary, JavaFieldSummary] =
+    this.copy(methods = mergeMethods(other), fields = mergeFields(other))
+
+  def asJavaCode: List[String] =
+    s"""
+       |public${if (isStatic) " static" else ""} class $name{
+       |${fields.flatMap(_.asJavaCode).mkString("\n")}
+       |${methods.flatMap(_.asJavaCode).mkString("\n")}
+       |${innerClasses.flatMap(_.asJavaCode).mkString("\n")}
+       |}""".stripMargin :: Nil
+}
+
+type NamespaceToTypeMap = Map[String, Set[JavaTypeSummary]]
+
+class JavaProgramSummary(initialMappings: List[NamespaceToTypeMap] = List.empty)
+    extends ProgramSummary[JavaTypeSummary] {
+
+  override val namespaceToType: NamespaceToTypeMap = initialMappings.reduceOption(_ ++ _).getOrElse(Map.empty)
+
+  @targetName("add")
+  def ++(other: JavaProgramSummary): JavaProgramSummary = JavaProgramSummary(
+    ProgramSummary.combine(this.namespaceToType, other.namespaceToType) :: Nil
+  )
+
+  def asJavaCode: List[String] = namespaceToType.flatMap { (nsName, types) =>
+    types.map { typeSummary =>
+      s"""
+         |package $nsName;
+         |${typeSummary.asJavaCode.mkString}
+         |""".stripMargin
+    }
+  }.toList
+}
+
+object JavaProgramSummary {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def empty: JavaProgramSummary = JavaProgramSummary(List.empty)
+
+  private def fromJsonInputStream(jsonInputStream: InputStream): Try[NamespaceToTypeMap] =
+    Try(read[NamespaceToTypeMap](ujson.Readable.fromByteArray(jsonInputStream.readAllBytes())))
+
+  def fromJsonString(jsonString: String): Try[NamespaceToTypeMap] =
+    fromJsonInputStream(ByteArrayInputStream(jsonString.getBytes))
+
+  def fromJsonDirectoryPath(path: String): List[NamespaceToTypeMap] = Try {
+    File(path)
+      .collectChildren(_.name.endsWith(".json"))
+      .flatMap { jsonFile =>
+        fromJsonInputStream(FileInputStream(jsonFile.toJava)) match {
+          case Success(mappings) => mappings :: Nil
+          case Failure(err) =>
+            logger.warn(s"Could not load Java type summary `${jsonFile.path}`:")
+            logger.warn(err.getMessage)
+            Nil
+        }
+      }
+      .toList
+  }.getOrElse(Nil)
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -28,7 +28,7 @@ class SourceParser(
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  /** Parse the given file into a JavaParser CompliationUnit that will be used for creating the CPG AST.
+  /** Parse the given file into a JavaParser CompilationUnit that will be used for creating the CPG AST.
     *
     * @param relativeFilename
     *   path to the input file relative to the project root.

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/programsummary_tests/okhttp3.json
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/programsummary_tests/okhttp3.json
@@ -1,0 +1,59 @@
+{
+  "okhttp3": [
+    {
+      "name": "OkHttpClient",
+      "methods": [
+        {
+          "name": "newCall",
+          "returnType": "Call",
+          "parameterTypes": [
+            [
+              "request",
+              "Request"
+            ]
+          ],
+          "isStatic": false
+        }
+      ],
+      "fields": [],
+      "isStatic": false,
+      "innerClasses": [
+        {
+          "name": "Builder",
+          "methods": [
+            {
+              "name": "build",
+              "returnType": "OkHttpClient",
+              "parameterTypes": [],
+              "isStatic": false
+            }
+          ],
+          "fields": [],
+          "isStatic": true,
+          "innerClasses": []
+        }
+      ]
+    },
+    {
+      "name": "Request",
+      "methods": [],
+      "fields": [],
+      "isStatic": false,
+      "innerClasses": []
+    },
+    {
+      "name": "Call",
+      "methods": [
+        {
+          "name": "executeAsync",
+          "returnType": "void",
+          "parameterTypes": [],
+          "isStatic": false
+        }
+      ],
+      "fields": [],
+      "isStatic": false,
+      "innerClasses": []
+    }
+  ]
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/JavaProgramSummaryTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/JavaProgramSummaryTests.scala
@@ -1,0 +1,270 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.Config
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.joern.javasrc2cpg.typesolvers.JavaProgramSummary
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.utils.ProjectRoot
+import org.scalatest.Inside.inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Success
+
+class JavaProgramSummaryTests extends AnyWordSpec with Matchers {
+
+  "empty JSON object" should {
+    "load properly" in {
+      val json = "{}"
+      inside(JavaProgramSummary.fromJsonString(json)) { case Success(mappings) =>
+        mappings shouldBe empty
+      }
+    }
+  }
+
+  "namespace without types" should {
+    "load properly" in {
+      val json =
+        """
+          |{
+          |  "Foo" : []
+          |}
+          |""".stripMargin
+      inside(JavaProgramSummary.fromJsonString(json)) { case Success(mappings) =>
+        mappings("Foo") shouldBe Set.empty
+      }
+    }
+  }
+
+  "namespace with single empty type" should {
+    "load and render properly" in {
+      val json =
+        """
+          |{
+          | "org.codeminers": [
+          |   {
+          |     "name": "Foo",
+          |     "methods": [],
+          |     "fields": [],
+          |     "isStatic": false,
+          |     "innerClasses": []
+          |   }
+          | ]
+          |}
+          |""".stripMargin
+
+      inside(JavaProgramSummary.fromJsonString(json)) { case Success(mappings) =>
+        JavaProgramSummary(mappings :: Nil).asJavaCode shouldBe
+          """
+              |package org.codeminers;
+              |
+              |public class Foo{
+              |
+              |
+              |
+              |}
+              |""".stripMargin :: Nil
+      }
+    }
+  }
+
+  "two namespaces with an empty type each" should {
+    "load and render properly" in {
+      val json =
+        """
+          |{
+          | "org.codeminers1": [
+          |   {
+          |     "name": "Foo",
+          |     "methods": [],
+          |     "fields": [],
+          |     "innerClasses": [],
+          |     "isStatic": false
+          |   }
+          | ],
+          | "org.codeminers2": [
+          |   {
+          |     "name": "Bar",
+          |     "methods": [],
+          |     "fields": [],
+          |     "innerClasses": [],
+          |     "isStatic": false
+          |   }
+          | ]
+          |}
+          |""".stripMargin
+
+      inside(JavaProgramSummary.fromJsonString(json)) { case Success(mappings) =>
+        JavaProgramSummary(mappings :: Nil).asJavaCode shouldBe List(
+          """
+            |package org.codeminers1;
+            |
+            |public class Foo{
+            |
+            |
+            |
+            |}
+            |""".stripMargin,
+          """
+            |package org.codeminers2;
+            |
+            |public class Bar{
+            |
+            |
+            |
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+  }
+
+  "two same-named namespaces with an empty type each" should {
+    "be merged and rendered properly" in {
+      val json1 =
+        """
+          |{
+          | "org.codeminers": [
+          |   {
+          |     "name": "Foo",
+          |     "methods": [],
+          |     "fields": [],
+          |     "innerClasses": [],
+          |     "isStatic": false
+          |   }
+          | ]
+          |}
+          |""".stripMargin
+
+      val json2 =
+        """
+          |{
+          | "org.codeminers": [
+          |   {
+          |     "name": "Bar",
+          |     "methods": [],
+          |     "fields": [],
+          |     "innerClasses": [],
+          |     "isStatic": false
+          |   }
+          | ]
+          |}
+          |""".stripMargin
+
+      val summary1 = JavaProgramSummary(JavaProgramSummary.fromJsonString(json1).toOption.toList)
+      val summary2 = JavaProgramSummary(JavaProgramSummary.fromJsonString(json2).toOption.toList)
+      inside((summary1 ++ summary2).asJavaCode.sorted) { case bar :: foo :: Nil =>
+        bar shouldBe
+          """
+              |package org.codeminers;
+              |
+              |public class Bar{
+              |
+              |
+              |
+              |}
+              |""".stripMargin
+        foo shouldBe
+          """
+              |package org.codeminers;
+              |
+              |public class Foo{
+              |
+              |
+              |
+              |}
+              |""".stripMargin
+      }
+    }
+  }
+}
+
+class FileSystemJavaProgramSummaryTests extends JavaSrcCode2CpgFixture {
+
+  private val config =
+    Config().withTypeSummariesPath(
+      ProjectRoot.relativise("joern-cli/frontends/javasrc2cpg/src/test/resources/programsummary_tests")
+    )
+
+  "okhttp3 newCall" should {
+    val cpg = code("""
+                     |import okhttp3.*;
+                     |
+                     |class Main {
+                     | void run(Request req) {
+                     |   var client = new OkHttpClient();
+                     |   var call = client.newCall(req);
+                     |   call.executeAsync();
+                     | }
+                     |}
+                     |""".stripMargin).withConfig(config)
+
+    "parameter `req` should have suggested type" in {
+      inside(cpg.parameter("req").l) { case req :: Nil => req.typeFullName shouldBe "okhttp3.Request" }
+    }
+
+    "call `newCall` should have suggested type" in {
+      inside(cpg.call("newCall").l) { case newCall :: Nil =>
+        newCall.methodFullName shouldBe "okhttp3.OkHttpClient.newCall:okhttp3.Call(okhttp3.Request)"
+        newCall.signature shouldBe "okhttp3.Call(okhttp3.Request)"
+      }
+    }
+
+    "local `call` should have suggested type" in {
+      inside(cpg.local("call").l) { case call :: Nil => call.typeFullName shouldBe "okhttp3.Call" }
+    }
+  }
+
+  "okhttp3 Builder" should {
+    val cpg = code("""
+        |import okhttp3.*;
+        |import okhttp3.OkHttpClient;
+        |
+        |public class Main {
+        |  OkHttpClient getHttpClient() {
+        |    var builder = new OkHttpClient.Builder();
+        |    var client = builder.build();
+        |    return client;
+        |  }
+        |  void run(Request req) {
+        |    var call = getHttpClient().newCall(req);
+        |    call.execute();
+        |  }
+        |}
+        |""".stripMargin).withConfig(config)
+
+    "parameter `req` should have suggested type" in {
+      inside(cpg.parameter("req").l) { case req :: Nil => req.typeFullName shouldBe "okhttp3.Request" }
+    }
+
+    "call `newCall` should have suggested type" in {
+      inside(cpg.call("newCall").l) { case newCall :: Nil =>
+        newCall.methodFullName shouldBe "okhttp3.OkHttpClient.newCall:okhttp3.Call(okhttp3.Request)"
+        newCall.signature shouldBe "okhttp3.Call(okhttp3.Request)"
+      }
+    }
+
+    "call `build` should have suggested type" in {
+      inside(cpg.call("build").l) { case build :: Nil =>
+        build.methodFullName shouldBe "okhttp3.OkHttpClient$Builder.build:okhttp3.OkHttpClient()"
+        build.signature shouldBe "okhttp3.OkHttpClient()"
+      }
+    }
+
+    "local `call` should have suggested type" in {
+      inside(cpg.local("call").l) { case call :: Nil => call.typeFullName shouldBe "okhttp3.Call" }
+    }
+
+    "local `builder` should have suggested type" in {
+      inside(cpg.local("builder").l) { case builder :: Nil =>
+        builder.typeFullName shouldBe "okhttp3.OkHttpClient$Builder"
+      }
+    }
+
+    "local `client` should have suggested type" in {
+      inside(cpg.local("client").l) { case client :: Nil => client.typeFullName shouldBe "okhttp3.OkHttpClient" }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Introduces an analog to `CSharpProgramSummary` for Java. The intended goal is to be able to provide a filesystem path containing type descriptions (in JSON) of external types to aid type resolution.

This is achieved by building a custom `TypeSolver` out of those JSON files. However, I wasn't able this time to elegantly build the TypeSolver: the quick solution I found was to translate (on-the-fly) those JSON files into Java declarations and in turn parse those, as if they were provided with the source-code being scanned. @johannescoetzee - do you know of a better way?

