### PR TITLE
[ruby] add missing token used to decide regex start

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RegexLiteralHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RegexLiteralHandling.scala
@@ -38,6 +38,7 @@ trait RegexLiteralHandling { this: RubyLexerBase =>
     EQ3,
     CARET,
     LTEQGT,
+    EQGT,
     EQTILDE,
     GT,
     GTEQ,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -34,6 +34,51 @@ class HashTests extends RubyCode2CpgFixture {
     one.code shouldBe "1"
   }
 
+  "`{:x => 1}` is represented by a `hashInitializer` operator call" in {
+    val cpg = code("""
+        |{:x => 1}
+        |""".stripMargin)
+
+    val List(hashCall) = cpg.call.name(RubyOperators.hashInitializer).l
+    hashCall.code shouldBe "{:x => 1}"
+    hashCall.lineNumber shouldBe Some(2)
+
+    val List(assocCall) = hashCall.inCall.astSiblings.assignment.l
+    val List(x, one)    = assocCall.argument.l
+    x.code shouldBe "<tmp-0>[:x]"
+    one.code shouldBe "1"
+  }
+
+  "`{:x => /(eu|us)/}` is represented by a `hashInitializer` operator call" in {
+    val cpg = code("""
+        |{:x => /(eu|us)/}
+        |""".stripMargin)
+
+    val List(hashCall) = cpg.call.name(RubyOperators.hashInitializer).l
+    hashCall.code shouldBe "{:x => /(eu|us)/}"
+    hashCall.lineNumber shouldBe Some(2)
+
+    val List(assocCall) = hashCall.inCall.astSiblings.assignment.l
+    val List(x, regexp) = assocCall.argument.l
+    x.code shouldBe "<tmp-0>[:x]"
+    regexp.code shouldBe "/(eu|us)/"
+  }
+
+  "`{:x : /(eu|us)/}` is represented by a `hashInitializer` operator call" in {
+    val cpg = code("""
+        |{:x : /(eu|us)/}
+        |""".stripMargin)
+
+    val List(hashCall) = cpg.call.name(RubyOperators.hashInitializer).l
+    hashCall.code shouldBe "{:x : /(eu|us)/}"
+    hashCall.lineNumber shouldBe Some(2)
+
+    val List(assocCall) = hashCall.inCall.astSiblings.assignment.l
+    val List(x, regexp) = assocCall.argument.l
+    x.code shouldBe "<tmp-0>[:x]"
+    regexp.code shouldBe "/(eu|us)/"
+  }
+
   "Inclusive Range of primitive ordinal type should expand in hash key" in {
     val cpg = code("""
         |{1..3:"abc", 4..5:"ade"}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -221,4 +221,15 @@ class LiteralTests extends RubyCode2CpgFixture {
     literal.lineNumber shouldBe Some(2)
     literal.typeFullName shouldBe "__builtin.Regexp"
   }
+
+  "`/fedora|el-|centos/` is represented by a LITERAL node" in {
+    val cpg = code("""
+        |/fedora|el-|centos/
+        |""".stripMargin)
+
+    val List(literal) = cpg.literal.l
+    literal.code shouldBe "/fedora|el-|centos/"
+    literal.lineNumber shouldBe Some(2)
+    literal.typeFullName shouldBe "__builtin.Regexp"
+  }
 }


### PR DESCRIPTION
The lexer predicate that decides when a `/.../` regex literal is about to start looks at the previous token to decide... and it was missing the `=>` token 🤦 

Credit for finding: @DavidBakerEffendi 