### PR TITLE
[c2cpg] Fix regression (incorrect end line numbers)

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -100,7 +100,7 @@ class AstCreator(
   }
 
   override protected def lineEnd(node: IASTNode): Option[Int] = {
-    nullSafeFileLocation(node).map(_.getEndingLineNumber)
+    nullSafeFileLocationLast(node).map(_.getEndingLineNumber)
   }
 
   protected def column(node: IASTNode): Option[Int] = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -79,6 +79,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   protected def nullSafeFileLocation(node: IASTNode): Option[IASTFileLocation] =
     Option(cdtAst.flattenLocationsToFile(node.getNodeLocations)).map(_.asFileLocation())
+  protected def nullSafeFileLocationLast(node: IASTNode): Option[IASTFileLocation] =
+    Option(cdtAst.flattenLocationsToFile(node.getNodeLocations.lastOption.toArray)).map(_.asFileLocation())
 
   protected def fileName(node: IASTNode): String = {
     val path = nullSafeFileLocation(node).map(_.getFileName).getOrElse(filename)


### PR DESCRIPTION
https://github.com/joernio/joern/commit/b4ff8b3ad17d6dcec6467db680ad82928807ee6b seems to contain a copy/paste error leading to incorrect `lineNumberEnd` fields. This PR fixes this.