### PR TITLE
[php2cpg] Use ControlStructureTypes for Try-Catch-Clauses

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -1,19 +1,27 @@
 package io.joern.php2cpg.parser
 
-import io.joern.php2cpg.astcreation.PhpBuiltins
-import io.joern.php2cpg.astcreation.AstCreator.TypeConstants
-import io.joern.php2cpg.parser.Domain.PhpAssignment.{AssignTypeMap, isAssignType}
-import io.joern.php2cpg.parser.Domain.PhpBinaryOp.{BinaryOpTypeMap, isBinaryOpType}
-import io.joern.php2cpg.parser.Domain.PhpCast.{CastTypeMap, isCastType}
-import io.joern.php2cpg.parser.Domain.PhpUnaryOp.{UnaryOpTypeMap, isUnaryOpType}
-import io.joern.php2cpg.parser.Domain.PhpUseType.{PhpUseType, getUseType}
-import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
-import org.slf4j.LoggerFactory
-import ujson.{Arr, Obj, Str, Value}
-
-import scala.util.{Success, Try}
 import io.joern.php2cpg.astcreation.AstCreator
+import io.joern.php2cpg.astcreation.AstCreator.TypeConstants
+import io.joern.php2cpg.parser.Domain.PhpAssignment.AssignTypeMap
+import io.joern.php2cpg.parser.Domain.PhpAssignment.isAssignType
+import io.joern.php2cpg.parser.Domain.PhpBinaryOp.BinaryOpTypeMap
+import io.joern.php2cpg.parser.Domain.PhpBinaryOp.isBinaryOpType
+import io.joern.php2cpg.parser.Domain.PhpCast.CastTypeMap
+import io.joern.php2cpg.parser.Domain.PhpCast.isCastType
+import io.joern.php2cpg.parser.Domain.PhpUnaryOp.UnaryOpTypeMap
+import io.joern.php2cpg.parser.Domain.PhpUnaryOp.isUnaryOpType
+import io.joern.php2cpg.parser.Domain.PhpUseType.PhpUseType
+import io.joern.php2cpg.parser.Domain.PhpUseType.getUseType
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
+import io.shiftleft.codepropertygraph.generated.Operators
+import org.slf4j.LoggerFactory
+import ujson.Arr
+import ujson.Obj
+import ujson.Str
+import ujson.Value
+
+import scala.util.Success
+import scala.util.Try
 
 object Domain {
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
@@ -739,32 +739,26 @@ class ControlStructureTests extends PhpCode2CpgFixture {
         |};
         |""".stripMargin)
 
-    "create the try block correctly" in {
-      inside(cpg.controlStructure.l) { case List(tryStructure) =>
-        tryStructure.controlStructureType shouldBe ControlStructureTypes.TRY
-        tryStructure.lineNumber shouldBe Some(2)
+    val List(tryNode) = cpg.controlStructure.isTry.l
 
-        inside(tryStructure.astChildren.l) { case List(body: Block, _, _, _) =>
-          body.order shouldBe 1
-          inside(body.astChildren.code.l) { case List(bodyCode) =>
-            bodyCode shouldBe "$body1"
-          }
-        }
-      }
+    "create the try block correctly" in {
+      val List(tryBlock) = tryNode.astChildren.isBlock.l
+      tryNode.lineNumber shouldBe Some(2)
+      tryBlock.astChildren.code.l shouldBe List("$body1")
     }
 
     "create the catch blocks correctly" in {
-      val catchBlocks = cpg.controlStructure.astChildren.order(2).toSet
-
-      catchBlocks.flatMap(_.astChildren.code.toSet) shouldBe Set("$body2", "$body3")
-      catchBlocks.flatMap(_.lineNumber) shouldBe Set(4, 6)
+      val List(catchA, catchB) = tryNode.astChildren.isControlStructure.isCatch.l
+      catchA.astChildren.isBlock.astChildren.code.l shouldBe List("$body2")
+      catchA.lineNumber shouldBe Some(4)
+      catchB.astChildren.isBlock.astChildren.code.l shouldBe List("$body3")
+      catchB.lineNumber shouldBe Some(6)
     }
 
     "create the finally block correctly" in {
-      inside(cpg.controlStructure.astChildren.order(3).l) { case List(finallyBlock) =>
-        finallyBlock.astChildren.code.toSet shouldBe Set("$body4")
-        finallyBlock.lineNumber shouldBe Some(8)
-      }
+      val List(finallyNode) = tryNode.astChildren.isControlStructure.isFinally.l
+      finallyNode.astChildren.isBlock.astChildren.code.l shouldBe List("$body4")
+      finallyNode.lineNumber shouldBe Some(8)
     }
   }
 
@@ -777,25 +771,18 @@ class ControlStructureTests extends PhpCode2CpgFixture {
         |};
         |""".stripMargin)
 
