### PR TITLE
[ruby] Make `<body>` Call Static Dispatch

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -195,7 +195,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         }
         .getOrElse(XDefines.Any -> XDefines.DynamicCallUnknownFullName)
       val argumentAsts = n.arguments.map(astForMethodCallArgument)
-      val dispatchType = DispatchTypes.DYNAMIC_DISPATCH
+      val dispatchType =
+        if (n.methodName == Defines.TypeDeclBody) DispatchTypes.STATIC_DISPATCH else DispatchTypes.DYNAMIC_DISPATCH
 
       val call = callNode(n, code(n), n.methodName, XDefines.DynamicCallUnknownFullName, dispatchType)
       if methodFullName != XDefines.DynamicCallUnknownFullName then call.possibleTypes(Seq(methodFullName))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -141,12 +141,20 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         .withChildren(fieldSingletonMemberNodes.map(_._2))
     val bodyMemberCallAst =
       node.bodyMemberCall match {
-        case Some(bodyMemberCall) => astForMemberCall(bodyMemberCall)
+        case Some(bodyMemberCall) => astForTypeDeclBodyCall(bodyMemberCall, classFullName)
         case None                 => Ast()
       }
 
     (typeDeclAst :: singletonTypeDeclAst :: Nil).foreach(Ast.storeInDiffGraph(_, diffGraph))
     prefixAst :: bodyMemberCallAst :: Nil
+  }
+
+  private def astForTypeDeclBodyCall(node: TypeDeclBodyCall, typeFullName: String): Ast = {
+    val callAst = astForMemberCall(node.toMemberCall)
+    callAst.nodes.collectFirst {
+      case c: NewCall if c.name == Defines.TypeDeclBody => c.methodFullName(s"$typeFullName:${Defines.TypeDeclBody}")
+    }
+    callAst
   }
 
   private def createTypeRefPointer(typeDecl: NewTypeDecl): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -52,14 +52,14 @@ object RubyIntermediateAst {
     def name: RubyNode
     def baseClass: Option[RubyNode]
     def body: RubyNode
-    def bodyMemberCall: Option[MemberCall]
+    def bodyMemberCall: Option[TypeDeclBodyCall]
   }
 
   final case class ModuleDeclaration(
     name: RubyNode,
     body: RubyNode,
     fields: List[RubyNode & RubyFieldIdentifier],
-    bodyMemberCall: Option[MemberCall]
+    bodyMemberCall: Option[TypeDeclBodyCall]
   )(span: TextSpan)
       extends RubyNode(span)
       with TypeDeclaration {
@@ -71,7 +71,7 @@ object RubyIntermediateAst {
     baseClass: Option[RubyNode],
     body: RubyNode,
     fields: List[RubyNode & RubyFieldIdentifier],
-    bodyMemberCall: Option[MemberCall]
+    bodyMemberCall: Option[TypeDeclBodyCall]
   )(span: TextSpan)
       extends RubyNode(span)
       with TypeDeclaration
@@ -82,7 +82,7 @@ object RubyIntermediateAst {
     name: RubyNode,
     baseClass: Option[RubyNode],
     body: RubyNode,
-    bodyMemberCall: Option[MemberCall] = None
+    bodyMemberCall: Option[TypeDeclBodyCall] = None
   )(span: TextSpan)
       extends RubyNode(span)
       with AnonymousTypeDeclaration
@@ -91,7 +91,7 @@ object RubyIntermediateAst {
     name: RubyNode,
     baseClass: Option[RubyNode],
     body: RubyNode,
-    bodyMemberCall: Option[MemberCall] = None
+    bodyMemberCall: Option[TypeDeclBodyCall] = None
   )(span: TextSpan)
       extends RubyNode(span)
       with AnonymousTypeDeclaration
@@ -367,6 +367,19 @@ object RubyIntermediateAst {
     span: TextSpan
   ) extends RubyNode(span)
       with RubyCall
+
+  /** Special class for `<body>` calls of type decls.
+    */
+  final case class TypeDeclBodyCall(target: RubyNode, typeName: String)(span: TextSpan)
+      extends RubyNode(span)
+      with RubyCall {
+
+    def toMemberCall: MemberCall = MemberCall(target, op, Defines.TypeDeclBody, arguments)(span)
+
+    def arguments: List[RubyNode] = Nil
+
+    def op: String = "::"
+  }
 
   final case class MemberCallWithBlock(
     target: RubyNode,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1058,15 +1058,13 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     )(ctx.toTextSpan)
   }
 
-  private def createBodyMemberCall(name: String, textSpan: TextSpan): MemberCall = {
-    MemberCall(
+  private def createBodyMemberCall(name: String, textSpan: TextSpan): TypeDeclBodyCall = {
+    TypeDeclBodyCall(
       MemberAccess(SelfIdentifier()(textSpan.spanStart(Defines.Self)), "::", name)(
         textSpan.spanStart(s"${Defines.Self}::$name")
       ),
-      "::",
-      Defines.TypeDeclBody,
-      List.empty
-    )(textSpan.spanStart(s"${Defines.Self}::$name::<body>"))
+      name
+    )(textSpan.spanStart(s"${Defines.Self}::$name::${Defines.TypeDeclBody}"))
   }
 
   /** Lowers all MethodDeclaration found in SingletonClassDeclaration to SingletonMethodDeclaration.

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.{GlobalTypes, Defines as RubyDefines}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -576,6 +576,15 @@ class ClassTests extends RubyCode2CpgFixture {
             case xs => fail(s"Expected one method for init, instead got ${xs.name.mkString(", ")}")
           }
         case xs => fail(s"Expected TypeDecl for Foo, instead got ${xs.name.mkString(", ")}")
+      }
+    }
+
+    "call the body method" in {
+      inside(cpg.call.nameExact(RubyDefines.TypeDeclBody).headOption) {
+        case Some(bodyCall) =>
+          bodyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+          bodyCall.methodFullName shouldBe s"Test0.rb:<global>::program.Foo:${RubyDefines.TypeDeclBody}"
+        case None => fail("Expected <body> call")
       }
     }
   }


### PR DESCRIPTION
As the `<body>` call is synthetic and meant to be immediately deterministic, so there is no reason it should be re-determined.