### PR TITLE
[ruby] Unhandled Receiver Types

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -641,10 +641,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   protected def astForUnknown(node: RubyNode): Ast = {
     val className = node.getClass.getSimpleName
     val text      = code(node)
-    node match {
-      case _: Unknown => // Unknowns are syntax errors which are logged by the parser already
-      case _ => logger.warn(s"Could not represent expression: $text ($className) ($relativeFileName), skipping")
-    }
+    logger.warn(s"Could not represent expression: $text ($className) ($relativeFileName), skipping")
     Ast(unknownNode(node, text))
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -92,7 +92,7 @@ object AntlrContextHelpers {
 
   sealed implicit class RegularExpressionLiteralContextHelper(ctx: RegularExpressionLiteralContext) {
     def isStatic: Boolean  = !isDynamic
-    def isDynamic: Boolean = ctx.regexpLiteralContent.asScala.exists(c => Option(c.compoundStatement()).isDefined)
+    def isDynamic: Boolean = interpolations.nonEmpty
 
     def interpolations: List[ParserRuleContext] = ctx
       .regexpLiteralContent()
@@ -100,6 +100,22 @@ object AntlrContextHelpers {
       .filter(ctx => Option(ctx.compoundStatement()).isDefined)
       .map(ctx => ctx.compoundStatement())
       .toList
+  }
+
+  sealed implicit class QuotedExpandedRegularExpressionLiteralContextHelper(
+    ctx: QuotedExpandedRegularExpressionLiteralContext
+  ) {
+
+    def isStatic: Boolean  = !isDynamic
+    def isDynamic: Boolean = interpolations.nonEmpty
+
+    def interpolations: List[ParserRuleContext] = ctx
+      .quotedExpandedLiteralStringContent()
+      .asScala
+      .filter(ctx => Option(ctx.compoundStatement()).isDefined)
+      .map(ctx => ctx.compoundStatement())
+      .toList
+
   }
 
   sealed implicit class CurlyBracesBlockContextHelper(ctx: CurlyBracesBlockContext) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -23,6 +23,7 @@ object Defines {
   val Proc: String       = "proc"
   val This: String       = "this"
   val Loop: String       = "loop"
+  val Self: String       = "self"
 
   val Program: String = ":program"
 


### PR DESCRIPTION
This PR fixes previously unhandled call receivers, which creates an issue later during dynamic call linking as the receiver would be an Unknown node.

* Handled quoted expanded regex literals
* Handled constant variable references

Additionally, this brings back warnings for `Unknown` nodes as these unhandled nodes are not syntax errors but don't necessarily have explicit warnings when unhandled.