### PR TITLE
[javasrc2cpg] add AstCreator `code` implementation removing comments 

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -129,7 +129,7 @@ class AstCreator(
   protected def column(node: Node): Option[Integer]    = node.getBegin.map(x => Integer.valueOf(x.column)).toScala
   protected def lineEnd(node: Node): Option[Integer]   = node.getEnd.map(x => Integer.valueOf(x.line)).toScala
   protected def columnEnd(node: Node): Option[Integer] = node.getEnd.map(x => Integer.valueOf(x.column)).toScala
-  protected def code(node: Node): String               = "" // TODO: javasrc2cpg uses custom code strings everywhere
+  protected def code(node: Node): String               = node.clone.removeComment().toString
 
   private val lineOffsetTable = OffsetUtils.getLineOffsetTable(fileContent)
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -15,6 +15,8 @@ import com.github.javaparser.ast.expr.{
 }
 import com.github.javaparser.ast.nodeTypes.{NodeWithName, NodeWithSimpleName}
 import com.github.javaparser.ast.{CompilationUnit, ImportDeclaration, Node, PackageDeclaration}
+import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption
+import com.github.javaparser.printer.configuration.{DefaultConfigurationOption, DefaultPrinterConfiguration}
 import com.github.javaparser.resolution.UnsolvedSymbolException
 import com.github.javaparser.resolution.declarations.{
   ResolvedMethodDeclaration,
@@ -125,11 +127,17 @@ class AstCreator(
       case _                        => None
     }
   }
+
+  /** Custom printer that omits comments. To be used by [[code]] */
+  private val codePrinterOptions = new DefaultPrinterConfiguration()
+    .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS))
+    .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_JAVADOC))
+
   protected def line(node: Node): Option[Integer]      = node.getBegin.map(x => Integer.valueOf(x.line)).toScala
   protected def column(node: Node): Option[Integer]    = node.getBegin.map(x => Integer.valueOf(x.column)).toScala
   protected def lineEnd(node: Node): Option[Integer]   = node.getEnd.map(x => Integer.valueOf(x.line)).toScala
   protected def columnEnd(node: Node): Option[Integer] = node.getEnd.map(x => Integer.valueOf(x.column)).toScala
-  protected def code(node: Node): String               = node.clone.removeComment().toString
+  protected def code(node: Node): String               = node.toString(codePrinterOptions)
 
   private val lineOffsetTable = OffsetUtils.getLineOffsetTable(fileContent)
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -233,7 +233,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
 
     val parameterNode = NewMethodParameterIn()
       .name(parameter.getName.toString)
-      .code(parameter.toString)
+      .code(code(parameter))
       .lineNumber(line(parameter))
       .columnNumber(column(parameter))
       .evaluationStrategy(evalStrat)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -357,7 +357,7 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     args.asScala
       .map {
         case _: LambdaExpr => "<lambda>"
-        case other         => other.toString
+        case other         => code(other)
       }
       .mkString(", ")
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -324,7 +324,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val typeFullName = expressionReturnTypeFullName(expr).map(typeInfoCalc.registerType).getOrElse(TypeConstants.Any)
     val literalNode =
       NewLiteral()
-        .code(expr.toString)
+        .code(code(expr))
         .lineNumber(line(expr))
         .columnNumber(column(expr))
         .typeFullName(typeFullName)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
@@ -89,7 +89,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
       .name("assert")
       .methodFullName("assert")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
-      .code(stmt.toString)
+      .code(code(stmt))
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
 
@@ -102,7 +102,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
       .controlStructureType(ControlStructureTypes.BREAK)
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
-      .code(stmt.toString)
+      .code(code(stmt))
     Ast(node)
   }
 
@@ -111,7 +111,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
       .controlStructureType(ControlStructureTypes.CONTINUE)
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
-      .code(stmt.toString)
+      .code(code(stmt))
     Ast(node)
   }
 
@@ -245,7 +245,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
     val returnNode = NewReturn()
       .lineNumber(line(ret))
       .columnNumber(column(ret))
