### PR TITLE
[ruby] Handle chain calls

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -284,7 +284,7 @@ primaryValue
         // Definitions
     |   CLASS classPath (LT commandOrPrimaryValueClass)? (SEMI | NL) bodyStatement END
         # classDefinition
-    |   CLASS LT2 commandOrPrimaryValue (SEMI | NL) bodyStatement END
+    |   CLASS LT2 commandOrPrimaryValueClass (SEMI | NL) bodyStatement END
         # singletonClassDefinition
     |   MODULE classPath bodyStatement END
         # moduleDefinition

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -282,7 +282,7 @@ primaryValue
         # assignmentWithRescue
         
         // Definitions
-    |   CLASS classPath (LT commandOrPrimaryValue)? (SEMI | NL) bodyStatement END
+    |   CLASS classPath (LT commandOrPrimaryValueClass)? (SEMI | NL) bodyStatement END
         # classDefinition
     |   CLASS LT2 commandOrPrimaryValue (SEMI | NL) bodyStatement END
         # singletonClassDefinition
@@ -407,15 +407,27 @@ primaryValue
         # hereDocs
     ;
 
-commandOrPrimaryValue
+// This is required to make chained calls work. For classes, we cannot move up the `primaryValue` due to the possible
+// presence of AMPDOT when inheriting (class Foo < Bar::Baz), but the command rule doesn't allow chained calls
+// in if statements to be created properly, and ends throwing away everything after the first call. Splitting these
+// allows us to have a rule for the class that parses properly, and a rule for everything else that allows us to move
+// up the `primaryValue` rule to the top.
+commandOrPrimaryValueClass
     :   command
+        # commandCommandOrPrimaryValueClass
+    |   primaryValue
+        # primaryValueCommandOrPrimaryValueClass
+    ;
+
+commandOrPrimaryValue
+    :   primaryValue
+        # primaryValueCommandOrPrimaryValue
+    |   command
         # commandCommandOrPrimaryValue
     |   NOT commandOrPrimaryValue
         # notCommandOrPrimaryValue
     |   commandOrPrimaryValue (AND|OR) NL* commandOrPrimaryValue
         # keywordAndOrCommandOrPrimaryValue
-    |   primaryValue
-        # primaryValueCommandOrPrimaryValue
     ;
 
 block

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -719,7 +719,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   override def visitSingletonClassDefinition(ctx: RubyParser.SingletonClassDefinitionContext): RubyNode = {
     SingletonClassDeclaration(
       freshClassName(ctx.toTextSpan),
-      Option(ctx.commandOrPrimaryValue()).map(visit),
+      Option(ctx.commandOrPrimaryValueClass()).map(visit),
       visit(ctx.bodyStatement())
     )(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.parser
 
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
+import io.joern.rubysrc2cpg.deprecated.passes.RubyImportResolverPass
 import io.joern.rubysrc2cpg.parser.AntlrContextHelpers.*
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
@@ -915,7 +916,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
 
     ClassDeclaration(
       visit(ctx.classPath()),
-      Option(ctx.commandOrPrimaryValue()).map(visit),
+      Option(ctx.commandOrPrimaryValueClass()).map(visit),
       StatementList(initMethodDecl +: allowedTypeDeclChildren)(stmts.span),
       fields
     )(ctx.toTextSpan)


### PR DESCRIPTION
This PR handles:
 * Chained calls - separated the `commandOrPrimaryValue` for classes and otherwise. This allows us to move the `primaryValue` up for other cases, without it breaking on class definitions with inheritance (`class Foo < Bar::Baz`)

resolves #4396 