### PR TITLE
[ruby] Grouped `facter` Bug Fixes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -178,7 +178,7 @@ object RubySrc2Cpg {
         ignoredFilesPath = Option(config.ignoredFiles)
       )
       .map { fileName => () =>
-        resourceManagedParser.parse(fileName) match {
+        resourceManagedParser.parse(File(config.inputPath), fileName) match {
           case Failure(exception) => throw exception
           case Success(ctx)       => new AstCreator(fileName, ctx, projectRoot)(config.schemaValidation)
         }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -131,8 +131,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       "|"   -> Operators.or,
       "^"   -> Operators.xor,
       "<<"  -> Operators.shiftLeft,
-      ">>"  -> Operators.logicalShiftRight,
-      "=~"  -> RubyOperators.regexpMatch
+      ">>"  -> Operators.logicalShiftRight
     )
 
   protected val AssignmentOperatorNames: Map[String, String] = Map(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -268,8 +268,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         astsForStatement(transform(expr))
       case node: MemberCallWithBlock => returnAstForRubyCall(node)
       case node: SimpleCallWithBlock => returnAstForRubyCall(node)
-      case _: (LiteralExpr | BinaryExpression | UnaryExpression | SimpleIdentifier | IndexAccess | Association |
-            YieldExpr | RubyCall | RubyFieldIdentifier) =>
+      case _: (LiteralExpr | BinaryExpression | UnaryExpression | SimpleIdentifier | SelfIdentifier | IndexAccess |
+            Association | YieldExpr | RubyCall | RubyFieldIdentifier | HereDocNode | Unknown) =>
         astForReturnStatement(ReturnExpression(List(node))(node.span)) :: Nil
       case node: SingleAssignment =>
         astForSingleAssignment(node) :: List(astForReturnStatement(ReturnExpression(List(node.lhs))(node.span)))
@@ -282,7 +282,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case ret: ReturnExpression => astForReturnStatement(ret) :: Nil
       case node: MethodDeclaration =>
         (astForMethodDeclaration(node) :+ astForReturnMethodDeclarationSymbolName(node)).toList
-
+      case _: BreakStatement => astsForStatement(node).toList
       case node =>
         logger.warn(
           s"Implicit return here not supported yet: ${node.text} (${node.getClass.getSimpleName}), only generating statement"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -93,6 +93,13 @@ object AntlrContextHelpers {
   sealed implicit class RegularExpressionLiteralContextHelper(ctx: RegularExpressionLiteralContext) {
     def isStatic: Boolean  = !isDynamic
     def isDynamic: Boolean = ctx.regexpLiteralContent.asScala.exists(c => Option(c.compoundStatement()).isDefined)
+
+    def interpolations: List[ParserRuleContext] = ctx
+      .regexpLiteralContent()
+      .asScala
+      .filter(ctx => Option(ctx.compoundStatement()).isDefined)
+      .map(ctx => ctx.compoundStatement())
+      .toList
   }
 
   sealed implicit class CurlyBracesBlockContextHelper(ctx: CurlyBracesBlockContext) {
@@ -104,12 +111,11 @@ object AntlrContextHelpers {
   }
 
   sealed implicit class CommandArgumentContextHelper(ctx: CommandArgumentContext) {
-    def arguments: List[ParserRuleContext] = ctx match
+    def arguments: List[ParserRuleContext] = ctx match {
       case ctx: CommandCommandArgumentListContext         => ctx.command() :: Nil
       case ctx: CommandArgumentCommandArgumentListContext => ctx.commandArgumentList().elements
-      case ctx =>
-        logger.warn(s"Unsupported argument type ${ctx.getClass}")
-        List()
+      case ctx                                            => Nil
+    }
   }
 
   sealed implicit class CommandArgumentListContextHelper(ctx: CommandArgumentListContext) {
@@ -164,7 +170,7 @@ object AntlrContextHelpers {
       case ctx: SplattingArgumentIndexingArgumentListContext => ctx.splattingArgument() :: Nil
       case ctx: OperatorExpressionListWithSplattingArgumentIndexingArgumentListContext => ctx.splattingArgument() :: Nil
       case ctx =>
-        logger.warn(s"Unsupported argument type ${ctx.getClass}")
+        logger.warn(s"IndexingArgumentListContextHelper - Unsupported argument type ${ctx.getClass}")
         List()
   }
 
@@ -173,7 +179,7 @@ object AntlrContextHelpers {
       case _: EmptyArgumentWithParenthesesContext          => List()
       case ctx: ArgumentListArgumentWithParenthesesContext => ctx.argumentList().elements
       case ctx =>
-        logger.warn(s"Unsupported argument type ${ctx.getClass}")
+        logger.warn(s"ArgumentWithParenthesesContextHelper - Unsupported argument type ${ctx.getClass}")
         List()
   }
 
@@ -189,8 +195,10 @@ object AntlrContextHelpers {
         Option(ctx.associationList()).map(_.associations).getOrElse(List.empty)
       case ctx: SplattingArgumentArgumentListContext =>
         Option(ctx.splattingArgument()).toList
+      case ctx: BlockArgumentArgumentListContext =>
+        Option(ctx.blockArgument()).toList
       case ctx =>
-        logger.warn(s"Unsupported element type ${ctx.getClass.getSimpleName}")
+        logger.warn(s"ArgumentListContextHelper - Unsupported element type ${ctx.getClass.getSimpleName}")
         List()
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -354,8 +354,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     if (ctx.isStatic) {
       StaticLiteral(getBuiltInType(Defines.Regexp))(ctx.toTextSpan)
     } else {
-      logger.warn(s"Unhandled regular expression literal '${ctx.toTextSpan}'")
-      Unknown()(ctx.toTextSpan)
+      DynamicLiteral(getBuiltInType(Defines.Regexp), ctx.interpolations.map(visit))(ctx.toTextSpan)
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -37,5 +37,6 @@ object Defines {
     val association     = "<operator>.association"
     val splat           = "<operator>.splat"
     val regexpMatch     = "=~"
+    val regexpNotMatch  = "!~"
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.*
 
 class LiteralTests extends RubyCode2CpgFixture {
@@ -221,4 +222,28 @@ class LiteralTests extends RubyCode2CpgFixture {
     literal.lineNumber shouldBe Some(2)
     literal.typeFullName shouldBe "__builtin.Regexp"
   }
+
+  "`/#{os_version_regex}/` is represented by a CALL node with a string format method full name" in {
+    val cpg = code("""
+        |os_version_regex = "1.2.0"
+        |/#{os_version_regex}/
+        |""".stripMargin)
+
+    val List(formatValueCall) = cpg.call.code("/#.*").l
+    formatValueCall.code shouldBe "/#{os_version_regex}/"
+    formatValueCall.lineNumber shouldBe Some(3)
+    formatValueCall.typeFullName shouldBe "__builtin.Regexp"
+    formatValueCall.methodFullName shouldBe Operators.formatString
+  }
+
+  "regex values in a hash literal" ignore {
+    val cpg = code("""
+        |PLATFORM_PATTERNS = {
+        | :redhat        => /fedora|el-|centos/
+        |}
+        |""".stripMargin)
+
+    cpg.method(":program").dotAst.foreach(println)
+  }
+
 }


### PR DESCRIPTION
The [`facter`](https://github.com/puppetlabs/facter) repository causes this frontend to throw a lot of warnings. This PR fixes much of the low-hanging fruit, and improves the warning techniques to help make the warnings more meaningful. There are still, however, quite a few syntax errors to handle from this repository.

* Handles regexes generated from string formating.
* Handled the `!~` regex not match function. Long term any unrecognized functions are interpreted as calls.
* Added more cases for implicit returns