### PR TITLE
[ruby] Named Argument with Symbol Value

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -16,7 +16,7 @@ final case class Config(
     with TypeRecoveryParserConfig[Config]
     with TypeStubConfig[Config] {
 
-  this.defaultIgnoredFilesRegex = List("spec", "test").flatMap { directory =>
+  this.defaultIgnoredFilesRegex = List("spec", "test", "tests").flatMap { directory =>
     List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|/)$directory($$|/)".r.unanchored)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1152,8 +1152,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     if (Option(ctx.operatorExpression()).isDefined) {
       visit(ctx.operatorExpression())
     } else {
-      logger.warn(s"Association keys without operator expressions are not handled '${ctx.toTextSpan}''")
-      Unknown()(ctx.toTextSpan)
+      SimpleIdentifier()(ctx.toTextSpan)
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -197,4 +197,12 @@ class CallTests extends RubyCode2CpgFixture {
     }
   }
 
+  "named parameters in parenthesis-less call to a symbol value should create a correctly named argument" in {
+    val cpg = code("on in: :sequence")
+
+    val List(_, inArg) = cpg.call.argument.l: @unchecked
+    inArg.code shouldBe ":sequence"
+    inArg.argumentName shouldBe Option("in")
+  }
+
 }


### PR DESCRIPTION
Symbols are not parsed as operator expressions, so when they are given as a value to a named argument, they trigger an unhandled RubyNodeCreator case. This PR fixes that.

Additionally, `tests` is added as an ignore pattern.