### PR TITLE
[ruby] Singleton methods on objects

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -360,6 +360,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
                     astForExpression(node.lhs)
                   case _ => astForExpression(node.lhs)
                 }
+
                 val rhsAst = astForExpression(node.rhs)
 
                 // If this is a simple object instantiation assignment, we can give the LHS variable a type hint

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -360,7 +360,11 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
                     astForExpression(node.lhs)
                   case _ => astForExpression(node.lhs)
                 }
-                val rhsAst = astForExpression(node.rhs)
+
+                val rhsAst = node.rhs match {
+                  case x: MethodDeclaration => astForMethodDeclaration(x, isClosure = true)(1) // (1) is methodRef
+                  case x                    => astForExpression(x)
+                }
 
                 // If this is a simple object instantiation assignment, we can give the LHS variable a type hint
                 if (node.rhs.isInstanceOf[ObjectInstantiation] && lhsAst.root.exists(_.isInstanceOf[NewIdentifier])) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -360,7 +360,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
                     astForExpression(node.lhs)
                   case _ => astForExpression(node.lhs)
                 }
-
                 val rhsAst = astForExpression(node.rhs)
 
                 // If this is a simple object instantiation assignment, we can give the LHS variable a type hint

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -361,10 +361,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
                   case _ => astForExpression(node.lhs)
                 }
 
-                val rhsAst = node.rhs match {
-                  case x: MethodDeclaration => astForMethodDeclaration(x, isClosure = true)(1) // (1) is methodRef
-                  case x                    => astForExpression(x)
-                }
+                val rhsAst = astForExpression(node.rhs)
 
                 // If this is a simple object instantiation assignment, we can give the LHS variable a type hint
                 if (node.rhs.isInstanceOf[ObjectInstantiation] && lhsAst.root.exists(_.isInstanceOf[NewIdentifier])) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -29,6 +29,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node)
     case node: MultipleAssignment         => node.assignments.map(astForExpression)
     case node: BreakStatement             => astForBreakStatement(node) :: Nil
+    case node: SingletonStatementList     => astForSingletonStatementList(node)
     case _                                => astForExpression(node) :: Nil
 
   private def astForWhileStatement(node: WhileExpression): Ast = {
@@ -322,6 +323,10 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       .columnNumber(column(node))
       .code(code(node))
     Ast(_node)
+  }
+
+  protected def astForSingletonStatementList(list: SingletonStatementList): Seq[Ast] = {
+    list.statements.map(astForExpression)
   }
 
   /** Wraps the last RubyNode with a ReturnExpression.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -56,7 +56,6 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     val className     = nameIdentifier.text
     val inheritsFrom  = node.baseClass.flatMap(getBaseClassName).toList
     val classFullName = computeClassFullName(className)
-
     val typeDecl = typeDeclNode(
       node = node,
       name = className,
@@ -81,9 +80,6 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       .fullName(s"$classFullName<class>")
       .inheritsFromTypeFullName(inheritsFrom.map(x => s"$x<class>"))
 
-    val classBody =
-      node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
-
     val (classModifiers, singletonModifiers) = node match {
       case _: ModuleDeclaration =>
         scope.pushNewScope(ModuleScope(classFullName))
@@ -98,6 +94,9 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
           ModifierTypes.VIRTUAL :: Nil map newModifierNode map Ast.apply
         )
     }
+
+    val classBody =
+      node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
 
     def handleDefaultConstructor(bodyAsts: Seq[Ast]): Seq[Ast] = bodyAsts match {
       case bodyAsts if scope.shouldGenerateDefaultConstructor && this.parseLevel == AstParseLevel.FULL_AST =>
@@ -153,7 +152,6 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
     (typeDeclAst :: singletonTypeDeclAst :: Nil).foreach(Ast.storeInDiffGraph(_, diffGraph))
     prefixAst :: bodyMemberCallAst :: Nil
-
   }
 
   private def createTypeRefPointer(typeDecl: NewTypeDecl): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -57,135 +57,102 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     val inheritsFrom  = node.baseClass.flatMap(getBaseClassName).toList
     val classFullName = computeClassFullName(className)
 
+    val typeDecl = typeDeclNode(
+      node = node,
+      name = className,
+      fullName = classFullName,
+      filename = relativeFileName,
+      code = code(node),
+      inherits = inheritsFrom,
+      alias = None
+    )
+    scope.surroundingAstLabel.foreach(typeDecl.astParentType(_))
+    scope.surroundingScopeFullName.foreach(typeDecl.astParentFullName(_))
+    /*
+      In Ruby, there are semantic differences between the ordinary class and singleton class (think "meta" class in
+      Python). Similar to how Java allows both static and dynamic methods/fields/etc. within the same type declaration,
+      Ruby allows `self` methods and @@ fields to be defined alongside ordinary methods and @ fields. However, both
+      classes are more dynamic and have separate behaviours in Ruby and we model it as such.
+
+      To signify the singleton type, we add the <class> tag.
+     */
+    val singletonTypeDecl = typeDecl.copy
+      .name(s"$className<class>")
+      .fullName(s"$classFullName<class>")
+      .inheritsFromTypeFullName(inheritsFrom.map(x => s"$x<class>"))
+
     val classBody =
       node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
 
