### PR TITLE
[ruby] Bug Fix `ANY` Method Full Name

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -154,7 +154,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     // TODO: Type recovery should potentially resolve this
     val fullName = typeFromCallTarget(node.target)
       .map(x => s"$x:${node.methodName}")
-      .getOrElse(XDefines.Any)
+      .getOrElse(XDefines.DynamicCallUnknownFullName)
 
     val receiver     = astForExpression(node.target)
     val argumentAsts = node.arguments.map(astForMethodCallArgument)


### PR DESCRIPTION
Some member calls have `ANY` as the full name when unresolved which is incorrect. Changed this to `<unknownMethodFullName>`