-      .code(ret.toString)
+      .code(code(ret))
     if (ret.getExpression.isPresent) {
       val expectedType = scope.enclosingMethodReturnType.getOrElse(ExpectedType.empty)
       val exprAsts     = astsForExpression(ret.getExpression.get(), expectedType)
@@ -268,7 +268,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
       .methodFullName("<operator>.throw")
       .lineNumber(line(stmt))
       .columnNumber(column(stmt))
-      .code(stmt.toString())
+      .code(code(stmt))
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
 
     val args = astsForExpression(stmt.getExpression, ExpectedType.empty)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -400,6 +400,31 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
       }
     }
 
+    "be correct for chained call interspersed with a line comment" in {
+      val cpg = code("""
+          |class Foo {
+          | private String value;
+          |
+          | public String getValue() {
+          |   return value;
+          | }
+          |
+          | public static void test() {
+          |   String s = new Foo()
+          |     // some comment
+          |     .getValue();
+          | }
+          |}
+          |""".stripMargin)
+
+      cpg.call.name("getValue").l match {
+        case List(getValueCall) =>
+          getValueCall.code shouldBe "new Foo().getValue()"
+
+        case result => fail(s"Expected single getValue call but got $result")
+      }
+    }
+
     "be correct for constructor invocations" in {
       lazy val cpg = code("""
           |class Foo {
@@ -414,6 +439,47 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
           initCall.code shouldBe "new Foo()"
 
         case result => fail(s"Expected single init call but got $result")
+      }
+    }
+
+    "be correct when there are line comments between arguments of a call" in {
+      val cpg = code("""
+          |import foo.*;
+          |public class Main {
+          |  public static void main(String[] args) {
+          |    Foo foo = Foo.create(
+          |                    "username", // hehe silly comment
+          |                    "password");
+          |    }
+          |}
+          |""".stripMargin)
+
+      cpg.call.name("create").argument.argumentIndexGt(0).l match {
+        case List(username: Literal, password: Literal) =>
+          username.code shouldBe "\"username\""
+          password.code shouldBe "\"password\""
+        case result => fail(s"Expected two arguments but got $result")
+      }
+    }
+
+    "be correct when there are multi-line comments between arguments of a call" in {
+      val cpg = code("""
+          |import foo.*;
+          |public class Main {
+          |  public static void main(String[] args) {
+          |    Foo foo = Foo.create(
+          |                    // another comment
+          |                    "username", /* hehe silly comment */
+          |                    "password");
+          |    }
+          |}
+          |""".stripMargin)
+
+      cpg.call.name("create").argument.argumentIndexGt(0).l match {
+        case List(username: Literal, password: Literal) =>
+          username.code shouldBe "\"username\""
+          password.code shouldBe "\"password\""
+        case result => fail(s"Expected two arguments but got $result")
       }
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodTests.scala
@@ -174,4 +174,25 @@ class MethodTests4 extends JavaSrcCode2CpgFixture {
     }
   }
 
+  "Method parameters interspersed with comments" should {
+    val cpg = code("""
+        |class Foo {
+        | abstract void run(
+        |   /* comment for 1st argument */
+        |   int arg1,
+        |   int arg2, // comment for arg2
+        |   int arg3);
+        |}
+        |""".stripMargin)
+
+    "have correct `code` fields" in {
+      cpg.method("run").parameter.indexFrom(1).l match
+        case List(arg1, arg2, arg3) =>
+          arg1.code shouldBe "int arg1"
+          arg2.code shouldBe "int arg2"
+          arg3.code shouldBe "int arg3"
+        case result => fail(s"Expected 3 parameters but got $result")
+    }
+  }
+
 }


### PR DESCRIPTION
The `.code` field for arguments presently includes comments, e.g. in

```java
Foo.create(
  "username", // hehe, silly comment
  "password"
);
```

the `.code` for `argument(2)` is ` // hehe, silly comment\n  "password"`.

This patch:
1. provides a default implementation for AstCreator's `code(Node): String` method that prints the node's text as if it didn't contain any comments attached, and
2. uses it (instead of `.toString`) throughout AstCreator.

Credit for finding: @sean-gahagan 