### PR TITLE
[c2cpg] Fix string repr for type of dependent expressions

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -146,11 +146,13 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         fixQualifiedName(t.substring(0, t.indexOf(" ->")))
       case t if t.contains("( ") =>
         fixQualifiedName(t.substring(0, t.indexOf("( ")))
-      case t if t.contains("?") => Defines.Any
-      case t if t.contains("#") => Defines.Any
+      case t if t.contains("?")                        => Defines.Any
+      case t if t.contains("#")                        => Defines.Any
+      case t if t.contains("::{") || t.contains("}::") => Defines.Any
       case t if t.contains("{") && t.contains("}") =>
-        val anonType =
-          s"${uniqueName("type", "", "")._1}${t.substring(0, t.indexOf("{"))}${t.substring(t.indexOf("}") + 1)}"
+        val beforeBracket = t.substring(0, t.indexOf("{"))
+        val afterBracket  = t.substring(t.indexOf("}") + 1)
+        val anonType      = s"${uniqueName("type", "", "")._1}$beforeBracket$afterBracket"
         anonType.replace(" ", "")
       case t if t.startsWith("[") && t.endsWith("]")       => Defines.Any
       case t if t.contains(Defines.QualifiedNameSeparator) => fixQualifiedName(t)


### PR DESCRIPTION
We are not able to represent them with the CPG format.
See e.g.:
```
template <class charT, class traits>
inline re_syntax_base* basic_regex_creator<charT, traits>::append_set(
   const basic_char_set<charT, traits>& char_set)
{
   typedef mpl::bool_< (sizeof(charT) == 1) > truth_type;
   return char_set.has_digraphs() 
      ? append_set(char_set, static_cast<mpl::false_*>(0))
      : append_set(char_set, static_cast<truth_type*>(0));
}
```

The type of `append_set` is dependent to some boost library magic w.r.t. to the method template instantiation. I just set it to ANY here.