### PR TITLE
[ruby] Create `<body>` method for `TypeDecl` statements

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -101,7 +101,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       val baseStmtBlockAst = astForMethodBody(node.body, optionalStatementList)
       transformAsClosureBody(refs, baseStmtBlockAst)
     } else {
-      if (methodName != Defines.Initialize && methodName != Defines.InitializeClass) {
+      if (
+        methodName != Defines.Initialize && methodName != Defines.InitializeClass && methodName != Defines.TypeDeclBody
+      ) {
         astForMethodBody(node.body, optionalStatementList)
       } else {
         astForConstructorMethodBody(node.body, optionalStatementList)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -101,9 +101,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       val baseStmtBlockAst = astForMethodBody(node.body, optionalStatementList)
       transformAsClosureBody(refs, baseStmtBlockAst)
     } else {
-      if (
-        methodName != Defines.Initialize && methodName != Defines.InitializeClass && methodName != Defines.TypeDeclBody
-      ) {
+      if (methodName == Defines.TypeDeclBody) {
+        astForMethodBody(node.body, optionalStatementList, returnLastExpression = false)
+      } else if (methodName != Defines.Initialize) {
         astForMethodBody(node.body, optionalStatementList)
       } else {
         astForConstructorMethodBody(node.body, optionalStatementList)
@@ -488,22 +488,28 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     )(TextSpan(None, None, None, None, ""))
   }
 
-  private def astForMethodBody(body: RubyNode, optionalStatementList: StatementList): Ast = {
+  private def astForMethodBody(
+    body: RubyNode,
+    optionalStatementList: StatementList,
+    returnLastExpression: Boolean = true
+  ): Ast = {
     if (this.parseLevel == AstParseLevel.SIGNATURES) {
       Ast()
     } else {
       body match
         case stmtList: StatementList =>
-          astForStatementListReturningLastExpression(
+          val combinedStmtList =
             StatementList(optionalStatementList.statements ++ stmtList.statements)(stmtList.span)
-          )
+          if returnLastExpression then astForStatementListReturningLastExpression(combinedStmtList)
+          else astForStatementList(combinedStmtList)
         case rescueExpr: RescueExpression =>
           astForRescueExpression(rescueExpr)
         case _: (StaticLiteral | BinaryExpression | SingleAssignment | SimpleIdentifier | ArrayLiteral | HashLiteral |
               SimpleCall | MemberAccess | MemberCall) =>
-          astForStatementListReturningLastExpression(
+          val combinedStmtList =
             StatementList(optionalStatementList.statements ++ List(body))(body.span)
-          )
+          if returnLastExpression then astForStatementListReturningLastExpression(combinedStmtList)
+          else astForStatementList(combinedStmtList)
         case body =>
           logger.warn(
             s"Non-linear method bodies are not supported yet: ${body.text} (${body.getClass.getSimpleName}) ($relativeFileName), skipping"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -102,7 +102,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       transformAsClosureBody(refs, baseStmtBlockAst)
     } else {
       if (methodName == Defines.TypeDeclBody) {
-        astForMethodBody(node.body, optionalStatementList, returnLastExpression = false)
+        val stmtList = node.body.asInstanceOf[StatementList]
+        astForStatementList(StatementList(stmtList.statements ++ optionalStatementList.statements)(stmtList.span))
       } else if (methodName != Defines.Initialize) {
         astForMethodBody(node.body, optionalStatementList)
       } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -171,8 +171,18 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         .withChildren(singletonModifiers)
         .withChildren(fieldSingletonMemberNodes.map(_._2))
         .withChildren(singletonBodyAsts.toSeq)
+    val bodyMemberCall = astForMemberCall(
+      MemberCall(
+        MemberAccess(SelfIdentifier()(TextSpan(None, None, None, None, "self")), "::", className)(
+          node.span.spanStart(s"self::$className")
+        ),
+        "::",
+        "<body>",
+        List.empty
+      )(node.span.spanStart(s"self::$className::<body>"))
+    )
 
-    prefixAst :: typeDeclAst :: singletonTypeDeclAst :: Nil filterNot (_.root.isEmpty)
+    prefixAst :: typeDeclAst :: singletonTypeDeclAst :: bodyMemberCall :: Nil filterNot (_.root.isEmpty)
   }
 
   private def createTypeRefPointer(typeDecl: NewTypeDecl): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -171,16 +171,12 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         .withChildren(singletonModifiers)
         .withChildren(fieldSingletonMemberNodes.map(_._2))
         .withChildren(singletonBodyAsts.toSeq)
-    val bodyMemberCall = astForMemberCall(
-      MemberCall(
-        MemberAccess(SelfIdentifier()(TextSpan(None, None, None, None, "self")), "::", className)(
-          node.span.spanStart(s"self::$className")
-        ),
-        "::",
-        "<body>",
-        List.empty
-      )(node.span.spanStart(s"self::$className::<body>"))
-    )
+
+    val bodyMemberCall =
+      node.bodyMemberCall match {
+        case Some(bodyMemberCall) => astForMemberCall(bodyMemberCall)
+        case None                 => Ast()
+      }
 
     prefixAst :: typeDeclAst :: singletonTypeDeclAst :: bodyMemberCall :: Nil filterNot (_.root.isEmpty)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -52,11 +52,20 @@ object RubyIntermediateAst {
     def name: RubyNode
     def baseClass: Option[RubyNode]
     def body: RubyNode
+    def bodyMemberCall: Option[MemberCall]
   }
 
-  final case class ModuleDeclaration(name: RubyNode, body: RubyNode, fields: List[RubyNode & RubyFieldIdentifier])(
-    span: TextSpan
-  ) extends RubyNode(span)
+  sealed trait SpecialBodyCall {
+    def bodyMemberCall: RubyNode
+  }
+
+  final case class ModuleDeclaration(
+    name: RubyNode,
+    body: RubyNode,
+    fields: List[RubyNode & RubyFieldIdentifier],
+    bodyMemberCall: Option[MemberCall]
+  )(span: TextSpan)
+      extends RubyNode(span)
       with TypeDeclaration {
     def baseClass: Option[RubyNode] = None
   }
@@ -65,21 +74,30 @@ object RubyIntermediateAst {
     name: RubyNode,
     baseClass: Option[RubyNode],
     body: RubyNode,
-    fields: List[RubyNode & RubyFieldIdentifier]
+    fields: List[RubyNode & RubyFieldIdentifier],
+    bodyMemberCall: Option[MemberCall]
   )(span: TextSpan)
       extends RubyNode(span)
       with TypeDeclaration
 
   sealed trait AnonymousTypeDeclaration extends RubyNode with TypeDeclaration
 
-  final case class AnonymousClassDeclaration(name: RubyNode, baseClass: Option[RubyNode], body: RubyNode)(
-    span: TextSpan
-  ) extends RubyNode(span)
+  final case class AnonymousClassDeclaration(
+    name: RubyNode,
+    baseClass: Option[RubyNode],
+    body: RubyNode,
+    bodyMemberCall: Option[MemberCall] = None
+  )(span: TextSpan)
+      extends RubyNode(span)
       with AnonymousTypeDeclaration
 
-  final case class SingletonClassDeclaration(name: RubyNode, baseClass: Option[RubyNode], body: RubyNode)(
-    span: TextSpan
-  ) extends RubyNode(span)
+  final case class SingletonClassDeclaration(
+    name: RubyNode,
+    baseClass: Option[RubyNode],
+    body: RubyNode,
+    bodyMemberCall: Option[MemberCall] = None
+  )(span: TextSpan)
+      extends RubyNode(span)
       with AnonymousTypeDeclaration
 
   final case class FieldsDeclaration(fieldNames: List[RubyNode])(span: TextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -55,10 +55,6 @@ object RubyIntermediateAst {
     def bodyMemberCall: Option[MemberCall]
   }
 
-  sealed trait SpecialBodyCall {
-    def bodyMemberCall: RubyNode
-  }
-
   final case class ModuleDeclaration(
     name: RubyNode,
     body: RubyNode,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1048,11 +1048,13 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
 
   private def createBodyMemberCall(name: String, textSpan: TextSpan): MemberCall = {
     MemberCall(
-      MemberAccess(SelfIdentifier()(textSpan.spanStart("self")), "::", name)(textSpan.spanStart(s"self::$name")),
+      MemberAccess(SelfIdentifier()(textSpan.spanStart(Defines.Self)), "::", name)(
+        textSpan.spanStart(s"${Defines.Self}::$name")
+      ),
       "::",
-      "<body>",
+      Defines.TypeDeclBody,
       List.empty
-    )(textSpan.spanStart(s"self::$name::<body>"))
+    )(textSpan.spanStart(s"${Defines.Self}::$name::<body>"))
   }
 
   /** Lowers all MethodDeclaration found in SingletonClassDeclaration to SingletonMethodDeclaration.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -914,35 +914,23 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
         val initStmtListStatements = genSingleAssignmentStmtList(instanceFields, instanceFieldsInMethodDecls)
         val clinitStmtList = genSingleAssignmentStmtList(classFields, classFieldsInMethodDecls) ++ fieldAssignments
 
-        val clinitMethod =
-          MethodDeclaration(Defines.InitializeClass, List.empty, StatementList(clinitStmtList)(stmtList.span))(
+        val bodyMethodStmtList =
+          StatementList(initStmtListStatements ++ clinitStmtList)(
             stmtList.span
+              .spanStart(initStmtListStatements.map(_.span.text).concat(clinitStmtList.map(_.span.text)).mkString("\n"))
           )
 
-        val updatedStmtList = initializeMethod match {
-          case Some(initMethod) =>
-            initMethod.body match {
-              // TODO: Filter out instance fields that are assigned an initial value in the constructor method. Current
-              //  implementation leads to "double" assignment happening when the instance field is assigned a value
-              //   where you end up having
-              //   <instanceField> = nil; <instanceField> = ...;
-              case stmtList: StatementList =>
-                val initializers = initStmtListStatements :+ clinitMethod
-                StatementList(initializers ++ rest)(stmtList.span)
-              case x => x
-            }
-          case None =>
-            val newInitMethod =
-              MethodDeclaration(Defines.Initialize, List.empty, StatementList(initStmtListStatements)(stmtList.span))(
-                stmtList.span
-              )
-            val initializers = newInitMethod :: clinitMethod :: Nil
-            StatementList(initializers ++ rest)(stmtList.span)
-        }
+        val bodyMethod = MethodDeclaration(Defines.TypeDeclBody, List.empty, bodyMethodStmtList)(
+          stmtList.span.spanStart(s"def <body>\n${bodyMethodStmtList.span.text}\nend")
+        )
+
         val combinedFields = rubyFieldIdentifiers ++ fieldsInMethodDecls ++
           fieldAssignments.collect { case SingleAssignment(lhs: RubyFieldIdentifier, _, _) => lhs }
 
-        (updatedStmtList, combinedFields.asInstanceOf[List[RubyNode & RubyFieldIdentifier]])
+        (
+          StatementList(bodyMethod +: rest)(bodyMethod.span),
+          combinedFields.asInstanceOf[List[RubyNode & RubyFieldIdentifier]]
+        )
       case decls => (decls, List.empty)
     }
   }
@@ -1003,7 +991,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     *   - `initialize` MethodDeclaration with all non-allowed children nodes added
     *   - list of all nodes allowed directly under type decl
     */
-  private def filterNonAllowedTypeDeclChildren(stmts: StatementList): (RubyNode, List[RubyNode]) = {
+  private def filterNonAllowedTypeDeclChildren(stmts: StatementList): RubyNode = {
     val (initMethod, nonInitStmts) = stmts.statements.partition {
       case x: MethodDeclaration if x.methodName == "initialize" => true
       case _                                                    => false
@@ -1014,19 +1002,25 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
       case _                              => false
     }
 
-    val initMethodDecl = initMethod.headOption match {
-      case Some(initMethodOpt) =>
-        val castInitMethod = initMethodOpt.asInstanceOf[MethodDeclaration]
-        val updatedMethodBody = StatementList(
-          castInitMethod.body.asStatementList.statements ++ nonAllowedTypeDeclChildren
-        )(castInitMethod.body.span)
-        MethodDeclaration("initialize", List.empty, updatedMethodBody)(castInitMethod.span)
-      case None =>
-        logger.warn("Could not find initialize method")
-        defaultResult()
+    val (bodyMethod, otherTypeDeclChildren) = allowedTypeDeclChildren.partition {
+      case x: MethodDeclaration if x.methodName == Defines.TypeDeclBody => true
+      case _                                                            => false
     }
 
-    (initMethodDecl, allowedTypeDeclChildren)
+    val updatedBodyMethod = bodyMethod
+      .asInstanceOf[List[MethodDeclaration]]
+      .map { x =>
+        val methodDeclStmts =
+          StatementList(x.body.asInstanceOf[StatementList].statements ++ nonAllowedTypeDeclChildren)(
+            x.span.spanStart(s"${x.body.span.text}${nonAllowedTypeDeclChildren.map(_.span.text).mkString("\n")}")
+          )
+
+        MethodDeclaration(x.methodName, x.parameters, methodDeclStmts)(
+          x.span.spanStart(s"def <body>\n${methodDeclStmts.span.text}\nend")
+        )
+      }
+
+    StatementList(otherTypeDeclChildren ++ updatedBodyMethod)(stmts.span)
   }
 
   override def visitClassDefinition(ctx: RubyParser.ClassDefinitionContext): RubyNode = {
@@ -1034,14 +1028,11 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
 
     val stmts = lowerAliasStatementsToMethods(nonFieldStmts)
 
-    val (initMethodDecl, allowedTypeDeclChildren) = filterNonAllowedTypeDeclChildren(stmts)
+    val classBody = filterNonAllowedTypeDeclChildren(stmts)
 
-    ClassDeclaration(
-      visit(ctx.classPath()),
-      Option(ctx.commandOrPrimaryValueClass()).map(visit),
-      StatementList(initMethodDecl +: allowedTypeDeclChildren)(stmts.span),
-      fields
-    )(ctx.toTextSpan)
+    ClassDeclaration(visit(ctx.classPath()), Option(ctx.commandOrPrimaryValueClass()).map(visit), classBody, fields)(
+      ctx.toTextSpan
+    )
   }
 
   /** Lowers all MethodDeclaration found in SingletonClassDeclaration to SingletonMethodDeclaration.

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -665,11 +665,13 @@ class MethodTests extends RubyCode2CpgFixture {
 
     "be placed directly before each entity's definition" in {
       inside(cpg.method.name(RDefines.Program).filename("t1.rb").block.astChildren.l) {
-        case (a1: Call) :: (_: TypeDecl) :: (_: TypeDecl) :: (a2: Call) :: (_: TypeDecl) :: (_: TypeDecl) :: (a3: Call) :: (_: Method) :: (_: TypeDecl) :: Nil =>
+        case (a1: Call) :: (_: TypeDecl) :: (_: TypeDecl) :: (a2: Call) :: (a3: Call) :: (_: TypeDecl) :: (_: TypeDecl) :: (a4: Call) :: (a5: Call) :: (_: Method) :: (_: TypeDecl) :: Nil =>
           a1.code shouldBe "self.A = module A (...)"
-          a2.code shouldBe "self.B = class B (...)"
-          a3.code shouldBe "self.c = def c (...)"
-        case xs => fail(s"Expected assignments to appear before definitions, instead got [$xs]")
+          a2.code shouldBe "self::A::<body>"
+          a3.code shouldBe "self.B = class B (...)"
+          a4.code shouldBe "self::B::<body>"
+          a5.code shouldBe "self.c = def c (...)"
+        case xs => fail(s"Expected assignments to appear before definitions, instead got [${xs.mkString("\n")}]")
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -17,7 +17,7 @@ class ModuleTests extends RubyCode2CpgFixture {
     m.fullName shouldBe "Test0.rb:<global>::program.M"
     m.lineNumber shouldBe Some(2)
     m.baseType.l shouldBe List()
-    m.member.name.l shouldBe List(Defines.Initialize)
-    m.method.name.l shouldBe List(Defines.Initialize)
+    m.member.name.l shouldBe List(Defines.TypeDeclBody)
+    m.method.name.l shouldBe List(Defines.TypeDeclBody)
   }
 }


### PR DESCRIPTION
This PR handles:
 * Create a new `<body>` `MethodDecl` in `RubyNodeCreator` that holds all statements that aren't `methods`/`singleton methods`/`type decls` which was previously put under the `initialize` and `initialize<class>` methods manually
 * Invoke a call to `self::className::<body>` after the `TypeDecl` is created

Resolves #4683 