### PR TITLE
[python] type-recovery for index accesses of calls

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1529,4 +1529,116 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       }
     }
   }
+
+  "assignment to non-chained index access of an imported member method call" should {
+    val cpg = code("""
+        |import foo
+        |x = foo.bar()
+        |y = x[0]
+        |""".stripMargin)
+
+    "provide meaningful typeFullName for the target of the first assignment" in {
+      cpg.assignment.target.isIdentifier.name("x").l match {
+        case List(x) => x.typeFullName shouldBe "foo.py:<module>.bar.<returnValue>"
+        case result  => fail(s"Expected single assignment to x, but got $result")
+      }
+    }
+
+    "provide meaningful typeFullName for the target of the second assignment" in {
+      cpg.assignment.target.isIdentifier.name("y").l match {
+        case List(y) => y.typeFullName shouldBe "foo.py:<module>.bar.<returnValue>.<indexAccess>"
+        case result  => fail(s"Expected single assignment to y, but got $result")
+      }
+    }
+  }
+
+  "assignment to chained index access of an imported member method call" should {
+    val cpg = code("""
+        |import foo
+        |y = foo.bar()[0]
+        |""".stripMargin)
+
+    "provide meaningful typeFullName for the target of the assignment" in {
+      cpg.assignment.target.isIdentifier.name("y").l match {
+        case List(y) => y.typeFullName shouldBe "foo.py:<module>.bar.<returnValue>.<indexAccess>"
+        case result  => fail(s"Expected single assignment to y, but got $result")
+      }
+    }
+  }
+
+  "assignment to interspersed index access with imported method calls" should {
+    val cpg = code("""
+        |import foo
+        |x = foo.bar()[0].baz()
+        |""".stripMargin)
+
+    "have correct methodFullName for `bar`" in {
+      cpg.call.name("bar").l match {
+        case List(bar) => bar.methodFullName shouldBe "foo.py:<module>.bar"
+        case result    => fail(s"Expected single call to bar, but got $result")
+      }
+    }
+
+    "have correct methodFullName for `baz`" in {
+      cpg.call.name("baz").l match {
+        case List(baz) => baz.methodFullName shouldBe "foo.py:<module>.bar.<returnValue>.<indexAccess>.baz"
+        case result    => fail(s"Expected single call to baz, but got $result")
+      }
+    }
+
+    // TODO: Missing the last <returnValue>. Needs to take into account the lowering of consecutive
+    //  field accesses into three-address code blocks.
+    "provide meaningful typeFullName for the target of the assignment" ignore {
+      cpg.assignment.target.isIdentifier.name("x").l match {
+        case List(x) => x.typeFullName shouldBe "foo.py:<module>.bar.<returnValue>.<indexAccess>.baz.<returnValue>"
+        case result  => fail(s"Expected single assignment to x, but got $result")
+      }
+    }
+  }
+
+  "call to interspersed index access with imported method calls and constructors" should {
+    val cpg = code("""
+        |import boto3
+        |sqs = boto3.resource('sqs')
+        |queue = sqs.Queue('url')
+        |queue.receive_messages()[0].delete()
+        |""".stripMargin)
+
+    "have correct methodFullName for `delete`" in {
+      cpg.call.name("delete").l match {
+        case List(delete) =>
+          delete.methodFullName shouldBe "boto3.py:<module>.resource.<returnValue>.Queue.receive_messages.<returnValue>.<indexAccess>.delete"
+        case result => fail(s"Expected single call to delete, but got $result")
+      }
+    }
+
+    "have correct methodFullName for `resource`" in {
+      cpg.call.name("resource").l match {
+        case List(resource) => resource.methodFullName shouldBe "boto3.py:<module>.resource"
+        case result         => fail(s"Expected single call to resource, but got $result")
+      }
+    }
+
+    "have correct methodFullName for `receive_messages`" in {
+      cpg.call.name("receive_messages").l match {
+        case List(recv) =>
+          recv.methodFullName shouldBe "boto3.py:<module>.resource.<returnValue>.Queue.receive_messages"
+        case result => fail(s"Expected single call to receive_messages, but got $result")
+      }
+    }
+
+    "provide meaningful typeFullName for `sqs`" in {
+      cpg.assignment.target.isIdentifier.name("sqs").l match {
+        case List(sqs) => sqs.typeFullName shouldBe "boto3.py:<module>.resource.<returnValue>"
+        case result    => fail(s"Expected single assignment to sqs, but got $result")
+      }
+    }
+
+    "provide meaningful typeFullName for `queue`" in {
+      cpg.assignment.target.isIdentifier.name("queue").l match {
+        case List(queue) => queue.typeFullName shouldBe "boto3.py:<module>.resource.<returnValue>.Queue"
+        case result      => fail(s"Expected single assignment to queue, but got $result")
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonTypeRecovery.scala
@@ -103,7 +103,7 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
       case "<operator>.dictLiteral"  => associateTypes(i, Set(s"${Constants.builtinPrefix}dict"))
       case "<operator>.setLiteral"   => associateTypes(i, Set(s"${Constants.builtinPrefix}set"))
       case Operators.conditional     => associateTypes(i, Set(s"${Constants.builtinPrefix}bool"))
-      case Operators.indexAccess     =>
+      case Operators.indexAccess =>
         c.argument.argumentIndex(1).isCall.foreach(setCallMethodFullNameFromBase)
         visitIdentifierAssignedToIndexAccess(i, c)
       case _ => super.visitIdentifierAssignedToOperator(i, c, operation)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonTypeRecovery.scala
@@ -103,7 +103,10 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
       case "<operator>.dictLiteral"  => associateTypes(i, Set(s"${Constants.builtinPrefix}dict"))
       case "<operator>.setLiteral"   => associateTypes(i, Set(s"${Constants.builtinPrefix}set"))
       case Operators.conditional     => associateTypes(i, Set(s"${Constants.builtinPrefix}bool"))
-      case _                         => super.visitIdentifierAssignedToOperator(i, c, operation)
+      case Operators.indexAccess     =>
+        c.argument.argumentIndex(1).isCall.foreach(setCallMethodFullNameFromBase)
+        visitIdentifierAssignedToIndexAccess(i, c)
+      case _ => super.visitIdentifierAssignedToOperator(i, c, operation)
     }
   }
 
@@ -223,6 +226,13 @@ private class RecoverForPythonFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder
   ): Unit = {
     if (funcName != "<module>")
       super.handlePotentialFunctionPointer(funcPtr, baseTypes, funcName, baseName)
+  }
+
+  override protected def getIndexAccessTypes(ia: Call): Set[String] = {
+    ia.argument.argumentIndex(1).isCall.headOption match {
+      case Some(c) => getTypesFromCall(c).map(x => s"$x$pathSep${XTypeRecovery.DummyIndexAccess}")
+      case _       => super.getIndexAccessTypes(ia)
+    }
   }
 
 }


### PR DESCRIPTION
Noticed that type recovery wasn't handling index accesses of field access calls, e.g.

```python
import foo
foo.bar()[0] # bar.methodFullName = <unknownFullName>
```

The igniting clue here was that `bar` was not in the symbol time at the right time (`getIndexAccessTypes`).