### PR TITLE
[dataflowengineoss] revert DdgGenerator usage of `globalFromLiteral`

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -5,17 +5,9 @@ import io.shiftleft.semanticcpg.language.*
 
 package object dataflowengineoss {
 
-  def globalFromLiteral(lit: Literal): Iterator[Expression] = {
-    val relevantLiteral = lit.start.where(_.method.isModule).l
-
-    // Gets <x> from `<x> = <lit>`
-    val lhsOfAssignment = relevantLiteral.inCall.assignment.argument(1)
-
-    // Gets <x> from `<x> = import(...<lit>...)` because of how Python imports are represented
-    val lhsOfImport = relevantLiteral.inCall.nameExact("import").inCall.assignment.argument(1)
-
-    lhsOfAssignment ++ lhsOfImport
-  }
+  def globalFromLiteral(lit: Literal): Iterator[Expression] = lit.start.inCall.assignment
+    .where(_.method.isModule)
+    .argument(1)
 
   def identifierToFirstUsages(node: Identifier): List[Identifier] = node.refsTo.flatMap(identifiersFromCapturedScopes).l
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -1,8 +1,8 @@
 package io.joern.dataflowengineoss.passes.reachingdef
 
+import io.joern.dataflowengineoss.identifierToFirstUsages
 import io.joern.dataflowengineoss.queryengine.AccessPathUsage.toTrackedBaseAndAccessPathSimple
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.dataflowengineoss.{globalFromLiteral, identifierToFirstUsages}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators, PropertyNames}
 import io.shiftleft.semanticcpg.accesspath.MatchResult
@@ -192,7 +192,7 @@ class DdgGenerator(semantics: Semantics) {
       // See PR #3735 on Joern for details
       val globalIdentifiers =
         (method._callViaContainsOut ++ method._returnViaContainsOut).ast.isLiteral
-          .flatMap(globalFromLiteral)
+          .flatMap(_.start.where(_.method.isMethod).inAssignment.argument(1))
           .collectAll[Identifier]
           .l
       globalIdentifiers

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -28,9 +28,9 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |x = foo(20)
         |print(x)
         |""".stripMargin)
-    val source     = cpg.literal("20")
-    val sink       = cpg.call("print").argument
-    val List(flow) = sink.reachableByFlows(source).map(flowToResultPairs).distinct.sortBy(_.length).l
+    def source     = cpg.literal("20")
+    def sink       = cpg.call("print").argument
+    val List(flow) = sink.reachableByFlows(source).map(flowToResultPairs).l
     flow shouldBe List(("foo(20)", 2), ("x = foo(20)", 2), ("print(x)", 3))
   }
 
@@ -298,6 +298,70 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     sinks.reachableByFlows(sources).size should not be 0
   }
 
+  "flow from expression that taints global variable to specifically-imported sink" in {
+    val cpg = code("""
+        |from foo import bar
+        |d = {
+        | 'x': F.sum('x'),
+        | 'y': F.sum('y'),
+        | 'z': F.sum('z'),
+        |}
+        |
+        |class Foo():
+        |   def foo(self):
+        |       return bar(d)
+        |""".stripMargin)
+    val sources    = cpg.call("<operator>.indexAccess").argument.isIdentifier.l
+    val sinks      = cpg.call("bar").l
+    val List(flow) = sinks.reachableByFlows(sources).map(flowToResultPairs).l
+    flow shouldBe List(
+      ("tmp0['z'] = F.sum('z')", 3),
+      ("tmp0['x'] = F.sum('x')", 3),
+      ("tmp0", 3),
+      (
+        """d = tmp0 = {}
+      |tmp0['x'] = F.sum('x')
+      |tmp0['y'] = F.sum('y')
+      |tmp0['z'] = F.sum('z')
+      |tmp0""".stripMargin,
+        3
+      ),
+      ("bar(d)", 11)
+    )
+  }
+
+  "flow from expression that taints global variable to imported member sink" in {
+    val cpg = code("""
+        |import bar
+        |d = {
+        | 'x': F.sum('x'),
+        | 'y': F.sum('y'),
+        | 'z': F.sum('z'),
+        |}
+        |
+        |class Foo():
+        |   def foo(self):
+        |       return bar.baz(d)
+        |""".stripMargin)
+    val sources    = cpg.call("<operator>.indexAccess").argument.isIdentifier.l
+    val sinks      = cpg.call("baz").l
+    val List(flow) = sinks.reachableByFlows(sources).map(flowToResultPairs).l
+    flow shouldBe List(
+      ("tmp0['z'] = F.sum('z')", 3),
+      ("tmp0['x'] = F.sum('x')", 3),
+      ("tmp0", 3),
+      (
+        """d = tmp0 = {}
+          |tmp0['x'] = F.sum('x')
+          |tmp0['y'] = F.sum('y')
+          |tmp0['z'] = F.sum('z')
+          |tmp0""".stripMargin,
+        3
+      ),
+      ("bar.baz(d)", 11)
+    )
+  }
+
   "lookup of __init__ call" in {
     val cpg = code("""
         |from models import Foo
@@ -336,6 +400,64 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     method.fullName shouldBe "models.py:<module>.Foo.__init__"
     val List(typeDeclFullName) = method.typeDecl.fullName.l
     typeDeclFullName shouldBe "models.py:<module>.Foo"
+  }
+
+  "flow from literal used in external call to dictionary value" in {
+    val cpg = code("""
+        |x = foo("X")
+        |bar = {"x": x}
+        |""".stripMargin)
+
+    def sink       = cpg.identifier("x").lineNumber(3)
+    def source     = cpg.literal("\"X\"")
+    val List(flow) = sink.reachableByFlows(source).map(flowToResultPairs).l
+    flow shouldBe List(("foo(\"X\")", 2), ("x = foo(\"X\")", 2), ("tmp0[\"x\"] = x", 3))
+  }
+
+  "flow from literal used in external call to dictionary value inside a method" in {
+    val cpg = code("""
+        |x = foo("X")
+        |def run():
+        |  print({"x": x})
+        |""".stripMargin)
+
+    def sink       = cpg.identifier("x").lineNumber(4)
+    def source     = cpg.literal("\"X\"")
+    val List(flow) = sink.reachableByFlows(source).map(flowToResultPairs).l
+    flow shouldBe List(("foo(\"X\")", 2), ("x = foo(\"X\")", 2), ("tmp0[\"x\"] = x", 4))
+  }
+
+  "flow from literal used in external call to dictionary value inside a try catch inside of a method" in {
+    val cpg = code("""
+        |x = foo("X")
+        |def run():
+        |  try:
+        |    bar = {"x": x}
+        |    print(bar)
+        |  except Exception as e:
+        |    print(e)
+        |""".stripMargin)
+
+    def sink       = cpg.identifier("x").lineNumber(5)
+    def source     = cpg.literal("\"X\"")
+    val List(flow) = sink.reachableByFlows(source).map(flowToResultPairs).l
+    flow shouldBe List(("foo(\"X\")", 2), ("x = foo(\"X\")", 2), ("tmp0[\"x\"] = x", 5))
+  }
+
+  "flow from literal used in imported member call to dictionary value used as keyword argument to another imported member" in {
+    val cpg = code("""
+        |import a
+        |import b
+        |x = a.run("X")
+        |def run():
+        |  y = b.run(Params={"x": x})
+        |  print(y)
+        |""".stripMargin)
+
+    def sink       = cpg.identifier("x").lineNumber(6)
+    def source     = cpg.literal("\"X\"")
+    val List(flow) = sink.reachableByFlows(source).map(flowToResultPairs).l
+    flow shouldBe List(("a.run(\"X\")", 4), ("x = a.run(\"X\")", 4), ("tmp0[\"x\"] = x", 6))
   }
 
   "flow from global variable defined in imported file and used as argument to `print`" in {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -302,31 +302,27 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     val cpg = code("""
         |from foo import bar
         |d = {
-        | 'x': F.sum('x'),
-        | 'y': F.sum('y'),
-        | 'z': F.sum('z'),
+        | 'x': 123
         |}
         |
         |class Foo():
         |   def foo(self):
         |       return bar(d)
         |""".stripMargin)
-    val sources    = cpg.call("<operator>.indexAccess").argument.isIdentifier.l
+    val sources    = cpg.literal("123").l
     val sinks      = cpg.call("bar").l
     val List(flow) = sinks.reachableByFlows(sources).map(flowToResultPairs).l
     flow shouldBe List(
-      ("tmp0['z'] = F.sum('z')", 3),
-      ("tmp0['x'] = F.sum('x')", 3),
+      ("tmp0['x'] = 123", 4),
+      ("tmp0['x'] = 123", 3),
       ("tmp0", 3),
       (
         """d = tmp0 = {}
-      |tmp0['x'] = F.sum('x')
-      |tmp0['y'] = F.sum('y')
-      |tmp0['z'] = F.sum('z')
+      |tmp0['x'] = 123
       |tmp0""".stripMargin,
         3
       ),
-      ("bar(d)", 11)
+      ("bar(d)", 9)
     )
   }
 
