### PR TITLE
[ruby] Type/Method Identifier Ref Prefixes Definition

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -96,81 +96,15 @@ class AstCreator(
         scope.pushNewScope(moduleScope)
         val block = blockNode(rootNode)
         scope.pushNewScope(BlockScope(block))
-        val statementAsts         = rootNode.statements.flatMap(astsForStatement)
-        val internalMethodRefAsts = methodRefNodesForInternalMethods()
-        val internalTypeRefAsts   = typeRefNodesForInternalDecls()
+        val statementAsts = rootNode.statements.flatMap(astsForStatement)
         scope.popScope()
-        val bodyAst = blockAst(block, internalTypeRefAsts ++ internalMethodRefAsts ++ statementAsts)
+        val bodyAst = blockAst(block, statementAsts)
         scope.popScope()
         methodAst(methodNode_, Seq.empty, bodyAst, methodReturn, newModifierNode(ModifierTypes.MODULE) :: Nil)
       }
       .getOrElse(Ast())
   }
 
-  private def methodRefNodesForInternalMethods(): List[Ast] = {
-    val typeNameForMethods = scope.surroundingTypeFullName
-      .map { x =>
-        x.stripSuffix(s":${Defines.Program}")
-      }
-      .getOrElse(Defines.Undefined)
-
-    scope.surroundingTypeFullName
-      .map { x =>
-        val typeNameForMethods = x.stripSuffix(s":${Defines.Program}")
-        programSummary.namespaceToType
-          .filter(_._1 == typeNameForMethods)
-          .flatMap(_._2)
-          .filter(!_.isInstanceOf[RubyStubbedType])
-          .flatMap(_.methods)
-          .map { method =>
-            val methodRefNode = NewMethodRef()
-              .code(s"def ${method.name} (...)")
-              .methodFullName(scope.surroundingTypeFullName.map { x => s"$x:${method.name}" }.getOrElse(method.name))
-              .typeFullName(Defines.Any)
-              .lineNumber(internalLineAndColNum)
-              .columnNumber(internalLineAndColNum)
-
-            val methodRefIdent = NewIdentifier()
-              .code(method.name)
-              .name(method.name)
-              .typeFullName(Defines.Any)
-              .lineNumber(internalLineAndColNum)
-              .columnNumber(internalLineAndColNum)
-
-            astForAssignment(methodRefIdent, methodRefNode, internalLineAndColNum, internalLineAndColNum)
-          }
-          .toList
-      }
-      .getOrElse(List.empty)
-
-  }
-
-  private def typeRefNodesForInternalDecls(): List[Ast] = {
-    scope.surroundingTypeFullName
-      .map { surroundingTypeFullName =>
-        programSummary.namespaceToType
-          .filter(_._1.contains(surroundingTypeFullName))
-          .flatMap(_._2)
-          .map { x =>
-            val typeRefName = x.name.split("[.]").takeRight(1).head
-            val typeRefNode = NewTypeRef()
-              .code(s"class ${x.name} (...)")
-              .typeFullName(x.name)
-
-            val typeRefIdent = NewIdentifier()
-              .code(typeRefName)
-              .name(typeRefName)
-              .typeFullName(x.name)
-              .lineNumber(internalLineAndColNum)
-              .columnNumber(internalLineAndColNum)
-
-            astForAssignment(typeRefIdent, typeRefNode, internalLineAndColNum, internalLineAndColNum)
-          }
-          .toList
-      }
-      .getOrElse(List.empty)
-
-  }
 }
 
 /** Determines till what depth the AST creator will parse until.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -23,10 +23,10 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case node: MemberCallWithBlock        => astsForCallWithBlock(node)
     case node: ReturnExpression           => astForReturnStatement(node) :: Nil
     case node: AnonymousTypeDeclaration   => astForAnonymousTypeDeclaration(node) :: Nil
-    case node: TypeDeclaration            => astForClassDeclaration(node) :: Nil
+    case node: TypeDeclaration            => astForClassDeclaration(node)
     case node: FieldsDeclaration          => astsForFieldDeclarations(node)
     case node: MethodDeclaration          => astForMethodDeclaration(node)
-    case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node) :: Nil
+    case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node)
     case node: MultipleAssignment         => node.assignments.map(astForExpression)
     case node: BreakStatement             => astForBreakStatement(node) :: Nil
     case _                                => astForExpression(node) :: Nil

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -48,6 +48,22 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     */
   def newProgramScope: Option[ProgramScope] = surroundingScopeFullName.map(ProgramScope.apply)
 
+  /** @return
+    *   true if the top of the stack is the program/module.
+    */
+  def isSurroundedByProgramScope: Boolean = {
+    stack
+      .take(2)
+      .filterNot {
+        case ScopeElement(BlockScope(_), _) => true
+        case _                              => false
+      }
+      .headOption match {
+      case Some(ScopeElement(ProgramScope(_), _)) => true
+      case _                                      => false
+    }
+  }
+
   def pushField(field: FieldDecl): Unit = {
     popScope().foreach {
       case TypeScope(fullName, fields) =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -26,6 +26,7 @@ class CallTests extends RubyCode2CpgFixture {
 
     hello.argumentIndex shouldBe 1
     hello.code shouldBe "'hello'"
+    hello.lineNumber shouldBe Some(2)
 
     val List(callBase: Call) = puts.receiver.l: @unchecked
     callBase.argumentIndex shouldBe -1
@@ -36,7 +37,6 @@ class CallTests extends RubyCode2CpgFixture {
     val List(baseSelf: Identifier, baseProperty: FieldIdentifier) = callBase.argument.l: @unchecked
     baseSelf.argumentIndex shouldBe 1
     baseSelf.name shouldBe RubyDefines.Self
-    hello.lineNumber shouldBe Some(2)
     baseProperty.argumentIndex shouldBe 2
     baseProperty.canonicalName shouldBe "puts"
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -4,7 +4,16 @@ import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, MethodRef, Return, TypeRef}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Call,
+  Identifier,
+  Literal,
+  Method,
+  MethodRef,
+  Return,
+  TypeDecl,
+  TypeRef
+}
 import io.shiftleft.semanticcpg.language.*
 
 class MethodTests extends RubyCode2CpgFixture {
@@ -635,6 +644,16 @@ class MethodTests extends RubyCode2CpgFixture {
           }
 
         case xs => fail(s"Expected two assignments, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "be placed directly before each entity's definition" in {
+      inside(cpg.method.name(RDefines.Program).filename("t1.rb").block.astChildren.l) {
+        case (a1: Call) :: (_: TypeDecl) :: (a2: Call) :: (_: TypeDecl) :: (a3: Call) :: (_: Method) :: (_: TypeDecl) :: Nil =>
+          a1.code shouldBe "A = class t1.rb:<global>::program.A (...)"
+          a2.code shouldBe "B = class t1.rb:<global>::program.B (...)"
+          a3.code shouldBe "c = def c (...)"
+        case xs => fail(s"Expected assignments to appear before definitions, instead got [$xs]")
       }
     }
   }


### PR DESCRIPTION
This change moves the type/method identifier references for entities exportable from the script to prefix the respective entity at the definition.