### PR TITLE
[c2cpg] Safe .getOverload.getType access / safer AstCreator.createAst

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -14,11 +14,15 @@ import io.joern.x2cpg.utils.TimeUtils
 
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
+import org.slf4j.{Logger, LoggerFactory}
 import scala.util.matching.Regex
+import scala.util.{Failure, Success, Try}
 import scala.jdk.CollectionConverters.*
 
 class AstCreationPass(cpg: Cpg, config: Config, report: Report = new Report())
     extends ForkJoinParallelCpgPass[String](cpg) {
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
   private val file2OffsetTable: ConcurrentHashMap[String, Array[Int]] = new ConcurrentHashMap()
   private val parser: CdtParser                                       = new CdtParser(config)
@@ -61,11 +65,17 @@ class AstCreationPass(cpg: Cpg, config: Config, report: Report = new Report())
       parseResult match {
         case Some(translationUnit) =>
           report.addReportInfo(relPath, fileLOC, parsed = true)
-          val localDiff = new AstCreator(relPath, global, config, translationUnit, file2OffsetTable)(
-            config.schemaValidation
-          ).createAst()
-          diffGraph.absorb(localDiff)
-          true
+          Try {
+            val localDiff = new AstCreator(relPath, global, config, translationUnit, file2OffsetTable)(
+              config.schemaValidation
+            ).createAst()
+            diffGraph.absorb(localDiff)
+          } match {
+            case Failure(exception) =>
+              logger.warn(s"Failed to generate a CPG for: '$filename'", exception)
+              false
+            case Success(_) => true
+          }
         case None =>
           report.addReportInfo(relPath, fileLOC)
           false


### PR DESCRIPTION
May crash with a NullPointerException.

Also: safer AstCreator.createAst so we do not crash c2cpg completely if createAst throws. (same as all other frontends now)

For: https://shiftleftinc.atlassian.net/browse/SEN-2777