### PR TITLE
[php2cpg] Handle utf-8 offsets correctly

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -17,6 +17,8 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
 import overflowdb.BatchedUpdate
 
+import java.nio.charset.StandardCharsets
+
 class AstCreator(filename: String, phpAst: PhpFile, fileContent: Option[String], disableFileContent: Boolean)(implicit
   withSchemaValidation: ValidationMode
 ) extends AstCreatorBase(filename)
@@ -1727,7 +1729,11 @@ class AstCreator(filename: String, phpAst: PhpFile, fileContent: Option[String],
 
   override protected def offset(phpNode: PhpNode): Option[(Int, Int)] = {
     Option.when(!disableFileContent) {
-      (phpNode.attributes.startFilePos, phpNode.attributes.endFilePos)
+      val startPos =
+        new String(fileContent.get.getBytes.slice(0, phpNode.attributes.startFilePos), StandardCharsets.UTF_8).length
+      val endPos =
+        new String(fileContent.get.getBytes.slice(0, phpNode.attributes.endFilePos), StandardCharsets.UTF_8).length
+      (startPos, endPos)
     }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -135,17 +135,16 @@ class MethodTests extends PhpCode2CpgFixture {
   "methods with unicode characters in source" should {
     val cpg = code("""<?php
         |function foo() {
-        |  $x = "🙂";
-        |}
-        |""".stripMargin).withConfig(Config().withDisableFileContent(false))
+        |  $x = "🙂🙂🙂🙂🙂🙂";
+        |}""".stripMargin).withConfig(Config().withDisableFileContent(false))
 
-    "set the content field correctly" ignore {
+    "set the content field correctly" in {
       inside(cpg.method.nameExact("foo").l) { case List(fooMethod) =>
         val offsetStart = fooMethod.offset.get
         val offsetEnd   = fooMethod.offsetEnd.get
         fooMethod.file.head.content.substring(offsetStart, offsetEnd) shouldBe
           """function foo() {
-            |  $x = "🙂";
+            |  $x = "🙂🙂🙂🙂🙂🙂";
             |}""".stripMargin
       }
     }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -135,7 +135,8 @@ class MethodTests extends PhpCode2CpgFixture {
   "methods with unicode characters in source" should {
     val cpg = code("""<?php
         |function foo() {
-        |  $x = "🙂🙂🙂🙂🙂🙂";
+        |  // ⦝
+        |  $x = "🙂⨌🙂𐇐🙂🙂🙂🙂";
         |}""".stripMargin).withConfig(Config().withDisableFileContent(false))
 
     "set the content field correctly" in {
@@ -144,7 +145,8 @@ class MethodTests extends PhpCode2CpgFixture {
         val offsetEnd   = fooMethod.offsetEnd.get
         fooMethod.file.head.content.substring(offsetStart, offsetEnd) shouldBe
           """function foo() {
-            |  $x = "🙂🙂🙂🙂🙂🙂";
+            |  // ⦝
+            |  $x = "🙂⨌🙂𐇐🙂🙂🙂🙂";
             |}""".stripMargin
       }
     }


### PR DESCRIPTION
This PR fixes offset calculations when processing utf-8 files with the file content feature enabled. The 2 main issues with this PR are that it assumes a utf-8 encoding (which will work for ascii as well, but not for more niche encodings) and a possible performance hit from the offset calculation. A potential optimization would be to cache known offsets and to calculate the new offset from the closest one, but since this is not a common operation, it likely won't be too much of a slow-down and we can revisit this decision if performance does turn out to be an issue.