-    "create the try block correctly" in {
-      inside(cpg.controlStructure.l) { case List(tryStructure) =>
-        tryStructure.controlStructureType shouldBe ControlStructureTypes.TRY
-        tryStructure.lineNumber shouldBe Some(2)
+    val List(tryNode) = cpg.controlStructure.isTry.l
 
-        inside(tryStructure.astChildren.l) { case List(body: Block, _) =>
-          body.order shouldBe 1
-          inside(body.astChildren.code.l) { case List(bodyCode) =>
-            bodyCode shouldBe "$body1"
-          }
-        }
-      }
+    "create the try block correctly" in {
+      val List(tryBlock) = tryNode.astChildren.isBlock.l
+      tryNode.lineNumber shouldBe Some(2)
+      tryBlock.astChildren.code.l shouldBe List("$body1")
     }
 
     "create the finally block correctly" in {
-      inside(cpg.controlStructure.astChildren.order(3).l) { case List(finallyBlock) =>
-        finallyBlock.astChildren.code.toSet shouldBe Set("$body4")
-        finallyBlock.lineNumber shouldBe Some(4)
-      }
+      val List(finallyNode) = tryNode.astChildren.isControlStructure.isFinally.l
+      finallyNode.astChildren.isBlock.astChildren.code.l shouldBe List("$body4")
+      finallyNode.lineNumber shouldBe Some(4)
     }
   }
 
@@ -810,25 +797,20 @@ class ControlStructureTests extends PhpCode2CpgFixture {
         |};
         |""".stripMargin)
 
-    "create the try block correctly" in {
-      inside(cpg.controlStructure.l) { case List(tryStructure) =>
-        tryStructure.controlStructureType shouldBe ControlStructureTypes.TRY
-        tryStructure.lineNumber shouldBe Some(2)
+    val List(tryNode) = cpg.controlStructure.isTry.l
 
-        inside(tryStructure.astChildren.l) { case List(body: Block, _, _) =>
-          body.order shouldBe 1
-          inside(body.astChildren.code.l) { case List(bodyCode) =>
-            bodyCode shouldBe "$body1"
-          }
-        }
-      }
+    "create the try block correctly" in {
+      val List(tryBlock) = tryNode.astChildren.isBlock.l
+      tryNode.lineNumber shouldBe Some(2)
+      tryBlock.astChildren.code.l shouldBe List("$body1")
     }
 
     "create the catch blocks correctly" in {
-      val catchBlocks = cpg.controlStructure.astChildren.order(2).toSet
-
-      catchBlocks.flatMap(_.astChildren.code.toSet) shouldBe Set("$body2", "$body3")
-      catchBlocks.flatMap(_.lineNumber) shouldBe Set(4, 6)
+      val List(catchA, catchB) = tryNode.astChildren.isControlStructure.isCatch.l
+      catchA.astChildren.isBlock.astChildren.code.l shouldBe List("$body2")
+      catchA.lineNumber shouldBe Some(4)
+      catchB.astChildren.isBlock.astChildren.code.l shouldBe List("$body3")
+      catchB.lineNumber shouldBe Some(6)
     }
   }
 
@@ -839,7 +821,7 @@ class ControlStructureTests extends PhpCode2CpgFixture {
         |} catch (A $a) {};
         |""".stripMargin)
 
-    inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.THROW).l) { case List(throwExpr) =>
+    inside(cpg.controlStructure.isThrow.l) { case List(throwExpr) =>
       throwExpr.lineNumber shouldBe Some(3)
       throwExpr.code shouldBe "throw $x"
       throwExpr.astChildren.code.l shouldBe List("$x")


### PR DESCRIPTION
Uses ControlStructureTypes.CATCH and ControlStructureTypes.FINALLY now instead of relying on explicit order values.