### PR TITLE
[ruby] Handle Rescue Exception Lists

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -382,8 +382,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         // Ensure never returns a value, only the main body, rescue & else clauses
         RescueExpression(
           transform(body),
-          rescueClauses.map(transform),
-          elseClause.map(transform).orElse(defaultElseBranch(node.span)),
+          rescueClauses.map(transform).collect { case x: RescueClause => x },
+          elseClause.map(transform).orElse(defaultElseBranch(node.span)).collect { case x: ElseClause => x },
           ensureClause
         )(node.span)
       case WhileExpression(condition, body)   => WhileExpression(condition, transform(body))(node.span)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -30,10 +30,10 @@ object RubyIntermediateAst {
   }
 
   implicit class RubyNodeHelper(node: RubyNode) {
-    def asStatementList = node match
+    def asStatementList: StatementList = node match {
       case stmtList: StatementList => stmtList
       case _                       => StatementList(List(node))(node.span)
-
+    }
   }
 
   final case class Unknown()(span: TextSpan) extends RubyNode(span)
@@ -150,16 +150,16 @@ object RubyIntermediateAst {
 
   final case class RescueExpression(
     body: RubyNode,
-    rescueClauses: List[RubyNode],
-    elseClause: Option[RubyNode],
-    ensureClause: Option[RubyNode]
+    rescueClauses: List[RescueClause],
+    elseClause: Option[ElseClause],
+    ensureClause: Option[EnsureClause]
   )(span: TextSpan)
       extends RubyNode(span)
       with ControlFlowExpression
 
   final case class RescueClause(
     exceptionClassList: Option[RubyNode],
-    assignment: Option[RubyNode],
+    variables: Option[RubyNode],
     thenClause: RubyNode
   )(span: TextSpan)
       extends RubyNode(span)


### PR DESCRIPTION
This PR handles rescue clauses specifying caught exceptions and creating their respective node. Exception types are assigned as dynamic type hints. This also tests that splatted exceptions are handled in a stable way.