### PR TITLE
[TypeRecovery] make sure base has argumentIndex 0

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1430,6 +1430,13 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         case result        => fail(s"Expected single foo call but got $result")
       }
     }
+
+    "provide meaningful typeFullName for the target of assignment" in {
+      cpg.assignment.target.isIdentifier.name("a").l match {
+        case List(a) => a.typeFullName shouldBe "foo.<returnValue>"
+        case result  => fail(s"Expected single assignment to a, but got $result")
+      }
+    }
   }
 
   "external non imported call with int variable for argument" should {
@@ -1442,6 +1449,27 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       cpg.call("foo").l match {
         case List(fooCall) => fooCall.methodFullName shouldBe "<unknownFullName>"
         case result        => fail(s"Expected single foo call but got $result")
+      }
+    }
+  }
+
+  "assignment to non imported call with int variable for argument" should {
+    val cpg = code("""
+        |a = 10
+        |b = foo(a)
+        |""".stripMargin)
+
+    "have correct methodFullName for `foo`" in {
+      cpg.call("foo").l match {
+        case List(fooCall) => fooCall.methodFullName shouldBe "<unknownFullName>"
+        case result        => fail(s"Expected single foo call but got $result")
+      }
+    }
+
+    "provide meaningful typeFullName for the target of the assignment" in {
+      cpg.assignment.target.isIdentifier.name("b").l match {
+        case List(b) => b.typeFullName shouldBe "foo.<returnValue>"
+        case result  => fail(s"Expected single assignment to b, but got $result")
       }
     }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -471,7 +471,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
       visitIdentifierAssignedToConstructor(i, c)
     } else if (symbolTable.contains(c)) {
       visitIdentifierAssignedToCallRetVal(i, c)
-    } else if (c.argument.headOption.exists(symbolTable.contains)) {
+    } else if (c.argument.argumentIndex(0).headOption.exists(symbolTable.contains)) {
       setCallMethodFullNameFromBase(c)
       // Repeat this method now that the call has a type
       visitIdentifierAssignedToCall(i, c)


### PR DESCRIPTION
Noticed the following discrepancy in Python:

```python
a = 10
foo(a) # methodFullName = <unknownFullName>
```

vs

```python
a = 10
b = foo(a) # methodFullName = __builtin.int.foo
```

`a` was being handled as if it were the receiver of `foo`. This patch proposes checking that `a` has `argumentIndex` 0.
