### PR TITLE
[dataflowengineoss] globalFromLiteral taking into account 3AC assignments

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -194,7 +194,7 @@ abstract class BaseSourceToStartingPoints extends Callable[Unit] {
         val usageInput = targetsToClassIdentifierPair(literalToInitializedMembers(lit), src)
         val uses       = usages(usageInput)
         val globals = globalFromLiteral(lit, recursive = false).flatMap {
-          case x: Identifier if x.isModuleVariable => x :: moduleVariableToFirstUsagesAcrossProgram(x)
+          case x: Identifier if x.isModuleVariable => moduleVariableToFirstUsagesAcrossProgram(x)
           case x                                   => x :: Nil
         }
         (lit :: (uses ++ globals), usageInput)


### PR DESCRIPTION
This was motivated by a Python sample like

```python
# main.py
from helper import bar
print(bar)
```

```python
# helper.py
bar = {'Property': 'Value'}
```

in which querying `cpg.call("print").argument(1).reachableBy(cpg.literal("'Value'"))` would be empty.

In this case, calling `globalFromLiteral` on `'Value'` would get us the temporary assignment `tmp0['Property'] = 'Value'`, not `bar = ...`. This makes sense since Python dictionary literals are lowered as blocks:
```
{
tmp0 = {}
tmp0['Property'] = 'Value'
tmp0
}
```

So, the assignment `bar = {'Property': 'Value'}` is actually modelled as 
```
bar = {tmp0 = {}; tmp0['Property'] = 'Value'; tmp0}
```
Now, `tmp0` is not a module-level/global variable, so we wouldn't catch its tainting to `bar`, which is the actual module-level/global variable here.

In this patch we skip over these lowerings and look for the topmost assignment.
