### PR TITLE
[c2cpg] More fullname fixes

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -280,17 +280,20 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def dereferenceTypeFullName(fullName: String): String =
     fullName.replace("*", "")
 
-  protected def fixQualifiedName(name: String): String =
-    name.stripPrefix(Defines.QualifiedNameSeparator).replace(Defines.QualifiedNameSeparator, ".")
+norm  protected def fixQualifiedName(name: String): String = {
+    val normalizedName = StringUtils.normalizeSpace(name)
+    normalizedName.stripPrefix(Defines.QualifiedNameSeparator).replace(Defines.QualifiedNameSeparator, ".")
+  }
 
   protected def isQualifiedName(name: String): Boolean =
     name.startsWith(Defines.QualifiedNameSeparator)
 
   protected def lastNameOfQualifiedName(name: String): String = {
-    val cleanedName = if (name.contains("<") && name.contains(">")) {
-      name.substring(0, name.indexOf("<"))
+    val normalizedName = StringUtils.normalizeSpace(name)
+    val cleanedName = if (normalizedName.contains("<") && normalizedName.contains(">")) {
+      name.substring(0, normalizedName.indexOf("<"))
     } else {
-      name
+      normalizedName
     }
     cleanedName.split(Defines.QualifiedNameSeparator).lastOption.getOrElse(cleanedName)
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -280,7 +280,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def dereferenceTypeFullName(fullName: String): String =
     fullName.replace("*", "")
 
-norm  protected def fixQualifiedName(name: String): String = {
+  protected def fixQualifiedName(name: String): String = {
     val normalizedName = StringUtils.normalizeSpace(name)
     normalizedName.stripPrefix(Defines.QualifiedNameSeparator).replace(Defines.QualifiedNameSeparator, ".")
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -296,9 +296,9 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   }
 
   protected def functionTypeToSignature(typ: IFunctionType): String = {
-    val returnType     = safeGetType(typ.getReturnType)
-    val parameterTypes = typ.getParameterTypes.map(safeGetType)
-    s"$returnType(${parameterTypes.mkString(",")})"
+    val returnType     = cleanType(safeGetType(typ.getReturnType))
+    val parameterTypes = typ.getParameterTypes.map(t => cleanType(safeGetType(t)))
+    StringUtils.normalizeSpace(s"$returnType(${parameterTypes.mkString(",")})")
   }
 
   protected def fullName(node: IASTNode): String = {
@@ -320,7 +320,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
               if (field.isExternC) {
                 field.getName
               } else {
-                s"$fullNameNoSig:${safeGetType(field.getType)}"
+                s"$fullNameNoSig:${cleanType(safeGetType(field.getType))}"
               }
             return fn
           case _: IProblemBinding =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -250,7 +250,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         )
         createCallAst(callCpgNode, args)
       case other =>
-        // This could either be a pointer or an operator() call we dont know at this point
+        // This could either be a pointer or an operator() call we do not know at this point
         // but since it is CPP we opt for the later.
         val args = call.getArguments.toList.map(a => astForNode(a))
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -219,7 +219,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         val instanceAst = astForExpression(fieldRefExpr.getFieldOwner)
         val args        = call.getArguments.toList.map(a => astForNode(a))
 
-        val name      = fieldRefExpr.getFieldName.toString
+        val name      = StringUtils.normalizeSpace(fieldRefExpr.getFieldName.toString)
         val signature = X2CpgDefines.UnresolvedSignature
         val fullName  = s"${X2CpgDefines.UnresolvedNamespace}.$name:$signature(${args.size})"
 
@@ -236,7 +236,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case idExpr: CPPASTIdExpression =>
         val args = call.getArguments.toList.map(a => astForNode(a))
 
-        val name      = idExpr.getName.getLastName.toString
+        val name      = StringUtils.normalizeSpace(idExpr.getName.getLastName.toString)
         val signature = X2CpgDefines.UnresolvedSignature
         val fullName  = s"${X2CpgDefines.UnresolvedNamespace}.$name:$signature(${args.size})"
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -5,6 +5,7 @@ import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.Defines as X2CpgDefines
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
+import org.apache.commons.lang3.StringUtils
 import org.eclipse.cdt.core.dom.ast
 import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.cpp.*
@@ -95,9 +96,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
             val fullName =
               if (function.isExternC) {
-                name
+                StringUtils.normalizeSpace(name)
               } else {
-                val fullNameNoSig = function.getQualifiedName.mkString(".")
+                val fullNameNoSig = StringUtils.normalizeSpace(function.getQualifiedName.mkString("."))
                 s"$fullNameNoSig:$signature"
               }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -112,10 +112,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val rawFullname = fullName(lambdaExpression)
     val fixedFullName = if (rawFullname.contains("[") || rawFullname.contains("{")) {
       // FIXME: the lambda may be located in something we are not able to generate a correct fullname yet
-      s"${X2CpgDefines.UnresolvedNamespace}."
+      s"${X2CpgDefines.UnresolvedSignature}."
     } else rawFullname
+    val fullname    = s"$fixedFullName$name"
     val signature   = s"$returnType${parameterListSignature(lambdaExpression)}"
-    val fullname    = s"$fixedFullName$name:$signature"
     val codeString  = code(lambdaExpression)
     val methodNode_ = methodNode(lambdaExpression, name, codeString, fullname, Some(signature), filename)
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -113,7 +113,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val fixedFullName = if (rawFullname.contains("[") || rawFullname.contains("{")) {
       // FIXME: the lambda may be located in something we are not able to generate a correct fullname yet
       s"${X2CpgDefines.UnresolvedSignature}."
-    } else rawFullname
+    } else StringUtils.normalizeSpace(rawFullname)
     val fullname    = s"$fixedFullName$name"
     val signature   = StringUtils.normalizeSpace(s"$returnType${parameterListSignature(lambdaExpression)}")
     val codeString  = code(lambdaExpression)
@@ -146,7 +146,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         val returnType = cleanType(
           typeForDeclSpecifier(funcDecl.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclSpecifier)
         )
-        val name = shortName(funcDecl)
+        val name = StringUtils.normalizeSpace(shortName(funcDecl))
         val fixedName = if (name.isEmpty) {
           nextClosureName()
         } else name
@@ -155,8 +155,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           case f if funcDecl.isInstanceOf[CPPASTFunctionDeclarator] && f == "" =>
             s"${X2CpgDefines.UnresolvedNamespace}.$fixedName:$signature"
           case f if funcDecl.isInstanceOf[CPPASTFunctionDeclarator] && f.contains("?") =>
-            s"${f.takeWhile(_ != ':')}:$signature"
-          case other => other
+            s"${StringUtils.normalizeSpace(f).takeWhile(_ != ':')}:$signature"
+          case other => StringUtils.normalizeSpace(other)
         }
 
         if (seenFunctionFullnames.add(fullname)) {
@@ -215,8 +215,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       case f if funcDef.isInstanceOf[CPPASTFunctionDefinition] && f == "" =>
         s"${X2CpgDefines.UnresolvedNamespace}.$name:$signature"
       case f if funcDef.isInstanceOf[CPPASTFunctionDefinition] && f.contains("?") =>
-        s"${f.takeWhile(_ != ':')}:$signature"
-      case other => other
+        s"${StringUtils.normalizeSpace(f).takeWhile(_ != ':')}:$signature"
+      case other => StringUtils.normalizeSpace(other)
     }
     seenFunctionFullnames.add(fullname)
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -115,7 +115,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       s"${X2CpgDefines.UnresolvedSignature}."
     } else rawFullname
     val fullname    = s"$fixedFullName$name"