-    node match {
-      case x: SingletonClassDeclaration if x.name.span.text.startsWith("<anon") =>
-        val inheritsFromObj = scope.lookupVariable(node.baseClass.flatMap(getBaseClassName).getOrElse("")).map {
-          case x: NewLocal => x
-        }
-
-        classBody.statements.foreach {
-          case x: MethodDeclaration =>
-            val memberAccessNode = MemberAccess(
-              SimpleIdentifier()(x.span.spanStart(inheritsFrom.head)),
-              ".",
-              x.methodName
-            )(x.span.spanStart(s"${inheritsFrom.head}.${x.methodName}"))
-            val singleAssignmentNode = SingleAssignment(memberAccessNode, "=", x)(
-              x.span.spanStart(s"${inheritsFrom.head}.${x.methodName} = ${x.span.text}")
-            )
-
-            val lhsAst = astForExpression(memberAccessNode)
-            val rhsAst = astForMethodDeclaration(x, isClosure = true)
-
-            val op   = Operators.assignment
-            val call = callNode(singleAssignmentNode, code(singleAssignmentNode), op, op, DispatchTypes.STATIC_DISPATCH)
-            val callAsts = callAst(call, Seq(lhsAst, rhsAst(1)))
-
-            Ast.storeInDiffGraph(callAsts, diffGraph)
-            callAsts :: Nil
-          case x => // do something
-        }
-
-        Ast() :: Nil
-
-      case _ =>
-        val typeDecl = typeDeclNode(
-          node = node,
-          name = className,
-          fullName = classFullName,
-          filename = relativeFileName,
-          code = code(node),
-          inherits = inheritsFrom,
-          alias = None
+    val (classModifiers, singletonModifiers) = node match {
+      case _: ModuleDeclaration =>
+        scope.pushNewScope(ModuleScope(classFullName))
+        (
+          ModifierTypes.VIRTUAL :: Nil map newModifierNode map Ast.apply,
+          ModifierTypes.VIRTUAL :: ModifierTypes.FINAL :: Nil map newModifierNode map Ast.apply
         )
-        scope.surroundingAstLabel.foreach(typeDecl.astParentType(_))
-        scope.surroundingScopeFullName.foreach(typeDecl.astParentFullName(_))
-        /*
-          In Ruby, there are semantic differences between the ordinary class and singleton class (think "meta" class in
-          Python). Similar to how Java allows both static and dynamic methods/fields/etc. within the same type declaration,
-          Ruby allows `self` methods and @@ fields to be defined alongside ordinary methods and @ fields. However, both
-          classes are more dynamic and have separate behaviours in Ruby and we model it as such.
-
-          To signify the singleton type, we add the <class> tag.
-         */
-        val singletonTypeDecl = typeDecl.copy
-          .name(s"$className<class>")
-          .fullName(s"$classFullName<class>")
-          .inheritsFromTypeFullName(inheritsFrom.map(x => s"$x<class>"))
-
-        val (classModifiers, singletonModifiers) = node match {
-          case _: ModuleDeclaration =>
-            scope.pushNewScope(ModuleScope(classFullName))
-            (
-              ModifierTypes.VIRTUAL :: Nil map newModifierNode map Ast.apply,
-              ModifierTypes.VIRTUAL :: ModifierTypes.FINAL :: Nil map newModifierNode map Ast.apply
-            )
-          case _: TypeDeclaration =>
-            scope.pushNewScope(TypeScope(classFullName, List.empty))
-            (
-              ModifierTypes.VIRTUAL :: Nil map newModifierNode map Ast.apply,
-              ModifierTypes.VIRTUAL :: Nil map newModifierNode map Ast.apply
-            )
-        }
-
-        def handleDefaultConstructor(bodyAsts: Seq[Ast]): Seq[Ast] = bodyAsts match {
-          case bodyAsts if scope.shouldGenerateDefaultConstructor && this.parseLevel == AstParseLevel.FULL_AST =>
-            val bodyStart  = classBody.span.spanStart()
-            val initBody   = StatementList(List())(bodyStart)
-            val methodDecl = astForMethodDeclaration(MethodDeclaration(Defines.Initialize, List(), initBody)(bodyStart))
-            methodDecl ++ bodyAsts
-          case bodyAsts => bodyAsts
-        }
-
-        val classBodyAsts = handleDefaultConstructor(classBody.statements.flatMap(astsForStatement))
-
-        val fields = node match {
-          case classDecl: ClassDeclaration   => classDecl.fields
-          case moduleDecl: ModuleDeclaration => moduleDecl.fields
-          case _                             => Seq.empty
-        }
-        val (fieldTypeMemberNodes, fieldSingletonMemberNodes) = fields
-          .map { x =>
-            val name = code(x)
-            x.isInstanceOf[InstanceFieldIdentifier] -> Ast(memberNode(x, name, name, Defines.Any))
-          }
-          .partition(_._1)
-
-        scope.popScope()
-
-        if scope.surroundingAstLabel.contains(NodeTypes.TYPE_DECL) then {
-          val typeDeclMember = NewMember()
-            .name(className)
-            .code(className)
-            .dynamicTypeHintFullName(Seq(s"$classFullName<class>"))
-          scope.surroundingScopeFullName.map(x => s"$x<class>").foreach { tfn =>
-            typeDeclMember.astParentFullName(tfn)
-            typeDeclMember.astParentType(NodeTypes.TYPE_DECL)
-          }
-          diffGraph.addNode(typeDeclMember)
-        }
-
-        val prefixAst = createTypeRefPointer(typeDecl)
-        val typeDeclAst = Ast(typeDecl)
-          .withChildren(classModifiers)
-          .withChildren(fieldTypeMemberNodes.map(_._2))
-          .withChildren(classBodyAsts)
-        val singletonTypeDeclAst =
-          Ast(singletonTypeDecl)
-            .withChildren(singletonModifiers)
-            .withChildren(fieldSingletonMemberNodes.map(_._2))
-        val bodyMemberCallAst =
-          node.bodyMemberCall match {
-            case Some(bodyMemberCall) => astForMemberCall(bodyMemberCall)
-            case None                 => Ast()
-          }
-
-        (typeDeclAst :: singletonTypeDeclAst :: Nil).foreach(Ast.storeInDiffGraph(_, diffGraph))
-        prefixAst :: bodyMemberCallAst :: Nil
+      case _: TypeDeclaration =>
+        scope.pushNewScope(TypeScope(classFullName, List.empty))
+        (
+          ModifierTypes.VIRTUAL :: Nil map newModifierNode map Ast.apply,
+          ModifierTypes.VIRTUAL :: Nil map newModifierNode map Ast.apply
+        )
     }
+
+    def handleDefaultConstructor(bodyAsts: Seq[Ast]): Seq[Ast] = bodyAsts match {
+      case bodyAsts if scope.shouldGenerateDefaultConstructor && this.parseLevel == AstParseLevel.FULL_AST =>
+        val bodyStart  = classBody.span.spanStart()
+        val initBody   = StatementList(List())(bodyStart)
+        val methodDecl = astForMethodDeclaration(MethodDeclaration(Defines.Initialize, List(), initBody)(bodyStart))
+        methodDecl ++ bodyAsts
+      case bodyAsts => bodyAsts
+    }
+
+    val classBodyAsts = handleDefaultConstructor(classBody.statements.flatMap(astsForStatement))
+
+    val fields = node match {
+      case classDecl: ClassDeclaration   => classDecl.fields
+      case moduleDecl: ModuleDeclaration => moduleDecl.fields
+      case _                             => Seq.empty
+    }
+    val (fieldTypeMemberNodes, fieldSingletonMemberNodes) = fields
+      .map { x =>
+        val name = code(x)
+        x.isInstanceOf[InstanceFieldIdentifier] -> Ast(memberNode(x, name, name, Defines.Any))
+      }
+      .partition(_._1)
+
+    scope.popScope()
+
+    if scope.surroundingAstLabel.contains(NodeTypes.TYPE_DECL) then {
+      val typeDeclMember = NewMember()
+        .name(className)
+        .code(className)
+        .dynamicTypeHintFullName(Seq(s"$classFullName<class>"))
+      scope.surroundingScopeFullName.map(x => s"$x<class>").foreach { tfn =>
+        typeDeclMember.astParentFullName(tfn)
+        typeDeclMember.astParentType(NodeTypes.TYPE_DECL)
+      }
+      diffGraph.addNode(typeDeclMember)
+    }
+
+    val prefixAst = createTypeRefPointer(typeDecl)
+    val typeDeclAst = Ast(typeDecl)
+      .withChildren(classModifiers)
+      .withChildren(fieldTypeMemberNodes.map(_._2))
+      .withChildren(classBodyAsts)
+    val singletonTypeDeclAst =
+      Ast(singletonTypeDecl)
+        .withChildren(singletonModifiers)
+        .withChildren(fieldSingletonMemberNodes.map(_._2))
+    val bodyMemberCallAst =
+      node.bodyMemberCall match {
+        case Some(bodyMemberCall) => astForMemberCall(bodyMemberCall)
+        case None                 => Ast()
+      }
+
+    (typeDeclAst :: singletonTypeDeclAst :: Nil).foreach(Ast.storeInDiffGraph(_, diffGraph))
+    prefixAst :: bodyMemberCallAst :: Nil
 
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -46,6 +46,14 @@ object RubyIntermediateAst {
     def size: Int = statements.size
   }
 
+  final case class SingletonStatementList(statements: List[RubyNode])(span: TextSpan) extends RubyNode(span) {
+    override def text: String = statements.size match
+      case 0 | 1 => span.text
+      case _     => "(...)"
+
+    def size: Int = statements.size
+  }
+
   sealed trait AllowedTypeDeclarationChild
 
   sealed trait TypeDeclaration extends AllowedTypeDeclarationChild {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -866,7 +866,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
               case x => x
             }
 
-            StatementList(stmts)(ctx.toTextSpan)
+            SingletonStatementList(stmts)(ctx.toTextSpan)
         }
       case None =>
         SingletonClassDeclaration(freshClassName(ctx.toTextSpan), baseClass, body)(ctx.toTextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -852,8 +852,9 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
         val stmts = body.statements.map {
           case x: MethodDeclaration =>
             val memberAccess =
-              MemberAccess(baseClass, ".", x.methodName)(x.span.spanStart(s"$baseClass.${x.methodName}"))
-            SingleAssignment(memberAccess, "=", x)(
+              MemberAccess(baseClass, ".", x.methodName)(x.span.spanStart(s"${baseClass.span.text}.${x.methodName}"))
+            val proc = ProcOrLambdaExpr(Block(x.parameters, x.body)(x.span))(x.span)
+            SingleAssignment(memberAccess, "=", proc)(
               ctx.toTextSpan.spanStart(s"${memberAccess.span.text} = ${x.span.text}")
             )
           case x => x

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -385,6 +385,16 @@ class ClassTests extends RubyCode2CpgFixture {
                   rhs.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
                 case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
               }
+
+              inside(legsAssignment.argument.l) {
+                case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
+                  val List(identifier, fieldIdentifier) = lhs.argument.l
+                  identifier.code shouldBe "animal"
+                  fieldIdentifier.code shouldBe "legs"
+
+                  rhs.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>1"
+                case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
+              }
             case xs => fail(s"Expected two assignments, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected one block for main program, got [${xs.code.mkString(",")}]")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -368,6 +368,13 @@ class ClassTests extends RubyCode2CpgFixture {
         |animal.bark # => 'Woof'
         |""".stripMargin)
 
+    "yeet" in {
+      cpg.call.name(Operators.assignment).dotAst.l.foreach(println)
+//      inside(cpg.call.name(Operators.assignment).l) {
+//        case
+//      }
+    }
+
     "generate a type decl with the associated members" in {
       inside(cpg.typeDecl.nameExact("<anon-class-0>").l) {
         case anonClass :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -355,7 +355,7 @@ class ClassTests extends RubyCode2CpgFixture {
   }
 
   // TODO: This should be remodelled as a property access `animal.bark = METHOD_REF`
-  "a basic singleton class" ignore {
+  "a basic singleton class" should {
     val cpg = code("""class Animal; end
         |animal = Animal.new
         |

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -354,7 +354,6 @@ class ClassTests extends RubyCode2CpgFixture {
 
   }
 
-  // TODO: This should be remodelled as a property access `animal.bark = METHOD_REF`
   "a basic singleton class" should {
     val cpg = code("""class Animal; end
         |animal = Animal.new
@@ -363,42 +362,46 @@ class ClassTests extends RubyCode2CpgFixture {
         |  def bark
         |    'Woof'
         |  end
+        |
+        |  def legs
+        |     4
+        |  end
         |end
         |
         |animal.bark # => 'Woof'
         |""".stripMargin)
 
-    "yeet" in {
-      cpg.call.name(Operators.assignment).dotAst.l.foreach(println)
-//      inside(cpg.call.name(Operators.assignment).l) {
-//        case
-//      }
-    }
+    "Create assignments to method refs for methods on singleton object" in {
+      inside(cpg.method.name(":program").astChildren.isBlock.astChildren.isBlock.l) {
+        case singletonMethodsBlock :: Nil =>
+          inside(singletonMethodsBlock.astChildren.isCall.name(Operators.assignment).l) {
+            case barkAssignment :: legsAssignment :: Nil =>
+              inside(barkAssignment.argument.l) {
+                case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
+                  val List(identifier, fieldIdentifier) = lhs.argument.l
+                  identifier.code shouldBe "animal"
+                  fieldIdentifier.code shouldBe "bark"
 
-    "generate a type decl with the associated members" in {
-      inside(cpg.typeDecl.nameExact("<anon-class-0>").l) {
-        case anonClass :: Nil =>
-          anonClass.name shouldBe "<anon-class-0>"
-          anonClass.fullName shouldBe "Test0.rb:<global>::program.<anon-class-0>"
-          // TODO: Attempt to resolve the below with the `scope` class once we're handling constructors
-          anonClass.inheritsFromTypeFullName shouldBe Seq("animal")
-          inside(anonClass.method.l) {
-            case defaultConstructor :: bark :: Nil =>
-              defaultConstructor.name shouldBe Defines.ConstructorMethodName
-              defaultConstructor.fullName shouldBe s"Test0.rb:<global>::program.<anon-class-0>:${Defines.ConstructorMethodName}"
-
-              bark.name shouldBe "bark"
-              bark.fullName shouldBe "Test0.rb:<global>::program.<anon-class-0>:bark"
-            case xs => fail(s"Expected a single method, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
+                  rhs.methodFullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+                case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
+              }
+            case xs => fail(s"Expected two assignments, got [${xs.code.mkString(",")}]")
           }
-        case xs => fail(s"Expected a single anonymous class, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
+        case xs => fail(s"Expected one block for main program, got [${xs.code.mkString(",")}]")
       }
     }
 
-    "register that `animal` may possibly be an instantiation of the singleton type" in {
-      cpg.local("animal").possibleTypes.l should contain("Test0.rb:<global>::program.<anon-class-0>")
-    }
+    "Create lambda methods for methods on singleton object" in {
+      inside(cpg.method.name("<lambda>\\d+").l) {
+        case barkLambda :: legsLambda :: Nil =>
+          val List(barkLambdaParam) = barkLambda.method.parameter.l
+          val List(legsLambdaParam) = legsLambda.method.parameter.l
 
+          barkLambdaParam.code shouldBe RubyDefines.Self
+          legsLambdaParam.code shouldBe RubyDefines.Self
+        case xs => fail(s"Expected two lambdas, got [${xs.code.mkString(",")}]")
+      }
+    }
   }
 
   "if: <val> as function param" should {


### PR DESCRIPTION
This PR changes the modelling of Singleton methods on objects. Ex:
```ruby
class Animal; end
animal = Animal.new

class << animal
  def bark
    "woof"
  end
end
```
Creates a lambda method for `animal.bark`, and assigns `animal.bark = methodRef(bark)`

Resolves #4721 