### PR TITLE
[ruby] Method Bindings & Constructor Modifier

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -65,7 +65,7 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
       val typeFullName     = s"$parentScope.${t.name}"
       val childrenTypes    = t.astChildren.collectAll[TypeDecl].l
       val typesOnThisLevel = childrenTypes.flatMap(handleNestedTypes(_, typeFullName))
-      Seq(typeFullName -> childrenTypes.map(toType).toSet) ++ typesOnThisLevel
+      Seq(typeFullName -> childrenTypes.whereNot(_.methodBinding).map(toType).toSet) ++ typesOnThisLevel
     }
 
     val mappings =
@@ -89,7 +89,7 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
             val childrenTypes = m.block.astChildren.collectAll[TypeDecl].l
             val fullName      = s"${namespace.fullName}:${m.name}"
             val nestedTypes   = childrenTypes.flatMap(handleNestedTypes(_, fullName))
-            (path, fullName) -> (childrenTypes.map(toType).toSet ++ nestedTypes.flatMap(_._2))
+            (path, fullName) -> (childrenTypes.whereNot(_.methodBinding).map(toType).toSet ++ nestedTypes.flatMap(_._2))
         }.toSeq
 
         moduleEntry +: typeEntries

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -32,7 +32,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
             case xs => fail(s"Expected a two method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
-          inside(program.block.astChildren.collectAll[TypeDecl].l) {
+          inside(program.block.astChildren.collectAll[TypeDecl].isLambda.l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
               closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -3,28 +3,40 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, MethodRef, Return, TypeRef}
 import io.shiftleft.semanticcpg.language.*
 
 class MethodTests extends RubyCode2CpgFixture {
 
-  "`def f(x) = 1` is represented by a METHOD node" in {
+  "`def f(x) = 1`" should {
     val cpg = code("""
-                     |def f(x) = 1
-                     |""".stripMargin)
+        |def f(x) = 1
+        |""".stripMargin)
 
-    val List(f) = cpg.method.name("f").l
+    "be represented by a METHOD node" in {
+      val List(f) = cpg.method.name("f").l
 
-    f.fullName shouldBe "Test0.rb:<global>::program:f"
-    f.isExternal shouldBe false
-    f.lineNumber shouldBe Some(2)
-    f.numberOfLines shouldBe 1
+      f.fullName shouldBe "Test0.rb:<global>::program:f"
+      f.isExternal shouldBe false
+      f.lineNumber shouldBe Some(2)
+      f.numberOfLines shouldBe 1
 
-    val List(x) = f.parameter.name("x").l
-    x.index shouldBe 1
-    x.isVariadic shouldBe false
-    x.lineNumber shouldBe Some(2)
+      val List(x) = f.parameter.name("x").l
+      x.index shouldBe 1
+      x.isVariadic shouldBe false
+      x.lineNumber shouldBe Some(2)
+    }
+
+    "have a corresponding bound type" in {
+      val List(fType) = cpg.typeDecl("f").l
+      fType.fullName shouldBe "Test0.rb:<global>::program:f"
+      fType.code shouldBe "def f(x) = 1"
+      fType.astParentFullName shouldBe "Test0.rb:<global>::program:f"
+      fType.astParentType shouldBe NodeTypes.METHOD
+      val List(fMethod) = fType.iterator.boundMethod.l
+      fType.fullName shouldBe "Test0.rb:<global>::program:f"
+    }
   }
 
   "`def f ... return 1 ... end` is represented by a METHOD node" in {


### PR DESCRIPTION
Methods require binding/ref edges with their corresponding type declaration in dynamic languages to correctly model their object-like behaviour. This PR implements these bindings following `pysrc2cpg`'s `createBinding` function.

Additionally, adds the `CONSTRUCTOR` modifier to constructors.

Resolves #4593