### PR TITLE
[ruby] Bind nested method members to method type

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -55,6 +55,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: SelfIdentifier           => astForSelfIdentifier(node)
     case node: BreakStatement           => astForBreakStatement(node)
     case node: StatementList            => astForStatementList(node)
+    case node: ReturnExpression         => astForReturnStatement(node)
     case node: DummyNode                => Ast(node.node)
     case node: Unknown                  => astForUnknown(node)
     case x =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -127,7 +127,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           case Some(astParentTfn) => memberForMethod(method, Option(NodeTypes.TYPE_DECL), Option(astParentTfn))
           case None               => memberForMethod(method, scope.surroundingAstLabel, scope.surroundingScopeFullName)
         }
-        Ast(memberForMethod(method, scope.surroundingAstLabel, scope.surroundingScopeFullName))
+        Ast(memberForMethod(method, Option(NodeTypes.TYPE_DECL), scope.surroundingScopeFullName))
       }
     // For closures, we also want the method/type refs for upstream use
     val methodAst_ = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -161,6 +161,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     ReturnExpression(expressions)(ctx.toTextSpan)
   }
 
+  override def visitReturnWithoutArguments(ctx: RubyParser.ReturnWithoutArgumentsContext): RubyNode = {
+    ReturnExpression(Nil)(ctx.toTextSpan)
+  }
+
   override def visitNumericLiteral(ctx: RubyParser.NumericLiteralContext): RubyNode = {
     if (ctx.hasSign) {
       UnaryExpression(ctx.sign.getText, visit(ctx.unsignedNumericLiteral()))(ctx.toTextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -439,4 +439,21 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
     }
   }
 
+  "a return in an expression position without arguments should generate a return node with no children" in {
+    val cpg = code("""
+        |def foo
+        | return unless baz()
+        | bar()
+        |end
+        |""".stripMargin)
+
+    inside(cpg.method.nameExact("foo").ast.isReturn.headOption) {
+      case Some(ret) =>
+        ret.code shouldBe "return"
+        ret.astChildren.size shouldBe 0
+        ret.astParent.astParent.code shouldBe "return unless baz()"
+      case None => fail(s"Expected at least one return node")
+    }
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -7,6 +7,8 @@ import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 
+import scala.util.{Failure, Success, Try}
+
 class MethodTests extends RubyCode2CpgFixture {
 
   "`def f(x) = 1`" should {
@@ -716,5 +718,18 @@ class MethodTests extends RubyCode2CpgFixture {
         }
       case xs => fail(s"Expected one call to foo, got [${xs.code.mkString(",")}]")
     }
+  }
+
+  "a nested method declaration inside of a do-block should connect the member node to the bound type decl" in {
+    val cpg = code("""
+        |foo do
+        | def bar
+        | end
+        |end
+        |""".stripMargin)
+
+    val parentType = cpg.member("bar").typeDecl.head
+    parentType.isLambda should not be empty
+    parentType.methodBinding.methodFullName.head should endWith("<lambda>0")
   }
 }


### PR DESCRIPTION
This PR fixes a bug where method members were not correctly linked to surrounding methods' bound type decls. Additionally, this handles `return` statements without any proceeding expression.

Resolves #4732