### PR TITLE
[ruby] Builtin type-stubs for `Ruby`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Delete `.cargo` directory # to save disk space
         run: rm -rf /home/runner/.cargo
         if: runner.os == 'Linux'
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.sbt
-            ~/.coursier
-          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
+#      - uses: actions/cache@v4
+#        with:
+#          path: |
+#            ~/.sbt
+#            ~/.coursier
+#          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
       - name: Compile and run tests
         run: sbt clean test
   formatting:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Delete `.cargo` directory # to save disk space
         run: rm -rf /home/runner/.cargo
         if: runner.os == 'Linux'
-#      - uses: actions/cache@v4
-#        with:
-#          path: |
-#            ~/.sbt
-#            ~/.coursier
-#          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.coursier
+          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
       - name: Compile and run tests
         run: sbt clean test
   formatting:

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ null
 **/dotnetastgen-win-arm.exe
 **/dotnetastgen-macos
 **/dotnetastgen-macos-arm
+**/*_builtin_types.zip
+**/*_builtin_types.zip.sha512
 slices.json
 **/.antlr
 /joern-cli/frontends/csharpsrc2cpg/bin
@@ -74,3 +76,5 @@ flake.lock
 .bloop
 **/.DS_Store
 **/.bsp
+
+

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -10,7 +10,6 @@ import java.io.{ByteArrayInputStream, InputStream}
 import scala.annotation.targetName
 import scala.collection.mutable.ListBuffer
 import scala.io.Source
-import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
 type NamespaceToTypeMap = Map[String, Set[CSharpType]]

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -14,6 +14,8 @@ import scala.util.{Failure, Success, Try}
 import java.net.JarURLConnection
 import scala.util.Using
 
