### PR TITLE
Add maven dependency fetcher support for MAVEN_CLI_OPTS flag used by gitlab

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -9,8 +9,23 @@ import scala.util.{Failure, Success}
 object MavenDependencies {
   private val logger = LoggerFactory.getLogger(getClass)
 
+  private val MavenCliOpts = "MAVEN_CLI_OPTS"
+  // we can't use -Dmdep.outputFile because that keeps overwriting its own output for each sub-project it's running for
+  // also separate this from fetchCommandWithOpts to log a version that clearly separates options we provide from
+  // options specified by the user via the MAVEN_CLI_OPTS environment variable, while also making it clear that this
+  // environment variable is being considered.
   private val fetchCommand =
-    "mvn --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out"
+    s"mvn $$$MavenCliOpts --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out"
+
+  private val fetchCommandWithOpts = {
+    // These options suppress output, so if they're provided we won't get any results.
+    // "-q" and "--quiet" are the only ones that would realistically be used.
+    val optionsToStrip = Set("-h", "--help", "-q", "--quiet", "-v", "--version")
+
+    val mavenOpts         = Option(System.getenv(MavenCliOpts)).getOrElse("")
+    val mavenOptsStripped = mavenOpts.split(raw"\s").filterNot(optionsToStrip.contains).mkString(" ")
+    fetchCommand.replace(s"$$$MavenCliOpts", mavenOptsStripped)
+  }
 
   private def logErrors(output: String): Unit = {
 
@@ -25,8 +40,7 @@ object MavenDependencies {
   }
 
   private[dependency] def get(projectDir: Path): Option[collection.Seq[String]] = {
-    // we can't use -Dmdep.outputFile because that keeps overwriting its own output for each sub-project it's running for
-    val lines = ExternalCommand.run(fetchCommand, projectDir.toString) match {
+    val lines = ExternalCommand.run(fetchCommandWithOpts, projectDir.toString) match {
       case Success(lines) =>
         if (lines.contains("[INFO] Build failures were ignored.")) {
           logErrors(lines.mkString(System.lineSeparator()))


### PR DESCRIPTION
# Without `MAVEN_CLI_OPTS` set

```
❯ unset MAVEN_CLI_OPTS
❯ echo $MAVEN_CLI_OPTS

❯ ./joern-cli/frontends/javasrc2cpg/javasrc2cpg ~/code/java/HelloShiftLeft --fetch-dependencies
...
[INFO ] Enabling dependency fetching: --fetch-dependencies flag was set
[INFO ] got 63 Maven dependencies
...
```

# With `MAVEN_CLI_OPTS` set (to a nonsense value to show it's being used)
```
❯ export MAVEN_CLI_OPTS="--file does/not/exist" && ./joern-cli/frontends/javasrc2cpg/javasrc2cpg ...
...
[INFO ] Enabling dependency fetching: --fetch-dependencies flag was set
[WARN ] Retrieval of compile class path via maven return with error.
The compile class path may be missing or partial.
Results will suffer from poor type information.
To fix this issue, please ensure that the below command can be executed successfully from the project root directory:
mvn $MAVEN_CLI_OPTS --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out


[INFO ] got 0 Maven dependencies
[WARN ] Could not fetch dependencies for project at path /home/johannes/code/java/HelloShiftLeft
...
```

# With `MAVEN_CLI_OPTS` set to quiet
```
❯ export MAVEN_CLI_OPTS="-q --quiet" && ./joern-cli/frontends/javasrc2cpg/javasrc2cpg ...
...
[INFO ] Enabling dependency fetching: --fetch-dependencies flag was set
[INFO ] got 63 Maven dependencies
...
```