### PR TITLE
[javasrc2cpg] Remove generic types from unresolved fullnames

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -42,6 +42,7 @@ import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import com.github.javaparser.ast.Node
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserParameterDeclaration
 import io.joern.javasrc2cpg.astcreation.declarations.AstForMethodsCreator.PartialConstructorDeclaration
+import io.joern.javasrc2cpg.util.Util
 
 private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   def astForMethod(methodDeclaration: MethodDeclaration): Ast = {
@@ -51,7 +52,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
 
     val maybeResolved      = tryWithSafeStackOverflow(methodDeclaration.resolve())
     val expectedReturnType = Try(symbolSolver.toResolvedType(methodDeclaration.getType, classOf[ResolvedType])).toOption
-    val simpleMethodReturnType = methodDeclaration.getTypeAsString()
+    val simpleMethodReturnType = Util.stripGenericTypes(methodDeclaration.getTypeAsString())
     val returnTypeFullName = expectedReturnType
       .flatMap(typeInfoCalc.fullName)
       .orElse(scope.lookupType(simpleMethodReturnType))
@@ -218,19 +219,14 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   }
 
   private def astForParameter(parameter: Parameter, childNum: Int): Ast = {
-    val maybeArraySuffix = if (parameter.isVarArgs) "[]" else ""
+    val maybeArraySuffix     = if (parameter.isVarArgs) "[]" else ""
+    val rawParameterTypeName = Util.stripGenericTypes(parameter.getTypeAsString)
     val typeFullName =
       typeInfoCalc
         .fullName(parameter.getType)
-        .orElse(scope.lookupType(parameter.getTypeAsString))
-        // In a scenario where we have an import of an external type e.g. `import foo.bar.Baz` and
-        // this parameter's type is e.g. `Baz<String>`, the lookup will fail. However, if we lookup
-        // for `Baz` instead (i.e. without type arguments), then the lookup will succeed.
-        .orElse(
-          Try(parameter.getType.asClassOrInterfaceType).toOption.flatMap(t => scope.lookupType(t.getNameAsString))
-        )
+        .orElse(scope.lookupType(rawParameterTypeName))
         .map(_ ++ maybeArraySuffix)
-        .getOrElse(s"${Defines.UnresolvedNamespace}.${parameter.getTypeAsString}")
+        .getOrElse(s"${Defines.UnresolvedNamespace}.$rawParameterTypeName")
     val evalStrat =
       if (parameter.getType.isPrimitiveType) EvaluationStrategies.BY_VALUE else EvaluationStrategies.BY_SHARING
     typeInfoCalc.registerType(typeFullName)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -568,34 +568,16 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     // TODO: Should be able to find expected type here
     val annotations = fieldDeclaration.getAnnotations
 
-    // variable can be declared with generic type, so we need to get rid of the <> part of it to get the package information
-    // and append the <> when forming the typeFullName again
-    // Ex - private Consumer<String, Integer> consumer;
-    // From Consumer<String, Integer> we need to get to Consumer so splitting it by '<' and then combining with '<' to
-    // form typeFullName as Consumer<String, Integer>
+    val rawTypeName = Util.stripGenericTypes(v.getTypeAsString)
 
-    val typeFullNameWithoutGenericSplit = typeInfoCalc
+    val typeFullName = typeInfoCalc
       .fullName(v.getType)
-      .orElse(scope.lookupType(v.getTypeAsString))
-      .getOrElse(s"${Defines.UnresolvedNamespace}.${v.getTypeAsString}")
-    val typeFullName = {
-      // Check if the typeFullName is unresolved and if it has generic information to resolve the typeFullName
-      if (
-        typeFullNameWithoutGenericSplit
-          .contains(Defines.UnresolvedNamespace) && v.getTypeAsString.contains(Defines.LeftAngularBracket)
-      ) {
-        val splitByLeftAngular = v.getTypeAsString.split(Defines.LeftAngularBracket)
-        scope.lookupType(splitByLeftAngular.head) match {
-          case Some(foundType) =>
-            foundType + splitByLeftAngular
-              .slice(1, splitByLeftAngular.size)
-              .mkString(Defines.LeftAngularBracket, Defines.LeftAngularBracket, "")
-          case None => typeFullNameWithoutGenericSplit
-        }
-      } else typeFullNameWithoutGenericSplit
-    }
-    val name           = v.getName.toString
-    val node           = memberNode(v, name, s"$typeFullName $name", typeFullName)
+      .orElse(scope.lookupType(rawTypeName))
+      .getOrElse(s"${Defines.UnresolvedNamespace}.$rawTypeName")
+
+    val name = v.getName.toString
+    // Use type name without generics stripped in code
+    val node           = memberNode(v, name, s"${v.getTypeAsString} $name", typeFullName)
     val memberAst      = Ast(node)
     val annotationAsts = annotations.asScala.map(astForAnnotationExpr)
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -204,8 +204,13 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val callNode = newOperatorCallNode(Operators.fieldAccess, expr.toString, someTypeFullName, line(expr), column(expr))
 
     val identifierType = typeInfoCalc.fullName(expr.getType)
-    val identifier = identifierNode(expr, expr.getTypeAsString, expr.getTypeAsString, identifierType.getOrElse("ANY"))
-    val idAst      = Ast(identifier)
+    val identifier = identifierNode(
+      expr,
+      Util.stripGenericTypes(expr.getTypeAsString),
+      expr.getTypeAsString,
+      identifierType.getOrElse("ANY")
+    )
+    val idAst = Ast(identifier)
 
     val fieldIdentifier = NewFieldIdentifier()
       .canonicalName("class")
@@ -388,8 +393,9 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
   private[expressions] def astForMethodReferenceExpr(expr: MethodReferenceExpr, expectedType: ExpectedType): Ast = {
     val typeFullName = expr.getScope match {
       case typeExpr: TypeExpr =>
+        val rawType = Util.stripGenericTypes(typeExpr.getTypeAsString)
         // JavaParser wraps the "type" scope of a MethodReferenceExpr in a TypeExpr, but this also catches variable names.
-        scope.lookupVariableOrType(typeExpr.getTypeAsString).orElse(expressionReturnTypeFullName(typeExpr))
+        scope.lookupVariableOrType(rawType).orElse(expressionReturnTypeFullName(typeExpr))
       case scopeExpr => expressionReturnTypeFullName(scopeExpr)
     }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
@@ -9,7 +9,7 @@ import com.github.javaparser.resolution.types.ResolvedType
 import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
 import io.joern.javasrc2cpg.scope.Scope.{NewVariableNode, typeFullName}
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
-import io.joern.javasrc2cpg.util.NameConstants
+import io.joern.javasrc2cpg.util.{NameConstants, Util}
 import io.joern.x2cpg.utils.AstPropertiesUtil.*
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.{
@@ -113,7 +113,7 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
       case typ: ClassOrInterfaceType =>
         val typeParams = typ.getTypeArguments.toScala.map(_.asScala.flatMap(typeInfoCalc.fullName))
         (typ.getName.asString(), typeParams)
-      case _ => (variableDeclarator.getTypeAsString, None)
+      case _ => (Util.stripGenericTypes(variableDeclarator.getTypeAsString), None)
     }
 
     val typeFullName = tryWithSafeStackOverflow(
@@ -131,6 +131,7 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
     val declarationNode: Option[NewVariableNode] = if (originNode.isInstanceOf[FieldDeclaration]) {
       scope.lookupVariable(variableName).variableNode
     } else {
+      // Use type name with generics for code
       val localCode = s"${variableDeclarator.getTypeAsString} ${variableDeclarator.getNameAsString}"
 
       val local =
@@ -181,7 +182,7 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
             Operators.assignment,
             "=",
             ExpectedType(typeFullName, expectedType),
-            Some(variableDeclarator.getTypeAsString)
+            Some(Util.stripGenericTypes(variableDeclarator.getTypeAsString))
           )
         }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Util.scala
@@ -50,6 +50,19 @@ object Util {
     s"${Defines.UnresolvedSignature}($paramCount)"
   }
 
+  def stripGenericTypes(typeName: String): String = {
+    if (typeName.startsWith(Defines.UnresolvedNamespace)) {
+      logger.warn(s"stripGenericTypes should not be used for javasrc2cpg type $typeName")
+      typeName.head +: takeUntilGenericStart(typeName.tail)
+    } else {
+      takeUntilGenericStart(typeName)
+    }
+  }
+
+  private def takeUntilGenericStart(typeName: String): String = {
+    typeName.takeWhile(char => char != '<')
+  }
+
   private def getAllParents(typ: ResolvedReferenceType, result: mutable.ArrayBuffer[ResolvedReferenceType]): Unit = {
     if (typ.isJavaLangObject) {
       Iterable.empty

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
@@ -59,7 +59,7 @@ class EnumTests extends JavaSrcCode2CpgFixture {
     cpg.typeDecl.name(".*Color.*").member.size shouldBe 3
     val List(r, b, l) = cpg.typeDecl.name(".*Color.*").member.l
 
-    l.code shouldBe "java.lang.String label"
+    l.code shouldBe "String label"
 
     r.code shouldBe "RED(\"Red\")"
     r.astChildren.size shouldBe 0

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericsTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericsTests.scala
@@ -5,194 +5,329 @@ import io.shiftleft.semanticcpg.language._
 
 class GenericsTests extends JavaSrcCode2CpgFixture {
 
-  val cpg = code("""
-      |import java.util.function.Function;
-      |
-      |// Box
-      |class Box<T> {
-      |
-      |    // java.lang.Object
-      |    private T item;
-      |
-      |    // Box.getItem:java.lang.Object()
-      |    public T getItem() {
-      |        return item;
-      |    }
-      |
-      |    public void setItem(T item) {
-      |        this.item = item;
-      |    }
-      |
-      |    // Box.map:Box(java.util.function.Function)
-      |    public <G> Box<G> map(Function<T, G> f) {
-      |        // java.util.function.Function.apply: java.lang.Object(java.lang.Object)
-      |        G newValue = f.apply(item);
-      |        // Box.<init>:void()
-      |        Box<G> newBox = new Box<G>();
-      |        return newBox.withValue(newValue);
-      |    }
-      |
-      |    // Box.withValue:Box(java.lang.Object)
-      |    public Box<T> withValue(T value) {
-      |        this.item = value;
-      |        return this;
-      |    }
-      |
-      |    public String toString() {
-      |        return "Box(" + item.toString() + ")";
-      |    }
-      |
-      |    // Box.idk:java.lang.Number(java.lang.Number)
-      |    public static <K extends Number> K idK(K item) {
-      |        return item;
-      |    }
-      |
-      |    // Box.idKC:java.lang.Number(java.lang.Number)
-      |    public static <K extends Number & Comparable> K idKC(K item) {
-      |        return item;
-      |    }
-      |
-      |    // Box.idC:java.lang.Comparable(java.lang.Comparable)
-      |    public static <K extends Comparable> K idC(K item) {
-      |        return item;
-      |    }
-      |
-      |    // Box.testWildCard:void(Box)
-      |    public static void testWildCard(Box<? extends Comparable> b) {
-      |        System.out.println(b);
-      |    }
-      |
-      |    // Box.testWildCardLower:void(Box)
-      |    public static void testWildCardLower(Box<? super Integer> b) {
-      |        System.out.println(b);
-      |    }
-      |}
-      |
-      |
-      |// inheritsFrom Box
-      |public class Test extends Box<String> {}
-      |""".stripMargin)
+  "resolved generic type declarations" should {
+    val cpg = code("""package box;
+                     |
+                     |public class Box<T> {
+                     |  public Box(T value) {}
+                     |
+                     |  public T get() { return null; }
+                     |
+                     |  public static void test() {
+                     |    Box<Integer> b = new Box<>(0);
+                     |    b.get();
+                     |  }
+                     |}
+                     |""".stripMargin)
 
-  "it should create the correct generic typeDecl name" in {
-    cpg.typeDecl.nameExact("Box").l match {
-      case decl :: Nil => decl.fullName shouldBe "Box"
+    "not include the type variable in the type decl name" in {
+      cpg.typeDecl.name(".*Box.*").fullName.l shouldBe List("box.Box")
+    }
 
-      case res => fail(s"Expected typeDecl Box but got $res")
+    "use erased types in the constructor full name" in {
+      cpg.method.nameExact("<init>").fullName.l shouldBe List("box.Box.<init>:void(java.lang.Object)")
+    }
+
+    "use erased types in the method full name" in {
+      cpg.method.nameExact("get").fullName.l shouldBe List("box.Box.get:java.lang.Object()")
+    }
+
+    "use erased types for the method full name in the constructor invocation" in {
+      cpg.call.nameExact("<init>").methodFullName.l shouldBe List("box.Box.<init>:void(java.lang.Object)")
+    }
+
+    "use erased types for the method full name in the get method invocation" in {
+      cpg.call.nameExact("get").methodFullName.l shouldBe List("box.Box.get:java.lang.Object()")
+    }
+
+    "not include generic types in type full names of objects" in {
+      cpg.local.name("b").typeFullName.l shouldBe List("box.Box<java.lang.Integer>")
+    }
+
+    "have type nodes mapping generic types to raw types" in {
+      inside(cpg.local.name("b").typ.l) { case List(typ) =>
+        typ.name shouldBe "Box<java.lang.Integer>"
+        typ.fullName shouldBe "box.Box<java.lang.Integer>"
+        typ.typeDeclFullName shouldBe "box.Box"
+      }
     }
   }
 
-  "it should default to Object for a simple generic type" in {
-    cpg.method.name("getItem").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Box.getItem:java.lang.Object()"
-        method.signature shouldBe "java.lang.Object()"
+  "unresolved generic type declarations" should {
+    val cpg = code("""import box.Box;
+                     |
+                     |public class Foo {
+                     |  public static void test() {
+                     |    Box<Integer> b = new Box<>(0);
+                     |    b.get();
+                     |  }
+                     |}
+                     |""".stripMargin)
 
-      case res => fail(s"Expected method getItem but got $res")
+    "use erased types for the method full name in the constructor invocation" in {
+      cpg.call.nameExact("<init>").methodFullName.l shouldBe List("box.Box.<init>:<unresolvedSignature>(1)")
+    }
+
+    "use erased types for the method full name in the get method invocation" in {
+      cpg.call.nameExact("get").methodFullName.l shouldBe List("box.Box.get:<unresolvedSignature>(0)")
+    }
+
+    "not include generic types in type full names of objects" in {
+      cpg.method.name("test").local.name("b").typeFullName.l shouldBe List("box.Box")
     }
   }
 
-  "it should default to Object for simple generic parameters" in {
-    cpg.method.name("setItem").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Box.setItem:void(java.lang.Object)"
-        method.signature shouldBe "void(java.lang.Object)"
+  "generic methods" should {
+    val cpg = code("""package foo;
+                     |
+                     |class Foo {
+                     |  public <S, T> T foo(S s) { return null; }
+                     |
+                     |  static void test(Foo f) {
+                     |      f.<Integer, String>foo(0);
+                     |  }
+                     |}
+                     |""".stripMargin)
 
-      case res => fail(s"Expected method setItem but got $res")
+    "use erased types in the method fullName" in {
+      cpg.method.name("foo").fullName.l shouldBe List("foo.Foo.foo:java.lang.Object(java.lang.Object)")
     }
 
-    cpg.method.name("setItem").parameter.name("item").l match {
-      case node :: Nil =>
-        node.typeFullName shouldBe "java.lang.Object"
-
-      case res => fail(s"Expected param item but got $res")
-    }
-  }
-
-  "it should erase generic types in parameters" in {
-    val List(method) = cpg.method.name("map").l
-    method.fullName shouldBe "Box.map:Box(java.util.function.Function)"
-    method.signature shouldBe "Box(java.util.function.Function)"
-
-    val List(param) = cpg.method.name("map").parameter.name("f").l
-    param.typeFullName shouldBe "java.util.function.Function"
-  }
-
-  "it should create correct constructor calls" in {
-    cpg.method.name("map").call.nameExact(io.joern.x2cpg.Defines.ConstructorMethodName).l match {
-      case const :: Nil =>
-        const.methodFullName shouldBe s"Box.${io.joern.x2cpg.Defines.ConstructorMethodName}:void()"
-        const.signature shouldBe "void()"
-
-      case res => fail(s"Expected call to <init> but got $res")
+    "use erased types in the call methodFullName" in {
+      cpg.method.name("test").call.name("foo").methodFullName.l shouldBe List(
+        "foo.Foo.foo:java.lang.Object(java.lang.Object)"
+      )
     }
   }
 
-  "it should correctly handle generic return types" in {
-    cpg.method.name("withValue").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Box.withValue:Box(java.lang.Object)"
-        method.signature shouldBe "Box(java.lang.Object)"
-
-      case res => fail(s"Expected method withValue but got $res")
-    }
+  "methods returning parameterized types" should {
+    val cpg = code("""package foo;
+                     |
+                     |class Box<T> {
+                     |  public <S> Box<S> into() { return null; }
+                     |
+                     |  public T get() { return null; }
+                     |
+                     |  static void test(Box<String> stringBox) {
+                     |    stringBox.<Integer>into().get();
+                     |  }
+                     |}
+                     |""".stripMargin)
+    
   }
 
-  "it should handle generics with upper bounds" in {
-    cpg.method.name("idK").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Box.idK:java.lang.Number(java.lang.Number)"
-        method.signature shouldBe "java.lang.Number(java.lang.Number)"
+  "unresolved generic variable types" should {
+    val cpg = code("""package foo;
+                     |import a.*;
+                     |import b.*;
+                     |
+                     |class Foo {
+                     |
+                     |  void foo(Bar<Integer> b) {
+                     |    b.bar();
+                     |  }
+                     |}
+                     |""".stripMargin)
 
-      case res => fail(s"Expected method idK but found $res")
+    "contain generic type information in the variable typeFullName" in {
+      cpg.method.name("foo").parameter.name("b").typeFullName.l shouldBe List("<unresolvedNamespace>.Bar<Integer>")
     }
+
+    "not contain generic type information in the bar call methodFullName" in {
+      cpg.call.name("bar").methodFullName.l shouldBe List("<unresolvedNamespace>.Bar.bar:<unresolvedSignature>")
+    }
+
   }
 
-  "it should handle generics with compound upper bounds" in {
-    cpg.method.name("idKC").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Box.idKC:java.lang.Number(java.lang.Number)"
-        method.signature shouldBe "java.lang.Number(java.lang.Number)"
+  "old generics tests" should {
+    val cpg = code("""import java.util.function.Function;
+                     |
+                     |// Box
+                     |class Box<T> {
+                     |
+                     |    // java.lang.Object
+                     |    private T item;
+                     |
+                     |    // Box.getItem:java.lang.Object()
+                     |    public T getItem() {
+                     |        return item;
+                     |    }
+                     |
+                     |    public void setItem(T item) {
+                     |        this.item = item;
+                     |    }
+                     |
+                     |    // Box.map:Box(java.util.function.Function)
+                     |    public <G> Box<G> map(Function<T, G> f) {
+                     |        // java.util.function.Function.apply: java.lang.Object(java.lang.Object)
+                     |        G newValue = f.apply(item);
+                     |        // Box.<init>:void()
+                     |        Box<G> newBox = new Box<G>();
+                     |        return newBox.withValue(newValue);
+                     |    }
+                     |
+                     |    // Box.withValue:Box(java.lang.Object)
+                     |    public Box<T> withValue(T value) {
+                     |        this.item = value;
+                     |        return this;
+                     |    }
+                     |
+                     |    public String toString() {
+                     |        return "Box(" + item.toString() + ")";
+                     |    }
+                     |
+                     |    // Box.idk:java.lang.Number(java.lang.Number)
+                     |    public static <K extends Number> K idK(K item) {
+                     |        return item;
+                     |    }
+                     |
+                     |    // Box.idKC:java.lang.Number(java.lang.Number)
+                     |    public static <K extends Number & Comparable> K idKC(K item) {
+                     |        return item;
+                     |    }
+                     |
+                     |    // Box.idC:java.lang.Comparable(java.lang.Comparable)
+                     |    public static <K extends Comparable> K idC(K item) {
+                     |        return item;
+                     |    }
+                     |
+                     |    // Box.testWildCard:void(Box)
+                     |    public static void testWildCard(Box<? extends Comparable> b) {
+                     |        System.out.println(b);
+                     |    }
+                     |
+                     |    // Box.testWildCardLower:void(Box)
+                     |    public static void testWildCardLower(Box<? super Integer> b) {
+                     |        System.out.println(b);
+                     |    }
+                     |}
+                     |
+                     |
+                     |// inheritsFrom Box
+                     |public class Test extends Box<String> {}
+                     |""".stripMargin)
 
-      case res => fail(s"Expected method idKC but found $res")
+    "it should create the correct generic typeDecl name" in {
+      cpg.typeDecl.nameExact("Box").l match {
+        case decl :: Nil => decl.fullName shouldBe "Box"
+
+        case res => fail(s"Expected typeDecl Box but got $res")
+      }
     }
-  }
 
-  "it should handle generics with an interface upper bound" in {
-    cpg.method.name("idC").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Box.idC:java.lang.Comparable(java.lang.Comparable)"
-        method.signature shouldBe "java.lang.Comparable(java.lang.Comparable)"
+    "it should default to Object for a simple generic type" in {
+      cpg.method.name("getItem").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Box.getItem:java.lang.Object()"
+          method.signature shouldBe "java.lang.Object()"
 
-      case res => fail(s"Expected method idC but found $res")
+        case res => fail(s"Expected method getItem but got $res")
+      }
     }
-  }
 
-  "it should handle wildcard subclass generics" in {
-    cpg.method.name("testWildCard").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Box.testWildCard:void(Box)"
-        method.signature shouldBe "void(Box)"
+    "it should default to Object for simple generic parameters" in {
+      cpg.method.name("setItem").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Box.setItem:void(java.lang.Object)"
+          method.signature shouldBe "void(java.lang.Object)"
 
-      case res => fail(s"Expected method testWildCard but found $res")
+        case res => fail(s"Expected method setItem but got $res")
+      }
+
+      cpg.method.name("setItem").parameter.name("item").l match {
+        case node :: Nil =>
+          node.typeFullName shouldBe "java.lang.Object"
+
+        case res => fail(s"Expected param item but got $res")
+      }
     }
-  }
 
-  "it should handle wildcard superclass generics" in {
-    cpg.method.name("testWildCardLower").l match {
-      case method :: Nil =>
-        method.fullName shouldBe "Box.testWildCardLower:void(Box)"
-        method.signature shouldBe "void(Box)"
+    "it should erase generic types in parameters" in {
+      val List(method) = cpg.method.name("map").l
+      method.fullName shouldBe "Box.map:Box(java.util.function.Function)"
+      method.signature shouldBe "Box(java.util.function.Function)"
 
-      case res => fail(s"Expected method testWildCardLower but found $res")
+      val List(param) = cpg.method.name("map").parameter.name("f").l
+      param.typeFullName shouldBe "java.util.function.Function"
     }
-  }
 
-  "it should handle generic inheritance" in {
-    cpg.typeDecl.name("Test").l match {
-      case decl :: Nil =>
-        decl.inheritsFromTypeFullName.head shouldBe "Box"
+    "it should create correct constructor calls" in {
+      cpg.method.name("map").call.nameExact(io.joern.x2cpg.Defines.ConstructorMethodName).l match {
+        case const :: Nil =>
+          const.methodFullName shouldBe s"Box.${io.joern.x2cpg.Defines.ConstructorMethodName}:void()"
+          const.signature shouldBe "void()"
 
-      case res => fail(s"Expected typeDecl Test but found $res")
+        case res => fail(s"Expected call to <init> but got $res")
+      }
+    }
+
+    "it should correctly handle generic return types" in {
+      cpg.method.name("withValue").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Box.withValue:Box(java.lang.Object)"
+          method.signature shouldBe "Box(java.lang.Object)"
+
+        case res => fail(s"Expected method withValue but got $res")
+      }
+    }
+
+    "it should handle generics with upper bounds" in {
+      cpg.method.name("idK").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Box.idK:java.lang.Number(java.lang.Number)"
+          method.signature shouldBe "java.lang.Number(java.lang.Number)"
+
+        case res => fail(s"Expected method idK but found $res")
+      }
+    }
+
+    "it should handle generics with compound upper bounds" in {
+      cpg.method.name("idKC").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Box.idKC:java.lang.Number(java.lang.Number)"
+          method.signature shouldBe "java.lang.Number(java.lang.Number)"
+
+        case res => fail(s"Expected method idKC but found $res")
+      }
+    }
+
+    "it should handle generics with an interface upper bound" in {
+      cpg.method.name("idC").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Box.idC:java.lang.Comparable(java.lang.Comparable)"
+          method.signature shouldBe "java.lang.Comparable(java.lang.Comparable)"
+
+        case res => fail(s"Expected method idC but found $res")
+      }
+    }
+
+    "it should handle wildcard subclass generics" in {
+      cpg.method.name("testWildCard").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Box.testWildCard:void(Box)"
+          method.signature shouldBe "void(Box)"
+
+        case res => fail(s"Expected method testWildCard but found $res")
+      }
+    }
+
+    "it should handle wildcard superclass generics" in {
+      cpg.method.name("testWildCardLower").l match {
+        case method :: Nil =>
+          method.fullName shouldBe "Box.testWildCardLower:void(Box)"
+          method.signature shouldBe "void(Box)"
+
+        case res => fail(s"Expected method testWildCardLower but found $res")
+      }
+    }
+
+    "it should handle generic inheritance" in {
+      cpg.typeDecl.name("Test").l match {
+        case decl :: Nil =>
+          decl.inheritsFromTypeFullName.head shouldBe "Box"
+
+        case res => fail(s"Expected typeDecl Test but found $res")
+      }
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericsTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericsTests.scala
@@ -65,6 +65,12 @@ class GenericsTests extends JavaSrcCode2CpgFixture {
                      |}
                      |""".stripMargin)
 
+    "not have the generic types in the methodFullName for calls" in {
+      cpg.call.name("into").methodFullName.l shouldBe List("foo.Box.into:foo.Box()")
+
+      cpg.call.name("get").methodFullName.l shouldBe List("foo.Box.get:java.lang.Object()")
+    }
+
   }
 
   "unresolved generic variable types" should {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MemberTests.scala
@@ -82,7 +82,7 @@ class NewMemberTests extends JavaSrcCode2CpgFixture {
       cpg.member
         .name("consumer")
         .typeFullName
-        .head shouldBe "org.apache.kafka.clients.consumer.Consumer<String,Integer>"
+        .head shouldBe "org.apache.kafka.clients.consumer.Consumer"
     }
 
     "have a resolved package name in methodFullName" in {
@@ -91,7 +91,7 @@ class NewMemberTests extends JavaSrcCode2CpgFixture {
         .methodFullName
         .head
         .split(":")
-        .head shouldBe "org.apache.kafka.clients.consumer.Consumer<String,Integer>.poll"
+        .head shouldBe "org.apache.kafka.clients.consumer.Consumer.poll"
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/VarDeclTests.scala
@@ -203,7 +203,7 @@ class VarDeclTests extends JavaSrcCode2CpgFixture {
         .codeExact("new FlinkKafkaProducer<String>(\"kafka-topic\", schema, kafkaProps)")
         .filterNot(_.name == Operators.alloc)
         .map(_.methodFullName)
-        .head shouldBe "org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer<java.lang.String>.<init>:<unresolvedSignature>(3)"
+        .head shouldBe "org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer.<init>:<unresolvedSignature>(3)"
     }
 
   }


### PR DESCRIPTION
At the last level of our type fallback mechanisms, we use `javaParserNode.getTypeAsString` to get the type name, but this still includes generic types which is inconsistent with what we do elsewhere. This PR strips the generic types from these fallback type names.