### PR TITLE
[jssrc2cpg] Make use of POSSIBLE_TYPES

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -50,7 +50,6 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
   protected val dynamicInstanceTypeStack      = new Stack[String]
   protected val localAstParentStack           = new Stack[NewBlock]()
   protected val rootTypeDecl                  = new Stack[NewTypeDecl]()
-  protected val typeFullNameToPostfix         = mutable.HashMap.empty[String, Int]
   protected val functionNodeToNameAndFullName = mutable.HashMap.empty[BabelNodeInfo, (String, String)]
   protected val usedVariableNames             = mutable.HashMap.empty[String, Int]
   protected val seenAliasTypes                = mutable.HashSet.empty[NewTypeDecl]

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -339,13 +339,14 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val declNodeInfo   = createBabelNodeInfo(declarator)
     val initNodeInfo   = Try(createBabelNodeInfo(declarator("init"))).toOption
     val declaratorCode = s"$kind ${code(declarator)}"
-    val typeFullName   = typeFor(declNodeInfo)
+    val tpe            = typeFor(declNodeInfo)
+    val typeFullName   = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
 
     val idName = idNodeInfo.node match {
       case Identifier => idNodeInfo.json("name").str
       case _          => idNodeInfo.code
     }
-    val nLocalNode = localNode(declNodeInfo, idName, idName, typeFullName).order(0)
+    val nLocalNode = localNode(declNodeInfo, idName, idName, typeFullName).order(0).possibleTypes(Seq(tpe))
     scope.addVariable(idName, nLocalNode, scopeType)
     diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -3,10 +3,10 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.datastructures.{BlockScope, MethodScope}
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
+import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newModifierNode}
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.nodes.{Identifier as _, *}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, EvaluationStrategies, ModifierTypes}
 import ujson.Value
@@ -60,13 +60,18 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       val nodeInfo = createBabelNodeInfo(param)
       val paramNode = nodeInfo.node match {
         case RestElement =>
-          val paramName = nodeInfo.code.replace("...", "")
-          val tpe       = typeFor(nodeInfo)
+          val paramName     = nodeInfo.code.replace("...", "")
+          val tpe           = typeFor(nodeInfo)
+          val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+          val possibleTypes = Seq(tpe)
           if (createLocals) {
-            val localTmpNode = localNode(nodeInfo, paramName, paramName, tpe).order(0)
+            val localTmpNode = localNode(nodeInfo, paramName, paramName, typeFullName)
+              .order(0)
+              .possibleTypes(possibleTypes)
             diffGraph.addEdge(localAstParentStack.head, localTmpNode, EdgeTypes.AST)
           }
-          parameterInNode(nodeInfo, paramName, nodeInfo.code, index, true, EvaluationStrategies.BY_VALUE, Option(tpe))
+          parameterInNode(nodeInfo, paramName, nodeInfo.code, index, true, EvaluationStrategies.BY_VALUE, typeFullName)
+            .possibleTypes(possibleTypes)
         case AssignmentPattern =>
           val lhsElement  = nodeInfo.json("left")
           val rhsElement  = nodeInfo.json("right")
@@ -91,20 +96,15 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
               param
             case _ =>
               additionalBlockStatements.addOne(convertParamWithDefault(nodeInfo))
-              val tpe = typeFor(lhsNodeInfo)
-              parameterInNode(
-                lhsNodeInfo,
-                lhsNodeInfo.code,
-                nodeInfo.code,
-                index,
-                false,
-                EvaluationStrategies.BY_VALUE,
-                Option(tpe)
-              )
+              val possibleTypes = Seq(typeFor(lhsNodeInfo))
+              parameterInNode(lhsNodeInfo, lhsNodeInfo.code, nodeInfo.code, index, false, EvaluationStrategies.BY_VALUE)
+                .possibleTypes(possibleTypes)
           }
         case ArrayPattern =>
