### PR TITLE
[ruby] `Kernel` Methods are Static Dispatch

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -9,7 +9,8 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
 }
 import io.joern.rubysrc2cpg.datastructures.{BlockScope, FieldDecl}
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinFunctions, builtinPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{kernelFunctions, kernelPrefix}
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
@@ -25,9 +26,11 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   override def lineEnd(node: RubyNode): Option[Integer]   = node.lineEnd
   override def code(node: RubyNode): String               = shortenCode(node.text)
 
-  protected def isBuiltin(x: String): Boolean      = builtinFunctions.contains(x)
-  protected def prefixAsBuiltin(x: String): String = s"$builtinPrefix$pathSep$x"
-  protected def pathSep                            = "."
+  protected def isBuiltin(x: String): Boolean            = kernelFunctions.contains(x)
+  protected def prefixAsKernelDefined(x: String): String = s"$kernelPrefix$pathSep$x"
+  protected def prefixAsBundledType(x: String): String   = s"<${GlobalTypes.builtinPrefix}.$x>"
+  protected def isBundledClass(x: String): Boolean       = GlobalTypes.bundledClasses.contains(x)
+  protected def pathSep                                  = "."
 
   private def astForFieldInstance(name: String, node: RubyNode & RubyFieldIdentifier): Ast = {
     val identName = node match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,5 +1,4 @@
 package io.joern.rubysrc2cpg.astcreation
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinFunctions, builtinPrefix}
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   ClassFieldIdentifier,
   DummyNode,
@@ -9,11 +8,11 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   RubyNode
 }
 import io.joern.rubysrc2cpg.datastructures.{BlockScope, FieldDecl}
-import io.joern.x2cpg.{Ast, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinFunctions, builtinPrefix}
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
 
 trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,5 +1,5 @@
 package io.joern.rubysrc2cpg.astcreation
-import io.joern.rubysrc2cpg.astcreation.GlobalTypes.{builtinFunctions, builtinPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinFunctions, builtinPrefix}
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   ClassFieldIdentifier,
   DummyNode,
@@ -155,94 +155,4 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     "||=" -> Operators.assignmentOr,
     "&&=" -> Operators.assignmentAnd
   )
-}
-
-// TODO: Move this to a more appropriate place?
-object GlobalTypes {
-  val builtinPrefix = "__builtin"
-
-  /* Sources:
-   * https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html
-   * https://ruby-doc.org/3.2.2/Kernel.html
-   *
-   * We comment-out methods that require an explicit "receiver" (target of member access.)
-   */
-  val builtinFunctions: Set[String] = Set(
-    "Array",
-    "Complex",
-    "Float",
-    "Hash",
-    "Integer",
-    "Rational",
-    "String",
-    "__callee__",
-    "__dir__",
-    "__method__",
-    "abort",
-    "at_exit",
-    "autoload",
-    "autoload?",
-    "binding",
-    "block_given?",
-    "callcc",
-    "caller",
-    "caller_locations",
-    "catch",
-    "chomp",
-    "chomp!",
-    "chop",
-    "chop!",
-    // "class",
-    // "clone",
-    "eval",
-    "exec",
-    "exit",
-    "exit!",
-    "fail",
-    "fork",
-    "format",
-    // "frozen?",
-    "gets",
-    "global_variables",
-    "gsub",
-    "gsub!",
-    "iterator?",
-    "lambda",
-    "load",
-    "local_variables",
-    "loop",
-    "open",
-    "p",
-    "print",
-    "printf",
-    "proc",
-    "putc",
-    "puts",
-    "raise",
-    "rand",
-    "readline",
-    "readlines",
-    "require",
-    "require_relative",
-    "select",
-    "set_trace_func",
-    "sleep",
-    "spawn",
-    "sprintf",
-    "srand",
-    "sub",
-    "sub!",
-    "syscall",
-    "system",
-    "tap",
-    "test",
-    // "then",
-    "throw",
-    "trace_var",
-    // "trap",
-    "untrace_var",
-    "warn"
-    // "yield_self",
-  )
-
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -684,7 +684,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       }
     val argumentAst = node.arguments.map(astForMethodCallArgument)
     val dispatchType =
