### PR TITLE
[ruby] Arrow Lambda Parameter Fix

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -59,6 +59,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val thisParameterAst = Ast(
       newThisParameterNode(
+        name = Defines.Self,
         code = Defines.Self,
         typeFullName = scope.surroundingTypeFullName.getOrElse(Defines.Any),
         line = method.lineNumber,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.parser
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{Block, *}
 import io.joern.rubysrc2cpg.parser.AntlrContextHelpers.*
 import io.joern.rubysrc2cpg.parser.RubyParser.{CommandWithDoBlockContext, ConstantVariableReferenceContext}
 import io.joern.rubysrc2cpg.passes.Defines
@@ -610,8 +610,9 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): RubyNode = {
-    val parameters = Option(ctx.parameterList()).fold(List())(_.parameters).map(visit)
-    val body       = visit(ctx.block())
+    val Block(blockParams, body) = visit(ctx.block()).asInstanceOf[Block]
+    val parameters =
+      (Option(ctx.parameterList()).fold(List())(_.parameters).map(visit) ++ blockParams).sortBy(x => (x.line, x.column))
     ProcOrLambdaExpr(Block(parameters, body)(ctx.toTextSpan))(ctx.toTextSpan)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -317,4 +317,56 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
   }
 
+  "A lambda with arrow syntax" should {
+
+    val cpg = code("""
+        |arrow_lambda = -> { |y| y }
+        |""".stripMargin)
+
+    "create a lambda method with a `y` parameter" in {
+      inside(cpg.method.isLambda.headOption) {
+        case Some(lambda) =>
+          lambda.code shouldBe "-> { |y| y }"
+          lambda.parameter.name.l shouldBe List("self", "y")
+        case xs => fail(s"Expected a lambda method")
+      }
+    }
+
+    "create a method ref assigned to `arrow_lambda`" in {
+      inside(cpg.method.isModule.assignment.code("arrow_lambda.*").headOption) {
+        case Some(lambdaAssign) =>
+          lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "arrow_lambda"
+          lambdaAssign.source.asInstanceOf[MethodRef].methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+        case xs => fail(s"Expected an assignment to a lambda")
+      }
+    }
+
+  }
+
+  "A lambda with lambda keyword syntax" should {
+
+    val cpg = code("""
+        |a_lambda = lambda { |y| y }
+        |""".stripMargin)
+
+    "create a lambda method with a `y` parameter" in {
+      inside(cpg.method.isLambda.headOption) {
+        case Some(lambda) =>
+          lambda.code shouldBe "{ |y| y }"
+          lambda.parameter.name.l shouldBe List("self", "y")
+        case xs => fail(s"Expected a lambda method")
+      }
+    }
+
+    "create a method ref assigned to `arrow_lambda`" in {
+      inside(cpg.method.isModule.assignment.code("a_lambda.*").headOption) {
+        case Some(lambdaAssign) =>
+          lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "a_lambda"
+          lambdaAssign.source.asInstanceOf[MethodRef].methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+        case xs => fail(s"Expected an assignment to a lambda")
+      }
+    }
+
+  }
+
 }


### PR DESCRIPTION
Arrow lambda parameters are part of the lambda body, so this adds a fix to lift those into the method creation visitor.