+import scala.jdk.CollectionConverters.*
+
 type NamespaceToTypeMap = Map[String, Set[CSharpType]]
 
 /** A mapping of type stubs of known types within the scope of the analysis.
@@ -64,6 +66,8 @@ object CSharpProgramSummary {
     /*
       Doing this because java actually cannot read directories from the classPath.
       We're assuming there's no further nesting in the builtin_types directory structure.
+      TODO: Once MessagePack types and compression is implemented for CSharp, the `resourcePaths` building can
+       be moved into `ProgramSummary` since all subclasses of it will need to do this to find builtin types
      */
     val resourcePaths: List[String] = Option(getClass.getClassLoader.getResource(builtinDirectory)) match {
       case Some(url) if url.getProtocol == "jar" =>

--- a/joern-cli/frontends/rubysrc2cpg/.gitignore
+++ b/joern-cli/frontends/rubysrc2cpg/.gitignore
@@ -1,3 +1,4 @@
 # Created by IntelliJ's ANTLR plugin
 gen/
 *.tokens
+type_stubs

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -60,9 +60,6 @@ joernTypeStubsDlTask := {
   val distDir = (Universal / stagingDirectory).value / "type_stubs"
   distDir.mkdirs()
   IO.copyDirectory(joernTypeStubsDir, distDir)
-
-  println(s"Type Stubs DIR: ${joernTypeStubsDir.list().mkString("Array(", ", ", ")")}")
-  println(s"Type Stubs Files: ${joernTypeStubsDir.listFiles().mkString("Array(", ", ", ")")}")
 }
 
 Compile / compile := ((Compile / compile) dependsOn joernTypeStubsDlTask).value

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -32,9 +32,9 @@ joernTypeStubsDlUrl := s"https://github.com/joernio/joern-type-stubs/releases/do
 
 lazy val joernTypeStubsDlTask = taskKey[Unit]("Download joern-type-stubs")
 joernTypeStubsDlTask := {
-  val joernTypeStubsDir = (Compile / resourceDirectory).value / "builtin_types"
+  val joernTypeStubsDir = baseDirectory.value / "type_stubs"
   val fileName = "rubysrc_builtin_types.zip"
-  val shaFileName = s"${fileName}.sha512"
+  val shaFileName = s"$fileName.sha512"
 
   joernTypeStubsDir.mkdir()
 
@@ -54,12 +54,10 @@ joernTypeStubsDlTask := {
   // Checksum from terminal adds the filename to the line, so we split on whitespace to get the checksum
   // separate from the filename
   if (checksumFile.lineIterator.next().split("\\s+")(0).toUpperCase != typestubsSha) {
-    throw new Exception("Checksums do not match for type-stubs!")
+    throw new Exception("Checksums do not match for type stubs!")
   }
 
-  checksumFile.delete()
-
-  val distDir = (Universal / stagingDirectory).value / "builtin_types"
+  val distDir = (Universal / stagingDirectory).value / "type_stubs"
   distDir.mkdirs()
   IO.copyDirectory(joernTypeStubsDir, distDir)
 

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -44,6 +44,21 @@ joernTypeStubsDlTask := {
   val typeStubsFile = better.files.File(joernTypeStubsDir.getAbsolutePath) / fileName
   val checksumFile = better.files.File(joernTypeStubsDir.getAbsolutePath)  / shaFileName
 
+  val typestubsSha = typeStubsFile.sha512
+
+  // Checksum file must contain exactly 1 line, if more or less we automatically fail.
+  if (checksumFile.lineIterator.size != 1) {
+    throw new IllegalStateException("Checksum File should only have 1 line")
+  }
+
+  // Checksum from terminal adds the filename to the line, so we split on whitespace to get the checksum
+  // separate from the filename
+  if (checksumFile.lineIterator.next().split("\\s+")(0).toUpperCase != typestubsSha) {
+    throw new Exception("Checksums do not match for type-stubs!")
+  }
+
+  checksumFile.delete()
+
   val distDir = (Universal / stagingDirectory).value / "builtin_types"
   distDir.mkdirs()
   IO.copyDirectory(joernTypeStubsDir, distDir)

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -1,4 +1,3 @@
-import better.files
 import com.typesafe.config.{Config, ConfigFactory}
 
 name := "rubysrc2cpg"
@@ -33,7 +32,7 @@ joernTypeStubsDlUrl := s"https://github.com/joernio/joern-type-stubs/releases/do
 
 lazy val joernTypeStubsDlTask = taskKey[Unit]("Download joern-type-stubs")
 joernTypeStubsDlTask := {
-  val joernTypeStubsDir = baseDirectory.value / "src" / "main" / "resources"
+  val joernTypeStubsDir = (Compile / resourceDirectory).value / "builtin_types"
   val fileName = "rubysrc_builtin_types.zip"
   val shaFileName = s"${fileName}.sha512"
 
@@ -41,6 +40,16 @@ joernTypeStubsDlTask := {
 
   DownloadHelper.ensureIsAvailable(s"${joernTypeStubsDlUrl.value}$fileName", joernTypeStubsDir / fileName)
   DownloadHelper.ensureIsAvailable(s"${joernTypeStubsDlUrl.value}$shaFileName", joernTypeStubsDir / shaFileName)
+
+  val typeStubsFile = better.files.File(joernTypeStubsDir.getAbsolutePath) / fileName
+  val checksumFile = better.files.File(joernTypeStubsDir.getAbsolutePath)  / shaFileName
+
+  val distDir = (Universal / stagingDirectory).value / "builtin_types"
+  distDir.mkdirs()
+  IO.copyDirectory(joernTypeStubsDir, distDir)
 }
 
 Compile / compile := ((Compile / compile) dependsOn joernTypeStubsDlTask).value
+
+Universal / packageName := name.value
+Universal / topLevelDirectory := None

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -62,6 +62,9 @@ joernTypeStubsDlTask := {
   val distDir = (Universal / stagingDirectory).value / "builtin_types"
   distDir.mkdirs()
   IO.copyDirectory(joernTypeStubsDir, distDir)
+
+  println(s"Type Stubs DIR: ${joernTypeStubsDir.list().mkString("Array(", ", ", ")")}")
+  println(s"Type Stubs Files: ${joernTypeStubsDir.listFiles().mkString("Array(", ", ", ")")}")
 }
 
 Compile / compile := ((Compile / compile) dependsOn joernTypeStubsDlTask).value

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -1,6 +1,19 @@
+import better.files
+import com.typesafe.config.{Config, ConfigFactory}
+
 name := "rubysrc2cpg"
 
 dependsOn(Projects.dataflowengineoss % "compile->compile;test->test", Projects.x2cpg % "compile->compile;test->test")
+
+lazy val appProperties = settingKey[Config]("App Properties")
+appProperties := {
+  val path = (Compile / resourceDirectory).value / "application.conf"
+  val applicationConf = ConfigFactory.parseFile(path).resolve()
+  applicationConf
+}
+
+lazy val joernTypeStubsVersion = settingKey[String]("joern_type_stub version")
+joernTypeStubsVersion := appProperties.value.getString("rubysrc2cpg.joern_type_stubs_version")
 
 libraryDependencies ++= Seq(
   "io.shiftleft"  %% "codepropertygraph" % Versions.cpg,
@@ -14,3 +27,20 @@ enablePlugins(JavaAppPackaging, LauncherJarPlugin, Antlr4Plugin)
 Antlr4 / antlr4Version    := Versions.antlr
 Antlr4 / antlr4GenVisitor := true
 Antlr4 / javaSource       := (Compile / sourceManaged).value
+
+lazy val joernTypeStubsDlUrl = settingKey[String]("joern_type_stubs download url")
+joernTypeStubsDlUrl := s"https://github.com/joernio/joern-type-stubs/releases/download/v${joernTypeStubsVersion.value}/"
+
+lazy val joernTypeStubsDlTask = taskKey[Unit]("Download joern-type-stubs")
+joernTypeStubsDlTask := {
+  val joernTypeStubsDir = baseDirectory.value / "src" / "main" / "resources"
+  val fileName = "rubysrc_builtin_types.zip"
+  val shaFileName = s"${fileName}.sha512"
+
+  joernTypeStubsDir.mkdir()
+
+  DownloadHelper.ensureIsAvailable(s"${joernTypeStubsDlUrl.value}$fileName", joernTypeStubsDir / fileName)
+  DownloadHelper.ensureIsAvailable(s"${joernTypeStubsDlUrl.value}$shaFileName", joernTypeStubsDir / shaFileName)
+}
+
+Compile / compile := ((Compile / compile) dependsOn joernTypeStubsDlTask).value

--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 rubysrc2cpg {
-    joern_type_stubs_version: "0.5.0"
+    joern_type_stubs_version: "0.6.0"
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 rubysrc2cpg {
-    joern_type_stubs_version: "0.4.0"
+    joern_type_stubs_version: "0.5.0"
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+rubysrc2cpg {
+    joern_type_stubs_version: "0.4.0"
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -2,16 +2,19 @@ package io.joern.rubysrc2cpg
 
 import io.joern.rubysrc2cpg.Frontend.*
 import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
+import io.joern.x2cpg.typestub.TypeStubConfig
 import io.joern.x2cpg.{DependencyDownloadConfig, X2CpgConfig, X2CpgMain}
 import scopt.OParser
 
 final case class Config(
   antlrCacheMemLimit: Double = 0.6d,
   useDeprecatedFrontend: Boolean = false,
-  downloadDependencies: Boolean = false
+  downloadDependencies: Boolean = false,
+  useTypeStubs: Boolean = true
 ) extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config]
-    with TypeRecoveryParserConfig[Config] {
+    with TypeRecoveryParserConfig[Config]
+    with TypeStubConfig[Config] {
 
   this.defaultIgnoredFilesRegex = List("spec", "test").flatMap { directory =>
     List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|/)$directory($$|/)".r.unanchored)
@@ -27,6 +30,10 @@ final case class Config(
 
   override def withDownloadDependencies(value: Boolean): Config = {
     copy(downloadDependencies = value).withInheritedFields(this)
+  }
+
+  override def withTypeStubs(value: Boolean): Config = {
+    copy(useTypeStubs = value).withInheritedFields(this)
   }
 }
 
@@ -55,7 +62,8 @@ private object Frontend {
         .action((_, c) => c.withUseDeprecatedFrontend(true))
         .text("uses the original (but deprecated) Ruby frontend (default false)"),
       DependencyDownloadConfig.parserOptions,
-      XTypeRecovery.parserOptions
+      XTypeRecovery.parserOptions,
+      TypeStubConfig.parserOptions
     )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -18,6 +18,7 @@ import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
+import io.joern.x2cpg.typestub.TypeStubMetaData
 import io.joern.x2cpg.utils.{ConcurrentTaskUtil, ExternalCommand}
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.Cpg
@@ -62,7 +63,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
           case Failure(exception) => logger.warn(s"Unable to pre-parse Ruby file, skipping - ", exception); None
           case Success(summary)   => Option(summary)
         }
-        .foldLeft(RubyProgramSummary(RubyProgramSummary.BuiltinTypes))(_ ++ _)
+        .foldLeft(RubyProgramSummary(RubyProgramSummary.BuiltinTypes(config.typeStubMetaData)))(_ ++ _)
 
       val programSummary = if (config.downloadDependencies) {
         DependencyDownloader(cpg, internalProgramSummary).download()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -65,8 +65,6 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
         .reduceOption((a, b) => a ++ b)
         .getOrElse(RubyProgramSummary())
 
-      RubyProgramSummary.readme()
-
       val programSummary = if (config.downloadDependencies) {
         DependencyDownloader(cpg, internalProgramSummary).download()
       } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -62,8 +62,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
           case Failure(exception) => logger.warn(s"Unable to pre-parse Ruby file, skipping - ", exception); None
           case Success(summary)   => Option(summary)
         }
-        .reduceOption((a, b) => a ++ b)
-        .getOrElse(RubyProgramSummary())
+        .foldLeft(RubyProgramSummary(RubyProgramSummary.BuiltinTypes))(_ ++ _)
 
       val programSummary = if (config.downloadDependencies) {
         DependencyDownloader(cpg, internalProgramSummary).download()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -59,6 +59,8 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
         .reduceOption((a, b) => a ++ b)
         .getOrElse(RubyProgramSummary())
 
+      RubyProgramSummary.readme()
+
       val programSummary = if (config.downloadDependencies) {
         DependencyDownloader(cpg, internalProgramSummary).download()
       } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -54,6 +54,7 @@ object RubyProgramSummary {
     val resourcePaths: List[String] =
       Option(getClass.getClassLoader.getResource(builtinDirectory)) match {
         case Some(url) if url.getProtocol == "jar" =>
+          logger.info("Reading from JAR")
           val connection = url.openConnection.asInstanceOf[JarURLConnection]
           Using.resource(connection.getJarFile) { jarFile =>
             jarFile
@@ -66,6 +67,7 @@ object RubyProgramSummary {
               .filter(_.endsWith(".zip"))
           }
         case _ =>
+          logger.info("Reading from builtin_dir")
           Source
             .fromResource(builtinDirectory)
             .getLines()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -52,9 +52,11 @@ object RubyProgramSummary {
     val builtinDirectory = "builtin_types"
 
     val resourcePaths: List[String] =
+      val resourceOpt = getClass.getClassLoader.getResource(builtinDirectory)
+      logger.warn(resourceOpt.toString)
       Option(getClass.getClassLoader.getResource(builtinDirectory)) match {
         case Some(url) if url.getProtocol == "jar" =>
-          logger.info("Reading from JAR")
+          logger.warn("Reading from JAR")
           val connection = url.openConnection.asInstanceOf[JarURLConnection]
           Using.resource(connection.getJarFile) { jarFile =>
             jarFile
@@ -67,7 +69,7 @@ object RubyProgramSummary {
               .filter(_.endsWith(".zip"))
           }
         case _ =>
-          logger.info("Reading from builtin_dir")
+          logger.warn("Reading from builtin_dir")
           Source
             .fromResource(builtinDirectory)
             .getLines()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -39,16 +39,16 @@ object RubyProgramSummary {
   private val logger = LoggerFactory.getLogger(getClass)
 
   def BuiltinTypes: NamespaceToTypeMap = {
-    mpkZipToinitialMapping(readme) match
+    mpkZipToInitialMapping(mergeBuiltinMpkZip) match
       case Failure(exception) => logger.warn("Unable to parse builtin types", exception); Map.empty
       case Success(mapping)   => mapping
   }
 
-  private def mpkZipToinitialMapping(inputStream: InputStream): Try[NamespaceToTypeMap] = {
+  private def mpkZipToInitialMapping(inputStream: InputStream): Try[NamespaceToTypeMap] = {
     Try(readBinary[NamespaceToTypeMap](inputStream.readAllBytes()))
   }
 
-  def readme: InputStream = {
+  def mergeBuiltinMpkZip: InputStream = {
     val classLoader      = getClass.getClassLoader
     val builtinDirectory = "builtin_types"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -3,7 +3,6 @@ package io.joern.rubysrc2cpg.datastructures
 import io.joern.x2cpg.Defines as XDefines
 import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, TypeLike}
 import org.slf4j.LoggerFactory
-import upickle.core.LinkedHashMap
 
 import java.io.{ByteArrayInputStream, InputStream}
 import scala.annotation.targetName

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -210,6 +210,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
 
   override def tryResolveTypeReference(typeName: String): Option[RubyType] = {
     val normalizedTypeName = typeName.replaceAll("::", ".")
+    val flatMapTypes       = summary.namespaceToType.flatMap(_._2).filter(x => x.name.toLowerCase.contains("csv"))
     // TODO: While we find better ways to understand how the implicit class loading works,
     //  we can approximate that all types are in scope in the mean time.
     super.tryResolveTypeReference(normalizedTypeName) match {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -150,4 +150,30 @@ class ImportTests extends RubyCode2CpgFixture with Inspectors {
 
   }
 
+  "Builtin Types type-map" should {
+    val cpg = code("""
+        |require 'csv'
+        |require 'pp'
+        |CSV.parse("")
+        |CSV::Table.new()
+        |PP.pp(obj)
+        |PP
+        |""".stripMargin)
+
+    cpg.call.l.foreach(x => println(x.code))
+    "resolve CSV parse call" in {
+      inside(cpg.call.l) {
+        case requireCsvCall :: requirePpCall :: csvCall :: ppCall :: ppCallTwo :: ppCallC :: Nil =>
+          println(ppCall.name)
+          println(ppCall.methodFullName)
+          println(ppCall.code)
+
+          println(ppCallTwo.methodFullName)
+
+          csvCall.methodFullName shouldBe "csv.CSV:parse"
+        case xs => fail(s"Expected two calls, got [${xs.code.mkString(",")}] instead")
+      }
+    }
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -157,23 +157,16 @@ class ImportTests extends RubyCode2CpgFixture with Inspectors {
         |CSV.parse("")
         |CSV::Table.new()
         |PP.pp(obj)
-        |PP
         |""".stripMargin)
 
-    cpg.call.l.foreach(x => println(x.code))
-    "resolve CSV parse call" in {
-      inside(cpg.call.l) {
-        case requireCsvCall :: requirePpCall :: csvCall :: ppCall :: ppCallTwo :: ppCallC :: Nil =>
-          println(ppCall.name)
-          println(ppCall.methodFullName)
-          println(ppCall.code)
-
-          println(ppCallTwo.methodFullName)
-
-          csvCall.methodFullName shouldBe "csv.CSV:parse"
-        case xs => fail(s"Expected two calls, got [${xs.code.mkString(",")}] instead")
+    "resolve calls to builtin functions" in {
+      inside(cpg.call.methodFullName("(pp|csv).*").l) {
+        case csvParseCall :: csvTableInitCall :: ppCall :: Nil =>
+          csvParseCall.methodFullName shouldBe "csv.CSV:parse"
+          ppCall.methodFullName shouldBe "pp.PP:pp"
+          csvTableInitCall.methodFullName shouldBe "csv.CSV.Table:<init>"
+        case xs => fail(s"Expected three calls, got [${xs.code.mkString(",")}] instead")
       }
     }
   }
-
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubConfig.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubConfig.scala
@@ -1,0 +1,50 @@
+package io.joern.x2cpg.typestub
+
+import io.joern.x2cpg.X2CpgConfig
+import scopt.OParser
+
+import java.net.URL
+
+/** Extends the config to download type stubs to help resolve type full names.
+  */
+trait TypeStubConfig[R <: X2CpgConfig[R]] { this: R =>
+
+  /** Whether to use type stubs to help resolve type information or not. Using type stubs may increase memory
+    * consumption.
+    */
+  def useTypeStubs: Boolean
+
+  /** The entrypoint to load the type stubs into the config.
+    */
+  def withTypeStubs(value: Boolean): R
+
+  /** Creates a meta-data class of information about the type stub management.
+    */
+  def typeStubMetaData: TypeStubMetaData =
+    TypeStubMetaData(useTypeStubs, getClass.getProtectionDomain.getCodeSource.getLocation)
+
+}
+
+/** The meta data around managing type stub resources for this frontend.
+  * @param useTypeStubs
+  *   a flag to indicate whether types stubs should be used.
+  * @param packagePath
+  *   the code path for the frontend.
+  */
+case class TypeStubMetaData(useTypeStubs: Boolean, packagePath: URL)
+
+object TypeStubConfig {
+
+  def parserOptions[R <: X2CpgConfig[R] & TypeStubConfig[R]]: OParser[?, R] = {
+    val builder = OParser.builder[R]
+    import builder.*
+    OParser.sequence(
+      opt[Unit]("disable-type-stubs")
+        .text(
+          "Disables the use type stubs for type information recovery. Using type stubs may increase memory consumption."
+        )
+        .action((x, c) => c.withTypeStubs(false))
+    )
+  }
+
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubUtil.scala
@@ -1,0 +1,31 @@
+package io.joern.x2cpg.typestub
+
+import better.files.File
+
+import java.nio.file.Paths
+
+object TypeStubUtil {
+
+  /** Obtains the type stub dir for this frontend.
+    * @param metaData
+    *   meta data describing the loaded type stubs.
+    * @return
+    *   the directory where type stubs are.
+    */
+  def typeStubDir(implicit metaData: TypeStubMetaData): File = {
+    val dir        = metaData.packagePath.toString
+    val indexOfLib = dir.lastIndexOf("lib")
+    val fixedDir = if (indexOfLib != -1) {
+      new java.io.File(dir.substring("file:".length, indexOfLib)).toString
+    } else {
+      val indexOfTarget = dir.lastIndexOf("target")
+      if (indexOfTarget != -1) {
+        new java.io.File(dir.substring("file:".length, indexOfTarget)).toString
+      } else {
+        "."
+      }
+    }
+    File(Paths.get(fixedDir, "/type_stubs").toAbsolutePath)
+  }
+
+}


### PR DESCRIPTION
This PR handles:
 * Downloads compressed type-stubs from `joern-type-stubs` release during `sbt stage` and sha512 checksums the downloaded files with the sha512 on `joern-type-stubs` release page
 * Populates the initial `namespaceToType` map from the builtin type-stubs

Todo:
* Filter out types from the `namespaceToType` map that are not imported
* 