### PR TITLE
[scan] Taint Analysis Queries & Re-use

### DIFF
--- a/console/src/main/scala/io/joern/console/scan/ScanPass.scala
+++ b/console/src/main/scala/io/joern/console/scan/ScanPass.scala
@@ -3,14 +3,94 @@ package io.joern.console.scan
 import io.joern.console.Query
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.CpgPass
+import io.joern.console.scan.*
+import io.joern.console.scan.TaintAnalysisKeys.{SANITIZER, SINK, SOURCE}
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.language.*
+import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
+import io.shiftleft.codepropertygraph.generated
+import io.shiftleft.semanticcpg.language.*
+import overflowdb.BatchedUpdate
 
 /** Each query runs the data-flow engine, which is already parallelized. Another layer of parallelism causes undefined
   * behaviour on the underlying database. This is why we use `CpgPass` instead of `ConcurrentWriterCpgPass` or similar.
   */
-class ScanPass(cpg: Cpg, queries: List[Query]) extends CpgPass(cpg) {
+class ScanPass(cpg: Cpg, queries: List[Query], maxCallDepth: Int) extends CpgPass(cpg) {
+
+  private val QueryTagTaint = "taint"
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
-    queries.flatMap(_.apply(cpg)).foreach(diffGraph.addNode)
+    val (taintQueries, otherQueries) = queries.partition(_.tags.contains(QueryTagTaint))
+    otherQueries.flatMap(_.apply(cpg)).foreach(diffGraph.addNode)
+    runTaintAnalysis(taintQueries, diffGraph)
+  }
+
+  private def runTaintAnalysis(taintQueries: List[Query], diffGraph: DiffGraphBuilder): Unit = {
+    implicit val taggingDiffGraph: DiffGraphBuilder = new DiffGraphBuilder()
+    taintQueries.foreach { q =>
+      val queryTags = q.tags.toSet
+      if (queryTags.contains(TaintAnalysisKeys.SOURCE)) {
+        q.traversal(cpg).tagAsSource(q.name)
+      } else if (queryTags.contains(TaintAnalysisKeys.SINK)) {
+        q.traversal(cpg).tagAsSink(q.name)
+      } else if (queryTags.contains(TaintAnalysisKeys.SANITIZER)) {
+        q.traversal(cpg).tagAsSanitizer(q.name)
+      }
+    }
+    BatchedUpdate.applyDiff(cpg.graph, taggingDiffGraph)
+
+    val queryLookup = taintQueries.map(q => q.name -> q).toMap
+
+    val semantics =
+      cpg.metaData.language.headOption.map(DefaultSemantics.semanticsFor).getOrElse(DefaultSemantics.semanticsFor(""))
+    val engineContext = EngineContext(semantics, EngineConfig(maxCallDepth))
+
+    logger.debug(
+      s"Joern Scan matched on " +
+        s"${cpg.sources.size} sources, " +
+        s"${cpg.sinks.size} sinks, " +
+        s"${cpg.sanitizers.size} sanitizers from ${taintQueries.size} queries"
+    )
+    val sinks   = cpg.sinks.l
+    val sources = cpg.sources.l
+    if (sinks.nonEmpty && sources.nonEmpty) {
+      sinks
+        .reachableByFlows(sources)(engineContext)
+        .passesNot(_.isSanitizer)
+        .zipWithIndex
+        .map { case (Path(elements), idx) =>
+          val sourceQuery = elements
+            .flatMap(_.tag.nameExact(SOURCE, SANITIZER, SINK).value.headOption)
+            .headOption
+            .map(queryLookup.apply)
+          val sinkQuery = elements
+            .flatMap(_.tag.nameExact(SOURCE, SANITIZER, SINK).value.headOption)
+            .lastOption
+            .map(queryLookup.apply)
+          val evidence             = elements.last
+          val (title, description) = buildTitleAndDescription(sourceQuery, sinkQuery)
+          val author = Seq(sourceQuery, sinkQuery)
+            .flatMap(_.map(_.author))
+            .distinct
+            .reduceOption((a, b) => s"$a & $b")
+            .getOrElse("Joern Scan")
+          val name  = s"$idx-tainted-${evidence.code}"
+          val score = (sourceQuery.map(_.score).getOrElse(5.0) + sinkQuery.map(_.score).getOrElse(5.0)) / 2d
+          QueryWrapper.finding(evidence, name, author, title, description, score)
+        }
+        .foreach(diffGraph.addNode)
+    }
+  }
+
+  private def buildTitleAndDescription(sourceQ: Option[Query], sinkQ: Option[Query]): (String, String) = {
+    (sourceQ, sinkQ) match {
+      case (Some(src), Some(snk)) => s"${src.title} flows to ${snk.title}" -> s"${src.description}\n${snk.description}"
+      case (None, Some(snk)) => s"Attacker-controlled data flows to ${snk.title}" -> snk.description
+      case (Some(src), None) => s"${src.title} data flows to a sensitive sink"    -> src.description
+      case (None, None) =>
+        s"Attacker-controlled data flows to a sensitive sink" ->
+          "Attacker-controlled data defining arguments to a sensitive sink may be a cause of security vulnerabilities."
+    }
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -1,7 +1,7 @@
 package io.joern.dataflowengineoss
 
 import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, PassThroughMapping, Semantics}
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{Operators, Languages}
 
 import scala.annotation.unused
 
@@ -13,6 +13,17 @@ object DefaultSemantics {
   def apply(): Semantics = {
     val list = operatorFlows ++ cFlows ++ javaFlows
     Semantics.fromList(list)
+  }
+
+  /** @param language
+    *   the programming language under analysis.
+    * @return
+    *   the semantics for the given language.
+    */
+  def semanticsFor(language: String): Semantics = language match {
+    case Languages.JAVA | Languages.JAVASRC | Languages.KOTLIN => Semantics.fromList(operatorFlows ++ javaFlows)
+    case Languages.C | Languages.NEWC                          => Semantics.fromList(operatorFlows ++ cFlows)
+    case _                                                     => Semantics.fromList(operatorFlows)
   }
 
   private def F = (x: String, y: List[(Int, Int)]) => FlowSemantic.from(x, y)
@@ -152,11 +163,5 @@ object DefaultSemantics {
     F("org.apache.http.HttpResponse.getEntity:org.apache.http.HttpEntity()", List((0, -1))),
     F("org.apache.http.HttpResponse.setEntity:void(org.apache.http.HttpEntity)", List((1, 0), (1, 1), (1, 0)))
   )
-
-  /** @return
-    *   procedure semantics for operators and common external Java calls only.
-    */
-  @unused
-  def javaSemantics(): Semantics = Semantics.fromList(operatorFlows ++ javaFlows)
 
 }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
@@ -1,7 +1,7 @@
 package io.joern.joerncli
 
 import better.files.*
-import io.joern.console.scan.{ScanPass, outputFindings}
+import io.joern.console.scan.{ScanPass, logger, outputFindings}
 import io.joern.console.{BridgeBase, DefaultArgumentProvider, Query, QueryDatabase}
 import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
@@ -11,11 +11,13 @@ import io.joern.joerncli.console.ReplBridge
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.language.{DefaultNodeExtensionFinder, NodeExtensionFinder}
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+
 import java.io.PrintStream
 import org.json4s.native.Serialization
 import org.json4s.{Formats, NoTypeHints}
+
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object JoernScanConfig {
   val defaultDbVersion: String    = "latest"
@@ -274,7 +276,7 @@ class Scan(options: ScanOptions)(implicit engineContext: EngineContext) extends 
       println("No queries matched current filter selection (total number of queries: `" + allQueries.length + "`)")
       return
     }
-    runPass(new ScanPass(context.cpg, queriesAfterFilter), context)
+    runPass(new ScanPass(context.cpg, queriesAfterFilter, options.maxCallDepth), context)
     outputFindings(context.cpg)
 
   }

