### PR TITLE
[kotlin] fix types for custom annotations

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
@@ -318,4 +318,27 @@ class AnnotationTests extends JavaSrcCode2CpgFixture {
       }
     }
   }
+
+  "CPG for code with a custom annotation" should {
+    val cpg = code("""
+        |package mypak;
+        |
+        |import retrofit2.http.Body;
+        |import retrofit2.http.POST;
+        |
+        |public interface User {
+        |
+        |    @POST("/name")
+        |    public Call<Response> getUser(@Body Request request);
+        |}
+        |""".stripMargin)
+
+    "contain an ANNOTATION node" in {
+      cpg.all.collectAll[Annotation].codeExact("@POST(\"/name\")").size shouldBe 1
+    }
+
+    "the ANNOTATION node should have correct full name" in {
+      cpg.all.collectAll[Annotation].codeExact("@POST(\"/name\")").fullName.head shouldBe "retrofit2.http.POST"
+    }
+  }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
@@ -251,7 +251,11 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   def astForAnnotationEntry(entry: KtAnnotationEntry)(implicit typeInfoProvider: TypeInfoProvider): Ast = {
-    val typeFullName = registerType(typeInfoProvider.typeFullName(entry, TypeConstants.any))
+    val typeFullName = registerType(typeInfoProvider.typeFullName(entry, TypeConstants.any) match {
+      case value if value != TypeConstants.any => value
+      case _ =>
+        typeInfoProvider.typeFromImports(entry.getShortName.toString, entry.getContainingKtFile).getOrElse("ANY")
+    })
     val node =
       NewAnnotation()
         .code(entry.getText)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
@@ -254,7 +254,7 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) {
     val typeFullName = registerType(typeInfoProvider.typeFullName(entry, TypeConstants.any) match {
       case value if value != TypeConstants.any => value
       case _ =>
-        typeInfoProvider.typeFromImports(entry.getShortName.toString, entry.getContainingKtFile).getOrElse("ANY")
+        typeInfoProvider.typeFromImports(entry.getShortName.toString, entry.getContainingKtFile).getOrElse(TypeConstants.any)
     })
     val node =
       NewAnnotation()

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
@@ -254,7 +254,9 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) {
     val typeFullName = registerType(typeInfoProvider.typeFullName(entry, TypeConstants.any) match {
       case value if value != TypeConstants.any => value
       case _ =>
-        typeInfoProvider.typeFromImports(entry.getShortName.toString, entry.getContainingKtFile).getOrElse(TypeConstants.any)
+        typeInfoProvider
+          .typeFromImports(entry.getShortName.toString, entry.getContainingKtFile)
+          .getOrElse(TypeConstants.any)
     })
     val node =
       NewAnnotation()

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnnotationsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnnotationsTests.scala
@@ -605,4 +605,25 @@ class AnnotationsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       cpg.all.collectAll[Annotation].codeExact("@Fancy").size shouldBe 1
     }
   }
+
+  "CPG for code with a custom annotation" should {
+    val cpg = code("""
+        |package mypkg
+        |import retrofit2.http.POST
+        |
+        |interface Username {
+        |    @Headers("Content-Type: application/json")
+        |    @POST("/name")
+        |    fun sendUsername(@Body username: UserDto): Call<Void>
+        |}
+        |""".stripMargin)
+
+    "contain an ANNOTATION node" in {
+      cpg.all.collectAll[Annotation].codeExact("@POST(\"/name\")").size shouldBe 1
+    }
+
+    "the ANNOTATION node should have correct full name" in {
+      cpg.all.collectAll[Annotation].codeExact("@POST(\"/name\")").fullName.head shouldBe "retrofit2.http.POST"
+    }
+  }
 }


### PR DESCRIPTION
 * populates types where local imports are used for annotations
 * add tests for java as well as kotlin to demonstrate parity