### PR TITLE
[dataflowengineoss] refine return value semantics honouring

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
@@ -22,6 +22,10 @@ object EdgeValidator {
       case (childNode: Expression, parentNode)
           if isCallRetval(parentNode) || !isValidEdgeToExpression(parentNode, childNode) =>
         false
+      case (childNode: Call, parentNode: Expression) if isCallRetval(childNode) =>
+        // e.g. foo(x), but there are semantics for `foo` that don't taint its return value
+        // in which case we don't want `x` to taint `foo(x)`.
+        false
       case (childNode: Expression, parentNode: Expression)
           if parentNode.isArgToSameCallWith(childNode) && childNode.isDefined && parentNode.isUsed =>
         parentNode.hasDefinedFlowTo(childNode)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/EdgeValidator.scala
@@ -22,7 +22,8 @@ object EdgeValidator {
       case (childNode: Expression, parentNode)
           if isCallRetval(parentNode) || !isValidEdgeToExpression(parentNode, childNode) =>
         false
-      case (childNode: Call, parentNode: Expression) if isCallRetval(childNode) =>
+      case (childNode: Call, parentNode: Expression)
+          if isCallRetval(childNode) && childNode.argument.contains(parentNode) =>
         // e.g. foo(x), but there are semantics for `foo` that don't taint its return value
         // in which case we don't want `x` to taint `foo(x)`.
         false

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -49,7 +49,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
     "find flows to `free`" in {
       val source = cpg.identifier
-      val sink   = cpg.call.name("free")
+      val sink   = cpg.call.name("free").argument(1)
       sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 6
     }
 
@@ -1311,7 +1311,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
 
     "find flows to `free`" in {
       val source = cpg.identifier
-      val sink   = cpg.call.name("free")
+      val sink   = cpg.call.name("free").argument(1)
       sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 6
     }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -83,7 +83,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     flows shouldBe empty
   }
 
-  "no flow from aliased literal to imported external method call return value given argument1-only semantics" ignore {
+  "no flow from aliased literal to imported external method call return value given argument1-only semantics" in {
     val cpg = code("""
         |from helpers import foo
         |a = 20
@@ -96,7 +96,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     flows shouldBe empty
   }
 
-  "no flow from literal to imported external method return value given empty semantics" ignore {
+  "no flow from literal to imported external method return value given empty semantics" in {
     val cpg = code("""
         |from helpers import foo
         |print(foo(20))
@@ -108,7 +108,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     flows shouldBe empty
   }
 
-  "no flow from literal to imported external method return value given receiver-only semantics" ignore {
+  "no flow from literal to imported external method return value given receiver-only semantics" in {
     val cpg = code("""
         |from helpers import foo
         |print(foo(20))
@@ -120,7 +120,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
     flows shouldBe empty
   }
 
-  "no flow from literal to imported external method return value given argument1-only semantics" ignore {
+  "no flow from literal to imported external method return value given argument1-only semantics" in {
     val cpg = code("""
         |from helpers import foo
         |print(foo(20))


### PR DESCRIPTION
In expressions such as `foo(x)`, for which there are semantics for `foo` that don't taint its return value (cf. `isCallRetval`), we prevent creating an edge from `x` to `foo(x)`.

Otherwise, an expression such as `print(foo(x))` would be tainted by `x` when it shouldn't (since there are semantics preventing from tainting `foo`'s return value.)