### PR TITLE
[ruby] `super` Argument `null` & Association Key Handling

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -819,7 +819,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
           x.argumentIndex_=(-1)
         }
         value
-      case _: StaticLiteral => astForExpression(assoc)
+      case _: (LiteralExpr | RubyCall) => astForExpression(assoc)
       case x =>
         logger.warn(s"Not explicitly handled argument association key of type ${x.getClass.getSimpleName}")
         astForExpression(assoc)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -281,8 +281,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         )
       case node: MemberAccess    => astForReturnMemberCall(node) :: Nil
       case ret: ReturnExpression => astForReturnStatement(ret) :: Nil
-      case node: MethodDeclaration =>
-        (astForMethodDeclaration(node) :+ astForReturnMethodDeclarationSymbolName(node)).toList
+      case node: (MethodDeclaration | SingletonMethodDeclaration) =>
+        (astsForStatement(node) :+ astForReturnMethodDeclarationSymbolName(node)).toList
       case _: BreakStatement => astsForStatement(node).toList
       case node =>
         logger.warn(
@@ -302,7 +302,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
   // The evaluation of a MethodDeclaration returns its name in symbol form.
   // E.g. `def f = 0` ===> `:f`
-  private def astForReturnMethodDeclarationSymbolName(node: MethodDeclaration): Ast = {
+  private def astForReturnMethodDeclarationSymbolName(node: RubyNode & ProcedureDeclaration): Ast = {
     val literalNode_ = literalNode(node, s":${node.methodName}", getBuiltInType(Defines.Symbol))
     val returnNode_  = returnNode(node, literalNode_.code)
     returnAst(returnNode_, Seq(Ast(literalNode_)))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -112,8 +112,15 @@ object RubyIntermediateAst {
     def hasSetter: Boolean = text.startsWith("attr_writer") || text.startsWith("attr_accessor")
   }
 
+  sealed trait ProcedureDeclaration {
+    def methodName: String
+    def parameters: List[RubyNode]
+    def body: RubyNode
+  }
+
   final case class MethodDeclaration(methodName: String, parameters: List[RubyNode], body: RubyNode)(span: TextSpan)
       extends RubyNode(span)
+      with ProcedureDeclaration
       with AllowedTypeDeclarationChild
 
   final case class SingletonMethodDeclaration(
@@ -123,6 +130,7 @@ object RubyIntermediateAst {
     body: RubyNode
   )(span: TextSpan)
       extends RubyNode(span)
+      with ProcedureDeclaration
       with AllowedTypeDeclarationChild
 
   sealed trait MethodParameter {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -26,6 +26,17 @@ object AntlrContextHelpers {
         text = ctx.getStart.getInputStream.getText(new Interval(startIndex, stopIndex))
       )
     }
+
+    /** @return
+      *   true if this token's text is the same as a keyword, false if otherwise.
+      */
+    def isKeyword: Boolean = {
+      // See RubyParser for why the bounds are used
+      val minBound = 19
+      val maxBound = 56
+      val typ      = ctx.start.getType
+      typ >= minBound && typ <= maxBound
+    }
   }
 
   sealed implicit class CompoundStatementContextHelper(ctx: CompoundStatementContext) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -577,13 +577,13 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
 
   override def visitSuperWithParentheses(ctx: RubyParser.SuperWithParenthesesContext): RubyNode = {
     val block     = Option(ctx.block()).map(visit)
-    val arguments = ctx.argumentWithParentheses().arguments.map(visit)
+    val arguments = Option(ctx.argumentWithParentheses()).map(_.arguments.map(visit)).getOrElse(Nil)
     visitSuperCall(ctx, arguments, block)
   }
 
   override def visitSuperWithoutParentheses(ctx: RubyParser.SuperWithoutParenthesesContext): RubyNode = {
     val block     = Option(ctx.block()).map(visit)
-    val arguments = ctx.argumentList().elements.map(visit)
+    val arguments = Option(ctx.argumentList()).map(_.elements.map(visit)).getOrElse(Nil)
     visitSuperCall(ctx, arguments, block)
   }
 
@@ -1261,10 +1261,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitAssociationKey(ctx: RubyParser.AssociationKeyContext): RubyNode = {
-    if (Option(ctx.operatorExpression()).isDefined) {
-      visit(ctx.operatorExpression())
-    } else {
-      SimpleIdentifier()(ctx.toTextSpan)
+    Option(ctx.operatorExpression()) match {
+      case Some(ctx) if ctx.isKeyword => SimpleIdentifier()(ctx.toTextSpan)
+      case Some(ctx)                  => visit(ctx)
+      case None                       => SimpleIdentifier()(ctx.toTextSpan)
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -260,6 +260,15 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     inArg.argumentName shouldBe Option("in")
   }
 
+  "named parameters in parenthesis-less call with a known keyword as the association key should shadow the keyword" in {
+    val cpg = code("""
+        |foo retry: 3
+        |""".stripMargin)
+    val List(_, retry) = cpg.call.nameExact("foo").argument.l: @unchecked
+    retry.code shouldBe "3"
+    retry.argumentName shouldBe Some("retry")
+  }
+
   "a call with a quoted regex literal should have a literal receiver" in {
     val cpg          = code("%r{^/}.freeze")
     val regexLiteral = cpg.call.nameExact("freeze").receiver.fieldAccess.argument(1).head.asInstanceOf[Literal]


### PR DESCRIPTION
* Safely handles the case when `super` call has a `null` argument from the parser
* Shadows keywords when they are used as keys in association keys for named arguments in calls
* Handles singleton methods in implicit returns