--- a/querydb/src/main/scala/io/joern/scanners/QueryTags.scala
+++ b/querydb/src/main/scala/io/joern/scanners/QueryTags.scala
@@ -25,4 +25,9 @@ object QueryTags {
   val cryptography           = "cryptography"
   val remoteCodeExecution    = "remote-code-execution"
 
+  val taint     = "taint"
+  val source    = "source"
+  val sink      = "sink"
+  val sanitizer = "sanitizer"
+
 }

--- a/querydb/src/main/scala/io/joern/scanners/java/JavaBuiltinsTagger.scala
+++ b/querydb/src/main/scala/io/joern/scanners/java/JavaBuiltinsTagger.scala
@@ -1,0 +1,72 @@
+package io.joern.scanners.java
+
+import io.joern.console.*
+import io.joern.macros.QueryMacros.*
+import io.joern.x2cpg.Defines
+import io.joern.scanners.{Crew, QueryTags}
+import io.shiftleft.semanticcpg.language.*
+
+/** Taggers for builtin Java classes.
+  */
+object JavaBuiltinsTagger extends QueryBundle {
+
+  implicit val resolver: ICallResolver = NoResolve
+
+  @q
+  def javaFileSinks(): Query =
+    Query.make(
+      name = "java-builtin-file-sources",
+      author = Crew.dave,
+      title = "Sensitive File Operations",
+      description = """
+          |File operations can allow attackers to control what files are accessed or read and/or 
+          |untrusted data to be written which can lead to remote-code execution.
+          |""".stripMargin,
+      score = 7,
+      withStrRep({ cpg =>
+        (cpg.method
+          .filter(_.fullName.startsWith("java.io.File"))
+          .nameExact(Defines.ConstructorMethodName, "write", "createNewFile") ++
+          cpg.method
+            .filter(_.fullName.startsWith("java.io.PrintWriter"))
+            .nameExact("print", "println") ++
+          cpg.method
+            .filter(_.fullName.startsWith("java.sql.Connection"))
+            .nameExact("prepareStatement") ++
+          cpg.method
+            .filter(_.fullName.startsWith("java.sql.Statement"))
+            .nameExact("execute", "executeUpdate", "executeQuery") ++
+          cpg.method
+            .filter(_.fullName.startsWith("java.io.FileInputStream"))
+            .nameExact(Defines.ConstructorMethodName) ++
+          cpg.method
+            .filter(_.fullName.startsWith("java.io.FileWriter"))
+            .nameExact(Defines.ConstructorMethodName)).parameter.argument
+          .where(_.argumentIndex(1))
+      }),
+      tags = List(QueryTags.taint, QueryTags.sink, QueryTags.default)
+    )
+
+  @q
+  def javaSqlSinks(): Query =
+    Query.make(
+      name = "java-builtin-sql-sources",
+      author = Crew.dave,
+      title = "Sensitive SQL Queries",
+      description = """
+          |Untrusted data directly injected into database queries can lead to data leaks
+          |and possible remote code execution.
+          |""".stripMargin,
+      score = 8,
+      withStrRep({ cpg =>
+        (cpg.method
+          .filter(_.fullName.startsWith("java.sql.Connection"))
+          .nameExact("prepareStatement") ++
+          cpg.method
+            .filter(_.fullName.startsWith("java.sql.Statement"))
+            .nameExact("execute", "executeUpdate", "executeQuery")).parameter.argument
+          .where(_.argumentIndex(1))
+      }),
+      tags = List(QueryTags.taint, QueryTags.sink, QueryTags.default)
+    )
+}

