### PR TITLE
[pysrc2cpg] Use ControlStructureTypes for Try-Catch-Clauses

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/TryCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/TryCpgTests.scala
@@ -1,0 +1,40 @@
+package io.joern.pysrc2cpg.cpg
+
+import io.joern.pysrc2cpg.Py2CpgTestContext
+import io.shiftleft.semanticcpg.language.*
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class TryCpgTests extends AnyFreeSpec with Matchers {
+  private val cpg = Py2CpgTestContext.buildCpg("""
+      |def divide(x, y):
+      |  try:
+      |    result = x / y
+      |  except ZeroDivisionError:
+      |    print("division by zero!")
+      |  except OtherError:
+      |    print("other error")
+      |  else:
+      |    print("result is", result)
+      |  finally:
+      |    print("executing finally clause")
+      |""".stripMargin)
+
+  "test try node properties" in {
+    val List(tryNode)      = cpg.tryBlock.l
+    val List(tryBlock)     = tryNode.astChildren.order(1).l
+    val List(tryBlockCall) = tryBlock.astChildren.isCall.l
+    tryBlockCall.code shouldBe "result = x / y"
+    val List(catchA, catchB) = tryNode.astChildren.isControlStructure.isCatch.l
+    catchA.order shouldBe 2
+    catchA.ast.isCall.code.l shouldBe List("""print("division by zero!")""")
+    catchB.order shouldBe 3
+    catchB.ast.isCall.code.l shouldBe List("""print("other error")""")
+    val List(elseBlock) = tryNode.astChildren.isControlStructure.isElse.l
+    elseBlock.order shouldBe 4
+    elseBlock.ast.isCall.code.l shouldBe List("""print("result is", result)""")
+    val List(finallyBlock) = tryNode.astChildren.isControlStructure.isFinally.l
+    finallyBlock.order shouldBe 5
+    finallyBlock.ast.isCall.code.l shouldBe List("""print("executing finally clause")""")
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -497,7 +497,8 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
 
     val tryBodyCfg: Cfg = maybeTryBlock.map(cfgFor).getOrElse(Cfg.empty)
 
-    val catchControlStructures = node.astChildren.isControlStructure.isCatch.toList
+    val catchControlStructures =
+      (node.astChildren.isControlStructure.isCatch ++ node.astChildren.isControlStructure.isElse).toList
     val catchBodyCfgs = if (catchControlStructures.isEmpty) {
       node.astChildren.order(2).toList match {
         case Nil  => List(Cfg.empty)


### PR DESCRIPTION
Uses `ControlStructureTypes.CATCH`, `ControlStructureTypes.FINALLY`, and `ControlStructureTypes.ELSE` now instead of relying on explicit order values.

Will do the same for all the other Joern frontends in individual PRs.