### PR TITLE
[ruby] Call Consistency & Precedence

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -154,9 +154,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val argumentAsts = node.arguments.map(astForMethodCallArgument)
 
     receiver.root.collect { case x: NewCall => x.typeFullName(fullName) }
-
-    val dispatchType    = if node.op == "::" then DispatchTypes.STATIC_DISPATCH else DispatchTypes.DYNAMIC_DISPATCH
-    val fieldAccessCall = callNode(node, code(node), node.methodName, fullName, dispatchType)
+    
+    val fieldAccessCall = callNode(node, code(node), node.methodName, fullName, DispatchTypes.DYNAMIC_DISPATCH)
 
     callAst(fieldAccessCall, argumentAsts, Option(receiver))
   }
@@ -232,7 +231,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         x.arguments.map(astForMethodCallArgument) :+ methodRef
     }
 
-    val constructorCall    = callNode(node, code(node), methodName, fullName, DispatchTypes.STATIC_DISPATCH)
+    val constructorCall    = callNode(node, code(node), methodName, fullName, DispatchTypes.DYNAMIC_DISPATCH)
     val constructorCallAst = callAst(constructorCall, argumentAsts, Option(tmpIdentifier))
     scope.popScope()
 
@@ -626,8 +625,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       .map(x => s"$x:$methodName")
       .getOrElse(XDefines.DynamicCallUnknownFullName)
     val argumentAsts = node.arguments.map(astForMethodCallArgument)
-    val dispatchType = if memberAccess.op == "::" then DispatchTypes.STATIC_DISPATCH else DispatchTypes.DYNAMIC_DISPATCH
-    val call         = callNode(node, code(node), methodName, methodFullName, dispatchType)
+    val call         = callNode(node, code(node), methodName, methodFullName, DispatchTypes.DYNAMIC_DISPATCH)
 
     callAst(call, argumentAsts, Some(receiverAst))
   }
@@ -642,7 +640,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case None => defaultResult
     }
     val argumentAst      = node.arguments.map(astForMethodCallArgument)
-    val call             = callNode(node, code(node), methodName, methodFullName, DispatchTypes.STATIC_DISPATCH)
+    val call             = callNode(node, code(node), methodName, methodFullName, DispatchTypes.DYNAMIC_DISPATCH)
     val receiverCallName = identifierNode(node, call.name, call.name, receiverType)
 
     callAst(call, argumentAst, Option(Ast(receiverCallName)))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -154,7 +154,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val argumentAsts = node.arguments.map(astForMethodCallArgument)
 
     receiver.root.collect { case x: NewCall => x.typeFullName(fullName) }
-    
+
     val fieldAccessCall = callNode(node, code(node), node.methodName, fullName, DispatchTypes.DYNAMIC_DISPATCH)
 
     callAst(fieldAccessCall, argumentAsts, Option(receiver))
@@ -344,9 +344,10 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val name = code(node)
 
     scope.lookupVariable(name) match {
+      case Some(_) => handleVariableOccurrence(node)
       case None if scope.tryResolveMethodInvocation(node.text, List.empty).isDefined =>
         astForSimpleCall(SimpleCall(node, List())(node.span))
-      case _ => handleVariableOccurrence(node)
+      case None => handleVariableOccurrence(node)
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -33,7 +33,7 @@ class CallTests extends RubyCode2CpgFixture {
 
     val List(foo) = cpg.call.name("foo").l
     foo.code shouldBe "foo(1,2)"
-    foo.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    foo.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
     foo.lineNumber shouldBe Some(2)
 
     val one = foo.argument(1)
@@ -51,7 +51,7 @@ class CallTests extends RubyCode2CpgFixture {
     val List(fieldAccess) = cpg.fieldAccess.l
 
     fieldAccess.code shouldBe "x.y"
-    fieldAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    fieldAccess.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
     fieldAccess.lineNumber shouldBe Some(2)
     fieldAccess.fieldIdentifier.code.l shouldBe List("y")
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -167,4 +167,18 @@ class CallTests extends RubyCode2CpgFixture {
     }
   }
 
+  "an identifier sharing the name of a previously defined method" should {
+    val cpg = code("""
+        |def foo()
+        |end
+        |
+        |foo = 1
+        |foo
+        |""".stripMargin)
+
+    "get precedence over the method" in {
+      cpg.call("foo").size shouldBe 0
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -149,7 +149,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
         .fullNameExact(allSuperClasses(typeDeclFullName).toIndexedSeq*)
         .astChildren
         .isMethod
-        .name(call.name)
+        .nameExact(call.name)
         .and(_.signatureExact(signature))
         .fullName
         .l


### PR DESCRIPTION
* Converted all calls' dispatch types to `DYNAMIC_DISPATCH` to match Ruby's semantics more closely
* using `nameExact` over `name` in `DynamicCallLinker` (unrelated "bug")
* Made sure identifiers have precedence over calls if an identifier is declared