### PR TITLE
[C#] Null safe json access for throw

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -201,14 +201,16 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   protected def astForThrowStatement(throwStmt: DotNetNodeInfo): Seq[Ast] = {
-    val expr = createDotNetNodeInfo(throwStmt.json(ParserKeys.Expression))
-    val args = astForNode(expr)
+    val argsAst = Try(throwStmt.json(ParserKeys.Expression)).toOption match {
+      case Some(_expr: ujson.Obj) => astForNode(createDotNetNodeInfo(_expr))
+      case _                      => Seq.empty[Ast]
+    }
     val throwCall = createCallNodeForOperator(
       throwStmt,
       CSharpOperators.throws,
-      typeFullName = Option(getTypeFullNameFromAstNode(args))
+      typeFullName = Option(getTypeFullNameFromAstNode(argsAst))
     )
-    Seq(callAst(throwCall, args))
+    Seq(callAst(throwCall, argsAst))
   }
 
   protected def astForTryStatement(tryStmt: DotNetNodeInfo): Seq[Ast] = {


### PR DESCRIPTION
The AST for `throw` statement in the test code snippet was not created, because it had no arguments, and the `json` access in the AST Creator expected some arguments.  The dataflow couldn't jump from the wrapping `try-catch` to the required call, resulting in the `sinks.reachableBy` query being stuck. Wrapped the throw `json` access in a try block to prevent this from happening.  