-          val paramName = generateUnusedVariableName(usedVariableNames, s"param$index")
-          val tpe       = typeFor(nodeInfo)
+          val paramName     = generateUnusedVariableName(usedVariableNames, s"param$index")
+          val tpe           = typeFor(nodeInfo)
+          val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+          val possibleTypes = Seq(tpe)
           val param = parameterInNode(
             nodeInfo,
             paramName,
@@ -112,8 +112,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             index,
             isVariadic = false,
             EvaluationStrategies.BY_VALUE,
-            Option(tpe)
-          )
+            typeFullName
+          ).possibleTypes(possibleTypes)
           additionalBlockStatements.addAll(nodeInfo.json("elements").arr.toList.map {
             case element if !element.isNull =>
               val elementNodeInfo = createBabelNodeInfo(element)
@@ -121,10 +121,12 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
                 case Identifier =>
                   val elemName       = code(elementNodeInfo.json)
                   val tpe            = typeFor(elementNodeInfo)
-                  val localParamNode = identifierNode(elementNodeInfo, elemName)
-                  localParamNode.typeFullName = tpe
-
-                  val localTmpNode = localNode(elementNodeInfo, elemName, elemName, tpe).order(0)
+                  val typeFullName   = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+                  val possibleTypes  = Seq(tpe)
+                  val localParamNode = identifierNode(elementNodeInfo, elemName).possibleTypes(possibleTypes)
+                  val localTmpNode = localNode(elementNodeInfo, elemName, elemName, typeFullName)
+                    .order(0)
+                    .possibleTypes(possibleTypes)
                   diffGraph.addEdge(localAstParentStack.head, localTmpNode, EdgeTypes.AST)
                   scope.addVariable(elemName, localTmpNode, MethodScope)
 
@@ -157,7 +159,19 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           val paramName = generateUnusedVariableName(usedVariableNames, s"param$index")
           // Handle de-structured parameters declared as `{ username: string; password: string; }`
           val typeDecl = astForTypeAlias(nodeInfo)
-          val tpe      = typeDecl.root.collect { case t: NewTypeDecl => t.fullName }.getOrElse(typeFor(nodeInfo))
+
+          val tpe          = typeFor(nodeInfo)
+          var typeFullName = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+
+          val possibleTypes =
+            Seq(
+              typeDecl.root
+                .collect { case t: NewTypeDecl =>
+                  typeFullName = t.fullName
+                  t.fullName
+                }
+                .getOrElse(tpe)
+            )
           val param = parameterInNode(
             nodeInfo,
             paramName,
@@ -165,8 +179,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             index,
             isVariadic = false,
             EvaluationStrategies.BY_VALUE,
-            Option(tpe)
-          )
+            typeFullName
+          ).possibleTypes(possibleTypes)
           Ast.storeInDiffGraph(typeDecl, diffGraph)
           scope.addVariable(paramName, param, MethodScope)
 
@@ -174,12 +188,16 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             val elementNodeInfo = createBabelNodeInfo(element)
             elementNodeInfo.node match {
               case ObjectProperty =>
-                val elemName       = code(elementNodeInfo.json("key"))
-                val tpe            = typeFor(elementNodeInfo)
-                val localParamNode = identifierNode(elementNodeInfo, elemName)
-                localParamNode.typeFullName = tpe
+                val elemName = code(elementNodeInfo.json("key"))
 
-                val localTmpNode = localNode(elementNodeInfo, elemName, elemName, tpe).order(0)
+                val tpe           = typeFor(elementNodeInfo)
+                val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+                val possibleTypes = Seq(tpe)
+
+                val localParamNode =
+                  identifierNode(elementNodeInfo, elemName).typeFullName(typeFullName).possibleTypes(possibleTypes)
+                val localTmpNode =
+                  localNode(elementNodeInfo, elemName, elemName, typeFullName).order(0).possibleTypes(possibleTypes)
                 diffGraph.addEdge(localAstParentStack.head, localTmpNode, EdgeTypes.AST)
                 scope.addVariable(elemName, localTmpNode, MethodScope)
 
@@ -209,37 +227,52 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           param
         case Identifier =>
           // Handle types declared as `credentials: { username: string; password: string; }`
-          val tpe = Try(createBabelNodeInfo(nodeInfo.json("typeAnnotation")("typeAnnotation")))
+          val tpe           = typeFor(nodeInfo)
+          var typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+          val possibleTypes = Seq(tpe)
+          val possibleType = Try(createBabelNodeInfo(nodeInfo.json("typeAnnotation")("typeAnnotation")))
             .map(x =>
               x.node match {
                 case TSTypeLiteral =>
                   val typeDecl = astForTypeAlias(x)
                   Ast.storeInDiffGraph(typeDecl, diffGraph)
-                  typeDecl.root.collect { case t: NewTypeDecl => t.fullName }.getOrElse(typeFor(nodeInfo))
-                case _ => typeFor(nodeInfo)
+                  typeDecl.root
+                    .collect { case t: NewTypeDecl =>
+                      typeFullName = t.fullName
+                      t.fullName
+                    }
+                    .getOrElse(tpe)
+                case _ => tpe
               }
             )
-            .getOrElse(typeFor(nodeInfo))
+            .getOrElse(tpe)
 
           val name = nodeInfo.json("name").str
           val node =
-            parameterInNode(nodeInfo, name, nodeInfo.code, index, false, EvaluationStrategies.BY_VALUE, Option(tpe))
+            parameterInNode(nodeInfo, name, nodeInfo.code, index, false, EvaluationStrategies.BY_VALUE, typeFullName)
+              .possibleTypes(Seq(possibleType))
           scope.addVariable(name, node, MethodScope)
           node
         case TSParameterProperty =>
           val unpackedParam = createBabelNodeInfo(nodeInfo.json("parameter"))
+
           val tpe           = typeFor(unpackedParam)
+          val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+          val possibleTypes = Seq(tpe)
 
           val name = unpackedParam.node match {
             case AssignmentPattern => createBabelNodeInfo(unpackedParam.json("left")).code
             case _                 => unpackedParam.json("name").str
           }
           val node =
-            parameterInNode(nodeInfo, name, nodeInfo.code, index, false, EvaluationStrategies.BY_VALUE, Option(tpe))
+            parameterInNode(nodeInfo, name, nodeInfo.code, index, false, EvaluationStrategies.BY_VALUE, typeFullName)
+              .possibleTypes(possibleTypes)
           scope.addVariable(name, node, MethodScope)
           node
         case _ =>
-          val tpe = typeFor(nodeInfo)
+          val tpe           = typeFor(nodeInfo)
+          val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+          val possibleTypes = Seq(tpe)
           val node =
             parameterInNode(
               nodeInfo,
@@ -248,8 +281,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
               index,
               isVariadic = false,
               EvaluationStrategies.BY_VALUE,
-              Option(tpe)
-            )
+              typeFullName
+            ).possibleTypes(possibleTypes)
           scope.addVariable(nodeInfo.code, node, MethodScope)
           node
       }
