### PR TITLE
changes to use includePackages option to process only used packages

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 gosrc2cpg {
-    goastgen_version: "0.15.0"
+    goastgen_version: "0.17.0"
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/model/GoMod.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/model/GoMod.scala
@@ -131,6 +131,7 @@ case class GoModDependency(
   usedPackages: util.Set[String] = new ConcurrentSkipListSet[String]()
 ) {
   def getIncludePackageRegex(): String = usedPackages.toArray.mkString("(", "|", ")")
+  def getIncludePackagesList(): String = usedPackages.toArray.mkString(",")
   def dependencyStr(): String          = s"$module@$version"
 }
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DownloadDependenciesPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DownloadDependenciesPass.scala
@@ -82,7 +82,7 @@ class DownloadDependenciesPass(cpg: Cpg, parentGoMod: GoModHelper, goGlobal: GoG
           .withInputPath(dependencyLocation)
           .withIgnoredFilesRegex(config.ignoredFilesRegex.toString())
           .withIgnoredFiles(config.ignoredFiles.toList)
-        val astGenResult = new AstGenRunner(depConfig, dependency.getIncludePackageRegex())
+        val astGenResult = new AstGenRunner(depConfig, dependency.getIncludePackagesList())
           .execute(astLocation)
           .asInstanceOf[GoAstGenRunnerResult]
         val goMod = new GoModHelper(

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
@@ -72,7 +72,7 @@ class AstGenRunner(config: Config, includeFileRegex: String = "") extends AstGen
     metaData: AstGenProgramMetaData
   ): Try[Seq[String]] = {
     val excludeCommand = if (exclude.isEmpty) "" else s"-exclude \"$exclude\""
-    val includeCommand = if (include.isEmpty) "" else s"-include \"$include\""
+    val includeCommand = if (include.isEmpty) "" else s"-include-packages \"$include\""
     ExternalCommand.run(s"$astGenCommand $excludeCommand $includeCommand -out ${out.toString()} $in", ".")
   }
 


### PR DESCRIPTION
Earlier changes to include packages with include regex, didn't filter all the packages and had a limitation to include all sub folders/packages if root package is being used. However, that wasn't the case. Hence, we introduced a mechanism to check the entire package folder path with `goastgen` with a separate flag `-includePacakges` and updated integration. 