### PR TITLE
Fixed Gradle script for dependency downloading with Gradle >9

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -90,22 +90,22 @@ object GradleDependencies {
        |""".stripMargin
   }
 
-  // this init script _should_ work with Gradle 4-8, but has not been tested thoroughly
+  // this init script _should_ work with Gradle >=4, but has not been tested thoroughly
   // TODO: add test cases for older Gradle versions
   private def gradle5OrLaterInitScript(
     taskName: String,
     destination: String,
     gradleConfigurationName: String
   ): String = {
+    val into = destination.replaceAll("\\\\", "/")
+    val fromConfigurations =
+      Set(s"from configurations.$gradleConfigurationName", "from configurations.runtimeClasspath").mkString("\n")
     s"""
      |allprojects {
      |  apply plugin: 'java'
      |  task $taskName(type: Copy) {
-     |    configurations.$gradleConfigurationName.setCanBeResolved(true)
-     |    configurations.implementation.setCanBeResolved(true)
-     |    configurations.default.setCanBeResolved(true)
-     |    into "${destination.replaceAll("\\\\", "/")}"
-     |    from configurations.default
+     |    $fromConfigurations
+     |    into "$into"
      |  }
      |}
      |""".stripMargin


### PR DESCRIPTION
`configurations.default` can not be resolved by default. The previous hack with `.setCanBeResolved(true)` will be deprecated with Gradle 9 and finally removed / disabled in future releases (same for `implementation`). The proper way to do this is by re-using a resolvable configuration (resolvable by default) in the `from` clause of the task.

More info: https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs and https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph