### PR TITLE
[jssrc2cpg] Update astgen to v3.16.0

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.15.0"
+    astgen_version: "3.16.0"
 }


### PR DESCRIPTION
This astgen version skips giant unparsable js files with EMSCRIPTEN code now by default.
(we did the same in js2cpg)

For: https://shiftleftinc.atlassian.net/browse/SEN-2797