### PR TITLE
[TypeRecovery] include <returnValue> dummy for index accesses of calls

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -716,6 +716,10 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   protected def getIndexAccessTypes(ia: Call): Set[String] = indexAccessToCollectionVar(ia) match {
     case Some(cVar) if symbolTable.contains(cVar) =>
       symbolTable.get(cVar)
+    case Some(cVar) if ia.argument(1).isCall && symbolTable.contains(CallAlias(cVar.identifier)) =>
+      symbolTable
+        .get(CallAlias(cVar.identifier))
+        .map(x => s"$x$pathSep${XTypeRecovery.DummyReturnType}$pathSep${XTypeRecovery.DummyIndexAccess}")
     case Some(cVar) if symbolTable.contains(LocalVar(cVar.identifier)) =>
       symbolTable.get(LocalVar(cVar.identifier)).map(x => s"$x$pathSep${XTypeRecovery.DummyIndexAccess}")
     case _ => Set.empty


### PR DESCRIPTION
It was observed (#4558) a discrepancy between typeFullNames in Python for the following two samples:

```python
from helpers import foo
x = foo()
y = x[0] # y.typeFullName = helpers.py:<module>.foo.<returnValue>.<indexAccess>
```

vs

```python
from helpers import foo
y = foo()[0] # y.typeFullName = helpers.py:<module>.foo.<indexAccess>
```

The difference is the missing `<returnValue>` dummy in the second sample. This patch checks (in `getIndexAccessTypes`) whether the indexAccess' target is a call and that there's already in the symbol table an entry for it.
