### PR TITLE
[python] Correct `try-except` AST `order` Property and Structure

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -2,13 +2,14 @@ package io.joern.pysrc2cpg
 
 import io.joern.pysrc2cpg.memop.{Load, MemoryOperation, Store}
 import io.joern.pythonparser.ast
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 
 import scala.collection.immutable.{::, Nil}
 import scala.collection.mutable
 
-trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
+trait PythonAstVisitorHelpers(implicit withSchemaValidation: ValidationMode) { this: PythonAstVisitor =>
 
   protected def codeOf(node: NewNode): String = {
     node.asInstanceOf[AstNodeNew].code
@@ -50,12 +51,31 @@ trait PythonAstVisitorHelpers { this: PythonAstVisitor =>
     val controlStructureNode =
       nodeBuilder.controlStructureNode("try: ...", ControlStructureTypes.TRY, lineAndColumn)
 
-    val bodyBlockNode     = createBlock(body, lineAndColumn)
-    val handlersBlockNode = createBlock(handlers, lineAndColumn)
-    val finalBlockNode    = createBlock(finalBlock, lineAndColumn)
-    val orElseBlockNode   = createBlock(orElseBlock, lineAndColumn)
+    val bodyBlockNode      = createBlock(body, lineAndColumn).asInstanceOf[NewBlock]
+    val handlersBlockNodes = handlers.map(x => createBlock(Iterable(x), lineAndColumn).asInstanceOf[NewBlock]).toSeq
 
-    addAstChildNodes(controlStructureNode, 1, bodyBlockNode, handlersBlockNode, finalBlockNode, orElseBlockNode)
+    val finalBlockSeq  = finalBlock.toSeq
+    val orElseBlockSeq = orElseBlock.toSeq
+
+    val finalBlockAst = if (finalBlockSeq.nonEmpty && orElseBlockSeq.nonEmpty) {
+      val _blockNode      = nodeBuilder.blockNode("<empty>", lineAndColumn)
+      val finalBlockNode  = createBlock(finalBlockSeq, lineAndColumn).asInstanceOf[NewBlock]
+      val orElseBlockNode = createBlock(orElseBlockSeq, lineAndColumn).asInstanceOf[NewBlock]
+      addAstChildNodes(_blockNode, 1, finalBlockNode, orElseBlockNode)
+      Seq(_blockNode)
+    } else if (finalBlockSeq.nonEmpty) {
+      Seq(createBlock(finalBlockSeq, lineAndColumn).asInstanceOf[NewBlock])
+    } else if (orElseBlockSeq.nonEmpty) {
+      Seq(createBlock(orElseBlockSeq, lineAndColumn).asInstanceOf[NewBlock])
+    } else {
+      Seq.empty
+    }
+
+    addAstChildNodes(controlStructureNode, 1, Seq(bodyBlockNode) ++ handlersBlockNodes ++ finalBlockAst*)
+
+    bodyBlockNode.order = 1
+    handlersBlockNodes.foreach(_.order = 2)
+    finalBlockAst.foreach(_.order = 3)
 
     controlStructureNode
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -57,6 +57,7 @@ trait PythonAstVisitorHelpers(implicit withSchemaValidation: ValidationMode) { t
     val finalBlockSeq  = finalBlock.toSeq
     val orElseBlockSeq = orElseBlock.toSeq
 
+    // TODO: orElse semantics are not yet handled, so if present, we group it under the finally block
     val finalBlockAst = if (finalBlockSeq.nonEmpty && orElseBlockSeq.nonEmpty) {
       val _blockNode      = nodeBuilder.blockNode("<empty>", lineAndColumn)
       val finalBlockNode  = createBlock(finalBlockSeq, lineAndColumn).asInstanceOf[NewBlock]
@@ -73,6 +74,7 @@ trait PythonAstVisitorHelpers(implicit withSchemaValidation: ValidationMode) { t
 
     addAstChildNodes(controlStructureNode, 1, Seq(bodyBlockNode) ++ handlersBlockNodes ++ finalBlockAst*)
 
+    // Performs the same ordering operation as io.joern.x2cpg.AstCreatorBase::tryCatchAst
     bodyBlockNode.order = 1
     handlersBlockNodes.foreach(_.order = 2)
     finalBlockAst.foreach(_.order = 3)


### PR DESCRIPTION
The current AST of the try except does not keep the `except` bodies as `order=2` and pass empty block nodes for `finally` and `else` bodies if they are not there.

This change keeps the `except` bodies as `order=2` and groups the `finally` and `else` bodies under a single body, while discarding empty blocks if they are unimplemented.

Partially addresses #4578, as the node is unfortunately still dangling. This could also be because `file` is a built-in function call and is re-assigned in `a9_lab` from the initial assignment under the parent `<module>`.

One note is that setting the source to `cpg.parameter.nameExact("request").l` does not work, and it may be due to the excessive AST depth under the assignment to `file`.