### PR TITLE
gitignore: remove `c2cpg/lib`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ null
 **/SwiftAstGen-mac
 **/SwiftAstGen-linux
 **/php2cpg/bin
-**/c2cpg/lib
 /foo.c
 /woo.c
 /cpg_*.bin.zip


### PR DESCRIPTION
this caused me some headaches as I had an old jar lying around there,
likely from a bisect session...