### PR TITLE
[ruby] Enable `ImplicitRequirePass` if `zeitwerk` is Detected

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -72,7 +72,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
       }
 
       AstCreationPass(cpg, astCreators.map(_.withSummary(programSummary))).createAndApply()
-      ImplicitRequirePass(cpg, programSummary).createAndApply()
+      if (cpg.dependency.name.contains("zeitwerk")) ImplicitRequirePass(cpg, programSummary).createAndApply()
       ImportsPass(cpg).createAndApply()
       TypeNodePass.withTypesFromCpg(cpg).createAndApply()
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/DependencyPass.scala
@@ -6,7 +6,7 @@ import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.language.*
 
 /** Parses the dependencies from the `Gemfile.lock` and `Gemfile` files. This pass uses a dependency node to store the
-  * Ruby Gems resolver with the `name`` as `Defines.Resolver` and `version` as the URL.
+  * Ruby Gems resolver with the `name` as `Defines.Resolver` and `version` as the URL.
   * @param cpg
   *   the graph.
   */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
@@ -9,7 +9,8 @@ import io.shiftleft.semanticcpg.language.*
 import scala.collection.mutable
 
 /** In some Ruby frameworks, it is common to have an autoloader library that implicitly loads requirements onto the
-  * stack. This pass makes these imports explicit.
+  * stack. This pass makes these imports explicit. The most popular one is <a
+  * href="https://github.com/fxn/zeitwerk">Zeitwerk</a> which we check in `Gemsfile.lock` to enable this pass.
   */
 class ImplicitRequirePass(cpg: Cpg, programSummary: RubyProgramSummary) extends ForkJoinParallelCpgPass[Method](cpg) {
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
@@ -5,6 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{Cpg, DispatchTypes, EdgeTypes, Operators}
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.language.*
+import org.apache.commons.text.CaseUtils
 
 import scala.collection.mutable
 
@@ -18,9 +19,19 @@ class ImplicitRequirePass(cpg: Cpg, programSummary: RubyProgramSummary) extends 
   private val typeToPath             = mutable.Map.empty[String, String]
 
   override def init(): Unit = {
-    programSummary.pathToType.foreach { case (path, types) =>
-      types.foreach { typ => typeToPath.put(typ.name, path) }
-    }
+    programSummary.pathToType
+      .map { case (path, types) =>
+        // zeitwerk will match types that share the name of the path.
+        // This match is insensitive to camel case, i.e, foo_bar will match type FooBar.
+        val fileName = path.split('/').last
+        path -> types.filter { t =>
+          val typeName = t.name.split("[.]").last
+          typeName == fileName || typeName == CaseUtils.toCamelCase(fileName, true, '_', '-')
+        }
+      }
+      .foreach { case (path, types) =>
+        types.foreach { typ => typeToPath.put(typ.name, path) }
+      }
   }
 
   override def generateParts(): Array[Method] =

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -123,6 +123,15 @@ class ImportTests extends RubyCode2CpgFixture with Inspectors {
           |""".stripMargin,
         "Bar.rb"
       )
+      .moreCode(
+        """
+          |GEM
+          |  remote: https://rubygems.org/
+          |  specs:
+          |    zeitwerk (2.2.1)
+          |""".stripMargin,
+        "Gemfile.lock"
+      )
 
     "be explicitly detected and imported for a constructor type" in {
       inside(cpg.imports.where(_.call.file.name(".*Foo.*")).headOption) {


### PR DESCRIPTION
Uses `Gemsfile.lock` which is parsed (if present) in the `DependencyPass` to determine if implicit imports are to be enabled.