### PR TITLE
[x2cpg] SemVer Utility Class & Parsing

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/SemVerParser.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/SemVerParser.scala
@@ -1,0 +1,133 @@
+package io.joern.x2cpg.utils
+
+/** Parses the given string as if it contains a semver version, or refers to some regex matching some other semver
+  * versions.
+  *
+  * @see
+  *   <a href="https://semver.org">SemVer</a>
+  */
+object SemVer {
+
+  def apply(rawString: String): SemVer = {
+    if (rawString.isBlank) throw SemVerParsingException("Blank string given")
+
+    val buildStart      = rawString.indexOf("+")
+    val hasBuild        = buildStart > 0
+    val preReleaseStart = rawString.indexOf("-")
+    val hasPreRelease   = preReleaseStart > 0 && (if hasBuild then preReleaseStart < buildStart else true)
+
+    val versionString =
+      if (hasPreRelease) rawString.substring(0, preReleaseStart)
+      else if (hasBuild) rawString.substring(0, buildStart)
+      else rawString
+
+    if versionString.endsWith(".") || versionString.startsWith(".") then
+      throw SemVerParsingException(s"Unable to parse core version '$versionString'")
+
+    val (major, minor, patch) = parseVersionCore(versionString)
+    if (major < 0 || minor < 0 || patch < 0)
+      throw new SemVerParsingException(s"Found a negative integer within the core version '$versionString'")
+
+    val preRelease =
+      if (hasPreRelease && hasBuild)
+        rawString.substring(versionString.length, buildStart).split("-").filterNot(_.isBlank).toList
+      else if (hasPreRelease) rawString.substring(versionString.length).split("-").filterNot(_.isBlank).toList
+      else Nil
+
+    val build =
+      if (hasBuild) Option(rawString.substring(buildStart + 1))
+      else None
+
+    SemVer(major, minor, patch, preRelease, build)
+  }
+
+  private def parseVersionCore(versionCore: String): (Int, Int, Int) = {
+    versionCore.split("[.]").map(Integer.parseInt).toList match {
+      case major :: minor :: patch :: xs => (major, minor, patch)
+      case major :: minor :: Nil         => (major, minor, 0)
+      case major :: Nil                  => (major, 0, 0)
+      case Nil => throw new SemVerParsingException("Empty core version found while parsing sem-ver version!")
+    }
+  }
+
+}
+
+/** Thrown whenever one cannot parse a semantic version string.
+  *
+  * @param msg
+  *   the error details.
+  * @see
+  *   * <a href="https://semver.org">SemVer</a>
+  */
+class SemVerParsingException(msg: String) extends RuntimeException(msg)
+
+/** A semantic version objects.
+  * @param major
+  *   the first integer in the core version.
+  * @param minor
+  *   the second integer in the core version.
+  * @param patch
+  *   the third integer in the core version.
+  * @param preRelease
+  *   an optional suffix after the core version delimited by hyphens.
+  * @param build
+  *   an optional suffix after pre-release (if specified) delimited by a plus.
+  */
+case class SemVer(
+  major: Int = 0,
+  minor: Int = 0,
+  patch: Int = 0,
+  preRelease: List[String] = List.empty,
+  build: Option[String] = None
+) extends Comparable[SemVer]
+    with Ordered[SemVer] {
+
+  /** Compares two SemVer objects. Note `build` is ignored during precedence checking.
+    * @param t
+    *   the other SemVer object.
+    * @return
+    *   > 0 if this object is greater than the other, 0 if both are equal, and < 0 if this object is less than the
+    *   other.
+    */
+  override def compareTo(t: SemVer): Int = {
+    if (this.major != t.major) {
+      this.major.compareTo(t.major)
+    } else if (this.minor != t.minor) {
+      this.minor.compareTo(t.minor)
+    } else if (this.patch != t.patch) {
+      this.patch.compareTo(t.patch)
+    } else {
+      (this.preRelease, t.preRelease) match {
+        case (Nil, Nil) => 0
+        case (xs, Nil)  => -1
+        case (Nil, ys)  => 1
+        case (xs, ys)   =>
+          // This not strictly correct and doesn't handle size differences "correctly" but this is probably good enough
+          xs.lazyZip(ys).map { case (x, y) => x.compareTo(y) }.collectFirst { case x if x != 0 => x }.getOrElse(0)
+      }
+    }
+  }
+
+  override def compare(that: SemVer): Int = this.compareTo(that)
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case o: SemVer => this.compareTo(o) == 0
+      case _         => false
+    }
+  }
+
+  override def toString: String = {
+    val sb = StringBuilder(s"$major.$minor.$patch")
+    preRelease match {
+      case Nil => // do nothing
+      case xs  => sb.append("-").append(xs.mkString("-"))
+    }
+    build match {
+      case Some(buildInfo) => sb.append("+").append(buildInfo)
+      case None            => // do nothing
+    }
+    sb.toString
+  }
+
+}

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/SemVerParserTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/SemVerParserTests.scala
@@ -62,4 +62,16 @@ class SemVerParserTests extends AnyWordSpec with Matchers {
     SemVer("~=3.*") shouldBe SemVer(3, 0, 0)
   }
 
