### PR TITLE
Add file content for php2cpg with broken unicode

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -71,16 +71,18 @@ object Domain {
   // Used for creating the default constructor.
   val ConstructorMethodName = "__construct"
 
-  final case class PhpAttributes(lineNumber: Option[Integer], kind: Option[Int])
+  final case class PhpAttributes(lineNumber: Option[Integer], kind: Option[Int], startFilePos: Int, endFilePos: Int)
   object PhpAttributes {
-    val Empty: PhpAttributes = PhpAttributes(None, None)
+    val Empty: PhpAttributes = PhpAttributes(None, None, -1, -1)
 
     def apply(json: Value): PhpAttributes = {
       Try(json("attributes")) match {
         case Success(Obj(attributes)) =>
-          val startLine = attributes.get("startLine").map(num => Integer.valueOf(num.num.toInt))
-          val kind      = attributes.get("kind").map(_.num.toInt)
-          PhpAttributes(startLine, kind)
+          val startLine    = attributes.get("startLine").map(num => Integer.valueOf(num.num.toInt))
+          val kind         = attributes.get("kind").map(_.num.toInt)
+          val startFilePos = attributes.get("startFilePos").map(_.num.toInt).getOrElse(-1)
+          val endFilePos   = attributes.get("endFilePos").map(_.num.toInt + 1).getOrElse(-1)
+          PhpAttributes(startLine, kind, startFilePos, endFilePos)
 
         case Success(Arr(_)) =>
           logger.debug(s"Found array attributes in $json")

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -35,8 +35,11 @@ class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser)(implicit with
       File(config.inputPath).relativize(File(filename)).toString
     }
     parser.parseFile(filename) match {
-      case Some(parseResult) =>
-        diffGraph.absorb(new AstCreator(relativeFilename, parseResult)(config.schemaValidation).createAst())
+      case Some((parseResult, fileContent)) =>
+        diffGraph.absorb(
+          new AstCreator(relativeFilename, parseResult, fileContent, config.disableFileContent)(config.schemaValidation)
+            .createAst()
+        )
 
       case None =>
         logger.warn(s"Could not parse file $filename. Results will be missing!")

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -1,5 +1,6 @@
 package io.joern.php2cpg.querying
 
+import io.joern.php2cpg.Config
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
@@ -107,15 +108,47 @@ class MethodTests extends PhpCode2CpgFixture {
     cpg.method.nameExact("<global>").fullName.l shouldBe List("test.php:<global>")
   }
 
-  "methods with non-unicode-legal characters should be created with escaped char codes" in {
+  "methods with non-unicode-legal characters" should {
     val cpg = code("""<?php
         |function foo() {
         |  $x = "\xFF";
         |}
-        |""".stripMargin)
+        |""".stripMargin).withConfig(Config().withDisableFileContent(false))
 
-    cpg.file.method.name.toSet shouldBe Set("<global>", "foo")
-    cpg.assignment.code.l shouldBe List("$x = \"\\\\xFF\"")
+    "be created with escaped char codes" in {
+      cpg.file.method.name.toSet shouldBe Set("<global>", "foo")
+      cpg.assignment.code.l shouldBe List("$x = \"\\\\xFF\"")
+    }
+
+    "set the file content correctly" in {
+      inside(cpg.method.nameExact("foo").l) { case List(fooMethod) =>
+        val offsetStart = fooMethod.offset.get
+        val offsetEnd   = fooMethod.offsetEnd.get
+        fooMethod.file.head.content.substring(offsetStart, offsetEnd) shouldBe
+          """function foo() {
+            |  $x = "\xFF";
+            |}""".stripMargin
+      }
+    }
+  }
+
+  "methods with unicode characters in source" should {
+    val cpg = code("""<?php
+        |function foo() {
+        |  $x = "🙂";
+        |}
+        |""".stripMargin).withConfig(Config().withDisableFileContent(false))
+
+    "set the content field correctly" ignore {
+      inside(cpg.method.nameExact("foo").l) { case List(fooMethod) =>
+        val offsetStart = fooMethod.offset.get
+        val offsetEnd   = fooMethod.offsetEnd.get
+        fooMethod.file.head.content.substring(offsetStart, offsetEnd) shouldBe
+          """function foo() {
+            |  $x = "🙂";
+            |}""".stripMargin
+      }
+    }
   }
 
   "explicit constructors" should {
@@ -126,7 +159,7 @@ class MethodTests extends PhpCode2CpgFixture {
         |}
         |""".stripMargin,
       fileName = "foo.php"
-    )
+    ).withConfig(Config().withDisableFileContent(false))
 
     "have the constructor modifier set" in {
       inside(cpg.method.nameExact("__construct").l) { case List(constructor) =>
@@ -140,6 +173,14 @@ class MethodTests extends PhpCode2CpgFixture {
       inside(cpg.method.nameExact("__construct").l) { case List(constructor) =>
         constructor.filename shouldBe "foo.php"
         constructor.file.name.l shouldBe List("foo.php")
+      }
+    }
+
+    "have the content offsets set correctly" in {
+      inside(cpg.method.nameExact("__construct").l) { case List(constructor) =>
+        val offsetStart = constructor.offset.get
+        val offsetEnd   = constructor.offsetEnd.get
+        constructor.file.head.content.substring(offsetStart, offsetEnd) shouldBe "function __construct() {}"
       }
     }
   }


### PR DESCRIPTION
This PR adds support for the file content field and offsets for php2cpg.

Currently multi-byte characters break this, since the offset returned by php-parser is the byte offset, not character offset. I'm going to fix that in our fork of php-parser, but my first attempt at doing so was unsuccessful. I think this PR still stands well on its own since all that will be required once php-parser is fixed is to bump the version we use of that and to un-ignore the currently broken testcase.