### PR TITLE
[ruby] Fixed Call/Method Dataflow Tests

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -248,7 +248,7 @@ object RubyIntermediateAst {
     def isString: Boolean = text.startsWith("\"") || text.startsWith("'")
 
     def innerText: String = {
-      val strRegex = ":?['\"]([\\w\\d_-]+)['\"]".r
+      val strRegex = "[./:]?['\"]([\\w\\d_-]+)(?:\\.rb)?['\"]".r
       text match {
         case s":'$content'"                       => content
         case s":$symbol"                          => symbol

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodReturnTests.scala
@@ -12,11 +12,11 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
         | return x
         |end
         |""".stripMargin)
-    val source = cpg.method.name("f").parameter
+    val source = cpg.method.name("f").parameter.index(1)
     val sink   = cpg.method.name("f").methodReturn
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("f(x)", 2), ("return x", 3), ("RET", 2)))
+      Set(List(("f(this, x)", 2), ("return x", 3), ("RET", 2)))
   }
 
   "flow from method parameter to implicit return of the same variable" in {
@@ -25,22 +25,22 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
         | x
         |end
         |""".stripMargin)
-    val source = cpg.method.name("f").parameter
+    val source = cpg.method.name("f").parameter.index(1)
     val sink   = cpg.method.name("f").methodReturn
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("f(x)", 2), ("x", 3), ("RET", 2)))
+      Set(List(("f(this, x)", 2), ("x", 3), ("RET", 2)))
   }
 
   "flow from endless method parameter to implicit return of the same variable" in {
     val cpg = code("""
         |def f(x) = x
         |""".stripMargin)
-    val source = cpg.method.name("f").parameter
+    val source = cpg.method.name("f").parameter.index(1)
     val sink   = cpg.method.name("f").methodReturn
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("f(x)", 2), ("x", 2), ("RET", 2)))
+      Set(List(("f(this, x)", 2), ("x", 2), ("RET", 2)))
   }
 
   "flow from method parameter to implicit return via assignment to temporary variable" in {
@@ -49,15 +49,14 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
         | y = x
         |end
         |""".stripMargin)
-    val source = cpg.method.name("f").parameter
+    val source = cpg.method.name("f").parameter.index(1)
     val sink   = cpg.method.name("f").methodReturn
     val flows  = sink.reachableByFlows(source)
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List(("f(x)", 2), ("y = x", 3), ("RET", 2)))
+      Set(List(("f(this, x)", 2), ("y = x", 3), ("RET", 2)))
   }
 
-  // Works in deprecated
-  "Implicit return in if-else block" ignore {
+  "Implicit return in if-else block" in {
     val cpg = code("""
                      |def foo(arg)
                      |if arg > 1
@@ -72,13 +71,24 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
                      |puts y
                      |""".stripMargin)
 
-    val src  = cpg.identifier.name("x").l
-    val sink = cpg.call.name("puts").l
-    sink.reachableByFlows(src).l.size shouldBe 2
+    val src   = cpg.method.name("foo").parameter.index(1).l
+    val sink  = cpg.call.name("puts").argument(1).l
+    val flows = sink.reachableByFlows(src)
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List(
+          ("foo(this, arg)", 2),
+          ("arg > 1", 3),
+          ("arg + 1", 4),
+          ("RET", 2),
+          ("foo x", 11),
+          ("y = foo x", 11),
+          ("puts y", 12)
+        )
+      )
   }
 
-  // Works in deprecated
-  "Implicit return in if-else block and underlying function call" ignore {
+  "Implicit return in if-else block and underlying function call" in {
     val cpg = code("""
                      |def add(arg)
                      |arg + 100
@@ -98,17 +108,32 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
                      |
                      |""".stripMargin)
 
-    val src  = cpg.identifier.name("x").l
-    val sink = cpg.call.name("puts").l
-    sink.reachableByFlows(src).l.size shouldBe 2
+    val src   = cpg.method.name("foo").parameter.index(1).l
+    val sink  = cpg.call.name("puts").argument(1).l
+    val flows = sink.reachableByFlows(src)
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List(
+          ("foo(this, arg)", 6),
+          ("arg > 1", 7),
+          ("add(arg)", 8),
+          ("add(this, arg)", 2),
+          ("arg + 100", 3),
+          ("RET", 2),
+          ("add(arg)", 8),
+          ("RET", 6),
+          ("foo x", 15),
+          ("y = foo x", 15),
+          ("puts y", 16)
+        )
+      )
   }
 
-  // Works in deprecated
-  "Return via call w/o initialization" ignore {
+  "Return via call w/o initialization" in {
     val cpg = code("""
                      |def add(p)
-                     |q = p
-                     |return q
+                     |  q = p
+                     |  return q
                      |end
                      |
                      |n = 1
@@ -116,8 +141,20 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
                      |puts ret
                      |""".stripMargin)
 
-    val src  = cpg.identifier.name("n").l
-    val sink = cpg.call.name("puts").l
-    sink.reachableByFlows(src).l.size shouldBe 2
+    val src   = cpg.method.name("add").parameter.index(1).l
+    val sink  = cpg.call.name("puts").argument(1).l
+    val flows = sink.reachableByFlows(src)
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List(
+          ("add(this, p)", 2),
+          ("q = p", 3),
+          ("return q", 4),
+          ("RET", 2),
+          ("add(n)", 8),
+          ("ret = add(n)", 8),
+          ("puts ret", 9)
+        )
+      )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -657,7 +657,7 @@ class ClassTests extends RubyCode2CpgFixture {
                           identifier.code shouldBe "scope"
                           literal.code shouldBe ":hits_by_ip"
                           methodRef.methodFullName shouldBe "Test0.rb:<global>::program.Foo:<init>:<lambda>0"
-                          methodRef.referencedMethod.parameter.name.l shouldBe List("ip", "col")
+                          methodRef.referencedMethod.parameter.indexGt(0).name.l shouldBe List("ip", "col")
                         case xs => fail(s"Expected three children, got ${xs.code.mkString(", ")} instead")
                       }
                     case xs => fail(s"Expected one call, got ${xs.code.mkString(", ")} instead")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -43,7 +43,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "have no parameters in the closure declaration" in {
-      inside(cpg.method("<lambda>0").parameter.l) {
+      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) {
         case Nil => // pass
         case xs  => fail(s"Expected the closure to have no parameters, instead got [${xs.code.mkString(", ")}]")
       }
@@ -88,7 +88,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "have the `item` parameter in the closure declaration" in {
-      inside(cpg.method("<lambda>0").parameter.l) {
+      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) {
         case itemParam :: Nil =>
           itemParam.name shouldBe "item"
         case xs => fail(s"Expected the closure to have a single parameter, instead got [${xs.code.mkString(", ")}]")
@@ -151,7 +151,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "have the `key` and `value` parameter in the closure declaration" in {
-      inside(cpg.method("<lambda>0").parameter.l) {
+      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) {
         case keyParam :: valParam :: Nil =>
           keyParam.name shouldBe "key"
           valParam.name shouldBe "value"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -403,7 +403,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
     }
 
     "have no parameters in the closure declaration" in {
-      inside(cpg.method("<lambda>0").parameter.l) {
+      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) {
         case Nil => // pass
         case xs  => fail(s"Expected the closure to have no parameters, instead got [${xs.code.mkString(", ")}]")
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -21,7 +21,7 @@ class MethodTests extends RubyCode2CpgFixture {
     f.numberOfLines shouldBe 1
 
     val List(x) = f.parameter.name("x").l
-    x.index shouldBe 0
+    x.index shouldBe 1
     x.isVariadic shouldBe false
     x.lineNumber shouldBe Some(2)
   }
@@ -39,7 +39,7 @@ class MethodTests extends RubyCode2CpgFixture {
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 3
-    f.parameter.size shouldBe 0
+    f.parameter.size shouldBe 1
   }
 
   "`def f = puts 'hi'` is represented by a METHOD node returning `puts 'hi'`" in {
@@ -53,7 +53,7 @@ class MethodTests extends RubyCode2CpgFixture {
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 1
-    f.parameter.size shouldBe 0
+    f.parameter.size shouldBe 1
 
     val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
     r.code shouldBe "puts 'hi'"
@@ -71,7 +71,7 @@ class MethodTests extends RubyCode2CpgFixture {
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 1
-    f.parameter.size shouldBe 1
+    f.parameter.size shouldBe 2
 
     val List(r: Return) = f.methodReturn.cfgIn.l: @unchecked
     r.code shouldBe "x.class"
@@ -234,7 +234,7 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "be interpreted as an array type parameter if a single star given" in {
-      inside(cpg.method("foo").parameter.l) {
+      inside(cpg.method("foo").parameter.indexGt(0).l) {
         case xs :: Nil =>
           xs.name shouldBe "xs"
           xs.code shouldBe "*xs"
@@ -245,7 +245,7 @@ class MethodTests extends RubyCode2CpgFixture {
     }
 
     "be interpreted as a hash type parameter if two stars given" in {
-      inside(cpg.method("bar").parameter.l) {
+      inside(cpg.method("bar").parameter.indexGt(0).l) {
         case ys :: Nil =>
           ys.name shouldBe "ys"
           ys.code shouldBe "**ys"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
@@ -41,11 +41,13 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
         }
 
         "add a block argument" in {
-          forAll(cpgs.zipWithIndex) { (cpg, i) =>
-            val List(param) = cpg.method("foo").parameter.code("&.*").l
-            param.name shouldBe "<proc-param-0>"
-            param.index shouldBe i
-          }
+          val List(param1) = cpg1.method("foo").parameter.code("&.*").l
+          param1.name shouldBe "<proc-param-0>"
+          param1.index shouldBe 1
+
+          val List(param2) = cpg2.method("foo").parameter.code("&.*").l
+          param2.name shouldBe "<proc-param-0>"
+          param2.index shouldBe 1
         }
       }
 


### PR DESCRIPTION
* Fixed parameter alignment issue where some methods didn't have a 0th parameter
* Fixed `require` regex to account for local relative file imports