### PR TITLE
reduce classpath dependencies from frontends: jssrc2cpg

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -5,7 +5,6 @@ enablePlugins(JavaAppPackaging)
 dependsOn(
   Projects.semanticcpg,
   Projects.macros,
-  Projects.jssrc2cpg,
   Projects.php2cpg,
   Projects.pysrc2cpg,
   Projects.rubysrc2cpg,

--- a/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -2,10 +2,11 @@ package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
 import io.joern.x2cpg.frontendspecific.javasrc2cpg
-import io.joern.x2cpg.passes.frontend.XTypeRecovery
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.nio.file.Path
+import scala.compiletime.uninitialized
 import scala.util.Try
 
 /** Source-based front-end for Java
@@ -13,20 +14,20 @@ import scala.util.Try
 case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("javasrc2cpg.bat") else rootPath.resolve("javasrc2cpg")
   private var enableTypeRecovery = false
-  private var disableDummyTypes  = false
+  private var typeRecoveryConfig: XTypeRecoveryConfig = uninitialized
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
   override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
     enableTypeRecovery = arguments.exists(_ == s"--${javasrc2cpg.ParameterNames.EnableTypeRecovery}")
-    disableDummyTypes = arguments.exists(_ == s"--${XTypeRecovery.ParameterNames.NoDummyTypes}")
+    if (enableTypeRecovery) typeRecoveryConfig = XTypeRecoveryConfig.parse(arguments)
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
     if (enableTypeRecovery)
-      javasrc2cpg.typeRecoveryPasses(cpg, disableDummyTypes).foreach(_.createAndApply())
+      javasrc2cpg.typeRecoveryPasses(cpg, typeRecoveryConfig).foreach(_.createAndApply())
     super.applyPostProcessingPasses(cpg)
   }
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -2,20 +2,23 @@ package io.joern.console.cpgcreation
 
 import better.files.File
 import io.joern.console.FrontendConfig
-import io.joern.jssrc2cpg.{Config, Frontend, JsSrc2Cpg}
-import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.frontendspecific.jssrc2cpg
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.nio.file.Path
+import scala.compiletime.uninitialized
 import scala.util.Try
 
 case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("jssrc2cpg.bat") else rootPath.resolve("jssrc2cpg.sh")
-  private var jsConfig: Option[Config] = None
+  private var typeRecoveryConfig: XTypeRecoveryConfig = uninitialized
 
   /** Generate a CPG for the given input path. Returns the output path, or None, if no CPG was generated.
     */
   override def generate(inputPath: String, outputPath: String = "cpg.bin.zip"): Try[String] = {
+    typeRecoveryConfig = XTypeRecoveryConfig.parse(config.cmdLineParams.toSeq)
+
     if (File(inputPath).isDirectory) {
       invoke(inputPath, outputPath)
     } else {
@@ -27,7 +30,6 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
 
   private def invoke(inputPath: String, outputPath: String): Try[String] = {
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
-    jsConfig = X2Cpg.parseCommandLine(arguments.toArray, Frontend.cmdLineParser, Config())
     runShellCommand(command.toString, arguments).map(_ => outputPath)
   }
 
@@ -35,7 +37,7 @@ case class JsSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cpg
     command.toFile.exists
 
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
-    JsSrc2Cpg.postProcessingPasses(cpg, jsConfig).foreach(_.createAndApply())
+    jssrc2cpg.postProcessingPasses(cpg, typeRecoveryConfig).foreach(_.createAndApply())
     cpg
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -2,7 +2,7 @@ package io.joern.csharpsrc2cpg
 
 import io.joern.csharpsrc2cpg.Frontend.{cmdLineParser, defaultConfig}
 import io.joern.x2cpg.astgen.AstGenConfig
-import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
+import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery, XTypeRecoveryConfig}
 import io.joern.x2cpg.utils.Environment
 import io.joern.x2cpg.{DependencyDownloadConfig, X2CpgConfig, X2CpgMain}
 import org.slf4j.LoggerFactory
@@ -31,7 +31,11 @@ object Frontend {
   val cmdLineParser: OParser[Unit, Config] = {
     val builder = OParser.builder[Config]
     import builder.*
-    OParser.sequence(programName("csharpsrc2cpg"), DependencyDownloadConfig.parserOptions, XTypeRecovery.parserOptions)
+    OParser.sequence(
+      programName("csharpsrc2cpg"),
+      DependencyDownloadConfig.parserOptions,
+      XTypeRecoveryConfig.parserOptions
+    )
   }
 
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -34,7 +34,7 @@ object Frontend {
     OParser.sequence(
       programName("csharpsrc2cpg"),
       DependencyDownloadConfig.parserOptions,
-      XTypeRecoveryConfig.parserOptions
+      XTypeRecoveryConfig.parserOptionsForParserConfig
     )
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -104,7 +104,7 @@ private object Frontend {
         .hidden()
         .action((_, c) => c.withEnableTypeRecovery(true))
         .text("enable generic type recovery"),
-      XTypeRecoveryConfig.parserOptions,
+      XTypeRecoveryConfig.parserOptionsForParserConfig,
       opt[String]("jdk-path")
         .action((path, c) => c.withJdkPath(path))
         .text("JDK used for resolving builtin Java types. If not set, current classpath will be used"),

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -4,7 +4,7 @@ import io.joern.javasrc2cpg.Frontend.*
 import io.joern.javasrc2cpg.jpastprinter.JavaParserAstPrinter
 import io.joern.x2cpg.frontendspecific.javasrc2cpg
 import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
-import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
+import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery, XTypeRecoveryConfig}
 import scopt.OParser
 
 /** Command line configuration parameters
@@ -104,7 +104,7 @@ private object Frontend {
         .hidden()
         .action((_, c) => c.withEnableTypeRecovery(true))
         .text("enable generic type recovery"),
-      XTypeRecovery.parserOptions,
+      XTypeRecoveryConfig.parserOptions,
       opt[String]("jdk-path")
         .action((path, c) => c.withJdkPath(path))
         .text("JDK used for resolving builtin Java types. If not set, current classpath will be used"),

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -6,6 +6,7 @@ import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, Semantic
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.frontendspecific.javasrc2cpg
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend, TestCpg}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
@@ -33,7 +34,7 @@ class JavaSrcTestCpg(enableTypeRecovery: Boolean = false)
   override protected def applyPasses(): Unit = {
     super.applyPasses()
     if (enableTypeRecovery)
-      javasrc2cpg.typeRecoveryPasses(this, disableDummyTypes = false).foreach(_.createAndApply())
+      javasrc2cpg.typeRecoveryPasses(this, XTypeRecoveryConfig(enabledDummyTypes = true)).foreach(_.createAndApply())
     applyOssDataFlow()
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -2,11 +2,11 @@ package io.joern.jssrc2cpg
 
 import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
-import io.joern.jssrc2cpg.JsSrc2Cpg.postProcessingPasses
 import io.joern.jssrc2cpg.passes.*
 import io.joern.jssrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.postProcessingPasses
 import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.joern.x2cpg.utils.{HashUtil, Report}
@@ -46,23 +46,10 @@ class JsSrc2Cpg extends X2CpgFrontend[Config] {
     val maybeCpg = createCpgWithOverlays(config)
     maybeCpg.map { cpg =>
       new OssDataFlow(new OssDataFlowOptions()).run(new LayerCreatorContext(cpg))
-      postProcessingPasses(cpg, Option(config)).foreach(_.createAndApply())
+      val typeRecoveryConfig = XTypeRecoveryConfig(config.typePropagationIterations, !config.disableDummyTypes)
+      postProcessingPasses(cpg, typeRecoveryConfig).foreach(_.createAndApply())
       cpg
     }
-  }
-
-}
-
-object JsSrc2Cpg {
-
-  def postProcessingPasses(cpg: Cpg, config: Option[Config] = None): List[CpgPassBase] = {
-    val typeRecoveryConfig = config
-      .map(c => XTypeRecoveryConfig(c.typePropagationIterations, !c.disableDummyTypes))
-      .getOrElse(XTypeRecoveryConfig())
-    List(new JavaScriptInheritanceNamePass(cpg), new ConstClosurePass(cpg), new JavaScriptImportResolverPass(cpg))
-      ++
-        new JavaScriptTypeRecoveryPassGenerator(cpg, typeRecoveryConfig).generate() ++
-        List(new JavaScriptTypeHintCallLinker(cpg), ObjectPropertyCallLinker(cpg), new NaiveCallLinker(cpg))
   }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
@@ -1,7 +1,7 @@
 package io.joern.jssrc2cpg
 
 import io.joern.jssrc2cpg.Frontend.*
-import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
+import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery, XTypeRecoveryConfig}
 import io.joern.x2cpg.utils.Environment
 import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import scopt.OParser
@@ -28,7 +28,7 @@ object Frontend {
         .hidden()
         .action((_, c) => c.withTsTypes(false))
         .text("disable generation of types via Typescript"),
-      XTypeRecovery.parserOptions
+      XTypeRecoveryConfig.parserOptions
     )
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
@@ -28,7 +28,7 @@ object Frontend {
         .hidden()
         .action((_, c) => c.withTsTypes(false))
         .text("disable generation of types via Typescript"),
-      XTypeRecoveryConfig.parserOptions
+      XTypeRecoveryConfig.parserOptionsForParserConfig
     )
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -5,8 +5,8 @@ import io.joern.jssrc2cpg.datastructures.{MethodScope, Scope}
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelJsonParser.ParseResult
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.NodeBuilders.{newMethodReturnNode, newModifierNode}
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
 import io.joern.x2cpg.datastructures.Global

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -3,7 +3,7 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.datastructures.*
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.NodeBuilders.{newClosureBindingNode, newLocalNode}
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -3,9 +3,9 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.datastructures.{BlockScope, MethodScope, ScopeType}
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.NodeBuilders.newDependencyNode
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewImport}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -2,8 +2,8 @@ package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines.OperatorsNew
-import io.joern.jssrc2cpg.passes.{Defines, EcmaBuiltins, GlobalBuiltins}
+import io.joern.jssrc2cpg.passes.EcmaBuiltins
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.{Defines, GlobalBuiltins}
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.datastructures.Stack.*
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
@@ -130,7 +130,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val receiverNode = astForNodeWithFunctionReference(callee)
 
-    val callAst = handleCallNodeArgs(newExpr, receiverNode, tmpAllocNode2, OperatorsNew)
+    val callAst = handleCallNodeArgs(newExpr, receiverNode, tmpAllocNode2, Defines.OperatorsNew)
 
     val tmpAllocReturnNode = Ast(identifierNode(newExpr, tmpAllocName))
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -3,8 +3,8 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.datastructures.{BlockScope, MethodScope}
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.NodeBuilders.{newBindingNode, newModifierNode}
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{Identifier as _, *}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -1,8 +1,8 @@
 package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 
 trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -2,10 +2,10 @@ package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.EdgeTypes

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -3,9 +3,9 @@ package io.joern.jssrc2cpg.astcreation
 import io.joern.jssrc2cpg.datastructures.BlockScope
 import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.NodeBuilders.newBindingNode
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, ModifierTypes, Operators}

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -1,9 +1,9 @@
 package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.x2cpg
 import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.DispatchTypes

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -2,7 +2,7 @@ package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.parser.BabelAst._
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
-import io.joern.jssrc2cpg.passes.Defines
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 
 import java.util.regex.Pattern
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -6,6 +6,7 @@ import io.joern.jssrc2cpg.parser.BabelJsonParser
 import io.joern.jssrc2cpg.utils.AstGenRunner.AstGenRunnerResult
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.datastructures.Global
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ConcurrentWriterCpgPass

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConfigPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConfigPass.scala
@@ -3,6 +3,7 @@ package io.joern.jssrc2cpg.passes
 import better.files.File
 import io.joern.jssrc2cpg.Config
 import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
@@ -3,6 +3,7 @@ package io.joern.jssrc2cpg.passes
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.utils.PackageJsonParser
 import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewDependency
 import io.shiftleft.passes.CpgPass

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeNodePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptTypeNodePass.scala
@@ -1,5 +1,6 @@
 package io.joern.jssrc2cpg.passes
 
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.passes.frontend.TypeNodePass
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConfigPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConfigPassTests.scala
@@ -2,6 +2,7 @@ package io.joern.jssrc2cpg.passes
 
 import better.files.File
 import io.joern.jssrc2cpg.Config
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.matchers.should.Matchers

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ImportsPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ImportsPassTests.scala
@@ -3,8 +3,10 @@ package io.joern.jssrc2cpg.passes
 import io.joern.jssrc2cpg.JsSrc2Cpg
 import io.joern.jssrc2cpg.testfixtures.JsSrc2CpgFrontend
 import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.frontendspecific.jssrc2cpg
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, TestCpg}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
 
 class ImportsPassTests extends Code2CpgFixture(() => new TestCpgWithoutDataFlow()) {
 
@@ -47,6 +49,6 @@ class TestCpgWithoutDataFlow extends TestCpg with JsSrc2CpgFrontend {
   override val fileSuffix: String = ".js"
   override def applyPasses(): Unit = {
     X2Cpg.applyDefaultOverlays(this)
-    JsSrc2Cpg.postProcessingPasses(this).foreach(_.createAndApply())
+    jssrc2cpg.postProcessingPasses(this, XTypeRecoveryConfig()).foreach(_.createAndApply())
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1,7 +1,7 @@
 package io.joern.jssrc2cpg.passes
 
-import io.joern.jssrc2cpg.passes.Defines.OperatorsNew
 import io.joern.jssrc2cpg.testfixtures.DataFlowCodeToCpgSuite
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.importresolver.*
 import io.shiftleft.semanticcpg.language.*
@@ -474,7 +474,7 @@ class TypeRecoveryPassTests extends DataFlowCodeToCpgSuite {
         |new Print("Hello")
         |""".stripMargin)
 
-    cpg.call.nameExact(OperatorsNew).methodFullName.head shouldBe "Test0.js::program:Print"
+    cpg.call.nameExact(Defines.OperatorsNew).methodFullName.head shouldBe "Test0.js::program:Print"
   }
 
   "A function assigned to a member should have it's full name resolved" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
@@ -1,7 +1,8 @@
 package io.joern.jssrc2cpg.passes.ast
 
-import io.joern.jssrc2cpg.passes.{Defines, EcmaBuiltins}
+import io.joern.jssrc2cpg.passes.EcmaBuiltins
 import io.joern.jssrc2cpg.testfixtures.AstJsSrc2CpgSuite
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTests.scala
@@ -1,7 +1,7 @@
 package io.joern.jssrc2cpg.passes.ast
 
 import io.joern.jssrc2cpg.testfixtures.AstJsSrc2CpgSuite
-import io.joern.jssrc2cpg.passes.Defines
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier}
 import io.shiftleft.semanticcpg.language.*

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTests.scala
@@ -1,7 +1,7 @@
 package io.joern.jssrc2cpg.passes.ast
 
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.jssrc2cpg.testfixtures.AstJsSrc2CpgSuite
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
 import io.shiftleft.semanticcpg.language.*

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsDecoratorAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsDecoratorAstCreationPassTests.scala
@@ -1,7 +1,7 @@
 package io.joern.jssrc2cpg.passes.ast
 
 import io.joern.jssrc2cpg.testfixtures.AstJsSrc2CpgSuite
-import io.joern.jssrc2cpg.passes.Defines
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.semanticcpg.language._
 
 class TsDecoratorAstCreationPassTests extends AstJsSrc2CpgSuite(".ts") {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -6,6 +6,8 @@ import io.joern.dataflowengineoss.layers.dataflows.OssDataFlowOptions
 import io.joern.dataflowengineoss.queryengine.EngineContext
 import io.joern.jssrc2cpg.JsSrc2Cpg
 import io.joern.x2cpg.X2Cpg
+import io.joern.x2cpg.frontendspecific.jssrc2cpg
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 import io.joern.x2cpg.testfixtures.TestCpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
@@ -19,7 +21,7 @@ class DataFlowTestCpg extends TestCpg with JsSrc2CpgFrontend {
     val context = new LayerCreatorContext(this)
     val options = new OssDataFlowOptions()
     new OssDataFlow(options).run(context)
-    JsSrc2Cpg.postProcessingPasses(this).foreach(_.createAndApply())
+    jssrc2cpg.postProcessingPasses(this, XTypeRecoveryConfig()).foreach(_.createAndApply())
   }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
@@ -1,8 +1,8 @@
 package io.joern.jssrc2cpg.types
 
 import io.joern.jssrc2cpg.testfixtures.AstJsSrc2CpgSuite
-import io.joern.jssrc2cpg.passes.Defines
 import io.joern.jssrc2cpg.Config
+import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.*
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
@@ -44,7 +44,7 @@ object Frontend {
       opt[String]("php-parser-bin")
         .action((x, c) => c.withPhpParserBin(x))
         .text("path to php-parser.phar binary. Defaults to php-parser shipped with Joern."),
-      XTypeRecovery.parserOptions,
+      XTypeRecoveryConfig.parserOptions,
       XTypeStubsParser.parserOptions,
       DependencyDownloadConfig.parserOptions
     )

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
@@ -44,7 +44,7 @@ object Frontend {
       opt[String]("php-parser-bin")
         .action((x, c) => c.withPhpParserBin(x))
         .text("path to php-parser.phar binary. Defaults to php-parser shipped with Joern."),
-      XTypeRecoveryConfig.parserOptions,
+      XTypeRecoveryConfig.parserOptionsForParserConfig,
       XTypeStubsParser.parserOptions,
       DependencyDownloadConfig.parserOptions
     )

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
@@ -33,7 +33,7 @@ private object Frontend {
           "Excludes all files where the relative path from input-dir contains at least one of names specified here."
         )
         .action((value, config) => config.withIgnoreDirNames(value)),
-      XTypeRecoveryConfig.parserOptions
+      XTypeRecoveryConfig.parserOptionsForParserConfig
     )
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
@@ -2,7 +2,7 @@ package io.joern.pysrc2cpg
 
 import io.joern.pysrc2cpg.Frontend.cmdLineParser
 import io.joern.x2cpg.X2CpgMain
-import io.joern.x2cpg.passes.frontend.XTypeRecovery
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import scopt.OParser
 
 import java.nio.file.Paths
@@ -33,7 +33,7 @@ private object Frontend {
           "Excludes all files where the relative path from input-dir contains at least one of names specified here."
         )
         .action((value, config) => config.withIgnoreDirNames(value)),
-      XTypeRecovery.parserOptions
+      XTypeRecoveryConfig.parserOptions
     )
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg
 
 import io.joern.rubysrc2cpg.Frontend.*
-import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
+import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery, XTypeRecoveryConfig}
 import io.joern.x2cpg.typestub.TypeStubConfig
 import io.joern.x2cpg.{DependencyDownloadConfig, X2CpgConfig, X2CpgMain}
 import scopt.OParser
@@ -62,7 +62,7 @@ private object Frontend {
         .action((_, c) => c.withUseDeprecatedFrontend(true))
         .text("uses the original (but deprecated) Ruby frontend (default false)"),
       DependencyDownloadConfig.parserOptions,
-      XTypeRecovery.parserOptions,
+      XTypeRecoveryConfig.parserOptions,
       TypeStubConfig.parserOptions
     )
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -62,7 +62,7 @@ private object Frontend {
         .action((_, c) => c.withUseDeprecatedFrontend(true))
         .text("uses the original (but deprecated) Ruby frontend (default false)"),
       DependencyDownloadConfig.parserOptions,
-      XTypeRecoveryConfig.parserOptions,
+      XTypeRecoveryConfig.parserOptionsForParserConfig,
       TypeStubConfig.parserOptions
     )
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
@@ -24,7 +24,7 @@ object Frontend {
     import builder.*
     OParser.sequence(
       programName("swiftsrc2cpg"),
-      XTypeRecoveryConfig.parserOptions,
+      XTypeRecoveryConfig.parserOptionsForParserConfig,
       opt[String]("define")
         .unbounded()
         .text("define a name")

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
@@ -1,7 +1,7 @@
 package io.joern.swiftsrc2cpg
 
 import io.joern.swiftsrc2cpg.Frontend.*
-import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery}
+import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery, XTypeRecoveryConfig}
 import io.joern.x2cpg.utils.Environment
 import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import scopt.OParser
@@ -24,7 +24,7 @@ object Frontend {
     import builder.*
     OParser.sequence(
       programName("swiftsrc2cpg"),
-      XTypeRecovery.parserOptions,
+      XTypeRecoveryConfig.parserOptions,
       opt[String]("define")
         .unbounded()
         .text("define a name")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/package.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/package.scala
@@ -10,8 +10,8 @@ package object javasrc2cpg {
     val EnableTypeRecovery = "enable-type-recovery"
   }
 
-  def typeRecoveryPasses(cpg: Cpg, disableDummyTypes: Boolean): List[CpgPassBase] = {
-    new JavaTypeRecoveryPassGenerator(cpg, XTypeRecoveryConfig(enabledDummyTypes = !disableDummyTypes)).generate() :+
+  def typeRecoveryPasses(cpg: Cpg, xtypeRecoveryConfig: XTypeRecoveryConfig): List[CpgPassBase] = {
+    new JavaTypeRecoveryPassGenerator(cpg, xtypeRecoveryConfig).generate() :+
       new JavaTypeHintCallLinker(cpg)
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/ConstClosurePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/ConstClosurePass.scala
@@ -1,4 +1,4 @@
-package io.joern.jssrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.jssrc2cpg
 
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.PropertyNames

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/Defines.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/Defines.scala
@@ -1,4 +1,4 @@
-package io.joern.jssrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.jssrc2cpg
 
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/GlobalBuiltins.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/GlobalBuiltins.scala
@@ -1,4 +1,4 @@
-package io.joern.jssrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.jssrc2cpg
 
 object GlobalBuiltins {
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptImportResolverPass.scala
@@ -1,4 +1,4 @@
-package io.joern.jssrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.jssrc2cpg
 
 import io.joern.x2cpg.Defines as XDefines
 import io.joern.x2cpg.passes.frontend.XImportResolverPass

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptInheritanceNamePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptInheritanceNamePass.scala
@@ -1,4 +1,4 @@
-package io.joern.jssrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.jssrc2cpg
 
 import io.joern.x2cpg.passes.frontend.XInheritanceFullNamePass
 import io.shiftleft.codepropertygraph.generated.Cpg

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptTypeHintCallLinker.scala
@@ -1,6 +1,5 @@
-package io.joern.jssrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.jssrc2cpg
 
-import io.joern.jssrc2cpg.passes.Defines.OperatorsNew
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Call
@@ -11,7 +10,7 @@ class JavaScriptTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
   override protected val pathSep = ":"
 
   override protected def calls: Iterator[Call] = cpg.call
-    .or(_.nameNot("<operator>.*", "<operators>.*"), _.name(OperatorsNew))
+    .or(_.nameNot("<operator>.*", "<operators>.*"), _.name(Defines.OperatorsNew))
     .filter(c => calleeNames(c).nonEmpty && c.callee.isEmpty)
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptTypeRecovery.scala
@@ -1,6 +1,5 @@
-package io.joern.jssrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.jssrc2cpg
 
-import io.joern.jssrc2cpg.passes.Defines.OperatorsNew
 import io.joern.x2cpg.Defines as XDefines
 import io.joern.x2cpg.Defines.ConstructorMethodName
 import io.joern.x2cpg.passes.frontend.*
@@ -124,7 +123,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
 
   override protected def visitIdentifierAssignedToConstructor(i: Identifier, c: Call): Set[String] = {
     val constructorPaths = if (c.methodFullName.endsWith(".alloc")) {
-      val newOp       = c.inAssignment.astSiblings.isCall.nameExact(OperatorsNew).headOption
+      val newOp       = c.inAssignment.astSiblings.isCall.nameExact(Defines.OperatorsNew).headOption
       val newChildren = newOp.astChildren.l
 
       val possibleImportIdentifier = newChildren.isIdentifier.headOption match {
@@ -152,7 +151,7 @@ private class RecoverForJavaScriptFile(cpg: Cpg, cu: File, builder: DiffGraphBui
 
   override protected def visitIdentifierAssignedToOperator(i: Identifier, c: Call, operation: String): Set[String] = {
     operation match {
-      case OperatorsNew =>
+      case Defines.OperatorsNew =>
         c.astChildren.l match {
           case ::(fa: Call, ::(id: Identifier, _)) if fa.name == Operators.fieldAccess =>
             symbolTable.append(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/ObjectPropertyCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/ObjectPropertyCallLinker.scala
@@ -1,4 +1,4 @@
-package io.joern.jssrc2cpg.passes
+package io.joern.x2cpg.frontendspecific.jssrc2cpg
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodRef}
 import io.shiftleft.codepropertygraph.generated.{Cpg, PropertyNames}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/package.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/package.scala
@@ -1,0 +1,16 @@
+package io.joern.x2cpg.frontendspecific
+
+import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.passes.CpgPassBase
+
+package object jssrc2cpg {
+
+  def postProcessingPasses(cpg: Cpg, typeRecoveryConfig: XTypeRecoveryConfig): List[CpgPassBase] = {
+    List(new JavaScriptInheritanceNamePass(cpg), new ConstClosurePass(cpg), new JavaScriptImportResolverPass(cpg))
+      ++
+        new JavaScriptTypeRecoveryPassGenerator(cpg, typeRecoveryConfig).generate() ++
+        List(new JavaScriptTypeHintCallLinker(cpg), ObjectPropertyCallLinker(cpg), new NaiveCallLinker(cpg))
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -1,6 +1,5 @@
 package io.joern.x2cpg.passes.frontend
 
-import io.joern.x2cpg.passes.frontend.XTypeRecovery.{ParameterNames, getClass}
 import io.joern.x2cpg.{Defines, X2CpgConfig}
 import io.shiftleft.codepropertygraph.generated.{Cpg, DispatchTypes, EdgeTypes, NodeTypes, Operators, PropertyNames}
 import io.shiftleft.codepropertygraph.generated.nodes.*
@@ -59,11 +58,11 @@ object XTypeRecoveryConfig {
     val builder = OParser.builder[C]
     import builder.*
     OParser.sequence(
-      opt[Unit](ParameterNames.NoDummyTypes)
+      opt[Unit]("no-dummyTypes")
         .hidden()
         .action((_, c) => configureNoDummyTypes(c))
         .text("disable generation of dummy types during type propagation"),
-      opt[Int](ParameterNames.TypePropagationIterations)
+      opt[Int]("type-prop-iterations")
         .hidden()
         .action((x, c) => configureIterations(x, c))
         .text("maximum iterations of type propagation")
@@ -242,11 +241,6 @@ abstract class XTypeRecovery[CompilationUnitType <: AstNode](cpg: Cpg, state: XT
 }
 
 object XTypeRecovery {
-  object ParameterNames {
-    val NoDummyTypes              = "no-dummyTypes"
-    val TypePropagationIterations = "type-prop-iterations"
-  }
-
   private val logger = LoggerFactory.getLogger(getClass)
 
   val DummyReturnType                       = "<returnValue>"

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -32,7 +32,7 @@ object XTypeRecoveryConfig {
 
   def parse(cmdLineArgs: Seq[String]): XTypeRecoveryConfig = {
     OParser
-      .parse(parserOptions1, cmdLineArgs, XTypeRecoveryConfig())
+      .parse(parserOptions, cmdLineArgs, XTypeRecoveryConfig())
       .getOrElse(
         throw new RuntimeException(
           s"unable to parse XTypeRecoveryConfig from commandline arguments ${cmdLineArgs.mkString(" ")}"
@@ -40,7 +40,7 @@ object XTypeRecoveryConfig {
       )
   }
 
-  def parserOptions1: OParser[Unit, XTypeRecoveryConfig] = {
+  def parserOptions: OParser[Unit, XTypeRecoveryConfig] = {
     _parserOptions[XTypeRecoveryConfig](
       configureNoDummyTypes = _.copy(enabledDummyTypes = false),
       configureIterations = (iterations, config) => config.copy(iterations = iterations)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -257,6 +257,10 @@ object XTypeRecovery {
     */
   def isDummyType(typ: String): Boolean = DummyTokens.exists(typ.contains)
 
+  @deprecated("please use XTypeRecoveryConfig.parserOptionsForParserConfig", since = "2.0.415")
+  def parserOptions[R <: X2CpgConfig[R] & TypeRecoveryParserConfig[R]]: OParser[?, R] =
+    XTypeRecoveryConfig.parserOptionsForParserConfig
+
   // The below are convenience calls for accessing type properties, one day when this pass uses `Tag` nodes instead of
   // the symbol table then perhaps this would work out better
   implicit class AllNodeTypesFromNodeExt(x: StoredNode) {

--- a/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
@@ -3,7 +3,8 @@ package io.joern.joerncli
 import better.files.File
 import io.joern.console.FrontendConfig
 import io.joern.console.cpgcreation.{CCpgGenerator, JsSrcCpgGenerator}
-import io.joern.jssrc2cpg.{JsSrc2Cpg, Config as JsConfig}
+import io.joern.x2cpg.frontendspecific.jssrc2cpg
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.utils.ProjectRoot
@@ -35,7 +36,7 @@ trait AbstractJoernCliTest {
     val cpg = DefaultOverlays.create(cpgOutFileName)
     language match {
       case Languages.JSSRC | Languages.JAVASCRIPT =>
-        JsSrc2Cpg.postProcessingPasses(cpg, Option(JsConfig().withDisableDummyTypes(true))).foreach(_.createAndApply())
+        jssrc2cpg.postProcessingPasses(cpg, XTypeRecoveryConfig(enabledDummyTypes = false)).foreach(_.createAndApply())
       case _ =>
     }
     (cpg, cpgOutFileName)


### PR DESCRIPTION
similar to https://github.com/joernio/joern/pull/4672, with one additional
refactor: reuse the scopt parser rather than manually fiddling with the
commandline args