### PR TITLE
[ruby] Fixed Grouped Stmt Flows & Splat Ambiguity

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -49,6 +49,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: ProcOrLambdaExpr         => astForProcOrLambdaExpr(node)
     case node: RubyCallWithBlock[_]     => astsForCallWithBlockInExpr(node)
     case node: SelfIdentifier           => astForSelfIdentifier(node)
+    case node: StatementList            => astForStatementList(node)
     case node: DummyNode                => Ast(node.node)
     case _                              => astForUnknown(node)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MultipleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MultipleAssignmentTests.scala
@@ -18,8 +18,7 @@ class MultipleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = t
     sink.reachableByFlows(src).l.size shouldBe 2
   }
 
-  // Works in deprecated - fails to parse in new frontend
-  "flow through multiple assignments with grouping" ignore {
+  "flow through multiple assignments with grouping" in {
     val cpg = code("""
                      |x = 1
                      |y = 2
@@ -29,11 +28,10 @@ class MultipleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = t
 
     val src  = cpg.identifier.name("x").l
     val sink = cpg.call.name("puts").l
-    sink.reachableByFlows(src).l.size shouldBe 2
+    sink.reachableByFlows(src).size shouldBe 2
   }
 
-  // Works in deprecated - fails to parse in new frontend
-  "Data flow through multiple assignments with grouping and method in RHS" ignore {
+  "Data flow through multiple assignments with grouping and method in RHS" in {
     val cpg = code("""
                      |def foo()
                      |x = 1
@@ -48,11 +46,10 @@ class MultipleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = t
 
     val src  = cpg.identifier.name("x").l
     val sink = cpg.call.name("puts").l
-    sink.reachableByFlows(src).l.size shouldBe 2
+    sink.reachableByFlows(src).size shouldBe 2
   }
 
-  // Works in deprecated
-  "Data flow through single LHS and splatting RHS" ignore {
+  "Data flow through single LHS and splatting RHS" in {
     val cpg = code("""
                      |x=1
                      |y=*x
@@ -61,7 +58,7 @@ class MultipleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = t
 
     val src  = cpg.identifier.name("x").l
     val sink = cpg.call.name("puts").l
-    sink.reachableByFlows(src).l.size shouldBe 2
+    sink.reachableByFlows(src).size shouldBe 2
   }
 
 }


### PR DESCRIPTION
* Fixed issue where lists of `StatementList` were not being unpacked in grouped assignments
* Fixed ambiguity of assignment to a splat without spacing being detected as a call multiplied by RHS, e.g. `y=*x`

Resolves #4506