### PR TITLE
[ruby] Handle `NEXT` control structure

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -57,6 +57,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     case node: BreakStatement                   => astForBreakStatement(node)
     case node: StatementList                    => astForStatementList(node)
     case node: ReturnExpression                 => astForReturnStatement(node)
+    case node: NextExpression                   => astForNextExpression(node)
     case node: DummyNode                        => Ast(node.node)
     case node: Unknown                          => astForUnknown(node)
     case x =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -231,6 +231,15 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     returnAst(returnNode_, argumentAsts)
   }
 
+  protected def astForNextExpression(node: NextExpression): Ast = {
+    val nextNode = NewControlStructure()
+      .controlStructureType(ControlStructureTypes.CONTINUE)
+      .lineNumber(line(node))
+      .columnNumber(column(node))
+      .code(code(node))
+    Ast(nextNode)
+  }
+
   protected def astForStatementListReturningLastExpression(node: StatementList): Ast = {
     val block = blockNode(node)
     scope.pushNewScope(BlockScope(block))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -259,6 +259,8 @@ object RubyIntermediateAst {
       extends RubyNode(span)
       with ControlFlowClause
 
+  final case class NextExpression()(span: TextSpan) extends RubyNode(span) with ControlFlowExpression
+
   final case class ReturnExpression(expressions: List[RubyNode])(span: TextSpan) extends RubyNode(span)
 
   /** Represents an unqualified identifier e.g. `X`, `x`,  `@@x`, `$x`, `$<`, etc. */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -43,6 +43,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     StatementList(ctx.getStatements.map(visit))(ctx.toTextSpan)
   }
 
+  override def visitNextWithoutArguments(ctx: RubyParser.NextWithoutArgumentsContext): RubyNode = {
+    NextExpression()(ctx.toTextSpan)
+  }
+
   override def visitGroupingStatement(ctx: RubyParser.GroupingStatementContext): RubyNode = {
     // When there's only 1 statement, we can use it directly, instead of wrapping it in a StatementList.
     val statements = ctx.compoundStatement().getStatements.map(visit)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -518,4 +518,18 @@ class ControlStructureTests extends RubyCode2CpgFixture {
       }
     }
   }
+
+  "Generate continue node for next" in {
+    val cpg = code("""
+                     |for i in arr do
+                     |   next if i % 2 == 0
+                     |end
+                     |""".stripMargin)
+
+    inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.CONTINUE).l) {
+      case nextControl :: Nil =>
+        nextControl.code shouldBe "next"
+      case xs => fail(s"Expected next to be continue, got [${xs.code.mkString(",")}]")
+    }
+  }
 }


### PR DESCRIPTION
This PR handles:
 * Added new `NextExpression` RubyNode
 * Generate `continue` control structure AST for `NEXT` in Ruby