### PR TITLE
[ruby] Some Proc/Lambda Flows

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -573,7 +573,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): RubyNode = {
     val parameters = Option(ctx.parameterList()).fold(List())(_.parameters).map(visit)
     val body       = visit(ctx.block())
-    Block(parameters, body)(ctx.toTextSpan)
+    ProcOrLambdaExpr(Block(parameters, body)(ctx.toTextSpan))(ctx.toTextSpan)
   }
 
   override def visitMethodCallWithParenthesesExpression(


### PR DESCRIPTION
* Added handling for `Block` lambda expressions
* Enabled more ProcParameterAndYieldTests
* Further passing tests require type propagation

Resolves #4520