### PR TITLE
[ruby] Grouped `logger` bug fixes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -506,6 +506,7 @@ definedMethodName
     |   EQ2
     |   EQ3
     |   LTEQGT
+    |   LT2
     ;
 
 methodParameterPart

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RegexLiteralHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RegexLiteralHandling.scala
@@ -69,10 +69,17 @@ trait RegexLiteralHandling { this: RubyLexerBase =>
     * may not start with a WS. E.g. `puts /x/` is valid, but `puts / x/` is not.
     */
   private def isInCommandArgumentPosition: Boolean = {
-    val previousNonWsIsIdentifier = previousNonWsTokenTypeOrEOF() == LOCAL_VARIABLE_IDENTIFIER
-    val previousIsWs              = previousTokenTypeOrEOF() == WS
-    val nextCharIsWs              = _input.LA(1) == ' '
+    val previousNonWsIsIdentifier =
+      previousNonWsTokenTypeOrEOF() == LOCAL_VARIABLE_IDENTIFIER || isControlStructureStart
+    val previousIsWs = previousTokenTypeOrEOF() == WS
+    val nextCharIsWs = _input.LA(1) == ' '
     previousNonWsIsIdentifier && previousIsWs && !nextCharIsWs
   }
 
+  private def isControlStructureStart: Boolean = {
+    previousNonWsTokenTypeOrEOF() == IF || previousNonWsTokenTypeOrEOF() == UNLESS
+    || previousNonWsTokenTypeOrEOF() == UNTIL || previousNonWsTokenTypeOrEOF() == YIELD
+    || previousNonWsTokenTypeOrEOF() == BEGIN || previousNonWsTokenTypeOrEOF() == CASE
+    || previousNonWsTokenTypeOrEOF() == WHILE || previousNonWsTokenTypeOrEOF() == FOR
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RegexLiteralHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RegexLiteralHandling.scala
@@ -78,10 +78,8 @@ trait RegexLiteralHandling { this: RubyLexerBase =>
 
   private def isControlStructureStart: Boolean = {
     previousNonWsTokenTypeOrEOF() == IF
-    // TODO: Determine which of the below control structures are also valid for regex use
-//      || previousNonWsTokenTypeOrEOF() == UNLESS
-//      || previousNonWsTokenTypeOrEOF() == UNTIL || previousNonWsTokenTypeOrEOF() == YIELD
-//      || previousNonWsTokenTypeOrEOF() == BEGIN || previousNonWsTokenTypeOrEOF() == CASE
-//      || previousNonWsTokenTypeOrEOF() == WHILE || previousNonWsTokenTypeOrEOF() == FOR
+    || previousNonWsTokenTypeOrEOF() == UNLESS
+    || previousNonWsTokenTypeOrEOF() == UNTIL || previousNonWsTokenTypeOrEOF() == YIELD
+    || previousNonWsTokenTypeOrEOF() == WHILE
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RegexLiteralHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RegexLiteralHandling.scala
@@ -77,9 +77,11 @@ trait RegexLiteralHandling { this: RubyLexerBase =>
   }
 
   private def isControlStructureStart: Boolean = {
-    previousNonWsTokenTypeOrEOF() == IF || previousNonWsTokenTypeOrEOF() == UNLESS
-    || previousNonWsTokenTypeOrEOF() == UNTIL || previousNonWsTokenTypeOrEOF() == YIELD
-    || previousNonWsTokenTypeOrEOF() == BEGIN || previousNonWsTokenTypeOrEOF() == CASE
-    || previousNonWsTokenTypeOrEOF() == WHILE || previousNonWsTokenTypeOrEOF() == FOR
+    previousNonWsTokenTypeOrEOF() == IF
+    // TODO: Determine which of the below control structures are also valid for regex use
+//      || previousNonWsTokenTypeOrEOF() == UNLESS
+//      || previousNonWsTokenTypeOrEOF() == UNTIL || previousNonWsTokenTypeOrEOF() == YIELD
+//      || previousNonWsTokenTypeOrEOF() == BEGIN || previousNonWsTokenTypeOrEOF() == CASE
+//      || previousNonWsTokenTypeOrEOF() == WHILE || previousNonWsTokenTypeOrEOF() == FOR
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -128,8 +128,16 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
         val condition = visit(ctx.expressionOrCommand())
         val body      = visit(ctx.statement())
         DoWhileExpression(condition, body)(ctx.toTextSpan)
+      case "rescue" =>
+        val body       = visit(ctx.statement())
+        val thenClause = visit(ctx.expressionOrCommand())
+        val rescueClause =
+          RescueClause(Option.empty, Option.empty, thenClause)(ctx.toTextSpan)
+        val rescExp =
+          RescueExpression(body, List(rescueClause), Option.empty, Option.empty)(ctx.toTextSpan)
+        rescExp
       case _ =>
-        logger.warn(s"Unhandled modifier statement ${ctx.getClass}")
+        logger.warn(s"Unhandled modifier statement ${ctx.getClass} ${ctx.toTextSpan} ")
         Unknown()(ctx.toTextSpan)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -298,6 +298,17 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     putsHi.lineNumber shouldBe Some(2)
   }
 
+  "rescue nil is represented by a TRY CONTROL_STRUCTURE node" in {
+    val cpg = code("""
+                     |def test1
+                     |  @dev.close rescue nil
+                     |end
+                     |""".stripMargin)
+    val List(rescueNode) = cpg.method("test1").tryBlock.l
+    rescueNode.controlStructureType shouldBe ControlStructureTypes.TRY
+    val List(body, rescueBody, implicitReturnBody) = rescueNode.astChildren.l
+  }
+
   "`begin ... rescue ... end is represented by a `TRY` CONTROL_STRUCTURE node" in {
     val cpg = code("""
         |def test1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
@@ -129,6 +129,25 @@ class DownloadDependencyTest extends RubyCode2CpgFixture(downloadDependencies = 
     }
   }
 
+  "parsing logger repo" should {
+    val cpg = code(
+      """
+        |require "logger"
+        |""".stripMargin,
+      "main.rb"
+    )
+      .moreCode(
+        """
+          |source 'https://rubygems.org'
+          |gem 'logger'
+          |
+          |""".stripMargin,
+        "Gemfile"
+      )
+
+    "Not throw any exceptions" in {}
+  }
+
 }
 
 object DependencyTests {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -3,8 +3,10 @@ package io.joern.rubysrc2cpg.querying
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.*
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+
 import scala.reflect.ClassTag
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
+import io.shiftleft.codepropertygraph.generated.nodes.Literal
 
 class RegexTests extends RubyCode2CpgFixture {
   "`'x' =~ y` is a member call `'x'.=~ /y/" in {
@@ -18,5 +20,30 @@ class RegexTests extends RubyCode2CpgFixture {
        |0
        |""".stripMargin)
     cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(s"__builtin.Regexp:${RubyOperators.regexpMatch}")
+  }
+
+  "Regex expression in if statements" in {
+    val cpg = code("""
+        |
+        |if /mswin|mingw|cygwin/ =~ "mswin"
+        |end
+        |""".stripMargin)
+
+    inside(cpg.controlStructure.isIf.l) {
+      case regexIf :: Nil =>
+        regexIf.condition.isCall.methodFullName.l shouldBe List(s"__builtin.Regexp:${RubyOperators.regexpMatch}")
+
+        inside(regexIf.condition.isCall.argument.l) {
+          case (lhs: Literal) :: (rhs: Literal) :: Nil =>
+            lhs.code shouldBe "/mswin|mingw|cygwin/"
+            lhs.typeFullName shouldBe "__builtin.Regexp"
+
+            rhs.code shouldBe "\"mswin\""
+            rhs.typeFullName shouldBe "__builtin.String"
+          case xs => fail(s"Expected two arguments, got [${xs.code.mkString(",")}]")
+        }
+
+      case xs => fail(s"One if statement expected, got [${xs.code.mkString(",")}]")
+    }
   }
 }


### PR DESCRIPTION
The [logger](https://github.com/ruby/logger) repository causes this frontend to throw a lot of warnings. This PR fixes these warnings

* Handles regexs used in conditions of IF statements
* Added `<<` as a valid `definedMethodName`
* Added handling of `rescue` as a modifier statement seen in the logger repo with `@dev.close rescue nil`