### PR TITLE
[ruby] Method/Type Full Name Simplification

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -78,8 +78,8 @@ class AstCreator(
   }
 
   private def astInFakeMethod(rootNode: StatementList): Ast = {
-    val name     = Defines.Program
-    val fullName = computeMethodFullName(name)
+    val name     = Defines.Main
+    val fullName = computeFullName(name)
     val code     = rootNode.text
     val methodNode_ = methodNode(
       node = rootNode,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -78,9 +78,11 @@ class AstCreator(
   }
 
   private def astInFakeMethod(rootNode: StatementList): Ast = {
-    val name     = Defines.Main
-    val fullName = computeFullName(name)
-    val code     = rootNode.text
+    val name = Defines.Main
+    // From the <main> method onwards, we do not embed the <global> namespace name in the full names
+    val fullName =
+      s"${scope.surroundingScopeFullName.head.stripSuffix(NamespaceTraversal.globalNamespaceName)}$name"
+    val code = rootNode.text
     val methodNode_ = methodNode(
       node = rootNode,
       name = name,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -17,8 +17,7 @@ import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Opera
 
 trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  protected def computeClassFullName(name: String): String  = s"${scope.surroundingScopeFullName.head}.$name"
-  protected def computeMethodFullName(name: String): String = s"${scope.surroundingScopeFullName.head}:$name"
+  protected def computeFullName(name: String): String = s"${scope.surroundingScopeFullName.head}.$name"
 
   override def column(node: RubyNode): Option[Int]    = node.column
   override def columnEnd(node: RubyNode): Option[Int] = node.columnEnd

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -49,7 +49,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val fullName = node match {
       case x: SingletonObjectMethodDeclaration => computeFullName(s"class<<${x.baseClass.span.text}.$methodName")
-      case _ => computeFullName(methodName)
+      case _                                   => computeFullName(methodName)
     }
 
     val method = methodNode(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -41,7 +41,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val isConstructor = (node.methodName == Defines.Initialize) && isInTypeDecl
     val methodName    = node.methodName
     // TODO: body could be a try
-    val fullName = computeMethodFullName(methodName)
+    val fullName = computeFullName(methodName)
     val method = methodNode(
       node = node,
       name = methodName,
@@ -180,10 +180,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     capturedLocalNodes
       .collect {
         case local: NewLocal =>
-          val closureBindingId = scope.variableScopeFullName(local.name).map(x => s"$x:${local.name}")
+          val closureBindingId = scope.variableScopeFullName(local.name).map(x => s"$x.${local.name}")
           (local, local.name, local.code, closureBindingId)
         case param: NewMethodParameterIn =>
-          val closureBindingId = scope.variableScopeFullName(param.name).map(x => s"$x:${param.name}")
+          val closureBindingId = scope.variableScopeFullName(param.name).map(x => s"$x.${param.name}")
           (param, param.name, param.code, closureBindingId)
       }
       .collect { case (capturedLocal, name, code, Some(closureBindingId)) =>
@@ -313,7 +313,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   protected def astForSingletonMethodDeclaration(node: SingletonMethodDeclaration): Seq[Ast] = {
     node.target match {
       case targetNode: SingletonMethodIdentifier =>
-        val fullName = computeMethodFullName(node.methodName)
+        val fullName = computeFullName(node.methodName)
 
         val (astParentType, astParentFullName, thisParamCode, addEdge) = targetNode match {
           case _: SelfIdentifier =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -50,7 +50,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   ): Seq[Ast] = {
     val className     = nameIdentifier.text
     val inheritsFrom  = node.baseClass.map(getBaseClassName).toList
-    val classFullName = computeClassFullName(className)
+    val classFullName = computeFullName(className)
     val typeDecl = typeDeclNode(
       node = node,
       name = className,
@@ -152,7 +152,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   private def astForTypeDeclBodyCall(node: TypeDeclBodyCall, typeFullName: String): Ast = {
     val callAst = astForMemberCall(node.toMemberCall, isStatic = true)
     callAst.nodes.collectFirst {
-      case c: NewCall if c.name == Defines.TypeDeclBody => c.methodFullName(s"$typeFullName:${Defines.TypeDeclBody}")
+      case c: NewCall if c.name == Defines.TypeDeclBody => c.methodFullName(s"$typeFullName.${Defines.TypeDeclBody}")
     }
     callAst
   }
@@ -211,7 +211,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   // creates a `def <name>() { return <fieldName> }` METHOD, for <fieldName> = @<name>.
   private def astForGetterMethod(node: FieldsDeclaration, fieldName: String): Ast = {
     val name     = fieldName.drop(1)
-    val fullName = computeMethodFullName(name)
+    val fullName = computeFullName(name)
     val method = methodNode(
       node = node,
       name = name,
@@ -241,7 +241,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   // creates a `def <name>=(x) { <fieldName> = x }` METHOD, for <fieldName> = @<name>
   private def astForSetterMethod(node: FieldsDeclaration, fieldName: String): Ast = {
     val name     = fieldName.drop(1) + "="
-    val fullName = computeMethodFullName(name)
+    val fullName = computeFullName(name)
     val method = methodNode(
       node = node,
       name = name,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -116,7 +116,7 @@ trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: A
         }.toSet
         // Map module types
         val typeEntries = namespace.method.collectFirst {
-          case m: Method if m.name == Defines.Program =>
+          case m: Method if m.name == Defines.Main =>
             val childrenTypes = m.astChildren.collectAll[TypeDecl].l
             val fullName =
               if childrenTypes.nonEmpty && asExternal then buildFullName(childrenTypes.head) else s"${m.fullName}"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -332,7 +332,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
           case None if GlobalTypes.kernelFunctions.contains(normalizedTypeName) =>
             Option(RubyType(s"${GlobalTypes.kernelPrefix}.$normalizedTypeName", List.empty, List.empty))
           case None if GlobalTypes.bundledClasses.contains(normalizedTypeName) =>
-            Option(RubyType(s"<${GlobalTypes.builtinPrefix}.$normalizedTypeName>", List.empty, List.empty))
+            Option(RubyType(s"${GlobalTypes.builtinPrefix}.$normalizedTypeName", List.empty, List.empty))
           case None =>
             None
           case x => x

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -8,6 +8,7 @@ import io.joern.rubysrc2cpg.passes.Defines as RDefines
 import io.joern.x2cpg.datastructures.{TypedScopeElement, *}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{DeclarationNew, NewLocal, NewMethodParameterIn}
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 import java.io.File as JFile
 import scala.collection.mutable
@@ -47,7 +48,8 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
   /** @return
     *   using the stack, will initialize a new module scope object.
     */
-  def newProgramScope: Option[ProgramScope] = surroundingScopeFullName.map(ProgramScope.apply)
+  def newProgramScope: Option[ProgramScope] =
+    surroundingScopeFullName.map(_.stripSuffix(NamespaceTraversal.globalNamespaceName)).map(ProgramScope.apply)
 
   /** @return
     *   true if the top of the stack is the program/module.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -35,7 +35,7 @@ trait TypeLikeScope extends TypedScopeElement {
   *   the relative file name.
   */
 case class ProgramScope(fileName: String) extends TypeLikeScope {
-  override def fullName: String = s"$fileName:${Defines.Program}"
+  override def fullName: String = s"$fileName.${Defines.Main}"
 }
 
 /** A Ruby module/abstract class.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -35,7 +35,7 @@ trait TypeLikeScope extends TypedScopeElement {
   *   the relative file name.
   */
 case class ProgramScope(fileName: String) extends TypeLikeScope {
-  override def fullName: String = s"$fileName.${Defines.Main}"
+  override def fullName: String = s"$fileName${Defines.Main}"
 }
 
 /** A Ruby module/abstract class.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -24,7 +24,7 @@ object Defines {
   val Initialize: String   = "initialize"
   val TypeDeclBody: String = "<body>"
 
-  val Program: String = ":program"
+  val Main: String = "<main>"
 
   val Resolver: String = "<dependency-resolver>"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/DependencySummarySolverPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/DependencySummarySolverPass.scala
@@ -16,7 +16,7 @@ class DependencySummarySolverPass(cpg: Cpg, dependencySummary: RubyProgramSummar
   override def runOnPart(diffGraph: DiffGraphBuilder, dependency: Dependency): Unit = {
     dependencySummary.namespaceToType.filter(_._1.startsWith(dependency.name)).flatMap(_._2).foreach { x =>
       val typeDeclName =
-        if x.name.endsWith(RDefines.Program) then RDefines.Program
+        if x.name.endsWith(RDefines.Main) then RDefines.Main
         else x.name.split("[.]").lastOption.getOrElse(Defines.Unknown)
 
       val dependencyTypeDecl = TypeDeclStubCreator

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
@@ -85,7 +85,7 @@ class ImplicitRequirePass(cpg: Cpg, programSummary: RubyProgramSummary) extends 
     val requireCallNode = NewCall()
       .name(importCallName)
       .code(s"$importCallName '$path'")
-      .methodFullName(s"__builtin:$importCallName")
+      .methodFullName(s"__builtin.$importCallName")
       .dispatchType(DispatchTypes.DYNAMIC_DISPATCH)
       .typeFullName(Defines.Any)
     val receiverIdentifier =

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyImportResolverPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyImportResolverPass.scala
@@ -61,7 +61,7 @@ class RubyImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
       // Expose methods which are directly present in a file, without any module, TypeDecl
       val resolvedMethods = cpg.method
         .where(_.file.name(filePattern))
-        .where(_.nameExact(RDefines.Program))
+        .where(_.nameExact(RDefines.Main))
         .astChildren
         .astChildren
         .isMethod

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeHintCallLinker.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeHintCallLinker.scala
@@ -26,7 +26,7 @@ class RubyTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
     }
     val name =
       if (methodName.contains(pathSep) && methodName.length > methodName.lastIndexOf(pathSep) + 1)
-        val strippedMethod = methodName.stripPrefix(s"${GlobalTypes.kernelPrefix}:")
+        val strippedMethod = methodName.stripPrefix(s"${GlobalTypes.kernelPrefix}.")
         if GlobalTypes.kernelFunctions.contains(strippedMethod) then strippedMethod
         else methodName.substring(methodName.lastIndexOf(pathSep) + pathSep.length)
       else methodName

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryPassGenerator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryPassGenerator.scala
@@ -96,7 +96,7 @@ private class RecoverForRubyFile(cpg: Cpg, cu: File, builder: DiffGraphBuilder, 
               else
                 fieldAccessParents
                   .filter(_.endsWith(fieldAccessName.stripSuffix(s".${c.name}")))
-                  .map(x => s"$x:${c.name}")
+                  .map(x => s"$x.${c.name}")
             } else {
               types
             }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -67,7 +67,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
 
     "present the declared method name when a built-in with the same name is used in the same compilation unit" in {
       val List(absCall) = cpg.call("sleep").l
-      absCall.methodFullName shouldBe s"main.rb:<global>.$Main.sleep"
+      absCall.methodFullName shouldBe s"main.rb:$Main.sleep"
     }
   }
 
@@ -142,7 +142,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
 
           inside(constructAssignment.argument.l) {
             case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe s"test2.rb:<global>.$Main.Test2A"
+              lhs.typeFullName shouldBe s"test2.rb:$Main.Test2A"
             case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
@@ -168,8 +168,8 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate to identifier" ignore {
       inside(cpg.identifier.name("(a|b)").l) {
         case aIdent :: bIdent :: Nil =>
-          aIdent.typeFullName shouldBe s"Test0.rb:<global>.$Main.A"
-          bIdent.typeFullName shouldBe s"Test0.rb:<global>.$Main.A"
+          aIdent.typeFullName shouldBe s"Test0.rb:$Main.A"
+          bIdent.typeFullName shouldBe s"Test0.rb:$Main.A"
         case xs => fail(s"Expected one identifier, got [${xs.name.mkString(",")}]")
       }
     }
@@ -361,7 +361,7 @@ class RubyExternalTypeRecoveryTests
 
     "resolved the type of call" in {
       val Some(create) = cpg.call("create").headOption: @unchecked
-      create.methodFullName shouldBe s"stripe.rb:<global>.$Main.Stripe.Customer.create"
+      create.methodFullName shouldBe s"stripe.rb:$Main.Stripe.Customer.create"
     }
 
     "resolved the type of identifier" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.passes
 
+import io.joern.rubysrc2cpg.passes.Defines.Main
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines as XDefines
 import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
@@ -59,14 +60,14 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
 
     "resolve 'print' and 'puts' StubbedRubyType calls" in {
       val List(printCall) = cpg.call("print").l
-      printCall.methodFullName shouldBe s"$kernelPrefix:print"
+      printCall.methodFullName shouldBe s"$kernelPrefix.print"
       val List(maxCall) = cpg.call("puts").l
-      maxCall.methodFullName shouldBe s"$kernelPrefix:puts"
+      maxCall.methodFullName shouldBe s"$kernelPrefix.puts"
     }
 
     "present the declared method name when a built-in with the same name is used in the same compilation unit" in {
       val List(absCall) = cpg.call("sleep").l
-      absCall.methodFullName shouldBe "main.rb:<global>::program:sleep"
+      absCall.methodFullName shouldBe s"main.rb:<global>.$Main.sleep"
     }
   }
 
@@ -141,7 +142,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
 
           inside(constructAssignment.argument.l) {
             case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe "test2.rb:<global>::program.Test2A"
+              lhs.typeFullName shouldBe s"test2.rb:<global>.$Main.Test2A"
             case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
@@ -167,8 +168,8 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate to identifier" ignore {
       inside(cpg.identifier.name("(a|b)").l) {
         case aIdent :: bIdent :: Nil =>
-          aIdent.typeFullName shouldBe "Test0.rb:<global>::program.A"
-          bIdent.typeFullName shouldBe "Test0.rb:<global>::program.A"
+          aIdent.typeFullName shouldBe s"Test0.rb:<global>.$Main.A"
+          bIdent.typeFullName shouldBe s"Test0.rb:<global>.$Main.A"
         case xs => fail(s"Expected one identifier, got [${xs.name.mkString(",")}]")
       }
     }
@@ -195,7 +196,7 @@ class RubyExternalTypeRecoveryTests
     // TODO: Revisit
     "be present in (Case 1)" ignore {
       cpg.identifier("sg").lineNumber(5).typeFullName.l shouldBe List("sendgrid-ruby.SendGrid.API")
-      cpg.call("client").methodFullName.headOption shouldBe Option("sendgrid-ruby.SendGrid.API:client")
+      cpg.call("client").methodFullName.headOption shouldBe Option("sendgrid-ruby.SendGrid.API.client")
     }
 
     "resolve correct imports via tag nodes" in {
@@ -219,7 +220,7 @@ class RubyExternalTypeRecoveryTests
 
     "be present in (Case 2)" ignore {
       cpg.call("post").methodFullName.l shouldBe List(
-        "sendgrid-ruby::program.SendGrid.API.client<returnValue>.mail<returnValue>.anonymous<returnValue>.post"
+        s"sendgrid-ruby.$Main.SendGrid.API.client<returnValue>.mail<returnValue>.anonymous<returnValue>.post"
       )
     }
   }
@@ -280,7 +281,7 @@ class RubyExternalTypeRecoveryTests
         .isIdentifier
         .name("d")
         .headOption: @unchecked
-      d.typeFullName shouldBe "dbi::program.DBI.connect.<returnValue>"
+      d.typeFullName shouldBe "dbi.$Main.DBI.connect.<returnValue>"
       d.dynamicTypeHintFullName shouldBe Seq()
     }
 
@@ -291,7 +292,7 @@ class RubyExternalTypeRecoveryTests
         .isCall
         .name("select_one")
         .l
-      d.methodFullName shouldBe "dbi::program.DBI.connect.<returnValue>.select_one"
+      d.methodFullName shouldBe "dbi.$Main.DBI.connect.<returnValue>.select_one"
       d.dynamicTypeHintFullName shouldBe Seq()
       d.callee(NoResolve).isExternal.headOption shouldBe Some(true)
     }
@@ -300,10 +301,10 @@ class RubyExternalTypeRecoveryTests
     "resolve correct imports via tag nodes" ignore {
       val List(foo: ResolvedTypeDecl) =
         cpg.file(".*foo.rb").ast.isCall.where(_.referencedImports).tag._toEvaluatedImport.toList: @unchecked
-      foo.fullName shouldBe "dbi::program.DBI"
+      foo.fullName shouldBe s"dbi.$Main.DBI"
       val List(bar: ResolvedTypeDecl) =
         cpg.file(".*bar.rb").ast.isCall.where(_.referencedImports).tag._toEvaluatedImport.toList: @unchecked
-      bar.fullName shouldBe "foo.rb::program.FooModule"
+      bar.fullName shouldBe s"foo.rb.$Main.FooModule"
     }
 
   }
@@ -341,7 +342,7 @@ class RubyExternalTypeRecoveryTests
       val Some(log) = cpg.identifier("log").headOption: @unchecked
       log.typeFullName shouldBe "logger.Logger"
       val List(errorCall) = cpg.call("error").l
-      errorCall.methodFullName shouldBe "logger.Logger:error"
+      errorCall.methodFullName shouldBe "logger.Logger.error"
     }
   }
 
@@ -360,12 +361,12 @@ class RubyExternalTypeRecoveryTests
 
     "resolved the type of call" in {
       val Some(create) = cpg.call("create").headOption: @unchecked
-      create.methodFullName shouldBe "stripe.rb:<global>::program.Stripe.Customer:create"
+      create.methodFullName shouldBe s"stripe.rb:<global>.$Main.Stripe.Customer.create"
     }
 
     "resolved the type of identifier" in {
       val Some(customer) = cpg.identifier("customer").headOption: @unchecked
-      customer.typeFullName shouldBe "stripe::program.Stripe.Customer.create.<returnValue>"
+      customer.typeFullName shouldBe s"stripe.$Main.Stripe.Customer.create.<returnValue>"
     }
   }
 
@@ -384,11 +385,11 @@ class RubyExternalTypeRecoveryTests
       .moreCode(RubyExternalTypeRecoveryTests.LOGGER_GEMFILE, "Gemfile")
 
     "have a correct type for call `connect`" in {
-      cpg.call("error").methodFullName.l shouldBe List("logger.Logger:error")
+      cpg.call("error").methodFullName.l shouldBe List("logger.Logger.error")
     }
 
     "have a correct type for identifier `d`" in {
-      cpg.identifier("e").typeFullName.l shouldBe List("logger.Logger:error.<returnValue>")
+      cpg.identifier("e").typeFullName.l shouldBe List("logger.Logger.error.<returnValue>")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -167,7 +167,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
           inside(assignment.argument.l) {
             case (a: Identifier) :: (_: Block) :: Nil =>
               a.name shouldBe "a"
-              a.dynamicTypeHintFullName should contain(s"Test0.rb:<global>.$Main.A")
+              a.dynamicTypeHintFullName should contain(s"Test0.rb:$Main.A")
             case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected a single assignment, got [${xs.code.mkString(",")}]")
@@ -196,7 +196,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
           inside(constructor.argument.l) {
             case (a: Identifier) :: Nil =>
               a.name shouldBe "<tmp-0>"
-              a.typeFullName shouldBe s"Test0.rb:<global>.$Main.A"
+              a.typeFullName shouldBe s"Test0.rb:$Main.A"
               a.argumentIndex shouldBe 0
             case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
           }
@@ -218,7 +218,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
       inside(cpg.call("src").l) {
         case src :: Nil =>
           src.name shouldBe "src"
-          src.methodFullName shouldBe s"Test0.rb:<global>.$Main.src"
+          src.methodFullName shouldBe s"Test0.rb:$Main.src"
         case xs => fail(s"Expected exactly one `src` call, instead got [${xs.code.mkString(",")}]")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.{GlobalTypes, Defines as RubyDefines}
-import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
+import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
 import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
@@ -19,7 +19,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     val List(puts) = cpg.call.name("puts").l
     puts.lineNumber shouldBe Some(2)
     puts.code shouldBe "puts 'hello'"
-    puts.methodFullName shouldBe s"$kernelPrefix:puts"
+    puts.methodFullName shouldBe s"$kernelPrefix.puts"
     puts.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
     val List(selfReceiver: Identifier, hello: Literal) = puts.argument.l: @unchecked
@@ -53,7 +53,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     val List(puts) = cpg.call.name("puts").l
     puts.lineNumber shouldBe Some(2)
     puts.code shouldBe "Kernel.puts 'hello'"
-    puts.methodFullName shouldBe s"$kernelPrefix:puts"
+    puts.methodFullName shouldBe s"$kernelPrefix.puts"
     puts.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
     val List(kernelRec: Call) = puts.receiver.l: @unchecked
@@ -71,7 +71,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     val List(atan2) = cpg.call.name("atan2").l
     atan2.lineNumber shouldBe Some(3)
     atan2.code shouldBe "Math.atan2(1, 1)"
-    atan2.methodFullName shouldBe s"${GlobalTypes.builtinPrefix}.Math:atan2"
+    atan2.methodFullName shouldBe s"${GlobalTypes.builtinPrefix}.Math.atan2"
     atan2.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
     val List(mathRec: Call) = atan2.receiver.l: @unchecked
@@ -161,13 +161,13 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |""".stripMargin)
 
     "create an assignment from `a` to an <init> invocation block" in {
-      inside(cpg.method(":program").assignment.where(_.target.isIdentifier.name("a")).l) {
+      inside(cpg.method.isModule.assignment.where(_.target.isIdentifier.name("a")).l) {
         case assignment :: Nil =>
           assignment.code shouldBe "a = A.new"
           inside(assignment.argument.l) {
             case (a: Identifier) :: (_: Block) :: Nil =>
               a.name shouldBe "a"
-              a.dynamicTypeHintFullName should contain("Test0.rb:<global>::program.A")
+              a.dynamicTypeHintFullName should contain(s"Test0.rb:<global>.$Main.A")
             case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected a single assignment, got [${xs.code.mkString(",")}]")
@@ -175,7 +175,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     }
 
     "create an assignment from a temp variable to the <init> call" in {
-      inside(cpg.method(":program").assignment.where(_.target.isIdentifier.name("<tmp-0>")).l) {
+      inside(cpg.method.isModule.assignment.where(_.target.isIdentifier.name("<tmp-0>")).l) {
         case assignment :: Nil =>
           inside(assignment.argument.l) {
             case (a: Identifier) :: (alloc: Call) :: Nil =>
@@ -196,7 +196,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
           inside(constructor.argument.l) {
             case (a: Identifier) :: Nil =>
               a.name shouldBe "<tmp-0>"
-              a.typeFullName shouldBe "Test0.rb:<global>::program.A"
+              a.typeFullName shouldBe s"Test0.rb:<global>.$Main.A"
               a.argumentIndex shouldBe 0
             case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
           }
@@ -218,7 +218,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
       inside(cpg.call("src").l) {
         case src :: Nil =>
           src.name shouldBe "src"
-          src.methodFullName shouldBe "Test0.rb:<global>::program:src"
+          src.methodFullName shouldBe s"Test0.rb:<global>.$Main.src"
         case xs => fail(s"Expected exactly one `src` call, instead got [${xs.code.mkString(",")}]")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -1,10 +1,9 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.Operators
-
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
 class CaseTests extends RubyCode2CpgFixture {
 
   "`case x ... end` should be represented with if-else chain and multiple match expressions should be or-ed together" in {
@@ -20,7 +19,7 @@ class CaseTests extends RubyCode2CpgFixture {
       |""".stripMargin
     val cpg = code(caseCode)
 
-    val block @ List(_) = cpg.method(":program").block.astChildren.isBlock.l
+    val block @ List(_) = cpg.method.isModule.block.astChildren.isBlock.l
 
     val List(assign)   = block.astChildren.assignment.l;
     val List(lhs, rhs) = assign.argument.l
@@ -68,7 +67,7 @@ class CaseTests extends RubyCode2CpgFixture {
       |end
       |""".stripMargin)
 
-    val block @ List(_) = cpg.method(":program").block.astChildren.isBlock.l
+    val block @ List(_) = cpg.method.isModule.block.astChildren.isBlock.l
 
     val headIf @ List(_)           = block.astChildren.isControlStructure.l
     val ifStmts @ List(_, _, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -401,8 +401,8 @@ class ClassTests extends RubyCode2CpgFixture {
     "Create TYPE_DECL nodes for two singleton methods" in {
       inside(cpg.typeDecl.name("(bark|legs)").l) {
         case barkTypeDecl :: legsTypeDecl :: Nil =>
-          barkTypeDecl.fullName shouldBe "Test0.rb:<global>::program.class<<animal.bark"
-          legsTypeDecl.fullName shouldBe "Test0.rb:<global>::program.class<<animal.legs"
+          barkTypeDecl.fullName shouldBe s"Test0.rb:$Main.class<<animal.bark"
+          legsTypeDecl.fullName shouldBe s"Test0.rb:$Main.class<<animal.legs"
         case xs => fail(s"Expected two type_decls, got [${xs.code.mkString(",")}]")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -6,6 +6,7 @@ import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
+import io.joern.rubysrc2cpg.passes.Defines.Main
 
 class ClassTests extends RubyCode2CpgFixture {
 
@@ -17,7 +18,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC) = cpg.typeDecl.name("C").l
 
     classC.inheritsFromTypeFullName shouldBe List()
-    classC.fullName shouldBe "Test0.rb:<global>::program.C"
+    classC.fullName shouldBe s"Test0.rb:<global>.$Main.C"
     classC.lineNumber shouldBe Some(2)
     classC.baseType.l shouldBe List()
     classC.member.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
@@ -25,7 +26,7 @@ class ClassTests extends RubyCode2CpgFixture {
 
     val List(singletonC) = cpg.typeDecl.nameExact("C<class>").l
     singletonC.inheritsFromTypeFullName shouldBe List()
-    singletonC.fullName shouldBe "Test0.rb:<global>::program.C<class>"
+    singletonC.fullName shouldBe s"Test0.rb:<global>.$Main.C<class>"
     singletonC.lineNumber shouldBe Some(2)
     singletonC.baseType.l shouldBe List()
     singletonC.member.name.l shouldBe List()
@@ -42,7 +43,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC) = cpg.typeDecl.name("C").l
 
     classC.inheritsFromTypeFullName shouldBe List("D")
-    classC.fullName shouldBe "Test0.rb:<global>::program.C"
+    classC.fullName shouldBe s"Test0.rb:<global>.$Main.C"
     classC.lineNumber shouldBe Some(2)
     classC.member.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
     classC.method.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
@@ -53,7 +54,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(singletonC) = cpg.typeDecl.nameExact("C<class>").l
 
     singletonC.inheritsFromTypeFullName shouldBe List("D<class>")
-    singletonC.fullName shouldBe "Test0.rb:<global>::program.C<class>"
+    singletonC.fullName shouldBe s"Test0.rb:<global>.$Main.C<class>"
     singletonC.lineNumber shouldBe Some(2)
     singletonC.member.name.l shouldBe List()
     singletonC.method.name.l shouldBe List()
@@ -103,7 +104,7 @@ class ClassTests extends RubyCode2CpgFixture {
     methodAbc.code shouldBe "def abc (...)"
     methodAbc.lineNumber shouldBe Some(3)
     methodAbc.parameter.isEmpty shouldBe true
-    methodAbc.fullName shouldBe "Test0.rb:<global>::program.C:abc"
+    methodAbc.fullName shouldBe s"Test0.rb:<global>.$Main.C.abc"
 
     // TODO: Make sure that @abc in this return is the actual field
     val List(ret: Return)          = methodAbc.methodReturn.cfgIn.l: @unchecked
@@ -152,7 +153,7 @@ class ClassTests extends RubyCode2CpgFixture {
 
     methodA.code shouldBe "def a= (...)"
     methodA.lineNumber shouldBe Some(3)
-    methodA.fullName shouldBe "Test0.rb:<global>::program.C:a="
+    methodA.fullName shouldBe s"Test0.rb:<global>.$Main.C.a="
 
     // TODO: there's probably a better way for testing this
     val List(param)                            = methodA.parameter.l
@@ -189,7 +190,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC)  = cpg.typeDecl.name("C").l
     val List(methodF) = classC.method.name("f").l
 
-    methodF.fullName shouldBe "Test0.rb:<global>::program.C:f"
+    methodF.fullName shouldBe s"Test0.rb:<global>.$Main.C.f"
 
     val List(memberF) = classC.member.nameExact("f").l
     memberF.dynamicTypeHintFullName.toSet should contain(methodF.fullName)
@@ -261,7 +262,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC)     = cpg.typeDecl.name("C").l
     val List(methodInit) = classC.method.name(RubyDefines.Initialize).l
 
-    methodInit.fullName shouldBe s"Test0.rb:<global>::program.C:${RubyDefines.Initialize}"
+    methodInit.fullName shouldBe s"Test0.rb:<global>.$Main.C.${RubyDefines.Initialize}"
     methodInit.isConstructor.isEmpty shouldBe false
   }
 
@@ -274,7 +275,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC)     = cpg.typeDecl.name("C").l
     val List(methodInit) = classC.method.name(RubyDefines.Initialize).l
 
-    methodInit.fullName shouldBe s"Test0.rb:<global>::program.C:${RubyDefines.Initialize}"
+    methodInit.fullName shouldBe s"Test0.rb:<global>.$Main.C.${RubyDefines.Initialize}"
   }
 
   "only `def initialize() ... end` directly under class has the constructor modifier" in {
@@ -312,8 +313,8 @@ class ClassTests extends RubyCode2CpgFixture {
         |
         |""".stripMargin)
 
-    cpg.member("MConst").typeDecl.fullName.head shouldBe "Test0.rb:<global>::program.MMM<class>"
-    cpg.member("NConst").typeDecl.fullName.head shouldBe "Test0.rb:<global>::program.MMM.Nested<class>"
+    cpg.member("MConst").typeDecl.fullName.head shouldBe s"Test0.rb:<global>.$Main.MMM<class>"
+    cpg.member("NConst").typeDecl.fullName.head shouldBe s"Test0.rb:<global>.$Main.MMM.Nested<class>"
   }
 
   "a basic anonymous class" should {
@@ -329,14 +330,14 @@ class ClassTests extends RubyCode2CpgFixture {
       inside(cpg.typeDecl.nameExact("<anon-class-0>").l) {
         case anonClass :: Nil =>
           anonClass.name shouldBe "<anon-class-0>"
-          anonClass.fullName shouldBe "Test0.rb:<global>::program.<anon-class-0>"
+          anonClass.fullName shouldBe s"Test0.rb:<global>.$Main.<anon-class-0>"
           inside(anonClass.method.l) {
             case hello :: defaultConstructor :: Nil =>
               defaultConstructor.name shouldBe RubyDefines.Initialize
-              defaultConstructor.fullName shouldBe s"Test0.rb:<global>::program.<anon-class-0>:${RubyDefines.Initialize}"
+              defaultConstructor.fullName shouldBe s"Test0.rb:<global>.$Main.<anon-class-0>.${RubyDefines.Initialize}"
 
               hello.name shouldBe "hello"
-              hello.fullName shouldBe "Test0.rb:<global>::program.<anon-class-0>:hello"
+              hello.fullName shouldBe s"Test0.rb:<global>.$Main.<anon-class-0>.hello"
             case xs => fail(s"Expected a single method, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
           }
         case xs => fail(s"Expected a single anonymous class, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
@@ -344,7 +345,7 @@ class ClassTests extends RubyCode2CpgFixture {
     }
 
     "generate an assignment to the variable `a` with the source being a constructor invocation of the class" in {
-      inside(cpg.method(":program").assignment.l) {
+      inside(cpg.method.isModule.assignment.l) {
         case aAssignment :: Nil =>
           aAssignment.target.code shouldBe "a"
           aAssignment.source.code shouldBe "Class.new <anon-class-0> (...)"
@@ -380,7 +381,7 @@ class ClassTests extends RubyCode2CpgFixture {
               identifier.code shouldBe "animal"
               fieldIdentifier.code shouldBe "bark"
 
-              rhs.typeFullName shouldBe "Test0.rb:<global>::program:<lambda>0&Proc"
+              rhs.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
             case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
           }
 
@@ -390,7 +391,7 @@ class ClassTests extends RubyCode2CpgFixture {
               identifier.code shouldBe "animal"
               fieldIdentifier.code shouldBe "legs"
 
-              rhs.typeFullName shouldBe "Test0.rb:<global>::program:<lambda>1&Proc"
+              rhs.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>1&Proc"
             case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected five assignments, got [${xs.code.mkString(",")}]")
@@ -599,7 +600,7 @@ class ClassTests extends RubyCode2CpgFixture {
       inside(cpg.call.nameExact(RubyDefines.TypeDeclBody).headOption) {
         case Some(bodyCall) =>
           bodyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-          bodyCall.methodFullName shouldBe s"Test0.rb:<global>::program.Foo:${RubyDefines.TypeDeclBody}"
+          bodyCall.methodFullName shouldBe s"Test0.rb:<global>.$Main.Foo.${RubyDefines.TypeDeclBody}"
 
           bodyCall.receiver.isEmpty shouldBe true
           inside(bodyCall.argumentOption(0)) {
@@ -715,7 +716,7 @@ class ClassTests extends RubyCode2CpgFixture {
 
     "create the `StandardError` local variable" in {
       cpg.local.nameExact("some_variable").dynamicTypeHintFullName.toList shouldBe List(
-        s"<${GlobalTypes.builtinPrefix}.StandardError>"
+        s"${GlobalTypes.builtinPrefix}.StandardError"
       )
     }
 
@@ -783,7 +784,7 @@ class ClassTests extends RubyCode2CpgFixture {
                           base.code shouldBe "self.scope"
                           self.name shouldBe "self"
                           literal.code shouldBe ":hits_by_ip"
-                          typeRef.typeFullName shouldBe s"Test0.rb:<global>::program.Foo:${RubyDefines.TypeDeclBody}:<lambda>0&Proc"
+                          typeRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.Foo.${RubyDefines.TypeDeclBody}.<lambda>0&Proc"
                           cpg.method
                             .fullNameExact(
                               typeRef.typ.referencedTypeDecl.member.name("call").dynamicTypeHintFullName.toSeq*
@@ -818,7 +819,7 @@ class ClassTests extends RubyCode2CpgFixture {
         case assignCall :: Nil =>
           inside(assignCall.argument.l) {
             case lhs :: (rhs: Call) :: Nil =>
-              rhs.typeFullName shouldBe "<__builtin.Encoding.Converter>:asciicompat_encoding"
+              rhs.typeFullName shouldBe "__builtin.Encoding.Converter.asciicompat_encoding"
             case xs => fail(s"Expected lhs and rhs for assignment call, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected one call for assignment, got [${xs.code.mkString(",")}]")
@@ -839,7 +840,7 @@ class ClassTests extends RubyCode2CpgFixture {
               inside(bodyMethod.block.astChildren.l) {
                 case (literal: Literal) :: Nil =>
                   literal.code shouldBe "1"
-                case xs => fail(s"Exepcted literal for body method, got [${xs.code.mkString(",")}]")
+                case xs => fail(s"Expected literal for body method, got [${xs.code.mkString(",")}]")
               }
             case xs => fail(s"Expected body and init method, got [${xs.code.mkString(",")}]")
           }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -18,7 +18,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC) = cpg.typeDecl.name("C").l
 
     classC.inheritsFromTypeFullName shouldBe List()
-    classC.fullName shouldBe s"Test0.rb:<global>.$Main.C"
+    classC.fullName shouldBe s"Test0.rb:$Main.C"
     classC.lineNumber shouldBe Some(2)
     classC.baseType.l shouldBe List()
     classC.member.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
@@ -26,7 +26,7 @@ class ClassTests extends RubyCode2CpgFixture {
 
     val List(singletonC) = cpg.typeDecl.nameExact("C<class>").l
     singletonC.inheritsFromTypeFullName shouldBe List()
-    singletonC.fullName shouldBe s"Test0.rb:<global>.$Main.C<class>"
+    singletonC.fullName shouldBe s"Test0.rb:$Main.C<class>"
     singletonC.lineNumber shouldBe Some(2)
     singletonC.baseType.l shouldBe List()
     singletonC.member.name.l shouldBe List()
@@ -43,7 +43,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC) = cpg.typeDecl.name("C").l
 
     classC.inheritsFromTypeFullName shouldBe List("D")
-    classC.fullName shouldBe s"Test0.rb:<global>.$Main.C"
+    classC.fullName shouldBe s"Test0.rb:$Main.C"
     classC.lineNumber shouldBe Some(2)
     classC.member.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
     classC.method.name.l shouldBe List(RubyDefines.TypeDeclBody, RubyDefines.Initialize)
@@ -54,7 +54,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(singletonC) = cpg.typeDecl.nameExact("C<class>").l
 
     singletonC.inheritsFromTypeFullName shouldBe List("D<class>")
-    singletonC.fullName shouldBe s"Test0.rb:<global>.$Main.C<class>"
+    singletonC.fullName shouldBe s"Test0.rb:$Main.C<class>"
     singletonC.lineNumber shouldBe Some(2)
     singletonC.member.name.l shouldBe List()
     singletonC.method.name.l shouldBe List()
@@ -104,7 +104,7 @@ class ClassTests extends RubyCode2CpgFixture {
     methodAbc.code shouldBe "def abc (...)"
     methodAbc.lineNumber shouldBe Some(3)
     methodAbc.parameter.isEmpty shouldBe true
-    methodAbc.fullName shouldBe s"Test0.rb:<global>.$Main.C.abc"
+    methodAbc.fullName shouldBe s"Test0.rb:$Main.C.abc"
 
     // TODO: Make sure that @abc in this return is the actual field
     val List(ret: Return)          = methodAbc.methodReturn.cfgIn.l: @unchecked
@@ -153,7 +153,7 @@ class ClassTests extends RubyCode2CpgFixture {
 
     methodA.code shouldBe "def a= (...)"
     methodA.lineNumber shouldBe Some(3)
-    methodA.fullName shouldBe s"Test0.rb:<global>.$Main.C.a="
+    methodA.fullName shouldBe s"Test0.rb:$Main.C.a="
 
     // TODO: there's probably a better way for testing this
     val List(param)                            = methodA.parameter.l
@@ -190,7 +190,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC)  = cpg.typeDecl.name("C").l
     val List(methodF) = classC.method.name("f").l
 
-    methodF.fullName shouldBe s"Test0.rb:<global>.$Main.C.f"
+    methodF.fullName shouldBe s"Test0.rb:$Main.C.f"
 
     val List(memberF) = classC.member.nameExact("f").l
     memberF.dynamicTypeHintFullName.toSet should contain(methodF.fullName)
@@ -262,7 +262,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC)     = cpg.typeDecl.name("C").l
     val List(methodInit) = classC.method.name(RubyDefines.Initialize).l
 
-    methodInit.fullName shouldBe s"Test0.rb:<global>.$Main.C.${RubyDefines.Initialize}"
+    methodInit.fullName shouldBe s"Test0.rb:$Main.C.${RubyDefines.Initialize}"
     methodInit.isConstructor.isEmpty shouldBe false
   }
 
@@ -275,7 +275,7 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(classC)     = cpg.typeDecl.name("C").l
     val List(methodInit) = classC.method.name(RubyDefines.Initialize).l
 
-    methodInit.fullName shouldBe s"Test0.rb:<global>.$Main.C.${RubyDefines.Initialize}"
+    methodInit.fullName shouldBe s"Test0.rb:$Main.C.${RubyDefines.Initialize}"
   }
 
   "only `def initialize() ... end` directly under class has the constructor modifier" in {
@@ -313,8 +313,8 @@ class ClassTests extends RubyCode2CpgFixture {
         |
         |""".stripMargin)
 
-    cpg.member("MConst").typeDecl.fullName.head shouldBe s"Test0.rb:<global>.$Main.MMM<class>"
-    cpg.member("NConst").typeDecl.fullName.head shouldBe s"Test0.rb:<global>.$Main.MMM.Nested<class>"
+    cpg.member("MConst").typeDecl.fullName.head shouldBe s"Test0.rb:$Main.MMM<class>"
+    cpg.member("NConst").typeDecl.fullName.head shouldBe s"Test0.rb:$Main.MMM.Nested<class>"
   }
 
   "a basic anonymous class" should {
@@ -330,14 +330,14 @@ class ClassTests extends RubyCode2CpgFixture {
       inside(cpg.typeDecl.nameExact("<anon-class-0>").l) {
         case anonClass :: Nil =>
           anonClass.name shouldBe "<anon-class-0>"
-          anonClass.fullName shouldBe s"Test0.rb:<global>.$Main.<anon-class-0>"
+          anonClass.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>"
           inside(anonClass.method.l) {
             case hello :: defaultConstructor :: Nil =>
               defaultConstructor.name shouldBe RubyDefines.Initialize
-              defaultConstructor.fullName shouldBe s"Test0.rb:<global>.$Main.<anon-class-0>.${RubyDefines.Initialize}"
+              defaultConstructor.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.${RubyDefines.Initialize}"
 
               hello.name shouldBe "hello"
-              hello.fullName shouldBe s"Test0.rb:<global>.$Main.<anon-class-0>.hello"
+              hello.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.hello"
             case xs => fail(s"Expected a single method, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
           }
         case xs => fail(s"Expected a single anonymous class, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
@@ -381,7 +381,7 @@ class ClassTests extends RubyCode2CpgFixture {
               identifier.code shouldBe "animal"
               fieldIdentifier.code shouldBe "bark"
 
-              rhs.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
+              rhs.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
             case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
           }
 
@@ -391,7 +391,7 @@ class ClassTests extends RubyCode2CpgFixture {
               identifier.code shouldBe "animal"
               fieldIdentifier.code shouldBe "legs"
 
-              rhs.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>1&Proc"
+              rhs.typeFullName shouldBe s"Test0.rb:$Main.<lambda>1&Proc"
             case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
           }
         case xs => fail(s"Expected five assignments, got [${xs.code.mkString(",")}]")
@@ -600,7 +600,7 @@ class ClassTests extends RubyCode2CpgFixture {
       inside(cpg.call.nameExact(RubyDefines.TypeDeclBody).headOption) {
         case Some(bodyCall) =>
           bodyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-          bodyCall.methodFullName shouldBe s"Test0.rb:<global>.$Main.Foo.${RubyDefines.TypeDeclBody}"
+          bodyCall.methodFullName shouldBe s"Test0.rb:$Main.Foo.${RubyDefines.TypeDeclBody}"
 
           bodyCall.receiver.isEmpty shouldBe true
           inside(bodyCall.argumentOption(0)) {
@@ -784,7 +784,7 @@ class ClassTests extends RubyCode2CpgFixture {
                           base.code shouldBe "self.scope"
                           self.name shouldBe "self"
                           literal.code shouldBe ":hits_by_ip"
-                          typeRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.Foo.${RubyDefines.TypeDeclBody}.<lambda>0&Proc"
+                          typeRef.typeFullName shouldBe s"Test0.rb:$Main.Foo.${RubyDefines.TypeDeclBody}.<lambda>0&Proc"
                           cpg.method
                             .fullNameExact(
                               typeRef.typ.referencedTypeDecl.member.name("call").dynamicTypeHintFullName.toSeq*

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -293,7 +293,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     whileCond.code shouldBe "true"
     whileCond.lineNumber shouldBe Some(2)
 
-    putsHi.methodFullName shouldBe s"$kernelPrefix:puts"
+    putsHi.methodFullName shouldBe s"$kernelPrefix.puts"
     putsHi.code shouldBe "puts 'hi'"
     putsHi.lineNumber shouldBe Some(2)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
@@ -5,6 +5,7 @@ import io.joern.x2cpg.Defines
 import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Identifier}
 import io.shiftleft.semanticcpg.language.*
+import io.joern.rubysrc2cpg.passes.Defines.Main
 
 class DependencyTests extends RubyCode2CpgFixture {
 
@@ -96,7 +97,7 @@ class DownloadDependencyTest extends RubyCode2CpgFixture(downloadDependencies = 
 
           inside(block.astChildren.isCall.nameExact("new").headOption) {
             case Some(constructorCall) =>
-              constructorCall.methodFullName shouldBe s"dummy_logger.Main_module.Main_outer_class:${RubyDefines.Initialize}"
+              constructorCall.methodFullName shouldBe s"dummy_logger.Main_module.Main_outer_class.${RubyDefines.Initialize}"
             case None => fail(s"Expected constructor call, did not find one")
           }
         case xs => fail(s"Expected two arguments under the constructor assignment, got [${xs.code.mkString(", ")}]")
@@ -110,7 +111,7 @@ class DownloadDependencyTest extends RubyCode2CpgFixture(downloadDependencies = 
 
           inside(block.astChildren.isCall.name("new").headOption) {
             case Some(constructorCall) =>
-              constructorCall.methodFullName shouldBe s"dummy_logger.Help:${RubyDefines.Initialize}"
+              constructorCall.methodFullName shouldBe s"dummy_logger.Help.${RubyDefines.Initialize}"
             case None => fail(s"Expected constructor call, did not find one")
           }
         case xs => fail(s"Expected two arguments under the constructor assignment, got [${xs.code.mkString(", ")}]")
@@ -120,12 +121,12 @@ class DownloadDependencyTest extends RubyCode2CpgFixture(downloadDependencies = 
     // TODO: This requires type propagation
     "recognise methodFullName for `first_fun`" ignore {
       cpg.call.name("first_fun").head.methodFullName should equal(
-        "dummy_logger::program:Main_module:Main_outer_class:first_fun"
+        s"dummy_logger.$Main.Main_module.Main_outer_class.first_fun"
       )
       cpg.call
         .name("help_print")
         .head
-        .methodFullName shouldBe "dummy_logger::program:Help:help_print"
+        .methodFullName shouldBe s"dummy_logger.$Main:Help:help_print"
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -30,14 +30,14 @@ class DoBlockTests extends RubyCode2CpgFixture {
               foo.name shouldBe "foo"
 
               closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
+              closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
             case xs => fail(s"Expected a two method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
           inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
+              closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
 
@@ -45,7 +45,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
             case closureType :: Nil =>
               val callMember = closureType.member.nameExact("call").head
               callMember.typeFullName shouldBe Defines.Any
-              callMember.dynamicTypeHintFullName shouldBe Seq(s"Test0.rb:<global>.$Main.<lambda>0")
+              callMember.dynamicTypeHintFullName shouldBe Seq(s"Test0.rb:$Main.<lambda>0")
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
         case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
@@ -89,14 +89,14 @@ class DoBlockTests extends RubyCode2CpgFixture {
           inside(program.astChildren.collectAll[Method].l) {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
+              closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
             case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
           inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
+              closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
         case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
@@ -119,7 +119,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           myArray.code shouldBe "my_array"
 
           lambdaRef.argumentIndex shouldBe 1
-          lambdaRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
+          lambdaRef.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
       }
@@ -151,7 +151,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           inside(program.astChildren.collectAll[Method].l) {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
+              closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
               closureMethod.isLambda.nonEmpty shouldBe true
             case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
@@ -159,7 +159,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
+              closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
               closureType.isLambda.nonEmpty shouldBe true
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
@@ -184,7 +184,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           hash.code shouldBe "hash"
 
           lambdaRef.argumentIndex shouldBe 1
-          lambdaRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
+          lambdaRef.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
       }
@@ -217,7 +217,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
         case m :: Nil =>
           m.name should startWith("<lambda>")
           val myValue = m.local.nameExact("myValue").head
-          myValue.closureBindingId shouldBe Option(s"Test0.rb:<global>.$Main.myValue")
+          myValue.closureBindingId shouldBe Option(s"Test0.rb:$Main.myValue")
         case xs => fail(s"Expected exactly one closure method decl, instead got [${xs.code.mkString(",")}]")
       }
 
@@ -235,12 +235,12 @@ class DoBlockTests extends RubyCode2CpgFixture {
           inside(myValue._localViaRefOut) {
             case Some(local) =>
               local.name shouldBe "myValue"
-              local.method.fullName.headOption shouldBe Option(s"Test0.rb:<global>.$Main")
+              local.method.fullName.headOption shouldBe Option(s"Test0.rb:$Main")
             case None => fail("Expected closure binding refer to the captured local")
           }
 
           inside(myValue._captureIn.l) {
-            case (x: TypeRef) :: Nil => x.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
+            case (x: TypeRef) :: Nil => x.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
             case xs                  => fail(s"Expected single method ref binding but got [${xs.mkString(",")}]")
           }
 
@@ -270,7 +270,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
               tmpAssign.code shouldBe "<tmp-0> = Array.new(x) { |i| i += 1 }"
 
               newCall.name shouldBe "new"
-              newCall.methodFullName shouldBe s"$builtinPrefix.Array:initialize"
+              newCall.methodFullName shouldBe s"$builtinPrefix.Array.initialize"
 
               inside(newCall.argument.l) {
                 case (_: Identifier) :: (x: Identifier) :: (closure: TypeRef) :: Nil =>
@@ -347,7 +347,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
       inside(cpg.method.isModule.assignment.code("arrow_lambda.*").headOption) {
         case Some(lambdaAssign) =>
           lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "arrow_lambda"
-          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
+          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
         case xs => fail(s"Expected an assignment to a lambda")
       }
     }
@@ -373,7 +373,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
       inside(cpg.method.isModule.assignment.code("a_lambda.*").headOption) {
         case Some(lambdaAssign) =>
           lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "a_lambda"
-          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
+          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
         case xs => fail(s"Expected an assignment to a lambda")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.Defines.Main
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.nodes.*
@@ -29,14 +30,14 @@ class DoBlockTests extends RubyCode2CpgFixture {
               foo.name shouldBe "foo"
 
               closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+              closureMethod.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
             case xs => fail(s"Expected a two method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
           inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+              closureType.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
 
@@ -44,7 +45,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
             case closureType :: Nil =>
               val callMember = closureType.member.nameExact("call").head
               callMember.typeFullName shouldBe Defines.Any
-              callMember.dynamicTypeHintFullName shouldBe Seq("Test0.rb:<global>::program:<lambda>0")
+              callMember.dynamicTypeHintFullName shouldBe Seq(s"Test0.rb:<global>.$Main.<lambda>0")
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
         case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
@@ -83,19 +84,19 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create an anonymous method with associated type declaration" in {
-      inside(cpg.method.nameExact(":program").l) {
+      inside(cpg.method.isModule.l) {
         case program :: Nil =>
           inside(program.astChildren.collectAll[Method].l) {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+              closureMethod.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
             case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
 
           inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+              closureType.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
         case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
@@ -118,7 +119,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           myArray.code shouldBe "my_array"
 
           lambdaRef.argumentIndex shouldBe 1
-          lambdaRef.typeFullName shouldBe "Test0.rb:<global>::program:<lambda>0&Proc"
+          lambdaRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
       }
@@ -150,7 +151,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           inside(program.astChildren.collectAll[Method].l) {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+              closureMethod.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
               closureMethod.isLambda.nonEmpty shouldBe true
             case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
           }
@@ -158,7 +159,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
             case closureType :: Nil =>
               closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe "Test0.rb:<global>::program:<lambda>0"
+              closureType.fullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0"
               closureType.isLambda.nonEmpty shouldBe true
             case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
           }
@@ -183,7 +184,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
           hash.code shouldBe "hash"
 
           lambdaRef.argumentIndex shouldBe 1
-          lambdaRef.typeFullName shouldBe "Test0.rb:<global>::program:<lambda>0&Proc"
+          lambdaRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
         case xs =>
           fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
       }
@@ -216,7 +217,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
         case m :: Nil =>
           m.name should startWith("<lambda>")
           val myValue = m.local.nameExact("myValue").head
-          myValue.closureBindingId shouldBe Option("Test0.rb:<global>::program:myValue")
+          myValue.closureBindingId shouldBe Option(s"Test0.rb:<global>.$Main.myValue")
         case xs => fail(s"Expected exactly one closure method decl, instead got [${xs.code.mkString(",")}]")
       }
 
@@ -234,12 +235,12 @@ class DoBlockTests extends RubyCode2CpgFixture {
           inside(myValue._localViaRefOut) {
             case Some(local) =>
               local.name shouldBe "myValue"
-              local.method.fullName.headOption shouldBe Option("Test0.rb:<global>::program")
+              local.method.fullName.headOption shouldBe Option(s"Test0.rb:<global>.$Main")
             case None => fail("Expected closure binding refer to the captured local")
           }
 
           inside(myValue._captureIn.l) {
-            case (x: TypeRef) :: Nil => x.typeFullName shouldBe "Test0.rb:<global>::program:<lambda>0&Proc"
+            case (x: TypeRef) :: Nil => x.typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
             case xs                  => fail(s"Expected single method ref binding but got [${xs.mkString(",")}]")
           }
 
@@ -346,7 +347,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
       inside(cpg.method.isModule.assignment.code("arrow_lambda.*").headOption) {
         case Some(lambdaAssign) =>
           lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "arrow_lambda"
-          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe "Test0.rb:<global>::program:<lambda>0&Proc"
+          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
         case xs => fail(s"Expected an assignment to a lambda")
       }
     }
@@ -372,7 +373,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
       inside(cpg.method.isModule.assignment.code("a_lambda.*").headOption) {
         case Some(lambdaAssign) =>
           lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "a_lambda"
-          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe "Test0.rb:<global>::program:<lambda>0&Proc"
+          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:<global>.$Main.<lambda>0&Proc"
         case xs => fail(s"Expected an assignment to a lambda")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
@@ -4,6 +4,7 @@ import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier, TypeRef}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
+import io.joern.rubysrc2cpg.passes.Defines.Main
 
 class FieldAccessTests extends RubyCode2CpgFixture {
 
@@ -105,7 +106,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
           bazAssign.code shouldBe "self.Baz"
 
           val bazTypeRef = baz.argument(2).asInstanceOf[TypeRef]
-          bazTypeRef.typeFullName shouldBe "Test0.rb:<global>::program.Baz<class>"
+          bazTypeRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.Baz<class>"
           bazTypeRef.code shouldBe "module Baz (...)"
 
           val fooAssign = foo.argument(1).asInstanceOf[Call]
@@ -113,7 +114,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
           fooAssign.code shouldBe "self.Foo"
 
           val fooTypeRef = foo.argument(2).asInstanceOf[TypeRef]
-          fooTypeRef.typeFullName shouldBe "Test0.rb:<global>::program.Foo<class>"
+          fooTypeRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.Foo<class>"
           fooTypeRef.code shouldBe "class Foo (...)"
         case _ => fail(s"Expected two type ref assignments on the module level")
       }
@@ -226,7 +227,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
       base.name shouldBe Operators.fieldAccess
       base.code shouldBe "A::B"
 
-      base.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe "Test0.rb:<global>::program.A<class>"
+      base.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:<global>.$Main.A<class>"
       base.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "B"
 
       val receiver = call.receiver.isCall.head
@@ -237,7 +238,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
       selfArg1.name shouldBe Operators.fieldAccess
       selfArg1.code shouldBe "A::B"
 
-      selfArg1.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe "Test0.rb:<global>::program.A<class>"
+      selfArg1.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:<global>.$Main.A<class>"
       selfArg1.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "B"
 
       val selfArg2 = receiver.argument(2).asInstanceOf[FieldIdentifier]

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
@@ -106,7 +106,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
           bazAssign.code shouldBe "self.Baz"
 
           val bazTypeRef = baz.argument(2).asInstanceOf[TypeRef]
-          bazTypeRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.Baz<class>"
+          bazTypeRef.typeFullName shouldBe s"Test0.rb:$Main.Baz<class>"
           bazTypeRef.code shouldBe "module Baz (...)"
 
           val fooAssign = foo.argument(1).asInstanceOf[Call]
@@ -114,7 +114,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
           fooAssign.code shouldBe "self.Foo"
 
           val fooTypeRef = foo.argument(2).asInstanceOf[TypeRef]
-          fooTypeRef.typeFullName shouldBe s"Test0.rb:<global>.$Main.Foo<class>"
+          fooTypeRef.typeFullName shouldBe s"Test0.rb:$Main.Foo<class>"
           fooTypeRef.code shouldBe "class Foo (...)"
         case _ => fail(s"Expected two type ref assignments on the module level")
       }
@@ -227,7 +227,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
       base.name shouldBe Operators.fieldAccess
       base.code shouldBe "A::B"
 
-      base.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:<global>.$Main.A<class>"
+      base.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:$Main.A<class>"
       base.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "B"
 
       val receiver = call.receiver.isCall.head
@@ -238,7 +238,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
       selfArg1.name shouldBe Operators.fieldAccess
       selfArg1.code shouldBe "A::B"
 
-      selfArg1.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:<global>.$Main.A<class>"
+      selfArg1.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:$Main.A<class>"
       selfArg1.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "B"
 
       val selfArg2 = receiver.argument(2).asInstanceOf[FieldIdentifier]

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -204,8 +204,8 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
 
     "allow the resolution for all modules in that directory" in {
       cpg.call("foo").methodFullName.l shouldBe List(
-        s"dir/module1.rb:<global>.$Main.Module1.foo",
-        s"dir/module2.rb:<global>.$Main.Module2.foo"
+        s"dir/module1.rb:$Main.Module1.foo",
+        s"dir/module2.rb:$Main.Module2.foo"
       )
     }
   }
@@ -277,9 +277,9 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
     "resolve the calls directly" in {
       inside(cpg.call.name("foo.*").l) {
         case foo1 :: foo2 :: foo3 :: Nil =>
-          foo1.methodFullName shouldBe s"lib/file1.rb:<global>.$Main.File1.foo"
-          foo2.methodFullName shouldBe s"lib/file2.rb:<global>.$Main.File2.foo"
-          foo3.methodFullName shouldBe s"src/file3.rb:<global>.$Main.File3.foo"
+          foo1.methodFullName shouldBe s"lib/file1.rb:$Main.File1.foo"
+          foo2.methodFullName shouldBe s"lib/file2.rb:$Main.File2.foo"
+          foo3.methodFullName shouldBe s"src/file3.rb:$Main.File3.foo"
         case xs => fail(s"Expected 3 calls, got [${xs.code.mkString(",")}] instead")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -1,10 +1,8 @@
 package io.joern.rubysrc2cpg.querying
 
+import io.joern.rubysrc2cpg.passes.Defines.Main
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
-import io.joern.rubysrc2cpg.RubySrc2Cpg
-import io.joern.rubysrc2cpg.Config
-import scala.util.{Success, Failure}
 import org.scalatest.Inspectors
 
 class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with Inspectors {
@@ -59,8 +57,8 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
       )
 
       val List(newCall) =
-        cpg.method.name(":program").filename("t1.rb").ast.isCall.methodFullName(".*:initialize").methodFullName.l
-      newCall should startWith(s"${path}.rb:")
+        cpg.method.isModule.filename("t1.rb").ast.isCall.methodFullName(".*\\.initialize").methodFullName.l
+      newCall should startWith(s"$path.rb:")
     }
   }
 
@@ -86,7 +84,7 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
       |""".stripMargin)
 
       val List(methodName) =
-        cpg.method.name("bar").ast.isCall.methodFullName(".*::program\\.(A|B):foo").methodFullName.l
+        cpg.method.name("bar").ast.isCall.methodFullName(s".*\\.$Main\\.(A|B).foo").methodFullName.l
       methodName should endWith(s"${moduleName}:foo")
     }
   }
@@ -171,9 +169,9 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
     "resolve calls to builtin functions" in {
       inside(cpg.call.methodFullName("(pp|csv).*").l) {
         case csvParseCall :: csvTableInitCall :: ppCall :: Nil =>
-          csvParseCall.methodFullName shouldBe "csv.CSV:parse"
-          ppCall.methodFullName shouldBe "pp.PP:pp"
-          csvTableInitCall.methodFullName shouldBe "csv.CSV.Table:initialize"
+          csvParseCall.methodFullName shouldBe "csv.CSV.parse"
+          ppCall.methodFullName shouldBe "pp.PP.pp"
+          csvTableInitCall.methodFullName shouldBe "csv.CSV.Table.initialize"
         case xs => fail(s"Expected three calls, got [${xs.code.mkString(",")}] instead")
       }
     }
@@ -206,8 +204,8 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
 
     "allow the resolution for all modules in that directory" in {
       cpg.call("foo").methodFullName.l shouldBe List(
-        "dir/module1.rb:<global>::program.Module1:foo",
-        "dir/module2.rb:<global>::program.Module2:foo"
+        s"dir/module1.rb:<global>.$Main.Module1.foo",
+        s"dir/module2.rb:<global>.$Main.Module2.foo"
       )
     }
   }
@@ -245,9 +243,9 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
         |require 'file2'
         |require 'file3'
         |
-        |File1::foo # lib/file1.rb::program:foo
-        |File2::foo # lib/file2.rb::program:foo
-        |File3::foo # src/file3.rb::program:foo
+        |File1::foo # lib/file1.rb.<main>.foo
+        |File2::foo # lib/file2.rb.<main>.foo
+        |File3::foo # src/file3.rb.<main>.foo
         |""".stripMargin,
       "main.rb"
     ).moreCode(
@@ -279,9 +277,9 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
     "resolve the calls directly" in {
       inside(cpg.call.name("foo.*").l) {
         case foo1 :: foo2 :: foo3 :: Nil =>
-          foo1.methodFullName shouldBe "lib/file1.rb:<global>::program.File1:foo"
-          foo2.methodFullName shouldBe "lib/file2.rb:<global>::program.File2:foo"
-          foo3.methodFullName shouldBe "src/file3.rb:<global>::program.File3:foo"
+          foo1.methodFullName shouldBe s"lib/file1.rb:<global>.$Main.File1.foo"
+          foo2.methodFullName shouldBe s"lib/file2.rb:<global>.$Main.File2.foo"
+          foo3.methodFullName shouldBe s"src/file3.rb:<global>.$Main.File3.foo"
         case xs => fail(s"Expected 3 calls, got [${xs.code.mkString(",")}] instead")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -1,10 +1,10 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
+import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal, Method, MethodRef, Return, TypeRef}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
 class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
@@ -72,7 +72,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
     r.lineNumber shouldBe Some(3)
 
     val List(c: Call) = r.astChildren.isCall.l
-    c.methodFullName shouldBe s"$kernelPrefix:puts"
+    c.methodFullName shouldBe s"$kernelPrefix.puts"
     c.lineNumber shouldBe Some(3)
     c.code shouldBe "puts x"
   }
@@ -380,7 +380,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
           inside(bar.astChildren.collectAll[Method].l) {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe "Test0.rb:<global>::program:bar:<lambda>0"
+              closureMethod.fullName shouldBe s"Test0.rb:<global>.$Main.bar.<lambda>0"
             case xs => fail(s"Expected closure method, but found ${xs.code.mkString(", ")} instead")
           }
 
@@ -393,7 +393,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
                   returnCall.name shouldBe "foo"
 
                   val List(_, arg: TypeRef) = returnCall.argument.l: @unchecked
-                  arg.typeFullName shouldBe "Test0.rb:<global>::program:bar:<lambda>0&Proc"
+                  arg.typeFullName shouldBe s"Test0.rb:<global>.$Main.bar.<lambda>0&Proc"
                 case xs => fail(s"Expected one call for return, but found ${xs.code.mkString(", ")} instead")
               }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -380,7 +380,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
           inside(bar.astChildren.collectAll[Method].l) {
             case closureMethod :: Nil =>
               closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe s"Test0.rb:<global>.$Main.bar.<lambda>0"
+              closureMethod.fullName shouldBe s"Test0.rb:$Main.bar.<lambda>0"
             case xs => fail(s"Expected closure method, but found ${xs.code.mkString(", ")} instead")
           }
 
@@ -393,7 +393,7 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
                   returnCall.name shouldBe "foo"
 
                   val List(_, arg: TypeRef) = returnCall.argument.l: @unchecked
-                  arg.typeFullName shouldBe s"Test0.rb:<global>.$Main.bar.<lambda>0&Proc"
+                  arg.typeFullName shouldBe s"Test0.rb:$Main.bar.<lambda>0&Proc"
                 case xs => fail(s"Expected one call for return, but found ${xs.code.mkString(", ")} instead")
               }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -1,13 +1,12 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
+import io.joern.rubysrc2cpg.passes.Defines.Main
 import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
-
-import scala.util.{Failure, Success, Try}
 
 class MethodTests extends RubyCode2CpgFixture {
 
@@ -19,7 +18,7 @@ class MethodTests extends RubyCode2CpgFixture {
     "be represented by a METHOD node" in {
       val List(f) = cpg.method.name("f").l
 
-      f.fullName shouldBe "Test0.rb:<global>::program:f"
+      f.fullName shouldBe s"Test0.rb:<global>.$Main.f"
       f.isExternal shouldBe false
       f.lineNumber shouldBe Some(2)
       f.numberOfLines shouldBe 1
@@ -32,17 +31,17 @@ class MethodTests extends RubyCode2CpgFixture {
 
     "have a corresponding bound type" in {
       val List(fType) = cpg.typeDecl("f").l
-      fType.fullName shouldBe "Test0.rb:<global>::program:f"
+      fType.fullName shouldBe s"Test0.rb:<global>.$Main.f"
       fType.code shouldBe "def f(x) = 1"
-      fType.astParentFullName shouldBe "Test0.rb:<global>::program"
+      fType.astParentFullName shouldBe s"Test0.rb:<global>.$Main"
       fType.astParentType shouldBe NodeTypes.METHOD
       val List(fMethod) = fType.iterator.boundMethod.l
-      fType.fullName shouldBe "Test0.rb:<global>::program:f"
+      fType.fullName shouldBe s"Test0.rb:<global>.$Main.f"
     }
 
     "create a 'fake' method for the file" in {
-      val List(m) = cpg.method.nameExact(RDefines.Program).l
-      m.fullName shouldBe "Test0.rb:<global>::program"
+      val List(m) = cpg.method.nameExact(RDefines.Main).l
+      m.fullName shouldBe s"Test0.rb:<global>.$Main"
       m.isModule.nonEmpty shouldBe true
     }
   }
@@ -56,7 +55,7 @@ class MethodTests extends RubyCode2CpgFixture {
 
     val List(f) = cpg.method.name("f").l
 
-    f.fullName shouldBe "Test0.rb:<global>::program:f"
+    f.fullName shouldBe s"Test0.rb:<global>.$Main.f"
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 3
@@ -70,7 +69,7 @@ class MethodTests extends RubyCode2CpgFixture {
 
     val List(f) = cpg.method.name("f").l
 
-    f.fullName shouldBe "Test0.rb:<global>::program:f"
+    f.fullName shouldBe s"Test0.rb:<global>.$Main.f"
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 1
@@ -88,7 +87,7 @@ class MethodTests extends RubyCode2CpgFixture {
 
     val List(f) = cpg.method.name("f").l
 
-    f.fullName shouldBe "Test0.rb:<global>::program:f"
+    f.fullName shouldBe s"Test0.rb:<global>.$Main.f"
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 1
@@ -195,7 +194,7 @@ class MethodTests extends RubyCode2CpgFixture {
             inside(funcF.parameter.l) {
               case thisParam :: xParam :: Nil =>
                 thisParam.code shouldBe RDefines.Self
-                thisParam.typeFullName shouldBe "Test0.rb:<global>::program.C"
+                thisParam.typeFullName shouldBe s"Test0.rb:<global>.$Main.C"
                 thisParam.index shouldBe 0
                 thisParam.isVariadic shouldBe false
 
@@ -229,7 +228,7 @@ class MethodTests extends RubyCode2CpgFixture {
             inside(funcF.parameter.l) {
               case thisParam :: xParam :: Nil =>
                 thisParam.code shouldBe RDefines.Self
-                thisParam.typeFullName shouldBe "Test0.rb:<global>::program.C"
+                thisParam.typeFullName shouldBe s"Test0.rb:<global>.$Main.C"
                 thisParam.index shouldBe 0
                 thisParam.isVariadic shouldBe false
 
@@ -353,7 +352,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case thisParam :: xParam :: Nil =>
               thisParam.name shouldBe RDefines.Self
               thisParam.code shouldBe "F"
-              thisParam.typeFullName shouldBe "Test0.rb:<global>::program.F"
+              thisParam.typeFullName shouldBe s"Test0.rb:<global>.$Main.F"
 
               xParam.name shouldBe "x"
             case xs => fail(s"Expected two parameters, got ${xs.name.mkString(", ")}")
@@ -363,7 +362,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case thisParam :: xParam :: Nil =>
               thisParam.name shouldBe RDefines.Self
               thisParam.code shouldBe "F"
-              thisParam.typeFullName shouldBe "Test0.rb:<global>::program.F"
+              thisParam.typeFullName shouldBe s"Test0.rb:<global>.$Main.F"
 
               xParam.name shouldBe "x"
               xParam.code shouldBe "x"
@@ -376,17 +375,17 @@ class MethodTests extends RubyCode2CpgFixture {
     // TODO: we cannot bind baz as this is a dynamic assignment to `F` which is trickier to determine
     //   Also, double check bindings
     "have bindings to the singleton module TYPE_DECL" ignore {
-      cpg.typeDecl.name("F<class>").methodBinding.methodFullName.l shouldBe List("Test0.rb:<global>::program.F:bar")
+      cpg.typeDecl.name("F<class>").methodBinding.methodFullName.l shouldBe List(s"Test0.rb:<global>.$Main.F.bar")
     }
 
-    "baz should not exist in the :program block" in {
-      inside(cpg.method.name(":program").l) {
+    "baz should not exist in the <main> block" in {
+      inside(cpg.method.isModule.l) {
         case prog :: Nil =>
           inside(prog.block.astChildren.isMethod.name("baz").l) {
             case Nil => // passing case
             case _   => fail("Baz should not exist under program method block")
           }
-        case _ => fail("Expected one Method for :program")
+        case _ => fail("Expected one Method for <block>")
       }
     }
   }
@@ -401,7 +400,7 @@ class MethodTests extends RubyCode2CpgFixture {
     "be represented by a METHOD node" in {
       inside(cpg.method.name("exists\\?").l) {
         case existsMethod :: Nil =>
-          existsMethod.fullName shouldBe "Test0.rb:<global>::program:exists?"
+          existsMethod.fullName shouldBe s"Test0.rb:<global>.$Main.exists?"
           existsMethod.isExternal shouldBe false
 
           inside(existsMethod.methodReturn.cfgIn.l) {
@@ -603,7 +602,7 @@ class MethodTests extends RubyCode2CpgFixture {
       )
 
     "be directly under :program" in {
-      inside(cpg.method.name(RDefines.Program).filename("t1.rb").assignment.l) {
+      inside(cpg.method.name(RDefines.Main).filename("t1.rb").assignment.l) {
         case moduleAssignment :: classAssignment :: methodAssignment :: Nil =>
           moduleAssignment.code shouldBe "self.A = module A (...)"
           classAssignment.code shouldBe "self.B = class B (...)"
@@ -613,7 +612,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
               lhs.code shouldBe "self.A"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe "t1.rb:<global>::program.A<class>"
+              rhs.typeFullName shouldBe s"t1.rb:<global>.$Main.A<class>"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -621,7 +620,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
               lhs.code shouldBe "self.B"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe "t1.rb:<global>::program.B<class>"
+              rhs.typeFullName shouldBe s"t1.rb:<global>.$Main.B<class>"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -629,8 +628,8 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
               lhs.code shouldBe "self.c"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.methodFullName shouldBe "t1.rb:<global>::program:c"
-              rhs.typeFullName shouldBe "t1.rb:<global>::program:c"
+              rhs.methodFullName shouldBe s"t1.rb:<global>.$Main.c"
+              rhs.typeFullName shouldBe s"t1.rb:<global>.$Main.c"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -639,7 +638,7 @@ class MethodTests extends RubyCode2CpgFixture {
     }
 
     "not be present in other files" in {
-      inside(cpg.method.name(RDefines.Program).filename("t2.rb").assignment.l) {
+      inside(cpg.method.name(RDefines.Main).filename("t2.rb").assignment.l) {
         case classAssignment :: methodAssignment :: Nil =>
           classAssignment.code shouldBe "self.D = class D (...)"
           methodAssignment.code shouldBe "self.e = def e (...)"
@@ -648,7 +647,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
               lhs.code shouldBe "self.D"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe "t2.rb:<global>::program.D<class>"
+              rhs.typeFullName shouldBe s"t2.rb:<global>.$Main.D<class>"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -656,8 +655,8 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
               lhs.code shouldBe "self.e"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.methodFullName shouldBe "t2.rb:<global>::program:e"
-              rhs.typeFullName shouldBe "t2.rb:<global>::program:e"
+              rhs.methodFullName shouldBe s"t2.rb:<global>.$Main.e"
+              rhs.typeFullName shouldBe s"t2.rb:<global>.$Main.e"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -666,7 +665,7 @@ class MethodTests extends RubyCode2CpgFixture {
     }
 
     "be placed in order of definition" in {
-      inside(cpg.method.name(RDefines.Program).filename("t1.rb").block.astChildren.l) {
+      inside(cpg.method.name(RDefines.Main).filename("t1.rb").block.astChildren.l) {
         case (a1: Call) :: (a2: Call) :: (a3: Call) :: (a4: Call) :: (a5: Call) :: Nil =>
           a1.code shouldBe "self.A = module A (...)"
           a2.code shouldBe "self::A::<body>"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -18,7 +18,7 @@ class MethodTests extends RubyCode2CpgFixture {
     "be represented by a METHOD node" in {
       val List(f) = cpg.method.name("f").l
 
-      f.fullName shouldBe s"Test0.rb:<global>.$Main.f"
+      f.fullName shouldBe s"Test0.rb:$Main.f"
       f.isExternal shouldBe false
       f.lineNumber shouldBe Some(2)
       f.numberOfLines shouldBe 1
@@ -31,17 +31,17 @@ class MethodTests extends RubyCode2CpgFixture {
 
     "have a corresponding bound type" in {
       val List(fType) = cpg.typeDecl("f").l
-      fType.fullName shouldBe s"Test0.rb:<global>.$Main.f"
+      fType.fullName shouldBe s"Test0.rb:$Main.f"
       fType.code shouldBe "def f(x) = 1"
-      fType.astParentFullName shouldBe s"Test0.rb:<global>.$Main"
+      fType.astParentFullName shouldBe s"Test0.rb:$Main"
       fType.astParentType shouldBe NodeTypes.METHOD
       val List(fMethod) = fType.iterator.boundMethod.l
-      fType.fullName shouldBe s"Test0.rb:<global>.$Main.f"
+      fType.fullName shouldBe s"Test0.rb:$Main.f"
     }
 
     "create a 'fake' method for the file" in {
       val List(m) = cpg.method.nameExact(RDefines.Main).l
-      m.fullName shouldBe s"Test0.rb:<global>.$Main"
+      m.fullName shouldBe s"Test0.rb:$Main"
       m.isModule.nonEmpty shouldBe true
     }
   }
@@ -55,7 +55,7 @@ class MethodTests extends RubyCode2CpgFixture {
 
     val List(f) = cpg.method.name("f").l
 
-    f.fullName shouldBe s"Test0.rb:<global>.$Main.f"
+    f.fullName shouldBe s"Test0.rb:$Main.f"
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 3
@@ -69,7 +69,7 @@ class MethodTests extends RubyCode2CpgFixture {
 
     val List(f) = cpg.method.name("f").l
 
-    f.fullName shouldBe s"Test0.rb:<global>.$Main.f"
+    f.fullName shouldBe s"Test0.rb:$Main.f"
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 1
@@ -87,7 +87,7 @@ class MethodTests extends RubyCode2CpgFixture {
 
     val List(f) = cpg.method.name("f").l
 
-    f.fullName shouldBe s"Test0.rb:<global>.$Main.f"
+    f.fullName shouldBe s"Test0.rb:$Main.f"
     f.isExternal shouldBe false
     f.lineNumber shouldBe Some(2)
     f.numberOfLines shouldBe 1
@@ -194,7 +194,7 @@ class MethodTests extends RubyCode2CpgFixture {
             inside(funcF.parameter.l) {
               case thisParam :: xParam :: Nil =>
                 thisParam.code shouldBe RDefines.Self
-                thisParam.typeFullName shouldBe s"Test0.rb:<global>.$Main.C"
+                thisParam.typeFullName shouldBe s"Test0.rb:$Main.C"
                 thisParam.index shouldBe 0
                 thisParam.isVariadic shouldBe false
 
@@ -228,7 +228,7 @@ class MethodTests extends RubyCode2CpgFixture {
             inside(funcF.parameter.l) {
               case thisParam :: xParam :: Nil =>
                 thisParam.code shouldBe RDefines.Self
-                thisParam.typeFullName shouldBe s"Test0.rb:<global>.$Main.C"
+                thisParam.typeFullName shouldBe s"Test0.rb:$Main.C"
                 thisParam.index shouldBe 0
                 thisParam.isVariadic shouldBe false
 
@@ -352,7 +352,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case thisParam :: xParam :: Nil =>
               thisParam.name shouldBe RDefines.Self
               thisParam.code shouldBe "F"
-              thisParam.typeFullName shouldBe s"Test0.rb:<global>.$Main.F"
+              thisParam.typeFullName shouldBe s"Test0.rb:$Main.F"
 
               xParam.name shouldBe "x"
             case xs => fail(s"Expected two parameters, got ${xs.name.mkString(", ")}")
@@ -362,7 +362,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case thisParam :: xParam :: Nil =>
               thisParam.name shouldBe RDefines.Self
               thisParam.code shouldBe "F"
-              thisParam.typeFullName shouldBe s"Test0.rb:<global>.$Main.F"
+              thisParam.typeFullName shouldBe s"Test0.rb:$Main.F"
 
               xParam.name shouldBe "x"
               xParam.code shouldBe "x"
@@ -375,7 +375,7 @@ class MethodTests extends RubyCode2CpgFixture {
     // TODO: we cannot bind baz as this is a dynamic assignment to `F` which is trickier to determine
     //   Also, double check bindings
     "have bindings to the singleton module TYPE_DECL" ignore {
-      cpg.typeDecl.name("F<class>").methodBinding.methodFullName.l shouldBe List(s"Test0.rb:<global>.$Main.F.bar")
+      cpg.typeDecl.name("F<class>").methodBinding.methodFullName.l shouldBe List(s"Test0.rb:$Main.F.bar")
     }
 
     "baz should not exist in the <main> block" in {
@@ -400,7 +400,7 @@ class MethodTests extends RubyCode2CpgFixture {
     "be represented by a METHOD node" in {
       inside(cpg.method.name("exists\\?").l) {
         case existsMethod :: Nil =>
-          existsMethod.fullName shouldBe s"Test0.rb:<global>.$Main.exists?"
+          existsMethod.fullName shouldBe s"Test0.rb:$Main.exists?"
           existsMethod.isExternal shouldBe false
 
           inside(existsMethod.methodReturn.cfgIn.l) {
@@ -612,7 +612,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
               lhs.code shouldBe "self.A"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe s"t1.rb:<global>.$Main.A<class>"
+              rhs.typeFullName shouldBe s"t1.rb:$Main.A<class>"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -620,7 +620,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
               lhs.code shouldBe "self.B"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe s"t1.rb:<global>.$Main.B<class>"
+              rhs.typeFullName shouldBe s"t1.rb:$Main.B<class>"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -628,8 +628,8 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
               lhs.code shouldBe "self.c"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.methodFullName shouldBe s"t1.rb:<global>.$Main.c"
-              rhs.typeFullName shouldBe s"t1.rb:<global>.$Main.c"
+              rhs.methodFullName shouldBe s"t1.rb:$Main.c"
+              rhs.typeFullName shouldBe s"t1.rb:$Main.c"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -647,7 +647,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
               lhs.code shouldBe "self.D"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe s"t2.rb:<global>.$Main.D<class>"
+              rhs.typeFullName shouldBe s"t2.rb:$Main.D<class>"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 
@@ -655,8 +655,8 @@ class MethodTests extends RubyCode2CpgFixture {
             case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
               lhs.code shouldBe "self.e"
               lhs.name shouldBe Operators.fieldAccess
-              rhs.methodFullName shouldBe s"t2.rb:<global>.$Main.e"
-              rhs.typeFullName shouldBe s"t2.rb:<global>.$Main.e"
+              rhs.methodFullName shouldBe s"t2.rb:$Main.e"
+              rhs.typeFullName shouldBe s"t2.rb:$Main.e"
             case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
           }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.rubysrc2cpg.passes.Defines.Main
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 
@@ -14,7 +15,7 @@ class ModuleTests extends RubyCode2CpgFixture {
 
     val List(m) = cpg.typeDecl.name("M").l
 
-    m.fullName shouldBe "Test0.rb:<global>::program.M"
+    m.fullName shouldBe s"Test0.rb:<global>.$Main.M"
     m.lineNumber shouldBe Some(2)
     m.baseType.l shouldBe List()
     m.member.name.l shouldBe List(Defines.TypeDeclBody)
@@ -31,7 +32,7 @@ class ModuleTests extends RubyCode2CpgFixture {
 
     val List(m) = cpg.typeDecl.name("M1").l
 
-    m.fullName shouldBe "Test0.rb:<global>::program.M1"
+    m.fullName shouldBe s"Test0.rb:<global>.$Main.M1"
     m.lineNumber shouldBe Some(2)
     m.baseType.l shouldBe List()
     m.member.name.l shouldBe List(Defines.TypeDeclBody)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -15,7 +15,7 @@ class ModuleTests extends RubyCode2CpgFixture {
 
     val List(m) = cpg.typeDecl.name("M").l
 
-    m.fullName shouldBe s"Test0.rb:<global>.$Main.M"
+    m.fullName shouldBe s"Test0.rb:$Main.M"
     m.lineNumber shouldBe Some(2)
     m.baseType.l shouldBe List()
     m.member.name.l shouldBe List(Defines.TypeDeclBody)
@@ -32,7 +32,7 @@ class ModuleTests extends RubyCode2CpgFixture {
 
     val List(m) = cpg.typeDecl.name("M1").l
 
-    m.fullName shouldBe s"Test0.rb:<global>.$Main.M1"
+    m.fullName shouldBe s"Test0.rb:$Main.M1"
     m.lineNumber shouldBe Some(2)
     m.baseType.l shouldBe List()
     m.member.name.l shouldBe List(Defines.TypeDeclBody)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -12,7 +12,7 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = true) {
        |0
        |""".stripMargin)
     cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(
-      s"$kernelPrefix.String:${RubyOperators.regexpMatch}"
+      s"$kernelPrefix.String.${RubyOperators.regexpMatch}"
     )
   }
   "`/x/ =~ 'y'` is a member call `/x/.=~ 'y'" in {
@@ -20,7 +20,7 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = true) {
        |0
        |""".stripMargin)
     cpg.call(RubyOperators.regexpMatch).methodFullName.l shouldBe List(
-      s"$kernelPrefix.Regexp:${RubyOperators.regexpMatch}"
+      s"$kernelPrefix.Regexp.${RubyOperators.regexpMatch}"
     )
   }
 
@@ -33,7 +33,7 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = true) {
 
     inside(cpg.controlStructure.isIf.l) {
       case regexIf :: Nil =>
-        regexIf.condition.isCall.methodFullName.l shouldBe List(s"$kernelPrefix.Regexp:${RubyOperators.regexpMatch}")
+        regexIf.condition.isCall.methodFullName.l shouldBe List(s"$kernelPrefix.Regexp.${RubyOperators.regexpMatch}")
 
         inside(regexIf.condition.isCall.argument.l) {
           case (lhs: Literal) :: (rhs: Literal) :: Nil =>


### PR DESCRIPTION
* Renamed `:program` to `<main>`
* Replaced `:` method separator to `.`
* Removed `<global>` from full names of types and methods