### PR TITLE
[csharpsrc2cpg] Use ControlStructureTypes for Try-Catch-Clauses

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ControlStructureTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ControlStructureTests.scala
@@ -3,8 +3,11 @@ package io.joern.csharpsrc2cpg.querying.ast
 import io.joern.csharpsrc2cpg.CSharpOperators
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, JumpTarget, Local}
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes}
+import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.nodes.Block
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.nodes.JumpTarget
 import io.shiftleft.semanticcpg.language.*
 
 class ControlStructureTests extends CSharpCode2CpgFixture {
@@ -51,58 +54,19 @@ class ControlStructureTests extends CSharpCode2CpgFixture {
         |}
         |""".stripMargin))
 
-    val tryBlocks = cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.TRY).astChildren.isBlock.l
+    val tryElements = cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.TRY).astChildren.l
 
-    "generate a try control structure with three children blocks" in {
-      inside(tryBlocks) {
-        case t :: c :: f :: Nil =>
-          t.code shouldBe "try"
-          c.code shouldBe "catch (Exception e)"
-          f.code shouldBe "finally"
-        case _ => fail("Invalid number of children under the `try` control structure!")
-      }
+    "generate a try control structure with three children correctly" in {
+      val List(tryBlock) = tryElements.isBlock.l
+      tryBlock.astChildren.isCall.code.l shouldBe List("""Console.WriteLine("Hello")""")
+      val List(catchBlock) = tryElements.isControlStructure.isCatch.astChildren.l
+      catchBlock.astChildren.isCall.code.l shouldBe List("""Console.WriteLine("Uh, oh!")""")
+      val List(finallyBlock) = tryElements.isControlStructure.isFinally.astChildren.l
+      finallyBlock.astChildren.isCall.code.l shouldBe List("""Busy = false""")
     }
-
-    "generate a try-block with the correct console call" in {
-      inside(tryBlocks.headOption) {
-        case Some(ctl) =>
-          inside(ctl.astChildren.isCall.l) {
-            case consoleCall :: Nil =>
-              consoleCall.code shouldBe "Console.WriteLine(\"Hello\")"
-            case _ => fail("No call node found!")
-          }
-        case None => fail("No `try` block found!")
-      }
-    }
-
-    "generate a catch-block with a child block containing the correct console call" in {
-      inside(Option(tryBlocks(1))) {
-        case Some(catchBlock: Block) =>
-          inside(catchBlock.astChildren.l) {
-            case (excepDecl: Local) :: (consoleCall: Call) :: Nil =>
-              excepDecl.name shouldBe "e"
-              consoleCall.code shouldBe "Console.WriteLine(\"Uh, oh!\")"
-            case _ => fail("Invalid `catch` block children!")
-          }
-        case None => fail("No `catch` block found!")
-      }
-    }
-
-    "generate a finally-block with an assignment of `Busy = false`" in {
-      inside(tryBlocks.lastOption) {
-        case Some(ctl) =>
-          inside(ctl.astChildren.isCall.l) {
-            case assignment :: Nil =>
-              assignment.code shouldBe "Busy = false"
-            case _ => fail("No call node found!")
-          }
-        case None => fail("No `finally` block found!")
-      }
-    }
-
   }
 
-  "the swtich statement" should {
+  "the switch statement" should {
     val cpg = code(basicBoilerplate("""
         |switch (i) {
         | case > 0:
@@ -195,29 +159,16 @@ class ControlStructureTests extends CSharpCode2CpgFixture {
         |}
         |""".stripMargin))
 
-    val tryBlocks = cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.TRY).astChildren.isBlock.l
+    val tryElements = cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.TRY).astChildren.l
 
-    "generate a try control structure with two children blocks" in {
-      inside(tryBlocks) {
-        case t :: f :: Nil =>
-          t.code shouldBe "try"
-          f.code shouldBe "finally"
-        case _ => fail("Invalid number of children under the `try` control structure!")
-      }
-    }
-
-    "generate a finally-block with the correct dispose call" in {
-      inside(tryBlocks.lastOption) {
-        case Some(ctl) =>
-          inside(ctl.astChildren.isCall.l) {
-            case disposeCall :: Nil =>
-              disposeCall.code shouldBe "reader.Dispose()"
-              disposeCall.name shouldBe "Dispose"
-              disposeCall.methodFullName shouldBe "System.Disposable.Dispose:System.Void()"
-            case _ => fail("No call node found!")
-          }
-        case None => fail("No `finally` block found!")
-      }
+    "generate a try control structure with two children correctly" in {
+      val List(tryBlock) = tryElements.isBlock.l
+      tryBlock.code shouldBe "try"
+      val List(finallyBlock) = tryElements.isControlStructure.isFinally.astChildren.l
+      val List(disposeCall)  = finallyBlock.astChildren.isCall.l
+      disposeCall.code shouldBe "reader.Dispose()"
+      disposeCall.name shouldBe "Dispose"
+      disposeCall.methodFullName shouldBe "System.Disposable.Dispose:System.Void()"
     }
 
   }


### PR DESCRIPTION
Uses ControlStructureTypes.CATCH and ControlStructureTypes.FINALLY now instead of relying on explicit order values.