### PR TITLE
[ruby] Handle Re-definitions

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -866,4 +866,33 @@ class ClassTests extends RubyCode2CpgFixture {
       superCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
     }
   }
+
+  "a class that is redefined should have a counter suffixed to ensure uniqueness" in {
+    val cpg = code("""
+        |class Foo
+        | def foo;end
+        |end
+        |class Bar;end
+        |class Foo
+        | def foo;end
+        |end
+        |class Foo;end
+        |""".stripMargin)
+
+    cpg.typeDecl.name("(Foo|Bar).*").filterNot(_.name.endsWith("<class>")).name.l shouldBe List(
+      "Foo",
+      "Bar",
+      "Foo",
+      "Foo"
+    )
+    cpg.typeDecl.name("(Foo|Bar).*").filterNot(_.name.endsWith("<class>")).fullName.l shouldBe List(
+      s"Test0.rb:$Main.Foo",
+      s"Test0.rb:$Main.Bar",
+      s"Test0.rb:$Main.Foo0",
+      s"Test0.rb:$Main.Foo1"
+    )
+
+    cpg.method.nameExact("foo").fullName.l shouldBe List(s"Test0.rb:$Main.Foo.foo", s"Test0.rb:$Main.Foo0.foo")
+
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -731,4 +731,21 @@ class MethodTests extends RubyCode2CpgFixture {
     parentType.isLambda should not be empty
     parentType.methodBinding.methodFullName.head should endWith("<lambda>0")
   }
+
+  "a method that is redefined should have a counter suffixed to ensure uniqueness" in {
+    val cpg = code("""
+        |def foo;end
+        |def bar;end
+        |def foo;end
+        |def foo;end
+        |""".stripMargin)
+
+    cpg.method.name("(foo|bar).*").name.l shouldBe List("foo", "bar", "foo", "foo")
+    cpg.method.name("(foo|bar).*").fullName.l shouldBe List(
+      s"Test0.rb:$Main.foo",
+      s"Test0.rb:$Main.bar",
+      s"Test0.rb:$Main.foo0",
+      s"Test0.rb:$Main.foo1"
+    )
+  }
 }


### PR DESCRIPTION
In the case of a type or method re-definition, the full name is ensured to be unique by a set that tracks all full-names for that compilation unit, and a counter.

Resolves #4742