### PR TITLE
add slightly more verbose logging to pysrc2cpg

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
@@ -131,5 +131,7 @@ class Py2CpgOnFileSystem extends X2CpgFrontend[Py2CpgOnFileSystemConfig] {
     logger.info(s"IgnorePaths: ${config.ignorePaths.mkString(", ")}")
     logger.info(s"IgnoreDirNames: ${config.ignoreDirNames.mkString(", ")}")
     logger.info(s"No dummy types: ${config.disableDummyTypes}")
+    logger.info(s"Enable file content: ${!config.disableFileContent}")
+    logger.info(s"Version: ${this.getClass.getPackage.getImplementationVersion}")
   }
 }


### PR DESCRIPTION
To help debug some issues.

Generally speaking, I think we should always always log exact versions in every run. Just to allow us to quickly ensure whether that is a possible cause of a bug.