### PR TITLE
[php2cpg] Annotation Support

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -136,8 +136,8 @@ object Domain {
     default: Option[PhpExpr],
     // TODO type
     flags: Int,
-    // TODO attributeGroups: Seq[PhpAttributeGroup],
-    attributes: PhpAttributes
+    attributes: PhpAttributes,
+    attributeGroups: Seq[PhpAttributeGroup]
   ) extends PhpNode
 
   sealed trait PhpArgument extends PhpNode
@@ -210,11 +210,15 @@ object Domain {
     returnType: Option[PhpNameExpr],
     stmts: List[PhpStmt],
     returnByRef: Boolean,
-    // TODO attributeGroups: Seq[PhpAttributeGroup],
     namespacedName: Option[PhpNameExpr],
     isClassMethod: Boolean,
-    attributes: PhpAttributes
+    attributes: PhpAttributes,
+    attributeGroups: Seq[PhpAttributeGroup]
   ) extends PhpStmtWithBody
+
+  final case class PhpAttributeGroup(attrs: List[PhpAttribute], attributes: PhpAttributes)
+
+  final case class PhpAttribute(name: PhpNameExpr, args: List[PhpArgument], attributes: PhpAttributes) extends PhpExpr
 
   final case class PhpClassLikeStmt(
     name: Option[PhpNameExpr],
@@ -226,7 +230,8 @@ object Domain {
     // Optionally used for enums with values
     scalarType: Option[PhpNameExpr],
     hasConstructor: Boolean,
-    attributes: PhpAttributes
+    attributes: PhpAttributes,
+    attributeGroups: Seq[PhpAttributeGroup]
   ) extends PhpStmtWithBody
   object ClassLikeTypes {
     val Class: String     = "class"
@@ -918,6 +923,8 @@ object Domain {
 
     val attributes = PhpAttributes(json)
 
+    val attributeGroups = json("attrGroups").arr.map(readAttributeGroup).toList
+
     PhpClassLikeStmt(
       name,
       modifiers,
@@ -927,7 +934,8 @@ object Domain {
       classLikeType,
       scalarType,
       hasConstructor,
-      attributes
+      attributes,
+      attributeGroups
     )
   }
 
@@ -1138,9 +1146,10 @@ object Domain {
     val returnType  = Option.unless(json("returnType").isNull)(readType(json("returnType")))
     val stmts       = json("stmts").arr.map(readStmt).toList
     // Only class methods have modifiers
-    val modifiers      = Nil
-    val namespacedName = Option.unless(json("namespacedName").isNull)(readName(json("namespacedName")))
-    val isClassMethod  = false
+    val modifiers       = Nil
+    val namespacedName  = Option.unless(json("namespacedName").isNull)(readName(json("namespacedName")))
+    val isClassMethod   = false
+    val attributeGroups = json("attrGroups").arr.map(readAttributeGroup).toSeq
 
     PhpMethodDecl(
       name,
@@ -1151,7 +1160,8 @@ object Domain {
       returnByRef,
       namespacedName,
       isClassMethod,
-      PhpAttributes(json)
+      PhpAttributes(json),
+      attributeGroups
     )
   }
 
@@ -1167,8 +1177,9 @@ object Domain {
       else
         json("stmts").arr.map(readStmt).toList
 
-    val namespacedName = None // only defined for functions
-    val isClassMethod  = true
+    val namespacedName  = None // only defined for functions
+    val isClassMethod   = true
+    val attributeGroups = json("attrGroups").arr.map(readAttributeGroup).toSeq
 
     PhpMethodDecl(
       name,
@@ -1179,8 +1190,17 @@ object Domain {
       returnByRef,
       namespacedName,
       isClassMethod,
-      PhpAttributes(json)
+      PhpAttributes(json),
+      attributeGroups
     )
+  }
+
+  private def readAttributeGroup(json: Value): PhpAttributeGroup = {
+    PhpAttributeGroup(json("attrs").arr.map(readAttribute).toList, PhpAttributes(json))
+  }
+
+  private def readAttribute(json: Value): PhpAttribute = {
+    PhpAttribute(readName(json("name")), json("args").arr.map(readCallArg).toList, PhpAttributes(json))
   }
 
   private def readProperty(json: Value): PhpPropertyStmt = {
@@ -1353,7 +1373,8 @@ object Domain {
   }
 
   private def readParam(json: Value): PhpParam = {
-    val paramType = Option.unless(json("type").isNull)(readType(json("type")))
+    val paramType       = Option.unless(json("type").isNull)(readType(json("type")))
+    val attributeGroups = json("attrGroups").arr.map(readAttributeGroup).toSeq
     PhpParam(
       name = json("var")("name").str,
       paramType = paramType,
@@ -1361,7 +1382,8 @@ object Domain {
       isVariadic = json("variadic").bool,
       default = json.obj.get("default").filterNot(_.isNull).map(readExpr),
       flags = json("flags").num.toInt,
-      attributes = PhpAttributes(json)
+      attributes = PhpAttributes(json),
+      attributeGroups
     )
   }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/AnnotationTests.scala
@@ -1,0 +1,39 @@
+package io.joern.php2cpg.querying
+
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class AnnotationTests extends PhpCode2CpgFixture {
+  "annotations for nodes" should {
+    "be populated" in {
+      val cpg = code("""
+          |<?php
+          | #[Route("/api")]
+          | class Foo {
+          |   #[Route("/edit", name: "hello")]
+          |   public function bar(#[SomeAttr] $pBar){}
+          | }
+          |>
+          |""".stripMargin)
+
+      inside(cpg.typeDecl("Foo").annotation.l) { case route :: Nil =>
+        route.name shouldBe "Route"
+        inside(route.astChildren.l) { case arg1 :: Nil =>
+          arg1.code shouldBe "\"/api\""
+        }
+      }
+
+      inside(cpg.method("bar").annotation.l) { case route :: Nil =>
+        route.name shouldBe "Route"
+        inside(route.astChildren.l) { case arg1 :: arg2 :: Nil =>
+          arg1.code shouldBe "\"/edit\""
+          arg2.code shouldBe "\"hello\""
+        }
+      }
+
+      inside(cpg.parameter("pBar").annotation.l) { case someAttr :: Nil =>
+        someAttr.name shouldBe "SomeAttr"
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/AnnotationTests.scala
@@ -16,23 +16,34 @@ class AnnotationTests extends PhpCode2CpgFixture {
           |>
           |""".stripMargin)
 
-      inside(cpg.typeDecl("Foo").annotation.l) { case route :: Nil =>
-        route.name shouldBe "Route"
-        inside(route.astChildren.l) { case arg1 :: Nil =>
-          arg1.code shouldBe "\"/api\""
-        }
+      inside(cpg.typeDecl("Foo").annotation.l) {
+        case route :: Nil =>
+          route.name shouldBe "Route"
+          inside(route.astChildren.l) {
+            case arg1 :: Nil =>
+              arg1.code shouldBe "\"/api\""
+            case _ => fail("Expected exactly 1 argument for the annotation")
+          }
+        case _ => fail("No annotation link found for the class `Foo`")
       }
 
-      inside(cpg.method("bar").annotation.l) { case route :: Nil =>
-        route.name shouldBe "Route"
-        inside(route.astChildren.l) { case arg1 :: arg2 :: Nil =>
-          arg1.code shouldBe "\"/edit\""
-          arg2.code shouldBe "\"hello\""
-        }
+      inside(cpg.method("bar").annotation.l) {
+        case route :: Nil =>
+          route.name shouldBe "Route"
+          inside(route.astChildren.l) {
+            case arg1 :: arg2 :: Nil =>
+              arg1.code shouldBe "\"/edit\""
+              arg2.code shouldBe "\"hello\""
+            case _ => fail("Expected exactly 2 arguments for the annotation")
+          }
+        case _ => fail("No annotation link found for the method `bar`")
+
       }
 
-      inside(cpg.parameter("pBar").annotation.l) { case someAttr :: Nil =>
-        someAttr.name shouldBe "SomeAttr"
+      inside(cpg.parameter("pBar").annotation.l) {
+        case someAttr :: Nil =>
+          someAttr.name shouldBe "SomeAttr"
+        case _ => fail("No annotation link found for the parameter `pBar`")
       }
     }
   }


### PR DESCRIPTION
This PR includes creating annotation nodes in the `php2cpg` frontend, and linking them to their corresponding parent AST nodes (methods, classes, parameters). 

Resolves #4453 