--- a/querydb/src/main/scala/io/joern/scanners/java/JavaxTagger.scala
+++ b/querydb/src/main/scala/io/joern/scanners/java/JavaxTagger.scala
@@ -1,0 +1,62 @@
+package io.joern.scanners.java
+
+import io.joern.console.*
+import io.joern.macros.QueryMacros.*
+import io.joern.scanners.{Crew, QueryTags}
+import io.shiftleft.semanticcpg.language.*
+
+/** Taggers for the javax namespace.
+  */
+object JavaxTagger extends QueryBundle {
+
+  implicit val resolver: ICallResolver = NoResolve
+
+  @q
+  def javaxSources(): Query =
+    Query.make(
+      name = "javax-servlet-sources",
+      author = Crew.dave,
+      title = "Attacker-Controlled HTTP Request",
+      description = """
+                      |One can consider the cookies, configs, property-map of `javax.servlet.http.HttpServletRequest`s
+                      |to be attacker-controlled.
+                      |""".stripMargin,
+      score = 8,
+      withStrRep({ cpg =>
+        cpg.typeDecl
+          .fullNameExact("javax.servlet.http.HttpServletRequest")
+          .referencingType
+          .flatMap(_.evalTypeIn)
+          .isParameter ++
+          cpg.typeDecl
+            .fullNameExact("javax.servlet.http.Cookie")
+            .method
+            .nameExact("getValue")
+            .methodReturn ++
+          cpg.method.nameExact("getServletConfig").methodReturn
+      }),
+      tags = List(QueryTags.taint, QueryTags.source, QueryTags.default)
+    )
+
+  @q
+  def javaxSinks(): Query =
+    Query.make(
+      name = "javax-servlet-sinks",
+      author = Crew.dave,
+      title = "Sensitive HTTP Response",
+      description = """
+          |An attacker controlling `HttpServletResponse.sendRedirect` may
+          |be able to redirect users to malicious websites.
+          |""".stripMargin,
+      score = 6,
+      withStrRep({ cpg =>
+        cpg.method
+          .filter(_.fullName.startsWith("javax.servlet.http.HttpServletResponse"))
+          .nameExact("sendRedirect")
+          .parameter
+          .argument
+          .where(_.argumentIndex(1))
+      }),
+      tags = List(QueryTags.taint, QueryTags.sink, QueryTags.default)
+    )
+}

