### PR TITLE
[javasrc] `keepTypeArguments` Flag

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -23,7 +23,7 @@ case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends C
   }
 
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
-    if (javaConfig.forall(_.enableTypeRecovery))
+    if (javaConfig.exists(_.enableTypeRecovery))
       JavaSrc2Cpg.typeRecoveryPasses(cpg, javaConfig).foreach(_.createAndApply())
     super.applyPostProcessingPasses(cpg)
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -21,7 +21,8 @@ final case class Config(
   showEnv: Boolean = false,
   skipTypeInfPass: Boolean = false,
   dumpJavaparserAsts: Boolean = false,
-  cacheJdkTypeSolver: Boolean = false
+  cacheJdkTypeSolver: Boolean = false,
+  keepTypeArguments: Boolean = true
 ) extends X2CpgConfig[Config]
     with TypeRecoveryParserConfig[Config] {
   def withInferenceJarPaths(paths: Set[String]): Config = {
@@ -66,6 +67,10 @@ final case class Config(
 
   def withCacheJdkTypeSolver(value: Boolean): Config = {
     copy(cacheJdkTypeSolver = value).withInheritedFields(this)
+  }
+
+  def withKeepTypeArguments(value: Boolean): Config = {
+    copy(keepTypeArguments = value).withInheritedFields(this)
   }
 }
 
@@ -120,7 +125,11 @@ private object Frontend {
       opt[Unit]("cache-jdk-type-solver")
         .hidden()
         .action((_, c) => c.withCacheJdkTypeSolver(true))
-        .text("Re-use JDK type solver between scans.")
+        .text("Re-use JDK type solver between scans."),
+      opt[Unit]("keep-type-arguments")
+        .hidden()
+        .action((_, c) => c.withKeepTypeArguments(true))
+        .text("Type full names of variables keep their type arguments.")
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -22,7 +22,7 @@ final case class Config(
   skipTypeInfPass: Boolean = false,
   dumpJavaparserAsts: Boolean = false,
   cacheJdkTypeSolver: Boolean = false,
-  keepTypeArguments: Boolean = true
+  keepTypeArguments: Boolean = false
 ) extends X2CpgConfig[Config]
     with TypeRecoveryParserConfig[Config] {
   def withInferenceJarPaths(paths: Set[String]): Config = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -84,7 +84,8 @@ class AstCreator(
   javaParserAst: CompilationUnit,
   fileContent: Option[String],
   global: Global,
-  val symbolSolver: JavaSymbolSolver
+  val symbolSolver: JavaSymbolSolver,
+  keepTypeArguments: Boolean
 )(implicit val withSchemaValidation: ValidationMode)
     extends AstCreatorBase(filename)
     with AstNodeBuilder[Node, AstCreator]
@@ -96,8 +97,9 @@ class AstCreator(
 
   private[astcreation] val scope = Scope()
 
-  private[astcreation] val typeInfoCalc: TypeInfoCalculator = TypeInfoCalculator(global, symbolSolver)
-  private[astcreation] val bindingTableCache                = mutable.HashMap.empty[String, BindingTable]
+  private[astcreation] val typeInfoCalc: TypeInfoCalculator =
+    TypeInfoCalculator(global, symbolSolver, keepTypeArguments)
+  private[astcreation] val bindingTableCache = mutable.HashMap.empty[String, BindingTable]
 
   /** Entry point of AST creation. Translates a compilation unit created by JavaParser into a DiffGraph containing the
     * corresponding CPG AST.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -51,7 +51,9 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
         symbolSolver.inject(compilationUnit)
         val contentToUse = if (!config.disableFileContent) fileContent else None
         diffGraph.absorb(
-          new AstCreator(filename, compilationUnit, contentToUse, global, symbolSolver)(config.schemaValidation)
+          new AstCreator(filename, compilationUnit, contentToUse, global, symbolSolver, config.keepTypeArguments)(
+            config.schemaValidation
+          )
             .createAst()
         )
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
@@ -1,8 +1,9 @@
 package io.joern.javasrc2cpg.querying
 
+import io.joern.javasrc2cpg.Config
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Local}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 class VarDeclTests extends JavaSrcCode2CpgFixture {
 
@@ -154,5 +155,32 @@ class VarDeclTests extends JavaSrcCode2CpgFixture {
 
     assigX.code shouldBe "x = 1"
     assigX.order shouldBe 6
+  }
+
+  "generics with 'keep type arguments' config" should {
+    val cpg = code("""
+        |import java.util.ArrayList;
+        |import java.util.List;
+        |import java.util.HashMap;
+        |
+        |public class Main {
+        |    public static void main(String[] args) {
+        |        // Create a List of Strings
+        |        List<String> stringList = new ArrayList<>();
+        |        var stringIntMap = new HashMap<String, Integer>();
+        |    }
+        |}
+        |
+        |""".stripMargin)
+      .withConfig(Config().withKeepTypeArguments(true))
+
+    "show the fully qualified type arguments for `List`" in {
+      cpg.identifier("stringList").typeFullName.head shouldBe "java.util.List<java.lang.String>"
+    }
+
+    "show the fully qualified type arguments for `Map`" in {
+      cpg.identifier("stringIntMap").typeFullName.head shouldBe "java.util.HashMap<java.lang.String,java.lang.Integer>"
+    }
+
   }
 }


### PR DESCRIPTION
The desire for type arguments to be persisted in type nodes and properties has been around for a while.

This PR adds a hidden, off-by-default flag, `keep-type-arguments`, signals to the `TypeInfoCalculator` to build the full name with the full names of the type arguments.

Resolves #4488