### PR TITLE
[kotlin2cpg] Partly revert #4187

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -135,7 +135,12 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] with UsesService {
         logger.warn("The list of directories to analyze is empty.")
       }
       val environment =
-        CompilerAPI.makeEnvironment(Seq(sourceDir), filesWithJavaExtension, defaultContentRootJars, messageCollector)
+        CompilerAPI.makeEnvironment(
+          dirsForSourcesToCompile,
+          filesWithJavaExtension,
+          defaultContentRootJars,
+          messageCollector
+        )
 
       val sourceEntries = entriesForSources(environment.getSourceFiles.asScala, sourceDir)
       val sources = sourceEntries.filter(entry =>


### PR DESCRIPTION
This PR partly reverts #4187. The change to `CompilerAPI.makeEnvironment` breaks sptests. We may want to revisit that change later as it was intented to improve performance.

With publishing this PR here locally sptests runs fine again.