--- a/querydb/src/main/scala/io/joern/scanners/kotlin/PathTraversals.scala
+++ b/querydb/src/main/scala/io/joern/scanners/kotlin/PathTraversals.scala
@@ -1,12 +1,12 @@
 package io.joern.scanners.kotlin
 
-import io.joern.scanners._
-import io.joern.console._
+import io.joern.scanners.*
+import io.joern.console.*
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.dataflowengineoss.semanticsloader.Semantics
-import io.joern.dataflowengineoss.language._
-import io.joern.macros.QueryMacros._
-import io.shiftleft.semanticcpg.language._
+import io.joern.dataflowengineoss.language.*
+import io.joern.macros.QueryMacros.*
+import io.shiftleft.semanticcpg.language.*
 
 object PathTraversals extends QueryBundle {
   implicit val engineContext: EngineContext = EngineContext(Semantics.empty)

--- a/querydb/src/test/scala/io/joern/suites/JavaQueryTestSuite.scala
+++ b/querydb/src/test/scala/io/joern/suites/JavaQueryTestSuite.scala
@@ -1,12 +1,13 @@
 package io.joern.suites
 
-import io.joern.console.scan._
+import io.joern.console.scan.*
 import io.joern.console.{CodeSnippet, Query, QueryBundle}
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.joern.util.QueryUtil
 import io.joern.x2cpg.testfixtures.TestCpg
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Method, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, Literal, Method, MethodParameterIn}
+import io.shiftleft.semanticcpg.language.*
 
 class JavaQueryTestSuite[QB <: QueryBundle](val queryBundle: QB)
     extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
@@ -43,12 +44,20 @@ class JavaQueryTestSuite[QB <: QueryBundle](val queryBundle: QB)
     q(cpg).flatMap(_.evidence).collect { case c: Call => c.code }
   }
 
+  def findMatchingArgumentCalls(cpg: Cpg, q: Query): List[String] = {
+    q(cpg).flatMap(_.evidence).collect { case c: Expression => c.inCall.code }.flatten
+  }
+
   def findMatchingLiterals(cpg: Cpg, q: Query): List[String] = {
     q(cpg).flatMap(_.evidence).collect { case c: Literal => c.code }
   }
 
   def findMatchingMethods(cpg: Cpg, q: Query): List[String] = {
     q(cpg).flatMap(_.evidence).collect { case c: Method => c.name }
+  }
+
+  def findMatchingParameters(cpg: Cpg, q: Query): List[String] = {
+    q(cpg).flatMap(_.evidence).collect { case c: MethodParameterIn => c.name }
   }
 
   protected val cpg: TestCpg = code(concatQueryCodeExamples)