@@ -334,31 +330,27 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     val cpg = code("""
         |import bar
         |d = {
-        | 'x': F.sum('x'),
-        | 'y': F.sum('y'),
-        | 'z': F.sum('z'),
+        | 'x': 123,
         |}
         |
         |class Foo():
         |   def foo(self):
         |       return bar.baz(d)
         |""".stripMargin)
-    val sources    = cpg.call("<operator>.indexAccess").argument.isIdentifier.l
+    val sources    = cpg.literal("123").l
     val sinks      = cpg.call("baz").l
     val List(flow) = sinks.reachableByFlows(sources).map(flowToResultPairs).l
     flow shouldBe List(
-      ("tmp0['z'] = F.sum('z')", 3),
-      ("tmp0['x'] = F.sum('x')", 3),
+      ("tmp0['x'] = 123", 4),
+      ("tmp0['x'] = 123", 3),
       ("tmp0", 3),
       (
         """d = tmp0 = {}
-          |tmp0['x'] = F.sum('x')
-          |tmp0['y'] = F.sum('y')
-          |tmp0['z'] = F.sum('z')
+          |tmp0['x'] = 123
           |tmp0""".stripMargin,
         3
       ),
-      ("bar.baz(d)", 11)
+      ("bar.baz(d)", 9)
     )
   }
 


### PR DESCRIPTION
Follow up on #4576:
* Reverts `globalFromLiteral` to the implementation that fixed #4549
* Makes `DdgGenerator` use the original (before 4549) `globalFromLiteral` implementation, inlined.

The issue in 4549 is that `globalFromLiteral` was being overly inclusive when computing the starting points for `reachableBy`. Having fixed that, we noticed missing flows afterward. The trouble is that `globalFromLiteral` is also being used by `DdgGenerator`. So, a quick fix is to have `DdgGenerator` use the original `globalFromLiteral` while keeping `reachableBy` use the updated version.