@@ -264,10 +297,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   private def convertParamWithDefault(element: BabelNodeInfo): Ast = {
     val lhsElement = element.json("left")
     val rhsElement = element.json("right")
-
-    val rhsAst = astForNodeWithFunctionReference(rhsElement)
-
-    val lhsAst = astForNode(lhsElement)
+    val rhsAst     = astForNodeWithFunctionReference(rhsElement)
+    val lhsAst     = astForNode(lhsElement)
 
     val testAst = {
       val keyNode = identifierNode(element, codeOf(lhsAst.nodes.head))
@@ -276,9 +307,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       val equalsCallAst = createEqualsCallAst(Ast(keyNode), Ast(voidCallNode), element.lineNumber, element.columnNumber)
       equalsCallAst
     }
+
     val falseNode = identifierNode(element, codeOf(lhsAst.nodes.head))
-    val ternaryNodeAst =
-      createTernaryCallAst(testAst, rhsAst, Ast(falseNode), element.lineNumber, element.columnNumber)
+
+    val ternaryNodeAst = createTernaryCallAst(testAst, rhsAst, Ast(falseNode), element.lineNumber, element.columnNumber)
     createAssignmentCallAst(
       lhsAst,
       ternaryNodeAst,
@@ -288,8 +320,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     )
   }
 