--- a/querydb/src/test/scala/io/joern/taggers/java/JavaSQLTaggerTests.scala
+++ b/querydb/src/test/scala/io/joern/taggers/java/JavaSQLTaggerTests.scala
@@ -1,0 +1,48 @@
+package io.joern.taggers.java
+
+import io.joern.scanners.java.JavaBuiltinsTagger
+import io.joern.suites.JavaQueryTestSuite
+
+class JavaSQLTaggerTests extends JavaQueryTestSuite(JavaBuiltinsTagger) {
+
+  "the `javax-sql` queries" when {
+
+    "a basic request can write directly to a SQL query" in {
+      val cpg = code("""import java.io.IOException;
+          |import java.sql.Connection;
+          |import java.sql.DriverManager;
+          |import java.sql.SQLException;
+          |import javax.servlet.http.HttpServletRequest;
+          |import javax.servlet.http.HttpServletResponse;
+          |
+          |public class Basic19 {
+          |    private static final String FIELD_NAME = "name";
+          |
+          |    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+          |        String name = req.getParameter(FIELD_NAME);
+          |
+          |        Connection con = null;
+          |        try {
+          |            con = DriverManager.getConnection(MicroTestCase.CONNECTION_STRING);
+          |            con.prepareStatement("select * from Users where name=" + name); /* BAD */
+          |        } catch (SQLException e) {
+          |            System.err.println("An error occurred");
+          |        } finally {
+          |            try {
+          |                if(con != null) con.close();
+          |            } catch (SQLException e) {
+          |                e.printStackTrace();
+          |            }
+          |        }
+          |    }
+          |
+          |}
+          |""".stripMargin)
+
+      val sources = findMatchingArgumentCalls(cpg, queryBundle.javaSqlSinks())
+      sources shouldBe List("con.prepareStatement(\"select * from Users where name=\" + name)")
+    }
+
+  }
+
+}

--- a/querydb/src/test/scala/io/joern/taggers/java/JavaxServletTaggerTests.scala
+++ b/querydb/src/test/scala/io/joern/taggers/java/JavaxServletTaggerTests.scala
@@ -1,0 +1,34 @@
+package io.joern.taggers.java
+
+import io.joern.scanners.java.JavaxTagger
+import io.joern.suites.JavaQueryTestSuite
+
+class JavaxServletTaggerTests extends JavaQueryTestSuite(JavaxTagger) {
+
+  "the `javax-servlet` queries" when {
+
+    "a basic request can write directly to the response" in {
+      val cpg = code("""import java.io.IOException;
+                       |import java.io.PrintWriter;
+                       |import javax.servlet.http.HttpServletRequest;
+                       |import javax.servlet.http.HttpServletResponse;
+                       |
+                       |public class Basic1  {
+                       |    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                       |        String str = req.getParameter("name");
+                       |        resp.sendRedirect(str);    /* BAD */
+                       |    }
+                       |
+                       |}
+          |""".stripMargin)
+
+      val sources = findMatchingParameters(cpg, queryBundle.javaxSources())
+      sources shouldBe List("req")
+
+      val sinks = findMatchingArgumentCalls(cpg, queryBundle.javaxSinks())
+      sinks shouldBe List("sendRedirect(str)")
+    }
+
+  }
+
+}


### PR DESCRIPTION
The goal of this is to re-use as much of the query DB mechanisms as possible, while only having `reachableByFlows` run once for this subset.

Right now, queries define some subset of sources and sinks, but any source flowing to any sink is a problem. This changes allows queries tagged with `taint` + `[source|sink|sanitizer]` to be included in the taint analysis scan, where flows and results are gathered dynamically.

Additionally, only the language's semantics are included in this scan.

Note: It appears that `joern-scan` options regarding query filtering are not being propagated.