### PR TITLE
[ruby] Handle `super` Calls

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -840,4 +840,25 @@ class ClassTests extends RubyCode2CpgFixture {
       }
     }
   }
+
+  "A call to super" should {
+    val cpg = code("""
+        |class A
+        |  def foo(a)
+        |  end
+        |end
+        |class B < A
+        |  def foo(a)
+        |    super(a)
+        |  end
+        |end
+        |""".stripMargin)
+
+    "create a simple call" in {
+      val superCall = cpg.call.nameExact("super").head
+      superCall.code shouldBe "super(a)"
+      superCall.name shouldBe "super"
+      superCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -339,7 +339,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
     }
   }
 
-  "implicit RETURN node for ASSOCIATION" in {
+  "implicit RETURN node for super call" in {
     val cpg = code("""
                      |def j
                      |  super(only: ["a"])
@@ -350,11 +350,11 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
       case jMethod :: Nil =>
         inside(jMethod.methodReturn.toReturn.l) {
           case retAssoc :: Nil =>
-            retAssoc.code shouldBe "only: [\"a\"]"
+            retAssoc.code shouldBe "super(only: [\"a\"])"
 
             val List(call: Call) = retAssoc.astChildren.l: @unchecked
-            call.name shouldBe RubyOperators.association
-            call.code shouldBe "only: [\"a\"]"
+            call.name shouldBe "super"
+            call.code shouldBe "super(only: [\"a\"])"
           case xs => fail(s"Expected exactly one return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case _ => fail("Only one method expected")


### PR DESCRIPTION
The parser emits calls to `super` as different from simple calls, this PR handles them.