### PR TITLE
[javasrc2cpg] Preserve path in ConfigFile name

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -61,4 +61,23 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
     }
   }
 
+  "it should populate config files correctly when they are nested" in {
+    val cpg = code("""public class Foo{}
+        |""".stripMargin)
+      .moreCode(code = "config.file=1", fileName = "config.properties")
+      .moreCode(code = "config.file=2", fileName = "someDir/config.properties")
+
+    cpg.typeDecl.name("Foo").nonEmpty shouldBe true
+    cpg.configFile.sortBy(_.name).l match {
+      case List(configFile1, configFile2) =>
+        configFile1.name shouldBe "config.properties"
+        configFile1.content shouldBe "config.file=1"
+
+        configFile2.name shouldBe "someDir/config.properties"
+        configFile2.content shouldBe "config.file=2"
+
+      case result => fail(s"Expected two config files but got $result")
+    }
+  }
+
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -62,18 +62,20 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
   }
 
   "it should populate config files correctly when they are nested" in {
+    val configFile1Path = Paths.get("config.properties").toString
+    val configFile2Path = Paths.get("someDir", "config.properties").toString
     val cpg = code("""public class Foo{}
         |""".stripMargin)
-      .moreCode(code = "config.file=1", fileName = "config.properties")
-      .moreCode(code = "config.file=2", fileName = "someDir/config.properties")
+      .moreCode(code = "config.file=1", fileName = configFile1Path)
+      .moreCode(code = "config.file=2", fileName = configFile2Path)
 
     cpg.typeDecl.name("Foo").nonEmpty shouldBe true
     cpg.configFile.sortBy(_.name).l match {
       case List(configFile1, configFile2) =>
-        configFile1.name shouldBe "config.properties"
+        configFile1.name shouldBe configFile1Path
         configFile1.content shouldBe "config.file=1"
 
-        configFile2.name shouldBe "someDir/config.properties"
+        configFile2.name shouldBe configFile2Path
         configFile2.content shouldBe "config.file=2"
 
       case result => fail(s"Expected two config files but got $result")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
@@ -55,7 +55,7 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
   }
 
   private def configFileName(configFile: File): String = {
-    Try(Paths.get(rootDir.get).toAbsolutePath)
+    Try(Paths.get(rootDir.getOrElse(cpg.metaData.root.head)).toAbsolutePath)
       .map(_.relativize(configFile.path.toAbsolutePath).toString)
       .getOrElse(configFile.name)
   }


### PR DESCRIPTION
When going from 2.0.352 to 2.0.353, we noticed that `ConfigFile`'s `.name` property no longer contained their path, but rather just their file name. 

An alternative fix would be to explicitly provide `rootDir = Option(config.inputPath)` in https://github.com/joernio/joern/blob/ebd93bf07ab3261c25fb27756d772768fec02979/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala#L34

but since XConfigFileCreationPass is expected to gather that from `metaData.root` when omitted, figured it would be preferable to patch it instead.