### PR TITLE
[slicing] Dataflow Slicing Concurrency Fix

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory
 
 import java.util.concurrent.Callable
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 object DataFlowSlicing {
 
@@ -23,7 +23,7 @@ object DataFlowSlicing {
     val tasks = (config.fileFilter match {
       case Some(fileName) => cpg.file.nameExact(fileName).method.call
       case None           => cpg.call
-    }).method.withMethodNameFilter.withMethodParameterFilter.withMethodAnnotationFilter.call.withExternalCalleeFilter
+    }).method.withMethodNameFilter.withMethodParameterFilter.withMethodAnnotationFilter.call.withExternalCalleeFilter.withSinkFilter
       .map(c => () => new TrackDataFlowTask(config, c).call())
       .iterator
 
@@ -38,10 +38,10 @@ object DataFlowSlicing {
       .reduceOption { (a, b) => DataFlowSlice(a.nodes ++ b.nodes, a.edges ++ b.edges) }
   }
 
-  private class TrackDataFlowTask(config: DataFlowConfig, c: Call) extends Callable[Option[DataFlowSlice]] {
+  private class TrackDataFlowTask(config: DataFlowConfig, c: Call) {
 
-    override def call(): Option[DataFlowSlice] = {
-      val sinks           = config.sinkPatternFilter.map(filter => c.argument.code(filter).l).getOrElse(c.argument.l)
+    def call(): Option[DataFlowSlice] = {
+      val sinks           = c.argument.l
       val sliceNodes      = sinks.iterator.repeat(_.ddgIn)(_.maxDepth(config.sliceDepth).emit).dedup.l
       val sliceNodesIdSet = sliceNodes.id.toSet
       // Lazily set up the rest if the filters are satisfied

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
@@ -27,7 +27,7 @@ object DataFlowSlicing {
       .map(c => () => new TrackDataFlowTask(config, c).call())
       .l
 
-    println(s"Processing ${tasks.size} sinks")
+    logger.info(s"Processing ${tasks.size} sinks")
 
     ConcurrentTaskUtil
       .runUsingThreadPool(tasks.iterator, config.parallelism.getOrElse(Runtime.getRuntime.availableProcessors()))

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
@@ -25,10 +25,12 @@ object DataFlowSlicing {
       case None           => cpg.call
     }).method.withMethodNameFilter.withMethodParameterFilter.withMethodAnnotationFilter.call.withExternalCalleeFilter.withSinkFilter
       .map(c => () => new TrackDataFlowTask(config, c).call())
-      .iterator
+      .l
+
+    println(s"Processing ${tasks.size} sinks")
 
     ConcurrentTaskUtil
-      .runUsingThreadPool(tasks, config.parallelism.getOrElse(Runtime.getRuntime.availableProcessors()))
+      .runUsingThreadPool(tasks.iterator, config.parallelism.getOrElse(Runtime.getRuntime.availableProcessors()))
       .flatMap {
         case Success(slice) => slice
         case Failure(e) =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
@@ -104,7 +104,7 @@ package object slicing {
     def withSinkFilter(implicit config: DataFlowConfig): Iterator[Call] = {
       config.sinkPatternFilter match {
         case Some(pattern) => trav.code(pattern)
-        case None => trav
+        case None          => trav
       }
     }
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
@@ -101,6 +101,13 @@ package object slicing {
       if (config.mustEndAtExternalMethod) trav.where(_.callee.filter(_.isExternal))
       else trav
 
+    def withSinkFilter(implicit config: DataFlowConfig): Iterator[Call] = {
+      config.sinkPatternFilter match {
+        case Some(pattern) => trav.code(pattern)
+        case None => trav
+      }
+    }
+
   }
 
   /** Adds extensions to modify a method traversal based on config options


### PR DESCRIPTION
It appears that running `.code` in a multi-threaded environment may lead to the database returning `null` to the regex matcher. It is a bit bizarre, but this PR moves the `code` filter in a serial position. See #4459 for more details.

Resolves #4459