### PR TITLE
[python] prevent overtainting dictLiterals

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -16,7 +16,7 @@ package object dataflowengineoss {
     */
   def globalFromLiteral(lit: Literal, recursive: Boolean = true): Iterator[Expression] = lit.start
     .where(_.method.isModule)
-    .flatMap(t => if (recursive) t.inAssignment else t.inCall.assignment)
+    .flatMap(t => if (recursive) t.inAssignment else t.inCall.isAssignment)
     .target
 
   def identifierToFirstUsages(node: Identifier): List[Identifier] = node.refsTo.flatMap(identifiersFromCapturedScopes).l

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -21,7 +21,8 @@ class CallTraversal(val traversal: Iterator[Call]) extends AnyVal {
 
   /** Only assignment calls
     */
-  def isAssignment: Iterator[Assignment] = traversal.nameExact(allAssignmentTypes.toSeq*).collectAll[Assignment]
+  def isAssignment: Iterator[Assignment] =
+    traversal.methodFullNameExact(allAssignmentTypes.toSeq*).collectAll[Assignment]
 
   /** The receiver of a call if the call has a receiver associated.
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
-import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
+import io.shiftleft.semanticcpg.language.operatorextension.allAssignmentTypes
 
 /** A call site
   */
@@ -21,7 +21,7 @@ class CallTraversal(val traversal: Iterator[Call]) extends AnyVal {
 
   /** Only assignment calls
     */
-  def isAssignment: Iterator[Assignment] = traversal.nameExact(Operators.assignment).collectAll[Assignment]
+  def isAssignment: Iterator[Assignment] = traversal.nameExact(allAssignmentTypes.toSeq*).collectAll[Assignment]
 
   /** The receiver of a call if the call has a receiver associated.
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -1,7 +1,9 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
 
 /** A call site
   */
@@ -16,6 +18,10 @@ class CallTraversal(val traversal: Iterator[Call]) extends AnyVal {
     */
   def isDynamic: Iterator[Call] =
     traversal.dispatchType("DYNAMIC_DISPATCH")
+
+  /** Only assignment calls
+    */
+  def isAssignment: Iterator[Assignment] = traversal.nameExact(Operators.assignment).collectAll[Assignment]
 
   /** The receiver of a call if the call has a receiver associated.
     */


### PR DESCRIPTION
In #4583, I didn't account for how Python dictionary literals are lowered as 3 address code. Specifically, the problem is at `inCall.assignment` here:

https://github.com/joernio/joern/blob/ff9c08f62539eba4194eee5c0a96f5d28d586ab7/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala#L19

In an expression such as `print(1, {'x': 10})`, `1.inCall.assignment` wouldn't be empty - it would contain the assignments that build `{'x': 10}`. The intent behind `inCall.assignment` was to filter the surrounding call by assignment. So, introduced a new CallTraversal `isAssignment` to do just that and used it here instead.

I'm a bit concerned about introducing a new API for CallTraversal. Any thoughts about that?

Resolves #4605 