### PR TITLE
[ruby] Remove `<|>` Tags From Builtins & Handle `[]` Differently

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -28,7 +28,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   protected def isBuiltin(x: String): Boolean            = kernelFunctions.contains(x)
   protected def prefixAsKernelDefined(x: String): String = s"$kernelPrefix$pathSep$x"
-  protected def prefixAsBundledType(x: String): String   = s"<${GlobalTypes.builtinPrefix}.$x>"
+  protected def prefixAsBundledType(x: String): String   = s"${GlobalTypes.builtinPrefix}.$x"
   protected def isBundledClass(x: String): Boolean       = GlobalTypes.bundledClasses.contains(x)
   protected def pathSep                                  = "."
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -241,9 +241,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         scope
           .tryResolveMethodInvocation("[]", typeFullName = Option(typeReference))
           .map { m =>
-            val expr = astForExpression(MemberCall(node.target, "::", "[]", node.indices)(node.span))
+            val expr = astForExpression(MemberCall(node.target, ".", "[]", node.indices)(node.span))
             expr.root.collect { case x: NewCall =>
-              x.methodFullName(s"$typeReference:${m.name}")
+              x.methodFullName(s"$typeReference.${m.name}")
               scope.tryResolveTypeReference(m.returnType).map(_.name).foreach(x.typeFullName(_))
             }
             expr
@@ -759,8 +759,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val argumentAst = node.arguments.map(astForMethodCallArgument)
     val (dispatchType, methodFullName) =
-      if receiverType.startsWith(s"<${GlobalTypes.builtinPrefix}") then
-        (DispatchTypes.STATIC_DISPATCH, methodFullNameHint)
+      if receiverType.startsWith(GlobalTypes.builtinPrefix) then (DispatchTypes.STATIC_DISPATCH, methodFullNameHint)
       else (DispatchTypes.DYNAMIC_DISPATCH, XDefines.DynamicCallUnknownFullName)
 
     val call = callNode(node, code(node), methodName, methodFullName, dispatchType)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -247,7 +247,7 @@ object RubyIntermediateAst {
   /** Represents a type reference successfully determined, e.g. module A; end; A
     */
   final case class TypeIdentifier(typeFullName: String)(span: TextSpan) extends RubyNode(span) with RubyIdentifier {
-    def isBuiltin: Boolean        = typeFullName.startsWith(s"<${GlobalTypes.builtinPrefix}")
+    def isBuiltin: Boolean        = typeFullName.startsWith(GlobalTypes.builtinPrefix)
     override def toString: String = s"TypeIdentifier(${span.text}, $typeFullName)"
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.datastructures
 
 import better.files.File
 import io.joern.rubysrc2cpg.passes.GlobalTypes
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
 import io.joern.x2cpg.datastructures.*
@@ -30,13 +30,13 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
   typesInScope.addAll(
     Seq(
       RubyType(
-        s"$kernelPrefix.Array",
-        List(RubyMethod("[]", List.empty, s"$kernelPrefix.Array", Option(s"$kernelPrefix.Array"))),
+        s"$builtinPrefix.Array",
+        List(RubyMethod("[]", List.empty, s"$builtinPrefix.Array", Option(s"$builtinPrefix.Array"))),
         List.empty
       ),
       RubyType(
-        s"$kernelPrefix.Hash",
-        List(RubyMethod("[]", List.empty, s"$kernelPrefix.Hash", Option(s"$kernelPrefix.Hash"))),
+        s"$builtinPrefix.Hash",
+        List(RubyMethod("[]", List.empty, s"$builtinPrefix.Hash", Option(s"$builtinPrefix.Hash"))),
         List.empty
       )
     )

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -43,8 +43,8 @@ object Defines {
 
 object GlobalTypes {
   val Kernel        = "Kernel"
-  val builtinPrefix = "__builtin"
-  val kernelPrefix  = s"<$builtinPrefix.$Kernel>"
+  val builtinPrefix = "__core"
+  val kernelPrefix  = s"$builtinPrefix.$Kernel"
 
   /** Source: https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html
     */

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language.*
@@ -106,8 +106,8 @@ class ArrayTests extends RubyCode2CpgFixture {
     inside(cpg.call.nameExact("[]").l) {
       case bracketCall :: Nil =>
         bracketCall.name shouldBe "[]"
-        bracketCall.methodFullName shouldBe s"$kernelPrefix.Array:[]"
-        bracketCall.typeFullName shouldBe s"$kernelPrefix.Array"
+        bracketCall.methodFullName shouldBe s"$builtinPrefix.Array.[]"
+        bracketCall.typeFullName shouldBe s"$builtinPrefix.Array"
 
         inside(bracketCall.argument.l) {
           case _ :: one :: two :: three :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -71,7 +71,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     val List(atan2) = cpg.call.name("atan2").l
     atan2.lineNumber shouldBe Some(3)
     atan2.code shouldBe "Math.atan2(1, 1)"
-    atan2.methodFullName shouldBe s"<${GlobalTypes.builtinPrefix}.Math>:atan2"
+    atan2.methodFullName shouldBe s"${GlobalTypes.builtinPrefix}.Math:atan2"
     atan2.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
     val List(mathRec: Call) = atan2.receiver.l: @unchecked
@@ -79,7 +79,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     mathRec.typeFullName shouldBe Defines.Any
     mathRec.code shouldBe s"Math.atan2"
 
-    mathRec.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"<${GlobalTypes.builtinPrefix}.Math>"
+    mathRec.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"${GlobalTypes.builtinPrefix}.Math"
     mathRec.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "atan2"
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -1,9 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.joern.x2cpg.Defines
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
-import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -260,7 +258,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
               tmpAssign.code shouldBe "<tmp-0> = Array.new(x) { |i| i += 1 }"
 
               newCall.name shouldBe "new"
-              newCall.methodFullName shouldBe s"$kernelPrefix.Array:initialize"
+              newCall.methodFullName shouldBe s"$builtinPrefix.Array:initialize"
 
               inside(newCall.argument.l) {
                 case (_: Identifier) :: (x: Identifier) :: (closure: MethodRef) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -1,9 +1,9 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, TypeRef}
 import io.shiftleft.semanticcpg.language.*
 
@@ -195,8 +195,8 @@ class HashTests extends RubyCode2CpgFixture {
       case hashCall :: Nil =>
         hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
         hashCall.lineNumber shouldBe Some(2)
-        hashCall.methodFullName shouldBe s"$kernelPrefix.Hash:[]"
-        hashCall.typeFullName shouldBe s"$kernelPrefix.Hash"
+        hashCall.methodFullName shouldBe s"$builtinPrefix.Hash.[]"
+        hashCall.typeFullName shouldBe s"$builtinPrefix.Hash"
 
         inside(hashCall.astChildren.l) {
           case (_: Call) :: (_: TypeRef) :: (one: Call) :: (two: Call) :: (three: Call) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -20,4 +20,22 @@ class ModuleTests extends RubyCode2CpgFixture {
     m.member.name.l shouldBe List(Defines.TypeDeclBody)
     m.method.name.l shouldBe List(Defines.TypeDeclBody)
   }
+
+  "nested modules are represented by nested TYPE_DECL nodes" in {
+    val cpg = code("""
+        |module M1
+        | module M2
+        | end
+        |end
+        |""".stripMargin)
+
+    val List(m) = cpg.typeDecl.name("M1").l
+
+    m.fullName shouldBe "Test0.rb:<global>::program.M1"
+    m.lineNumber shouldBe Some(2)
+    m.baseType.l shouldBe List()
+    m.member.name.l shouldBe List(Defines.TypeDeclBody)
+    m.method.name.l shouldBe List(Defines.TypeDeclBody)
+  }
+
 }


### PR DESCRIPTION
* Builtins are renamed from `__builtin` -> `__core` to more closely resemble the core gem in Ruby
* Removed surrounding `<` and `>` tags from builtin packages
* Handling `Array:[]` type calls as `Array.[]` calls