### PR TITLE
[dataflowengineoss] handle python imports in globalFromLiteral

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -12,7 +12,7 @@ package object dataflowengineoss {
     val lhsOfAssignment = relevantLiteral.inCall.assignment.argument(1)
 
     // Gets <x> from `<x> = import(...<lit>...)` because of how Python imports are represented
-    val lhsOfImport = relevantLiteral.inCall.name("import").inCall.assignment.argument(1)
+    val lhsOfImport = relevantLiteral.inCall.nameExact("import").inCall.assignment.argument(1)
 
     lhsOfAssignment ++ lhsOfImport
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -5,9 +5,17 @@ import io.shiftleft.semanticcpg.language.*
 
 package object dataflowengineoss {
 
-  def globalFromLiteral(lit: Literal): Iterator[Expression] = lit.start.inCall.assignment
-    .where(_.method.isModule)
-    .argument(1)
+  def globalFromLiteral(lit: Literal): Iterator[Expression] = {
+    val relevantLiteral = lit.start.where(_.method.isModule).l
+
+    // Gets <x> from `<x> = <lit>`
+    val lhsOfAssignment = relevantLiteral.inCall.assignment.argument(1)
+
+    // Gets <x> from `<x> = import(...<lit>...)` because of how Python imports are represented
+    val lhsOfImport = relevantLiteral.inCall.name("import").inCall.assignment.argument(1)
+
+    lhsOfAssignment ++ lhsOfImport
+  }
 
   def identifierToFirstUsages(node: Identifier): List[Identifier] = node.refsTo.flatMap(identifiersFromCapturedScopes).l
 


### PR DESCRIPTION
Noticed a regression after #4559, in which flows from imported members would not longer propagate, e.g.

```python
from models import FOOBAR # defined as e.g. FOOBAR = "123" in `models.py`
print(FOOBAR)             # this FOOBAR (argument) would not be tainted by "123"
```

At play is the representation of `import` statements, which look like `FOOBAR = import("models", "FOOBAR")`. 

Prior to #4559, `globalFromLiteral` would yield `FOOBAR` in the aforementioned import statement, since it would recursively look for literals in assignments. That wasn't bullet-proof because then in `x = foo(20)` we would also yield `x`, leading to an extra (incorrect) data-flow from `20` to `x` (see #4549.)

In #4559, we changed that to only look for literals as the proper RHS of assignments, which then misses this particular representation of import statements.

So in this patch we extend `globalFromLiteral` to also account for literals found inside `import` statements.