### PR TITLE
use scala primitives (e.g. Integer -> Int) and some cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.4.2"
 
-val cpgVersion = "1.6.14+3-edeffe48"
+val cpgVersion = "1.6.15"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.4.2"
 
-val cpgVersion = "1.6.14+2-a107fecd"
+val cpgVersion = "1.6.14+3-edeffe48"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.4.2"
 
-val cpgVersion = "1.6.13"
+val cpgVersion = "1.6.14+1-df813683"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.4.2"
 
-val cpgVersion = "1.6.14+1-df813683"
+val cpgVersion = "1.6.14+2-a107fecd"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/dotgenerator/DdgGenerator.scala
@@ -91,7 +91,7 @@ class DdgGenerator {
     val allInEdges = v
       .inE(EdgeTypes.REACHING_DEF)
       .map(x =>
-        Edge(x.outNode.asInstanceOf[StoredNode], v, srcVisible = true, x.property(Properties.VARIABLE), edgeType)
+        Edge(x.outNode.asInstanceOf[StoredNode], v, srcVisible = true, x.property(Properties.Variable), edgeType)
       )
 
     v match {

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
@@ -7,7 +7,7 @@ import overflowdb.traversal.help.Table
 import overflowdb.traversal.help.Table.AvailableWidthProvider
 
 case class Path(elements: List[AstNode]) {
-  def resultPairs(): List[(String, Option[Integer])] = {
+  def resultPairs(): List[(String, Option[Int])] = {
     val pairs = elements.map {
       case point: MethodParameterIn =>
         val method      = point.method

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -207,7 +207,7 @@ object Engine {
   ): Option[PathElement] = {
     val curNode  = e.inNode().asInstanceOf[CfgNode]
     val parNode  = e.outNode().asInstanceOf[CfgNode]
-    val outLabel = Some(e.property(Properties.VARIABLE)).getOrElse("")
+    val outLabel = Some(e.property(Properties.Variable)).getOrElse("")
 
     if (!EdgeValidator.isValidEdge(curNode, parNode)) {
       return None

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
@@ -161,8 +161,8 @@ package object slicing {
     typeFullName: String = "",
     parentMethod: String = "",
     parentFile: String = "",
-    lineNumber: Option[Integer] = None,
-    columnNumber: Option[Integer] = None
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None
   ) derives ReadWriter
 
   case class SliceEdge(src: Long, dst: Long, label: String) derives ReadWriter

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/AccessPathUsageTests.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/queryengine/AccessPathUsageTests.scala
@@ -26,29 +26,29 @@ class AccessPathUsageTests extends AnyWordSpec {
 
   private def genCALL(graph: Graph, op: String, args: Node*): Call = {
     val ret = graph + NodeTypes.CALL // (NodeTypes.CALL, Properties.NAME -> op)
-    ret.setProperty(Properties.NAME, op)
+    ret.setProperty(Properties.Name, op)
     args.reverse.zipWithIndex.foreach { case (arg, idx) =>
       ret --- EdgeTypes.ARGUMENT --> arg
-      arg.setProperty(Properties.ARGUMENT_INDEX, idx + 1)
+      arg.setProperty(Properties.ArgumentIndex, idx + 1)
     }
     ret.asInstanceOf[Call]
   }
 
   private def genLit(graph: Graph, payload: String): Literal = {
     val ret = graph + NodeTypes.LITERAL
-    ret.setProperty(Properties.CODE, payload)
+    ret.setProperty(Properties.Code, payload)
     ret.asInstanceOf[Literal]
   }
 
   private def genID(graph: Graph, payload: String): Identifier = {
     val ret = graph + NodeTypes.IDENTIFIER
-    ret.setProperty(Properties.NAME, payload)
+    ret.setProperty(Properties.Name, payload)
     ret.asInstanceOf[Identifier]
   }
 
   private def genFID(graph: Graph, payload: String): FieldIdentifier = {
     val ret = graph + NodeTypes.FIELD_IDENTIFIER
-    ret.setProperty(Properties.CANONICAL_NAME, payload)
+    ret.setProperty(Properties.CanonicalName, payload)
     ret.asInstanceOf[FieldIdentifier]
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -95,21 +95,21 @@ class AstCreator(
 
   override protected def code(node: IASTNode): String = shortenCode(nodeSignature(node))
 
-  override protected def line(node: IASTNode): Option[Integer] = {
+  override protected def line(node: IASTNode): Option[Int] = {
     nullSafeFileLocation(node).map(_.getStartingLineNumber)
   }
 
-  override protected def lineEnd(node: IASTNode): Option[Integer] = {
+  override protected def lineEnd(node: IASTNode): Option[Int] = {
     nullSafeFileLocation(node).map(_.getEndingLineNumber)
   }
 
-  protected def column(node: IASTNode): Option[Integer] = {
+  protected def column(node: IASTNode): Option[Int] = {
     nodeOffsets(node).map { case (startOffset, _) =>
       offsetToColumn(node, startOffset)
     }
   }
 
-  protected def columnEnd(node: IASTNode): Option[Integer] = {
+  protected def columnEnd(node: IASTNode): Option[Int] = {
     nodeOffsets(node).map { case (_, endOffset) =>
       offsetToColumn(node, endOffset - 1)
     }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -170,10 +170,10 @@ object AstCreatorHelper {
     */
   def createDotNetNodeInfo(json: Value, relativeFileName: Option[String] = None): DotNetNodeInfo = {
     val metaData = json(ParserKeys.MetaData)
-    val ln       = metaData(ParserKeys.LineStart).numOpt.map(_.toInt.asInstanceOf[Integer])
-    val cn       = metaData(ParserKeys.ColumnStart).numOpt.map(_.toInt.asInstanceOf[Integer])
-    val lnEnd    = metaData(ParserKeys.LineEnd).numOpt.map(_.toInt.asInstanceOf[Integer])
-    val cnEnd    = metaData(ParserKeys.ColumnEnd).numOpt.map(_.toInt.asInstanceOf[Integer])
+    val ln       = metaData(ParserKeys.LineStart).numOpt.map(_.toInt)
+    val cn       = metaData(ParserKeys.ColumnStart).numOpt.map(_.toInt)
+    val lnEnd    = metaData(ParserKeys.LineEnd).numOpt.map(_.toInt)
+    val cnEnd    = metaData(ParserKeys.ColumnEnd).numOpt.map(_.toInt)
     val node     = nodeType(metaData, relativeFileName)
     val c = node.toString match
       case "Attribute" =>

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/package.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/package.scala
@@ -11,10 +11,10 @@ package object parser {
     node: DotNetParserNode,
     json: Value,
     code: String,
-    lineNumber: Option[Integer],
-    columnNumber: Option[Integer],
-    lineNumberEnd: Option[Integer],
-    columnNumberEnd: Option[Integer]
+    lineNumber: Option[Int],
+    columnNumber: Option[Int],
+    lineNumberEnd: Option[Int],
+    columnNumberEnd: Option[Int]
   ) extends BaseNodeInfo[DotNetParserNode]
 
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/testfixtures/CSharpCode2CpgFixture.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/testfixtures/CSharpCode2CpgFixture.scala
@@ -29,7 +29,7 @@ class CSharpCode2CpgFixture(
   implicit val resolver: ICallResolver = NoResolve
 
   protected def flowToResultPairs(path: Path): List[(String, Integer)] =
-    path.resultPairs().collect { case (firstElement: String, secondElement: Option[Integer]) =>
+    path.resultPairs().collect { case (firstElement, secondElement) =>
       (firstElement, secondElement.get)
     }
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreatorHelper.scala
@@ -131,13 +131,13 @@ trait AstCreatorHelper { this: AstCreator =>
     }
   }
 
-  protected def line(node: Value): Option[Integer] = Try(node(ParserKeys.NodeLineNo).num).toOption.map(_.toInt)
+  protected def line(node: Value): Option[Int] = Try(node(ParserKeys.NodeLineNo).num).toOption.map(_.toInt)
 
-  protected def column(node: Value): Option[Integer] = Try(node(ParserKeys.NodeColNo).num).toOption.map(_.toInt)
+  protected def column(node: Value): Option[Int] = Try(node(ParserKeys.NodeColNo).num).toOption.map(_.toInt)
 
-  protected def lineEndNo(node: Value): Option[Integer] = Try(node(ParserKeys.NodeLineEndNo).num).toOption.map(_.toInt)
+  protected def lineEndNo(node: Value): Option[Int] = Try(node(ParserKeys.NodeLineEndNo).num).toOption.map(_.toInt)
 
-  protected def columnEndNo(node: Value): Option[Integer] = Try(node(ParserKeys.NodeColEndNo).num).toOption.map(_.toInt)
+  protected def columnEndNo(node: Value): Option[Int] = Try(node(ParserKeys.NodeColEndNo).num).toOption.map(_.toInt)
 
   protected def positionLookupTables: Map[Int, String] = {
     val result = if (!goGlobal.processingDependencies) {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserNodeInfo.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/ParserNodeInfo.scala
@@ -8,8 +8,8 @@ case class ParserNodeInfo(
   node: ParserNode,
   json: Value,
   code: String,
-  lineNumber: Option[Integer],
-  columnNumber: Option[Integer],
-  lineNumberEnd: Option[Integer],
-  columnNumberEnd: Option[Integer]
+  lineNumber: Option[Int],
+  columnNumber: Option[Int],
+  lineNumberEnd: Option[Int],
+  columnNumberEnd: Option[Int]
 ) extends BaseNodeInfo[ParserNode]

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -135,11 +135,11 @@ class AstCreator(
     .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS))
     .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_JAVADOC))
 
-  protected def line(node: Node): Option[Integer]      = node.getBegin.map(x => Integer.valueOf(x.line)).toScala
-  protected def column(node: Node): Option[Integer]    = node.getBegin.map(x => Integer.valueOf(x.column)).toScala
-  protected def lineEnd(node: Node): Option[Integer]   = node.getEnd.map(x => Integer.valueOf(x.line)).toScala
-  protected def columnEnd(node: Node): Option[Integer] = node.getEnd.map(x => Integer.valueOf(x.column)).toScala
-  protected def code(node: Node): String               = node.toString(codePrinterOptions)
+  protected def line(node: Node): Option[Int]      = node.getBegin.map(x => x.line).toScala
+  protected def column(node: Node): Option[Int]    = node.getBegin.map(x => x.column).toScala
+  protected def lineEnd(node: Node): Option[Int]   = node.getEnd.map(x => x.line).toScala
+  protected def columnEnd(node: Node): Option[Int] = node.getEnd.map(x => x.column).toScala
+  protected def code(node: Node): String           = node.toString(codePrinterOptions)
 
   private val lineOffsetTable = OffsetUtils.getLineOffsetTable(fileContent)
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForMethodsCreator.scala
@@ -464,8 +464,8 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
   }
 
   private def constructorReturnNode(constructorDeclaration: ConstructorDeclaration): NewMethodReturn = {
-    val line   = constructorDeclaration.getEnd.map(x => Integer.valueOf(x.line)).toScala
-    val column = constructorDeclaration.getEnd.map(x => Integer.valueOf(x.column)).toScala
+    val line   = constructorDeclaration.getEnd.map(x => x.line).toScala
+    val column = constructorDeclaration.getEnd.map(x => x.column).toScala
     newMethodReturnNode(TypeConstants.Void, None, line, column)
   }
 
@@ -500,7 +500,7 @@ private[declarations] trait AstForMethodsCreator { this: AstCreator =>
     methodNode(declaration, declaration.getNameAsString(), code, placeholderFullName, None, filename)
   }
 
-  def thisNodeForMethod(maybeTypeFullName: Option[String], lineNumber: Option[Integer]): NewMethodParameterIn = {
+  def thisNodeForMethod(maybeTypeFullName: Option[String], lineNumber: Option[Int]): NewMethodParameterIn = {
     val typeFullName = typeInfoCalc.registerType(maybeTypeFullName.getOrElse(TypeConstants.Any))
     NodeBuilders.newThisParameterNode(
       typeFullName = typeFullName,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -336,8 +336,8 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     argumentTypes: Option[List[String]],
     argsSize: Int,
     code: String,
-    lineNumber: Option[Integer] = None,
-    columnNumber: Option[Integer] = None
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None
   ): NewCall = {
     val initSignature = argumentTypes match {
       case Some(tpe)          => composeMethodLikeSignature(TypeConstants.Void, tpe)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -291,8 +291,8 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     identifierType: Option[String],
     fieldIdentifierName: String,
     returnType: Option[String],
-    lineNo: Option[Integer],
-    columnNo: Option[Integer]
+    lineNo: Option[Int],
+    columnNo: Option[Int]
   ): Ast = {
     val typeFullName     = identifierType.orElse(Some(TypeConstants.Any)).map(typeInfoCalc.registerType)
     val identifier       = newIdentifierNode(identifierName, typeFullName.getOrElse("ANY"))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -230,7 +230,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
     )
   }
 
-  private def nativeForEachIdxLocalNode(lineNo: Option[Integer]): NewLocal = {
+  private def nativeForEachIdxLocalNode(lineNo: Option[Int]): NewLocal = {
     val idxName      = nextIndexName()
     val typeFullName = TypeConstants.Int
     val idxLocal =
@@ -243,7 +243,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
     idxLocal
   }
 
-  private def nativeForEachIdxInitializerAst(lineNo: Option[Integer], idxLocal: NewLocal): Ast = {
+  private def nativeForEachIdxInitializerAst(lineNo: Option[Int], idxLocal: NewLocal): Ast = {
     val idxName = idxLocal.name
     val idxInitializerCallNode = newOperatorCallNode(
       Operators.assignment,
@@ -262,11 +262,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
       .withRefEdge(idxIdentifierArg, idxLocal)
   }
 
-  private def nativeForEachCompareAst(
-    lineNo: Option[Integer],
-    iterableSource: NodeTypeInfo,
-    idxLocal: NewLocal
-  ): Ast = {
+  private def nativeForEachCompareAst(lineNo: Option[Int], iterableSource: NodeTypeInfo, idxLocal: NewLocal): Ast = {
     val idxName = idxLocal.name
 
     val compareNode = newOperatorCallNode(
@@ -296,7 +292,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
       .withRefEdges(fieldAccessIdentifier, iterableSourceNode.toList)
   }
 
-  private def nativeForEachIncrementAst(lineNo: Option[Integer], idxLocal: NewLocal): Ast = {
+  private def nativeForEachIncrementAst(lineNo: Option[Int], idxLocal: NewLocal): Ast = {
     val incrementNode = newOperatorCallNode(
       Operators.postIncrement,
       code = s"${idxLocal.name}++",
@@ -343,7 +339,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
     }
   }
 
-  private def iteratorLocalForForEach(lineNumber: Option[Integer]): NewLocal = {
+  private def iteratorLocalForForEach(lineNumber: Option[Int]): NewLocal = {
     val iteratorLocalName = nextIterableName()
     NewLocal()
       .name(iteratorLocalName)
@@ -356,7 +352,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
     iterExpr: Expression,
     iteratorLocalNode: NewLocal,
     iterableType: Option[String],
-    lineNo: Option[Integer]
+    lineNo: Option[Int]
   ): Ast = {
     val iteratorAssignNode =
       newOperatorCallNode(Operators.assignment, code = "", typeFullName = Some(TypeConstants.Iterator), line = lineNo)
@@ -385,7 +381,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
       .withRefEdge(iteratorAssignIdentifier, iteratorLocalNode)
   }
 
-  private def hasNextCallAstForForEach(iteratorLocalNode: NewLocal, lineNo: Option[Integer]): Ast = {
+  private def hasNextCallAstForForEach(iteratorLocalNode: NewLocal, lineNo: Option[Int]): Ast = {
     val iteratorHasNextCallNode =
       newCallNode(
         "hasNext",

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -48,5 +48,5 @@ class JavaDataflowFixture(extraFlows: List[FlowSemantic] = List.empty) extends A
     (source, sink)
   }
 
-  protected def flowToResultPairs(path: Path): List[(String, Option[Integer])] = path.resultPairs()
+  protected def flowToResultPairs(path: Path): List[(String, Option[Int])] = path.resultPairs()
 }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
@@ -264,21 +264,21 @@ class AstCreator(
     }
   }
 
-  override def line(node: Host): Option[Integer] = {
+  override def line(node: Host): Option[Int] = {
     if (node == null) None
     else if (node.getJavaSourceStartLineNumber == -1) None
     else Option(node.getJavaSourceStartLineNumber)
   }
 
-  override def column(node: Host): Option[Integer] = {
+  override def column(node: Host): Option[Int] = {
     if (node == null) None
     else if (node.getJavaSourceStartColumnNumber == -1) None
     else Option(node.getJavaSourceStartColumnNumber)
   }
 
-  override def columnEnd(node: Host): Option[Integer] = None
+  override def columnEnd(node: Host): Option[Int] = None
 
-  override def lineEnd(node: Host): Option[Integer] = None
+  override def lineEnd(node: Host): Option[Int] = None
 
   override def code(node: Host): String = node.toString
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -253,11 +253,11 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
 
   private def astsForProgram(program: BabelNodeInfo): List[Ast] = createBlockStatementAsts(program.json("body"))
 
-  protected def line(node: BabelNodeInfo): Option[Integer]      = node.lineNumber
-  protected def column(node: BabelNodeInfo): Option[Integer]    = node.columnNumber
-  protected def lineEnd(node: BabelNodeInfo): Option[Integer]   = node.lineNumberEnd
-  protected def columnEnd(node: BabelNodeInfo): Option[Integer] = node.columnNumberEnd
-  protected def code(node: BabelNodeInfo): String               = node.code
+  protected def line(node: BabelNodeInfo): Option[Int]      = node.lineNumber
+  protected def column(node: BabelNodeInfo): Option[Int]    = node.columnNumber
+  protected def lineEnd(node: BabelNodeInfo): Option[Int]   = node.lineNumberEnd
+  protected def columnEnd(node: BabelNodeInfo): Option[Int] = node.columnNumberEnd
+  protected def code(node: BabelNodeInfo): String           = node.code
 
   protected def nodeOffsets(node: Value): Option[(Int, Int)] = {
     for {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -105,13 +105,13 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   protected def pos(node: Value): Option[Int] = Try(node("start").num.toInt).toOption
 
-  protected def line(node: Value): Option[Integer] = start(node).map(getLineOfSource)
+  protected def line(node: Value): Option[Int] = start(node).map(getLineOfSource)
 
-  protected def lineEnd(node: Value): Option[Integer] = end(node).map(getLineOfSource)
+  protected def lineEnd(node: Value): Option[Int] = end(node).map(getLineOfSource)
 
-  protected def column(node: Value): Option[Integer] = start(node).map(getColumnOfSource)
+  protected def column(node: Value): Option[Int] = start(node).map(getColumnOfSource)
 
-  protected def columnEnd(node: Value): Option[Integer] = end(node).map(getColumnOfSource)
+  protected def columnEnd(node: Value): Option[Int] = end(node).map(getColumnOfSource)
 
   // Returns the line number for a given position in the source.
   private def getLineOfSource(position: Int): Int = {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -43,8 +43,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   protected def createIndexAccessCallAst(
     baseNode: NewNode,
     partNode: NewNode,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode = createCallNode(
       s"${codeOf(baseNode)}[${codeOf(partNode)}]",
@@ -57,12 +57,7 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     callAst(callNode, arguments)
   }
 
-  protected def createIndexAccessCallAst(
-    baseAst: Ast,
-    partAst: Ast,
-    line: Option[Integer],
-    column: Option[Integer]
-  ): Ast = {
+  protected def createIndexAccessCallAst(baseAst: Ast, partAst: Ast, line: Option[Int], column: Option[Int]): Ast = {
     val callNode = createCallNode(
       s"${codeOf(baseAst.nodes.head)}[${codeOf(partAst.nodes.head)}]",
       Operators.indexAccess,
@@ -77,8 +72,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   protected def createFieldAccessCallAst(
     baseNode: NewNode,
     partNode: NewNode,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode = createCallNode(
       s"${codeOf(baseNode)}.${codeOf(partNode)}",
@@ -94,8 +89,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   protected def createFieldAccessCallAst(
     baseAst: Ast,
     partNode: NewNode,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode = createCallNode(
       s"${codeOf(baseAst.nodes.head)}.${codeOf(partNode)}",
@@ -112,8 +107,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     testAst: Ast,
     trueAst: Ast,
     falseAst: Ast,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val code      = s"${codeOf(testAst.nodes.head)} ? ${codeOf(trueAst.nodes.head)} : ${codeOf(falseAst.nodes.head)}"
     val callNode  = createCallNode(code, Operators.conditional, DispatchTypes.STATIC_DISPATCH, line, column)
@@ -132,8 +127,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     code: String,
     callName: String,
     dispatchType: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): NewCall = NewCall()
     .code(code)
     .name(callName)
@@ -145,14 +140,10 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     .columnNumber(column)
     .typeFullName(Defines.Any)
 
-  protected def createVoidCallNode(line: Option[Integer], column: Option[Integer]): NewCall =
+  protected def createVoidCallNode(line: Option[Int], column: Option[Int]): NewCall =
     createCallNode("void 0", "<operator>.void", DispatchTypes.STATIC_DISPATCH, line, column)
 
-  protected def createFieldIdentifierNode(
-    name: String,
-    line: Option[Integer],
-    column: Option[Integer]
-  ): NewFieldIdentifier = {
+  protected def createFieldIdentifierNode(name: String, line: Option[Int], column: Option[Int]): NewFieldIdentifier = {
     val cleanedName = stripQuotes(name)
     NewFieldIdentifier()
       .code(cleanedName)
@@ -169,7 +160,7 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     literalNode(node, code, typeFullName, dynamicTypeOption.toList)
   }
 
-  protected def createEqualsCallAst(dest: Ast, source: Ast, line: Option[Integer], column: Option[Integer]): Ast = {
+  protected def createEqualsCallAst(dest: Ast, source: Ast, line: Option[Int], column: Option[Int]): Ast = {
     val code      = s"${codeOf(dest.nodes.head)} === ${codeOf(source.nodes.head)}"
     val callNode  = createCallNode(code, Operators.equals, DispatchTypes.STATIC_DISPATCH, line, column)
     val arguments = List(dest, source)
@@ -180,8 +171,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     destId: NewNode,
     sourceId: NewNode,
     code: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode  = createCallNode(code, Operators.assignment, DispatchTypes.STATIC_DISPATCH, line, column)
     val arguments = List(Ast(destId), Ast(sourceId))
@@ -192,8 +183,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     dest: Ast,
     source: Ast,
     code: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode  = createCallNode(code, Operators.assignment, DispatchTypes.STATIC_DISPATCH, line, column)
     val arguments = List(dest, source)
@@ -218,8 +209,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     code: String,
     callName: String,
     fullName: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): NewCall = NewCall()
     .code(code)
     .name(callName)
@@ -233,8 +224,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   protected def createTemplateDomNode(
     name: String,
     code: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): NewTemplateDom =
     NewTemplateDom()
       .name(name)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelNodeInfo.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelNodeInfo.scala
@@ -7,8 +7,8 @@ case class BabelNodeInfo(
   node: BabelNode,
   json: Value,
   code: String,
-  lineNumber: Option[Integer],
-  columnNumber: Option[Integer],
-  lineNumberEnd: Option[Integer],
-  columnNumberEnd: Option[Integer]
+  lineNumber: Option[Int],
+  columnNumber: Option[Int],
+  lineNumberEnd: Option[Int],
+  columnNumberEnd: Option[Int]
 )

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -87,7 +87,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
   // TODO: use this everywhere in kotlin2cpg instead of manual .getText calls
   override def code(element: PsiElement): String = shortenCode(element.getText)
 
-  override def line(element: PsiElement): Option[Integer] = {
+  override def line(element: PsiElement): Option[Int] = {
     try {
       Some(
         element.getContainingFile.getViewProvider.getDocument
@@ -98,7 +98,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     }
   }
 
-  override def column(element: PsiElement): Option[Integer] = {
+  override def column(element: PsiElement): Option[Int] = {
     try {
       val lineNumber =
         element.getContainingFile.getViewProvider.getDocument
@@ -111,7 +111,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     }
   }
 
-  override def lineEnd(element: PsiElement): Option[Integer] = {
+  override def lineEnd(element: PsiElement): Option[Int] = {
     val lastElement = element match {
       case namedFn: KtNamedFunction =>
         Option(namedFn.getBodyBlockExpression)
@@ -122,7 +122,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
     line(lastElement)
   }
 
-  override def columnEnd(element: PsiElement): Option[Integer] = {
+  override def columnEnd(element: PsiElement): Option[Int] = {
     val lastElement = element match {
       case namedFn: KtNamedFunction =>
         Option(namedFn.getBodyBlockExpression)
@@ -134,7 +134,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, xTypeInfoProvider: TypeInfoProvid
   }
 
   protected def getName(node: NewImport): String = {
-    val isWildcard = node.isWildcard.getOrElse(false: java.lang.Boolean)
+    val isWildcard = node.isWildcard.getOrElse(false)
     if (isWildcard) Constants.wildcardImportName
     else node.importedEntity.getOrElse("")
   }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -66,5 +66,5 @@ class KotlinCode2CpgFixture(
     )
     with SemanticCpgTestFixture(extraFlows) {
 
-  protected def flowToResultPairs(path: Path): List[(String, Option[Integer])] = path.resultPairs()
+  protected def flowToResultPairs(path: Path): List[(String, Option[Int])] = path.resultPairs()
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -166,7 +166,7 @@ class AstCreator(filename: String, phpAst: PhpFile, fileContent: Option[String],
     Ast(thisNode)
   }
 
-  private def thisIdentifier(lineNumber: Option[Integer]): NewIdentifier = {
+  private def thisIdentifier(lineNumber: Option[Int]): NewIdentifier = {
     val typ = scope.getEnclosingTypeDeclTypeName
     newIdentifierNode(NameConstants.This, typ.getOrElse("ANY"), typ.toList, lineNumber)
       .code(s"$$${NameConstants.This}")
@@ -562,7 +562,7 @@ class AstCreator(filename: String, phpAst: PhpFile, fileContent: Option[String],
     wrapMultipleInBlock(imports, line(stmt))
   }
 
-  private def astForKeyValPair(key: PhpExpr, value: PhpExpr, lineNo: Option[Integer]): Ast = {
+  private def astForKeyValPair(key: PhpExpr, value: PhpExpr, lineNo: Option[Int]): Ast = {
     val keyAst   = astForExpr(key)
     val valueAst = astForExpr(value)
 
@@ -661,7 +661,7 @@ class AstCreator(filename: String, phpAst: PhpFile, fileContent: Option[String],
     simpleAssignAst(assignItemTargetAst, valueAst, line(stmt))
   }
 
-  private def simpleAssignAst(target: Ast, source: Ast, lineNo: Option[Integer]): Ast = {
+  private def simpleAssignAst(target: Ast, source: Ast, lineNo: Option[Int]): Ast = {
     val code     = s"${target.rootCodeOrEmpty} = ${source.rootCodeOrEmpty}"
     val callNode = newOperatorCallNode(Operators.assignment, code, line = lineNo)
     callAst(callNode, target :: source :: Nil)
@@ -1723,11 +1723,11 @@ class AstCreator(filename: String, phpAst: PhpFile, fileContent: Option[String],
     }
   }
 
-  protected def line(phpNode: PhpNode): Option[Integer]      = phpNode.attributes.lineNumber
-  protected def column(phpNode: PhpNode): Option[Integer]    = None
-  protected def lineEnd(phpNode: PhpNode): Option[Integer]   = None
-  protected def columnEnd(phpNode: PhpNode): Option[Integer] = None
-  protected def code(phpNode: PhpNode): String               = "" // Sadly, the Php AST does not carry any code fields
+  protected def line(phpNode: PhpNode): Option[Int]      = phpNode.attributes.lineNumber
+  protected def column(phpNode: PhpNode): Option[Int]    = None
+  protected def lineEnd(phpNode: PhpNode): Option[Int]   = None
+  protected def columnEnd(phpNode: PhpNode): Option[Int] = None
+  protected def code(phpNode: PhpNode): String           = "" // Sadly, the Php AST does not carry any code fields
 
   override protected def offset(phpNode: PhpNode): Option[(Int, Int)] = {
     Option.when(!disableFileContent) {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -82,14 +82,14 @@ object Domain {
   // Used for creating the default constructor.
   val ConstructorMethodName = "__construct"
 
-  final case class PhpAttributes(lineNumber: Option[Integer], kind: Option[Int], startFilePos: Int, endFilePos: Int)
+  final case class PhpAttributes(lineNumber: Option[Int], kind: Option[Int], startFilePos: Int, endFilePos: Int)
   object PhpAttributes {
     val Empty: PhpAttributes = PhpAttributes(None, None, -1, -1)
 
     def apply(json: Value): PhpAttributes = {
       Try(json("attributes")) match {
         case Success(Obj(attributes)) =>
-          val startLine    = attributes.get("startLine").map(num => Integer.valueOf(num.num.toInt))
+          val startLine    = attributes.get("startLine").map(_.num.toInt)
           val kind         = attributes.get("kind").map(_.num.toInt)
           val startFilePos = attributes.get("startFilePos").map(_.num.toInt).getOrElse(-1)
           val endFilePos   = attributes.get("endFilePos").map(_.num.toInt + 1).getOrElse(-1)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/LocalCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/LocalCreationPass.scala
@@ -28,11 +28,11 @@ object LocalCreationPass {
 abstract class LocalCreationPass[ScopeType <: AstNode](cpg: Cpg)
     extends ForkJoinParallelCpgPass[ScopeType](cpg)
     with AstNodeBuilder[AstNode, LocalCreationPass[ScopeType]] {
-  override protected def line(node: AstNode)                       = node.lineNumber
-  override protected def column(node: AstNode)                     = node.columnNumber
-  override protected def lineEnd(node: AstNode): Option[Integer]   = None
-  override protected def columnEnd(node: AstNode): Option[Integer] = None
-  override protected def code(node: AstNode): String               = node.code
+  override protected def line(node: AstNode)                   = node.lineNumber
+  override protected def column(node: AstNode)                 = node.columnNumber
+  override protected def lineEnd(node: AstNode): Option[Int]   = None
+  override protected def columnEnd(node: AstNode): Option[Int] = None
+  override protected def code(node: AstNode): String           = node.code
 
   protected def getIdentifiersInScope(node: AstNode): List[Identifier] = {
     node match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -20,11 +20,11 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def computeClassFullName(name: String): String  = s"${scope.surroundingScopeFullName.head}.$name"
   protected def computeMethodFullName(name: String): String = s"${scope.surroundingScopeFullName.head}:$name"
 
-  override def column(node: RubyNode): Option[Integer]    = node.column
-  override def columnEnd(node: RubyNode): Option[Integer] = node.columnEnd
-  override def line(node: RubyNode): Option[Integer]      = node.line
-  override def lineEnd(node: RubyNode): Option[Integer]   = node.lineEnd
-  override def code(node: RubyNode): String               = shortenCode(node.text)
+  override def column(node: RubyNode): Option[Int]    = node.column
+  override def columnEnd(node: RubyNode): Option[Int] = node.columnEnd
+  override def line(node: RubyNode): Option[Int]      = node.line
+  override def lineEnd(node: RubyNode): Option[Int]   = node.lineEnd
+  override def code(node: RubyNode): String           = shortenCode(node.text)
 
   protected def isBuiltin(x: String): Boolean            = kernelFunctions.contains(x)
   protected def prefixAsKernelDefined(x: String): String = s"$kernelPrefix$pathSep$x"
@@ -86,18 +86,13 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def astForAssignment(
     lhs: NewNode,
     rhs: NewNode,
-    lineNumber: Option[Integer],
-    columnNumber: Option[Integer]
+    lineNumber: Option[Int],
+    columnNumber: Option[Int]
   ): Ast = {
     astForAssignment(Ast(lhs), Ast(rhs), lineNumber, columnNumber)
   }
 
-  protected def astForAssignment(
-    lhs: Ast,
-    rhs: Ast,
-    lineNumber: Option[Integer],
-    columnNumber: Option[Integer]
-  ): Ast = {
+  protected def astForAssignment(lhs: Ast, rhs: Ast, lineNumber: Option[Int], columnNumber: Option[Int]): Ast = {
     val code = Seq(lhs, rhs).flatMap(_.root).collect { case x: ExpressionNew => x.code }.mkString(" = ")
     val assignment = NewCall()
       .name(Operators.assignment)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -8,23 +8,23 @@ import scala.annotation.tailrec
 object RubyIntermediateAst {
 
   case class TextSpan(
-    line: Option[Integer],
-    column: Option[Integer],
-    lineEnd: Option[Integer],
-    columnEnd: Option[Integer],
+    line: Option[Int],
+    column: Option[Int],
+    lineEnd: Option[Int],
+    columnEnd: Option[Int],
     text: String
   ) {
     def spanStart(newText: String = ""): TextSpan = TextSpan(line, column, line, column, newText)
   }
 
   sealed class RubyNode(val span: TextSpan) {
-    def line: Option[Integer] = span.line
+    def line: Option[Int] = span.line
 
-    def column: Option[Integer] = span.column
+    def column: Option[Int] = span.column
 
-    def lineEnd: Option[Integer] = span.lineEnd
+    def lineEnd: Option[Int] = span.lineEnd
 
-    def columnEnd: Option[Integer] = span.columnEnd
+    def columnEnd: Option[Int] = span.columnEnd
 
     def text: String = span.text
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/deprecated/astcreation/AstCreatorHelper.scala
@@ -2,7 +2,6 @@ package io.joern.rubysrc2cpg.deprecated.astcreation
 
 import io.joern.rubysrc2cpg.deprecated.parser.DeprecatedRubyParser.*
 import io.joern.rubysrc2cpg.deprecated.passes.Defines as RubyDefines
-import io.joern.rubysrc2cpg.deprecated.utils.MethodTableModel
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, nodes}
@@ -17,15 +16,17 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   import io.joern.rubysrc2cpg.deprecated.astcreation.GlobalTypes.*
 
-  protected def line(ctx: ParserRuleContext): Option[Integer] = Try[Integer](ctx.getStart.getLine).toOption
+  protected def line(ctx: ParserRuleContext): Option[Int] =
+    Try(ctx.getStart.getLine).toOption
 
-  protected def column(ctx: ParserRuleContext): Option[Integer] =
-    Try[Integer](ctx.getStart.getCharPositionInLine).toOption
+  protected def column(ctx: ParserRuleContext): Option[Int] =
+    Try(ctx.getStart.getCharPositionInLine).toOption
 
-  protected def lineEnd(ctx: ParserRuleContext): Option[Integer] = Try[Integer](ctx.getStop.getLine).toOption
+  protected def lineEnd(ctx: ParserRuleContext): Option[Int] =
+    Try(ctx.getStop.getLine).toOption
 
-  protected def columnEnd(ctx: ParserRuleContext): Option[Integer] =
-    Try[Integer](ctx.getStop.getCharPositionInLine).toOption
+  protected def columnEnd(ctx: ParserRuleContext): Option[Int] =
+    Try(ctx.getStop.getCharPositionInLine).toOption
 
   override def code(node: ParserRuleContext): String = shortenCode(text(node))
 
@@ -91,8 +92,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     code: String,
     typeFullName: String,
     dynamicTypeHints: Seq[String],
-    lineNumber: Option[Integer],
-    columnNumber: Option[Integer],
+    lineNumber: Option[Int],
+    columnNumber: Option[Int],
     definitelyIdentifier: Boolean
   ): NewNode = {
     methodsWithName(name) match
@@ -145,8 +146,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def astForAssignment(
     lhs: NewNode,
     rhs: NewNode,
-    lineNumber: Option[Integer] = None,
-    colNumber: Option[Integer] = None
+    lineNumber: Option[Int] = None,
+    colNumber: Option[Int] = None
   ): Ast = {
     val code = Seq(lhs, rhs).collect { case x: AstNodeNew => x.code }.mkString(" = ")
     val assignment = NewCall()
@@ -187,8 +188,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   protected def createMethodParameterIn(
     name: String,
-    lineNumber: Option[Integer] = None,
-    colNumber: Option[Integer] = None,
+    lineNumber: Option[Int] = None,
+    colNumber: Option[Int] = None,
     typeFullName: String = RubyDefines.Any,
     order: Int = -1,
     index: Int = -1

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -73,8 +73,8 @@ class RubyCode2CpgFixture(
 
   implicit val resolver: ICallResolver = NoResolve
 
-  protected def flowToResultPairs(path: Path): List[(String, Integer)] =
-    path.resultPairs().collect { case (firstElement: String, secondElement: Option[Integer]) =>
+  protected def flowToResultPairs(path: Path): List[(String, Int)] =
+    path.resultPairs().collect { case (firstElement, secondElement) =>
       (firstElement, secondElement.getOrElse(-1))
     }
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -121,10 +121,10 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
     case null                               => notHandledYet(node)
   }
 
-  override protected def line(node: SwiftNode): Option[Integer]      = node.startLine.map(Integer.valueOf)
-  override protected def column(node: SwiftNode): Option[Integer]    = node.startColumn.map(Integer.valueOf)
-  override protected def lineEnd(node: SwiftNode): Option[Integer]   = node.endLine.map(Integer.valueOf)
-  override protected def columnEnd(node: SwiftNode): Option[Integer] = node.endColumn.map(Integer.valueOf)
+  override protected def line(node: SwiftNode): Option[Int]      = node.startLine.map(Integer.valueOf)
+  override protected def column(node: SwiftNode): Option[Int]    = node.startColumn.map(Integer.valueOf)
+  override protected def lineEnd(node: SwiftNode): Option[Int]   = node.endLine.map(Integer.valueOf)
+  override protected def columnEnd(node: SwiftNode): Option[Int] = node.endColumn.map(Integer.valueOf)
 
   private val lineOffsetTable =
     OffsetUtils.getLineOffsetTable(Option(parserResult.fileContent))

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
@@ -92,8 +92,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   protected def createIndexAccessCallAst(
     baseNode: NewNode,
     partNode: NewNode,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode = createCallNode(
       s"${codeOf(baseNode)}[${codeOf(partNode)}]",
@@ -109,8 +109,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   protected def createIndexAccessCallAst(
     baseAst: Ast,
     partAst: Ast,
-    line: Option[Integer],
-    column: Option[Integer],
+    line: Option[Int],
+    column: Option[Int],
     additionalArgsAst: Seq[Ast] = Seq.empty
   ): Ast = {
     val callNode = createCallNode(
@@ -127,8 +127,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   protected def createFieldAccessCallAst(
     baseNode: NewNode,
     partNode: NewNode,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode = createCallNode(
       s"${codeOf(baseNode)}.${codeOf(partNode)}",
@@ -144,8 +144,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   protected def createFieldAccessCallAst(
     baseAst: Ast,
     partNode: NewNode,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode = createCallNode(
       s"${codeOf(baseAst.nodes.head)}.${codeOf(partNode)}",
@@ -169,8 +169,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     code: String,
     callName: String,
     dispatchType: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): NewCall = NewCall()
     .code(code)
     .name(callName)
@@ -182,11 +182,7 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     .columnNumber(column)
     .typeFullName(Defines.Any)
 
-  protected def createFieldIdentifierNode(
-    name: String,
-    line: Option[Integer],
-    column: Option[Integer]
-  ): NewFieldIdentifier = {
+  protected def createFieldIdentifierNode(name: String, line: Option[Int], column: Option[Int]): NewFieldIdentifier = {
     NewFieldIdentifier()
       .code(name)
       .canonicalName(name)
@@ -206,8 +202,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     destId: NewNode,
     sourceId: NewNode,
     code: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode  = createCallNode(code, Operators.assignment, DispatchTypes.STATIC_DISPATCH, line, column)
     val arguments = List(Ast(destId), Ast(sourceId))
@@ -218,8 +214,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     dest: Ast,
     source: Ast,
     code: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): Ast = {
     val callNode  = createCallNode(code, Operators.assignment, DispatchTypes.STATIC_DISPATCH, line, column)
     val arguments = List(dest, source)
@@ -251,8 +247,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     signature: Option[String],
     returnType: String,
     fileName: Option[String] = None,
-    lineNumber: Option[Integer] = None,
-    columnNumber: Option[Integer] = None
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None
   ): AstAndMethod = {
     val methodNode = NewMethod()
       .name(io.joern.x2cpg.Defines.StaticInitMethodName)
@@ -275,8 +271,8 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     code: String,
     callName: String,
     fullName: String,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): NewCall = NewCall()
     .code(code)
     .name(callName)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -97,8 +97,8 @@ abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: V
     signature: Option[String],
     returnType: String,
     fileName: Option[String] = None,
-    lineNumber: Option[Integer] = None,
-    columnNumber: Option[Integer] = None
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None
   ): Ast = {
     val methodNode = NewMethod()
       .name(Defines.StaticInitMethodName)
@@ -147,7 +147,7 @@ abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: V
     }
   }
 
-  def wrapMultipleInBlock(asts: Seq[Ast], lineNumber: Option[Integer]): Ast = {
+  def wrapMultipleInBlock(asts: Seq[Ast], lineNumber: Option[Int]): Ast = {
     asts.toList match {
       case Nil        => blockAst(NewBlock().lineNumber(lineNumber))
       case ast :: Nil => ast
@@ -159,8 +159,8 @@ abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: V
     condition: Option[Ast],
     body: Seq[Ast],
     code: Option[String] = None,
-    lineNumber: Option[Integer] = None,
-    columnNumber: Option[Integer] = None
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None
   ): Ast = {
     var whileNode = NewControlStructure()
       .controlStructureType(ControlStructureTypes.WHILE)
@@ -176,8 +176,8 @@ abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: V
     condition: Option[Ast],
     body: Seq[Ast],
     code: Option[String] = None,
-    lineNumber: Option[Integer] = None,
-    columnNumber: Option[Integer] = None
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None
   ): Ast = {
     var doWhileNode = NewControlStructure()
       .controlStructureType(ControlStructureTypes.DO)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -27,10 +27,10 @@ import org.apache.commons.lang3.StringUtils
 
 import scala.util.Try
 trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
-  protected def line(node: Node): Option[Integer]
-  protected def column(node: Node): Option[Integer]
-  protected def lineEnd(node: Node): Option[Integer]
-  protected def columnEnd(element: Node): Option[Integer]
+  protected def line(node: Node): Option[Int]
+  protected def column(node: Node): Option[Int]
+  protected def lineEnd(node: Node): Option[Int]
+  protected def columnEnd(element: Node): Option[Int]
 
   private val MinCodeLength: Int        = 50
   private val DefaultMaxCodeLength: Int = 1000

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenNodeBuilder.scala
@@ -10,12 +10,12 @@ trait AstGenNodeBuilder[NodeProcessor] extends AstNodeBuilder[BaseNodeInfo[?], N
 
   override def code(node: BaseNodeInfo[?]): String = Option(node).map(_.code).getOrElse(PropertyDefaults.Code)
 
-  override def line(node: BaseNodeInfo[?]): Option[Integer] = Option(node).flatMap(_.lineNumber)
+  override def line(node: BaseNodeInfo[?]): Option[Int] = Option(node).flatMap(_.lineNumber)
 
-  override def lineEnd(node: BaseNodeInfo[?]): Option[Integer] = Option(node).flatMap(_.lineNumberEnd)
+  override def lineEnd(node: BaseNodeInfo[?]): Option[Int] = Option(node).flatMap(_.lineNumberEnd)
 
-  override def column(node: BaseNodeInfo[?]): Option[Integer] = Option(node).flatMap(_.columnNumber)
+  override def column(node: BaseNodeInfo[?]): Option[Int] = Option(node).flatMap(_.columnNumber)
 
-  override def columnEnd(node: BaseNodeInfo[?]): Option[Integer] = Option(node).flatMap(_.columnNumberEnd)
+  override def columnEnd(node: BaseNodeInfo[?]): Option[Int] = Option(node).flatMap(_.columnNumberEnd)
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/package.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/package.scala
@@ -12,10 +12,10 @@ package object astgen {
     def node: T
     def json: Value
     def code: String
-    def lineNumber: Option[Integer]
-    def columnNumber: Option[Integer]
-    def lineNumberEnd: Option[Integer]
-    def columnNumberEnd: Option[Integer]
+    def lineNumber: Option[Int]
+    def columnNumber: Option[Int]
+    def lineNumberEnd: Option[Int]
+    def columnNumberEnd: Option[Int]
   }
 
   /** The basic components of the results from parsing the JSON AST.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -1143,8 +1143,8 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     baseName: Option[String],
     funcName: String,
     methodFullName: String,
-    lineNo: Option[Integer],
-    columnNo: Option[Integer]
+    lineNo: Option[Int],
+    columnNo: Option[Int]
   ): NewMethodRef =
     NewMethodRef()
       .code(s"${baseName.map(_ + pathSep).getOrElse("")}$funcName")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/LinkingUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/LinkingUtil.scala
@@ -79,7 +79,7 @@ trait LinkingUtil {
             }
           }
       } else {
-        srcNode.out(edgeType).property(Properties.FULL_NAME).nextOption() match {
+        srcNode.out(edgeType).property(Properties.FullName).nextOption() match {
           case Some(dstFullName) =>
             dstGraph.setNodeProperty(
               srcNode.asInstanceOf[StoredNode],
@@ -125,7 +125,7 @@ trait LinkingUtil {
           }
         }
       } else {
-        val dstFullNames = srcNode.out(edgeType).property(Properties.FULL_NAME).l
+        val dstFullNames = srcNode.out(edgeType).property(Properties.FullName).l
         dstGraph.setNodeProperty(srcNode, dstFullNameKey, dstFullNames.map(dereference.dereferenceTypeFullName))
         if (!loggedDeprecationWarning) {
           logger.info(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -70,8 +70,8 @@ object NodeBuilders {
     dispatchType: String,
     argumentTypes: Iterable[String] = Nil,
     code: String = PropertyDefaults.Code,
-    lineNumber: Option[Integer] = None,
-    columnNumber: Option[Integer] = None
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None
   ): NewCall = {
     val signature      = composeCallSignature(returnTypeFullName, argumentTypes)
     val methodFullName = composeMethodFullName(typeDeclFullName, methodName, signature)
@@ -92,11 +92,7 @@ object NodeBuilders {
       .dependencyGroupId(groupId)
       .version(version)
 
-  def newFieldIdentifierNode(
-    name: String,
-    line: Option[Integer] = None,
-    column: Option[Integer] = None
-  ): NewFieldIdentifier = {
+  def newFieldIdentifierNode(name: String, line: Option[Int] = None, column: Option[Int] = None): NewFieldIdentifier = {
     NewFieldIdentifier()
       .canonicalName(name)
       .code(name)
@@ -114,7 +110,7 @@ object NodeBuilders {
     name: String,
     typeFullName: String,
     dynamicTypeHints: Seq[String],
-    line: Option[Integer]
+    line: Option[Int]
   ): NewIdentifier = {
     NewIdentifier()
       .code(name)
@@ -128,8 +124,8 @@ object NodeBuilders {
     name: String,
     code: String,
     typeFullName: Option[String] = None,
-    line: Option[Integer] = None,
-    column: Option[Integer] = None
+    line: Option[Int] = None,
+    column: Option[Int] = None
   ): NewCall = {
     NewCall()
       .name(name)
@@ -147,8 +143,8 @@ object NodeBuilders {
     code: String = "this",
     typeFullName: String,
     dynamicTypeHintFullName: Seq[String] = Seq.empty,
-    line: Option[Integer] = None,
-    column: Option[Integer] = None,
+    line: Option[Int] = None,
+    column: Option[Int] = None,
     evaluationStrategy: String = EvaluationStrategies.BY_SHARING
   ): NewMethodParameterIn = {
     NewMethodParameterIn()
@@ -168,8 +164,8 @@ object NodeBuilders {
   def newMethodReturnNode(
     typeFullName: String,
     dynamicTypeHintFullName: Option[String] = None,
-    line: Option[Integer],
-    column: Option[Integer]
+    line: Option[Int],
+    column: Option[Int]
   ): NewMethodReturn =
     NewMethodReturn()
       .typeFullName(typeFullName)

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/passes/MethodDecoratorPassTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/passes/MethodDecoratorPassTests.scala
@@ -15,12 +15,12 @@ class MethodDecoratorPassTests extends AnyWordSpec with Matchers {
     val parameterIn = graph
       .+(
         NodeTypes.METHOD_PARAMETER_IN,
-        Properties.CODE                -> "p1",
-        Properties.ORDER               -> 1,
-        Properties.NAME                -> "p1",
-        Properties.EVALUATION_STRATEGY -> EvaluationStrategies.BY_REFERENCE,
-        Properties.TYPE_FULL_NAME      -> "some.Type",
-        Properties.LINE_NUMBER         -> 10
+        Properties.Code               -> "p1",
+        Properties.Order              -> 1,
+        Properties.Name               -> "p1",
+        Properties.EvaluationStrategy -> EvaluationStrategies.BY_REFERENCE,
+        Properties.TypeFullName       -> "some.Type",
+        Properties.LineNumber         -> 10
       )
       .asInstanceOf[MethodParameterIn]
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/passes/NamespaceCreatorTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/passes/NamespaceCreatorTests.scala
@@ -12,9 +12,9 @@ import overflowdb._
 class NamespaceCreatorTests extends AnyWordSpec with Matchers {
   "NamespaceCreateor test " in EmptyGraphFixture { graph =>
     val cpg    = new Cpg(graph)
-    val block1 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace1")
-    val block2 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace1")
-    val block3 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace2")
+    val block1 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.Name -> "namespace1")
+    val block2 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.Name -> "namespace1")
+    val block3 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.Name -> "namespace2")
 
     val namespaceCreator = new NamespaceCreator(new Cpg(graph))
     namespaceCreator.createAndApply()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -13,7 +13,7 @@ object Overlays {
         cpg.metaData.headOption match {
           case Some(metaData) =>
             val newValue = metaData.overlays :+ overlayName
-            diffGraph.setNodeProperty(metaData, Properties.OVERLAYS.name, newValue)
+            diffGraph.setNodeProperty(metaData, Properties.Overlays.name, newValue)
           case None =>
             System.err.println("Missing metaData block")
         }
@@ -27,7 +27,7 @@ object Overlays {
         cpg.metaData.headOption match {
           case Some(metaData) =>
             val newValue = metaData.overlays.dropRight(1)
-            diffGraph.setNodeProperty(metaData, Properties.OVERLAYS.name, newValue)
+            diffGraph.setNodeProperty(metaData, Properties.Overlays.name, newValue)
           case None =>
             System.err.println("Missing metaData block")
         }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -102,9 +102,9 @@ object CodeDumper {
     */
   def code(
     filename: String,
-    startLine: Integer,
-    endLine: Integer,
-    lineToHighlight: Option[Integer] = None,
+    startLine: Int,
+    endLine: Int,
+    lineToHighlight: Option[Int] = None,
     locationFullName: Option[String] = None
   ): String = {
     Try(IOUtils.readLinesInFile(Paths.get(filename))) match {
@@ -117,9 +117,9 @@ object CodeDumper {
 
   private def sliceCode(
     lines: Seq[String],
-    startLine: Integer,
-    endLine: Integer,
-    lineToHighlight: Option[Integer] = None,
+    startLine: Int,
+    endLine: Int,
+    lineToHighlight: Option[Int] = None,
     locationFullName: Option[String] = None
   ): String = {
     lines

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/AccessPathHandling.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/AccessPathHandling.scala
@@ -44,7 +44,7 @@ object AccessPathHandling {
             case node: Identifier => ConstantAccess(node.name)
             case other if other.propertyOption(PropertyNames.NAME).isPresent =>
               logger.warn(s"unexpected/deprecated node encountered: $other with properties: ${other.propertiesMap()}")
-              ConstantAccess(other.property(Properties.NAME))
+              ConstantAccess(other.property(Properties.Name))
           }
           .getOrElse(VariableAccess) :: tail
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -29,13 +29,7 @@ object LocationCreator {
     }
   }
 
-  def apply(
-    node: StoredNode,
-    symbol: String,
-    label: String,
-    lineNumber: Option[Integer],
-    method: Method
-  ): NewLocation = {
+  def apply(node: StoredNode, symbol: String, label: String, lineNumber: Option[Int], method: Method): NewLocation = {
 
     if (method == null) {
       NewLocation().node(node)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -59,7 +59,7 @@ class NodeTypeStarters(cpg: Cpg) extends TraversalSource(cpg.graph) {
   /** Shorthand for `cpg.comment.code(code)`
     */
   def comment(code: String): Traversal[Comment] =
-    comment.has(Properties.CODE -> code)
+    comment.has(Properties.Code -> code)
 
   /** Traverse to all config files
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -23,11 +23,11 @@ class ControlStructureTraversal(val traversal: Iterator[ControlStructure]) exten
 
   @Doc(info = "Sub tree taken when condition evaluates to true")
   def whenTrue: Iterator[AstNode] =
-    traversal.out.has(Properties.ORDER, secondChildIndex: Int).cast[AstNode]
+    traversal.out.has(Properties.Order, secondChildIndex: Int).cast[AstNode]
 
   @Doc(info = "Sub tree taken when condition evaluates to false")
   def whenFalse: Iterator[AstNode] =
-    traversal.out.has(Properties.ORDER, thirdChildIndex).cast[AstNode]
+    traversal.out.has(Properties.Order, thirdChildIndex).cast[AstNode]
 
   @Doc(info = "Only `Try` control structures")
   def isTry: Iterator[ControlStructure] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
@@ -41,6 +41,6 @@ class EvalTypeAccessors[A <: AstNode](val traversal: Iterator[A]) extends AnyVal
     }
 
   private def evalType(traversal: Iterator[A]): Iterator[String] =
-    traversal.flatMap(_._evalTypeOut).flatMap(_._refOut).property(Properties.FULL_NAME)
+    traversal.flatMap(_._evalTypeOut).flatMap(_._refOut).property(Properties.FullName)
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -321,8 +321,8 @@ class StepsTest extends AnyWordSpec with Matchers {
 //    def cfg: Iterator[CfgNode] = cpg.method.name("add")
 
     def ast: Iterator[AstNode] = cpg.method.name("foo").cast[AstNode]
-    ast.astParent.property(Properties.NAME).head shouldBe "AClass"
-    ast.head.astParent.property(Properties.NAME) shouldBe "AClass"
+    ast.astParent.property(Properties.Name).head shouldBe "AClass"
+    ast.head.astParent.property(Properties.Name) shouldBe "AClass"
 
     // methodForCallGraph
     method.call.size shouldBe 1
@@ -370,21 +370,21 @@ class StepsTest extends AnyWordSpec with Matchers {
 
     val (Seq(emptyCall), Seq(callWithProperties)) = cpg.call.l.partition(_.argumentName.isEmpty)
 
-    emptyCall.propertyOption(Properties.TYPE_FULL_NAME) shouldBe Optional.of("<empty>")
-    emptyCall.propertyOption(Properties.TYPE_FULL_NAME.name) shouldBe Optional.of("<empty>")
-    emptyCall.propertyOption(Properties.ARGUMENT_NAME) shouldBe Optional.empty
-    emptyCall.propertyOption(Properties.ARGUMENT_NAME.name) shouldBe Optional.empty
+    emptyCall.propertyOption(Properties.TypeFullName) shouldBe Optional.of("<empty>")
+    emptyCall.propertyOption(Properties.TypeFullName.name) shouldBe Optional.of("<empty>")
+    emptyCall.propertyOption(Properties.ArgumentName) shouldBe Optional.empty
+    emptyCall.propertyOption(Properties.ArgumentName.name) shouldBe Optional.empty
     // these ones are rather a historic accident it'd be better and more consistent to return `None` here -
     // we'll defer that change until after the flatgraph port though and just document it for now
-    emptyCall.propertyOption(Properties.DYNAMIC_TYPE_HINT_FULL_NAME) shouldBe Optional.of(Seq.empty)
-    emptyCall.propertyOption(Properties.DYNAMIC_TYPE_HINT_FULL_NAME.name) shouldBe Optional.of(Seq.empty)
+    emptyCall.propertyOption(Properties.DynamicTypeHintFullName) shouldBe Optional.of(Seq.empty)
+    emptyCall.propertyOption(Properties.DynamicTypeHintFullName.name) shouldBe Optional.of(Seq.empty)
 
-    callWithProperties.propertyOption(Properties.TYPE_FULL_NAME) shouldBe Optional.of("aa")
-    callWithProperties.propertyOption(Properties.TYPE_FULL_NAME.name) shouldBe Optional.of("aa")
-    callWithProperties.propertyOption(Properties.ARGUMENT_NAME) shouldBe Optional.of("bb")
-    callWithProperties.propertyOption(Properties.ARGUMENT_NAME.name) shouldBe Optional.of("bb")
-    callWithProperties.propertyOption(Properties.DYNAMIC_TYPE_HINT_FULL_NAME) shouldBe Optional.of(Seq("cc", "dd"))
-    callWithProperties.propertyOption(Properties.DYNAMIC_TYPE_HINT_FULL_NAME.name) shouldBe Optional.of(Seq("cc", "dd"))
+    callWithProperties.propertyOption(Properties.TypeFullName) shouldBe Optional.of("aa")
+    callWithProperties.propertyOption(Properties.TypeFullName.name) shouldBe Optional.of("aa")
+    callWithProperties.propertyOption(Properties.ArgumentName) shouldBe Optional.of("bb")
+    callWithProperties.propertyOption(Properties.ArgumentName.name) shouldBe Optional.of("bb")
+    callWithProperties.propertyOption(Properties.DynamicTypeHintFullName) shouldBe Optional.of(Seq("cc", "dd"))
+    callWithProperties.propertyOption(Properties.DynamicTypeHintFullName.name) shouldBe Optional.of(Seq("cc", "dd"))
   }
 
 }


### PR DESCRIPTION
motivation: minify diff for flatgraph migration (https://github.com/joernio/joern/pull/4630)

depends on https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1771 and https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/271