### PR TITLE
[dataflowengineoss] Refactor isCallRetVal

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
@@ -1,10 +1,17 @@
 package io.joern.dataflowengineoss.passes.reachingdef
 
-import io.joern.dataflowengineoss.language._
+import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.Engine.isOutputArgOfInternalMethod
-import io.joern.dataflowengineoss.semanticsloader.{FlowMapping, ParameterNode, PassThroughMapping, Semantics}
+import io.joern.dataflowengineoss.semanticsloader.{
+  FlowMapping,
+  FlowPath,
+  FlowSemantic,
+  ParameterNode,
+  PassThroughMapping,
+  Semantics
+}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, CfgNode, Expression, StoredNode}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 object EdgeValidator {
 
@@ -34,17 +41,20 @@ object EdgeValidator {
         curNode.isUsed
     }
 
+  /** Is it a CALL for which semantics exist but don't taint its return value?
+    */
   private def isCallRetval(parentNode: StoredNode)(implicit semantics: Semantics): Boolean =
     parentNode match {
-      case call: Call =>
-        val sem = semantics.forMethod(call.methodFullName)
-        sem.isDefined && !sem.get.mappings.exists {
-          case FlowMapping(_, ParameterNode(dst, _)) => dst == -1
-          case PassThroughMapping                    => true
-          case _                                     => false
-        }
-      case _ =>
-        false
+      case call: Call => semantics.forMethod(call.methodFullName).exists(!explicitlyFlowsToReturnValue(_))
+      case _          => false
     }
 
+  private def explicitlyFlowsToReturnValue(flowSemantic: FlowSemantic): Boolean =
+    flowSemantic.mappings.exists(explicitlyFlowsToReturnValue)
+
+  private def explicitlyFlowsToReturnValue(flowPath: FlowPath): Boolean = flowPath match {
+    case FlowMapping(_, ParameterNode(dst, _)) => dst == -1
+    case PassThroughMapping                    => true
+    case _                                     => false
+  }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -34,6 +34,191 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     flow shouldBe List(("foo(20)", 2), ("x = foo(20)", 2), ("print(x)", 3))
   }
 
+  "flow from aliased literal to imported external method call return value" in {
+    val cpg = code("""
+        |from helpers import foo
+        |a = 20
+        |print(foo(a))
+        |""".stripMargin)
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows.map(flowToResultPairs) shouldBe List(List(("a = 20", 3), ("foo(a)", 4)))
+  }
+
+  "flow from literal directly used in imported external method call return value" in {
+    val cpg = code("""
+        |from helpers import foo
+        |print(foo(20))
+        |""".stripMargin)
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows.map(flowToResultPairs) shouldBe List(List(("foo(20)", 3)))
+  }
+
+  "no flow from aliased literal to imported external method call return value given empty semantics" in {
+    val cpg = code("""
+        |from helpers import foo
+        |a = 20
+        |print(foo(a))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List())))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from aliased literal to imported external method call return value given receiver-only semantics" in {
+    val cpg = code("""
+        |from helpers import foo
+        |a = 20
+        |print(foo(a))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(0, 0)))))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from aliased literal to imported external method call return value given argument1-only semantics" ignore {
+    val cpg = code("""
+        |from helpers import foo
+        |a = 20
+        |print(foo(a))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(1, 1)))))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from literal to imported external method return value given empty semantics" ignore {
+    val cpg = code("""
+        |from helpers import foo
+        |print(foo(20))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List())))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from literal to imported external method return value given receiver-only semantics" ignore {
+    val cpg = code("""
+        |from helpers import foo
+        |print(foo(20))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(0, 0)))))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from literal to imported external method return value given argument1-only semantics" ignore {
+    val cpg = code("""
+        |from helpers import foo
+        |print(foo(20))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(1, 1)))))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from aliased literal to method call return value given empty semantics" in {
+    val cpg = code("""
+        |def foo(x):
+        |  return x
+        |
+        |a = 20
+        |print(foo(a))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List())))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from aliased literal to method call return value given receiver-only semantics" in {
+    val cpg = code("""
+        |def foo(x):
+        |  return x
+        |
+        |a = 20
+        |print(foo(a))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(0, 0)))))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from aliased literal to method call return value given argument1-only semantics" ignore {
+    val cpg = code("""
+        |def foo(x):
+        |  return x
+        |
+        |a = 20
+        |print(foo(a))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(1, 1)))))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from literal to method call return value given empty semantics" ignore {
+    val cpg = code("""
+        |def foo(x):
+        |  return x
+        |
+        |print(foo(20))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List())))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from literal to method call return value given receiver-only semantics" ignore {
+    val cpg = code("""
+        |def foo(x):
+        |  return x
+        |
+        |print(foo(20))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(0, 0)))))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
+  "no flow from literal to method call return value given argument1-only semantics" ignore {
+    val cpg = code("""
+        |def foo(x):
+        |  return x
+        |
+        |print(foo(20))
+        |""".stripMargin)
+      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(1, 1)))))
+    val source = cpg.literal("20").l
+    val sink   = cpg.call("print").argument(1).l
+    val flows  = sink.reachableByFlows(source).l
+    flows shouldBe empty
+  }
+
   "chained call" in {
     val cpg: Cpg = code("""
       |a = 42


### PR DESCRIPTION
Apropos #4664, adds a couple of ignored failing tests with the intention of validating the intended behaviour. I was able to resolve a few of them (not included in this patch), but wanted to make sure this is right expectation before causing too much damage.