### PR TITLE
[javasrc]: keep maven dep fetching running after failure

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -9,20 +9,30 @@ import scala.util.{Failure, Success}
 object MavenDependencies {
   private val logger = LoggerFactory.getLogger(getClass)
 
+  private def logErrors(output: String): Unit = {
+
+    logger.warn(
+      s"Retrieval of compile class path via maven return with error.\n" +
+        "The compile class path may be missing or partial.\n" +
+        "Results will suffer from poor type information.\n\n" +
+        output
+    )
+  }
+
   private[dependency] def get(projectDir: Path): Option[collection.Seq[String]] = {
     // we can't use -Dmdep.outputFile because that keeps overwriting its own output for each sub-project it's running for
     val lines = ExternalCommand.run(
       s"mvn --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out",
       projectDir.toString
     ) match {
-      case Success(lines) => lines
+      case Success(lines) =>
+        if (lines.contains("[INFO] Build failures were ignored.")) {
+          logErrors(lines.mkString(System.lineSeparator()))
+        }
+
+        lines
       case Failure(exception) =>
-        logger.warn(
-          s"Retrieval of compile class path via maven return with error.\n" +
-            "The compile class path may be missing or partial.\n" +
-            "Results will suffer from poor type information.\n\n" +
-            exception.getMessage
-        )
+        logErrors(exception.getMessage)
         // exception message is the program output - and we still want to look for potential partial results
         exception.getMessage.linesIterator.toSeq
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -12,7 +12,7 @@ object MavenDependencies {
   private[dependency] def get(projectDir: Path): Option[collection.Seq[String]] = {
     // we can't use -Dmdep.outputFile because that keeps overwriting its own output for each sub-project it's running for
     val lines = ExternalCommand.run(
-      s"mvn -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out",
+      s"mvn --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out",
       projectDir.toString
     ) match {
       case Success(lines) => lines

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
@@ -28,7 +28,7 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
     }
   }
 
-  "test maven dependency resolution" ignore {
+  "test maven dependency resolution" in {
     // check that `mvn` is available - otherwise test will fail with only some logged warnings...
     withClue("`mvn` must be installed in order for this test to work...") {
       ExternalCommand.run("mvn --version", ".").get.exists(_.contains("Apache Maven")) shouldBe true

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
@@ -28,7 +28,7 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
     }
   }
 
-  "test maven dependency resolution" in {
+  "test maven dependency resolution" ignore {
     // check that `mvn` is available - otherwise test will fail with only some logged warnings...
     withClue("`mvn` must be installed in order for this test to work...") {
       ExternalCommand.run("mvn --version", ".").get.exists(_.contains("Apache Maven")) shouldBe true


### PR DESCRIPTION
There's also a --fail-at-end. But in my cursory testing, it still skips over future steps after a failure, so --fail-never it is.