-      if methodName.startsWith(GlobalTypes.builtinPrefix) then DispatchTypes.STATIC_DISPATCH
+      if receiverType == GlobalTypes.builtinPrefix then DispatchTypes.STATIC_DISPATCH
       else DispatchTypes.DYNAMIC_DISPATCH
     val call = callNode(node, code(node), methodName, methodFullName, dispatchType)
     val receiverAst = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -215,8 +215,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         Ast(parameterIn)
       case node: CollectionParameter =>
         val typeFullName = node match {
-          case ArrayParameter(_) => prefixAsBuiltin("Array")
-          case HashParameter(_)  => prefixAsBuiltin("Hash")
+          case ArrayParameter(_) => prefixAsKernelDefined("Array")
+          case HashParameter(_)  => prefixAsKernelDefined("Hash")
         }
         val parameterIn = parameterInNode(
           node = node,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -1,8 +1,8 @@
 package io.joern.rubysrc2cpg.datastructures
 
 import better.files.File
-import io.joern.rubysrc2cpg.astcreation.GlobalTypes
-import io.joern.rubysrc2cpg.astcreation.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
 import io.joern.x2cpg.datastructures.*

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.datastructures
 
 import better.files.File
 import io.joern.rubysrc2cpg.passes.GlobalTypes
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
 import io.joern.x2cpg.datastructures.*
@@ -17,25 +17,25 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     extends Scope[String, DeclarationNew, TypedScopeElement]
     with TypedScope[RubyMethod, RubyField, RubyType](summary) {
 
-  private val builtinMethods = GlobalTypes.builtinFunctions
-    .map(m => RubyMethod(m, List.empty, Defines.Any, Some(GlobalTypes.builtinPrefix)))
+  private val builtinMethods = GlobalTypes.kernelFunctions
+    .map(m => RubyMethod(m, List.empty, Defines.Any, Some(GlobalTypes.kernelPrefix)))
     .toList
 
   override val typesInScope: mutable.Set[RubyType] =
-    mutable.Set(RubyType(GlobalTypes.builtinPrefix, builtinMethods, List.empty))
+    mutable.Set(RubyType(GlobalTypes.kernelPrefix, builtinMethods, List.empty))
 
   // Add some built-in methods that are significant
   // TODO: Perhaps create an offline pre-built list of methods
   typesInScope.addAll(
     Seq(
       RubyType(
-        s"$builtinPrefix.Array",
-        List(RubyMethod("[]", List.empty, s"$builtinPrefix.Array", Option(s"$builtinPrefix.Array"))),
+        s"$kernelPrefix.Array",
+        List(RubyMethod("[]", List.empty, s"$kernelPrefix.Array", Option(s"$kernelPrefix.Array"))),
         List.empty
       ),
       RubyType(
-        s"$builtinPrefix.Hash",
-        List(RubyMethod("[]", List.empty, s"$builtinPrefix.Hash", Option(s"$builtinPrefix.Hash"))),
+        s"$kernelPrefix.Hash",
+        List(RubyMethod("[]", List.empty, s"$kernelPrefix.Hash", Option(s"$kernelPrefix.Hash"))),
         List.empty
       )
     )
@@ -290,8 +290,8 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
       .orElse(tryResolveStubbedTypeReference(typeName))
       .orElse {
         super.tryResolveTypeReference(normalizedTypeName) match {
-          case None if GlobalTypes.builtinFunctions.contains(normalizedTypeName) =>
-            Option(RubyType(s"${GlobalTypes.builtinPrefix}.$normalizedTypeName", List.empty, List.empty))
+          case None if GlobalTypes.kernelFunctions.contains(normalizedTypeName) =>
+            Option(RubyType(s"${GlobalTypes.kernelPrefix}.$normalizedTypeName", List.empty, List.empty))
           case None =>
             summary.namespaceToType.flatMap(_._2).collectFirst {
               case x if x.name.split("[.]").endsWith(normalizedTypeName.split("[.]")) =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -2,7 +2,11 @@ package io.joern.rubysrc2cpg.parser
 
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.parser.AntlrContextHelpers.*
-import io.joern.rubysrc2cpg.parser.RubyParser.{CommandWithDoBlockContext, ConstantVariableReferenceContext}
+import io.joern.rubysrc2cpg.parser.RubyParser.{
+  CommandWithDoBlockContext,
+  ConstantVariableReferenceContext,
+  MethodCallOrVariableReferenceContext
+}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.rubysrc2cpg.utils.FreshNameGenerator
@@ -635,6 +639,13 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   ): RubyNode = {
     val arguments = ctx.primaryValueList().primaryValue().asScala.map(visit).toList
     YieldExpr(arguments)(ctx.toTextSpan)
+  }
+
+  override def visitMemberAccessCommand(ctx: RubyParser.MemberAccessCommandContext): RubyNode = {
+    val arg        = visit(ctx.commandArgument())
+    val methodName = visit(ctx.methodName())
+    val base       = visit(ctx.primary())
+    MemberCall(base, ".", methodName.text, List(arg))(ctx.toTextSpan)
   }
 
   override def visitConstantIdentifierVariable(ctx: RubyParser.ConstantIdentifierVariableContext): RubyNode = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -2,11 +2,7 @@ package io.joern.rubysrc2cpg.parser
 
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.parser.AntlrContextHelpers.*
-import io.joern.rubysrc2cpg.parser.RubyParser.{
-  CommandWithDoBlockContext,
-  ConstantVariableReferenceContext,
-  MethodCallOrVariableReferenceContext
-}
+import io.joern.rubysrc2cpg.parser.RubyParser.{CommandWithDoBlockContext, ConstantVariableReferenceContext}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.rubysrc2cpg.utils.FreshNameGenerator

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -40,7 +40,8 @@ object Defines {
 }
 
 object GlobalTypes {
-  val builtinPrefix = "Kernel"
+  val Kernel        = "Kernel"
+  val builtinPrefix = s"<__builtin.$Kernel>"
 
   /* Sources:
    * https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -1,7 +1,5 @@
 package io.joern.rubysrc2cpg.passes
 
-import io.joern.rubysrc2cpg.astcreation.GlobalTypes
-
 object Defines {
 
   val Any: String        = "ANY"
@@ -39,4 +37,93 @@ object Defines {
     val regexpMatch     = "=~"
     val regexpNotMatch  = "!~"
   }
+}
+
+object GlobalTypes {
+  val builtinPrefix = "Kernel"
+
+  /* Sources:
+   * https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html
+   * https://ruby-doc.org/3.2.2/Kernel.html
+   *
+   * We comment-out methods that require an explicit "receiver" (target of member access.)
+   */
+  val builtinFunctions: Set[String] = Set(
+    "Array",
+    "Complex",
+    "Float",
+    "Hash",
+    "Integer",
+    "Rational",
+    "String",
+    "__callee__",
+    "__dir__",
+    "__method__",
+    "abort",
+    "at_exit",
+    "autoload",
+    "autoload?",
+    "binding",
+    "block_given?",
+    "callcc",
+    "caller",
+    "caller_locations",
+    "catch",
+    "chomp",
+    "chomp!",
+    "chop",
+    "chop!",
+    // "class",
+    // "clone",
+    "eval",
+    "exec",
+    "exit",
+    "exit!",
+    "fail",
+    "fork",
+    "format",
+    // "frozen?",
+    "gets",
+    "global_variables",
+    "gsub",
+    "gsub!",
+    "iterator?",
+    "lambda",
+    "load",
+    "local_variables",
+    "loop",
+    "open",
+    "p",
+    "print",
+    "printf",
+    "proc",
+    "putc",
+    "puts",
+    "raise",
+    "rand",
+    "readline",
+    "readlines",
+    "require",
+    "require_relative",
+    "select",
+    "set_trace_func",
+    "sleep",
+    "spawn",
+    "sprintf",
+    "srand",
+    "sub",
+    "sub!",
+    "syscall",
+    "system",
+    "tap",
+    "test",
+    // "then",
+    "throw",
+    "trace_var",
+    // "trap",
+    "untrace_var",
+    "warn"
+    // "yield_self",
+  )
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -28,7 +28,7 @@ object Defines {
 
   val AnonymousProcParameter = "<anonymous-proc-param>"
 
-  def getBuiltInType(typeInString: String) = s"${GlobalTypes.builtinPrefix}.$typeInString"
+  def getBuiltInType(typeInString: String) = s"${GlobalTypes.kernelPrefix}.$typeInString"
 
   object RubyOperators {
     val hashInitializer = "<operator>.hashInitializer"
@@ -41,15 +41,30 @@ object Defines {
 
 object GlobalTypes {
   val Kernel        = "Kernel"
-  val builtinPrefix = s"<__builtin.$Kernel>"
+  val builtinPrefix = "__builtin"
+  val kernelPrefix  = s"<$builtinPrefix.$Kernel>"
 
-  /* Sources:
-   * https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html
-   * https://ruby-doc.org/3.2.2/Kernel.html
+  /** Source: https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html
+    */
+  val bundledClasses: Set[String] = Set(
+    "Comparable",
+    "Enumerable",
+    "Errno",
+    "FileTest",
+    "GC",
+    Kernel,
+    "Marshal",
+    "Math",
+    "ObjectSpace",
+    "Precision",
+    "Process"
+  )
+
+  /* Source: https://ruby-doc.org/3.2.2/Kernel.html
    *
    * We comment-out methods that require an explicit "receiver" (target of member access.)
    */
-  val builtinFunctions: Set[String] = Set(
+  val kernelFunctions: Set[String] = Set(
     "Array",
     "Complex",
     "Float",

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.passes
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines as XDefines
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.semanticcpg.language.importresolver.*
 import io.shiftleft.semanticcpg.language.*
@@ -58,9 +58,9 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
 
     "resolve 'print' and 'puts' StubbedRubyType calls" in {
       val List(printCall) = cpg.call("print").l
-      printCall.methodFullName shouldBe s"$builtinPrefix:print"
+      printCall.methodFullName shouldBe s"$kernelPrefix:print"
       val List(maxCall) = cpg.call("puts").l
-      maxCall.methodFullName shouldBe s"$builtinPrefix:puts"
+      maxCall.methodFullName shouldBe s"$kernelPrefix:puts"
     }
 
     "present the declared method name when a built-in with the same name is used in the same compilation unit" in {
@@ -87,8 +87,8 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate function return types" in {
       inside(cpg.method.name("func2?").l) {
         case func :: func2 :: Nil =>
-          func.methodReturn.typeFullName shouldBe s"$builtinPrefix.String"
-          func2.methodReturn.typeFullName shouldBe s"$builtinPrefix.String"
+          func.methodReturn.typeFullName shouldBe s"$kernelPrefix.String"
+          func2.methodReturn.typeFullName shouldBe s"$kernelPrefix.String"
         case xs => fail(s"Expected 2 functions, got [${xs.name.mkString(",")}]")
       }
     }
@@ -96,7 +96,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate return type to identifier c" in {
       inside(cpg.identifier.name("c").l) {
         case cIdent :: Nil =>
-          cIdent.typeFullName shouldBe s"$builtinPrefix.String"
+          cIdent.typeFullName shouldBe s"$kernelPrefix.String"
         case xs => fail(s"Expected one identifier for c, got [${xs.name.mkString(",")}]")
       }
     }
@@ -133,7 +133,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
         case funcAssignment :: constructAssignment :: tmpAssignment :: Nil =>
           inside(funcAssignment.argument.l) {
             case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe s"$builtinPrefix.String"
+              lhs.typeFullName shouldBe s"$kernelPrefix.String"
             case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}] ")
           }
 
@@ -235,9 +235,9 @@ class RubyExternalTypeRecoveryTests
 
     "resolve 'x' and 'y' locally under foo.rb" in {
       val Some(x) = cpg.identifier("x").where(_.file.name(".*foo.*")).headOption: @unchecked
-      x.typeFullName shouldBe s"$builtinPrefix.Integer"
+      x.typeFullName shouldBe s"$kernelPrefix.Integer"
       val Some(y) = cpg.identifier("y").where(_.file.name(".*foo.*")).headOption: @unchecked
-      y.typeFullName shouldBe s"$builtinPrefix.String"
+      y.typeFullName shouldBe s"$kernelPrefix.String"
     }
 
     "resolve 'FooModule.x' and 'FooModule.y' field access primitive types correctly" in {
@@ -248,9 +248,9 @@ class RubyExternalTypeRecoveryTests
         .name("z")
         .l
       z1.typeFullName shouldBe "ANY"
-      z1.dynamicTypeHintFullName shouldBe Seq(s"$builtinPrefix.Integer", s"$builtinPrefix.String")
+      z1.dynamicTypeHintFullName shouldBe Seq(s"$kernelPrefix.Integer", s"$kernelPrefix.String")
       z2.typeFullName shouldBe "ANY"
-      z2.dynamicTypeHintFullName shouldBe Seq(s"$builtinPrefix.Integer", s"$builtinPrefix.String")
+      z2.dynamicTypeHintFullName shouldBe Seq(s"$kernelPrefix.Integer", s"$kernelPrefix.String")
     }
 
     "resolve 'FooModule.d' field access object types correctly" ignore {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.passes
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines as XDefines
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.semanticcpg.language.importresolver.*
 import io.shiftleft.semanticcpg.language.*
@@ -57,9 +58,9 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
 
     "resolve 'print' and 'puts' StubbedRubyType calls" in {
       val List(printCall) = cpg.call("print").l
-      printCall.methodFullName shouldBe "__builtin:print"
+      printCall.methodFullName shouldBe s"$builtinPrefix:print"
       val List(maxCall) = cpg.call("puts").l
-      maxCall.methodFullName shouldBe "__builtin:puts"
+      maxCall.methodFullName shouldBe s"$builtinPrefix:puts"
     }
 
     "present the declared method name when a built-in with the same name is used in the same compilation unit" in {
@@ -86,8 +87,8 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate function return types" in {
       inside(cpg.method.name("func2?").l) {
         case func :: func2 :: Nil =>
-          func.methodReturn.typeFullName shouldBe "__builtin.String"
-          func2.methodReturn.typeFullName shouldBe "__builtin.String"
+          func.methodReturn.typeFullName shouldBe s"$builtinPrefix.String"
+          func2.methodReturn.typeFullName shouldBe s"$builtinPrefix.String"
         case xs => fail(s"Expected 2 functions, got [${xs.name.mkString(",")}]")
       }
     }
@@ -95,7 +96,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate return type to identifier c" in {
       inside(cpg.identifier.name("c").l) {
         case cIdent :: Nil =>
-          cIdent.typeFullName shouldBe "__builtin.String"
+          cIdent.typeFullName shouldBe s"$builtinPrefix.String"
         case xs => fail(s"Expected one identifier for c, got [${xs.name.mkString(",")}]")
       }
     }
@@ -132,7 +133,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
         case funcAssignment :: constructAssignment :: tmpAssignment :: Nil =>
           inside(funcAssignment.argument.l) {
             case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe "__builtin.String"
+              lhs.typeFullName shouldBe s"$builtinPrefix.String"
             case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}] ")
           }
 
@@ -234,9 +235,9 @@ class RubyExternalTypeRecoveryTests
 
     "resolve 'x' and 'y' locally under foo.rb" in {
       val Some(x) = cpg.identifier("x").where(_.file.name(".*foo.*")).headOption: @unchecked
-      x.typeFullName shouldBe "__builtin.Integer"
+      x.typeFullName shouldBe s"$builtinPrefix.Integer"
       val Some(y) = cpg.identifier("y").where(_.file.name(".*foo.*")).headOption: @unchecked
-      y.typeFullName shouldBe "__builtin.String"
+      y.typeFullName shouldBe s"$builtinPrefix.String"
     }
 
     "resolve 'FooModule.x' and 'FooModule.y' field access primitive types correctly" in {
@@ -247,9 +248,9 @@ class RubyExternalTypeRecoveryTests
         .name("z")
         .l
       z1.typeFullName shouldBe "ANY"
-      z1.dynamicTypeHintFullName shouldBe Seq("__builtin.Integer", "__builtin.String")
+      z1.dynamicTypeHintFullName shouldBe Seq(s"$builtinPrefix.Integer", s"$builtinPrefix.String")
       z2.typeFullName shouldBe "ANY"
-      z2.dynamicTypeHintFullName shouldBe Seq("__builtin.Integer", "__builtin.String")
+      z2.dynamicTypeHintFullName shouldBe Seq(s"$builtinPrefix.Integer", s"$builtinPrefix.String")
     }
 
     "resolve 'FooModule.d' field access object types correctly" ignore {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.*
@@ -77,7 +77,7 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     val List(foo) = arrayCall.argument.isLiteral.l
     foo.code shouldBe "foo"
-    foo.typeFullName shouldBe s"$builtinPrefix.String"
+    foo.typeFullName shouldBe s"$kernelPrefix.String"
   }
 
   "`%i(x y)` is represented by an `arrayInitializer` operator call with arguments `:x`, `:y`" in {
@@ -95,7 +95,7 @@ class ArrayTests extends RubyCode2CpgFixture {
     x.typeFullName shouldBe y.typeFullName
 
     y.code shouldBe "y"
-    y.typeFullName shouldBe s"$builtinPrefix.Symbol"
+    y.typeFullName shouldBe s"$kernelPrefix.Symbol"
   }
 
   "an implicit array constructor (Array::[]) should be lowered to an array initializer" in {
@@ -106,8 +106,8 @@ class ArrayTests extends RubyCode2CpgFixture {
     inside(cpg.call.nameExact("[]").l) {
       case bracketCall :: Nil =>
         bracketCall.name shouldBe "[]"
-        bracketCall.methodFullName shouldBe s"$builtinPrefix.Array:[]"
-        bracketCall.typeFullName shouldBe s"$builtinPrefix.Array"
+        bracketCall.methodFullName shouldBe s"$kernelPrefix.Array:[]"
+        bracketCall.typeFullName shouldBe s"$kernelPrefix.Array"
 
         inside(bracketCall.argument.l) {
           case _ :: one :: two :: three :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.*
@@ -76,7 +77,7 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     val List(foo) = arrayCall.argument.isLiteral.l
     foo.code shouldBe "foo"
-    foo.typeFullName shouldBe "__builtin.String"
+    foo.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`%i(x y)` is represented by an `arrayInitializer` operator call with arguments `:x`, `:y`" in {
@@ -94,7 +95,7 @@ class ArrayTests extends RubyCode2CpgFixture {
     x.typeFullName shouldBe y.typeFullName
 
     y.code shouldBe "y"
-    y.typeFullName shouldBe "__builtin.Symbol"
+    y.typeFullName shouldBe s"$builtinPrefix.Symbol"
   }
 
   "an implicit array constructor (Array::[]) should be lowered to an array initializer" in {
@@ -105,8 +106,8 @@ class ArrayTests extends RubyCode2CpgFixture {
     inside(cpg.call.nameExact("[]").l) {
       case bracketCall :: Nil =>
         bracketCall.name shouldBe "[]"
-        bracketCall.methodFullName shouldBe "__builtin.Array:[]"
-        bracketCall.typeFullName shouldBe "__builtin.Array"
+        bracketCall.methodFullName shouldBe s"$builtinPrefix.Array:[]"
+        bracketCall.typeFullName shouldBe s"$builtinPrefix.Array"
 
         inside(bracketCall.argument.l) {
           case _ :: one :: two :: three :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, NodeTypes, Operators}
@@ -18,6 +19,7 @@ class CallTests extends RubyCode2CpgFixture {
     val List(puts) = cpg.call.name("puts").l
     puts.lineNumber shouldBe Some(2)
     puts.code shouldBe "puts 'hello'"
+    puts.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
     val List(selfReceiver: Identifier, hello: Literal) = puts.argument.l: @unchecked
     selfReceiver.argumentIndex shouldBe 0
@@ -221,7 +223,7 @@ class CallTests extends RubyCode2CpgFixture {
   "a call with a quoted regex literal should have a literal receiver" in {
     val cpg                         = code("%r{^/}.freeze")
     val List(regexLiteral: Literal) = cpg.call.nameExact("freeze").receiver.l: @unchecked
-    regexLiteral.typeFullName shouldBe "__builtin.Regexp"
+    regexLiteral.typeFullName shouldBe s"$builtinPrefix.Regexp"
     regexLiteral.code shouldBe "%r{^/}"
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -19,6 +19,7 @@ class CallTests extends RubyCode2CpgFixture {
     val List(puts) = cpg.call.name("puts").l
     puts.lineNumber shouldBe Some(2)
     puts.code shouldBe "puts 'hello'"
+    puts.methodFullName shouldBe s"$builtinPrefix:puts"
     puts.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
     val List(selfReceiver: Identifier, hello: Literal) = puts.argument.l: @unchecked

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal}
@@ -293,7 +293,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     whileCond.code shouldBe "true"
     whileCond.lineNumber shouldBe Some(2)
 
-    putsHi.methodFullName shouldBe s"$builtinPrefix:puts"
+    putsHi.methodFullName shouldBe s"$kernelPrefix:puts"
     putsHi.code shouldBe "puts 'hi'"
     putsHi.lineNumber shouldBe Some(2)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.SimpleIdentifier
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal}
@@ -293,7 +293,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     whileCond.code shouldBe "true"
     whileCond.lineNumber shouldBe Some(2)
 
-    putsHi.methodFullName shouldBe "__builtin:puts"
+    putsHi.methodFullName shouldBe s"$builtinPrefix:puts"
     putsHi.code shouldBe "puts 'hi'"
     putsHi.lineNumber shouldBe Some(2)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -250,7 +251,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
               tmpAssign.code shouldBe "<tmp-0> = Array.new(x) { |i| i += 1 }"
 
               newCall.name shouldBe Defines.ConstructorMethodName
-              newCall.methodFullName shouldBe "__builtin.Array:<init>"
+              newCall.methodFullName shouldBe s"$builtinPrefix.Array:<init>"
 
               inside(newCall.argument.l) {
                 case (_: Identifier) :: (x: Identifier) :: (closure: MethodRef) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -251,7 +251,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
               tmpAssign.code shouldBe "<tmp-0> = Array.new(x) { |i| i += 1 }"
 
               newCall.name shouldBe Defines.ConstructorMethodName
-              newCall.methodFullName shouldBe s"$builtinPrefix.Array:<init>"
+              newCall.methodFullName shouldBe s"$kernelPrefix.Array:<init>"
 
               inside(newCall.argument.l) {
                 case (_: Identifier) :: (x: Identifier) :: (closure: MethodRef) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language.*
 
@@ -102,7 +102,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe s"$builtinPrefix.String"
+                rhs.typeFullName shouldBe s"$kernelPrefix.String"
               case _ => fail("Expected LHS and RHS after lowering")
             }
 
@@ -111,7 +111,7 @@ class HashTests extends RubyCode2CpgFixture {
               lhs.name shouldBe Operators.indexAccess
 
               rhs.code shouldBe "\"ade\""
-              rhs.typeFullName shouldBe s"$builtinPrefix.String"
+              rhs.typeFullName shouldBe s"$kernelPrefix.String"
             }
           case _ => fail("Expected 5 calls (one per item in range)")
         }
@@ -128,7 +128,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe s"$builtinPrefix.String"
+                rhs.typeFullName shouldBe s"$kernelPrefix.String"
               case _ => fail("Expected LHS and RHS after lowering")
             }
           case _ => fail("Expected 3 calls (one per item in range)")
@@ -176,7 +176,7 @@ class HashTests extends RubyCode2CpgFixture {
                   case _ => fail("Expected range operator for non-primitive range key")
                 }
 
-                rhs.typeFullName shouldBe s"$builtinPrefix.String"
+                rhs.typeFullName shouldBe s"$kernelPrefix.String"
                 rhs.code shouldBe "\"a\""
               case _ => fail("Expected LHS and RHS for association")
             }
@@ -196,8 +196,8 @@ class HashTests extends RubyCode2CpgFixture {
       case hashCall :: Nil =>
         hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
         hashCall.lineNumber shouldBe Some(2)
-        hashCall.methodFullName shouldBe s"$builtinPrefix.Hash:[]"
-        hashCall.typeFullName shouldBe s"$builtinPrefix.Hash"
+        hashCall.methodFullName shouldBe s"$kernelPrefix.Hash:[]"
+        hashCall.typeFullName shouldBe s"$kernelPrefix.Hash"
 
         inside(hashCall.astChildren.l) {
           case _ :: (one: Call) :: (two: Call) :: (three: Call) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language.*
 
@@ -101,7 +102,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe "__builtin.String"
+                rhs.typeFullName shouldBe s"$builtinPrefix.String"
               case _ => fail("Expected LHS and RHS after lowering")
             }
 
@@ -110,7 +111,7 @@ class HashTests extends RubyCode2CpgFixture {
               lhs.name shouldBe Operators.indexAccess
 
               rhs.code shouldBe "\"ade\""
-              rhs.typeFullName shouldBe "__builtin.String"
+              rhs.typeFullName shouldBe s"$builtinPrefix.String"
             }
           case _ => fail("Expected 5 calls (one per item in range)")
         }
@@ -127,7 +128,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe "__builtin.String"
+                rhs.typeFullName shouldBe s"$builtinPrefix.String"
               case _ => fail("Expected LHS and RHS after lowering")
             }
           case _ => fail("Expected 3 calls (one per item in range)")
@@ -175,7 +176,7 @@ class HashTests extends RubyCode2CpgFixture {
                   case _ => fail("Expected range operator for non-primitive range key")
                 }
 
-                rhs.typeFullName shouldBe "__builtin.String"
+                rhs.typeFullName shouldBe s"$builtinPrefix.String"
                 rhs.code shouldBe "\"a\""
               case _ => fail("Expected LHS and RHS for association")
             }
@@ -195,8 +196,8 @@ class HashTests extends RubyCode2CpgFixture {
       case hashCall :: Nil =>
         hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
         hashCall.lineNumber shouldBe Some(2)
-        hashCall.methodFullName shouldBe "__builtin.Hash:[]"
-        hashCall.typeFullName shouldBe "__builtin.Hash"
+        hashCall.methodFullName shouldBe s"$builtinPrefix.Hash:[]"
+        hashCall.typeFullName shouldBe s"$builtinPrefix.Hash"
 
         inside(hashCall.astChildren.l) {
           case _ :: (one: Call) :: (two: Call) :: (three: Call) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Local, Method, Return}
 import io.shiftleft.semanticcpg.language.*
 
@@ -25,7 +26,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               localAst.code shouldBe "a"
               callAst.code shouldBe "a = 10"
 
-              literalAst.typeFullName shouldBe "__builtin.String"
+              literalAst.typeFullName shouldBe s"$builtinPrefix.String"
 
               returnAst.code shouldBe "a"
             case _ =>
@@ -54,7 +55,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               inside(assignmentCall.argument.l) {
                 case lhsArg :: (rhsArg: Literal) :: Nil =>
                   lhsArg.code shouldBe "a"
-                  rhsArg.typeFullName shouldBe "__builtin.String"
+                  rhsArg.typeFullName shouldBe s"$builtinPrefix.String"
                 case _ => fail("Expected LHS and RHS for assignment")
               }
             case _ => fail("Expected call for assignment")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Local, Method, Return}
 import io.shiftleft.semanticcpg.language.*
 
@@ -26,7 +26,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               localAst.code shouldBe "a"
               callAst.code shouldBe "a = 10"
 
-              literalAst.typeFullName shouldBe s"$builtinPrefix.String"
+              literalAst.typeFullName shouldBe s"$kernelPrefix.String"
 
               returnAst.code shouldBe "a"
             case _ =>
@@ -55,7 +55,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               inside(assignmentCall.argument.l) {
                 case lhsArg :: (rhsArg: Literal) :: Nil =>
                   lhsArg.code shouldBe "a"
-                  rhsArg.typeFullName shouldBe s"$builtinPrefix.String"
+                  rhsArg.typeFullName shouldBe s"$kernelPrefix.String"
                 case _ => fail("Expected LHS and RHS for assignment")
               }
             case _ => fail("Expected call for assignment")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.shiftleft.semanticcpg.language.*
 
 class LiteralTests extends RubyCode2CpgFixture {
@@ -14,7 +15,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "123"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Integer"
+    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
   }
 
   "`3.14` is represented by a LITERAL node" in {
@@ -25,7 +26,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3.14"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Float"
+    literal.typeFullName shouldBe s"$builtinPrefix.Float"
   }
 
   "`3e10` is represented by a LITERAL node" in {
@@ -36,7 +37,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3e10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Float"
+    literal.typeFullName shouldBe s"$builtinPrefix.Float"
   }
 
   "`12e-10` is represented by a LITERAL node" in {
@@ -47,7 +48,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "12e-10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Float"
+    literal.typeFullName shouldBe s"$builtinPrefix.Float"
   }
 
   "`0b01` is represented by a LITERAL node" in {
@@ -58,7 +59,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0b01"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Integer"
+    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
   }
 
   "`0xabc` is represented by a LITERAL node" in {
@@ -69,7 +70,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0xabc"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Integer"
+    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
   }
 
   "`true` is represented by a LITERAL node" in {
@@ -80,7 +81,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "true"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.TrueClass"
+    literal.typeFullName shouldBe s"$builtinPrefix.TrueClass"
   }
 
   "`false` is represented by a LITERAL node" in {
@@ -91,7 +92,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "false"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.FalseClass"
+    literal.typeFullName shouldBe s"$builtinPrefix.FalseClass"
   }
 
   "`nil` is represented by a LITERAL node" in {
@@ -102,7 +103,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "nil"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.NilClass"
+    literal.typeFullName shouldBe s"$builtinPrefix.NilClass"
   }
 
   "`'hello'` is represented by a LITERAL node" in {
@@ -113,7 +114,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "'hello'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`'x' 'y' 'z'` is represented by a LITERAL node" in {
@@ -124,7 +125,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "'x' 'y' 'z'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`\"hello\"` is represented by a LITERAL node" in {
@@ -135,7 +136,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "\"hello\""
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`%q(hello)` is represented by a LITERAL node" in {
@@ -146,7 +147,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%q(hello)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`%Q(hello world)` is represented by a LITERAL node" in {
@@ -157,7 +158,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%Q(hello world)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`%(foo \"bar\" baz)` is represented by a LITERAL node" in {
@@ -168,7 +169,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%(foo \"bar\" baz)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   """`%q<\n...\n>` is represented by a LITERAL node""" in {
@@ -186,7 +187,7 @@ class LiteralTests extends RubyCode2CpgFixture {
         |123
         |>""".stripMargin
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
 
   }
 
@@ -198,7 +199,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":symbol"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Symbol"
+    literal.typeFullName shouldBe s"$builtinPrefix.Symbol"
   }
 
   "`:'symbol'` is represented by a LITERAL node" in {
@@ -209,7 +210,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":'symbol'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Symbol"
+    literal.typeFullName shouldBe s"$builtinPrefix.Symbol"
   }
 
   "`/(eu|us)/` is represented by a LITERAL node" in {
@@ -220,7 +221,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/(eu|us)/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Regexp"
+    literal.typeFullName shouldBe s"$builtinPrefix.Regexp"
   }
 
   "`/fedora|el-|centos/` is represented by a LITERAL node" in {
@@ -231,7 +232,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/fedora|el-|centos/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe "__builtin.Regexp"
+    literal.typeFullName shouldBe s"$builtinPrefix.Regexp"
   }
 
   "`/#{os_version_regex}/` is represented by a CALL node with a string format method full name" in {
@@ -243,7 +244,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(formatValueCall) = cpg.call.code("/#.*").l
     formatValueCall.code shouldBe "/#{os_version_regex}/"
     formatValueCall.lineNumber shouldBe Some(3)
-    formatValueCall.typeFullName shouldBe "__builtin.Regexp"
+    formatValueCall.typeFullName shouldBe s"$builtinPrefix.Regexp"
     formatValueCall.methodFullName shouldBe Operators.formatString
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.semanticcpg.language.*
 
 class LiteralTests extends RubyCode2CpgFixture {
@@ -15,7 +15,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "123"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
+    literal.typeFullName shouldBe s"$kernelPrefix.Integer"
   }
 
   "`3.14` is represented by a LITERAL node" in {
@@ -26,7 +26,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3.14"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Float"
+    literal.typeFullName shouldBe s"$kernelPrefix.Float"
   }
 
   "`3e10` is represented by a LITERAL node" in {
@@ -37,7 +37,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3e10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Float"
+    literal.typeFullName shouldBe s"$kernelPrefix.Float"
   }
 
   "`12e-10` is represented by a LITERAL node" in {
@@ -48,7 +48,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "12e-10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Float"
+    literal.typeFullName shouldBe s"$kernelPrefix.Float"
   }
 
   "`0b01` is represented by a LITERAL node" in {
@@ -59,7 +59,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0b01"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
+    literal.typeFullName shouldBe s"$kernelPrefix.Integer"
   }
 
   "`0xabc` is represented by a LITERAL node" in {
@@ -70,7 +70,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0xabc"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
+    literal.typeFullName shouldBe s"$kernelPrefix.Integer"
   }
 
   "`true` is represented by a LITERAL node" in {
@@ -81,7 +81,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "true"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.TrueClass"
+    literal.typeFullName shouldBe s"$kernelPrefix.TrueClass"
   }
 
   "`false` is represented by a LITERAL node" in {
@@ -92,7 +92,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "false"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.FalseClass"
+    literal.typeFullName shouldBe s"$kernelPrefix.FalseClass"
   }
 
   "`nil` is represented by a LITERAL node" in {
@@ -103,7 +103,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "nil"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.NilClass"
+    literal.typeFullName shouldBe s"$kernelPrefix.NilClass"
   }
 
   "`'hello'` is represented by a LITERAL node" in {
@@ -114,7 +114,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "'hello'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$kernelPrefix.String"
   }
 
   "`'x' 'y' 'z'` is represented by a LITERAL node" in {
@@ -125,7 +125,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "'x' 'y' 'z'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$kernelPrefix.String"
   }
 
   "`\"hello\"` is represented by a LITERAL node" in {
@@ -136,7 +136,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "\"hello\""
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$kernelPrefix.String"
   }
 
   "`%q(hello)` is represented by a LITERAL node" in {
@@ -147,7 +147,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%q(hello)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$kernelPrefix.String"
   }
 
   "`%Q(hello world)` is represented by a LITERAL node" in {
@@ -158,7 +158,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%Q(hello world)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$kernelPrefix.String"
   }
 
   "`%(foo \"bar\" baz)` is represented by a LITERAL node" in {
@@ -169,7 +169,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%(foo \"bar\" baz)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$kernelPrefix.String"
   }
 
   """`%q<\n...\n>` is represented by a LITERAL node""" in {
@@ -187,7 +187,7 @@ class LiteralTests extends RubyCode2CpgFixture {
         |123
         |>""".stripMargin
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$kernelPrefix.String"
 
   }
 
@@ -199,7 +199,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":symbol"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Symbol"
+    literal.typeFullName shouldBe s"$kernelPrefix.Symbol"
   }
 
   "`:'symbol'` is represented by a LITERAL node" in {
@@ -210,7 +210,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":'symbol'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Symbol"
+    literal.typeFullName shouldBe s"$kernelPrefix.Symbol"
   }
 
   "`/(eu|us)/` is represented by a LITERAL node" in {
@@ -221,7 +221,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/(eu|us)/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Regexp"
+    literal.typeFullName shouldBe s"$kernelPrefix.Regexp"
   }
 
   "`/fedora|el-|centos/` is represented by a LITERAL node" in {
@@ -232,7 +232,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/fedora|el-|centos/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Regexp"
+    literal.typeFullName shouldBe s"$kernelPrefix.Regexp"
   }
 
   "`/#{os_version_regex}/` is represented by a CALL node with a string format method full name" in {
@@ -244,7 +244,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(formatValueCall) = cpg.call.code("/#.*").l
     formatValueCall.code shouldBe "/#{os_version_regex}/"
     formatValueCall.lineNumber shouldBe Some(3)
-    formatValueCall.typeFullName shouldBe s"$builtinPrefix.Regexp"
+    formatValueCall.typeFullName shouldBe s"$kernelPrefix.Regexp"
     formatValueCall.methodFullName shouldBe Operators.formatString
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Method, MethodRef, Return}
 import io.shiftleft.semanticcpg.language.*
 
@@ -71,7 +72,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
     r.lineNumber shouldBe Some(3)
 
     val List(c: Call) = r.astChildren.isCall.l
-    c.methodFullName shouldBe "__builtin:puts"
+    c.methodFullName shouldBe s"$builtinPrefix:puts"
     c.lineNumber shouldBe Some(3)
     c.code shouldBe "puts x"
   }
@@ -155,7 +156,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
 
     val List(s: Literal) = r.astChildren.isLiteral.l
     s.code shouldBe ":g"
-    s.typeFullName shouldBe "__builtin.Symbol"
+    s.typeFullName shouldBe s"$builtinPrefix.Symbol"
   }
 
   "explicit RETURN node for `\"\"` exists" in {
@@ -191,14 +192,14 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe "__builtin.Integer"
+            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
 
             returnNil.code shouldBe "return nil"
             returnNil.lineNumber shouldBe Some(3)
             val List(nil: Literal) = returnNil.astChildren.l: @unchecked
             nil.code shouldBe "nil"
             nil.lineNumber shouldBe Some(3)
-            nil.typeFullName shouldBe "__builtin.NilClass"
+            nil.typeFullName shouldBe s"$builtinPrefix.NilClass"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -226,14 +227,14 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe "__builtin.Integer"
+            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(6)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(6)
-            forty.typeFullName shouldBe "__builtin.Integer"
+            forty.typeFullName shouldBe s"$builtinPrefix.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -296,14 +297,14 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(2)
-            twenty.typeFullName shouldBe "__builtin.Integer"
+            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(2)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(2)
-            forty.typeFullName shouldBe "__builtin.Integer"
+            forty.typeFullName shouldBe s"$builtinPrefix.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -432,7 +433,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
 
     inside(cpg.method.nameExact("custom_fact_content").methodReturn.toReturn.astChildren.l) {
       case (heredoc: Literal) :: Nil =>
-        heredoc.typeFullName shouldBe "__builtin.String"
+        heredoc.typeFullName shouldBe s"$builtinPrefix.String"
         heredoc.code should startWith("<<-EOM")
       case xs => fail(s"Expected a single literal node, instead got [${xs.code.mkString(", ")}]")
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Method, MethodRef, Return}
 import io.shiftleft.semanticcpg.language.*
 
@@ -72,7 +72,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
     r.lineNumber shouldBe Some(3)
 
     val List(c: Call) = r.astChildren.isCall.l
-    c.methodFullName shouldBe s"$builtinPrefix:puts"
+    c.methodFullName shouldBe s"$kernelPrefix:puts"
     c.lineNumber shouldBe Some(3)
     c.code shouldBe "puts x"
   }
@@ -156,7 +156,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
 
     val List(s: Literal) = r.astChildren.isLiteral.l
     s.code shouldBe ":g"
-    s.typeFullName shouldBe s"$builtinPrefix.Symbol"
+    s.typeFullName shouldBe s"$kernelPrefix.Symbol"
   }
 
   "explicit RETURN node for `\"\"` exists" in {
@@ -192,14 +192,14 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            twenty.typeFullName shouldBe s"$kernelPrefix.Integer"
 
             returnNil.code shouldBe "return nil"
             returnNil.lineNumber shouldBe Some(3)
             val List(nil: Literal) = returnNil.astChildren.l: @unchecked
             nil.code shouldBe "nil"
             nil.lineNumber shouldBe Some(3)
-            nil.typeFullName shouldBe s"$builtinPrefix.NilClass"
+            nil.typeFullName shouldBe s"$kernelPrefix.NilClass"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -227,14 +227,14 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            twenty.typeFullName shouldBe s"$kernelPrefix.Integer"
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(6)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(6)
-            forty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            forty.typeFullName shouldBe s"$kernelPrefix.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -297,14 +297,14 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(2)
-            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            twenty.typeFullName shouldBe s"$kernelPrefix.Integer"
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(2)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(2)
-            forty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            forty.typeFullName shouldBe s"$kernelPrefix.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -433,7 +433,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
 
     inside(cpg.method.nameExact("custom_fact_content").methodReturn.toReturn.astChildren.l) {
       case (heredoc: Literal) :: Nil =>
-        heredoc.typeFullName shouldBe s"$builtinPrefix.String"
+        heredoc.typeFullName shouldBe s"$kernelPrefix.String"
         heredoc.code should startWith("<<-EOM")
       case xs => fail(s"Expected a single literal node, instead got [${xs.code.mkString(", ")}]")
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, ModifierTypes, NodeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{
   Call,
@@ -273,7 +273,7 @@ class MethodTests extends RubyCode2CpgFixture {
           xs.name shouldBe "xs"
           xs.code shouldBe "*xs"
           xs.isVariadic shouldBe true
-          xs.typeFullName shouldBe s"$builtinPrefix.Array"
+          xs.typeFullName shouldBe s"$kernelPrefix.Array"
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }
@@ -284,7 +284,7 @@ class MethodTests extends RubyCode2CpgFixture {
           ys.name shouldBe "ys"
           ys.code shouldBe "**ys"
           ys.isVariadic shouldBe true
-          ys.typeFullName shouldBe s"$builtinPrefix.Hash"
+          ys.typeFullName shouldBe s"$kernelPrefix.Hash"
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{
   Call,
@@ -261,7 +262,7 @@ class MethodTests extends RubyCode2CpgFixture {
           xs.name shouldBe "xs"
           xs.code shouldBe "*xs"
           xs.isVariadic shouldBe true
-          xs.typeFullName shouldBe "__builtin.Array"
+          xs.typeFullName shouldBe s"$builtinPrefix.Array"
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }
@@ -272,7 +273,7 @@ class MethodTests extends RubyCode2CpgFixture {
           ys.name shouldBe "ys"
           ys.code shouldBe "**ys"
           ys.isVariadic shouldBe true
-          ys.typeFullName shouldBe "__builtin.Hash"
+          ys.typeFullName shouldBe s"$builtinPrefix.Hash"
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
 import io.shiftleft.semanticcpg.language.*
@@ -12,7 +12,7 @@ class RegexTests extends RubyCode2CpgFixture {
        |0
        |""".stripMargin)
     cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(
-      s"$builtinPrefix.String:${RubyOperators.regexpMatch}"
+      s"$kernelPrefix.String:${RubyOperators.regexpMatch}"
     )
   }
   "`/x/ =~ 'y'` is a member call `/x/.=~ 'y'" in {
@@ -20,7 +20,7 @@ class RegexTests extends RubyCode2CpgFixture {
        |0
        |""".stripMargin)
     cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(
-      s"$builtinPrefix.Regexp:${RubyOperators.regexpMatch}"
+      s"$kernelPrefix.Regexp:${RubyOperators.regexpMatch}"
     )
   }
 
@@ -33,15 +33,15 @@ class RegexTests extends RubyCode2CpgFixture {
 
     inside(cpg.controlStructure.isIf.l) {
       case regexIf :: Nil =>
-        regexIf.condition.isCall.methodFullName.l shouldBe List(s"$builtinPrefix.Regexp:${RubyOperators.regexpMatch}")
+        regexIf.condition.isCall.methodFullName.l shouldBe List(s"$kernelPrefix.Regexp:${RubyOperators.regexpMatch}")
 
         inside(regexIf.condition.isCall.argument.l) {
           case (lhs: Literal) :: (rhs: Literal) :: Nil =>
             lhs.code shouldBe "/mswin|mingw|cygwin/"
-            lhs.typeFullName shouldBe s"$builtinPrefix.Regexp"
+            lhs.typeFullName shouldBe s"$kernelPrefix.Regexp"
 
             rhs.code shouldBe "\"mswin\""
-            rhs.typeFullName shouldBe s"$builtinPrefix.String"
+            rhs.typeFullName shouldBe s"$kernelPrefix.String"
           case xs => fail(s"Expected two arguments, got [${xs.code.mkString(",")}]")
         }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -1,25 +1,27 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.semanticcpg.language.*
-import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-
-import scala.reflect.ClassTag
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
+import io.shiftleft.semanticcpg.language.*
 
 class RegexTests extends RubyCode2CpgFixture {
   "`'x' =~ y` is a member call `'x'.=~ /y/" in {
     val cpg = code("""|'x' =~ /y/
        |0
        |""".stripMargin)
-    cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(s"__builtin.String:${RubyOperators.regexpMatch}")
+    cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(
+      s"$builtinPrefix.String:${RubyOperators.regexpMatch}"
+    )
   }
   "`/x/ =~ 'y'` is a member call `/x/.=~ 'y'" in {
     val cpg = code("""|/x/ =~ 'y'
        |0
        |""".stripMargin)
-    cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(s"__builtin.Regexp:${RubyOperators.regexpMatch}")
+    cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(
+      s"$builtinPrefix.Regexp:${RubyOperators.regexpMatch}"
+    )
   }
 
   "Regex expression in if statements" in {
@@ -31,15 +33,15 @@ class RegexTests extends RubyCode2CpgFixture {
 
     inside(cpg.controlStructure.isIf.l) {
       case regexIf :: Nil =>
-        regexIf.condition.isCall.methodFullName.l shouldBe List(s"__builtin.Regexp:${RubyOperators.regexpMatch}")
+        regexIf.condition.isCall.methodFullName.l shouldBe List(s"$builtinPrefix.Regexp:${RubyOperators.regexpMatch}")
 
         inside(regexIf.condition.isCall.argument.l) {
           case (lhs: Literal) :: (rhs: Literal) :: Nil =>
             lhs.code shouldBe "/mswin|mingw|cygwin/"
-            lhs.typeFullName shouldBe "__builtin.Regexp"
+            lhs.typeFullName shouldBe s"$builtinPrefix.Regexp"
 
             rhs.code shouldBe "\"mswin\""
-            rhs.typeFullName shouldBe "__builtin.String"
+            rhs.typeFullName shouldBe s"$builtinPrefix.String"
           case xs => fail(s"Expected two arguments, got [${xs.code.mkString(",")}]")
         }
 


### PR DESCRIPTION
To simplify the call graph, methods resolved to the `Kernel` class are dispatched as static.

Additionally, replaced `__builtin` with `Kernel` to map more closely to Ruby's internals and implemented `MemberAccessCommandContext`.