### PR TITLE
[java] Resolve External Non-JDK Types with Type Arguments

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -85,7 +85,7 @@ class AstCreator(
   fileContent: Option[String],
   global: Global,
   val symbolSolver: JavaSymbolSolver,
-  keepTypeArguments: Boolean
+  protected val keepTypeArguments: Boolean
 )(implicit val withSchemaValidation: ValidationMode)
     extends AstCreatorBase(filename)
     with AstNodeBuilder[Node, AstCreator]

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
@@ -12,7 +12,14 @@ import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
 import io.joern.javasrc2cpg.util.NameConstants
 import io.joern.x2cpg.utils.AstPropertiesUtil.*
 import io.joern.x2cpg.Ast
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, NewCall, NewFieldIdentifier, NewIdentifier, NewMember, NewUnknown}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  AstNodeNew,
+  NewCall,
+  NewFieldIdentifier,
+  NewIdentifier,
+  NewMember,
+  NewUnknown
+}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import org.slf4j.LoggerFactory
 
@@ -115,7 +122,7 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
     ).toOption.flatten.map { typ =>
       maybeTypeArgs match {
         case Some(typeArgs) if keepTypeArguments => s"$typ<${typeArgs.mkString(",")}>"
-        case _ => typ
+        case _                                   => typ
       }
     }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
@@ -2,6 +2,7 @@ package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.Config
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Local}
 import io.shiftleft.semanticcpg.language.*
 
@@ -158,29 +159,53 @@ class VarDeclTests extends JavaSrcCode2CpgFixture {
   }
 
   "generics with 'keep type arguments' config" should {
-    val cpg = code("""
-        |import java.util.ArrayList;
-        |import java.util.List;
-        |import java.util.HashMap;
-        |
-        |public class Main {
-        |    public static void main(String[] args) {
-        |        // Create a List of Strings
-        |        List<String> stringList = new ArrayList<>();
-        |        var stringIntMap = new HashMap<String, Integer>();
-        |    }
-        |}
-        |
-        |""".stripMargin)
-      .withConfig(Config().withKeepTypeArguments(true))
 
-    "show the fully qualified type arguments for `List`" in {
+    "show the fully qualified type arguments for stdlib `List and `Map` objects" in {
+      val cpg = code("""
+          |import java.util.ArrayList;
+          |import java.util.List;
+          |import java.util.HashMap;
+          |
+          |public class Main {
+          |    public static void main(String[] args) {
+          |        // Create a List of Strings
+          |        List<String> stringList = new ArrayList<>();
+          |        var stringIntMap = new HashMap<String, Integer>();
+          |    }
+          |}
+          |
+          |""".stripMargin)
+        .withConfig(Config().withKeepTypeArguments(true))
+
       cpg.identifier("stringList").typeFullName.head shouldBe "java.util.List<java.lang.String>"
-    }
-
-    "show the fully qualified type arguments for `Map`" in {
       cpg.identifier("stringIntMap").typeFullName.head shouldBe "java.util.HashMap<java.lang.String,java.lang.Integer>"
     }
 
+    "show the fully qualified names of external types" in {
+      val cpg = code("""
+          |import org.apache.flink.streaming.api.datastream.DataStream;
+          |import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+          |import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
+          |import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
+          |
+          |import java.util.Properties;
+          |
+          |public class FlinkKafkaExample {
+          |    public static void main() throws Exception {
+          |        Properties kafkaProps = new Properties();
+          |        SimpleStringSchema schema = new SimpleStringSchema();
+          |        FlinkKafkaProducer<String> kafkaProducer = new FlinkKafkaProducer<String>("kafka-topic", schema, kafkaProps);
+          |    }
+          |}
+          |""".stripMargin).withConfig(Config().withKeepTypeArguments(true))
+
+      cpg.call
+        .codeExact("new FlinkKafkaProducer<String>(\"kafka-topic\", schema, kafkaProps)")
+        .filterNot(_.name == Operators.alloc)
+        .map(_.methodFullName)
+        .head shouldBe "org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer<java.lang.String>.<init>:<unresolvedSignature>(3)"
+    }
+
   }
+
 }


### PR DESCRIPTION
It's been known that certain types return as `ANY` when it's an external type with type arguments. However, the type would resolve when type arguments are removed.

This PR detects if the type to be resolved is a `ClassOrInterfaceType`, and if so, will only pass the type name to the type resolver, and resolve the type arguments separately. The type arguments are then placed in the `fullName` if `keepFullNames` is enabled.