### PR TITLE
[ruby] Fixed Persistence Issue of Captured Variable Info

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -169,10 +169,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     capturedLocalNodes
       .collect {
         case local: NewLocal =>
-          val closureBindingId = scope.surroundingScopeFullName.map(x => s"$x:${local.name}")
+          val closureBindingId = scope.variableScopeFullName(local.name).map(x => s"$x:${local.name}")
           (local, local.name, local.code, closureBindingId)
         case param: NewMethodParameterIn =>
-          val closureBindingId = scope.surroundingScopeFullName.map(x => s"$x:${param.name}")
+          val closureBindingId = scope.variableScopeFullName(param.name).map(x => s"$x:${param.name}")
           (param, param.name, param.code, closureBindingId)
       }
       .collect { case (capturedLocal, name, code, Some(closureBindingId)) =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -5,7 +5,7 @@ import io.joern.rubysrc2cpg.passes.GlobalTypes
 import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
-import io.joern.x2cpg.datastructures.*
+import io.joern.x2cpg.datastructures.{TypedScopeElement, *}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{DeclarationNew, NewLocal, NewMethodParameterIn}
 
@@ -337,6 +337,24 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
             None
           case x => x
         }
+      }
+  }
+
+  /** @param identifier
+    *   the name of the variable.
+    * @return
+    *   the full name of the variable's scope, if available.
+    */
+  def variableScopeFullName(identifier: String): Option[String] = {
+    stack
+      .collectFirst {
+        case scopeElement if scopeElement.variables.contains(identifier) =>
+          scopeElement
+      }
+      .map {
+        case ScopeElement(x: NamespaceLikeScope, _) => x.fullName
+        case ScopeElement(x: TypeLikeScope, _)      => x.fullName
+        case ScopeElement(x: MethodLikeScope, _)    => x.fullName
       }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -207,14 +207,16 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     // Basic assertions for expected behaviour
-    "create the declarations for the closure" in {
-      inside(cpg.method("<lambda>.*").l) {
+    "create the declarations for the closure with captured local" in {
+      inside(cpg.method.isLambda.l) {
         case m :: Nil =>
           m.name should startWith("<lambda>")
+          val myValue = m.local.nameExact("myValue").head
+          myValue.closureBindingId shouldBe Option("Test0.rb:<global>::program:myValue")
         case xs => fail(s"Expected exactly one closure method decl, instead got [${xs.code.mkString(",")}]")
       }
 
-      inside(cpg.typeDecl("<lambda>.*").l) {
+      inside(cpg.typeDecl.isLambda.l) {
         case m :: Nil =>
           m.name should startWith("<lambda>")
         case xs => fail(s"Expected exactly one closure type decl, instead got [${xs.code.mkString(",")}]")
@@ -224,7 +226,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
     "annotate the nodes via CAPTURE bindings" in {
       cpg.all.collectAll[ClosureBinding].l match {
         case myValue :: Nil =>
-          myValue.closureOriginalName.head shouldBe "myValue"
+          myValue.closureOriginalName shouldBe Option("myValue")
           inside(myValue._localViaRefOut) {
             case Some(local) =>
               local.name shouldBe "myValue"


### PR DESCRIPTION
The initial implementation of the edge creation and captured local node was wrongly added to the `Ast` object instead of the diff graph. This PR rectifies this.