### PR TITLE
[javascript] `new` Function Calls

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -79,7 +79,7 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
     val columnNumber    = astNodeInfo.columnNumber
     val lineNumberEnd   = astNodeInfo.lineNumberEnd
     val columnNumberEnd = astNodeInfo.columnNumberEnd
-    val name            = ":program"
+    val name            = Defines.Program
     val fullName        = s"$path:$name"
 
     val programMethod =

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -2,6 +2,7 @@ package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
+import io.joern.jssrc2cpg.passes.Defines.OperatorsNew
 import io.joern.jssrc2cpg.passes.{Defines, EcmaBuiltins, GlobalBuiltins}
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.datastructures.Stack.*
@@ -129,8 +130,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val receiverNode = astForNodeWithFunctionReference(callee)
 
-    // TODO: place "<operator>.new" into the schema
-    val callAst = handleCallNodeArgs(newExpr, receiverNode, tmpAllocNode2, "<operator>.new")
+    val callAst = handleCallNodeArgs(newExpr, receiverNode, tmpAllocNode2, OperatorsNew)
 
     val tmpAllocReturnNode = Ast(identifierNode(newExpr, tmpAllocName))
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -110,7 +110,7 @@ trait TypeHelper { this: AstCreator =>
     val matcher = ImportMatcher.matcher(value)
     this.rootTypeDecl.headOption match {
       case Some(typeDecl)            => typeDecl.fullName
-      case None if matcher.matches() => matcher.group(2).stripSuffix(".js").concat(".js::program")
+      case None if matcher.matches() => matcher.group(2).stripSuffix(".js").concat(s".js:${Defines.Program}")
       case None                      => value
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/Defines.scala
@@ -19,7 +19,9 @@ object Defines {
   val Never: String             = Any
   val Undefined: String         = Any
   val NodeModulesFolder: String = "node_modules"
+  val Program: String           = ":program"
   val GlobalNamespace: String   = NamespaceTraversal.globalNamespaceName
+  val OperatorsNew: String      = "<operator>.new" // TODO: place "<operator>.new" into the schema
 
   val JsTypes: List[String] =
     List(

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptImportResolverPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptImportResolverPass.scala
@@ -49,7 +49,7 @@ class JavaScriptImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
         cpg
           .file(s"${Pattern.quote(resolvedPath)}\\.?.*")
           .method
-          .nameExact(":program")
+          .nameExact(Defines.Program)
       else
         Iterator.empty
     ) match {
@@ -60,7 +60,7 @@ class JavaScriptImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
     }
 
     def targetAssignments = targetModule
-      .nameExact(":program")
+      .nameExact(Defines.Program)
       .flatMap(_._callViaContainsOut)
       .assignment
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptInheritanceNamePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptInheritanceNamePass.scala
@@ -9,7 +9,7 @@ import io.shiftleft.codepropertygraph.Cpg
 class JavaScriptInheritanceNamePass(cpg: Cpg) extends XInheritanceFullNamePass(cpg) {
 
   override val pathSep: Char      = ':'
-  override val moduleName: String = ":program"
+  override val moduleName: String = Defines.Program
   override val fileExt: String    = ".js"
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeHintCallLinker.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeHintCallLinker.scala
@@ -1,5 +1,6 @@
 package io.joern.jssrc2cpg.passes
 
+import io.joern.jssrc2cpg.passes.Defines.OperatorsNew
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Call
@@ -10,7 +11,7 @@ class JavaScriptTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
   override protected val pathSep = ":"
 
   override protected def calls: Iterator[Call] = cpg.call
-    .or(_.nameNot("<operator>.*", "<operators>.*"), _.name("<operator>.new"))
+    .or(_.nameNot("<operator>.*", "<operators>.*"), _.name(OperatorsNew))
     .filter(c => calleeNames(c).nonEmpty && c.callee.isEmpty)
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeNodePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeNodePass.scala
@@ -14,10 +14,10 @@ object JavaScriptTypeNodePass {
 
       override def fullToShortName(typeName: String): String = {
         typeName match {
-          case name if name.endsWith(":program") => ":program"
-          case name if name.contains("=>")       => name
-          case name if name.contains(":")        => name.split(':').lastOption.getOrElse(typeName)
-          case _                                 => typeName.split('.').lastOption.getOrElse(typeName)
+          case name if name.endsWith(Defines.Program) => Defines.Program
+          case name if name.contains("=>")            => name
+          case name if name.contains(":")             => name.split(':').lastOption.getOrElse(typeName)
+          case _                                      => typeName.split('.').lastOption.getOrElse(typeName)
         }
       }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeRecovery.scala
@@ -1,5 +1,6 @@
 package io.joern.jssrc2cpg.passes
 
+import io.joern.jssrc2cpg.passes.Defines.OperatorsNew
 import io.joern.x2cpg.Defines as XDefines
 import io.joern.x2cpg.Defines.ConstructorMethodName
 import io.joern.x2cpg.passes.frontend.*
@@ -94,7 +95,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
         }
         .flatMap {
           case (t, ts) if Set(t) == ts => Set(t)
-          case (_, ts)                 => ts.map(_.replaceAll("\\.(?!js::program)", pathSep))
+          case (_, ts)                 => ts.map(_.replaceAll(s"\\.(?!js:${Defines.Program})", pathSep))
         }
       p match {
         case _: MethodParameterIn => symbolTable.put(p, resolvedHints)
@@ -109,7 +110,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
   }
 
   private lazy val exportedIdentifiers = cu.method
-    .nameExact(":program")
+    .nameExact(Defines.Program)
     .flatMap(_._callViaContainsOut)
     .nameExact(Operators.assignment)
     .filter(_.code.startsWith("exports.*"))
@@ -123,11 +124,16 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
 
   override protected def visitIdentifierAssignedToConstructor(i: Identifier, c: Call): Set[String] = {
     val constructorPaths = if (c.methodFullName.endsWith(".alloc")) {
-      def newChildren = c.inAssignment.astSiblings.isCall.nameExact("<operator>.new").astChildren
+      val newOp       = c.inAssignment.astSiblings.isCall.nameExact(OperatorsNew).headOption
+      val newChildren = newOp.astChildren.l
+
       val possibleImportIdentifier = newChildren.isIdentifier.headOption match {
         case Some(id) if GlobalBuiltins.builtins.contains(id.name) => Set(s"__ecma.${id.name}")
-        case Some(id)                                              => symbolTable.get(id)
-        case None                                                  => Set.empty[String]
+        case Some(id) =>
+          val typs = symbolTable.get(CallAlias(id.name, Option("this")))
+          if typs.nonEmpty then newOp.foreach(symbolTable.put(_, typs))
+          symbolTable.get(id)
+        case None => Set.empty[String]
       }
       lazy val possibleConstructorPointer =
         newChildren.astChildren.isFieldIdentifier
@@ -146,7 +152,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
 
   override protected def visitIdentifierAssignedToOperator(i: Identifier, c: Call, operation: String): Set[String] = {
     operation match {
-      case "<operator>.new" =>
+      case OperatorsNew =>
         c.astChildren.l match {
           case ::(fa: Call, ::(id: Identifier, _)) if fa.name == Operators.fieldAccess =>
             symbolTable.append(

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1,6 +1,8 @@
 package io.joern.jssrc2cpg.passes
 
+import io.joern.jssrc2cpg.passes.Defines.OperatorsNew
 import io.joern.jssrc2cpg.testfixtures.DataFlowCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.importresolver.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -461,6 +463,18 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
       cpg.call("post").methodFullName.headOption shouldBe Option("@angular/common/http:HttpClient:post")
     }
 
+  }
+
+  "resolve a function full name called as a constructor" in {
+    val cpg = code("""
+        |var Print = function(str) {
+        |	console.log(str);
+        |}
+        |
+        |new Print("Hello")
+        |""".stripMargin)
+
+    cpg.call.nameExact(OperatorsNew).methodFullName.head shouldBe "Test0.js::program:Print"
   }
 
 }


### PR DESCRIPTION
The `new` operator can prefix an ordinary call, e.g.
```javascript
var Print = function(str) {
	console.log(str)
}

new Print("Hello")
```
The type recovery pass only considers object instantiations from type declarations on `new` calls, but this change allows it to consider functions too.

Other changes include adding constants for `:program` and `<operator>.new`