### PR TITLE
Add environment variable to javasrc to fetch dependencies

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -78,5 +78,10 @@ object JavaSrc2Cpg {
           "JAVASRC_JDK_PATH",
           "Path to the JDK home used for retrieving type information about builtin Java types."
         )
+    case FetchDependencies
+        extends JavaSrcEnvVar(
+          "JAVASRC_FETCH_DEPENDENCIES",
+          "If set, javasrc2cpg will fetch dependencies regardless of the --fetch-dependencies flag."
+        )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -66,7 +66,8 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
   }
 
   private def getDependencyList(inputPath: String): List[String] = {
-    val shouldFetch = if (System.getenv(JavaSrcEnvVar.FetchDependencies.name).nonEmpty) {
+    val envVarValue = Option(System.getenv(JavaSrcEnvVar.FetchDependencies.name))
+    val shouldFetch = if (envVarValue.exists(_.nonEmpty)) {
       logger.info(s"Enabling dependency fetching: Environment variable ${JavaSrcEnvVar.FetchDependencies.name} is set")
       true
     } else if (config.fetchDependencies) {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -78,13 +78,16 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
       false
     }
 
-    Option.when(shouldFetch)(DependencyResolver.getDependencies(Paths.get(inputPath))).flatten match {
-      case Some(deps) => deps.toList
-      case None =>
-        logger.warn(s"Could not fetch dependencies for project at path $inputPath")
-        List()
+    if (shouldFetch) {
+      DependencyResolver.getDependencies(Paths.get(inputPath)) match {
+        case Some(deps) => deps.toList
+        case None =>
+          logger.warn(s"Could not fetch dependencies for project at path $inputPath")
+          List()
+      }
+    } else {
+      List()
     }
-
   }
 
   private def createSymbolSolver(


### PR DESCRIPTION
Tested this manually since I'm not aware of a way to easily do this in our unit test setup.

```
❯ export JAVASRC_FETCH_DEPENDENCIES=t
❯ ./joern-cli/frontends/javasrc2cpg/javasrc2cpg ~/code/java/HelloShiftLeft
...
[INFO ] Enabling dependency fetching: Environment variable JAVASRC_FETCH_DEPENDENCIES is set
[INFO ] got 63 Maven dependencies
```

The idea is to set this by default in SL, but then customers can still unset it if they want to (which should be a rare case).