### PR TITLE
Wrap all javaparser getType calls in Try

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -252,8 +252,8 @@ class AstCreator(
         * unresolved types or a bug, don't log them.
         */
       Try(expr) match {
-        case success: Success[_] => success
-        // case Failure(exception: UnsolvedSymbolException) => Failure(exception)
+        case success: Success[_]                         => success
+        case Failure(exception: UnsolvedSymbolException) => Failure(exception)
         case failure: Failure[_] =>
           val exceptionType = failure.exception.getClass
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -257,19 +257,12 @@ class AstCreator(
         case failure: Failure[_] =>
           val exceptionType = failure.exception.getClass
 
-          val shouldLog = loggedExceptionCounts.get(exceptionType) match {
-            case Some(count) if count <= 3 =>
-              loggedExceptionCounts.put(exceptionType, count + 1)
-              true
-
-            case None =>
-              loggedExceptionCounts.put(exceptionType, 1)
-              true
-
-            case _ => false
+          val loggedCount = loggedExceptionCounts.updateWith(exceptionType) {
+            case Some(value) => Some(value + 1)
+            case None        => Some(1)
           }
 
-          if (shouldLog) {
+          if (loggedCount.exists(_ <= 3)) {
             logger.debug("tryWithFailureLogging encountered exception", failure.exception)
           }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -151,7 +151,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   private def getIdentifiersForTypeParameters(methodDeclaration: MethodDeclaration): List[NewIdentifier] = {
     methodDeclaration.getTypeParameters.asScala.map { typeParameter =>
       val name = typeParameter.getNameAsString
-      val typeFullName = Try(typeParameter.getTypeBound.asScala.headOption).toOption.flatten
+      val typeFullName = tryWithSafeStackOverflow(typeParameter.getTypeBound.asScala.headOption).toOption.flatten
         .flatMap(typeInfoCalc.fullName)
         .getOrElse(TypeConstants.Object)
       typeInfoCalc.registerType(typeFullName)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -33,7 +33,7 @@ import io.joern.javasrc2cpg.scope.JavaScopeElement.fullName
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 import io.shiftleft.codepropertygraph.generated.nodes.AstNodeNew
 import io.shiftleft.codepropertygraph.generated.nodes.NewCall
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -42,7 +42,7 @@ import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import com.github.javaparser.ast.Node
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserParameterDeclaration
 import io.joern.javasrc2cpg.astcreation.declarations.AstForMethodsCreator.PartialConstructorDeclaration
-import io.joern.javasrc2cpg.util.Util
+import io.joern.javasrc2cpg.util.{NameConstants, Util}
 
 private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   def astForMethod(methodDeclaration: MethodDeclaration): Ast = {
@@ -52,14 +52,14 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
 
     val maybeResolved      = tryWithSafeStackOverflow(methodDeclaration.resolve())
     val expectedReturnType = Try(symbolSolver.toResolvedType(methodDeclaration.getType, classOf[ResolvedType])).toOption
-    val simpleMethodReturnType = Util.stripGenericTypes(methodDeclaration.getTypeAsString())
+    val simpleMethodReturnType = Try(methodDeclaration.getTypeAsString).map(Util.stripGenericTypes).toOption
     val returnTypeFullName = expectedReturnType
       .flatMap(typeInfoCalc.fullName)
-      .orElse(scope.lookupType(simpleMethodReturnType))
+      .orElse(simpleMethodReturnType.flatMap(scope.lookupType(_)))
       .orElse(
         Try(methodDeclaration.getType.asClassOrInterfaceType).toOption.flatMap(t => scope.lookupType(t.getNameAsString))
       )
-      .orElse(typeParameters.find(_.name == simpleMethodReturnType).map(_.typeFullName))
+      .orElse(typeParameters.find(typeParam => simpleMethodReturnType.contains(typeParam.name)).map(_.typeFullName))
 
     scope.pushMethodScope(
       methodNode,
@@ -89,12 +89,11 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
     }
 
     val bodyAst = methodDeclaration.getBody.toScala.map(astForBlockStatement(_)).getOrElse(Ast(NewBlock()))
-    val methodReturn = newMethodReturnNode(
-      returnTypeFullName.getOrElse(TypeConstants.Any),
-      None,
-      line(methodDeclaration.getType),
-      column(methodDeclaration.getType)
-    )
+    val (lineNr, columnNr) = Try(methodDeclaration.getType) match {
+      case Success(typ) => (line(typ), column(typ))
+      case Failure(_)   => (line(methodDeclaration), column(methodDeclaration))
+    }
+    val methodReturn = newMethodReturnNode(returnTypeFullName.getOrElse(TypeConstants.Any), None, lineNr, columnNr)
 
     val annotationAsts = methodDeclaration.getAnnotations.asScala.map(astForAnnotationExpr).toSeq
 
@@ -147,7 +146,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   private def getIdentifiersForTypeParameters(methodDeclaration: MethodDeclaration): List[NewIdentifier] = {
     methodDeclaration.getTypeParameters.asScala.map { typeParameter =>
       val name = typeParameter.getNameAsString
-      val typeFullName = typeParameter.getTypeBound.asScala.headOption
+      val typeFullName = Try(typeParameter.getTypeBound.asScala.headOption).toOption.flatten
         .flatMap(typeInfoCalc.fullName)
         .getOrElse(TypeConstants.Object)
       typeInfoCalc.registerType(typeFullName)
@@ -219,16 +218,18 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   }
 
   private def astForParameter(parameter: Parameter, childNum: Int): Ast = {
-    val maybeArraySuffix     = if (parameter.isVarArgs) "[]" else ""
-    val rawParameterTypeName = Util.stripGenericTypes(parameter.getTypeAsString)
+    val maybeArraySuffix = if (parameter.isVarArgs) "[]" else ""
+    val rawParameterTypeName =
+      Try(parameter.getTypeAsString).map(Util.stripGenericTypes).getOrElse(NameConstants.Unknown)
+    val parameterType = Try(parameter.getType).toOption
     val typeFullName =
-      typeInfoCalc
-        .fullName(parameter.getType)
+      parameterType
+        .flatMap(typeInfoCalc.fullName)
         .orElse(scope.lookupType(rawParameterTypeName))
         .map(_ ++ maybeArraySuffix)
         .getOrElse(s"${Defines.UnresolvedNamespace}.$rawParameterTypeName")
     val evalStrat =
-      if (parameter.getType.isPrimitiveType) EvaluationStrategies.BY_VALUE else EvaluationStrategies.BY_SHARING
+      if (parameterType.exists(_.isPrimitiveType)) EvaluationStrategies.BY_VALUE else EvaluationStrategies.BY_SHARING
     typeInfoCalc.registerType(typeFullName)
 
     val parameterNode = NewMethodParameterIn()
@@ -292,7 +293,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
 
     val maybeReturnType =
       Try(method.getReturnType).toOption
-        .flatMap(returnType => typeInfoCalc.fullName(returnType, typeParamValues))
+        .flatMap(typeInfoCalc.fullName(_, typeParamValues))
 
     composeSignature(maybeReturnType, maybeParameterTypes, method.getNumberOfParams)
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -568,17 +568,18 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     // TODO: Should be able to find expected type here
     val annotations = fieldDeclaration.getAnnotations
 
-    val rawTypeName = Try(v.getTypeAsString).map(Util.stripGenericTypes).getOrElse(NameConstants.Unknown)
+    val rawTypeName =
+      tryWithSafeStackOverflow(v.getTypeAsString).map(Util.stripGenericTypes).getOrElse(NameConstants.Unknown)
 
     val typeFullName =
-      Try(v.getType).toOption
+      tryWithSafeStackOverflow(v.getType).toOption
         .flatMap(typeInfoCalc.fullName)
         .orElse(scope.lookupType(rawTypeName))
         .getOrElse(s"${Defines.UnresolvedNamespace}.$rawTypeName")
 
     val name = v.getName.toString
     // Use type name without generics stripped in code
-    val variableTypeString = Try(v.getTypeAsString).getOrElse("")
+    val variableTypeString = tryWithSafeStackOverflow(v.getTypeAsString).getOrElse("")
     val node               = memberNode(v, name, s"$variableTypeString $name", typeFullName)
     val memberAst          = Ast(node)
     val annotationAsts     = annotations.asScala.map(astForAnnotationExpr)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -568,18 +568,20 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     // TODO: Should be able to find expected type here
     val annotations = fieldDeclaration.getAnnotations
 
-    val rawTypeName = Util.stripGenericTypes(v.getTypeAsString)
+    val rawTypeName = Try(v.getTypeAsString).map(Util.stripGenericTypes).getOrElse(NameConstants.Unknown)
 
-    val typeFullName = typeInfoCalc
-      .fullName(v.getType)
-      .orElse(scope.lookupType(rawTypeName))
-      .getOrElse(s"${Defines.UnresolvedNamespace}.$rawTypeName")
+    val typeFullName =
+      Try(v.getType).toOption
+        .flatMap(typeInfoCalc.fullName)
+        .orElse(scope.lookupType(rawTypeName))
+        .getOrElse(s"${Defines.UnresolvedNamespace}.$rawTypeName")
 
     val name = v.getName.toString
     // Use type name without generics stripped in code
-    val node           = memberNode(v, name, s"${v.getTypeAsString} $name", typeFullName)
-    val memberAst      = Ast(node)
-    val annotationAsts = annotations.asScala.map(astForAnnotationExpr)
+    val variableTypeString = Try(v.getTypeAsString).getOrElse("")
+    val node               = memberNode(v, name, s"$variableTypeString $name", typeFullName)
+    val memberAst          = Ast(node)
+    val annotationAsts     = annotations.asScala.map(astForAnnotationExpr)
 
     val fieldDeclModifiers = modifiersForFieldDeclaration(fieldDeclaration)
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -192,8 +192,8 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
 
     val anonymousClassBody = expr.getAnonymousClassBody.toScala.map(_.asScala.toList)
     val nameSuffix         = if (anonymousClassBody.isEmpty) "" else s"$$${scope.getNextAnonymousClassIndex()}"
-    val rawType            = Util.stripGenericTypes(expr.getTypeAsString)
-    val typeName           = s"$rawType$nameSuffix"
+    val rawType  = Try(expr.getTypeAsString).map(Util.stripGenericTypes).toOption.getOrElse(NameConstants.Unknown)
+    val typeName = s"$rawType$nameSuffix"
 
     val baseTypeFromScope = scope.lookupScopeType(rawType)
     // These will be the same for non-anonymous type decls, but in that case only the typeFullName will be used.
@@ -314,9 +314,9 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
         val paramCount = methodDecl.getNumberOfParams
 
         val resolvedType = if (idx < paramCount) {
-          Some(methodDecl.getParam(idx).getType)
+          Try(methodDecl.getParam(idx).getType).toOption
         } else if (paramCount > 0 && methodDecl.getParam(paramCount - 1).isVariadic) {
-          Some(methodDecl.getParam(paramCount - 1).getType)
+          Try(methodDecl.getParam(paramCount - 1).getType).toOption
         } else {
           None
         }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -352,7 +352,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
         // this will yield the erased types which is why the actual lambda
         // expression parameters are only used as a fallback.
         lambdaParameters
-          .flatMap(param => Try(typeInfoCalc.fullName(param.getType)).toOption)
+          .flatMap(param => tryWithSafeStackOverflow(typeInfoCalc.fullName(param.getType)).toOption)
     }
 
     if (paramTypesList.sizeIs != lambdaParameters.size) {
@@ -367,7 +367,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
         val typeFullName = maybeType.getOrElse(TypeConstants.Any)
         val code         = s"$typeFullName $name"
         val evalStrat =
-          if (Try(param.getType).toOption.exists(_.isPrimitiveType)) EvaluationStrategies.BY_VALUE
+          if (tryWithSafeStackOverflow(param.getType).toOption.exists(_.isPrimitiveType)) EvaluationStrategies.BY_VALUE
           else EvaluationStrategies.BY_SHARING
         val paramNode = NewMethodParameterIn()
           .name(name)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -352,8 +352,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
         // this will yield the erased types which is why the actual lambda
         // expression parameters are only used as a fallback.
         lambdaParameters
-          .map(_.getType)
-          .map(typeInfoCalc.fullName)
+          .flatMap(param => Try(typeInfoCalc.fullName(param.getType)).toOption)
     }
 
     if (paramTypesList.sizeIs != lambdaParameters.size) {
@@ -368,7 +367,8 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
         val typeFullName = maybeType.getOrElse(TypeConstants.Any)
         val code         = s"$typeFullName $name"
         val evalStrat =
-          if (param.getType.isPrimitiveType) EvaluationStrategies.BY_VALUE else EvaluationStrategies.BY_SHARING
+          if (Try(param.getType).toOption.exists(_.isPrimitiveType)) EvaluationStrategies.BY_VALUE
+          else EvaluationStrategies.BY_SHARING
         val paramNode = NewMethodParameterIn()
           .name(name)
           .index(idx + 1)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -33,7 +33,7 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators}
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 trait AstForSimpleExpressionsCreator { this: AstCreator =>
 
@@ -174,8 +174,8 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
 
   private[expressions] def astForCastExpr(expr: CastExpr, expectedType: ExpectedType): Ast = {
     val typeFullName =
-      typeInfoCalc
-        .fullName(expr.getType)
+      Try(expr.getType).toOption
+        .flatMap(typeInfoCalc.fullName)
         .orElse(expectedType.fullName)
         .getOrElse(TypeConstants.Any)
 
@@ -188,7 +188,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     )
 
     val typeNode = NewTypeRef()
-      .code(expr.getType.toString)
+      .code(Try(expr.getType.toString).getOrElse(code(expr)))
       .lineNumber(line(expr))
       .columnNumber(column(expr))
       .typeFullName(typeFullName)
@@ -203,13 +203,11 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val someTypeFullName = Some(TypeConstants.Class)
     val callNode = newOperatorCallNode(Operators.fieldAccess, expr.toString, someTypeFullName, line(expr), column(expr))
 
-    val identifierType = typeInfoCalc.fullName(expr.getType)
-    val identifier = identifierNode(
-      expr,
-      Util.stripGenericTypes(expr.getTypeAsString),
-      expr.getTypeAsString,
-      identifierType.getOrElse("ANY")
-    )
+    val identifierType = Try(expr.getType).toOption.flatMap(typeInfoCalc.fullName)
+    val exprTypeString =
+      Try(expr.getTypeAsString).toOption.orElse(identifierType).getOrElse(code(expr).stripSuffix(".class"))
+    val identifier =
+      identifierNode(expr, Util.stripGenericTypes(exprTypeString), exprTypeString, identifierType.getOrElse("ANY"))
     val idAst = Ast(identifier)
 
     val fieldIdentifier = NewFieldIdentifier()
@@ -273,12 +271,13 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
       newOperatorCallNode(Operators.instanceOf, expr.toString, booleanTypeFullName, line(expr), column(expr))
 
     val exprAst      = astsForExpression(expr.getExpression, ExpectedType.empty)
-    val typeFullName = typeInfoCalc.fullName(expr.getType).getOrElse(TypeConstants.Any)
+    val exprType     = Try(expr.getType).toOption
+    val typeFullName = exprType.flatMap(typeInfoCalc.fullName).getOrElse(TypeConstants.Any)
     val typeNode =
       NewTypeRef()
-        .code(expr.getType.toString)
+        .code(exprType.map(_.toString).getOrElse(code(expr).split("instanceof").lastOption.getOrElse("")))
         .lineNumber(line(expr))
-        .columnNumber(column(expr.getType))
+        .columnNumber(exprType.map(column(_)).getOrElse(column(expr)))
         .typeFullName(typeFullName)
     val typeAst = Ast(typeNode)
 
@@ -393,9 +392,9 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
   private[expressions] def astForMethodReferenceExpr(expr: MethodReferenceExpr, expectedType: ExpectedType): Ast = {
     val typeFullName = expr.getScope match {
       case typeExpr: TypeExpr =>
-        val rawType = Util.stripGenericTypes(typeExpr.getTypeAsString)
+        val rawType = Try(typeExpr.getTypeAsString).map(Util.stripGenericTypes).toOption
         // JavaParser wraps the "type" scope of a MethodReferenceExpr in a TypeExpr, but this also catches variable names.
-        scope.lookupVariableOrType(rawType).orElse(expressionReturnTypeFullName(typeExpr))
+        rawType.flatMap(scope.lookupVariableOrType).orElse(expressionReturnTypeFullName(typeExpr))
       case scopeExpr => expressionReturnTypeFullName(scopeExpr)
     }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -407,7 +407,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
       case Failure(_) => Defines.UnresolvedSignature
 
       case Success(resolvedMethod) =>
-        val returnType     = typeInfoCalc.fullName(resolvedMethod.getReturnType)
+        val returnType = tryWithSafeStackOverflow(resolvedMethod.getReturnType).toOption.flatMap(typeInfoCalc.fullName)
         val parameterTypes = argumentTypesForMethodLike(Success(resolvedMethod))
         composeSignature(returnType, parameterTypes, resolvedMethod.getNumberOfParams)
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
@@ -107,7 +107,7 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
 
   def astsForVariableDeclarator(variableDeclarator: VariableDeclarator, originNode: Node): Seq[Ast] = {
 
-    val declaratorType = Try(variableDeclarator.getType).toOption
+    val declaratorType = tryWithSafeStackOverflow(variableDeclarator.getType).toOption
     // If generics are in the type name, we may be unable to resolve the type
     val (variableTypeString, maybeTypeArgs) = declaratorType match {
       case Some(typ: ClassOrInterfaceType) =>
@@ -176,7 +176,8 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
               symbolSolver.toResolvedType(variableDeclarator.getType, classOf[ResolvedType])
             ).toOption
 
-          val strippedType = Try(variableDeclarator.getTypeAsString).map(Util.stripGenericTypes).toOption
+          val strippedType =
+            tryWithSafeStackOverflow(variableDeclarator.getTypeAsString).map(Util.stripGenericTypes).toOption
           astsForAssignment(
             variableDeclarator,
             assignmentTarget,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 import io.joern.javasrc2cpg.scope.JavaScopeElement.PartialInit
 
 trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
@@ -107,19 +107,20 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
 
   def astsForVariableDeclarator(variableDeclarator: VariableDeclarator, originNode: Node): Seq[Ast] = {
 
-    val variableDeclaratorType = variableDeclarator.getType
+    val declaratorType = Try(variableDeclarator.getType).toOption
     // If generics are in the type name, we may be unable to resolve the type
-    val (variableTypeString, maybeTypeArgs) = variableDeclaratorType match {
-      case typ: ClassOrInterfaceType =>
+    val (variableTypeString, maybeTypeArgs) = declaratorType match {
+      case Some(typ: ClassOrInterfaceType) =>
         val typeParams = typ.getTypeArguments.toScala.map(_.asScala.flatMap(typeInfoCalc.fullName))
-        (typ.getName.asString(), typeParams)
-      case _ => (Util.stripGenericTypes(variableDeclarator.getTypeAsString), None)
+        (Some(typ.getName.asString()), typeParams)
+      case Some(typ) => (Some(Util.stripGenericTypes(typ.toString)), None)
+      case None      => (None, None)
     }
 
     val typeFullName = tryWithSafeStackOverflow(
-      scope
-        .lookupType(variableTypeString, includeWildcards = false)
-        .orElse(typeInfoCalc.fullName(variableDeclarator.getType))
+      variableTypeString
+        .flatMap(scope.lookupType(_, includeWildcards = false))
+        .orElse(declaratorType.flatMap(typeInfoCalc.fullName))
     ).toOption.flatten.map { typ =>
       maybeTypeArgs match {
         case Some(typeArgs) if keepTypeArguments => s"$typ<${typeArgs.mkString(",")}>"
@@ -132,7 +133,7 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
       scope.lookupVariable(variableName).variableNode
     } else {
       // Use type name with generics for code
-      val localCode = s"${variableDeclarator.getTypeAsString} ${variableDeclarator.getNameAsString}"
+      val localCode = s"${declaratorType.map(_.toString).getOrElse("")} ${variableDeclarator.getNameAsString}"
 
       val local =
         localNode(originNode, variableDeclarator.getNameAsString, localCode, typeFullName.getOrElse(TypeConstants.Any))
@@ -175,6 +176,7 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
               symbolSolver.toResolvedType(variableDeclarator.getType, classOf[ResolvedType])
             ).toOption
 
+          val strippedType = Try(variableDeclarator.getTypeAsString).map(Util.stripGenericTypes).toOption
           astsForAssignment(
             variableDeclarator,
             assignmentTarget,
@@ -182,7 +184,7 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
             Operators.assignment,
             "=",
             ExpectedType(typeFullName, expectedType),
-            Some(Util.stripGenericTypes(variableDeclarator.getTypeAsString))
+            strippedType
           )
         }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -326,8 +326,9 @@ trait AstForForLoopsCreator { this: AstCreator =>
 
     maybeVariable match {
       case Some(variable) =>
-        val name         = variable.getNameAsString
-        val typeFullName = Try(variable.getType).toOption.flatMap(typeInfoCalc.fullName).getOrElse("ANY")
+        val name = variable.getNameAsString
+        val typeFullName =
+          tryWithSafeStackOverflow(variable.getType).toOption.flatMap(typeInfoCalc.fullName).getOrElse("ANY")
         val localNode = partialLocalNode
           .name(name)
           .code(variable.getNameAsString)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
+import scala.util.Try
 
 trait AstForForLoopsCreator { this: AstCreator =>
 
@@ -326,7 +327,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
     maybeVariable match {
       case Some(variable) =>
         val name         = variable.getNameAsString
-        val typeFullName = typeInfoCalc.fullName(variable.getType).getOrElse("ANY")
+        val typeFullName = Try(variable.getType).toOption.flatMap(typeInfoCalc.fullName).getOrElse("ANY")
         val localNode = partialLocalNode
           .name(name)
           .code(variable.getNameAsString)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -30,7 +30,9 @@ import org.slf4j.LoggerFactory
 
 import java.net.URLClassLoader
 import java.nio.file.{Path, Paths}
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.parallel.CollectionConverters.*
+import scala.collection.concurrent
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.{Success, Try}
@@ -38,8 +40,9 @@ import scala.util.{Success, Try}
 class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[String]] = None)
     extends ConcurrentWriterCpgPass[String](cpg) {
 
-  val global: Global = new Global()
-  private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
+  val global: Global                = new Global()
+  private val logger                = LoggerFactory.getLogger(classOf[AstCreationPass])
+  private val loggedExceptionCounts = new ConcurrentHashMap[Class[?], Int]().asScala
 
   val (sourceParser, symbolSolver) = initParserAndUtils(config)
 
@@ -50,10 +53,17 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
       case Some(compilationUnit, fileContent) =>
         symbolSolver.inject(compilationUnit)
         val contentToUse = if (!config.disableFileContent) fileContent else None
+
         diffGraph.absorb(
-          new AstCreator(filename, compilationUnit, contentToUse, global, symbolSolver, config.keepTypeArguments)(
-            config.schemaValidation
-          )
+          new AstCreator(
+            filename,
+            compilationUnit,
+            contentToUse,
+            global,
+            symbolSolver,
+            config.keepTypeArguments,
+            loggedExceptionCounts
+          )(config.schemaValidation)
             .createAst()
         )
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -108,7 +108,8 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver, keepTyp
         } else {
           val extendsBoundOption = Try(typeParamDecl.getBounds.asScala.find(_.isExtends)).toOption.flatten
           extendsBoundOption
-            .flatMap(bound => nameOrFullName(bound.getType, typeParamValues, fullyQualified))
+            .flatMap(bound => Try(bound.getType).toOption)
+            .flatMap(boundType => nameOrFullName(boundType, typeParamValues, fullyQualified))
             .orElse(objectType(fullyQualified))
         }
       case lambdaConstraintType: ResolvedLambdaConstraintType =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.Try
+import scala.util.{Failure, Try}
 
 class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver, keepTypeArguments: Boolean) {
   private val logger               = LoggerFactory.getLogger(this.getClass)
@@ -108,7 +108,14 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver, keepTyp
         } else {
           val extendsBoundOption = Try(typeParamDecl.getBounds.asScala.find(_.isExtends)).toOption.flatten
           extendsBoundOption
-            .flatMap(bound => Try(bound.getType).toOption)
+            .flatMap(bound =>
+              Try(bound.getType)
+                .recoverWith(throwable => {
+                  logger.debug("Error getting bound type", throwable)
+                  Failure(throwable)
+                })
+                .toOption
+            )
             .flatMap(boundType => nameOrFullName(boundType, typeParamValues, fullyQualified))
             .orElse(objectType(fullyQualified))
         }


### PR DESCRIPTION
Related to https://github.com/joernio/joern/pull/4665

The AstCreator is crashing on a customer project due to an `UnsolvedSymbolException`. As mentioned in the PR, there isn't enough information in the logs to locate the exact issue, but my theory is that it is due to a `getType` call somewhere. For this PR, I've wrapped all `getType` calls in a `Try` (unless they were already wrapped) since the JavaParser symbol solver and the interactions between the various kinds of solvers are too complex to easily tell when these calls should be safe and when not.

Revision 2: I've changed `Try` to `tryWithSafeStackOverflow`, which also logs stack traces for errors now. This isn't called during regular type resolution, so we won't log every failed type (since those are often to be expected), but we should keep an eye on javasrc log sizes and more selectively log these if it turns out to be too much