### PR TITLE
[jimple] Upgrade Soot

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -31,7 +31,7 @@ object Versions {
   val scalatest              = "3.2.18"
   val scopt                  = "4.1.0"
   val semverParser           = "0.0.6"
-  val soot                   = "4.4.1"
+  val soot                   = "4.5.0"
   val slf4j                  = "2.0.7"
   val log4j                  = "2.20.0"
   val upickle                = "3.3.0"


### PR DESCRIPTION
Soot 4.5.0 uses [ASM 9.7](https://github.com/soot-oss/soot/blob/4.5.0/pom.xml#L76) compared to 4.4.1 which uses ASM 9.4.

This will help parse newer versions of JVM bytecode.