### PR TITLE
[php] fallback to default for range exceptions

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/DependencyDownloader.scala
@@ -51,8 +51,13 @@ class DependencyDownloader(cpg: Cpg, config: Config) {
     Thread.sleep(100) // throttling
 
     val dependencyName = dependency.name.strip()
-    // adjust version for exceptional cases like "abc/def/ghi"
-    val dependencyRange = if dependency.version.contains("/") then Range(">=0.0.0") else Range(dependency.version)
+    // Fall back for exceptional cases like "abc/def/ghi" or "abc-def#8def05" etc.
+    val dependencyRange =
+      try {
+        Range(dependency.version)
+      } catch {
+        case _: Throwable => Range(">=0.0.0")
+      }
 
     def getCompatiblePackage(vendor: String, pack: String): Option[Package] = Try {
       Using.resource(URI(s"https://$PACKAGIST_API/$vendor/$pack.json").toURL.openStream()) { is =>

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpDownloadDependenciesTest.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpDownloadDependenciesTest.scala
@@ -94,7 +94,8 @@ class PhpDownloadDependenciesTest extends PhpCode2CpgFixture() {
       """
         |{
         |    "require": {
-        |        "doctrine/cache": "abc/XY-1234/def"
+        |        "doctrine/cache": "abc/XY-1234/def",
+        |        "doctrine/orm": "dev-main#8adb"
         |    }
         |}
         |""".stripMargin,
@@ -103,6 +104,7 @@ class PhpDownloadDependenciesTest extends PhpCode2CpgFixture() {
 
     "resolve and still get all namespaces" in {
       cpg.typ.fullName.count(_.startsWith("Doctrine\\Common\\Cache\\")) should be > 0
+      cpg.typ.fullName.count(_.startsWith("Doctrine\\ORM\\")) should be > 0
     }
 
   }


### PR DESCRIPTION
We are finding a few more challenging cases and weird versions in real code. To avoid failing the scans with an exception, I've added a blanket version to try downloading default dependency