### PR TITLE
[ruby] Fix Bug where Proc & Lambda Parameters Aren't Created

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -6,7 +6,7 @@ import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{NewMethod, NewMethodRef, NewTypeDecl, NewControlStructure}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewControlStructure, NewMethod, NewMethodRef, NewTypeDecl}
 
 trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -208,8 +208,10 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val methodName = nextClosureName()
 
     val methodAstsWithRefs = block.body match {
-      case x: Block => astForMethodDeclaration(x.toMethodDeclaration(methodName), isClosure = true)
-      case _        => astForMethodDeclaration(block.toMethodDeclaration(methodName), isClosure = true)
+      case x: Block =>
+        astForMethodDeclaration(x.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
+      case _ =>
+        astForMethodDeclaration(block.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
     }
 
     // Set span contents

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -373,7 +373,10 @@ object RubyIntermediateAst {
   /** Represents a `do` or `{ .. }` (braces) block. */
   final case class Block(parameters: List[RubyNode], body: RubyNode)(span: TextSpan) extends RubyNode(span) {
 
-    def toMethodDeclaration(name: String): MethodDeclaration = MethodDeclaration(name, parameters, body)(span)
+    def toMethodDeclaration(name: String, parameters: Option[List[RubyNode]]): MethodDeclaration = parameters match {
+      case Some(givenParameters) => MethodDeclaration(name, givenParameters, body)(span)
+      case None                  => MethodDeclaration(name, this.parameters, body)(span)
+    }
 
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -657,6 +657,7 @@ class ClassTests extends RubyCode2CpgFixture {
                           identifier.code shouldBe "scope"
                           literal.code shouldBe ":hits_by_ip"
                           methodRef.methodFullName shouldBe "Test0.rb:<global>::program.Foo:<init>:<lambda>0"
+                          methodRef.referencedMethod.parameter.name.l shouldBe List("ip", "col")
                         case xs => fail(s"Expected three children, got ${xs.code.mkString(", ")} instead")
                       }
                     case xs => fail(s"Expected one call, got ${xs.code.mkString(", ")} instead")


### PR DESCRIPTION
Made sure the correct parameters are used in `toMethodDeclaration` call