### PR TITLE
[ruby] Fix binding name

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -165,7 +165,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     */
   private def createMethodTypeBindings(method: NewMethod, refs: List[Ast]): Unit = {
     refs.flatMap(_.root).collectFirst { case typeRef: NewTypeDecl =>
-      val bindingNode = newBindingNode(method.name, "", method.fullName)
+      val bindingNode = newBindingNode("", "", method.fullName)
       diffGraph.addEdge(typeRef, bindingNode, EdgeTypes.BINDS)
       diffGraph.addEdge(bindingNode, method, EdgeTypes.REF)
     }


### PR DESCRIPTION
In ruby as for all other dynamic language there is no vtable and thus
only a single entry in the binding tables with name=="" and
signature=="".