### PR TITLE
[ruby] Move over dataflow tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ null
 slices.json
 **/.antlr
 /joern-cli/frontends/csharpsrc2cpg/bin
+/joern-cli/frontends/rubysrc2cpg/type_stubs
 
 ##############
 # Nix flakes #

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ArrayTests.scala
@@ -114,4 +114,58 @@ class ArrayTests extends RubyCode2CpgFixture(withPostProcessing = true, withData
     sink.reachableByFlows(source).size shouldBe 2
   }
 
+  "flow through %w array" in {
+    val cpg = code("""
+                     |a = %w[b c]
+                     |puts a
+                     |""".stripMargin)
+
+    val source = cpg.literal.code("b").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "flow through %i array" in {
+    val cpg = code("""
+                     |a = %i[b
+                     |    c]
+                     |puts a
+                     |""".stripMargin)
+
+    val source = cpg.literal.code("b").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "flow through array constructor using []" in {
+    val cpg = code("""
+                     |x=1
+                     |y=x
+                     |z = Array[y,2]
+                     |puts "#{z}"
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "flow through array constructor using [] and command in []" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |return arg
+                     |end
+                     |
+                     |x=1
+                     |y=x
+                     |z = Array[foo y]
+                     |puts "#{z}"
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ArrayTests.scala
@@ -1,0 +1,117 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class ArrayTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  "Data flow through array constructor expressionsOnlyIndexingArguments" in {
+    val cpg = code("""
+                     |x = 1
+                     |array = [x,2]
+                     |puts x
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 3
+  }
+
+  // Works in deprecated - unable to parse SplattingArgumentIndexingArgument
+  "Data flow through array constructor splattingOnlyIndexingArguments" ignore {
+    val cpg = code("""
+                     |def foo(*splat_args)
+                     |array = [*splat_args]
+                     |puts array
+                     |end
+                     |
+                     |x = 1
+                     |y = 2
+                     |y = foo(x,y)
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  // Works in deprecated - unable to parse OperatorExpressionListWithSplattingArgumentIndexingArgumentList
+  "Data flow through array constructor expressionsAndSplattingIndexingArguments" ignore {
+    val cpg = code("""
+                     |def foo(*splat_args)
+                     |array = [1,2,*splat_args]
+                     |puts array
+                     |end
+                     |
+                     |x = 3
+                     |foo(x)
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through array constructor associationsOnlyIndexingArguments" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |array = [1 => arg, 2 => arg]
+                     |puts array
+                     |end
+                     |
+                     |x = 3
+                     |foo(x)
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through array constructor commandOnlyIndexingArguments" ignore {
+    val cpg = code("""
+                     |def increment(arg)
+                     |return arg + 1
+                     |end
+                     |
+                     |x = 1
+                     |array = [ increment(x), increment(x+1)]
+                     |puts array
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 3
+  }
+
+  "Data flow through indexingExpressionPrimary" in {
+    val cpg = code("""
+                     |x = [1,2,3]
+                     |y = x[0]
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through array assignments" ignore {
+    val cpg = code("""
+                     |x = 10
+                     |array = [0, 1]
+                     |array[0] = x
+                     |puts array
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/CallTests.scala
@@ -1,0 +1,65 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class CallTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+
+  // Works on deprecated
+  "Flow through call" ignore {
+    val cpg = code("""
+        |def print(content)
+        |puts content
+        |end
+        |
+        |def main
+        |n = 1
+        |print( n )
+        |end
+        |""".stripMargin)
+
+    val src  = cpg.method.name("print").parameter.where(_.index(1)).argument.l
+    val sink = cpg.method.name("puts").callIn.argument(1).l
+    sink.reachableByFlows(src).size shouldBe 1
+  }
+
+  // Works on deprecated
+  "Explicit return via call with initialization" ignore {
+    val cpg = code("""
+                     |def add(p)
+                     |q = 5
+                     |q = p
+                     |return q
+                     |end
+                     |
+                     |n = 1
+                     |ret = add(n)
+                     |puts ret
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("n").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  // Works on deprecated
+  "Implicit return via call with initialization" ignore {
+    val cpg = code("""
+                     |def add(p)
+                     |q = 5
+                     |q = p
+                     |q
+                     |end
+                     |
+                     |n = 1
+                     |ret = add(n)
+                     |puts ret
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("n").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/CallTests.scala
@@ -62,4 +62,266 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataF
     sink.reachableByFlows(src).l.size shouldBe 2
   }
 
+  // Works in deprecated
+  "Data flow through grouping expression with negation" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |return arg
+                     |end
+                     |
+                     |x = false
+                     |y = !(foo x)
+                     |puts y
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through variable params" ignore {
+    val cpg = code("""
+                     |def foo(*args)
+                     |  return args
+                     |end
+                     |
+                     |x = 1
+                     |y = foo(x, "another param")
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through optional params" ignore {
+    val cpg = code("""
+                     |def foo(arg=10)
+                     |  return arg + 10
+                     |end
+                     |
+                     |x = 1
+                     |y = foo(x)
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow across files" ignore {
+    val cpg = code(
+      """
+        |def my_func(x)
+        | puts x
+        |end
+        |""".stripMargin,
+      "foo.rb"
+    )
+      .moreCode(
+        """
+          |require_relative 'foo.rb'
+          |x = 1
+          |my_func(x)
+          |""".stripMargin,
+        "bar.rb"
+      )
+
+    val source = cpg.literal.code("1").l
+    val sink   = cpg.call.name("puts").argument(1).l
+    sink.reachableByFlows(source).size shouldBe 1
+  }
+
+  // Works in deprecated
+  "Across the file data flow test" ignore {
+    val cpg = code(
+      """
+        |def foo(arg)
+        | puts arg
+        | loop do
+        | arg += 1
+        |  if arg > 3
+        |        puts arg
+        |        return
+        |  end
+        | end
+        |end
+        |""".stripMargin,
+      "foo.rb"
+    )
+      .moreCode(
+        """
+          |require_relative 'foo.rb'
+          |x = 1
+          |foo x
+          |""".stripMargin,
+        "bar.rb"
+      )
+
+    val source = cpg.literal.code("1").l
+    val sink   = cpg.call.name("puts").argument(1).lineNumber(3).l
+    sink.reachableByFlows(source).size shouldBe 1
+    val src = cpg.identifier("x").lineNumber(3).l
+    sink.reachableByFlows(src).size shouldBe 1
+
+//    // TODO: Need to be fixed.
+//    "be found for sink in nested block" ignore {
+//      val src  = cpg.identifier("x").lineNumber(3).l
+//      val sink = cpg.call.name("puts").argument(1).lineNumber(7).l
+//      sink.reachableByFlows(src).size shouldBe 1
+//    }
+  }
+
+  // Works in deprecated - does not parse on new frontend
+  "Data flow through invocation or command with EMARK" ignore {
+    val cpg = code("""
+                     |x=12
+                     |def woo(x)
+                     |    return x == 10
+                     |end
+                     |
+                     |if !woo x
+                     |    puts x
+                     |else
+                     |    puts "No"
+                     |end
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 3
+  }
+
+  // Works in deprecated
+  "Flow for nested puts calls" ignore {
+    val cpg = code("""
+                     |x=10
+                     |def put_name(x)
+                     |    puts x
+                     |end
+                     |def nested_put(x)
+                     |    put_name(x)
+                     |end
+                     |def double_nested_put(x)
+                     |    nested_put(x)
+                     |end
+                     |double_nested_put(x)
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 5
+  }
+
+  "Data flow through a keyword? named method usage" in {
+    val cpg = code("""
+                     |x = 1
+                     |y = x.nil?
+                     |puts y
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through a keyword inside a association" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |puts arg
+                     |end
+                     |
+                     |x = 1
+                     |foo if: x.nil?
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "flow through a method call with safe navigation operator with parantheses" ignore {
+    val cpg = code("""
+                     |class Foo
+                     | def bar(arg)
+                     |   return arg
+                     | end
+                     |end
+                     |x=1
+                     |foo = Foo.new
+                     |y = foo&.bar(x)
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "flow through a method call with safe navigation operator without parantheses" ignore {
+    val cpg = code("""
+                     |class Foo
+                     | def bar(arg)
+                     |   return arg
+                     | end
+                     |end
+                     |x=1
+                     |foo = Foo.new
+                     |y = foo&.bar x
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "flow through a method call present in next line, with the second line starting with `.`" in {
+    val cpg = code("""
+                     |class Foo
+                     | def bar(x)
+                     |   return x
+                     | end
+                     |end
+                     |
+                     |x = 1
+                     |foo = Foo.new
+                     |y = foo
+                     | .bar(1)
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 1
+  }
+
+  "flow through a method call present in next line, with the first line ending with `.`" in {
+    val cpg = code("""
+                     |class Foo
+                     | def bar(x)
+                     |   return x
+                     | end
+                     |end
+                     |
+                     |x = 1
+                     |foo = Foo.new
+                     |y = foo.
+                     |  bar(1)
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 1
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/CaseTests.scala
@@ -27,4 +27,32 @@ class CaseTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataF
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).size shouldBe 8
   }
+
+  // TODO:
+  "Data flow through a when argument context" ignore {
+    val cpg = code("""
+                         |x = 10
+                         |
+                         |case x
+                         |
+                         |when 1..5
+                         |    y = x
+                         |when 5..10
+                         |    z = x
+                         |when 10..15
+                         |    w = x
+                         |else
+                         |    _p = x
+                         |end
+                         |
+                         |puts _p
+                         |puts w
+                         |puts y
+                         |puts z
+                         |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 3
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/CaseTests.scala
@@ -1,0 +1,30 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class CaseTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  "Data flow through case statement" in {
+    val cpg = code("""
+                     |x = 2
+                     |b = x
+                     |
+                     |case b
+                     |when 1
+                     |    puts b
+                     |when 2
+                     |    puts b
+                     |when 3
+                     |    puts b
+                     |else
+                     |    puts b
+                     |end
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 8
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ClassTests.scala
@@ -1,0 +1,51 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class ClassTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  // Works in deprecated
+  "Data flow through class member" ignore {
+    val cpg = code("""
+        |class MyClass
+        | @instanceVariable
+        |
+        | def initialize(value)
+        |        @instanceVariable = value
+        | end
+        |
+        | def getValue()
+        |        @instanceVariable
+        | end
+        |end
+        |
+        |x = 12345
+        |inst = MyClass.new(x)
+        |y = inst.getValue
+        |puts y
+        |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  "flow through module method" in {
+    val cpg = code("""
+                     |module MyModule
+                     |  def MyModule.print(text)
+                     |    puts text
+                     |  end
+                     |end
+                     |
+                     |x = "some text"
+                     |
+                     |MyModule::print(x)
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ConditionalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ConditionalTests.scala
@@ -19,4 +19,22 @@ class ConditionalTests extends RubyCode2CpgFixture(withPostProcessing = true, wi
     flows.map(flowToResultPairs).sortBy(_.headOption.map(_._1)).toSet shouldBe
       Set(List(("x = 1", 2), ("z = x", 4), ("puts z", 5)), List(("y = 2", 3), ("z = y", 4), ("puts z", 5)))
   }
+
+  // Works in deprecated
+  "flow through statement with ternary operator with multiple line" ignore {
+    val cpg = code("""
+                     |x = 2
+                     |y = 3
+                     |z = 4
+                     |
+                     |w = x == 2 ?
+                     | y
+                     | : z
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("y").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ControlStructureTests.scala
@@ -54,6 +54,157 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
       Set(List(("x = 1", 2), ("y - x", 5), ("puts x", 7)))
   }
 
+  // Works in deprecated - does not parse in new frontend
+  "flow in through until modifier" ignore {
+    val cpg = code("""
+                     |i = 0
+                     |num = 5
+                     |begin
+                     |   num = i + 3
+                     |end until i < num
+                     |puts num
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("i").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 3
+  }
+
+  "flow through for loop" in {
+    val cpg = code("""
+                     |x = 0
+                     |arr = [1,2,3,4,5]
+                     |num = 0
+                     |for i in arr do
+                     |   y = x + i
+                     |   num = y*i
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "flow through for loop simple" in {
+    val cpg = code("""
+                     |x = 0
+                     |arr = [1,2,3,4,5]
+                     |num = 0
+                     |for i in arr do
+                     |   num = x
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "flow through for and next AFTER statement" in {
+    val cpg = code("""
+                     |x = 0
+                     |arr = [1,2,3,4,5]
+                     |num = 0
+                     |for i in arr do
+                     |   num = x
+                     |   next if i % 2 == 0
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "flow through for and next BEFORE statement" in {
+    val cpg = code("""
+                     |x = 0
+                     |arr = [1,2,3,4,5]
+                     |num = 0
+                     |for i in arr do
+                     |   next if i % 2 == 0
+                     |   num = x
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "flow through for and redo AFTER statement" in {
+    val cpg = code("""
+                     |x = 0
+                     |arr = [1,2,3,4,5]
+                     |num = 0
+                     |for i in arr do
+                     |   num = x
+                     |   redo if i % 2 == 0
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "flow through for and redo BEFORE statement" in {
+    val cpg = code("""
+                     |x = 0
+                     |arr = [1,2,3,4,5]
+                     |num = 0
+                     |for i in arr do
+                     |   redo if i % 2 == 0
+                     |   num = x
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "flow through for and retry AFTER statement" in {
+    val cpg = code("""
+                     |x = 0
+                     |arr = [1,2,3,4,5]
+                     |num = 0
+                     |for i in arr do
+                     |   num = x
+                     |   retry if i % 2 == 0
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "Data flow through for and retry BEFORE statement" in {
+    val cpg = code("""
+                     |x = 0
+                     |arr = [1,2,3,4,5]
+                     |num = 0
+                     |for i in arr do
+                     |   retry if i % 2 == 0
+                     |   num = x
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
   "flow through the 1st branch of an `if-end` statement" in {
     val cpg = code("""
         |t = 100
@@ -154,6 +305,284 @@ class ControlStructureTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink   = cpg.method.name("puts").callIn.argument
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet should not be empty
+  }
+
+  // Works in deprecated
+  "Data flow for begin/rescue with sink in begin" ignore {
+    val cpg = code("""
+                     |x = 1
+                     |begin
+                     |  puts x
+                     |rescue SomeException
+                     |  puts "SomeException occurred"
+                     |rescue => exceptionVar
+                     |  puts "Caught exception in variable #{exceptionVar}"
+                     |rescue
+                     |  puts "Catch-all block"
+                     |end
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow for begin/rescue with sink in else" should {
+    val cpg = code("""
+                     |x = 1
+                     |begin
+                     |  puts "In begin"
+                     |rescue SomeException
+                     |  puts "SomeException occurred"
+                     |rescue => exceptionVar
+                     |  puts "Caught exception in variable #{exceptionVar}"
+                     |rescue
+                     |  puts "Catch-all block"
+                     |else
+                     |  puts x
+                     |end
+                     |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).size shouldBe 2
+    }
+  }
+
+  "flow for begin/rescue with sink in rescue" in {
+    val cpg = code("""
+                     |x = 1
+                     |begin
+                     |  puts "in begin"
+                     |rescue SomeException
+                     |  puts x
+                     |rescue => exceptionVar
+                     |  puts "Caught exception in variable #{exceptionVar}"
+                     |rescue
+                     |  puts "Catch-all block"
+                     |end
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow for begin/rescue with sink in rescue with exception var" in {
+    val cpg = code("""
+                     |begin
+                     |  puts "in begin"
+                     |rescue SomeException
+                     |  puts "SomeException occurred"
+                     |rescue => x
+                     |  y = x
+                     |  puts "Caught exception in variable #{y}"
+                     |rescue
+                     |  puts "Catch-all block"
+                     |end
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 1
+  }
+
+  "Data flow for begin/rescue with sink in catch-all rescue" in {
+    val cpg = code("""
+                     |x = 1
+                     |begin
+                     |  puts "in begin"
+                     |rescue SomeException
+                     |   puts "SomeException occurred"
+                     |rescue => exceptionVar
+                     |  puts "Caught exception in variable #{exceptionVar}"
+                     |rescue
+                     |  puts x
+                     |end
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow for begin/rescue with sink in ensure" in {
+    val cpg = code("""
+                     |x = 1
+                     |begin
+                     |  puts "in begin"
+                     |rescue SomeException
+                     |   puts "SomeException occurred"
+                     |rescue => exceptionVar
+                     |  puts "Caught exception in variable #{exceptionVar}"
+                     |rescue
+                     |  puts "In rescue all"
+                     |ensure
+                     |  puts x
+                     |end
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow for begin/rescue with data flow through the exception" in {
+    val cpg = code("""
+                     |x = "Exception message: "
+                     |begin
+                     |1/0
+                     |rescue ZeroDivisionError => e
+                     |   y = x + e.message
+                     |   puts y
+                     |end
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow for begin/rescue with data flow through block with multiple exceptions being caught" in {
+    val cpg = code("""
+                     |x = 1
+                     |y = 10
+                     |begin
+                     |1/0
+                     |rescue SystemCallError, ZeroDivisionError
+                     |   y = x + 100
+                     |end
+                     |
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow for begin/rescue with sink in function without begin" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |  puts "in begin"
+                     |rescue SomeException
+                     |  return arg
+                     |rescue => exvar
+                     |  puts "Caught exception in variable #{exvar}"
+                     |rescue
+                     |  puts "Catch-all block"
+                     |end
+                     |
+                     |x = 1
+                     |y = foo x
+                     |puts y
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow for begin/rescue with sink in function without begin and sink in rescue with exception" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |  puts "in begin"
+                     |rescue SomeException
+                     |  puts "SomeException occurred #{arg}"
+                     |rescue => exvar
+                     |  puts "Caught exception in variable #{exvar}"
+                     |rescue
+                     |  puts "Catch-all block"
+                     |end
+                     |
+                     |x = 1
+                     |foo x
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow for begin/rescue with sink in function without begin and sink in catch-call rescue" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |  puts "in begin"
+                     |  raise "This is an exception"
+                     |rescue
+                     |  puts "Catch-all block. Arg is #{arg}"
+                     |end
+                     |
+                     |x = 1
+                     |foo x
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow for begin/rescue with sink in function without begin with return from begin" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |  puts "in begin"
+                     |  return arg
+                     |rescue SomeException
+                     |  puts "Caught SomeException"
+                     |rescue => exvar
+                     |  puts "Caught exception in variable #{exvar}"
+                     |rescue
+                     |  puts "Catch-all block"
+                     |end
+                     |
+                     |x = 1
+                     |y = foo x
+                     |puts y
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow for begin/rescue with sink in function within do block" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |  puts "in begin"
+                     |  arg do |y|
+                     |  return y
+                     |rescue SomeException
+                     |  puts "Caught SomeException"
+                     |rescue => exvar
+                     |  puts "Caught exception in variable #{exvar}"
+                     |rescue
+                     |  puts "Catch-all block"
+                     |end
+                     |
+                     |x = 1
+                     |z = foo x
+                     |puts z
+                     |
+                     |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").lineNumber(8).l
+      sink.reachableByFlows(source).size shouldBe 1
+    }
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DestructuredAssignmentsTests.scala
@@ -1,0 +1,62 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class DestructuredAssignmentsTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  "Data flow through packing left hand side through the first identifier" in {
+    val cpg = code("""
+                     |x = 1
+                     |p = 2
+                     |*y = x,p
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow through packing left hand side through beyond the first identifier" in {
+    val cpg = code("""
+                     |x = 1
+                     |y = 2
+                     |z = 3
+                     |*a = z,y,x
+                     |puts a
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow through packing left hand side with unequal RHS" in {
+    val cpg = code("""
+                     |x = 1
+                     |y = 2
+                     |z = 3
+                     |p,*a = z,y,x
+                     |puts a
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow through single LHS and multiple RHS" in {
+    val cpg = code("""
+                     |x = 1
+                     |y = 2
+                     |z = 3
+                     |a = z,y,x
+                     |puts a
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DoBlockTests.scala
@@ -50,4 +50,44 @@ class DoBlockTests extends RubyCode2CpgFixture(withPostProcessing = true, withDa
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).l.size shouldBe 1
   }
+
+  // Works in deprecated
+  "Data flow through argsAndDoBlockAndMethodIdCommandWithDoBlock" ignore {
+    val cpg = code("""
+                     |def foo (blockArg,&block)
+                     |block.call(blockArg)
+                     |end
+                     |
+                     |x = 10
+                     |foo :a_symbol do |arg|
+                     |  y = x + arg.length
+                     |  puts y
+                     |end
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow through primaryMethodArgsDoBlockCommandWithDoBlock" in {
+    val cpg = code("""
+                     |module FooModule
+                     |def foo (blockArg,&block)
+                     |block.call(blockArg)
+                     |end
+                     |end
+                     |
+                     |x = 10
+                     |FooModule.foo :a_symbol do |arg|
+                     |  y = x + arg.length
+                     |  puts y
+                     |end
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DoBlockTests.scala
@@ -1,0 +1,53 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class DoBlockTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  // Works in deprecated
+  "Data flow through chainedInvocationPrimary usage" ignore {
+    val cpg = code("""
+                     |x = 1
+                     |
+                     |[x, x+1].each do |number|
+                     |  puts "#{number} was passed to the block"
+                     |end
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  // TODO:
+  "Data flow coming out of chainedInvocationPrimary usage" ignore {
+    val cpg = code("""
+                     |x = 1
+                     |y = 10
+                     |[x, x+1].each do |number|
+                     |  y += x
+                     |end
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through chainedInvocationPrimary without arguments to block usage" ignore {
+    val cpg = code("""
+                     |x = 1
+                     |
+                     |[1,2,3].each do
+                     |  puts "Right here #{x}"
+                     |end
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 1
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DoBlockTests.scala
@@ -90,4 +90,107 @@ class DoBlockTests extends RubyCode2CpgFixture(withPostProcessing = true, withDa
     sink.reachableByFlows(source).size shouldBe 2
   }
 
+  "Data flow through break with args" in {
+    val cpg = code("""
+                     |x = 1
+                     |arr = [x, 2, 3]
+                     |y = arr.each do |num|
+                     |  break num if num < 2
+                     |  puts num
+                     |end
+                     |puts y
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 4
+  }
+
+  // TODO:
+  "Data flow through next with args" ignore {
+    val cpg = code("""
+                     |x = 10
+                     |a = [1, 2, 3]
+                     |y = a.map do |num|
+                     |  next x if num.even?
+                     |  num
+                     |end
+                     |
+                     |puts y
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow for chained command with do-block with parentheses" ignore {
+    val cpg = code("""
+                     |def foo()
+                     |  yield if block_given?
+                     |end
+                     |
+                     |y = foo do
+                     |    x = 1
+                     |    [x+1,x+2]
+                     |end.sum(10)
+                     |
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow for chained command with do-block without parentheses" ignore {
+    val cpg = code("""
+                     |def foo()
+                     |  yield if block_given?
+                     |end
+                     |
+                     |y = foo do
+                     |    x = 1
+                     |    [x+1,x+2]
+                     |end.sum 10
+                     |
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow for yield block specified alongwith the call" should {
+    val cpg = code("""
+                     |x=10
+                     |def foo(x)
+                     |    a = yield
+                     |    puts a
+                     |end
+                     |
+                     |foo(x) {
+                     |    x + 2
+                     |}
+                     |""".stripMargin)
+
+    "find flows to the sink" in {
+      val source = cpg.identifier.name("x").l
+      val sink   = cpg.call.name("puts").l
+      sink.reachableByFlows(source).size shouldBe 1
+      /*
+       * TODO the flow count shows 1 since the origin is considered as x + 2
+       * The actual origin is x=10. However, this is not considered since there is
+       * no REACHING_DEF edge from the x of 'x=10' to the x of 'x + 2'.
+       * There are already other disabled data flow test cases for this problem. Once solved, it should
+       * be possible to set the required count to 2
+       */
+
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/DoBlockTests.scala
@@ -70,7 +70,8 @@ class DoBlockTests extends RubyCode2CpgFixture(withPostProcessing = true, withDa
     sink.reachableByFlows(source).size shouldBe 2
   }
 
-  "Data flow through primaryMethodArgsDoBlockCommandWithDoBlock" in {
+  // Works in deprecated
+  "Data flow through primaryMethodArgsDoBlockCommandWithDoBlock" ignore {
     val cpg = code("""
                      |module FooModule
                      |def foo (blockArg,&block)
@@ -166,7 +167,8 @@ class DoBlockTests extends RubyCode2CpgFixture(withPostProcessing = true, withDa
     sink.reachableByFlows(source).size shouldBe 2
   }
 
-  "Data flow for yield block specified alongwith the call" should {
+  // Works in deprecated
+  "Data flow for yield block specified alongwith the call" ignore {
     val cpg = code("""
                      |x=10
                      |def foo(x)
@@ -179,18 +181,16 @@ class DoBlockTests extends RubyCode2CpgFixture(withPostProcessing = true, withDa
                      |}
                      |""".stripMargin)
 
-    "find flows to the sink" in {
-      val source = cpg.identifier.name("x").l
-      val sink   = cpg.call.name("puts").l
-      sink.reachableByFlows(source).size shouldBe 1
-      /*
-       * TODO the flow count shows 1 since the origin is considered as x + 2
-       * The actual origin is x=10. However, this is not considered since there is
-       * no REACHING_DEF edge from the x of 'x=10' to the x of 'x + 2'.
-       * There are already other disabled data flow test cases for this problem. Once solved, it should
-       * be possible to set the required count to 2
-       */
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 1
+    /*
+     * TODO the flow count shows 1 since the origin is considered as x + 2
+     * The actual origin is x=10. However, this is not considered since there is
+     * no REACHING_DEF edge from the x of 'x=10' to the x of 'x + 2'.
+     * There are already other disabled data flow test cases for this problem. Once solved, it should
+     * be possible to set the required count to 2
+     */
 
-    }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/HashTests.scala
@@ -22,15 +22,17 @@ class HashTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataF
     sink.reachableByFlows(source).l.size shouldBe 2
   }
 
-  "Data flow through string interpolation" in {
+  // Works in deprecated - syntax error on new frontend
+  "flow through hash containing splatting literal" ignore {
     val cpg = code("""
-                     |x = 1
-                     |str = "The source is #{x}"
-                     |puts str
+                     |x={:y=>1}
+                     |z = {
+                     |**x
+                     |}
+                     |puts z
                      |""".stripMargin)
-
     val source = cpg.identifier.name("x").l
     val sink   = cpg.call.name("puts").l
-    sink.reachableByFlows(source).l.size shouldBe 2
+    sink.reachableByFlows(source).size shouldBe 2
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/HashTests.scala
@@ -1,0 +1,36 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class HashTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  // Works in deprecated
+  "Data flow through hash constructor" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |hash = {1 => arg, 2 => arg}
+                     |puts hash
+                     |end
+                     |
+                     |x = 3
+                     |foo(x)
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "Data flow through string interpolation" in {
+    val cpg = code("""
+                     |x = 1
+                     |str = "The source is #{x}"
+                     |puts str
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/LiteralTests.scala
@@ -1,0 +1,49 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class LiteralTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  "Data flow through string interpolation" in {
+    val cpg = code("""
+                     |x = 1
+                     |str = "The source is #{x}"
+                     |puts str
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  // Works in deprecated - Could not represent expression x on new frontend
+  "flow through interpolated double-quoted string literal " ignore {
+    val cpg = code("""
+                     |x = "foo"
+                     |y = :"bar #{x}"
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "flow through symbol literal defined using \\:" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |hash = {:y => arg}
+                     |puts hash
+                     |end
+                     |
+                     |x = 3
+                     |foo(x)
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodReturnTests.scala
@@ -56,4 +56,68 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
       Set(List(("f(x)", 2), ("y = x", 3), ("RET", 2)))
   }
 
+  // Works in deprecated
+  "Implicit return in if-else block" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |if arg > 1
+                     |        arg + 1
+                     |else
+                     |        arg + 10
+                     |end
+                     |end
+                     |
+                     |x = 1
+                     |y = foo x
+                     |puts y
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Implicit return in if-else block and underlying function call" ignore {
+    val cpg = code("""
+                     |def add(arg)
+                     |arg + 100
+                     |end
+                     |
+                     |def foo(arg)
+                     |if arg > 1
+                     |        add(arg)
+                     |else
+                     |        add(arg)
+                     |end
+                     |end
+                     |
+                     |x = 1
+                     |y = foo x
+                     |puts y
+                     |
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Return via call w/o initialization" ignore {
+    val cpg = code("""
+                     |def add(p)
+                     |q = p
+                     |return q
+                     |end
+                     |
+                     |n = 1
+                     |ret = add(n)
+                     |puts ret
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("n").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodTests.scala
@@ -153,4 +153,103 @@ class MethodTests extends RubyCode2CpgFixture(withPostProcessing = true, withDat
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).size shouldBe 2
   }
+
+  // TODO:
+  "Data flow through overloaded operator method" ignore {
+    val cpg = code("""
+                     |class Foo
+                     |    @@x = 1
+                     |    def +(y)
+                     |        @@x + y
+                     |    end
+                     |end
+                     |
+                     |y = Foo.new + 1
+                     |
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.member.name("@@x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 3
+  }
+
+  // TODO:
+  // Works in deprecated
+  "Data flow through assignment-like method identifier" ignore {
+    val cpg = code("""
+                     |class Foo
+                     |    @@x = 1
+                     |    def CONST=(y)
+                     |        return @@x == y
+                     |    end
+                     |end
+                     |puts Foo::CONST= 2
+                     |""".stripMargin)
+
+    val source = cpg.member.name("@@x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 3
+  }
+
+  // Works in deprecated
+  "Data flow through block argument context" ignore {
+    val cpg = code("""
+                     |x=10
+                     |y=0
+                     |def foo(n, &block)
+                     |   woo(n, &block)
+                     |end
+                     |
+                     |def woo(n, &block)
+                     |    n.times {yield}
+                     |end
+                     |
+                     |foo(5) {
+                     |    y = x
+                     |}
+                     |
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Flow through tainted object" ignore {
+    val cpg = code("""
+                     |def put_req(api_endpoint, params)
+                     |    puts "Hitting " + api_endpoint + " with params: " + params
+                     |end
+                     |class TestClient
+                     |    def get_event_data(accountId)
+                     |        payload = accountId
+                     |        r = put_req(
+                     |            "https://localhost:8080/v3/users/me/",
+                     |            params=payload
+                     |        )
+                     |    end
+                     |end
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("accountId").l
+    val sink   = cpg.call.name("put_req").l
+    sink.reachableByFlows(source).size shouldBe 1
+  }
+
+  // Works in deprecated
+  "flow through endless method" ignore {
+    val cpg = code("""
+                     |def multiply(a,b) = a*b
+                     |x = 10
+                     |y = multiply(3,x)
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodTests.scala
@@ -56,4 +56,101 @@ class MethodTests extends RubyCode2CpgFixture(withPostProcessing = true, withDat
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).l.size shouldBe 2
   }
+
+  // Works in deprecated
+  "Data flow through blockExprAssocTypeArguments" ignore {
+    val cpg = code("""
+                     |def foo(*args)
+                     |puts args
+                     |end
+                     |
+                     |x = "value1"
+                     |foo(key1: x, key2: "value2")
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated - Unsupported element type SplattingArgumentArgumentList
+  "Data flow through blockSplattingTypeArguments" ignore {
+    val cpg = code("""
+                     |def foo(arg)
+                     |puts arg
+                     |end
+                     |
+                     |x = 1
+                     |foo(*x)
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through blockSplattingExprAssocTypeArguments without block" ignore {
+    val cpg = code("""
+                     |def foo(*arg)
+                     |puts arg
+                     |end
+                     |
+                     |x = 1
+                     |foo( x+1, key1: x*2, key2: x*3 )
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated - Unsupported element type SplattingArgumentArgumentList
+  "Data flow through blockSplattingTypeArguments without block" ignore {
+    val cpg = code("""
+                     |def foo (blockArg,&block)
+                     |block.call(blockArg)
+                     |end
+                     |
+                     |x = 10
+                     |foo(*x do |arg|
+                     |  y = x + arg
+                     |  puts y
+                     |end
+                     |)
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "Data flow through blockExprAssocTypeArguments with block argument in the wrapper function" in {
+    val cpg = code("""
+                     |def foo (blockArg,&block)
+                     |block.call(blockArg)
+                     |end
+                     |
+                     |def foo_wrap (blockArg,&block)
+                     |foo(blockArg,&block)
+                     |end
+                     |
+                     |
+                     |x = 10
+                     |foo_wrap x do |arg|
+                     |  y = 100 + arg
+                     |  puts y
+                     |end
+                     |
+                     |
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodTests.scala
@@ -1,0 +1,59 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class MethodTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  // Works in deprecated
+  "Data flow through class method" ignore {
+    val cpg = code("""
+                     |class MyClass
+                     |  def print(text)
+                     |    puts text
+                     |  end
+                     |end
+                     |
+                     |
+                     |x = "some text"
+                     |inst = MyClass.new
+                     |inst.print(x)
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through do-while loop" ignore {
+    val cpg = code("""
+                     |x = 0
+                     |num = -1
+                     |loop do
+                     |   num = x + 1
+                     |   x = x + 1
+                     |   if x > 10
+                     |     break
+                     |   end
+                     |end
+                     |puts num
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "Data flow through methodOnlyIdentifier usage" in {
+    val cpg = code("""
+                     |x = 1
+                     |y = SomeConstant! + x
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MultipleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MultipleAssignmentTests.scala
@@ -1,0 +1,67 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class MultipleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  "flow through multiple assignments" in {
+    val cpg = code("""
+                     |x = 1
+                     |y = 2
+                     |c, d = x, y
+                     |puts c
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  // Works in deprecated - fails to parse in new frontend
+  "flow through multiple assignments with grouping" ignore {
+    val cpg = code("""
+                     |x = 1
+                     |y = 2
+                     |(c, d) = x, y
+                     |puts c
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  // Works in deprecated - fails to parse in new frontend
+  "Data flow through multiple assignments with grouping and method in RHS" ignore {
+    val cpg = code("""
+                     |def foo()
+                     |x = 1
+                     |return x
+                     |end
+                     |
+                     |b = 2
+                     |(c, d) = foo, b
+                     |puts c
+                     |
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through single LHS and splatting RHS" ignore {
+    val cpg = code("""
+                     |x=1
+                     |y=*x
+                     |puts y
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ProcParameterAndYieldTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ProcParameterAndYieldTests.scala
@@ -1,0 +1,127 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class ProcParameterAndYieldTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  // Works in deprecated
+  "Data flow through yield with argument having parenthesis" ignore {
+    val cpg = code("""
+                     |def yield_with_arguments
+                     |  a = "something"
+                     |  yield(a)
+                     |end
+                     |
+                     |yield_with_arguments { |arg| puts "Argument is #{arg}" }
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("a").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).size shouldBe 2
+  }
+
+  // Works in deprecated
+  "Data flow through yield with argument without parenthesis and multiple yield blocks" ignore {
+    val cpg = code("""
+                     |def yield_with_arguments
+                     |  x = "something"
+                     |  y = "something_else"
+                     |  yield(x,y)
+                     |end
+                     |
+                     |yield_with_arguments { |arg1, arg2| puts "Yield block 1 #{arg1} and #{arg2}" }
+                     |yield_with_arguments { |arg1, arg2| puts "Yield block 2 #{arg2} and #{arg1}" }
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).size shouldBe 4
+  }
+
+  // Works in deprecated
+  "Data flow through yield without argument" ignore {
+    val cpg = code("""
+                     |x = 1
+                     |def yield_method
+                     |  yield
+                     |end
+                     |yield_method { puts x }
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).size shouldBe 1
+  }
+
+  // Works in deprecated
+  "Data flow coming out of yield without argument" ignore {
+    val cpg = code("""
+                     |def foo
+                     |        x=10
+                     |        z = yield
+                     |        puts z
+                     |end
+                     |
+                     |x = 100
+                     |foo{ x + 10 }
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("x").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).size shouldBe 1
+  }
+
+  // TODO: From deprecated
+  "Data flow through yield with argument and multiple yield blocks" ignore {
+    val cpg = code("""
+                     |def yield_with_arguments
+                     |  x = "something"
+                     |  y = "something_else"
+                     |  yield(x)
+                     |  yield(y)
+                     |end
+                     |
+                     |yield_with_arguments { |arg| puts "Yield block 1 #{arg}" }
+                     |yield_with_arguments { |arg| puts "Yield block 2 #{arg}" }
+                     |""".stripMargin)
+
+    val src1  = cpg.identifier.name("x").l
+    val sink1 = cpg.call.name("puts").l
+    sink1.reachableByFlows(src1).size shouldBe 2
+
+    val src2  = cpg.identifier.name("y").l
+    val sink2 = cpg.call.name("puts").l
+    sink2.reachableByFlows(src2).size shouldBe 2
+  }
+
+  "Data flow through invocationWithBlockOnlyPrimary usage" in {
+    val cpg = code("""
+                     |def hello(&block)
+                     |  block.call
+                     |end
+                     |
+                     |x = "hello"
+                     |hello { puts x }
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "Data flow through invocationWithBlockOnlyPrimary and method name starting with capital usage" in {
+    val cpg = code("""
+                     |def Hello(&block)
+                     | block.call
+                     |end
+                     |x = "hello"
+                     |Hello = "this should not be used"
+                     |Hello { puts x }
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ProcParameterAndYieldTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ProcParameterAndYieldTests.scala
@@ -124,4 +124,84 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture(withPostProcessing 
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).l.size shouldBe 2
   }
+
+  // Works in deprecated
+  "Data flow for yield block specified alongwith the call" ignore {
+    val cpg = code("""
+                     |x=10
+                     |def foo(x)
+                     |    a = yield
+                     |    puts a
+                     |end
+                     |
+                     |foo(x) {
+                     |    x + 2
+                     |}
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 1
+    /*
+     * TODO the flow count shows 1 since the origin is considered as x + 2
+     * The actual origin is x=10. However, this is not considered since there is
+     * no REACHING_DEF edge from the x of 'x=10' to the x of 'x + 2'.
+     * There are already other disabled data flow test cases for this problem. Once solved, it should
+     * be possible to set the required count to 2
+     */
+
+  }
+
+  // Works in deprecated - Unsupported element type SplattingArgumentArgumentList
+  "Data flow through block splatting type arguments context" ignore {
+    val cpg = code("""
+                     |x=10
+                     |y=0
+                     |def foo(*n, &block)
+                     |   woo(*n, &block)
+                     |end
+                     |
+                     |def woo(n, &block)
+                     |    n.times {yield}
+                     |end
+                     |
+                     |foo(5) {
+                     |    y = x
+                     |}
+                     |
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  "flow through a proc definition with non-empty block and zero parameters" ignore {
+    val cpg = code("""
+                     |x=10
+                     |y = x
+                     |-> {
+                     |puts y
+                     |}.call
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated - Could not represent expression: -> (arg) {puts arg} in new frontend
+  "flow through a proc definition with non-empty block and non-zero parameters" ignore {
+    val cpg = code("""
+                     |x=10
+                     |-> (arg){
+                     |puts arg
+                     |}.call(x)
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/RangeTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/RangeTests.scala
@@ -1,0 +1,27 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class RangeTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  // Works in deprecated
+  "Data flows through range operators" ignore {
+    val cpg = code("""
+                     |x = 10
+                     |y=0
+                     |for i in 1...10 do
+                     |   x += i
+                     |   if (x > 10)
+                     |     y = x
+                     |   end
+                     |end
+                     |
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 3
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/RegexTests.scala
@@ -1,0 +1,50 @@
+package io.joern.rubysrc2cpg.dataflow
+
+import io.joern.dataflowengineoss.language.*
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class RegexTests extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true) {
+  // Works in deprecated - could not represent expression /x#{x}b/ in new frontend
+  "Data flow through a regex interpolation" ignore {
+    val cpg = code(s"""
+                      |x="abc"
+                      |y=/x#{x}b/
+                      |puts y
+                      |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+  // Works in deprecated - could not represent expression /x#{x}b#{x+'z}... in new frontend
+  "flow through a regex interpolation with multiple expressions" ignore {
+    val cpg = code("""
+                     |x="abc"
+                     |y=/x#{x}b#{x+'z'}b{x+'y'+'z'}w/
+                     |puts y
+                     |""".stripMargin)
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 3
+  }
+
+  "flow through statement when regular expression literal passed after `when`" in {
+    val cpg = code("""
+                     |x = 2
+                     |a = 2
+                     |
+                     |case a
+                     | when /^ch/
+                     |   b = x
+                     |   puts b
+                     |end
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
@@ -72,4 +72,16 @@ class SingleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink   = cpg.call.name("puts").l
     sink.reachableByFlows(source).l.size shouldBe 2
   }
+
+  "Data flow for __LINE__ variable identifier" in {
+    val cpg = code("""
+        |x=1
+        |a=x+__LINE__
+        |puts a
+        |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
@@ -25,4 +25,51 @@ class SingleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
     flow5 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("puts x", 4), ("puts z", 5))
     flow6 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("z = x = y = 1", 2), ("puts z", 5))
   }
+
+  "flow through expressions" in {
+    val cpg = code("""
+                     |a = 1
+                     |b = a+3
+                     |c = 2 + b%6
+                     |d = c + b & !c + -b
+                     |e = c/d + b || d
+                     |f = c - d & ~e
+                     |g = f-c%d - +d
+                     |h = g**5 << b*g
+                     |i = b && c || e > g
+                     |j = b>c ? (e+-6) : (f +5)
+                     |k = i..h
+                     |l = j...g
+                     |
+                     |puts l
+                     |""".stripMargin)
+
+    val src  = cpg.identifier.name("a").l
+    val sink = cpg.call.name("puts").l
+    sink.reachableByFlows(src).l.size shouldBe 2
+  }
+
+  "Data flow through grouping expression" in {
+    val cpg = code("""
+                     |x = 0
+                     |y = (x==0)
+                     |puts y
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
+
+  "Data flow through variable assigned a scoped constant" in {
+    val cpg = code("""
+                     |MyConst = 10
+                     |x = ::MyConst
+                     |puts x
+                     |""".stripMargin)
+
+    val source = cpg.identifier.name("x").l
+    val sink   = cpg.call.name("puts").l
+    sink.reachableByFlows(source).l.size shouldBe 2
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/dataflow/DataFlowTests.scala
@@ -5,7 +5,7 @@ import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 
 class DataFlowTests
-    extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true, useDeprecatedFrontend = false) {
+    extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true, useDeprecatedFrontend = true) {
 
   "Data flow through if-elseif-else" should {
     val cpg = code("""
@@ -47,14 +47,8 @@ class DataFlowTests
 
     "be found" in {
       implicit val resolver: ICallResolver = NoResolve
-      cpg.method.name(":program").dotAst.l.foreach(println)
-      cpg.dotCallGraph.l.foreach(println)
-      cpg.method.name("print").dotDdg.l.foreach(println)
-      cpg.method.name("print").dotCdg.l.foreach(println)
-      cpg.method.name("print").dotCfg.l.foreach(println)
-      cpg.method.name("print").dotPdg.l.foreach(println)
-      val src  = cpg.identifier.name("n").where(_.inCall.name("print")).l
-      val sink = cpg.method.name("puts").callIn.argument(1).l
+      val src                              = cpg.identifier.name("n").where(_.inCall.name("print")).l
+      val sink                             = cpg.method.name("puts").callIn.argument(1).l
       sink.reachableByFlows(src).size shouldBe 1
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/deprecated/dataflow/DataFlowTests.scala
@@ -5,7 +5,7 @@ import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 
 class DataFlowTests
-    extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true, useDeprecatedFrontend = true) {
+    extends RubyCode2CpgFixture(withPostProcessing = true, withDataFlow = true, useDeprecatedFrontend = false) {
 
   "Data flow through if-elseif-else" should {
     val cpg = code("""
@@ -47,8 +47,14 @@ class DataFlowTests
 
     "be found" in {
       implicit val resolver: ICallResolver = NoResolve
-      val src                              = cpg.identifier.name("n").where(_.inCall.name("print")).l
-      val sink                             = cpg.method.name("puts").callIn.argument(1).l
+      cpg.method.name(":program").dotAst.l.foreach(println)
+      cpg.dotCallGraph.l.foreach(println)
+      cpg.method.name("print").dotDdg.l.foreach(println)
+      cpg.method.name("print").dotCdg.l.foreach(println)
+      cpg.method.name("print").dotCfg.l.foreach(println)
+      cpg.method.name("print").dotPdg.l.foreach(println)
+      val src  = cpg.identifier.name("n").where(_.inCall.name("print")).l
+      val sink = cpg.method.name("puts").callIn.argument(1).l
       sink.reachableByFlows(src).size shouldBe 1
     }
   }


### PR DESCRIPTION
Moved all of the dataflow tests to the new Ruby frontend from the deprecated one. Ignored the ones that aren't working for now, the next step is to start working on fixing those tests.