### PR TITLE
[php] Dependency Pass for Composer Files

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -52,6 +52,9 @@ object Domain {
     val isNull    = s"is_null"
     val unset     = s"unset"
     val shellExec = s"shell_exec"
+
+    // Used for composer dependencies
+    val autoload = "<autoload>"
   }
 
   object PhpDomainTypeConstants {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/DependencyPass.scala
@@ -1,0 +1,72 @@
+package io.joern.php2cpg.passes
+
+import better.files.File
+import io.joern.php2cpg.parser.Domain.PhpOperators
+import io.shiftleft.codepropertygraph.generated.nodes.{NewDependency, NewTag}
+import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}
+import io.shiftleft.passes.ForkJoinParallelCpgPass
+import org.slf4j.LoggerFactory
+import overflowdb.BatchedUpdate
+import upickle.default.*
+
+import scala.annotation.targetName
+import scala.util.{Failure, Success, Try}
+
+/** Parses the `composer.json` file for all `require` dependencies.
+  */
+class DependencyPass(cpg: Cpg, composerPaths: List[String]) extends ForkJoinParallelCpgPass[File](cpg) {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  override def generateParts(): Array[File] = composerPaths.map(File(_)).toArray
+
+  override def runOnPart(builder: DiffGraphBuilder, composerFile: File): Unit = {
+    val composer =
+      composerFile.inputStream.apply(is => Try(read[Composer](ujson.Readable.fromByteArray(is.readAllBytes())))) match {
+        case Failure(exception) =>
+          logger.error("Unable to deserialize `composer.json`", exception)
+          Composer()
+        case Success(composer) => composer
+      }
+    composer.require.foreach { case (name, version) =>
+      builder.addNode(NewDependency().name(name).version(version))
+    }
+    // For `autoload`, the version is the matcher path prefixed with `autoload`
+    composer.autoload.`psr-4`.foreach {
+      case (namespace, StringOrArray(name: String)) =>
+        builder.addNode(NewDependency().name(namespace).version(s"${PhpOperators.autoload}$name"))
+      case (namespace, StringOrArray(array: Array[String])) =>
+        array.foreach { name =>
+          builder.addNode(NewDependency().name(namespace).version(s"${PhpOperators.autoload}$name"))
+        }
+    }
+  }
+
+}
+
+case class StringOrArray(obj: String | Array[String])
+
+object StringOrArray:
+  given ReadWriter[StringOrArray] = {
+    val logger = LoggerFactory.getLogger(getClass)
+
+    readwriter[ujson.Value]
+      .bimap[StringOrArray](
+        x =>
+          x.obj match {
+            case o: String        => ujson.Str(o)
+            case o: Array[String] => ujson.Arr(o.map(ujson.Str.apply)*)
+          },
+        {
+          case json @ (j: ujson.Str) => StringOrArray(json.str)
+          case json @ (j: ujson.Arr) => StringOrArray(json.arr.map(_.str).toArray)
+          case x =>
+            logger.warn(s"Unexpected value type for `autoload.psr-4`: ${x.getClass}")
+            StringOrArray("<unknown>")
+        }
+      )
+  }
+
+case class Autoload(@targetName("psr4") `psr-4`: Map[String, StringOrArray] = Map.empty) derives ReadWriter
+
+case class Composer(require: Map[String, String] = Map.empty, autoload: Autoload = Autoload()) derives ReadWriter

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/DependencyPass.scala
@@ -24,7 +24,7 @@ class DependencyPass(cpg: Cpg, composerPaths: List[String]) extends ForkJoinPara
     val composer =
       composerFile.inputStream.apply(is => Try(read[Composer](ujson.Readable.fromByteArray(is.readAllBytes())))) match {
         case Failure(exception) =>
-          logger.error("Unable to deserialize `composer.json`", exception)
+          logger.error(s"Unable to deserialize `${composerFile.pathAsString}`", exception)
           Composer()
         case Success(composer) => composer
       }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpDependencyPassTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpDependencyPassTests.scala
@@ -1,0 +1,58 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.parser.Domain.PhpOperators
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class PhpDependencyPassTests extends PhpCode2CpgFixture() {
+
+  "a composer file" should {
+
+    val cpg = code(
+      """
+        |{
+        |    "require": {
+        |        "composer/semver": "3.4.0",
+        |        "aws/aws-sdk-php": "3.*",
+        |        "php": ">=7.4.3"
+        |    },
+        |    "autoload": {
+        |        "psr-4": {
+        |            "MediaWiki\\Composer\\": "includes/composer",
+        |            "Monolog\\": ["src/", "lib/"]
+        |        }
+        |    }
+        |}
+        |""".stripMargin,
+      "composer.json"
+    )
+
+    "have its dependencies under `require` parsed and given nodes" in {
+      inside(cpg.dependency.filterNot(_.version.startsWith(PhpOperators.autoload)).l) {
+        case semver :: aws :: php :: Nil =>
+          semver.name shouldBe "composer/semver"
+          semver.version shouldBe "3.4.0"
+          aws.name shouldBe "aws/aws-sdk-php"
+          aws.version shouldBe "3.*"
+          php.name shouldBe "php"
+          php.version shouldBe ">=7.4.3"
+        case xs => fail(s"Expected exactly 3 dependencies, instead got [${xs.name.mkString(",")}]")
+      }
+    }
+
+    "have `autoload` fields parsed and given versions prefixed with `<autoload>`" in {
+      inside(cpg.dependency.filter(_.version.startsWith(PhpOperators.autoload)).l) {
+        case composer :: monologSrc :: monologLib :: Nil =>
+          composer.name shouldBe "MediaWiki\\Composer\\"
+          composer.version shouldBe s"${PhpOperators.autoload}includes/composer"
+          monologSrc.name shouldBe "Monolog\\"
+          monologSrc.version shouldBe s"${PhpOperators.autoload}src/"
+          monologLib.name shouldBe "Monolog\\"
+          monologLib.version shouldBe s"${PhpOperators.autoload}lib/"
+        case xs => fail(s"Expected exactly 3 dependencies, instead got [${xs.name.mkString(",")}]")
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
* Added parsing of `composer.json`
* This results in two kinds of dependencies
  - The usual that are downloaded without namespace modifications/autoloading
  - Those that have custom namespaces/autoloading The latter is prefixed with `<autoload>` as dependency nodes can't be tagged.

Next steps are to add import nodes for these whenever a composer autoload is referenced. This is the first PR to address #4403