### PR TITLE
[kotlin] `keepTypeArguments` Flag

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -7,8 +7,7 @@ import io.joern.kotlin2cpg.files.SourceFilesPicker
 import io.joern.kotlin2cpg.interop.JavasrcInterop
 import io.joern.kotlin2cpg.jar4import.UsesService
 import io.joern.kotlin2cpg.passes.*
-import io.joern.kotlin2cpg.types.ContentSourcesPicker
-import io.joern.kotlin2cpg.types.DefaultTypeInfoProvider
+import io.joern.kotlin2cpg.types.{ContentSourcesPicker, DefaultTypeInfoProvider, TypeRenderer}
 import io.joern.kotlin2cpg.utils.PathUtils
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.X2CpgFrontend
@@ -228,8 +227,11 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] with UsesService {
 
       new MetaDataPass(cpg, Languages.KOTLIN, config.inputPath).createAndApply()
 
+      val typeRenderer = new TypeRenderer(config.keepTypeArguments)
       val astCreator =
-        new AstCreationPass(sourceFiles, new DefaultTypeInfoProvider(environment), cpg)(config.schemaValidation)
+        new AstCreationPass(sourceFiles, new DefaultTypeInfoProvider(environment, typeRenderer), cpg)(
+          config.schemaValidation
+        )
       astCreator.createAndApply()
 
       val kotlinAstCreatorTypes = astCreator.global.usedTypes.keys().asScala.toList

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
@@ -87,7 +87,11 @@ private object Frontend {
       opt[Unit]("generate-nodes-for-dependencies")
         .text("Generate nodes for the dependencies of the target project")
         .action((_, c) => c.withGenerateNodesForDependencies(true)),
-      DependencyDownloadConfig.parserOptions
+      DependencyDownloadConfig.parserOptions,
+      opt[Unit]("keep-type-arguments")
+        .hidden()
+        .action((_, c) => c.withKeepTypeArguments(true))
+        .text("Type full names of variables keep their type arguments.")
     )
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
@@ -14,7 +14,8 @@ final case class Config(
   jar4importServiceUrl: Option[String] = None,
   includeJavaSourceFiles: Boolean = false,
   generateNodesForDependencies: Boolean = false,
-  downloadDependencies: Boolean = false
+  downloadDependencies: Boolean = false,
+  keepTypeArguments: Boolean = false
 ) extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config] {
 
@@ -48,6 +49,10 @@ final case class Config(
 
   override def withDownloadDependencies(value: Boolean): Config = {
     this.copy(downloadDependencies = value).withInheritedFields(this)
+  }
+
+  def withKeepTypeArguments(value: Boolean): Config = {
+    copy(keepTypeArguments = value).withInheritedFields(this)
   }
 }
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.{
 
 case class AnonymousObjectContext(declaration: KtElement)
 
-trait TypeInfoProvider {
+trait TypeInfoProvider(val typeRenderer: TypeRenderer = new TypeRenderer()) {
   def isExtensionFn(fn: KtNamedFunction): Boolean
 
   def usedAsExpression(expr: KtExpression): Option[Boolean]


### PR DESCRIPTION
* Similar to https://github.com/joernio/joern/pull/4502, but for Kotlin.
* Made `TypeRenderer` an object for easier global setting of `keepTypeArgument`
* Improved null safety of `expr.getCalleeExpression` under `AstForExpressionsCreator.astsForNonCtorCall`

Note: This acknowledges that enabling this flag may break type linking, thus it is hidden and disabled by default.