### PR TITLE
[ruby] Handle Splatting Argument in Call

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -175,6 +175,8 @@ object AntlrContextHelpers {
         operatorExpressions ++ associations ++ splatting ++ block
       case ctx: AssociationsArgumentListContext =>
         Option(ctx.associationList()).map(_.associations).getOrElse(List.empty)
+      case ctx: SplattingArgumentArgumentListContext =>
+        Option(ctx.splattingArgument()).toList
       case ctx =>
         logger.warn(s"Unsupported element type ${ctx.getClass.getSimpleName}")
         List()

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
+import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
@@ -178,6 +179,21 @@ class CallTests extends RubyCode2CpgFixture {
 
     "get precedence over the method" in {
       cpg.call("foo").size shouldBe 0
+    }
+  }
+
+  "splatting argument for a call should be a single argument" in {
+    val cpg = code("""
+        |args = [1, 2]
+        |foo(*args)
+        |""".stripMargin)
+
+    inside(cpg.call("foo").argument.l) {
+      case _ :: (args: Call) :: Nil =>
+        args.methodFullName shouldBe RubyOperators.splat
+        args.code shouldBe "*args"
+        args.lineNumber shouldBe Some(3)
+      case xs => fail(s"Expected a single `*args` argument under `foo`, got [${xs.code.mkString(",")}]")
     }
   }
 


### PR DESCRIPTION
Handles splatting argument when given to a call.

Resolves #4437