### PR TITLE
[kotlin] Fixed Missing MethodDecl in Lambda Arg

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeRenderer.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeRenderer.scala
@@ -168,7 +168,10 @@ class TypeRenderer(val keepTypeArguments: Boolean = false) {
       // We do this because at the beginning of a type name we cannot
       // have type parameters but instead <unresolvedNamespace> which
       // we do not want to strip.
-      typeName.replaceAll("(?<!^)<.*>", "")
+      // Sometimes with a lambda expression as an argument, we see a
+      // named function instead of a lambda, so we keep the
+      // <anonymous> tag.
+      typeName.replaceAll("(?<!^)<(?!anonymous).*>", "")
     }
     def stripOut(name: String): String = {
       if (name.contains("<") && name.contains(">") && name.contains("out")) {
@@ -188,6 +191,10 @@ class TypeRenderer(val keepTypeArguments: Boolean = false) {
       }
     }
 
-    stripTypeParams(stripOptionality(stripDebugInfo(stripOut(typeName))).trim().replaceAll(" ", "")).replaceAll("`", "")
+    val t1 = stripOut(typeName)
+    val t2 = stripDebugInfo(t1)
+    val t3 = stripOptionality(t2)
+    val t4 = stripTypeParams(t3)
+    t4.trim().replaceAll(" ", "").replaceAll("`", "")
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ObjectExpressionTests.scala
@@ -209,7 +209,7 @@ class ObjectExpressionTests extends KotlinCode2CpgFixture(withOssDataflow = fals
       c.methodFullName shouldBe "mypkg.addListener:void(mypkg.SomeInterface)"
       val List(objExpr: TypeDecl, l: Local, alloc: Call, init: Call, i: Identifier) =
         c.astChildren.isBlock.astChildren.l: @unchecked
-      objExpr.fullName shouldBe "mypkg.f1$object$1"
+      objExpr.fullName shouldBe "mypkg.f1.<anonymous>$object$1"
       l.code shouldBe "tmp_obj_1"
       alloc.code shouldBe "tmp_obj_1 = <alloc>"
       init.code shouldBe "<init>"


### PR DESCRIPTION
A specific kind of lambda expression assigned to a function with a lambda block argument produces a "named function" under the initial lambda expression which is technically not true.

However, this leads to an issue where an assumption of only one AST in the lambda expression is returned when this is false as the second is the method declaration. The method declaration also has its <anonymous> tag escaped, leading to some weird full names.

This change:
* No longer escapes <anonymous> in the case where <anonymous> is the "name" of the "named function"
* Processes idx > 0 ASTs from a lambda body as other lambdas. Added warning if expectation is not true.