+  "be able to deserialize SemVer from JSON" in {
+    import upickle.default.*
+
+    val jsonStr =
+      """{
+        |   "foo": "1.0.0"
+        |}
+        |""".stripMargin
+
+    read[Map[String, SemVer]](jsonStr) shouldBe Map("foo" -> SemVer(1, 0, 0))
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/SemVerParserTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/SemVerParserTests.scala
@@ -1,0 +1,60 @@
+package io.joern.x2cpg.utils
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.{Failure, Success}
+
+class SemVerParserTests extends AnyWordSpec with Matchers {
+
+  "a basic major.minor.patch version should parse successfully" in {
+    val semVer = SemVer("1.9.1")
+    semVer.major shouldBe 1
+    semVer.minor shouldBe 9
+    semVer.patch shouldBe 1
+  }
+
+  "a basic major.minor version should parse successfully with defaults" in {
+    val semVer = SemVer("1.9")
+    semVer.major shouldBe 1
+    semVer.minor shouldBe 9
+    semVer.patch shouldBe 0
+  }
+
+  "a negative integer in the core version should throw an exception" in {
+    assertThrows[SemVerParsingException](SemVer("1.-9.0"))
+  }
+
+  "an empty string should throw an exception" in {
+    assertThrows[SemVerParsingException](SemVer(""))
+  }
+
+  "a version with a pre-release entry should parse successfully" in {
+    SemVer("1.0.0-0.3.7") shouldBe SemVer(1, 0, 0, "0.3.7" :: Nil, None)
+    SemVer("1.0.0-x.7.z.92") shouldBe SemVer(1, 0, 0, "x.7.z.92" :: Nil, None)
+    SemVer("1.0.0-x-y-z.--") shouldBe SemVer(1, 0, 0, "x" :: "y" :: "z." :: Nil, None)
+  }
+
+  "a version with a build entry should parse successfully" in {
+    SemVer("1.0.0+20130313144700") shouldBe SemVer(1, 0, 0, Nil, Option("20130313144700"))
+    SemVer("1.0.0+21AF26D3----117B344092BD") shouldBe SemVer(1, 0, 0, Nil, Option("21AF26D3----117B344092BD"))
+  }
+
+  "a version with both a pre-release and build entry should parse successfully" in {
+    SemVer("1.0.0-alpha+001") shouldBe SemVer(1, 0, 0, "alpha" :: Nil, Option("001"))
+    SemVer("1.0.0-beta+exp.sha.5114f85") shouldBe SemVer(1, 0, 0, "beta" :: Nil, Option("exp.sha.5114f85"))
+  }
+
+  "two versions with the same version core should be equal, regardless of build meta" in {
+    SemVer("1.0.0") shouldEqual SemVer("1.0.0")
+    SemVer("1.0.0+foo") shouldEqual SemVer("1.0.0")
+    SemVer("1.0.0+foo") shouldEqual SemVer("1.0.0+bar")
+  }
+
+  "two versions with differing versions should obey major.minor.patch and pre-release precedence" in {
+    // In this test, the set disregards order, then we convert to list and sort
+    Set(SemVer("1.0.0"), SemVer("2.0.0"), SemVer("2.1.0"), SemVer("2.1.1"), SemVer("1.0.0-alpha")).toList.sorted
+      .map(_.toString) shouldBe List("1.0.0-alpha", "1.0.0", "2.0.0", "2.1.0", "2.1.1")
+  }
+
+}

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/SemVerParserTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/SemVerParserTests.scala
@@ -57,4 +57,9 @@ class SemVerParserTests extends AnyWordSpec with Matchers {
       .map(_.toString) shouldBe List("1.0.0-alpha", "1.0.0", "2.0.0", "2.1.0", "2.1.1")
   }
 
+  "be able to parse a fuzzy regex and normalize it" in {
+    SemVer(">=7.*.0") shouldBe SemVer(7, 0, 0)
+    SemVer("~=3.*") shouldBe SemVer(3, 0, 0)
+  }
+
 }


### PR DESCRIPTION
While handling build files and parsing dependencies, I often find myself wanting something that can help parse the actual versions while preserving their natural ordering. To address this, I've gone ahead with building this myself.

* Added parsing for SemVer according to https://semver.org/
* Added fuzzy semver handling, where it's simply converted to a normalized semver
* Added JSON deserialization and serialization with `ujson`