### PR TITLE
[C#] Fix `dotnetastgen` runner to handle space containing paths

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/build.sbt
+++ b/joern-cli/frontends/csharpsrc2cpg/build.sbt
@@ -34,7 +34,7 @@ enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 
 lazy val AstgenWin      = "dotnetastgen-win.exe"
 lazy val AstgenLinux    = "dotnetastgen-linux"
-lazy val AstgenLinuxArm = "dotnetastgen-linux-arm"
+lazy val AstgenLinuxArm = "dotnetastgen-linux-arm64"
 lazy val AstgenMac      = "dotnetastgen-macos"
 
 lazy val AllPlatforms = Seq(AstgenWin, AstgenLinux, AstgenLinuxArm, AstgenMac)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 csharpsrc2cpg {
-    dotnetastgen_version: "0.29.0"
+    dotnetastgen_version: "0.34.0"
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
@@ -64,7 +64,7 @@ class DotNetAstGenRunner(config: Config) extends AstGenRunnerBase(config) {
     metaData: AstGenProgramMetaData
   ): Try[Seq[String]] = {
     val excludeCommand = if (exclude.isEmpty) "" else s"-e \"$exclude\""
-    ExternalCommand.run(s"$astGenCommand -o ${out.toString()} -i $in $excludeCommand", ".")
+    ExternalCommand.run(s"$astGenCommand -o ${out.toString()} -i \"$in\" $excludeCommand", ".")
   }
 
 }


### PR DESCRIPTION
This solves an issue where for a joern scan, a directory containing spaces in the name would not get scanned by DotNetAstGen