### PR TITLE
use AST edges for modifier accessors

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ModifierAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ModifierAccessors.scala
@@ -1,12 +1,12 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
-import io.shiftleft.codepropertygraph.generated.nodes.Modifier
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Modifier}
 import io.shiftleft.codepropertygraph.generated.traversal.toModifierTraversalExtGen
 import io.shiftleft.semanticcpg.language.*
 import overflowdb.*
 
-class ModifierAccessors[A <: Node](val traversal: Iterator[A]) extends AnyVal {
+class ModifierAccessors[A <: AstNode](val traversal: Iterator[A]) extends AnyVal {
 
   /** Filter: only `public` nodes */
   def isPublic: Iterator[A] =
@@ -49,10 +49,10 @@ class ModifierAccessors[A <: Node](val traversal: Iterator[A]) extends AnyVal {
     hasModifier(ModifierTypes.LAMBDA)
 
   def hasModifier(modifier: String): Iterator[A] =
-    traversal.where(_.out.collectAll[Modifier].modifierType(modifier))
+    traversal.where(_._astOut.collectAll[Modifier].modifierTypeExact(modifier))
 
   /** Traverse to modifiers, e.g., "static", "public".
     */
   def modifier: Iterator[Modifier] =
-    traversal.out.collectAll[Modifier]
+    traversal._astOut.collectAll[Modifier]
 }


### PR DESCRIPTION
I have a (large) CPG here where the general `.out` is catastrophically slow: 130k calls to `method.isConstructor` took 8 minutes on my machine before, compared to 500ms with this change. I haven't dug deeper but I guess part of this is that methods have a LOT of outgoing CONTAINS edges that are irrelevant for modifiers.