### PR TITLE
[ruby] Members for Methods to Related to Bound Type Decls

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -108,6 +108,10 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     callAst(assignment, Seq(lhs, rhs))
   }
 
+  protected def memberForMethod(method: NewMethod): NewMember = {
+    NewMember().name(method.name).code(method.name).dynamicTypeHintFullName(Seq(method.fullName))
+  }
+
   protected val UnaryOperatorNames: Map[String, String] = Map(
     "!"   -> Operators.logicalNot,
     "not" -> Operators.logicalNot,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -116,10 +116,13 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     createMethodTypeBindings(method, refs)
 
-    val prefixAsts = if isClosure then Ast() else createMethodRefPointer(method)
+    val prefixMemberAst =
+      if isClosure || scope.isSurroundedByProgramScope then Ast() // program scope members are set elsewhere
+      else Ast(memberForMethod(method))
+    val prefixRefAssignAst = if isClosure then Ast() else createMethodRefPointer(method)
     // For closures, we also want the method/type refs for upstream use
     val suffixAsts = if isClosure then refs else refs.filter(_.root.exists(_.isInstanceOf[NewTypeDecl]))
-    val methodAsts = prefixAsts ::
+    val methodAsts = prefixMemberAst :: prefixRefAssignAst ::
       methodAst(
         method,
         parameterAsts ++ anonProcParam,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
@@ -18,8 +18,8 @@ class SingleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val flows  = sink.reachableByFlows(source).map(flowToResultPairs).distinct.sortBy(_.length).l
     val List(flow1, flow2, flow3, flow4, flow5) = flows
     flow1 shouldBe List(("y = 1", 2), ("puts y", 3))
-    flow2 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("puts x", 4))
-    flow3 shouldBe List(("y = 1", 2), ("puts y", 3), ("puts x", 4))
+    flow2 shouldBe List(("y = 1", 2), ("puts y", 3), ("puts x", 4))
+    flow3 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("puts x", 4))
     flow4 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("z = x = y = 1", 2), ("puts z", 5))
     flow5 shouldBe List(("y = 1", 2), ("x = y = 1", 2), ("puts x", 4), ("puts z", 5))
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -29,7 +29,7 @@ class ClassTests extends RubyCode2CpgFixture {
     classC.fullName shouldBe "Test0.rb:<global>::program.C"
     classC.lineNumber shouldBe Some(2)
     classC.baseType.l shouldBe List()
-    classC.member.l shouldBe List()
+    classC.member.name.l shouldBe List("<init>", "<clinit>")
     classC.method.name.l shouldBe List("<init>", "<clinit>")
   }
 
@@ -45,7 +45,7 @@ class ClassTests extends RubyCode2CpgFixture {
     classC.inheritsFromTypeFullName shouldBe List("D")
     classC.fullName shouldBe "Test0.rb:<global>::program.C"
     classC.lineNumber shouldBe Some(2)
-    classC.member.l shouldBe List()
+    classC.member.name.l shouldBe List("<init>", "<clinit>")
     classC.method.name.l shouldBe List("<init>", "<clinit>")
 
     val List(typeD) = classC.baseType.l
@@ -60,9 +60,8 @@ class ClassTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     val List(classC)  = cpg.typeDecl.name("C").l
-    val List(aMember) = classC.member.l
+    val List(aMember) = classC.member.nameExact("@a").l
 
-    aMember.name shouldBe "@a"
     aMember.code shouldBe "attr_reader :a"
     aMember.lineNumber shouldBe Some(3)
   }
@@ -181,6 +180,9 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(methodF) = classC.method.name("f").l
 
     methodF.fullName shouldBe "Test0.rb:<global>::program.C:f"
+
+    val List(memberF) = classC.member.nameExact("f").l
+    memberF.dynamicTypeHintFullName.toSet should contain(methodF.fullName)
   }
 
   "`def initialize() ... end` directly inside a class has method name `<init>`" in {
@@ -443,7 +445,7 @@ class ClassTests extends RubyCode2CpgFixture {
     "create respective member nodes" in {
       inside(cpg.typeDecl.name("Foo").l) {
         case fooType :: Nil =>
-          inside(fooType.member.l) {
+          inside(fooType.member.name("@.*").l) {
             case aMember :: bMember :: cMember :: dMember :: oMember :: Nil =>
               // Test that all members in class are present
               aMember.code shouldBe "@a"
@@ -520,7 +522,7 @@ class ClassTests extends RubyCode2CpgFixture {
     "create respective member nodes" in {
       inside(cpg.typeDecl.name("Foo").l) {
         case fooType :: Nil =>
-          inside(fooType.member.l) {
+          inside(fooType.member.name("@.*").l) {
             case aMember :: bMember :: cMember :: dMember :: oMember :: Nil =>
               // Test that all members in class are present
               aMember.code shouldBe "@@a"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, ModifierTypes, NodeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{
   Call,
   Identifier,
@@ -45,6 +45,17 @@ class MethodTests extends RubyCode2CpgFixture {
       fType.astParentType shouldBe NodeTypes.METHOD
       val List(fMethod) = fType.iterator.boundMethod.l
       fType.fullName shouldBe "Test0.rb:<global>::program:f"
+    }
+
+    "create a 'fake' method for the file" in {
+      val List(m) = cpg.method.nameExact(RDefines.Program).l
+      m.fullName shouldBe "Test0.rb:<global>::program"
+      m.isModule.nonEmpty shouldBe true
+
+      val List(t) = cpg.typeDecl.nameExact(RDefines.Program).l
+      m.fullName shouldBe "Test0.rb:<global>::program"
+      m.isModule.nonEmpty shouldBe true
+      t.methodBinding.methodFullName.toSet should contain(m.fullName)
     }
   }
 


### PR DESCRIPTION
* Added `Member` nodes for each method, to relate to their respective bound `TypeDecl` nodes.
* Added a type decl for "fake methods" that include the methods and classes exported by the file