### PR TITLE
[javasrc2cpg] Clear JavaParser caches after AST creation

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -31,6 +31,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       val astCreationPass = new AstCreationPass(config, cpg)
       astCreationPass.createAndApply()
       astCreationPass.sourceParser.cleanupDelombokOutput()
+      astCreationPass.clearJavaParserCaches()
       new ConfigFileCreationPass(cpg).createAndApply()
       if (!config.skipTypeInfPass) {
         TypeNodePass.withRegisteredTypes(astCreationPass.global.usedTypes.keys().asScala.toList, cpg).createAndApply()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -6,6 +6,7 @@ import com.github.javaparser.ParserConfiguration.LanguageLevel
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.Node.Parsedness
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade
 import com.github.javaparser.symbolsolver.resolution.typesolvers.{
   ClassLoaderTypeSolver,
   JarTypeSolver,
@@ -56,6 +57,13 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
 
       case None => logger.warn(s"Skipping AST creation for $filename")
     }
+  }
+
+  /** Clear JavaParser caches. Should only be invoked after we no longer need JavaParser, e.g. as soon as we've built
+    * the AST layer for all files.
+    */
+  def clearJavaParserCaches(): Unit = {
+    JavaParserFacade.clearInstances()
   }
 
   private def initParserAndUtils(config: Config): (SourceParser, JavaSymbolSolver) = {


### PR DESCRIPTION
We reach out-of-memory exceptions when running consecutive scans (within the same process) and providing the so-called «inference jar paths» (`--inference-jar-paths`).

This can be observed if we run all javasrc2cpg unit-tests with some additional inference jar. In the following experiment, I've used the same 100MB .jar throughout unit-tests and the 8GB limit is quickly reached, precluding them from finishing.

<img width="1334" alt="Screenshot 2024-04-24 at 16 11 49" src="https://github.com/joernio/joern/assets/3519109/db7ecbf9-7ce6-44eb-8f0e-4852cd5e1932">

Poking around, it seems clear that each time an inference jar is loaded its TypeSolver remains in memory. 

By clearing JavaParser caches the situation improves considerably:

<img width="1341" alt="Screenshot 2024-04-24 at 16 16 14" src="https://github.com/joernio/joern/assets/3519109/ccb04b1f-6897-4fc1-9282-b5fcbffd864c">


