### PR TITLE
[php2cpg] Don't use target code in php method full names

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -974,7 +974,7 @@ class AstCreator(filename: String, phpAst: PhpFile, fileContent: Option[String],
         DispatchTypes.STATIC_DISPATCH
       else
         DispatchTypes.DYNAMIC_DISPATCH
-        
+
     val signature = s"$UnresolvedSignature(${call.args.size})"
 
     val fullName = call.target match {
@@ -985,8 +985,8 @@ class AstCreator(filename: String, phpAst: PhpFile, fileContent: Option[String],
       }
 
       case Some(_) =>
-        val targetSuffix = targetAst.flatMap(_.rootType).filterNot(_ == TypeConstants.Any).map(typ => s"\\$typ").getOrElse("")
-        s"$UnresolvedNamespace$targetSuffix$callOperator$name:$signature"
+        val targetPrefix = targetAst.flatMap(_.rootType).filterNot(_ == TypeConstants.Any).map(typ => s"\\$typ").getOrElse(UnresolvedNamespace)
+        s"$targetPrefix$callOperator$name"
 
       case None if PhpBuiltins.FuncNames.contains(name) =>
         // No signature/namespace for MFN for builtin functions to ensure stable names as type info improves.

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -123,6 +123,22 @@ class CallTests extends PhpCode2CpgFixture {
       barCall.code shouldBe "self::bar($x)"
     }
   }
+  
+  "chained method calls should have the correct code and mfn values" in {
+    val cpg = code("""<?php
+        |$f->foo(A::class)->bar();
+        |""".stripMargin)
+    
+    inside(cpg.call.sortBy(_.name).l) { case List(barCall, fooCall) =>
+      barCall.name shouldBe "bar"
+      barCall.methodFullName shouldBe "<unresolvedNamespace>->bar:<unresolvedSignature>(0)"
+      barCall.code shouldBe "$f->foo(A::class)->bar();"
+      
+      fooCall.name shouldBe "foo"
+      fooCall.methodFullName shouldBe "<unresolvedNamespace>->foo:<unresolvedSignature>(1)"
+      fooCall.code shouldBe "$f->foo(A::class)"
+    }
+  } 
 
   "method calls with simple names should be correct" in {
     val cpg = code("""<?php

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -131,11 +131,11 @@ class CallTests extends PhpCode2CpgFixture {
     
     inside(cpg.call.sortBy(_.name).l) { case List(barCall, fooCall) =>
       barCall.name shouldBe "bar"
-      barCall.methodFullName shouldBe "<unresolvedNamespace>->bar:<unresolvedSignature>(0)"
-      barCall.code shouldBe "$f->foo(A::class)->bar();"
+      barCall.methodFullName shouldBe "<unresolvedNamespace>->bar"
+      barCall.code shouldBe "$f->foo(A::class)->bar()"
       
       fooCall.name shouldBe "foo"
-      fooCall.methodFullName shouldBe "<unresolvedNamespace>->foo:<unresolvedSignature>(1)"
+      fooCall.methodFullName shouldBe "<unresolvedNamespace>->foo"
       fooCall.code shouldBe "$f->foo(A::class)"
     }
   } 
@@ -147,7 +147,7 @@ class CallTests extends PhpCode2CpgFixture {
 
     inside(cpg.call.l) { case List(fooCall) =>
       fooCall.name shouldBe "foo"
-      fooCall.methodFullName shouldBe """<unresolvedNamespace>\$f->foo"""
+      fooCall.methodFullName shouldBe """<unresolvedNamespace>->foo"""
       fooCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       fooCall.lineNumber shouldBe Some(2)
       fooCall.code shouldBe "$f->foo($x)"
@@ -169,7 +169,7 @@ class CallTests extends PhpCode2CpgFixture {
 
     inside(cpg.call.filter(_.name != Operators.fieldAccess).l) { case List(fooCall) =>
       fooCall.name shouldBe "$foo"
-      fooCall.methodFullName shouldBe """<unresolvedNamespace>\$$f->$foo"""
+      fooCall.methodFullName shouldBe """<unresolvedNamespace>->$foo"""
       fooCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       fooCall.lineNumber shouldBe Some(2)
       fooCall.code shouldBe "$$f->$foo($x)"


### PR DESCRIPTION
We're sometimes using the receiver/base code as part of the method full name in php2cpg, which led to the weird-looking expectations changes in https://github.com/ShiftLeftSecurity/codescience/pull/7595. This was a deliberate decision at the time since we effectively never have type full names for php cpgs anyways and at least that way we get some information, but in case that's not desired behaviour, this is an alternative.