### PR TITLE
[javasrc2cpg] Don't add unknown nodes to cpg for unhandled captured variables

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
@@ -97,14 +97,14 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
     val variable      = capturedVariable.variable
     val typeDeclChain = capturedVariable.typeDeclChain
 
-    scope.enclosingMethod.map(_.lookupVariable("this")) match {
-      case None | Some(NotInScope) | Some(CapturedVariable(_, _)) =>
+    scope.lookupVariable("this") match {
+      case NotInScope | CapturedVariable(_, _) =>
         logger.warn(
           s"Attempted to create AST for captured variable ${variable.name}, but could not find `this` param in direct scope."
         )
         Ast(NewUnknown().code(variable.name).lineNumber(line(nameExpr)).columnNumber(column(nameExpr)))
 
-      case Some(SimpleVariable(ScopeParameter(thisNode: NewMethodParameterIn))) =>
+      case SimpleVariable(ScopeParameter(thisNode: NewMethodParameterIn)) =>
         val thisIdentifier = identifierNode(
           nameExpr,
           thisNode.name,
@@ -140,7 +140,7 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
         val captureFieldIdentifier = fieldIdentifierNode(nameExpr, variable.name, variable.name)
         callAst(finalFieldAccess, List(outerClassChain, Ast(captureFieldIdentifier)))
 
-      case Some(SimpleVariable(thisNode)) =>
+      case SimpleVariable(thisNode) =>
         logger.warn(
           s"Attempted to create AST for captured variable ${variable.name}, but found non-parameter `this`: ${thisNode}."
         )

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
@@ -104,15 +104,10 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
         )
         Ast(NewUnknown().code(variable.name).lineNumber(line(nameExpr)).columnNumber(column(nameExpr)))
 
-      case SimpleVariable(ScopeParameter(thisNode: NewMethodParameterIn)) =>
-        val thisIdentifier = identifierNode(
-          nameExpr,
-          thisNode.name,
-          thisNode.code,
-          thisNode.typeFullName,
-          thisNode.dynamicTypeHintFullName
-        )
-        val thisAst = Ast(thisIdentifier).withRefEdge(thisIdentifier, thisNode)
+      case SimpleVariable(scopeVariable) =>
+        val thisIdentifier =
+          identifierNode(nameExpr, scopeVariable.name, scopeVariable.name, scopeVariable.typeFullName)
+        val thisAst = Ast(thisIdentifier).withRefEdge(thisIdentifier, scopeVariable.node)
 
         val lineNumber   = line(nameExpr)
         val columnNumber = column(nameExpr)
@@ -139,12 +134,6 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
 
         val captureFieldIdentifier = fieldIdentifierNode(nameExpr, variable.name, variable.name)
         callAst(finalFieldAccess, List(outerClassChain, Ast(captureFieldIdentifier)))
-
-      case SimpleVariable(thisNode) =>
-        logger.warn(
-          s"Attempted to create AST for captured variable ${variable.name}, but found non-parameter `this`: ${thisNode}."
-        )
-        Ast(NewUnknown().code(variable.name).lineNumber(line(nameExpr)).columnNumber(column(nameExpr)))
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
@@ -102,7 +102,7 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
         logger.warn(
           s"Attempted to create AST for captured variable ${variable.name}, but could not find `this` param in direct scope."
         )
-        Ast(NewUnknown().code(variable.name).lineNumber(line(nameExpr)).columnNumber(column(nameExpr)))
+        Ast(identifierNode(nameExpr, variable.name, variable.name, variable.typeFullName))
 
       case SimpleVariable(scopeVariable) =>
         val thisIdentifier =

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -743,28 +743,71 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
     }
   }
 
