### PR TITLE
[jssrc2cpg] Reduce logging noise

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -33,7 +33,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
       val (rootPath, fileName) = skippedFile
       val filePath             = Paths.get(rootPath, fileName)
       val fileLOC = Try(IOUtils.readLinesInFile(filePath)) match {
-        case Success(filecontent) => filecontent.size
+        case Success(fileContent) => fileContent.size
         case Failure(exception) =>
           logger.warn(s"Failed to read file: '$filePath'", exception)
           0
@@ -56,7 +56,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
           logger.warn(s"Failed to generate a CPG for: '${parseResult.fullPath}'", exception)
           (false, parseResult.filename)
         case Success(_) =>
-          logger.info(s"Generated a CPG for: '${parseResult.fullPath}'")
+          logger.debug(s"Generated a CPG for: '${parseResult.fullPath}'")
           (true, parseResult.filename)
       }
     }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -130,13 +130,13 @@ object AstGenRunner {
     val debugMsgPath  = path.getOrElse("PATH")
     ExternalCommand.run(s"$astGenCommand --version", localPath).toOption.map(_.mkString.strip()) match {
       case Some(installedVersion)
-          if installedVersion != "unknown" && Try(VersionHelper.compare(installedVersion, astGenVersion)).toOption
-            .getOrElse(-1) >= 0 =>
-        logger.debug(s"Using astgen v$installedVersion from $debugMsgPath")
+          if installedVersion != "unknown" &&
+            Try(VersionHelper.compare(installedVersion, astGenVersion)).toOption.getOrElse(-1) >= 0 =>
+        logger.debug(s"Found astgen v$installedVersion in '$debugMsgPath'")
         true
       case Some(installedVersion) =>
         logger.debug(
-          s"Found astgen v$installedVersion in $debugMsgPath but jssrc2cpg requires at least v$astGenVersion"
+          s"Found astgen v$installedVersion in '$debugMsgPath' but jssrc2cpg requires at least v$astGenVersion"
         )
         false
       case _ =>
@@ -160,15 +160,16 @@ object AstGenRunner {
         logger.debug(
           s"Did not find any astgen binary on this system (environment variable ASTGEN_BIN not set and no entry in the systems PATH)"
         )
-        val localPath = s"$executableDir/$executableName"
-        logger.debug(s"Using astgen from '$localPath'")
+        val localPath = s"$executableDir${java.io.File.separator}$executableName"
         localPath
   }
 
   private lazy val astGenCommand = {
     val conf          = ConfigFactory.load
     val astGenVersion = conf.getString("jssrc2cpg.astgen_version")
-    compatibleAstGenPath(astGenVersion)
+    val astGenPath    = compatibleAstGenPath(astGenVersion)
+    logger.info(s"Using astgen from '$astGenPath'")
+    astGenPath
   }
 }
 
@@ -354,7 +355,6 @@ class AstGenRunner(config: Config) {
 
   def execute(out: File): AstGenRunnerResult = {
     val in = File(config.inputPath)
-    logger.info(s"Running astgen in '$in' ...")
     runAstGenNative(in, out) match {
       case Success(result) =>
         val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString(), Set(".json")), out), in)


### PR DESCRIPTION
 - log cpg creation for each file in DEBUG only instead of INFO
 - log the astgen path only once with INFO
 - removed logging that astgen runs now in the given input folder