### PR TITLE
Log stack trace if javasrc AstCreator crashes due to an UnsolvedSymbolException

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -217,11 +217,11 @@ class AstCreator(
       scope.popNamespaceScope()
       Ast(namespaceBlock).withChildren(typeDeclAsts).withChildren(importNodes)
     } catch {
-      case t: UnsolvedSymbolException =>
-        logger.error(s"Unsolved symbol exception caught in $filename")
+      case exception: UnsolvedSymbolException =>
+        logger.warn(s"Unsolved symbol exception caught in $filename", exception)
         Ast()
       case t: Throwable =>
-        logger.error(s"Parsing file $filename failed", t)
+        logger.warn(s"Parsing file $filename failed", t)
         Ast()
     }
   }


### PR DESCRIPTION
While attempting to debug a customer issue, I got as far as "the AstCreator is crashing due to a UnsolvedSymbolException somewhere after processing a lambda", but since the stack trace wasn't logged in this case, the issue could be more-or-less anywhere.

Logging the stack trace is ugly, but also makes debugging much easier for projects we don't have the source code to.

I also lowered the logging level to a warning since this is more consistent with what these levels mean elsewhere