### PR TITLE
[javasrc2cpg] fix ext method call full name with same name of a scope var

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -303,7 +303,7 @@ class AstCreator(
       scope.lookupType(annotation.getNameAsString)
     case namedExpr: NodeWithName[_] =>
       scope.lookupVariableOrType(namedExpr.getNameAsString)
-    case namedExpr: NodeWithSimpleName[_] =>
+    case namedExpr: NodeWithSimpleName[_] if !expr.isMethodCallExpr =>
       scope.lookupVariableOrType(namedExpr.getNameAsString)
     // JavaParser doesn't handle literals well for some reason
     case _: BooleanLiteralExpr   => Some("boolean")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -521,6 +521,37 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
         .last shouldBe "Derived.getCurrentSession:org.hibernate.Session()"
     }
   }
+
+  "call to external method in a builder-like pattern" should {
+    val cpg = code("""
+        |package example;
+        |import org.Builder;
+        |import org.Client;
+        |
+        |class Main {
+        | static void main(String[] args) {
+        |   Client foo = new Builder().foo().buildClient(); // 8
+        |   new Builder().somethingElse().buildClient();    // 9
+        | }
+        |}
+        |""".stripMargin)
+
+    "have correct method full name for `buildClient` call on line 8" in {
+      cpg.call("buildClient").lineNumber(8).l match {
+        case List(buildClient) =>
+          buildClient.methodFullName shouldBe "<unresolvedNamespace>.buildClient:<unresolvedSignature>(0)"
+        case result => fail(s"Expected single buildClient call but got $result")
+      }
+    }
+
+    "have correct method full name for `buildClient` call on line 9" in {
+      cpg.call("buildClient").lineNumber(9).l match {
+        case List(buildClient) =>
+          buildClient.methodFullName shouldBe "<unresolvedNamespace>.buildClient:<unresolvedSignature>(0)"
+        case result => fail(s"Expected single buildClient call but got $result")
+      }
+    }
+  }
 }
 
 class CallTests extends JavaSrcCode2CpgFixture {


### PR DESCRIPTION
When dealing with:
* external method calls whose receiver type we can't resolve, and
* if there is a variable in scope with that same name, then

 we are resolving to that variable's type, as in:

```java
import org.Client;
import org.Builder;
...
Client foo = new Builder().foo().build(); // build's receiver is org.Client
Client bar = new Builder().somethingElse().build(); // build's receiver is <unresolvedNamespace>
```

This gets worse: if in the 2nd statement above we had used `foo()` again instead of `somethingElse()`, it would resolve again to `org.Client`.

This patch stinks, though: I'm not a fan of that edge condition. Hopefully we can find something nicer.
