### PR TITLE
[c2cpg] Improve full names and signatures for C++.

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -3,10 +3,29 @@ package io.joern.c2cpg.astcreation
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewIdentifier, NewMethodRef}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.Defines as X2CpgDefines
+import org.eclipse.cdt.core.dom.ast
 import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.cpp.*
 import org.eclipse.cdt.core.dom.ast.gnu.IGNUASTCompoundStatementExpression
-import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTQualifiedName
+import org.eclipse.cdt.core.model.IMethod
+import org.eclipse.cdt.internal.core.dom.parser.c.{
+  CASTFieldReference,
+  CASTFunctionCallExpression,
+  CASTIdExpression,
+  CBasicType,
+  CFunctionType,
+  CPointerType
+}
+import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.{EvalBinding, EvalFunctionCall}
+import org.eclipse.cdt.internal.core.dom.parser.cpp.{
+  CPPASTIdExpression,
+  CPPASTQualifiedName,
+  CPPClosureType,
+  CPPField,
+  CPPFunction,
+  CPPFunctionType
+}
 
 trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -63,66 +82,265 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     callAst(callNode_, childAsts.toIndexedSeq)
   }
 
-  private def astForCallExpression(call: IASTFunctionCallExpression): Ast = {
-    val rec = call.getFunctionNameExpression match {
-      case unaryExpression: IASTUnaryExpression if unaryExpression.getOperand.isInstanceOf[IASTBinaryExpression] =>
-        astForBinaryExpression(unaryExpression.getOperand.asInstanceOf[IASTBinaryExpression])
-      case unaryExpression: IASTUnaryExpression if unaryExpression.getOperand.isInstanceOf[IASTFieldReference] =>
-        astForFieldReference(unaryExpression.getOperand.asInstanceOf[IASTFieldReference])
-      case unaryExpression: IASTUnaryExpression
-          if unaryExpression.getOperand.isInstanceOf[IASTArraySubscriptExpression] =>
-        astForArrayIndexExpression(unaryExpression.getOperand.asInstanceOf[IASTArraySubscriptExpression])
-      case unaryExpression: IASTUnaryExpression if unaryExpression.getOperand.isInstanceOf[IASTConditionalExpression] =>
-        astForUnaryExpression(unaryExpression)
-      case unaryExpression: IASTUnaryExpression if unaryExpression.getOperand.isInstanceOf[IASTUnaryExpression] =>
-        astForUnaryExpression(unaryExpression.getOperand.asInstanceOf[IASTUnaryExpression])
-      case lambdaExpression: ICPPASTLambdaExpression =>
-        astForMethodRefForLambda(lambdaExpression)
-      case other => astForExpression(other)
-    }
+  private def astForCppCallExpression(call: ICPPASTFunctionCallExpression): Ast = {
+    val functionNameExpr = call.getFunctionNameExpression
+    val typ              = functionNameExpr.getExpressionType
+    typ match {
+      case pointerType: IPointerType =>
+        createPointerCallAst(call, cleanType(ASTTypeUtil.getType(call.getExpressionType)))
+      case functionType: ICPPFunctionType =>
+        functionNameExpr match {
+          case idExpr: CPPASTIdExpression =>
+            val function = idExpr.getName.getBinding.asInstanceOf[ICPPFunction]
+            val name     = idExpr.getName.getLastName.toString
+            val signature =
+              if (function.isExternC) {
+                ""
+              } else {
+                functionTypeToSignature(functionType)
+              }
 
-    val (dd, name) = call.getFunctionNameExpression match {
-      case _: ICPPASTLambdaExpression =>
-        (DispatchTypes.STATIC_DISPATCH, rec.root.get.asInstanceOf[NewMethodRef].methodFullName)
-      case _ if rec.root.exists(_.isInstanceOf[NewIdentifier]) =>
-        (DispatchTypes.STATIC_DISPATCH, rec.root.get.asInstanceOf[NewIdentifier].name)
-      case _
-          if rec.root.exists(_.isInstanceOf[NewCall]) && call.getFunctionNameExpression
-            .isInstanceOf[IASTFieldReference] =>
-        (
+            val fullName =
+              if (function.isExternC) {
+                name
+              } else {
+                val fullNameNoSig = function.getQualifiedName.mkString(".")
+                s"$fullNameNoSig:$signature"
+              }
+
+            val dispatchType = DispatchTypes.STATIC_DISPATCH
+
+            val callCpgNode = callNode(
+              call,
+              code(call),
+              name,
+              fullName,
+              dispatchType,
+              Some(signature),
+              Some(cleanType(ASTTypeUtil.getType(call.getExpressionType)))
+            )
+            val args = call.getArguments.toList.map(a => astForNode(a))
+
+            createCallAst(callCpgNode, args)
+          case fieldRefExpr: ICPPASTFieldReference =>
+            val instanceAst = astForExpression(fieldRefExpr.getFieldOwner)
+            val args        = call.getArguments.toList.map(a => astForNode(a))
+
+            // TODO This wont do if the name is a reference.
+            val name      = fieldRefExpr.getFieldName.toString
+            val signature = functionTypeToSignature(functionType)
+
+            val classFullName = cleanType(ASTTypeUtil.getType(fieldRefExpr.getFieldOwnerType))
+            val fullName      = s"$classFullName.$name:$signature"
+
+            fieldRefExpr.getFieldName.resolveBinding()
+            val method = fieldRefExpr.getFieldName.getBinding().asInstanceOf[ICPPMethod]
+            val (dispatchType, receiver) =
+              if (method.isVirtual || method.isPureVirtual) {
+                (DispatchTypes.DYNAMIC_DISPATCH, Some(instanceAst))
+              } else {
+                (DispatchTypes.STATIC_DISPATCH, None)
+              }
+            val callCpgNode = callNode(
+              call,
+              code(call),
+              name,
+              fullName,
+              dispatchType,
+              Some(signature),
+              Some(cleanType(ASTTypeUtil.getType(call.getExpressionType)))
+            )
+
+            createCallAst(callCpgNode, args, base = Some(instanceAst), receiver)
+        }
+      case classType: ICPPClassType =>
+        val evaluation   = call.getEvaluation.asInstanceOf[EvalFunctionCall]
+        val functionType = evaluation.getOverload.getType
+        val signature    = functionTypeToSignature(functionType)
+        val name         = "<operator>()"
+
+        classType match {
+          case closureType: CPPClosureType =>
+            val fullName     = s"$name:$signature"
+            val dispatchType = DispatchTypes.DYNAMIC_DISPATCH
+
+            val callCpgNode = callNode(
+              call,
+              code(call),
+              name,
+              fullName,
+              dispatchType,
+              Some(signature),
+              Some(cleanType(ASTTypeUtil.getType(call.getExpressionType)))
+            )
+
+            val receiverAst = astForExpression(functionNameExpr)
+            val args        = call.getArguments.toList.map(a => astForNode(a))
+
+            createCallAst(callCpgNode, args, receiver = Some(receiverAst))
+          case _ =>
+            val classFullName = cleanType(ASTTypeUtil.getType(classType))
+            val fullName      = s"$classFullName.$name:$signature"
+
+            val method = evaluation.getOverload.asInstanceOf[ICPPMethod]
+            val dispatchType =
+              if (method.isVirtual || method.isPureVirtual) {
+                DispatchTypes.DYNAMIC_DISPATCH
+              } else {
+                DispatchTypes.STATIC_DISPATCH
+              }
+
+            val callCpgNode = callNode(
+              call,
+              code(call),
+              name,
+              fullName,
+              dispatchType,
+              Some(signature),
+              Some(cleanType(ASTTypeUtil.getType(call.getExpressionType)))
+            )
+
+            val instanceAst = astForExpression(functionNameExpr)
+            val args        = call.getArguments.toList.map(a => astForNode(a))
+
+            createCallAst(callCpgNode, args, base = Some(instanceAst), receiver = Some(instanceAst))
+        }
+      case _: IProblemType =>
+        astForCppCallExpressionUntyped(call)
+      case _: IProblemBinding =>
+        astForCppCallExpressionUntyped(call)
+    }
+  }
+
+  private def astForCppCallExpressionUntyped(call: ICPPASTFunctionCallExpression): Ast = {
+    val functionNameExpr = call.getFunctionNameExpression
+
+    functionNameExpr match {
+      case fieldRefExpr: ICPPASTFieldReference =>
+        val instanceAst = astForExpression(fieldRefExpr.getFieldOwner)
+        val args        = call.getArguments.toList.map(a => astForNode(a))
+
+        val name      = fieldRefExpr.getFieldName.toString
+        val signature = X2CpgDefines.UnresolvedSignature
+        val fullName  = s"${X2CpgDefines.UnresolvedNamespace}.$name:$signature(${args.size})"
+
+        val callCpgNode = callNode(
+          call,
+          code(call),
+          name,
+          fullName,
           DispatchTypes.STATIC_DISPATCH,
-          code(call.getFunctionNameExpression.asInstanceOf[IASTFieldReference].getFieldName)
+          Some(signature),
+          Some(X2CpgDefines.Any)
         )
-      case _ if rec.root.exists(_.isInstanceOf[NewCall]) =>
-        (DispatchTypes.STATIC_DISPATCH, rec.root.get.asInstanceOf[NewCall].code)
-      case reference: IASTIdExpression =>
-        (DispatchTypes.STATIC_DISPATCH, code(reference))
-      case _ =>
-        (DispatchTypes.STATIC_DISPATCH, "")
-    }
 
-    val shortName = fixQualifiedName(name)
-    val fullName = typeFor(call.getFunctionNameExpression) match {
-      case t if t == shortName || t.endsWith(s".$shortName") => dereferenceTypeFullName(t)
-      case t if t != Defines.anyTypeName                     => s"${dereferenceTypeFullName(t)}.$shortName"
-      case _                                                 => shortName
+        createCallAst(callCpgNode, args, base = Some(instanceAst), receiver = Some(instanceAst))
+      case idExpr: CPPASTIdExpression =>
+        val args = call.getArguments.toList.map(a => astForNode(a))
+
+        val name      = idExpr.getName.getLastName.toString
+        val signature = X2CpgDefines.UnresolvedSignature
+        val fullName  = s"${X2CpgDefines.UnresolvedNamespace}.$name:$signature(${args.size})"
+
+        val callCpgNode = callNode(
+          call,
+          code(call),
+          name,
+          fullName,
+          DispatchTypes.STATIC_DISPATCH,
+          Some(signature),
+          Some(X2CpgDefines.Any)
+        )
+
+        createCallAst(callCpgNode, args)
+      case other =>
+        // This could either be a pointer or an operator() call we dont know at this point
+        // but since it is CPP we opt for the later.
+        val args = call.getArguments.toList.map(a => astForNode(a))
+
+        val name      = "<operator>()"
+        val signature = X2CpgDefines.UnresolvedSignature
+        val fullName  = s"${X2CpgDefines.UnresolvedNamespace}.$name:$signature(${args.size})"
+
+        val callCpgNode = callNode(
+          call,
+          code(call),
+          name,
+          fullName,
+          DispatchTypes.STATIC_DISPATCH,
+          Some(signature),
+          Some(X2CpgDefines.Any)
+        )
+
+        val instanceAst = astForExpression(functionNameExpr)
+        createCallAst(callCpgNode, args, base = Some(instanceAst), receiver = Some(instanceAst))
     }
-    val cpgCall = callNode(call, code(call), shortName, fullName, dd)
-    val args    = call.getArguments.toList.map(a => astForNode(a))
-    rec.root match {
-      // Optimization: do not include the receiver if the receiver is just the function name,
-      // e.g., for `f(x)`, don't include an `f` identifier node as a first child. Since we
-      // have so many call sites in CPGs, this drastically reduces the number of nodes.
-      // Moreover, the data flow tracker does not need to track `f`, which would not make
-      // much sense anyway.
-      case Some(r: NewIdentifier) if r.name == shortName =>
-        callAst(cpgCall, args)
-      case Some(r: NewMethodRef) if r.code == shortName =>
-        callAst(cpgCall, args)
-      case Some(_) =>
-        callAst(cpgCall, args, Option(rec))
-      case None =>
-        callAst(cpgCall, args)
+  }
+
+  private def astForCCallExpression(call: CASTFunctionCallExpression): Ast = {
+    val functionNameExpr = call.getFunctionNameExpression
+    val typ              = functionNameExpr.getExpressionType
+    typ match {
+      case pointerType: CPointerType =>
+        createPointerCallAst(call, cleanType(ASTTypeUtil.getType(call.getExpressionType)))
+      case functionType: CFunctionType =>
+        functionNameExpr match {
+          case idExpr: CASTIdExpression =>
+            createCFunctionCallAst(call, idExpr, cleanType(ASTTypeUtil.getType(call.getExpressionType)))
+          case _ =>
+            createPointerCallAst(call, cleanType(ASTTypeUtil.getType(call.getExpressionType)))
+        }
+      case _ =>
+        astForCCallExpressionUntyped(call)
+    }
+  }
+
+  private def createCFunctionCallAst(
+    call: CASTFunctionCallExpression,
+    idExpr: CASTIdExpression,
+    callTypeFullName: String
+  ): Ast = {
+    val name      = idExpr.getName.getLastName.toString
+    val signature = ""
+
+    val dispatchType = DispatchTypes.STATIC_DISPATCH
+
+    val callCpgNode = callNode(call, code(call), name, name, dispatchType, Some(signature), Some(callTypeFullName))
+    val args        = call.getArguments.toList.map(a => astForNode(a))
+
+    createCallAst(callCpgNode, args)
+  }
+
+  private def createPointerCallAst(call: IASTFunctionCallExpression, callTypeFullName: String): Ast = {
+    val functionNameExpr = call.getFunctionNameExpression
+    val name             = "<operator>.pointerCall"
+    val signature        = ""
+
+    val callCpgNode =
+      callNode(call, code(call), name, name, DispatchTypes.DYNAMIC_DISPATCH, Some(signature), Some(callTypeFullName))
+
+    val args        = call.getArguments.toList.map(a => astForNode(a))
+    val receiverAst = astForExpression(functionNameExpr)
+    createCallAst(callCpgNode, args, receiver = Some(receiverAst))
+  }
+
+  private def astForCCallExpressionUntyped(call: CASTFunctionCallExpression): Ast = {
+    val functionNameExpr = call.getFunctionNameExpression
+
+    functionNameExpr match {
+      case idExpr: CASTIdExpression =>
+        createCFunctionCallAst(call, idExpr, X2CpgDefines.Any)
+      case _ =>
+        createPointerCallAst(call, X2CpgDefines.Any)
+    }
+  }
+
+  private def astForCallExpression(call: IASTFunctionCallExpression): Ast = {
+    call match {
+      case cppCall: ICPPASTFunctionCallExpression =>
+        astForCppCallExpression(cppCall)
+      case cCall: CASTFunctionCallExpression =>
+        astForCCallExpression(cCall)
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -23,11 +23,10 @@ class AstCreationPassTests extends AstC2CpgSuite {
        |char *hello();
        |""".stripMargin)
       inside(cpg.method("foo").l) { case List(foo) =>
-        foo.signature shouldBe "char* foo ()"
+        foo.signature shouldBe "char*()"
       }
       inside(cpg.method("hello").l) { case List(hello) =>
-        hello.signature shouldBe "char* hello ()"
-
+        hello.signature shouldBe "char*()"
       }
     }
 
@@ -39,7 +38,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
         "test.cpp"
       )
       inside(cpg.method("foo").l) { case List(m) =>
-        m.signature shouldBe "void foo (int,int*)"
+        m.signature shouldBe "void(int,int*)"
         inside(m.parameter.l) { case List(x, args) =>
           x.name shouldBe "x"
           x.code shouldBe "int x"
@@ -129,32 +128,32 @@ class AstCreationPassTests extends AstC2CpgSuite {
       inside(cpg.method.fullNameExact(lambda1FullName).isLambda.l) { case List(l1) =>
         l1.name shouldBe lambda1FullName
         l1.code should startWith("[] (int a, int b) -> int")
-        l1.signature shouldBe s"int $lambda1FullName (int,int)"
+        l1.signature shouldBe s"int(int,int)"
         l1.body.code shouldBe "{ return a + b; }"
       }
 
       inside(cpg.method.fullNameExact(lambda2FullName).isLambda.l) { case List(l2) =>
         l2.name shouldBe lambda2FullName
         l2.code should startWith("[] (string a, string b) -> string")
-        l2.signature shouldBe s"string $lambda2FullName (string,string)"
+        l2.signature shouldBe s"string(string,string)"
         l2.body.code shouldBe "{ return a + b; }"
       }
 
       inside(cpg.typeDecl(NamespaceTraversal.globalNamespaceName).head.bindsOut.l) {
         case List(bX: Binding, bY: Binding) =>
           bX.name shouldBe lambda1FullName
-          bX.signature shouldBe s"int $lambda1FullName (int,int)"
+          bX.signature shouldBe s"int(int,int)"
           inside(bX.refOut.l) { case List(method: Method) =>
             method.name shouldBe lambda1FullName
             method.fullName shouldBe lambda1FullName
-            method.signature shouldBe s"int $lambda1FullName (int,int)"
+            method.signature shouldBe s"int(int,int)"
           }
           bY.name shouldBe lambda2FullName
-          bY.signature shouldBe s"string $lambda2FullName (string,string)"
+          bY.signature shouldBe s"string(string,string)"
           inside(bY.refOut.l) { case List(method: Method) =>
             method.name shouldBe lambda2FullName
             method.fullName shouldBe lambda2FullName
-            method.signature shouldBe s"string $lambda2FullName (string,string)"
+            method.signature shouldBe s"string(string,string)"
           }
       }
     }
@@ -174,7 +173,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
       )
       val lambdaName     = "<lambda>0"
       val lambdaFullName = s"Foo.$lambdaName"
-      val signature      = s"int $lambdaFullName (int,int)"
+      val signature      = s"int(int,int)"
 
       cpg.member.name("x").order.l shouldBe List(1)
 
@@ -217,7 +216,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
       )
       val lambdaName     = "<lambda>0"
       val lambdaFullName = s"A.B.Foo.$lambdaName"
-      val signature      = s"int $lambdaFullName (int,int)"
+      val signature      = s"int(int,int)"
 
       cpg.member.name("x").order.l shouldBe List(1)
 
@@ -261,9 +260,9 @@ class AstCreationPassTests extends AstC2CpgSuite {
         "test.cpp"
       )
       val lambda1Name = "<lambda>0"
-      val signature1  = s"int $lambda1Name (int)"
+      val signature1  = s"int(int)"
       val lambda2Name = "<lambda>1"
-      val signature2  = s"int $lambda2Name (int)"
+      val signature2  = s"int(int)"
 
       cpg.local.name("x").order.l shouldBe List(1)
       cpg.local.name("foo1").order.l shouldBe List(3)
@@ -302,33 +301,36 @@ class AstCreationPassTests extends AstC2CpgSuite {
           }
       }
 
-      inside(cpg.call("x").l) { case List(lambda1call) =>
-        lambda1call.name shouldBe "x"
-        lambda1call.methodFullName shouldBe "x"
-        lambda1call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-        inside(lambda1call.astChildren.l) { case List(lit: Literal) =>
+      inside(cpg.call.nameExact("<operator>()").l) { case List(lambda1call, lambda2call) =>
+        lambda1call.name shouldBe "<operator>()"
+        lambda1call.methodFullName shouldBe "<operator>():int(int)"
+        lambda1call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        inside(lambda1call.astChildren.l) { case List(id: Identifier, lit: Literal) =>
+          id.code shouldBe "x"
           lit.code shouldBe "10"
         }
         inside(lambda1call.argument.l) { case List(lit: Literal) =>
           lit.code shouldBe "10"
         }
-        lambda1call.receiver.l shouldBe empty
-      }
+        inside(lambda1call.receiver.l) { case List(receiver: Identifier) =>
+          receiver.code shouldBe "x"
+        }
 
-      inside(cpg.call(lambda2Name).l) { case List(lambda2call) =>
-        lambda2call.name shouldBe lambda2Name
-        lambda2call.methodFullName shouldBe lambda2Name
-        // TODO: lambda2call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        lambda2call.name shouldBe "<operator>()"
+        lambda2call.methodFullName shouldBe "<operator>():int(int)"
+        lambda2call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
         inside(lambda2call.astChildren.l) { case List(ref: MethodRef, lit: Literal) =>
           ref.methodFullName shouldBe lambda2Name
           ref.code should startWith("[](int n) -> int")
           lit.code shouldBe "10"
         }
 
-        inside(lambda2call.argument.l) { case List(ref: MethodRef, lit: Literal) =>
+        inside(lambda2call.argument.l) { case List(lit: Literal) =>
+          lit.code shouldBe "10"
+        }
+        inside(lambda2call.receiver.l) { case List(ref: MethodRef) =>
           ref.methodFullName shouldBe lambda2Name
           ref.code should startWith("[](int n) -> int")
-          lit.code shouldBe "10"
         }
       }
     }
@@ -907,8 +909,8 @@ class AstCreationPassTests extends AstC2CpgSuite {
        |}
       """.stripMargin)
       inside(cpg.method.name("main").ast.isCall.codeExact("(*strLenFunc)(\"123\")").l) { case List(call) =>
-        call.name shouldBe "*strLenFunc"
-        call.methodFullName shouldBe "*strLenFunc"
+        call.name shouldBe "<operator>.pointerCall"
+        call.methodFullName shouldBe "<operator>.pointerCall"
       }
     }
 
@@ -1149,32 +1151,6 @@ class AstCreationPassTests extends AstC2CpgSuite {
       cpg.typeDecl
         .name("Derived")
         .count(_.inheritsFromTypeFullName == List("Base")) shouldBe 1
-    }
-
-    "be correct for field access" in {
-      val cpg = code(
-        """
-        |class Foo {
-        |public:
-        | char x;
-        | int method(){return i;};
-        |};
-        |
-        |Foo f;
-        |int x = f.method();
-      """.stripMargin,
-        "file.cpp"
-      )
-      cpg.typeDecl
-        .name("Foo")
-        .l
-        .size shouldBe 1
-
-      inside(cpg.call.code("f.method()").l) { case List(call: Call) =>
-        call.methodFullName shouldBe Operators.fieldAccess
-        call.argument(1).code shouldBe "f"
-        call.argument(2).code shouldBe "method"
-      }
     }
 
     "be correct for type initializer expression" in {
@@ -2146,9 +2122,9 @@ class AstCreationPassTests extends AstC2CpgSuite {
       val cpg          = code("class Foo { char (*(*x())[5])() }", "test.cpp")
       val List(method) = cpg.method.nameNot("<global>").l
       method.name shouldBe "x"
-      method.fullName shouldBe "Foo.x"
+      method.fullName shouldBe "Foo.x:char (* (*)[5])()()"
       method.code shouldBe "char (*(*x())[5])()"
-      method.signature shouldBe "char Foo.x ()"
+      method.signature shouldBe "char()"
     }
 
     "be consistent with pointer types" in {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/CallTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/CallTests.scala
@@ -1,11 +1,14 @@
 package io.joern.c2cpg.passes.ast
 
 import io.joern.c2cpg.testfixtures.C2CpgSuite
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
 import io.shiftleft.semanticcpg.language.NoResolve
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.*
+
+import java.nio.file.{Files, Path}
 
 class CallTests extends C2CpgSuite {
 
@@ -127,8 +130,8 @@ class CallTests extends C2CpgSuite {
       "test.cpp"
     )
     "have correct names for static methods / calls" in {
-      cpg.method.name("square").fullName.head shouldBe "square"
-      cpg.method.name("call_square").call.methodFullName.head shouldBe "square"
+      cpg.method.name("square").fullName.head shouldBe "square:int(int)"
+      cpg.method.name("call_square").call.methodFullName.head shouldBe "square:int(int)"
     }
   }
 
@@ -149,8 +152,8 @@ class CallTests extends C2CpgSuite {
       "test.cpp"
     )
     "have correct names for static methods / calls from classes" in {
-      cpg.method.name("square").fullName.head shouldBe "A.square"
-      cpg.method.name("call_square").call.methodFullName.head shouldBe "A.square"
+      cpg.method.name("square").fullName.head shouldBe "A.square:int(int)"
+      cpg.method.name("call_square").call.methodFullName.head shouldBe "A.square:int(int)"
     }
   }
 
@@ -168,9 +171,9 @@ class CallTests extends C2CpgSuite {
     )
     "have correct type full names for calls" in {
       val List(bCall) = cpg.call.l
-      bCall.methodFullName shouldBe "A.b"
+      bCall.methodFullName shouldBe "A.b:void()"
       val List(bMethod) = cpg.method.name("b").internal.l
-      bMethod.fullName shouldBe "A.b"
+      bMethod.fullName shouldBe "A.b:void()"
       bMethod.callIn.head shouldBe bCall
       bCall.callee.head shouldBe bMethod
     }
@@ -196,10 +199,429 @@ class CallTests extends C2CpgSuite {
     )
     "have correct type full names for calls" in {
       val List(foo2Call) = cpg.call("foo2").l
-      foo2Call.methodFullName shouldBe "A.foo2"
+      foo2Call.methodFullName shouldBe "A.foo2:void()"
       val List(foo2Method) = cpg.method("foo2").l
-      foo2Method.fullName shouldBe "A.foo2"
+      foo2Method.fullName shouldBe "A.foo2:void()"
     }
   }
 
+  "Successfully typed calls" should {
+    "have correct call for call on non virtual class method" in {
+      val cpg = code(
+        """
+          |namespace NNN {
+          |  class A {
+          |    public:
+          |      void foo(int a){}
+          |  };
+          |}
+          |
+          |void outer() {
+          |  NNN::A a;
+          |  a.foo(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("foo").l
+      call.signature shouldBe "void(int)"
+      call.methodFullName shouldBe "NNN.A.foo:void(int)"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(instArg, arg1) = call.argument.l
+      instArg.code shouldBe "a"
+      instArg.argumentIndex shouldBe 0
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      call.receiver.isEmpty shouldBe true
+    }
+
+    "have correct call for call on virtual class method" in {
+      val cpg = code(
+        """
+          |namespace NNN {
+          |  class A {
+          |    public:
+          |      virtual void foo(int a){}
+          |  };
+          |}
+          |
+          |void outer() {
+          |  NNN::A a;
+          |  a.foo(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("foo").l
+      call.signature shouldBe "void(int)"
+      call.methodFullName shouldBe "NNN.A.foo:void(int)"
+      call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(instArg, arg1) = call.argument.l
+      instArg.code shouldBe "a"
+      instArg.argumentIndex shouldBe 0
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver shouldBe instArg
+    }
+
+    "have correct call for call on stand alone method (CPP)" in {
+      val cpg = code(
+        """
+          |namespace NNN {
+          |  void foo(int a){}
+          |}
+          |
+          |void outer() {
+          |  NNN::foo(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("foo").l
+      call.signature shouldBe "void(int)"
+      call.methodFullName shouldBe "NNN.foo:void(int)"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+
+      call.receiver.isEmpty shouldBe true
+    }
+
+    "have correct call for call on lambda function" in {
+      val cpg = code(
+        """
+          |void outer() {
+          |  [](int a) {}(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("<operator>()").l
+      call.signature shouldBe "void(int)"
+      call.methodFullName shouldBe "<operator>():void(int)"
+      call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver.isMethodRef shouldBe true
+      receiver.argumentIndex shouldBe -1
+    }
+
+    "have correct call for call on function pointer (CPP)" in {
+      val cpg = code(
+        """
+          |class A {
+          |  public:
+          |    void (*foo)(int);
+          |};
+          |
+          |void outer() {
+          |  A a;
+          |  a.foo(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("<operator>.pointerCall").l
+      call.signature shouldBe ""
+      call.methodFullName shouldBe "<operator>.pointerCall"
+      call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver.code shouldBe "a.foo"
+      receiver.argumentIndex shouldBe -1
+    }
+
+    "have correct call for call on callable object" in {
+      val cpg = code(
+        """
+          |namespace NNN {
+          |  class Callable {
+          |    public:
+          |      void operator()(int a){}
+          |  };
+          |}
+          |class A {
+          |  public:
+          |    NNN::Callable foo;
+          |};
+          |
+          |void outer() {
+          |  A a;
+          |  a.foo(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("<operator>()").l
+      call.signature shouldBe "void(int)"
+      call.methodFullName shouldBe "NNN.Callable.<operator>():void(int)"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(instArg, arg1) = call.argument.l
+      instArg.code shouldBe "a.foo"
+      instArg.argumentIndex shouldBe 0
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver shouldBe instArg
+    }
+
+    "have correct call for call on function pointer (C)" in {
+      val cpg = code(
+        """
+          |struct A {
+          |  void (*foo)(int);
+          |}
+          |void outer() {
+          |  struct A a;
+          |  a.foo(1);
+          |}
+          |""".stripMargin,
+        "test.c"
+      )
+
+      val List(call) = cpg.call.nameExact("<operator>.pointerCall").l
+      call.signature shouldBe ""
+      call.methodFullName shouldBe "<operator>.pointerCall"
+      call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver.code shouldBe "a.foo"
+      receiver.argumentIndex shouldBe -1
+    }
+
+    "have correct call for call on stand alone method (C)" in {
+      val cpg = code(
+        """
+          |void foo(int) {}
+          |void outer() {
+          |  foo(1);
+          |}
+          |""".stripMargin,
+        "test.c"
+      )
+
+      val List(call) = cpg.call.nameExact("foo").l
+      call.signature shouldBe ""
+      call.methodFullName shouldBe "foo"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+
+      call.receiver.isEmpty shouldBe true
+    }
+
+    "have correct call for call on extern C function" in {
+      val cpg = code(
+        """
+          |extern "C" {
+          |  void foo(int);
+          |}
+          |
+          |void outer() {
+          |  foo(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("foo").l
+      call.signature shouldBe ""
+      call.methodFullName shouldBe "foo"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe "void"
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      call.receiver.isEmpty shouldBe true
+    }
+  }
+
+  "Not successfully typed calls" should {
+    "have correct call for field reference style call (CPP)" in {
+      val cpg = code(
+        """
+          |void outer() {
+          |  Unknown a;
+          |  a.foo(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("foo").l
+      call.signature shouldBe Defines.UnresolvedSignature
+      call.methodFullName shouldBe s"${Defines.UnresolvedNamespace}.foo:${Defines.UnresolvedSignature}(1)"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe Defines.Any
+
+      val List(instArg, arg1) = call.argument.l
+      instArg.code shouldBe "a"
+      instArg.argumentIndex shouldBe 0
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver shouldBe instArg
+    }
+
+    "have correct call for plain call (CPP)" in {
+      val cpg = code(
+        """
+          |void outer() {
+          |  foo(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("foo").l
+      call.signature shouldBe Defines.UnresolvedSignature
+      call.methodFullName shouldBe s"${Defines.UnresolvedNamespace}.foo:${Defines.UnresolvedSignature}(1)"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe Defines.Any
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      call.receiver.isEmpty shouldBe true
+    }
+
+    "have correct call for call on arbitrary expression (CPP)" in {
+      val cpg = code(
+        """
+          |void outer() {
+          |  getX()(1);
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+
+      val List(call) = cpg.call.nameExact("<operator>()").l
+      call.signature shouldBe Defines.UnresolvedSignature
+      call.methodFullName shouldBe s"${Defines.UnresolvedNamespace}.<operator>():${Defines.UnresolvedSignature}(1)"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe Defines.Any
+
+      val List(instArg, arg1) = call.argument.l
+      instArg.code shouldBe "getX()"
+      instArg.argumentIndex shouldBe 0
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver shouldBe instArg
+    }
+
+    "have correct call for field reference style call (C)" in {
+      val cpg = code(
+        """
+          |void outer() {
+          |  struct A a;
+          |  a.foo(1);
+          |}
+          |""".stripMargin,
+        "test.c"
+      )
+
+      val List(call) = cpg.call.nameExact("<operator>.pointerCall").l
+      call.signature shouldBe ""
+      call.methodFullName shouldBe "<operator>.pointerCall"
+      call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      call.typeFullName shouldBe Defines.Any
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver.code shouldBe "a.foo"
+      receiver.argumentIndex shouldBe -1
+    }
+
+    "have correct call for plain call (C)" in {
+      val cpg = code(
+        """
+          |void outer() {
+          |  foo(1);
+          |}
+          |""".stripMargin,
+        "test.c"
+      )
+
+      val List(call) = cpg.call.nameExact("foo").l
+      call.signature shouldBe ""
+      call.methodFullName shouldBe s"foo"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.typeFullName shouldBe Defines.Any
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      call.receiver.isEmpty shouldBe true
+    }
+
+    "have correct call for call on arbitrary expression (C)" in {
+      val cpg = code(
+        """
+          |void outer() {
+          |  getX()(1);
+          |}
+          |""".stripMargin,
+        "test.c"
+      )
+
+      val List(call) = cpg.call.nameExact("<operator>.pointerCall").l
+      call.signature shouldBe ""
+      call.methodFullName shouldBe "<operator>.pointerCall"
+      call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      call.typeFullName shouldBe Defines.Any
+
+      val List(arg1) = call.argument.l
+      arg1.code shouldBe "1"
+      arg1.argumentIndex shouldBe 1
+
+      val List(receiver) = call.receiver.l
+      receiver.code shouldBe "getX()"
+      receiver.argumentIndex shouldBe -1
+    }
+  }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
@@ -155,7 +155,7 @@ class ClassTypeTests extends C2CpgSuite(FileDefaults.CPP_EXT) {
         |}""".stripMargin)
 
       val List(call) = cpg.call("foo2").l
-      call.methodFullName shouldBe "B.foo2"
+      call.methodFullName shouldBe "B.foo2:void()"
     }
   }
 
@@ -170,7 +170,7 @@ class ClassTypeTests extends C2CpgSuite(FileDefaults.CPP_EXT) {
           |    ): Bar::Foo(a, b) {}
           |}""".stripMargin)
       val List(constructor) = cpg.typeDecl.nameExact("FooT").method.isConstructor.l
-      constructor.signature shouldBe "Bar.Foo FooT.FooT (std.string,Bar.SomeClass)"
+      constructor.signature shouldBe "Bar.Foo(std.string,Bar.SomeClass)"
       val List(p1, p2) = constructor.parameter.l
       p1.typ.fullName shouldBe "std.string"
       p2.typ.fullName shouldBe "Bar.SomeClass"

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/NamespaceTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/NamespaceTypeTests.scala
@@ -35,8 +35,8 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
         |}
         |""".stripMargin)
       inside(cpg.method.isNotStub.fullName.l) { case List(f, m) =>
-        f shouldBe "Q.V.f"
-        m shouldBe "Q.V.C.m"
+        f shouldBe "Q.V.f:int()"
+        m shouldBe "Q.V.C.m:int()"
       }
 
       inside(cpg.namespaceBlock.nameNot("<global>").l) { case List(q, v) =>
@@ -50,12 +50,23 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
 
         inside(q.method.l) { case List(f, m) =>
           f.name shouldBe "f"
-          f.fullName shouldBe "Q.V.f"
+          f.fullName shouldBe "Q.V.f:int()"
           m.name shouldBe "m"
-          m.fullName shouldBe "Q.V.C.m"
+          m.fullName shouldBe "Q.V.C.m:int()"
         }
       }
 
+    }
+
+    "foo" in {
+      val cpg = code("""
+                       |namespace NNN {
+                       |  extern void hhh();
+                       |  void fff();
+                       |}
+                       |""".stripMargin)
+      val foo = cpg.method.l
+      println(foo.fullName.l)
     }
 
     "be correct for nested namespaces in C++17 style" in {
@@ -66,25 +77,23 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
         |  int f(); // f is a member of V, but is only declared here
         |}
         | 
-        |int V::f() // definition of V's member f outside of V
+        |int Q::V::f() // definition of V's member f outside of V
         |           // f's enclosing namespaces are still the global namespace, Q, and Q::V
         |{
-        |  extern void h(); // This declares ::Q::V::h
+        |  extern void h();
         |  return 0;
         |}
         | 
-        |int V::C::m() // definition of V::C::m outside of the namespace (and the class body)
+        |int Q::V::C::m() // definition of V::C::m outside of the namespace (and the class body)
         |              // enclosing namespaces are the global namespace, Q, and Q::V
         |{ return 0; }
         |""".stripMargin)
       inside(cpg.method.nameNot("<global>").fullName.l) { case List(m1, f1, f2, h, m2) =>
-        // TODO: this looks strange too it first glance. But as Eclipse CDT does not provide any
-        //  mapping from definitions outside of namespace into them we cant reconstruct proper full-names.
-        m1 shouldBe "Q.V.C.m"
-        f1 shouldBe "Q.V.f"
-        h shouldBe "V.f.h"
-        f2 shouldBe "V.f"
-        m2 shouldBe "V.C.m"
+        m1 shouldBe "Q.V.C.m:int()"
+        f1 shouldBe "Q.V.f:int()"
+        f2 shouldBe "Q.V.f:int()"
+        h shouldBe "h:void()"
+        m2 shouldBe "Q.V.C.m:int()"
       }
 
       inside(cpg.namespaceBlock.nameNot("<global>").l) { case List(q, v) =>
@@ -129,9 +138,9 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
       }
 
       inside(cpg.method.internal.nameNot("<global>").fullName.l) { case List(f, g, h) =>
-        f shouldBe "f"
-        g shouldBe "A.g"
-        h shouldBe "h"
+        f shouldBe "f:void()"
+        g shouldBe "A.g:void()"
+        h shouldBe "h:void()"
       }
 
       inside(cpg.method.nameExact("h").ast.isCall.code.l) { case List(c1, c2, c3, c4) =>
@@ -165,16 +174,16 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
       }
 
       inside(cpg.method.internal.nameNot("<global>").fullName.l) { case List(f, g, h) =>
-        f shouldBe "f"
-        g shouldBe "A.g"
-        h shouldBe "h"
+        f shouldBe "f:void()"
+        g shouldBe "A.g:void()"
+        h shouldBe "h:void()"
       }
 
       inside(cpg.call.filterNot(_.name == Operators.fieldAccess).l) { case List(f, g) =>
-        f.name shouldBe "X.f"
-        f.methodFullName shouldBe "X.f"
-        g.name shouldBe "X.g"
-        g.methodFullName shouldBe "X.g"
+        f.name shouldBe "f"
+        f.methodFullName shouldBe "f:void()"
+        g.name shouldBe "g"
+        g.methodFullName shouldBe "A.g:void()"
       }
     }
 
@@ -204,19 +213,19 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
       }
 
       inside(cpg.method.internal.nameNot("<global>").l) { case List(f1, f2, foo, bar) =>
-        f1.fullName shouldBe "A.f"
-        f1.signature shouldBe "void A.f (int)"
-        f2.fullName shouldBe "A.f"
-        f2.signature shouldBe "void A.f (char)"
-        foo.fullName shouldBe "foo"
-        bar.fullName shouldBe "bar"
+        f1.fullName shouldBe "A.f:void(int)"
+        f1.signature shouldBe "void(int)"
+        f2.fullName shouldBe "A.f:void(char)"
+        f2.signature shouldBe "void(char)"
+        foo.fullName shouldBe "foo:void()"
+        bar.fullName shouldBe "bar:void()"
       }
 
       inside(cpg.call.l) { case List(c1, c2) =>
         c1.name shouldBe "f"
-        c1.methodFullName shouldBe "f"
+        c1.methodFullName shouldBe "A.f:void(int)"
         c2.name shouldBe "f"
-        c2.methodFullName shouldBe "f"
+        c2.methodFullName shouldBe "A.f:void(char)"
       }
     }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/TemplateTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/TemplateTypeTests.scala
@@ -72,11 +72,11 @@ class TemplateTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
        |""".stripMargin)
       inside(cpg.method.nameNot("<global>").internal.l) { case List(x, y) =>
         x.name shouldBe "x"
-        x.fullName shouldBe "x"
-        x.signature shouldBe "void x<T,U> (T,U)"
+        x.fullName shouldBe "x:void(#0,#1)"
+        x.signature shouldBe "void(T,U)"
         y.name shouldBe "y"
-        y.fullName shouldBe "y"
-        y.signature shouldBe "void y<T,U> (T,U)"
+        y.fullName shouldBe "y:void(#0,#1)"
+        y.signature shouldBe "void(T,U)"
       }
     }
 


### PR DESCRIPTION
The C++ method full names did not include signatures which caused a lot
of methods to have the same full name which is not allowed. The
situation is not yet fully resolved because method/function declarations
independent from the implementation still created method stubs with full
name collisions. But it is a step in the right direction and the stubs
are easy to filter out via `isStub` step.

The call node generation has been reworked to accomodate this change.
Most noteable changes there:
- Full names where required contain signatures
- Signatures do not contain method names anymore
- Dispatch type is properly set if known.