### PR TITLE
 [jssrc2cpg] Fix for TypeDecl creation from TypeAliasNode for function params

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -158,14 +158,15 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         case ObjectPattern =>
           val paramName = generateUnusedVariableName(usedVariableNames, s"param$index")
           // Handle de-structured parameters declared as `{ username: string; password: string; }`
-          val typeDecl = astForTypeAlias(nodeInfo)
+          val typeDeclAst = astForTypeAlias(nodeInfo)
+          Ast.storeInDiffGraph(typeDeclAst, diffGraph)
 
           val tpe          = typeFor(nodeInfo)
           var typeFullName = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
 
           val possibleTypes =
             Seq(
-              typeDecl.root
+              typeDeclAst.root
                 .collect { case t: NewTypeDecl =>
                   typeFullName = t.fullName
                   t.fullName
@@ -181,7 +182,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             EvaluationStrategies.BY_VALUE,
             typeFullName
           ).possibleTypes(possibleTypes)
-          Ast.storeInDiffGraph(typeDecl, diffGraph)
           scope.addVariable(paramName, param, MethodScope)
 
           additionalBlockStatements.addAll(nodeInfo.json("properties").arr.toList.map { element =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTests.scala
@@ -342,6 +342,8 @@ class TsClassesAstCreationPassTests extends AstJsSrc2CpgSuite(".ts") {
       cpg.all.collectAll[CfgNode].whereNot(_._astIn).size shouldBe 0
       cpg.identifier.count(_.refsTo.size > 1) shouldBe 0
       cpg.identifier.whereNot(_.refsTo).size shouldBe 0
+      // should not produce assignment calls directly under typedecls
+      cpg.call.assignment.astParent.isTypeDecl shouldBe empty
     }
 
     "AST generation for destructured type in a parameter" in {
@@ -360,6 +362,8 @@ class TsClassesAstCreationPassTests extends AstJsSrc2CpgSuite(".ts") {
       cpg.all.collectAll[CfgNode].whereNot(_._astIn).size shouldBe 0
       cpg.identifier.count(_.refsTo.size > 1) shouldBe 0
       cpg.identifier.whereNot(_.refsTo).size shouldBe 0
+      // should not produce assignment calls directly under typedecls
+      cpg.call.assignment.astParent.isTypeDecl shouldBe empty
     }
 
   }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
@@ -152,11 +152,10 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
      |""".stripMargin,
       "Test0.ts"
     ).withConfig(Config().withTsTypes(true))
-    inside(cpg.identifier.l) { case List(idX) =>
-      idX.name shouldBe "x"
-      idX.code shouldBe "x"
-      idX.typeFullName shouldBe Defines.String // we can actually follow type intrinsics
-    }
+    val List(idX) = cpg.identifier.nameExact("x").l
+    idX.name shouldBe "x"
+    idX.code shouldBe "x"
+    idX.typeFullName shouldBe Defines.String // we can actually follow type intrinsics
   }
 
   "have correct types for TS function parameters" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
@@ -152,10 +152,11 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
      |""".stripMargin,
       "Test0.ts"
     ).withConfig(Config().withTsTypes(true))
-    val List(idX) = cpg.identifier.nameExact("x").l
-    idX.name shouldBe "x"
-    idX.code shouldBe "x"
-    idX.typeFullName shouldBe Defines.String // we can actually follow type intrinsics
+    inside(cpg.identifier.l) { case List(idX) =>
+      idX.name shouldBe "x"
+      idX.code shouldBe "x"
+      idX.typeFullName shouldBe Defines.String // we can actually follow type intrinsics
+    }
   }
 
   "have correct types for TS function parameters" in {


### PR DESCRIPTION
Assignment calls from TypeAliasNode members created for object parameters to functions are not stored directly under the TypeDecl any longer. We only attach members now.