### PR TITLE
[kotlin2cpg] Fixed type info provider

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
@@ -107,9 +107,7 @@ trait TypeInfoProvider(val typeRenderer: TypeRenderer = new TypeRenderer()) {
 
   def typeFullName(expr: KtTypeReference, defaultValue: String): String
 
-  def typeFullName(expr: KtPrimaryConstructor, defaultValue: String): String
-
-  def typeFullName(expr: KtSecondaryConstructor, defaultValue: String): String
+  def typeFullName(expr: KtPrimaryConstructor | KtSecondaryConstructor, defaultValue: String): String
 
   def typeFullName(expr: KtCallExpression, defaultValue: String): String
 


### PR DESCRIPTION
For whatever reason `if desc.getKind == CallableMemberDescriptor.Kind.DECLARATION` slipped into `resolvedCallDescriptor(expr: KtExpression)` with the previous PR (most likely something I debugged there and forgot about).