### PR TITLE
[ruby] Type/Method Identifier Ref Self Access

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -87,7 +87,16 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     lineNumber: Option[Integer],
     columnNumber: Option[Integer]
   ): Ast = {
-    val code = Seq(lhs, rhs).collect { case x: AstNodeNew => x.code }.mkString(" = ")
+    astForAssignment(Ast(lhs), Ast(rhs), lineNumber, columnNumber)
+  }
+
+  protected def astForAssignment(
+    lhs: Ast,
+    rhs: Ast,
+    lineNumber: Option[Integer],
+    columnNumber: Option[Integer]
+  ): Ast = {
+    val code = Seq(lhs, rhs).flatMap(_.root).collect { case x: ExpressionNew => x.code }.mkString(" = ")
     val assignment = NewCall()
       .name(Operators.assignment)
       .methodFullName(Operators.assignment)
@@ -96,7 +105,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       .lineNumber(lineNumber)
       .columnNumber(columnNumber)
 
-    callAst(assignment, Seq(Ast(lhs), Ast(rhs)))
+    callAst(assignment, Seq(lhs, rhs))
   }
 
   protected val UnaryOperatorNames: Map[String, String] = Map(

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodReturnTests.scala
@@ -81,8 +81,12 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
           ("arg > 1", 3),
           ("arg + 1", 4),
           ("RET", 2),
+          ("self.foo = def foo (...)", 2),
+          ("self.foo = def foo (...)", -1),
           ("foo x", 11),
-          ("y = foo x", 11),
+          ("foo(self, arg)", 2),
+          ("RET", 2),
+          ("foo x", 11),
           ("puts y", 12)
         )
       )
@@ -122,8 +126,12 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
           ("RET", 2),
           ("add(arg)", 8),
           ("RET", 6),
+          ("self.foo = def foo (...)", 6),
+          ("self.foo = def foo (...)", -1),
           ("foo x", 15),
-          ("y = foo x", 15),
+          ("foo(self, arg)", 6),
+          ("RET", 6),
+          ("foo x", 15),
           ("puts y", 16)
         )
       )
@@ -151,8 +159,12 @@ class MethodReturnTests extends RubyCode2CpgFixture(withPostProcessing = true, w
           ("q = p", 3),
           ("return q", 4),
           ("RET", 2),
+          ("self.add = def add (...)", 2),
+          ("self.add = def add (...)", -1),
           ("add(n)", 8),
-          ("ret = add(n)", 8),
+          ("add(self, p)", 2),
+          ("RET", 2),
+          ("add(n)", 8),
           ("puts ret", 9)
         )
       )

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -592,27 +592,30 @@ class MethodTests extends RubyCode2CpgFixture {
     "be directly under :program" in {
       inside(cpg.method.name(RDefines.Program).filename("t1.rb").assignment.l) {
         case moduleAssignment :: classAssignment :: methodAssignment :: Nil =>
-          moduleAssignment.code shouldBe "A = class t1.rb:<global>::program.A (...)"
-          classAssignment.code shouldBe "B = class t1.rb:<global>::program.B (...)"
-          methodAssignment.code shouldBe "c = def c (...)"
+          moduleAssignment.code shouldBe "self.A = class A (...)"
+          classAssignment.code shouldBe "self.B = class B (...)"
+          methodAssignment.code shouldBe "self.c = def c (...)"
 
           inside(moduleAssignment.argument.l) {
-            case (lhs: Identifier) :: (rhs: TypeRef) :: Nil =>
-              lhs.name shouldBe "A"
+            case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
+              lhs.code shouldBe "self.A"
+              lhs.name shouldBe Operators.fieldAccess
               rhs.typeFullName shouldBe "t1.rb:<global>::program.A"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
           inside(classAssignment.argument.l) {
-            case (lhs: Identifier) :: (rhs: TypeRef) :: Nil =>
-              lhs.name shouldBe "B"
+            case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
+              lhs.code shouldBe "self.B"
+              lhs.name shouldBe Operators.fieldAccess
               rhs.typeFullName shouldBe "t1.rb:<global>::program.B"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
           inside(methodAssignment.argument.l) {
-            case (lhs: Identifier) :: (rhs: MethodRef) :: Nil =>
-              lhs.name shouldBe "c"
+            case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
+              lhs.code shouldBe "self.c"
+              lhs.name shouldBe Operators.fieldAccess
               rhs.methodFullName shouldBe "t1.rb:<global>::program:c"
               rhs.typeFullName shouldBe RDefines.Any
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
@@ -625,19 +628,21 @@ class MethodTests extends RubyCode2CpgFixture {
     "not be present in other files" in {
       inside(cpg.method.name(RDefines.Program).filename("t2.rb").assignment.l) {
         case classAssignment :: methodAssignment :: Nil =>
-          classAssignment.code shouldBe "D = class t2.rb:<global>::program.D (...)"
-          methodAssignment.code shouldBe "e = def e (...)"
+          classAssignment.code shouldBe "self.D = class D (...)"
+          methodAssignment.code shouldBe "self.e = def e (...)"
 
           inside(classAssignment.argument.l) {
-            case (lhs: Identifier) :: (rhs: TypeRef) :: Nil =>
-              lhs.name shouldBe "D"
+            case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
+              lhs.code shouldBe "self.D"
+              lhs.name shouldBe Operators.fieldAccess
               rhs.typeFullName shouldBe "t2.rb:<global>::program.D"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
           inside(methodAssignment.argument.l) {
-            case (lhs: Identifier) :: (rhs: MethodRef) :: Nil =>
-              lhs.name shouldBe "e"
+            case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
+              lhs.code shouldBe "self.e"
+              lhs.name shouldBe Operators.fieldAccess
               rhs.methodFullName shouldBe "t2.rb:<global>::program:e"
               rhs.typeFullName shouldBe RDefines.Any
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
@@ -650,9 +655,9 @@ class MethodTests extends RubyCode2CpgFixture {
     "be placed directly before each entity's definition" in {
       inside(cpg.method.name(RDefines.Program).filename("t1.rb").block.astChildren.l) {
         case (a1: Call) :: (_: TypeDecl) :: (a2: Call) :: (_: TypeDecl) :: (a3: Call) :: (_: Method) :: (_: TypeDecl) :: Nil =>
-          a1.code shouldBe "A = class t1.rb:<global>::program.A (...)"
-          a2.code shouldBe "B = class t1.rb:<global>::program.B (...)"
-          a3.code shouldBe "c = def c (...)"
+          a1.code shouldBe "self.A = class A (...)"
+          a2.code shouldBe "self.B = class B (...)"
+          a3.code shouldBe "self.c = def c (...)"
         case xs => fail(s"Expected assignments to appear before definitions, instead got [$xs]")
       }
     }


### PR DESCRIPTION
This changes makes the type decl/method references at the module-level explicitly assign members of the `self` object.