-  private def getParentTypeDecl: NewTypeDecl =
+  private def getParentTypeDecl: NewTypeDecl = {
     methodAstParentStack.collectFirst { case n: NewTypeDecl => n }.getOrElse(rootTypeDecl.head)
+  }
 
   protected def astForTSDeclareFunction(func: BabelNodeInfo): Ast = {
     val functionNode = createMethodDefinitionNode(func)
@@ -306,10 +339,12 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   ): NewMethod = {
     val (methodName, methodFullName) = calcMethodNameAndFullName(func)
     val methodNode_ = methodNode(func, methodName, func.code, methodFullName, None, parserResult.filename)
-    val modifiers =
-      newModifierNode(ModifierTypes.VIRTUAL) :: (if methodName.startsWith(Defines.ClosurePrefix) then
-                                                   newModifierNode(ModifierTypes.LAMBDA) :: Nil
-                                                 else Nil)
+    val lambdaModifier = if (methodName.startsWith(io.joern.x2cpg.Defines.ClosurePrefix)) {
+      newModifierNode(ModifierTypes.LAMBDA) :: Nil
+    } else {
+      Nil
+    }
+    val modifiers = newModifierNode(ModifierTypes.VIRTUAL) :: lambdaModifier
     methodAstParentStack.push(methodNode_)
 
     val thisNode =
@@ -366,9 +401,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     methodBlockContent: List[Ast] = List.empty
   ): MethodAst = {
     val (methodName, methodFullName) = calcMethodNameAndFullName(func)
-    val methodRefNode_ = if (!shouldCreateFunctionReference) {
-      None
-    } else { Option(methodRefNode(func, methodName, methodFullName, methodFullName)) }
+
+    val methodRefNode_ = if (!shouldCreateFunctionReference) { None }
+    else { Option(methodRefNode(func, methodName, methodFullName, methodFullName)) }
 
     val callAst = if (shouldCreateAssignmentCall && shouldCreateFunctionReference) {
       val idNode  = identifierNode(func, methodName)
@@ -384,9 +419,12 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     }
 
     val methodNode_ = methodNode(func, methodName, func.code, methodFullName, None, parserResult.filename)
-    val modifierNodes = newModifierNode(ModifierTypes.VIRTUAL) :: (if methodName.startsWith(Defines.ClosurePrefix) then
-                                                                     newModifierNode(ModifierTypes.LAMBDA) :: Nil
-                                                                   else Nil)
+    val lambdaModifier = if (methodName.startsWith(io.joern.x2cpg.Defines.ClosurePrefix)) {
+      newModifierNode(ModifierTypes.LAMBDA) :: Nil
+    } else {
+      Nil
+    }
+    val modifierNodes = newModifierNode(ModifierTypes.VIRTUAL) :: lambdaModifier
 
     methodAstParentStack.push(methodNode_)
 
@@ -395,18 +433,14 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val blockNode                 = createBlockNode(bodyNodeInfo)
     val additionalBlockStatements = mutable.ArrayBuffer.empty[Ast]
 
-    val capturingRefNode =
-      if (shouldCreateFunctionReference) {
-        methodRefNode_
-      } else {
-        typeRefIdStack.headOption
-      }
+    val capturingRefNode = if (shouldCreateFunctionReference) { methodRefNode_ }
+    else { typeRefIdStack.headOption }
+
     scope.pushNewMethodScope(methodFullName, methodName, blockNode, capturingRefNode)
     localAstParentStack.push(blockNode)
 
-    val thisNode =
-      parameterInNode(func, "this", "this", 0, false, EvaluationStrategies.BY_VALUE)
-        .dynamicTypeHintFullName(typeHintForThisExpression())
+    val thisNode = parameterInNode(func, "this", "this", 0, false, EvaluationStrategies.BY_VALUE)
+      .dynamicTypeHintFullName(typeHintForThisExpression())
     scope.addVariable("this", thisNode, MethodScope)
 
     val paramNodes = handleParameters(func.json("params").arr.toSeq, additionalBlockStatements)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -7,15 +7,17 @@ import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 
 trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  protected def astForIdentifier(ident: BabelNodeInfo, typeFullName: Option[String] = None): Ast = {
+  protected def astForIdentifier(ident: BabelNodeInfo, maybePossibleType: Option[String] = None): Ast = {
     val name      = ident.json("name").str
     val identNode = identifierNode(ident, name)
-    val tpe = typeFullName match {
+    val possibleType = maybePossibleType match {
+      case None              => typeFor(ident)
       case Some(Defines.Any) => typeFor(ident)
       case Some(otherType)   => otherType
-      case None              => typeFor(ident)
     }
-    identNode.typeFullName = tpe
+    val typeFullName = if (Defines.isBuiltinType(possibleType)) possibleType else Defines.Any
+    identNode.typeFullName(typeFullName)
+    identNode.possibleTypes(Seq(possibleType))
     scope.addVariableReference(name, identNode)
     Ast(identNode)
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -17,12 +17,15 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
   protected def astForTypeAlias(alias: BabelNodeInfo): Ast = {
     val (aliasName, aliasFullName) = calcTypeNameAndFullName(alias)
-    val name = if (hasKey(alias.json, "right")) {
-      typeFor(createBabelNodeInfo(alias.json("right")))
-    } else {
-      typeFor(createBabelNodeInfo(alias.json))
-    }
     registerType(aliasFullName)
+
+    val nameNodeInfo = if (hasKey(alias.json, "right")) {
+      createBabelNodeInfo(alias.json("right"))
+    } else { createBabelNodeInfo(alias.json) }
+    val nameTpe = typeFor(nameNodeInfo)
+    val name = if (nameTpe.contains("{") || nameTpe.contains("(")) {
+      calcTypeNameAndFullName(nameNodeInfo)._1
+    } else nameTpe
 
     val astParentType     = methodAstParentStack.head.label
     val astParentFullName = methodAstParentStack.head.properties("FULL_NAME").toString
@@ -145,8 +148,11 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     }
 
   private def astsForEnumMember(tsEnumMember: BabelNodeInfo): Seq[Ast] = {
-    val name        = code(tsEnumMember.json("id"))
-    val memberNode_ = memberNode(tsEnumMember, name, tsEnumMember.code, typeFor(tsEnumMember))
+    val name          = code(tsEnumMember.json("id"))
+    val tpe           = typeFor(tsEnumMember)
+    val possibleTypes = Seq(tpe)
+    val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
+    val memberNode_   = memberNode(tsEnumMember, name, tsEnumMember.code, typeFullName).possibleTypes(possibleTypes)
     addModifier(memberNode_, tsEnumMember.json)
 
     if (hasKey(tsEnumMember.json, "initializer")) {
@@ -162,8 +168,10 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   }
 
   private def astForClassMember(classElement: Value, typeDeclNode: NewTypeDecl): Ast = {
-    val nodeInfo     = createBabelNodeInfo(classElement)
-    val typeFullName = typeFor(nodeInfo)
+    val nodeInfo      = createBabelNodeInfo(classElement)
+    val tpe           = typeFor(nodeInfo)
+    val possibleTypes = Seq(tpe)
+    val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
     val memberNode_ = nodeInfo.node match {
       case TSDeclareMethod | TSDeclareFunction =>
         val function    = createMethodDefinitionNode(nodeInfo)
@@ -172,6 +180,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         diffGraph.addEdge(bindingNode, function, EdgeTypes.REF)
         addModifier(function, nodeInfo.json)
         memberNode(nodeInfo, function.name, nodeInfo.code, typeFullName, Seq(function.fullName))
+          .possibleTypes(possibleTypes)
       case ClassMethod | ClassPrivateMethod =>
         val function    = createMethodAstAndNode(nodeInfo).methodNode
         val bindingNode = newBindingNode("", "", "")
@@ -179,14 +188,15 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         diffGraph.addEdge(bindingNode, function, EdgeTypes.REF)
         addModifier(function, nodeInfo.json)
         memberNode(nodeInfo, function.name, nodeInfo.code, typeFullName, Seq(function.fullName))
+          .possibleTypes(possibleTypes)
       case ExpressionStatement if isInitializedMember(classElement) =>
         val memberNodeInfo = createBabelNodeInfo(nodeInfo.json("expression")("left")("property"))
         val name           = memberNodeInfo.code
-        memberNode(nodeInfo, name, nodeInfo.code, typeFullName)
+        memberNode(nodeInfo, name, nodeInfo.code, typeFullName).possibleTypes(possibleTypes)
       case TSPropertySignature | ObjectProperty if hasKey(nodeInfo.json("key"), "name") =>
         val memberNodeInfo = createBabelNodeInfo(nodeInfo.json("key"))
         val name           = memberNodeInfo.json("name").str
-        memberNode(nodeInfo, name, nodeInfo.code, typeFullName)
+        memberNode(nodeInfo, name, nodeInfo.code, typeFullName).possibleTypes(possibleTypes)
       case _ =>
         val name = nodeInfo.node match {
           case ClassProperty        => code(nodeInfo.json("key"))
@@ -194,7 +204,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
           // TODO: name field most likely needs adjustment for other Babel AST types
           case _ => nodeInfo.code
         }
-        memberNode(nodeInfo, name, nodeInfo.code, typeFullName)
+        memberNode(nodeInfo, name, nodeInfo.code, typeFullName).possibleTypes(possibleTypes)
     }
 
     addModifier(memberNode_, classElement)
@@ -491,8 +501,10 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     val interfaceBodyElements = classMembers(tsInterface, withConstructor = false)
 
     interfaceBodyElements.foreach { classElement =>
-      val nodeInfo     = createBabelNodeInfo(classElement)
-      val typeFullName = typeFor(nodeInfo)
+      val nodeInfo      = createBabelNodeInfo(classElement)
+      val tpe           = typeFor(nodeInfo)
+      val possibleTypes = Seq(tpe)
+      val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
       val memberNodes = nodeInfo.node match {
         case TSCallSignatureDeclaration | TSMethodSignature =>
           val functionNode = createMethodDefinitionNode(nodeInfo)
@@ -500,7 +512,10 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
           diffGraph.addEdge(typeDeclNode_, bindingNode, EdgeTypes.BINDS)
           diffGraph.addEdge(bindingNode, functionNode, EdgeTypes.REF)
           addModifier(functionNode, nodeInfo.json)
-          Seq(memberNode(nodeInfo, functionNode.name, nodeInfo.code, typeFullName, Seq(functionNode.fullName)))
+          Seq(
+            memberNode(nodeInfo, functionNode.name, nodeInfo.code, typeFullName, Seq(functionNode.fullName))
+              .possibleTypes(possibleTypes)
+          )
         case _ =>
           val names = nodeInfo.node match {
             case TSPropertySignature | TSMethodSignature =>
@@ -513,7 +528,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
             case _ => Seq(nodeInfo.code)
           }
           names.map { n =>
-            val node = memberNode(nodeInfo, n, nodeInfo.code, typeFullName)
+            val node = memberNode(nodeInfo, n, nodeInfo.code, typeFullName).possibleTypes(possibleTypes)
             addModifier(node, nodeInfo.json)
             node
           }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -49,26 +49,34 @@ trait TypeHelper { this: AstCreator =>
     case BooleanLiteralTypeAnnotation => code(flowType.json)
     case NullLiteralTypeAnnotation    => code(flowType.json)
     case StringLiteralTypeAnnotation  => code(flowType.json)
-    case GenericTypeAnnotation        => code(flowType.json("id"))
-    case ThisTypeAnnotation           => typeHintForThisExpression(Option(flowType)).headOption.getOrElse(Defines.Any);
-    case NullableTypeAnnotation       => typeForTypeAnnotation(createBabelNodeInfo(flowType.json(TypeAnnotationKey)))
-    case _                            => Defines.Any
+    case GenericTypeAnnotation =>
+      val idCode = code(flowType.json("id"))
+      if (isNumberType(idCode)) Defines.Number
+      else if (isStringType(idCode)) Defines.String
+      else idCode
+    case ThisTypeAnnotation     => typeHintForThisExpression(Option(flowType)).headOption.getOrElse(Defines.Any);
+    case NullableTypeAnnotation => typeForTypeAnnotation(createBabelNodeInfo(flowType.json(TypeAnnotationKey)))
+    case _                      => Defines.Any
   }
 
   private def typeForTsType(tsType: BabelNodeInfo): String = tsType.node match {
-    case TSBooleanKeyword    => Defines.Boolean
-    case TSBigIntKeyword     => Defines.Number
-    case TSNullKeyword       => Defines.Null
-    case TSNumberKeyword     => Defines.Number
-    case TSObjectKeyword     => Defines.Object
-    case TSStringKeyword     => Defines.String
-    case TSSymbolKeyword     => Defines.Symbol
-    case TSUnknownKeyword    => Defines.Unknown
-    case TSVoidKeyword       => Defines.Void
-    case TSUndefinedKeyword  => Defines.Undefined
-    case TSNeverKeyword      => Defines.Never
-    case TSIntrinsicKeyword  => code(tsType.json)
-    case TSTypeReference     => code(tsType.json)
+    case TSBooleanKeyword   => Defines.Boolean
+    case TSBigIntKeyword    => Defines.Number
+    case TSNullKeyword      => Defines.Null
+    case TSNumberKeyword    => Defines.Number
+    case TSObjectKeyword    => Defines.Object
+    case TSStringKeyword    => Defines.String
+    case TSSymbolKeyword    => Defines.Symbol
+    case TSUnknownKeyword   => Defines.Unknown
+    case TSVoidKeyword      => Defines.Void
+    case TSUndefinedKeyword => Defines.Undefined
+    case TSNeverKeyword     => Defines.Never
+    case TSIntrinsicKeyword => code(tsType.json)
+    case TSTypeReference =>
+      val refCode = code(tsType.json)
+      if (isNumberType(refCode)) Defines.Number
+      else if (isStringType(refCode)) Defines.String
+      else refCode
     case TSArrayType         => code(tsType.json)
     case TSThisType          => typeHintForThisExpression(Option(tsType)).headOption.getOrElse(Defines.Any)
     case TSOptionalType      => typeForTypeAnnotation(createBabelNodeInfo(tsType.json(TypeAnnotationKey)))
@@ -86,27 +94,21 @@ trait TypeHelper { this: AstCreator =>
   }
 
   private def isStringType(tpe: String): Boolean =
-    tpe.startsWith("\"") && tpe.endsWith("\"")
+    tpe.isEmpty || tpe == "string" || tpe.startsWith("\"") && tpe.endsWith("\"")
 
   private def isNumberType(tpe: String): Boolean =
-    tpe.toDoubleOption.isDefined
+    tpe == "number" || tpe == "int" || tpe.toDoubleOption.isDefined
 
   private def typeFromTypeMap(node: BabelNodeInfo): String =
     pos(node.json).flatMap(parserResult.typeMap.get) match {
-      case Some(value) if value.isEmpty                          => Defines.String
-      case Some(value) if value == "string"                      => Defines.String
       case Some(value) if isStringType(value)                    => Defines.String
-      case Some(value) if value == "number"                      => Defines.Number
       case Some(value) if isNumberType(value)                    => Defines.Number
       case Some(value) if value == "null"                        => Defines.Null
       case Some(value) if value == "boolean"                     => Defines.Boolean
       case Some(value) if value == "any"                         => Defines.Any
       case Some(value) if ImportMatcher.matcher(value).matches() => importToModule(value)
-      case Some(other) =>
-        (TypeReplacements ++ ArrayReplacements).foldLeft(other) { case (typeStr, (m, r)) =>
-          typeStr.replace(m, r)
-        }
-      case None => Defines.Any
+      case Some(value)                                           => value
+      case None                                                  => Defines.Any
     }
 
   private def importToModule(value: String): String = {
@@ -123,8 +125,13 @@ trait TypeHelper { this: AstCreator =>
       case Some(key) => typeForTypeAnnotation(createBabelNodeInfo(node.json(key)))
       case None      => typeFromTypeMap(node)
     }
-    registerType(tpe)
-    tpe
+    val cleanedType = (TypeReplacements ++ ArrayReplacements).foldLeft(tpe) { case (typeStr, (m, r)) =>
+      typeStr.replace(m, r)
+    }
+    if (!cleanedType.contains("{") && !tpe.contains("(")) {
+      registerType(cleanedType)
+    }
+    cleanedType
   }
 
   protected def typeHintForThisExpression(node: Option[BabelNodeInfo] = None): Seq[String] = {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/Defines.scala
@@ -22,4 +22,6 @@ object Defines {
 
   val JsTypes: List[String] =
     List(Any, Number, String, Boolean, Null, Math, Symbol, Console, Object, BigInt, Unknown, Never, Void, Undefined)
+
+  def isBuiltinType(tpe: String): Boolean = JsTypes.contains(tpe.stripSuffix("[]"))
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTests.scala
@@ -35,7 +35,7 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
     "anonymous constructor of anonymous class full name" in {
       val cpg = code("var x = class { constructor(y) {} };")
       cpg.method.fullName.toSetMutable should contain(
-        s"Test0.js::program:_anon_cdecl:${io.joern.x2cpg.Defines.ConstructorMethodName}"
+        s"Test0.js::program:<anon-class>0:${io.joern.x2cpg.Defines.ConstructorMethodName}"
       )
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTests.scala
@@ -320,7 +320,7 @@ class TsClassesAstCreationPassTests extends AstJsSrc2CpgSuite(".ts") {
         |""".stripMargin)
       val List(userType) = cpg.typeDecl.name("User").l
       userType.member.name.l shouldBe List("email", "organizationIds", "username", "name", "gender")
-      userType.member.typeFullName.toSet shouldBe Set("__ecma.String", "string[]")
+      userType.member.typeFullName.toSet shouldBe Set("__ecma.String", "__ecma.String[]")
     }
 
     "AST generation for dynamically defined type in a parameter" in {
@@ -332,12 +332,12 @@ class TsClassesAstCreationPassTests extends AstJsSrc2CpgSuite(".ts") {
         |    }
         |}
         |""".stripMargin)
-      val List(credentialsType) = cpg.typeDecl.nameExact("_anon_cdecl").l
-      credentialsType.fullName shouldBe "Test0.ts::program:Test:run:_anon_cdecl"
+      val List(credentialsType) = cpg.typeDecl.nameExact("<anon-class>0").l
+      credentialsType.fullName shouldBe "Test0.ts::program:Test:run:<anon-class>0"
       credentialsType.member.name.l shouldBe List("username", "password")
       credentialsType.member.typeFullName.toSet shouldBe Set("__ecma.String")
       val List(credentialsParam) = cpg.parameter.nameExact("credentials").l
-      credentialsParam.typeFullName shouldBe "Test0.ts::program:Test:run:_anon_cdecl"
+      credentialsParam.typeFullName shouldBe "Test0.ts::program:Test:run:<anon-class>0"
       // should not produce dangling nodes that are meant to be inside procedures
       cpg.all.collectAll[CfgNode].whereNot(_._astIn).size shouldBe 0
       cpg.identifier.count(_.refsTo.size > 1) shouldBe 0
@@ -350,12 +350,12 @@ class TsClassesAstCreationPassTests extends AstJsSrc2CpgSuite(".ts") {
         |    log(`${username}: ${password}`);
         |}
         |""".stripMargin)
-      val List(credentialsType) = cpg.typeDecl.nameExact("_anon_cdecl").l
-      credentialsType.fullName shouldBe "Test0.ts::program:apiCall:_anon_cdecl"
+      val List(credentialsType) = cpg.typeDecl.nameExact("<anon-class>0").l
+      credentialsType.fullName shouldBe "Test0.ts::program:apiCall:<anon-class>0"
       credentialsType.member.name.l shouldBe List("username", "password")
       credentialsType.member.typeFullName.toSet shouldBe Set(Defines.Any)
       val List(credentialsParam) = cpg.parameter.nameExact("param1_0").l
-      credentialsParam.typeFullName shouldBe "Test0.ts::program:apiCall:_anon_cdecl"
+      credentialsParam.typeFullName shouldBe "Test0.ts::program:apiCall:<anon-class>0"
       // should not produce dangling nodes that are meant to be inside procedures
       cpg.all.collectAll[CfgNode].whereNot(_._astIn).size shouldBe 0
       cpg.identifier.count(_.refsTo.size > 1) shouldBe 0

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/JsClassesCfgCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/JsClassesCfgCreationPassTests.scala
@@ -100,8 +100,8 @@ class JsClassesCfgCreationPassTests extends CfgTestFixture(() => new JsSrcCfgTes
     "be correct for outer method of anonymous class declaration" in {
       implicit val cpg: Cpg = code("var a = class {}")
       succOf(":program") shouldBe expected(("a", AlwaysEdge))
-      succOf("a") shouldBe expected(("class _anon_cdecl", AlwaysEdge))
-      succOf("class _anon_cdecl") shouldBe expected(("var a = class {}", AlwaysEdge))
+      succOf("a") shouldBe expected(("class <anon-class>0", AlwaysEdge))
+      succOf("class <anon-class>0") shouldBe expected(("var a = class {}", AlwaysEdge))
       succOf("var a = class {}") shouldBe expected(("RET", AlwaysEdge))
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
@@ -48,7 +48,8 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
   "have return types for arrow functions" in {
     val cpg       = code("const foo = () => 42;").withConfig(Config().withTsTypes(true))
     val List(foo) = cpg.identifier("foo").l
-    foo.typeFullName shouldBe s"() => ${Defines.Number}"
+    foo.typeFullName shouldBe Defines.Any
+    foo.possibleTypes shouldBe Seq(s"() => ${Defines.Number}")
     val List(ret) = cpg.method("<lambda>0").methodReturn.l
     ret.typeFullName shouldBe Defines.Number
   }
@@ -74,7 +75,8 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
       |var y = new Foo();
       |""".stripMargin).withConfig(Config().withTsTypes(true))
     val List(y) = cpg.identifier("y").l
-    y.typeFullName shouldBe "Foo"
+    y.typeFullName shouldBe Defines.Any
+    y.possibleTypes shouldBe Seq("Foo")
   }
 
   "have types for parameters" in {
@@ -89,14 +91,17 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
       "Test0.ts"
     ).withConfig(Config().withTsTypes(true))
     val List(y1, y2) = cpg.identifier("y").l
-    y1.typeFullName shouldBe "Foo"
-    y2.typeFullName shouldBe "Foo"
+    y1.typeFullName shouldBe Defines.Any
+    y1.possibleTypes shouldBe Seq("Foo")
+    y2.typeFullName shouldBe Defines.Any
+    y2.possibleTypes shouldBe Seq("Foo")
     val List(p1) = cpg.parameter("p1").l
     p1.typeFullName shouldBe Defines.Number
     val List(p2) = cpg.parameter("p2").l
     p2.typeFullName shouldBe Defines.String
     val List(barRet) = cpg.method("bar").methodReturn.l
-    barRet.typeFullName shouldBe "Foo"
+    barRet.typeFullName shouldBe Defines.Any
+    barRet.possibleTypes shouldBe Seq("Foo")
     cpg.typ.name.sorted.l shouldBe List(
       ":program",
       io.joern.x2cpg.Defines.ConstructorMethodName,
@@ -133,7 +138,8 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
       idX.typeFullName shouldBe Defines.String
       idY.name shouldBe "y"
       idY.code shouldBe "y"
-      idY.typeFullName shouldBe "Foo"
+      idY.typeFullName shouldBe Defines.Any
+      idY.possibleTypes shouldBe Seq("Foo")
     }
   }
 
@@ -166,7 +172,8 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
       paramA.typeFullName shouldBe Defines.String
       paramB.name shouldBe "b"
       paramB.code shouldBe "b: Foo"
-      paramB.typeFullName shouldBe "Foo"
+      paramB.typeFullName shouldBe Defines.Any
+      paramB.possibleTypes shouldBe Seq("Foo")
     }
   }
 
@@ -292,8 +299,8 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
     }
     cpg.local("x").typeFullName.l shouldBe List(Defines.String)
     cpg.identifier("x").typeFullName.l shouldBe List(Defines.String)
-    cpg.local("y").typeFullName.l shouldBe List("int")
-    cpg.identifier("y").typeFullName.l shouldBe List("int")
+    cpg.local("y").typeFullName.l shouldBe List(Defines.Number)
+    cpg.identifier("y").typeFullName.l shouldBe List(Defines.Number)
     cpg.local("z").typeFullName.l shouldBe List(Defines.Boolean)
     cpg.identifier("z").typeFullName.l shouldBe List(Defines.Boolean)
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -169,7 +169,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     evaluationStrategy: String,
     typeFullName: String
   ): NewMethodParameterIn =
-    parameterInNode(node, name, code, index, isVariadic, evaluationStrategy, Some(typeFullName))
+    parameterInNode(node, name, code, index, isVariadic, evaluationStrategy, Option(typeFullName))
 
   protected def parameterInNode(
     node: Node,
@@ -285,7 +285,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
   }
 
   def methodNode(node: Node, name: String, fullName: String, signature: String, fileName: String): NewMethod = {
-    methodNode(node, name, name, fullName, Some(signature), fileName)
+    methodNode(node, name, name, fullName, Option(signature), fileName)
   }
 
   protected def methodNode(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeHintCallLinker.scala
@@ -82,8 +82,11 @@ abstract class XTypeHintCallLinker(cpg: Cpg) extends CpgPass(cpg) {
   def linkCallToCallee(call: Call, method: MethodBase, builder: DiffGraphBuilder): Unit = {
     builder.addEdge(call, method, EdgeTypes.CALL)
     method match {
-      case method: Method =>
-        builder.setNodeProperty(call, PropertyNames.TYPE_FULL_NAME, method.methodReturn.typeFullName)
+      case m: Method if m.methodReturn.possibleTypes.headOption.exists(_ != "ANY") =>
+        val typeFullName = m.methodReturn.possibleTypes.headOption.getOrElse(m.methodReturn.typeFullName)
+        builder.setNodeProperty(call, PropertyNames.TYPE_FULL_NAME, typeFullName)
+      case m: Method =>
+        builder.setNodeProperty(call, PropertyNames.TYPE_FULL_NAME, m.methodReturn.typeFullName)
       case _ =>
     }
   }


### PR DESCRIPTION
With this PR we put all type information into `POSSIBLE_TYPES` instead of `TYPE_FULL_NAME` except for builtin types which is safe to do.

The type recovery (which is only ever run in Joern for JS via `JavaScriptTypeRecovery`) simply adds entries from `POSSIBLE_TYPES` to its existing calculations based on `TYPE_FULL_NAME` so no change in behavior there.