### PR TITLE
reduce classpath dependencies from frontends: javasrc

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -5,7 +5,6 @@ enablePlugins(JavaAppPackaging)
 dependsOn(
   Projects.semanticcpg,
   Projects.macros,
-  Projects.javasrc2cpg,
   Projects.jssrc2cpg,
   Projects.php2cpg,
   Projects.pysrc2cpg,

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
-import io.joern.javasrc2cpg.{JavaSrc2Cpg, Main, Config}
-import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.frontendspecific.javasrc2cpg
+import io.joern.x2cpg.passes.frontend.XTypeRecovery
 import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.nio.file.Path
@@ -12,19 +12,21 @@ import scala.util.Try
   */
 case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("javasrc2cpg.bat") else rootPath.resolve("javasrc2cpg")
-  private var javaConfig: Option[Config] = None
+  private var enableTypeRecovery = false
+  private var disableDummyTypes  = false
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
   override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    javaConfig = X2Cpg.parseCommandLine(arguments.toArray, Main.getCmdLineParser, Config())
+    enableTypeRecovery = arguments.exists(_ == s"--${javasrc2cpg.ParameterNames.EnableTypeRecovery}")
+    disableDummyTypes = arguments.exists(_ == s"--${XTypeRecovery.ParameterNames.NoDummyTypes}")
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
-    if (javaConfig.exists(_.enableTypeRecovery))
-      JavaSrc2Cpg.typeRecoveryPasses(cpg, javaConfig).foreach(_.createAndApply())
+    if (enableTypeRecovery)
+      javasrc2cpg.typeRecoveryPasses(cpg, disableDummyTypes).foreach(_.createAndApply())
     super.applyPostProcessingPasses(cpg)
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -1,18 +1,11 @@
 package io.joern.javasrc2cpg
 
-import better.files.File
-import io.joern.javasrc2cpg.passes.{
-  AstCreationPass,
-  JavaTypeHintCallLinker,
-  JavaTypeRecoveryPassGenerator,
-  TypeInferencePass
-}
+import io.joern.javasrc2cpg.passes.{AstCreationPass, TypeInferencePass}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
-import io.joern.x2cpg.passes.frontend.{JavaConfigFileCreationPass, MetaDataPass, TypeNodePass, XTypeRecoveryConfig}
+import io.joern.x2cpg.passes.frontend.{JavaConfigFileCreationPass, MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.X2CpgFrontend
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.shiftleft.passes.CpgPassBase
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.*
@@ -55,12 +48,6 @@ object JavaSrc2Cpg {
     Config().withDefaultIgnoredFilesRegex(DefaultIgnoredFilesRegex)
 
   def apply(): JavaSrc2Cpg = new JavaSrc2Cpg()
-
-  def typeRecoveryPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = {
-    new JavaTypeRecoveryPassGenerator(cpg, XTypeRecoveryConfig(enabledDummyTypes = !config.exists(_.disableDummyTypes)))
-      .generate() ++
-      List(new JavaTypeHintCallLinker(cpg))
-  }
 
   def showEnv(): Unit = {
     val value =

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -1,12 +1,11 @@
 package io.joern.javasrc2cpg
 
 import io.joern.javasrc2cpg.Frontend.*
-import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
-import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
-import scopt.OParser
-import scala.util.matching.Regex
-import io.joern.javasrc2cpg.typesolvers.SimpleCombinedTypeSolver
 import io.joern.javasrc2cpg.jpastprinter.JavaParserAstPrinter
+import io.joern.x2cpg.frontendspecific.javasrc2cpg
+import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
+import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
+import scopt.OParser
 
 /** Command line configuration parameters
   */
@@ -80,7 +79,7 @@ private object Frontend {
 
   val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
-    import builder._
+    import builder.*
     OParser.sequence(
       programName("javasrc2cpg"),
       opt[Seq[String]]("inference-jar-paths")
@@ -101,7 +100,7 @@ private object Frontend {
                  | run-delombok => run delombok and use delomboked source for both analysis and type information.""".stripMargin
         )
         .action((mode, c) => c.withDelombokMode(mode)),
-      opt[Unit]("enable-type-recovery")
+      opt[Unit](javasrc2cpg.ParameterNames.EnableTypeRecovery)
         .hidden()
         .action((_, c) => c.withEnableTypeRecovery(true))
         .text("enable generic type recovery"),

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -5,6 +5,7 @@ import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.frontendspecific.javasrc2cpg
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
@@ -31,7 +32,8 @@ class JavaSrcTestCpg(enableTypeRecovery: Boolean = false)
 
   override protected def applyPasses(): Unit = {
     super.applyPasses()
-    if (enableTypeRecovery) JavaSrc2Cpg.typeRecoveryPasses(this).foreach(_.createAndApply())
+    if (enableTypeRecovery)
+      javasrc2cpg.typeRecoveryPasses(this, disableDummyTypes = false).foreach(_.createAndApply())
     applyOssDataFlow()
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/JavaTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/JavaTypeHintCallLinker.scala
@@ -1,12 +1,10 @@
-package io.joern.javasrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.javasrc2cpg
 
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.semanticcpg.language._
-
-import java.util.regex.Pattern
+import io.shiftleft.semanticcpg.language.*
 
 class JavaTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/JavaTypeRecoveryPassGenerator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/JavaTypeRecoveryPassGenerator.scala
@@ -1,11 +1,10 @@
-package io.joern.javasrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.javasrc2cpg
 
 import io.joern.x2cpg.Defines
-import io.joern.x2cpg.passes.frontend._
-import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.codepropertygraph.generated.PropertyNames
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.semanticcpg.language._
+import io.joern.x2cpg.passes.frontend.*
+import io.shiftleft.codepropertygraph.generated.{Cpg, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 import overflowdb.BatchedUpdate.DiffGraphBuilder
 
 class JavaTypeRecoveryPassGenerator(cpg: Cpg, config: XTypeRecoveryConfig = XTypeRecoveryConfig())

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/package.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/package.scala
@@ -1,0 +1,18 @@
+package io.joern.x2cpg.frontendspecific
+
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.passes.CpgPassBase
+
+package object javasrc2cpg {
+
+  object ParameterNames {
+    val EnableTypeRecovery = "enable-type-recovery"
+  }
+
+  def typeRecoveryPasses(cpg: Cpg, disableDummyTypes: Boolean): List[CpgPassBase] = {
+    new JavaTypeRecoveryPassGenerator(cpg, XTypeRecoveryConfig(enabledDummyTypes = !disableDummyTypes)).generate() :+
+      new JavaTypeHintCallLinker(cpg)
+  }
+
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/package.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/package.scala
@@ -1,0 +1,13 @@
+package io.joern.x2cpg
+
+/** This package solely exists to extract some code from the frontends that is shared between joern and the frontends,
+  * e.g. for parsing commandline arguments and running postprocessing passes.
+  *
+  * If this code was to be in the frontend's subproject, joern would need to have classpath-dependencies on the
+  * frontends, inheriting all their transitive dependencies. As discussed in e.g.
+  * https://github.com/joernio/joern/issues/4625#issuecomment-2166427270 we want to avoid having classpath dependencies
+  * on the frontends and instead invoke them frontends as external processes (i.e. execute their start script).
+  * Otherwise we'll end in jar hell with various incompatible versions of many different dependencies, and complex
+  * issues with things like OSGI and JPMS.
+  */
+package object frontendspecific

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -186,6 +186,9 @@ abstract class XTypeRecovery[CompilationUnitType <: AstNode](cpg: Cpg, state: XT
 }
 
 object XTypeRecovery {
+  object ParameterNames {
+    val NoDummyTypes = "no-dummyTypes"
+  }
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -209,7 +212,7 @@ object XTypeRecovery {
     val builder = OParser.builder[R]
     import builder.*
     OParser.sequence(
-      opt[Unit]("no-dummyTypes")
+      opt[Unit](ParameterNames.NoDummyTypes)
         .hidden()
         .action((_, c) => c.withDisableDummyTypes(true))
         .text("disable generation of dummy types during type propagation"),


### PR DESCRIPTION
Please review with care - this is the archetype setup for all other frontends. 

As discussed in e.g. https://github.com/joernio/joern/issues/4625#issuecomment-2166427270
we want to avoid having classpath dependencies on the frontends and instead invoke them
frontends as external processes (i.e. execute their start script). Otherwise we'll end in
jar hell with various incompatible versions of many different dependencies, and complex
issues with things like OSGI and JPMS.

There's no perfect way to do so, this is the one I currently like the most...

Fixes tab completion bug https://github.com/joernio/joern/issues/4625