### PR TITLE
[ruby] Nested Methods & Types

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -302,9 +302,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val argumentAsts = node match {
       case x: SimpleObjectInstantiation => x.arguments.map(astForMethodCallArgument)
       case x: ObjectInstantiationWithBlock =>
-        val Seq(methodDecl, typeDecl, _, methodRef) = astForDoBlock(x.block): @unchecked
-        Ast.storeInDiffGraph(methodDecl, diffGraph)
-        Ast.storeInDiffGraph(typeDecl, diffGraph)
+        val Seq(_, methodRef) = astForDoBlock(x.block): @unchecked
         x.arguments.map(astForMethodCallArgument) :+ methodRef
     }
 
@@ -777,11 +775,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   private def astForProcOrLambdaExpr(node: ProcOrLambdaExpr): Ast = {
-    val Seq(methodDecl, typeDecl, _, methodRef) = astForDoBlock(node.block): @unchecked
-
-    Ast.storeInDiffGraph(methodDecl, diffGraph)
-    Ast.storeInDiffGraph(typeDecl, diffGraph)
-
+    val Seq(_, methodRef) = astForDoBlock(node.block): @unchecked
     methodRef
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -51,7 +51,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: SplattingRubyNode        => astForSplattingRubyNode(node)
     case node: AnonymousTypeDeclaration => astForAnonymousTypeDeclaration(node)
     case node: ProcOrLambdaExpr         => astForProcOrLambdaExpr(node)
-    case node: RubyCallWithBlock[_]     => astsForCallWithBlockInExpr(node)
+    case node: RubyCallWithBlock[_]     => astForCallWithBlock(node)
     case node: SelfIdentifier           => astForSelfIdentifier(node)
     case node: BreakStatement           => astForBreakStatement(node)
     case node: StatementList            => astForStatementList(node)
@@ -777,15 +777,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   private def astForProcOrLambdaExpr(node: ProcOrLambdaExpr): Ast = {
     val Seq(_, methodRef) = astForDoBlock(node.block): @unchecked
     methodRef
-  }
-
-  private def astsForCallWithBlockInExpr[C <: RubyCall](node: RubyNode & RubyCallWithBlock[C]): Ast = {
-    val Seq(methodDecl, typeDecl, callWithLambdaArg) = astsForCallWithBlock(node): @unchecked
-
-    Ast.storeInDiffGraph(methodDecl, diffGraph)
-    Ast.storeInDiffGraph(typeDecl, diffGraph)
-
-    callWithLambdaArg
   }
 
   private def astForMethodCallArgument(node: RubyNode): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -19,8 +19,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case node: ForExpression              => astForForExpression(node) :: Nil
     case node: CaseExpression             => astsForCaseExpression(node)
     case node: StatementList              => astForStatementList(node) :: Nil
-    case node: SimpleCallWithBlock        => astsForCallWithBlock(node)
-    case node: MemberCallWithBlock        => astsForCallWithBlock(node)
+    case node: SimpleCallWithBlock        => astForCallWithBlock(node) :: Nil
+    case node: MemberCallWithBlock        => astForCallWithBlock(node) :: Nil
     case node: ReturnExpression           => astForReturnStatement(node) :: Nil
     case node: AnonymousTypeDeclaration   => astForAnonymousTypeDeclaration(node) :: Nil
     case node: TypeDeclaration            => astForClassDeclaration(node)
@@ -194,9 +194,9 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
    * foo(<args>, <method_ref>)
    * ```
    */
-  protected def astsForCallWithBlock[C <: RubyCall](node: RubyNode & RubyCallWithBlock[C]): Seq[Ast] = {
+  protected def astForCallWithBlock[C <: RubyCall](node: RubyNode & RubyCallWithBlock[C]): Ast = {
     val Seq(_, methodRefAst) = astForDoBlock(node.block): @unchecked
-    val methodRefDummyNode                      = methodRefAst.root.map(DummyNode(_)(node.span)).toList
+    val methodRefDummyNode   = methodRefAst.root.map(DummyNode(_)(node.span)).toList
 
     // Create call with argument referencing the MethodRef
     val callWithLambdaArg = node.withoutBlock match {
@@ -207,7 +207,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         Ast()
     }
 
-    callWithLambdaArg :: Nil
+    callWithLambdaArg
   }
 
   protected def astForDoBlock(block: Block & RubyNode): Seq[Ast] = {
@@ -291,11 +291,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   private def returnAstForRubyCall[C <: RubyCall](node: RubyNode & RubyCallWithBlock[C]): Seq[Ast] = {
-    val Seq(methodDecl, typeDecl, callAst) = astsForCallWithBlock(node): @unchecked
-
-    Ast.storeInDiffGraph(methodDecl, diffGraph)
-    Ast.storeInDiffGraph(typeDecl, diffGraph)
-
+    val callAst = astForCallWithBlock(node)
     returnAst(returnNode(node, code(node)), List(callAst)) :: Nil
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -195,8 +195,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
    * ```
    */
   protected def astsForCallWithBlock[C <: RubyCall](node: RubyNode & RubyCallWithBlock[C]): Seq[Ast] = {
-    val Seq(methodDecl, typeDecl, _, methodRef) = astForDoBlock(node.block): @unchecked
-    val methodRefDummyNode                      = methodRef.root.map(DummyNode(_)(node.span)).toList
+    val Seq(_, methodRefAst) = astForDoBlock(node.block): @unchecked
+    val methodRefDummyNode                      = methodRefAst.root.map(DummyNode(_)(node.span)).toList
 
     // Create call with argument referencing the MethodRef
     val callWithLambdaArg = node.withoutBlock match {
@@ -207,7 +207,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         Ast()
     }
 
-    methodDecl :: typeDecl :: callWithLambdaArg :: Nil
+    callWithLambdaArg :: Nil
   }
 
   protected def astForDoBlock(block: Block & RubyNode): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -20,8 +20,8 @@ class ClassTests extends RubyCode2CpgFixture {
     classC.fullName shouldBe "Test0.rb:<global>::program.C"
     classC.lineNumber shouldBe Some(2)
     classC.baseType.l shouldBe List()
-    classC.member.name.l shouldBe List(RubyDefines.Initialize, RubyDefines.TypeDeclBody)
-    classC.method.name.l shouldBe List(RubyDefines.Initialize, RubyDefines.TypeDeclBody)
+    classC.member.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
+    classC.method.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
 
     val List(singletonC) = cpg.typeDecl.nameExact("C<class>").l
     singletonC.inheritsFromTypeFullName shouldBe List()
@@ -44,8 +44,8 @@ class ClassTests extends RubyCode2CpgFixture {
     classC.inheritsFromTypeFullName shouldBe List("D")
     classC.fullName shouldBe "Test0.rb:<global>::program.C"
     classC.lineNumber shouldBe Some(2)
-    classC.member.name.l shouldBe List(RubyDefines.Initialize, RubyDefines.TypeDeclBody)
-    classC.method.name.l shouldBe List(RubyDefines.Initialize, RubyDefines.TypeDeclBody)
+    classC.member.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
+    classC.method.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
 
     val List(typeD) = classC.baseType.l
     typeD.name shouldBe "D"
@@ -331,7 +331,7 @@ class ClassTests extends RubyCode2CpgFixture {
           anonClass.name shouldBe "<anon-class-0>"
           anonClass.fullName shouldBe "Test0.rb:<global>::program.<anon-class-0>"
           inside(anonClass.method.l) {
-            case defaultConstructor :: hello :: Nil =>
+            case hello :: defaultConstructor :: Nil =>
               defaultConstructor.name shouldBe RubyDefines.Initialize
               defaultConstructor.fullName shouldBe s"Test0.rb:<global>::program.<anon-class-0>:${RubyDefines.Initialize}"
 
@@ -347,7 +347,7 @@ class ClassTests extends RubyCode2CpgFixture {
       inside(cpg.method(":program").assignment.l) {
         case aAssignment :: Nil =>
           aAssignment.target.code shouldBe "a"
-          aAssignment.source.code shouldBe "Class.new"
+          aAssignment.source.code shouldBe "Class.new <anon-class-0> (...)"
         case xs => fail(s"Expected a single assignment, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -23,9 +23,9 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create an anonymous method with associated type declaration" in {
-      inside(cpg.method.nameExact(":program").l) {
+      inside(cpg.method.isModule.l) {
         case program :: Nil =>
-          inside(program.block.astChildren.collectAll[Method].l) {
+          inside(program.astChildren.collectAll[Method].l) {
             case foo :: closureMethod :: Nil =>
               foo.name shouldBe "foo"
 
@@ -34,7 +34,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
             case xs => fail(s"Expected a two method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
-          inside(program.block.astChildren.collectAll[TypeDecl].isLambda.l) {
+          inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
               closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
@@ -72,14 +72,14 @@ class DoBlockTests extends RubyCode2CpgFixture {
     "create an anonymous method with associated type declaration" in {
       inside(cpg.method.nameExact(":program").l) {
         case program :: Nil =>
-          inside(program.block.astChildren.collectAll[Method].l) {
+          inside(program.astChildren.collectAll[Method].l) {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
               closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
             case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
-          inside(program.block.astChildren.collectAll[TypeDecl].l) {
+          inside(program.astChildren.collectAll[TypeDecl].l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
               closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
@@ -134,7 +134,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
     "create an anonymous method with associated type declaration" in {
       inside(cpg.method.nameExact(":program").l) {
         case program :: Nil =>
-          inside(program.block.astChildren.collectAll[Method].l) {
+          inside(program.astChildren.collectAll[Method].l) {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
               closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
@@ -142,7 +142,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
             case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
-          inside(program.block.astChildren.collectAll[TypeDecl].l) {
+          inside(program.astChildren.collectAll[TypeDecl].l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
               closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -663,9 +663,9 @@ class MethodTests extends RubyCode2CpgFixture {
       }
     }
 
-    "be placed directly before each entity's definition" in {
+    "be placed in order of definition" in {
       inside(cpg.method.name(RDefines.Program).filename("t1.rb").block.astChildren.l) {
-        case (a1: Call) :: (_: TypeDecl) :: (_: TypeDecl) :: (a2: Call) :: (a3: Call) :: (_: TypeDecl) :: (_: TypeDecl) :: (a4: Call) :: (a5: Call) :: (_: Method) :: (_: TypeDecl) :: Nil =>
+        case (a1: Call) :: (a2: Call) :: (a3: Call) :: (a4: Call) :: (a5: Call) :: Nil =>
           a1.code shouldBe "self.A = module A (...)"
           a2.code shouldBe "self::A::<body>"
           a3.code shouldBe "self.B = class B (...)"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -32,7 +32,7 @@ class MethodTests extends RubyCode2CpgFixture {
       val List(fType) = cpg.typeDecl("f").l
       fType.fullName shouldBe "Test0.rb:<global>::program:f"
       fType.code shouldBe "def f(x) = 1"
-      fType.astParentFullName shouldBe "Test0.rb:<global>::program:f"
+      fType.astParentFullName shouldBe "Test0.rb:<global>::program"
       fType.astParentType shouldBe NodeTypes.METHOD
       val List(fMethod) = fType.iterator.boundMethod.l
       fType.fullName shouldBe "Test0.rb:<global>::program:f"
@@ -345,11 +345,11 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "exist under the module TYPE_DECL" in {
-      inside(cpg.typeDecl.name("F").method.l) {
-        case init :: bar :: baz :: Nil =>
+      inside(cpg.typeDecl.name("F").method.nameExact("bar", "baz").l) {
+        case bar :: baz :: Nil =>
           inside(bar.parameter.l) {
             case thisParam :: xParam :: Nil =>
-              thisParam.name shouldBe "this"
+              thisParam.name shouldBe RDefines.Self
               thisParam.code shouldBe "F"
               thisParam.typeFullName shouldBe "Test0.rb:<global>::program.F"
 
@@ -359,7 +359,7 @@ class MethodTests extends RubyCode2CpgFixture {
 
           inside(baz.parameter.l) {
             case thisParam :: xParam :: Nil =>
-              thisParam.name shouldBe "this"
+              thisParam.name shouldBe RDefines.Self
               thisParam.code shouldBe "F"
               thisParam.typeFullName shouldBe "Test0.rb:<global>::program.F"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -12,7 +12,7 @@ class ModuleTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    val List(m) = cpg.typeDecl.name("M").baseTypeDeclTransitive.l
+    val List(m) = cpg.typeDecl.name("M").l
 
     m.fullName shouldBe "Test0.rb:<global>::program.M"
     m.lineNumber shouldBe Some(2)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -12,7 +12,7 @@ class ModuleTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    val List(m) = cpg.typeDecl.name("M").l
+    val List(m) = cpg.typeDecl.name("M").baseTypeDeclTransitive.l
 
     m.fullName shouldBe "Test0.rb:<global>::program.M"
     m.lineNumber shouldBe Some(2)


### PR DESCRIPTION
Moved nested methods and type decls to be connected directly to the surrounding method via `AstLinker` instead of against the `Block` of the method.