-    val signature   = s"$returnType${parameterListSignature(lambdaExpression)}"
+    val signature   = StringUtils.normalizeSpace(s"$returnType${parameterListSignature(lambdaExpression)}")
     val codeString  = code(lambdaExpression)
     val methodNode_ = methodNode(lambdaExpression, name, codeString, fullname, Some(signature), filename)
 
@@ -143,12 +143,14 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   protected def astForFunctionDeclarator(funcDecl: IASTFunctionDeclarator): Ast = {
     funcDecl.getName.resolveBinding() match {
       case function: IFunction =>
-        val returnType = typeForDeclSpecifier(funcDecl.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclSpecifier)
-        val name       = shortName(funcDecl)
+        val returnType = cleanType(
+          typeForDeclSpecifier(funcDecl.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclSpecifier)
+        )
+        val name = shortName(funcDecl)
         val fixedName = if (name.isEmpty) {
           nextClosureName()
         } else name
-        val signature = s"$returnType${parameterListSignature(funcDecl)}"
+        val signature = StringUtils.normalizeSpace(s"$returnType${parameterListSignature(funcDecl)}")
         val fullname = fullName(funcDecl) match {
           case f if funcDecl.isInstanceOf[CPPASTFunctionDeclarator] && f == "" =>
             s"${X2CpgDefines.UnresolvedNamespace}.$fixedName:$signature"
@@ -207,7 +209,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val returnType = if (isCppConstructor(funcDef)) {
       typeFor(funcDef.asInstanceOf[CPPASTFunctionDefinition].getMemberInitializers.head.getInitializer)
     } else typeForDeclSpecifier(funcDef.getDeclSpecifier)
-    val signature = s"$returnType${parameterListSignature(funcDef)}"
+    val signature = StringUtils.normalizeSpace(s"$returnType${parameterListSignature(funcDef)}")
     val name      = shortName(funcDef)
     val fullname = fullName(funcDef) match {
       case f if funcDef.isInstanceOf[CPPASTFunctionDefinition] && f == "" =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -152,7 +152,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         } else name
         val signature = StringUtils.normalizeSpace(s"$returnType${parameterListSignature(funcDecl)}")
         val fullname = fullName(funcDecl) match {
-          case f if funcDecl.isInstanceOf[CPPASTFunctionDeclarator] && f == "" =>
+          case f
+              if funcDecl.isInstanceOf[CPPASTFunctionDeclarator] &&
+                (f == "" || f == s"${X2CpgDefines.UnresolvedNamespace}.") =>
             s"${X2CpgDefines.UnresolvedNamespace}.$fixedName:$signature"
           case f if funcDecl.isInstanceOf[CPPASTFunctionDeclarator] && f.contains("?") =>
             s"${StringUtils.normalizeSpace(f).takeWhile(_ != ':')}:$signature"
@@ -213,7 +215,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val signature = StringUtils.normalizeSpace(s"$returnType${parameterListSignature(funcDef)}")
     val name      = shortName(funcDef)
     val fullname = fullName(funcDef) match {
-      case f if funcDef.isInstanceOf[CPPASTFunctionDefinition] && f == "" =>
+      case f
+          if funcDef.isInstanceOf[CPPASTFunctionDefinition] &&
+            (f == "" || f == s"${X2CpgDefines.UnresolvedNamespace}.") =>
         s"${X2CpgDefines.UnresolvedNamespace}.$name:$signature"
       case f if funcDef.isInstanceOf[CPPASTFunctionDefinition] && f.contains("?") =>
         s"${StringUtils.normalizeSpace(f).takeWhile(_ != ':')}:$signature"

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -156,7 +156,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             s"${X2CpgDefines.UnresolvedNamespace}.$fixedName:$signature"
           case f if funcDecl.isInstanceOf[CPPASTFunctionDeclarator] && f.contains("?") =>
             s"${StringUtils.normalizeSpace(f).takeWhile(_ != ':')}:$signature"
-          case other => StringUtils.normalizeSpace(other)
+          case other if other.nonEmpty => StringUtils.normalizeSpace(other)
+          case other                   => s"${X2CpgDefines.UnresolvedNamespace}.$name"
         }
 
         if (seenFunctionFullnames.add(fullname)) {
@@ -216,7 +217,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         s"${X2CpgDefines.UnresolvedNamespace}.$name:$signature"
       case f if funcDef.isInstanceOf[CPPASTFunctionDefinition] && f.contains("?") =>
         s"${StringUtils.normalizeSpace(f).takeWhile(_ != ':')}:$signature"
-      case other => StringUtils.normalizeSpace(other)
+      case other if other.nonEmpty => StringUtils.normalizeSpace(other)
+      case other                   => s"${X2CpgDefines.UnresolvedNamespace}.$name"
     }
     seenFunctionFullnames.add(fullname)
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -1,13 +1,11 @@
 package io.joern.c2cpg.astcreation
 
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.joern.x2cpg.{Ast, ValidationMode}
-import io.joern.x2cpg.Defines as X2CpgDefines
+import io.joern.x2cpg.{Ast, ValidationMode, Defines as X2CpgDefines}
 import io.shiftleft.codepropertygraph.generated.nodes.NewMethodRef
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.internal.core.dom.parser.c.ICInternalBinding
-import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTQualifiedName
-import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPInternalBinding
+import org.eclipse.cdt.internal.core.dom.parser.cpp.{CPPASTQualifiedName, ICPPInternalBinding}
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -2123,7 +2123,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
       val cpg          = code("class Foo { char (*(*x())[5])() }", "test.cpp")
       val List(method) = cpg.method.nameNot("<global>").l
       method.name shouldBe "x"
-      method.fullName shouldBe "Foo.x:char (* (*)[5])()()"
+      method.fullName shouldBe "Foo.x:char(*(*)[5])()()"
       method.code shouldBe "char (*(*x())[5])()"
       method.signature shouldBe "char()"
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -109,8 +109,10 @@ class AstCreationPassTests extends AstC2CpgSuite {
         |""".stripMargin,
         "test.cpp"
       )
-      val lambda1FullName = "<lambda>0"
-      val lambda2FullName = "<lambda>1"
+      val lambda1Name     = "<lambda>0"
+      val lambda1FullName = s"$lambda1Name:int(int,int)"
+      val lambda2Name     = "<lambda>1"
+      val lambda2FullName = s"$lambda2Name:string(string,string)"
 
       cpg.local.name("x").order.l shouldBe List(1)
       cpg.local.name("y").order.l shouldBe List(3)
@@ -127,14 +129,14 @@ class AstCreationPassTests extends AstC2CpgSuite {
       }
 
       inside(cpg.method.fullNameExact(lambda1FullName).isLambda.l) { case List(l1) =>
-        l1.name shouldBe lambda1FullName
+        l1.name shouldBe lambda1Name
         l1.code should startWith("[] (int a, int b) -> int")
         l1.signature shouldBe s"int(int,int)"
         l1.body.code shouldBe "{ return a + b; }"
       }
 
       inside(cpg.method.fullNameExact(lambda2FullName).isLambda.l) { case List(l2) =>
-        l2.name shouldBe lambda2FullName
+        l2.name shouldBe lambda2Name
         l2.code should startWith("[] (string a, string b) -> string")
         l2.signature shouldBe s"string(string,string)"
         l2.body.code shouldBe "{ return a + b; }"
@@ -142,19 +144,19 @@ class AstCreationPassTests extends AstC2CpgSuite {
 
       inside(cpg.typeDecl(NamespaceTraversal.globalNamespaceName).head.bindsOut.l) {
         case List(bX: Binding, bY: Binding) =>
-          bX.name shouldBe lambda1FullName
-          bX.signature shouldBe s"int(int,int)"
+          bX.name shouldBe lambda1Name
+          bX.signature shouldBe "int(int,int)"
           inside(bX.refOut.l) { case List(method: Method) =>
-            method.name shouldBe lambda1FullName
+            method.name shouldBe lambda1Name
             method.fullName shouldBe lambda1FullName
-            method.signature shouldBe s"int(int,int)"
+            method.signature shouldBe "int(int,int)"
           }
-          bY.name shouldBe lambda2FullName
-          bY.signature shouldBe s"string(string,string)"
+          bY.name shouldBe lambda2Name
+          bY.signature shouldBe "string(string,string)"
           inside(bY.refOut.l) { case List(method: Method) =>
-            method.name shouldBe lambda2FullName
+            method.name shouldBe lambda2Name
             method.fullName shouldBe lambda2FullName
-            method.signature shouldBe s"string(string,string)"
+            method.signature shouldBe "string(string,string)"
           }
       }
     }
@@ -172,9 +174,9 @@ class AstCreationPassTests extends AstC2CpgSuite {
         |""".stripMargin,
         "test.cpp"
       )
-      val lambdaName     = "<lambda>0"
-      val lambdaFullName = s"Foo.$lambdaName"
       val signature      = s"int(int,int)"
+      val lambdaName     = "<lambda>0"
+      val lambdaFullName = s"Foo.$lambdaName:$signature"
 
       cpg.member.name("x").order.l shouldBe List(1)
 
@@ -215,9 +217,9 @@ class AstCreationPassTests extends AstC2CpgSuite {
         |""".stripMargin,
         "test.cpp"
       )
-      val lambdaName     = "<lambda>0"
-      val lambdaFullName = s"A.B.Foo.$lambdaName"
       val signature      = s"int(int,int)"
+      val lambdaName     = "<lambda>0"
+      val lambdaFullName = s"A.B.Foo.$lambdaName:$signature"
 
       cpg.member.name("x").order.l shouldBe List(1)
 
@@ -260,10 +262,11 @@ class AstCreationPassTests extends AstC2CpgSuite {
         |""".stripMargin,
         "test.cpp"
       )
-      val lambda1Name = "<lambda>0"
-      val signature1  = s"int(int)"
-      val lambda2Name = "<lambda>1"
-      val signature2  = s"int(int)"
+      val signature       = "int(int)"
+      val lambda1Name     = "<lambda>0"
+      val lambda2Name     = "<lambda>1"
+      val lambda1FullName = s"$lambda1Name:$signature"
+      val lambda2FullName = s"$lambda2Name:$signature"
 
       cpg.local.name("x").order.l shouldBe List(1)
       cpg.local.name("foo1").order.l shouldBe List(3)
@@ -274,31 +277,31 @@ class AstCreationPassTests extends AstC2CpgSuite {
         assignment2.order shouldBe 4
         assignment3.order shouldBe 6
         inside(assignment1.astMinusRoot.isMethodRef.l) { case List(ref) =>
-          ref.methodFullName shouldBe lambda1Name
+          ref.methodFullName shouldBe lambda1FullName
         }
       }
 
-      inside(cpg.method.fullNameExact(lambda1Name).isLambda.l) { case List(l1) =>
+      inside(cpg.method.fullNameExact(lambda1FullName).isLambda.l) { case List(l1) =>
         l1.name shouldBe lambda1Name
         l1.code should startWith("[](int n) -> int")
-        l1.signature shouldBe signature1
+        l1.signature shouldBe signature
       }
 
       inside(cpg.typeDecl(NamespaceTraversal.globalNamespaceName).head.bindsOut.l) {
         case List(b1: Binding, b2: Binding) =>
           b1.name shouldBe lambda1Name
-          b1.signature shouldBe signature1
+          b1.signature shouldBe signature
           inside(b1.refOut.l) { case List(method: Method) =>
             method.name shouldBe lambda1Name
-            method.fullName shouldBe lambda1Name
-            method.signature shouldBe signature1
+            method.fullName shouldBe lambda1FullName
+            method.signature shouldBe signature
           }
           b2.name shouldBe lambda2Name
-          b2.signature shouldBe signature2
+          b2.signature shouldBe signature
           inside(b2.refOut.l) { case List(method: Method) =>
             method.name shouldBe lambda2Name
-            method.fullName shouldBe lambda2Name
-            method.signature shouldBe signature2
+            method.fullName shouldBe lambda2FullName
+            method.signature shouldBe signature
           }
       }
 
@@ -321,7 +324,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
         lambda2call.methodFullName shouldBe "<operator>():int(int)"
         lambda2call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
         inside(lambda2call.astChildren.l) { case List(ref: MethodRef, lit: Literal) =>
-          ref.methodFullName shouldBe lambda2Name
+          ref.methodFullName shouldBe lambda2FullName
           ref.code should startWith("[](int n) -> int")
           lit.code shouldBe "10"
         }
@@ -330,7 +333,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
           lit.code shouldBe "10"
         }
         inside(lambda2call.receiver.l) { case List(ref: MethodRef) =>
-          ref.methodFullName shouldBe lambda2Name
+          ref.methodFullName shouldBe lambda2FullName
           ref.code should startWith("[](int n) -> int")
         }
       }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -109,10 +109,8 @@ class AstCreationPassTests extends AstC2CpgSuite {
         |""".stripMargin,
         "test.cpp"
       )
-      val lambda1Name     = "<lambda>0"
-      val lambda1FullName = s"$lambda1Name:int(int,int)"
-      val lambda2Name     = "<lambda>1"
-      val lambda2FullName = s"$lambda2Name:string(string,string)"
+      val lambda1FullName = "<lambda>0"
+      val lambda2FullName = "<lambda>1"
 
       cpg.local.name("x").order.l shouldBe List(1)
       cpg.local.name("y").order.l shouldBe List(3)
@@ -129,14 +127,14 @@ class AstCreationPassTests extends AstC2CpgSuite {
       }
 
       inside(cpg.method.fullNameExact(lambda1FullName).isLambda.l) { case List(l1) =>
-        l1.name shouldBe lambda1Name
+        l1.name shouldBe lambda1FullName
         l1.code should startWith("[] (int a, int b) -> int")
         l1.signature shouldBe s"int(int,int)"
         l1.body.code shouldBe "{ return a + b; }"
       }
 
       inside(cpg.method.fullNameExact(lambda2FullName).isLambda.l) { case List(l2) =>
-        l2.name shouldBe lambda2Name
+        l2.name shouldBe lambda2FullName
         l2.code should startWith("[] (string a, string b) -> string")
         l2.signature shouldBe s"string(string,string)"
         l2.body.code shouldBe "{ return a + b; }"
@@ -144,19 +142,19 @@ class AstCreationPassTests extends AstC2CpgSuite {
 
       inside(cpg.typeDecl(NamespaceTraversal.globalNamespaceName).head.bindsOut.l) {
         case List(bX: Binding, bY: Binding) =>
-          bX.name shouldBe lambda1Name
-          bX.signature shouldBe "int(int,int)"
+          bX.name shouldBe lambda1FullName
+          bX.signature shouldBe s"int(int,int)"
           inside(bX.refOut.l) { case List(method: Method) =>
-            method.name shouldBe lambda1Name
+            method.name shouldBe lambda1FullName
             method.fullName shouldBe lambda1FullName
-            method.signature shouldBe "int(int,int)"
+            method.signature shouldBe s"int(int,int)"
           }
-          bY.name shouldBe lambda2Name
-          bY.signature shouldBe "string(string,string)"
+          bY.name shouldBe lambda2FullName
+          bY.signature shouldBe s"string(string,string)"
           inside(bY.refOut.l) { case List(method: Method) =>
-            method.name shouldBe lambda2Name
+            method.name shouldBe lambda2FullName
             method.fullName shouldBe lambda2FullName
-            method.signature shouldBe "string(string,string)"
+            method.signature shouldBe s"string(string,string)"
           }
       }
     }
@@ -174,9 +172,9 @@ class AstCreationPassTests extends AstC2CpgSuite {
         |""".stripMargin,
         "test.cpp"
       )
-      val signature      = s"int(int,int)"
       val lambdaName     = "<lambda>0"
-      val lambdaFullName = s"Foo.$lambdaName:$signature"
+      val lambdaFullName = s"Foo.$lambdaName"
+      val signature      = s"int(int,int)"
 
       cpg.member.name("x").order.l shouldBe List(1)
 
@@ -217,9 +215,9 @@ class AstCreationPassTests extends AstC2CpgSuite {
         |""".stripMargin,
         "test.cpp"
       )
-      val signature      = s"int(int,int)"
       val lambdaName     = "<lambda>0"
-      val lambdaFullName = s"A.B.Foo.$lambdaName:$signature"
+      val lambdaFullName = s"A.B.Foo.$lambdaName"
+      val signature      = s"int(int,int)"
 
       cpg.member.name("x").order.l shouldBe List(1)
 
@@ -262,11 +260,10 @@ class AstCreationPassTests extends AstC2CpgSuite {
         |""".stripMargin,
         "test.cpp"
       )
-      val signature       = "int(int)"
-      val lambda1Name     = "<lambda>0"
-      val lambda2Name     = "<lambda>1"
-      val lambda1FullName = s"$lambda1Name:$signature"
-      val lambda2FullName = s"$lambda2Name:$signature"
+      val lambda1Name = "<lambda>0"
+      val signature1  = s"int(int)"
+      val lambda2Name = "<lambda>1"
+      val signature2  = s"int(int)"
 
       cpg.local.name("x").order.l shouldBe List(1)
       cpg.local.name("foo1").order.l shouldBe List(3)
@@ -277,31 +274,31 @@ class AstCreationPassTests extends AstC2CpgSuite {
         assignment2.order shouldBe 4
         assignment3.order shouldBe 6
         inside(assignment1.astMinusRoot.isMethodRef.l) { case List(ref) =>
-          ref.methodFullName shouldBe lambda1FullName
+          ref.methodFullName shouldBe lambda1Name
         }
       }
 
-      inside(cpg.method.fullNameExact(lambda1FullName).isLambda.l) { case List(l1) =>
+      inside(cpg.method.fullNameExact(lambda1Name).isLambda.l) { case List(l1) =>
         l1.name shouldBe lambda1Name
         l1.code should startWith("[](int n) -> int")
-        l1.signature shouldBe signature
+        l1.signature shouldBe signature1
       }
 
       inside(cpg.typeDecl(NamespaceTraversal.globalNamespaceName).head.bindsOut.l) {
         case List(b1: Binding, b2: Binding) =>
           b1.name shouldBe lambda1Name
-          b1.signature shouldBe signature
+          b1.signature shouldBe signature1
           inside(b1.refOut.l) { case List(method: Method) =>
             method.name shouldBe lambda1Name
-            method.fullName shouldBe lambda1FullName
-            method.signature shouldBe signature
+            method.fullName shouldBe lambda1Name
+            method.signature shouldBe signature1
           }
           b2.name shouldBe lambda2Name
-          b2.signature shouldBe signature
+          b2.signature shouldBe signature2
           inside(b2.refOut.l) { case List(method: Method) =>
             method.name shouldBe lambda2Name
-            method.fullName shouldBe lambda2FullName
-            method.signature shouldBe signature
+            method.fullName shouldBe lambda2Name
+            method.signature shouldBe signature2
           }
       }
 
@@ -324,7 +321,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
         lambda2call.methodFullName shouldBe "<operator>():int(int)"
         lambda2call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
         inside(lambda2call.astChildren.l) { case List(ref: MethodRef, lit: Literal) =>
-          ref.methodFullName shouldBe lambda2FullName
+          ref.methodFullName shouldBe lambda2Name
           ref.code should startWith("[](int n) -> int")
           lit.code shouldBe "10"
         }
@@ -333,7 +330,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
           lit.code shouldBe "10"
         }
         inside(lambda2call.receiver.l) { case List(ref: MethodRef) =>
-          ref.methodFullName shouldBe lambda2FullName
+          ref.methodFullName shouldBe lambda2Name
           ref.code should startWith("[](int n) -> int")
         }
       }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/TemplateTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/TemplateTypeTests.scala
@@ -72,10 +72,10 @@ class TemplateTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
        |""".stripMargin)
       inside(cpg.method.nameNot("<global>").internal.l) { case List(x, y) =>
         x.name shouldBe "x"
-        x.fullName shouldBe "x:void(#0,#1)"
+        x.fullName shouldBe "x:void(ANY,ANY)"
         x.signature shouldBe "void(T,U)"
         y.name shouldBe "y"
-        y.fullName shouldBe "y:void(#0,#1)"
+        y.fullName shouldBe "y:void(ANY,ANY)"
         y.signature shouldBe "void(T,U)"
       }
     }


### PR DESCRIPTION
Happened during more sptests testing.
We need to normalize all names as they may contain linebreaks in their generic parameters, e.g.:
```
std::pair<StringRef, StringRef> *Buff = Allocator.Allocate<std::pair<StringRef,
      StringRef>>(Arr.size());
```