### PR TITLE
[ruby] Syntax Error On Negated Conditionals

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -298,21 +298,21 @@ primaryValue
         # lambdaExpression
 
         // Control structures
-    |   IF NL* commandOrPrimaryValue thenClause elsifClause* elseClause? END
+    |   IF NL* expressionOrCommand thenClause elsifClause* elseClause? END
         # ifExpression
-    |   UNLESS NL* commandOrPrimaryValue thenClause elseClause? END
+    |   UNLESS NL* expressionOrCommand thenClause elseClause? END
         # unlessExpression
-    |   UNTIL NL* commandOrPrimaryValue doClause END
+    |   UNTIL NL* expressionOrCommand doClause END
         # untilExpression
     |   YIELD argumentWithParentheses?
         # yieldExpression
     |   BEGIN bodyStatement END
         # beginEndExpression
-    |   CASE NL* commandOrPrimaryValue (SEMI | NL)* whenClause+ elseClause? END
+    |   CASE NL* expressionOrCommand (SEMI | NL)* whenClause+ elseClause? END
         # caseWithExpression
     |   CASE (SEMI | NL)* whenClause+ elseClause? END
         # caseWithoutExpression
-    |   WHILE NL* commandOrPrimaryValue doClause END
+    |   WHILE NL* expressionOrCommand doClause END
         # whileExpression
     |   FOR NL* forVariable IN NL* commandOrPrimaryValue doClause END
         # forExpression

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -57,13 +57,13 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitWhileExpression(ctx: RubyParser.WhileExpressionContext): RubyNode = {
-    val condition = visit(ctx.commandOrPrimaryValue())
+    val condition = visit(ctx.expressionOrCommand())
     val body      = visit(ctx.doClause())
     WhileExpression(condition, body)(ctx.toTextSpan)
   }
 
   override def visitUntilExpression(ctx: RubyParser.UntilExpressionContext): RubyNode = {
-    val condition = visit(ctx.commandOrPrimaryValue())
+    val condition = visit(ctx.expressionOrCommand())
     val body      = visit(ctx.doClause())
     UntilExpression(condition, body)(ctx.toTextSpan)
   }
@@ -73,7 +73,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitIfExpression(ctx: RubyParser.IfExpressionContext): RubyNode = {
-    val condition = visit(ctx.commandOrPrimaryValue())
+    val condition = visit(ctx.expressionOrCommand())
     val thenBody  = visit(ctx.thenClause())
     val elsifs    = ctx.elsifClause().asScala.map(visit).toList
     val elseBody  = Option(ctx.elseClause()).map(visit)
@@ -89,7 +89,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitUnlessExpression(ctx: RubyParser.UnlessExpressionContext): RubyNode = {
-    val condition = visit(ctx.commandOrPrimaryValue())
+    val condition = visit(ctx.expressionOrCommand())
     val thenBody  = visit(ctx.thenClause())
     val elseBody  = Option(ctx.elseClause()).map(visit)
     UnlessExpression(condition, thenBody, elseBody)(ctx.toTextSpan)
@@ -1113,7 +1113,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitCaseWithExpression(ctx: RubyParser.CaseWithExpressionContext): RubyNode = {
-    val expression  = Option(ctx.commandOrPrimaryValue()).map(visit)
+    val expression  = Option(ctx.expressionOrCommand()).map(visit)
     val whenClauses = Option(ctx.whenClause().asScala).fold(List())(_.map(visit).toList)
     val elseClause  = Option(ctx.elseClause()).map(visit)
     CaseExpression(expression, whenClauses, elseClause)(ctx.toTextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ConditionalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ConditionalTests.scala
@@ -20,8 +20,7 @@ class ConditionalTests extends RubyCode2CpgFixture(withPostProcessing = true, wi
       Set(List(("x = 1", 2), ("z = x", 4), ("puts z", 5)), List(("y = 2", 3), ("z = y", 4), ("puts z", 5)))
   }
 
-  // Works in deprecated
-  "flow through statement with ternary operator with multiple line" ignore {
+  "flow through statement with ternary operator with multiple line" in {
     val cpg = code("""
                      |x = 2
                      |y = 3
@@ -33,8 +32,29 @@ class ConditionalTests extends RubyCode2CpgFixture(withPostProcessing = true, wi
                      |puts y
                      |""".stripMargin)
 
-    val source = cpg.identifier.name("y").l
-    val sink   = cpg.call.name("puts").l
-    sink.reachableByFlows(source).size shouldBe 2
+    val source = cpg.literal.code("3").l
+    val sink   = cpg.call.name("puts").argument(1).l
+    sink.reachableByFlows(source).size shouldBe 1
   }
+
+  "flow through method conditional over-approximates a flow disregarding outcome of the conditional" in {
+    val cpg = code("""
+        |x = 12
+        |def woo(x)
+        |  return x == 10
+        |end
+        |
+        |if !woo x
+        |  puts x
+        |else
+        |  puts "No"
+        |end
+        |
+        |""".stripMargin)
+
+    val source = cpg.literal.code("12").l
+    val sink   = cpg.call.name("puts").argument(1).l
+    sink.reachableByFlows(source).size shouldBe 1
+  }
+
 }


### PR DESCRIPTION
The parser rule that handles the conditional component in a conditional expression never expected an exclamation mark (negation). This change swaps out the old rule with one that does expect a "negatable" expression.

Resolves #4518