### PR TITLE
[TypeRecovery] Handle Member without AST Parent Safely

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -554,7 +554,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     isFieldCache.getOrElseUpdate(i, isFieldUncached(i))
 
   protected def isFieldUncached(i: Identifier): Boolean =
-    i.method.typeDecl.member.nameExact(i.name).nonEmpty
+    Try(i.method.typeDecl.member.nameExact(i.name).nonEmpty).getOrElse(false)
 
   /** Associates the types with the identifier. This may sometimes be an identifier that should be considered a field
     * which this method uses [[isField]] to determine.
@@ -568,7 +568,9 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
     val fieldName = getFieldName(fa).split(Pattern.quote(pathSep)).last
     Try(cpg.member.nameExact(fieldName).typeDecl.fullName.filterNot(_.contains("ANY")).toSet) match
       case Failure(exception) =>
-        logger.warn("Unable to obtain name of member's parent type declaration", exception)
+        logger.warn(
+          s"Unable to obtain name of member's parent type declaration: ${cpg.member.nameExact(fieldName).propertiesMap.mkString(",")}"
+        )
         Set.empty
       case Success(typeDeclNames) => typeDeclNames
   }


### PR DESCRIPTION
For new frontends with potentially malformed ASTs, type recovery must safely handle instances where members don't have AST parents.

Allows for a CPG to result from the analysis. See #4732

Following up with a fix for this missing AST edge.

cc @spingARbor