-  "calls on captured variables in lambdas" should {
+  "calls on captured variables in lambdas contained in anonymous classes" should {
     val cpg = code("""
-                     |
-                     |public class Foo {
-                     |
-                     |    public static void sink(String s) {};
-                     |
-                     |    public static Object test(Foo captured) {
-                     |      Visitor v = new Visitor() {
-                     |        public void visit(Visited visited) {
-                     |          visited.getList().forEach(lambdaParam -> captured.remove(lambdaParam));
-                     |        }
-                     |      };
-                     |    }
-                     |}
-                     |""".stripMargin)
+        |
+        |public class Foo {
+        |
+        |    public static void sink(String s) {};
+        |
+        |    public static Object test(Bar captured) {
+        |      Visitor v = new Visitor() {
+        |        public void visit(Visited visited) {
+        |          visited.getList().forEach(lambdaParam -> captured.remove(lambdaParam));
+        |        }
+        |      };
+        |    }
+        |}
+        |""".stripMargin)
 
+    // This behaviour isn't exactly correct, but is on par with how we currently handle field captures in lambdas.
     "have the correct receiver ast" in {
-      inside(cpg.call.name("remove").receiver.l) { case List(receiver: Identifier) =>
-        receiver.name shouldBe "captured"
-        receiver.typeFullName shouldBe "<unresolvedNamespace>.Foo"
+      inside(cpg.call.name("remove").receiver.l) { case List(fieldAccessCall: Call) =>
+        fieldAccessCall.name shouldBe Operators.fieldAccess
+
+        inside(fieldAccessCall.argument.l) { case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+          identifier.name shouldBe "this"
+          identifier.typeFullName shouldBe "Foo.test.Visitor$0"
+
+          fieldIdentifier.canonicalName shouldBe "captured"
+
+          fieldAccessCall.typeFullName shouldBe "<unresolvedNamespace>.Bar"
+        }
       }
+    }
+  }
+
+  // These tests exist to document current behaviour, but the current behaviour is wrong.
+  "lambdas capturing parameters" should {
+    val cpg = code("""
+        |import java.util.function.Consumer;
+        |
+        |public class Foo {
+        |  public String capturedField;
+        |
+        |  public void foo() {
+        |    Consumer<String> consumer = lambdaParam -> System.out.println(capturedField);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "represent the captured field as a field access" in {
+      inside(cpg.method.name(".*lambda.*").call.name("println").argument.l) { case List(_, fieldAccessCall: Call) =>
+        fieldAccessCall.name shouldBe Operators.fieldAccess
+
+        inside(fieldAccessCall.argument.l) { case List(identifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+          identifier.name shouldBe "this"
+          identifier.typeFullName shouldBe "Foo"
+
+          fieldIdentifier.canonicalName shouldBe "capturedField"
+        }
+      }
+    }
+
+    // It should, but it doesn't.
+    "have a captured local for the enclosing class" in {
+      // There should be an `outerClass` local which captures the outer method `this`.
+      cpg.method.name(".*lambda.*").local.name("this").typeFullName(".*Foo.*").isEmpty shouldBe true
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -760,7 +760,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         |}
         |""".stripMargin)
 
-    // This behaviour isn't exactly correct, but is on par with how we currently handle field captures in lambdas.
+    // TODO: This behaviour isn't exactly correct, but is on par with how we currently handle field captures in lambdas.
     "have the correct receiver ast" in {
       inside(cpg.call.name("remove").receiver.l) { case List(fieldAccessCall: Call) =>
         fieldAccessCall.name shouldBe Operators.fieldAccess
@@ -777,7 +777,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
     }
   }
 
-  // These tests exist to document current behaviour, but the current behaviour is wrong.
+  // TODO: These tests exist to document current behaviour, but the current behaviour is wrong.
   "lambdas capturing parameters" should {
     val cpg = code("""
         |import java.util.function.Consumer;
@@ -804,7 +804,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
       }
     }
 
-    // It should, but it doesn't.
+    // TODO: It should, but it doesn't.
     "have a captured local for the enclosing class" in {
       // There should be an `outerClass` local which captures the outer method `this`.
       cpg.method.name(".*lambda.*").local.name("this").typeFullName(".*Foo.*").isEmpty shouldBe true


### PR DESCRIPTION
Due to an interaction between regular/anonymous class capture logic and lambda capture logic, the assumption that a `this` parameter will always be available in the direct enclosing method when handling captures is sometimes false. In this case, an `Unknown` node was added to the cpg, causing dynamic call linker failures.

This pr fixes the lambda issue by seaching the entire scope for a `this` param, which correctly (-ish, see note below) creates the field access with the correct type, but also replaces the `Unknown` fallback with an identifier which would still result in dynamic linking failing (probably), but won't crash.

Note on captured params in lambdas: the current representation just treats them as `this.capturedField`, but with the type of `this` set to the class in which it is declared. I would be very surprised if this works, so a rework is required (creating an `outerClass` local in the lambda method with a closure binding pointing at the captured this parameter, for example), but that's out of the scope of this PR