### PR TITLE
[jimple] General Archive Detection

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -54,12 +54,11 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
     *   [[tmpDir]]
     */
   private def loadClassFiles(src: File, tmpDir: File, recurse: Boolean, depth: Int): List[ClassFile] = {
-    val archiveFileExtensions = Set(".jar", ".war", ".zip")
     extractClassesInPackageLayout(
       src,
       tmpDir,
       isClass = e => e.extension.contains(".class"),
-      isArchive = e => e.extension.exists(archiveFileExtensions.contains),
+      isArchive = e => e.isZipFile,
       recurse,
       depth
     )


### PR DESCRIPTION
Currently, archives are determined by extension, and then corruption is detected if there is a failure along the line.

This change ignores file name completely, and runs through the whole zip to make sure it's valid and uncorrupted before processing. This adds a bit more computation but helps with validity.