### PR TITLE
[language] Fix `Annotation.asInstanceOf[CfgNode].method` Throwing NullException

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
@@ -1,8 +1,8 @@
 package io.joern.javasrc2cpg.querying
 
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Annotation, AnnotationLiteral, ArrayInitializer}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 
 class AnnotationTests extends JavaSrcCode2CpgFixture {
   "normal value annotations" should {
@@ -24,6 +24,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
       annotationNode.fullName shouldBe "some.NormalAnnotation"
       annotationNode.lineNumber shouldBe Some(5)
       annotationNode.columnNumber shouldBe Some(3)
+      annotationNode.asInstanceOf[CfgNode].method.fullName shouldBe "SomeClass.function:void()"
     }
 
     "test annotation node parameter assignment child" in {
@@ -84,6 +85,7 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
       paramValue.code shouldBe "classAnnotation"
       paramValue.order shouldBe 2
       paramValue.argumentIndex shouldBe 2
+      paramValue.method.fullName shouldBe "SomeClass.function:void()"
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -108,7 +108,12 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     case _: MethodParameterIn | _: MethodParameterOut | _: MethodReturn =>
       walkUpAst(node)
     case _: CallRepr if !node.isInstanceOf[Call] => walkUpAst(node)
-    case _: Expression | _: JumpTarget           => walkUpContains(node)
+    case _: Annotation | _: AnnotationLiteral | _: AnnotationParameter | _: AnnotationParameterAssign =>
+      node.astParent match {
+        case method: Method => method
+        case x: Expression  => x.method
+      }
+    case _: Expression | _: JumpTarget => walkUpContains(node)
   }
 
   /** Obtain hexadecimal string representation of lineNumber field.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -108,12 +108,8 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     case _: MethodParameterIn | _: MethodParameterOut | _: MethodReturn =>
       walkUpAst(node)
     case _: CallRepr if !node.isInstanceOf[Call] => walkUpAst(node)
-    case _: Annotation | _: AnnotationLiteral | _: AnnotationParameter | _: AnnotationParameterAssign =>
-      node.astParent match {
-        case method: Method => method
-        case x: Expression  => x.method
-      }
-    case _: Expression | _: JumpTarget => walkUpContains(node)
+    case _: Annotation | _: AnnotationLiteral    => node.inAst.collectAll[Method].head
+    case _: Expression | _: JumpTarget           => walkUpContains(node)
   }
 
   /** Obtain hexadecimal string representation of lineNumber field.


### PR DESCRIPTION
Added additional annotation specific cases to `CfgNodeMethods.method`.

Resolves #4529