### PR TITLE
[ruby] Calls with reserved keywords

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -32,6 +32,7 @@ options {
     superClass = RubyLexerBase;
 }
 
+
 // --------------------------------------------------------
 // Keywords
 // --------------------------------------------------------
@@ -78,49 +79,6 @@ WHEN: 'when';
 WHILE: 'while';
 YIELD: 'yield';
 
-fragment KEYWORD
-    :   LINE__
-    |   ENCODING__
-    |   FILE__
-    |   BEGIN_
-    |   END_
-    |   ALIAS
-    |   AND
-    |   BEGIN
-    |   BREAK
-    |   CASE
-    |   CLASS
-    |   DEF
-    |   IS_DEFINED
-    |   DO
-    |   ELSE
-    |   ELSIF
-    |   END
-    |   ENSURE
-    |   FOR
-    |   FALSE
-    |   IF
-    |   IN
-    |   MODULE
-    |   NEXT
-    |   NIL
-    |   NOT
-    |   OR
-    |   REDO
-    |   RESCUE
-    |   RETRY
-    |   RETURN
-    |   SELF
-    |   SUPER
-    |   THEN
-    |   TRUE
-    |   UNDEF
-    |   UNLESS
-    |   UNTIL
-    |   WHEN
-    |   WHILE
-    |   YIELD
-    ;
 
 // --------------------------------------------------------
 // Punctuators
@@ -544,9 +502,52 @@ fragment SYMBOL_NAME
 // --------------------------------------------------------
 // Identifiers
 // --------------------------------------------------------
-
 LOCAL_VARIABLE_IDENTIFIER
-    :   (LOWERCASE_CHARACTER | '_') IDENTIFIER_CHARACTER*
+    :   (LOWERCASE_CHARACTER | '_') IDENTIFIER_CHARACTER* { setKeywordTokenType(); }
+    ;
+
+fragment KEYWORD
+    :   LINE__
+    |   ENCODING__
+    |   FILE__
+    |   BEGIN_
+    |   END_
+    |   ALIAS
+    |   AND
+    |   BEGIN
+    |   BREAK
+    |   CASE
+    |   CLASS
+    |   DEF
+    |   IS_DEFINED
+    |   DO
+    |   ELSE
+    |   ELSIF
+    |   END
+    |   ENSURE
+    |   FOR
+    |   FALSE
+    |   IF
+    |   IN
+    |   MODULE
+    |   NEXT
+    |   NIL
+    |   NOT
+    |   OR
+    |   REDO
+    |   RESCUE
+    |   RETRY
+    |   RETURN
+    |   SELF
+    |   SUPER
+    |   THEN
+    |   TRUE
+    |   UNDEF
+    |   UNLESS
+    |   UNTIL
+    |   WHEN
+    |   WHILE
+    |   YIELD
     ;
 
 GLOBAL_VARIABLE_IDENTIFIER

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyLexer.g4
@@ -32,54 +32,6 @@ options {
     superClass = RubyLexerBase;
 }
 
-
-// --------------------------------------------------------
-// Keywords
-// --------------------------------------------------------
-
-LINE__:'__LINE__';
-ENCODING__: '__ENCODING__';
-FILE__: '__FILE__';
-BEGIN_: 'BEGIN';
-END_: 'END';
-ALIAS: 'alias';
-AND: 'and';
-BEGIN: 'begin';
-BREAK: 'break';
-CASE: 'case';
-CLASS: 'class';
-DEF: 'def';
-IS_DEFINED: 'defined?';
-DO: 'do';
-ELSE: 'else';
-ELSIF: 'elsif';
-END: 'end';
-ENSURE: 'ensure';
-FOR: 'for';
-FALSE: 'false';
-IF: 'if';
-IN: 'in';
-MODULE: 'module';
-NEXT: 'next';
-NIL: 'nil';
-NOT: 'not';
-OR: 'or';
-REDO: 'redo';
-RESCUE: 'rescue';
-RETRY: 'retry';
-RETURN: 'return';
-SELF: 'self';
-SUPER: 'super';
-THEN: 'then';
-TRUE: 'true';
-UNDEF: 'undef';
-UNLESS: 'unless';
-UNTIL: 'until';
-WHEN: 'when';
-WHILE: 'while';
-YIELD: 'yield';
-
-
 // --------------------------------------------------------
 // Punctuators
 // --------------------------------------------------------
@@ -505,6 +457,52 @@ fragment SYMBOL_NAME
 LOCAL_VARIABLE_IDENTIFIER
     :   (LOWERCASE_CHARACTER | '_') IDENTIFIER_CHARACTER* { setKeywordTokenType(); }
     ;
+
+// --------------------------------------------------------
+// Keywords
+// --------------------------------------------------------
+
+LINE__:'__LINE__';
+ENCODING__: '__ENCODING__';
+FILE__: '__FILE__';
+BEGIN_: 'BEGIN';
+END_: 'END';
+ALIAS: 'alias';
+AND: 'and';
+BEGIN: 'begin';
+BREAK: 'break';
+CASE: 'case';
+CLASS: 'class';
+DEF: 'def';
+IS_DEFINED: 'defined?';
+DO: 'do';
+ELSE: 'else';
+ELSIF: 'elsif';
+END: 'end';
+ENSURE: 'ensure';
+FOR: 'for';
+FALSE: 'false';
+IF: 'if';
+IN: 'in';
+MODULE: 'module';
+NEXT: 'next';
+NIL: 'nil';
+NOT: 'not';
+OR: 'or';
+REDO: 'redo';
+RESCUE: 'rescue';
+RETRY: 'retry';
+RETURN: 'return';
+SELF: 'self';
+SUPER: 'super';
+THEN: 'then';
+TRUE: 'true';
+UNDEF: 'undef';
+UNLESS: 'unless';
+UNTIL: 'until';
+WHEN: 'when';
+WHILE: 'while';
+YIELD: 'yield';
 
 fragment KEYWORD
     :   LINE__

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -10,7 +10,8 @@ final case class Config(
   antlrCacheMemLimit: Double = 0.6d,
   useDeprecatedFrontend: Boolean = false,
   downloadDependencies: Boolean = false,
-  useTypeStubs: Boolean = true
+  useTypeStubs: Boolean = true,
+  antlrDebug: Boolean = false
 ) extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config]
@@ -28,6 +29,10 @@ final case class Config(
     copy(useDeprecatedFrontend = value).withInheritedFields(this)
   }
 
+  def withAntlrDebugging(value: Boolean): Config = {
+    copy(antlrDebug = value).withInheritedFields(this)
+  }
+
   override def withDownloadDependencies(value: Boolean): Config = {
     copy(downloadDependencies = value).withInheritedFields(this)
   }
@@ -35,6 +40,7 @@ final case class Config(
   override def withTypeStubs(value: Boolean): Config = {
     copy(useTypeStubs = value).withInheritedFields(this)
   }
+
 }
 
 private object Frontend {
@@ -61,6 +67,9 @@ private object Frontend {
       opt[Unit]("useDeprecatedFrontend")
         .action((_, c) => c.withUseDeprecatedFrontend(true))
         .text("uses the original (but deprecated) Ruby frontend (default false)"),
+      opt[Unit]("antlrDebug")
+        .hidden()
+        .action((_, c) => c.withAntlrDebugging(true)),
       DependencyDownloadConfig.parserOptions,
       XTypeRecoveryConfig.parserOptionsForParserConfig,
       TypeStubConfig.parserOptions

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -51,7 +51,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
   }
 
   private def newCreateCpgAction(cpg: Cpg, config: Config): Unit = {
-    Using.resource(new parser.ResourceManagedParser(config.antlrCacheMemLimit)) { parser =>
+    Using.resource(new parser.ResourceManagedParser(config.antlrCacheMemLimit, config.antlrDebug)) { parser =>
       val astCreators = ConcurrentTaskUtil
         .runUsingThreadPool(RubySrc2Cpg.generateParserTasks(parser, config, cpg.metaData.root.headOption))
         .flatMap {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrParser.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrParser.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.parser
 
-import better.files.{EOF, File}
+import better.files.File
 import org.antlr.v4.runtime.*
 import org.antlr.v4.runtime.atn.{ATN, ATNConfigSet}
 import org.antlr.v4.runtime.dfa.DFA

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrParser.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrParser.scala
@@ -1,10 +1,11 @@
 package io.joern.rubysrc2cpg.parser
 
-import better.files.File
+import better.files.{EOF, File}
 import org.antlr.v4.runtime.*
 import org.antlr.v4.runtime.atn.{ATN, ATNConfigSet}
 import org.antlr.v4.runtime.dfa.DFA
 import org.slf4j.LoggerFactory
+
 import java.io.File.separator
 import java.util
 import scala.collection.mutable.ListBuffer
@@ -18,8 +19,9 @@ import scala.util.Try
   */
 class AntlrParser(inputDir: File, filename: String) {
 
-  private val charStream  = CharStreams.fromFileName(filename)
-  private val lexer       = new RubyLexer(charStream)
+  private val charStream = CharStreams.fromFileName(filename)
+  private val lexer      = new RubyLexer(charStream)
+
   private val tokenStream = new CommonTokenStream(RubyLexerPostProcessor(lexer))
   val parser: RubyParser  = new RubyParser(tokenStream)
 
@@ -82,7 +84,7 @@ class AntlrParser(inputDir: File, filename: String) {
   * @param clearLimit
   *   the percentage of used heap to clear the DFA-cache on.
   */
-class ResourceManagedParser(clearLimit: Double) extends AutoCloseable {
+class ResourceManagedParser(clearLimit: Double, debug: Boolean = false) extends AutoCloseable {
 
   private val logger                                 = LoggerFactory.getLogger(getClass)
   private val runtime                                = Runtime.getRuntime
@@ -92,7 +94,8 @@ class ResourceManagedParser(clearLimit: Double) extends AutoCloseable {
   def parse(inputFile: File, filename: String): Try[RubyParser.ProgramContext] = {
     val inputDir    = if inputFile.isDirectory then inputFile else inputFile.parent
     val antlrParser = AntlrParser(inputDir, filename)
-    val interp      = antlrParser.parser.getInterpreter
+    antlrParser.parser.setTrace(debug) // enables printing of ANTLR parse tree
+    val interp = antlrParser.parser.getInterpreter
     // We need to grab a live instance in order to get the static variables as they are protected from static access
     maybeDecisionToDFA = Option(interp.decisionToDFA)
     maybeAtn = Option(interp.atn)
@@ -101,6 +104,7 @@ class ResourceManagedParser(clearLimit: Double) extends AutoCloseable {
       logger.debug(s"Runtime memory consumption at $usedMemory, clearing ANTLR DFA cache")
       clearDFA()
     }
+
     val (programCtx, errors) = antlrParser.parse()
     errors.foreach(logger.warn)
     programCtx

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/KeywordHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/KeywordHandling.scala
@@ -53,14 +53,17 @@ trait KeywordHandling { this: RubyLexerBase =>
     previousToken == RubyLexer.DOT || previousToken == RubyLexer.COLON || previousToken == RubyLexer.COLON2
   }
 
+  private def isNextTokenColonOrDot: Boolean = {
+    _input.LA(1) == '.' || _input.LA(1) == ':'
+  }
+
   def setKeywordTokenType(): Unit = {
     val tokenText = getText
     if (tokenText == null) {
       return
     }
 
-    // _input.LA(1) == ':' indicates named parameter
-    if (isPreviousTokenColonOrDot || _input.LA(1) == ':' || !keywordMap.contains(tokenText.toUpperCase)) {
+    if (isPreviousTokenColonOrDot || isNextTokenColonOrDot || !keywordMap.contains(tokenText.toUpperCase)) {
       setType(RubyLexer.LOCAL_VARIABLE_IDENTIFIER)
     } else {
       keywordMap.get(tokenText.toUpperCase).foreach(setType)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/KeywordHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/KeywordHandling.scala
@@ -63,7 +63,11 @@ trait KeywordHandling { this: RubyLexerBase =>
       return
     }
 
-    if (isPreviousTokenColonOrDot || isNextTokenColonOrDot || !keywordMap.contains(tokenText.toUpperCase)) {
+    if (
+      isPreviousTokenColonOrDot || (isNextTokenColonOrDot && tokenText.toUpperCase != "SELF") || !keywordMap.contains(
+        tokenText.toUpperCase
+      )
+    ) {
       setType(RubyLexer.LOCAL_VARIABLE_IDENTIFIER)
     } else {
       keywordMap.get(tokenText.toUpperCase).foreach(setType)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/KeywordHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/KeywordHandling.scala
@@ -1,0 +1,62 @@
+package io.joern.rubysrc2cpg.parser
+
+import io.joern.rubysrc2cpg.parser.RubyLexer.*
+
+trait KeywordHandling { this: RubyLexerBase =>
+
+  val keywordMap: Map[String, Int] = Map(
+    "LINE__"     -> LINE__,
+    "ENCODING__" -> ENCODING__,
+    "FILE__"     -> FILE__,
+    "BEGIN_"     -> BEGIN_,
+    "END_"       -> END_,
+    "ALIAS"      -> ALIAS,
+    "AND"        -> AND,
+    "BEGIN"      -> BEGIN,
+    "BREAK"      -> BREAK,
+    "CASE"       -> CASE,
+    "CLASS"      -> CLASS,
+    "DEF"        -> DEF,
+    "IS_DEFINED" -> IS_DEFINED,
+    "DO"         -> DO,
+    "ELSE"       -> ELSE,
+    "ELSIF"      -> ELSIF,
+    "END"        -> END,
+    "ENSURE"     -> ENSURE,
+    "FOR"        -> FOR,
+    "FALSE"      -> FALSE,
+    "IF"         -> IF,
+    "IN"         -> IN,
+    "MODULE"     -> MODULE,
+    "NEXT"       -> NEXT,
+    "NIL"        -> NIL,
+    "NOT"        -> NOT,
+    "OR"         -> OR,
+    "REDO"       -> REDO,
+    "RESCUE"     -> RESCUE,
+    "RETRY"      -> RETRY,
+    "RETURN"     -> RETURN,
+    "SELF"       -> SELF,
+    "SUPER"      -> SUPER,
+    "THEN"       -> THEN,
+    "TRUE"       -> TRUE,
+    "UNDEF"      -> UNDEF,
+    "UNLESS"     -> UNLESS,
+    "UNTIL"      -> UNTIL,
+    "WHEN"       -> WHEN,
+    "WHILE"      -> WHILE,
+    "YIELD"      -> YIELD
+  )
+
+  def setKeywordTokenType(): Unit = {
+    if (_token == null) {
+      return
+    }
+
+    if (previousNonWsTokenTypeOrEOF() == RubyLexer.DOT || !keywordMap.contains(_token.getText)) {
+      setType(RubyLexer.LOCAL_VARIABLE_IDENTIFIER)
+    } else {
+      keywordMap.get(_token.getText).foreach(setType)
+    }
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/KeywordHandling.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/KeywordHandling.scala
@@ -48,15 +48,22 @@ trait KeywordHandling { this: RubyLexerBase =>
     "YIELD"      -> YIELD
   )
 
+  private def isPreviousTokenColonOrDot: Boolean = {
+    val previousToken = previousTokenTypeOrEOF()
+    previousToken == RubyLexer.DOT || previousToken == RubyLexer.COLON || previousToken == RubyLexer.COLON2
+  }
+
   def setKeywordTokenType(): Unit = {
-    if (_token == null) {
+    val tokenText = getText
+    if (tokenText == null) {
       return
     }
 
-    if (previousNonWsTokenTypeOrEOF() == RubyLexer.DOT || !keywordMap.contains(_token.getText)) {
+    // _input.LA(1) == ':' indicates named parameter
+    if (isPreviousTokenColonOrDot || _input.LA(1) == ':' || !keywordMap.contains(tokenText.toUpperCase)) {
       setType(RubyLexer.LOCAL_VARIABLE_IDENTIFIER)
     } else {
-      keywordMap.get(_token.getText).foreach(setType)
+      keywordMap.get(tokenText.toUpperCase).foreach(setType)
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyLexerBase.scala
@@ -10,6 +10,7 @@ abstract class RubyLexerBase(input: CharStream)
     with RegexLiteralHandling
     with InterpolationHandling
     with QuotedLiteralHandling
+    with KeywordHandling
     with HereDocHandling {
 
   /** The previously (non-WS) emitted token (in DEFAULT_CHANNEL.) */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -32,7 +32,6 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     currentResult.isInstanceOf[Unknown]
 
   override def visit(tree: ParseTree): RubyNode = {
-    println(tree.getClass)
     Option(tree).map(super.visit).getOrElse(defaultResult())
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -32,6 +32,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     currentResult.isInstanceOf[Unknown]
 
   override def visit(tree: ParseTree): RubyNode = {
+    println(tree.getClass)
     Option(tree).map(super.visit).getOrElse(defaultResult())
   }
 
@@ -732,9 +733,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   override def visitMemberAccessExpression(ctx: RubyParser.MemberAccessExpressionContext): RubyNode = {
     val hasArguments = Option(ctx.argumentWithParentheses()).isDefined
     val hasBlock     = Option(ctx.block()).isDefined
-    val isClassDecl = Option(ctx.primaryValue()).map(_.getText).contains("Class") && Option(ctx.methodName())
-      .map(_.getText)
-      .contains("new")
+    val isClassDecl =
+      Option(ctx.primaryValue()).map(_.getText).contains("Class") && Option(ctx.methodName())
+        .map(_.getText)
+        .contains("new")
     val methodName = ctx.methodName().getText
 
     if (!hasBlock) {
@@ -750,6 +752,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
           if (methodName.headOption.exists(_.isUpper)) {
             return MemberAccess(target, ctx.op.getText, methodName)(ctx.toTextSpan)
           } else {
+            val a = MemberCall(target, ctx.op.getText, methodName, Nil)(ctx.toTextSpan)
             return MemberCall(target, ctx.op.getText, methodName, Nil)(ctx.toTextSpan)
           }
         } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesParserTests.scala
@@ -19,4 +19,9 @@ class InvocationWithoutParenthesesParserTests extends RubyParserFixture with Mat
     test("foo&.bar")
     test("foo&.bar 1,2")
   }
+
+  "method invocation without parenthesis with reserved keywords" in {
+    test("batch.retry!")
+    test("batch.retry")
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -734,11 +734,11 @@ class MethodTests extends RubyCode2CpgFixture {
 
   "a method that is redefined should have a counter suffixed to ensure uniqueness" in {
     val cpg = code("""
-        |def foo;end
-        |def bar;end
-        |def foo;end
-        |def foo;end
-        |""".stripMargin)
+          |def foo;end
+          |def bar;end
+          |def foo;end
+          |def foo;end
+          |""".stripMargin)
 
     cpg.method.name("(foo|bar).*").name.l shouldBe List("foo", "bar", "foo", "foo")
     cpg.method.name("(foo|bar).*").fullName.l shouldBe List(
@@ -748,4 +748,13 @@ class MethodTests extends RubyCode2CpgFixture {
       s"Test0.rb:$Main.foo1"
     )
   }
+
+  "shadowed keyword in member call with emark" in {
+    val cpg = code("""
+        |batch.retry!
+        |""".stripMargin)
+
+    cpg.method.isModule.l
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -777,4 +777,87 @@ class MethodTests extends RubyCode2CpgFixture {
     }
   }
 
+  "Call with :: syntax and reserved keyword" in {
+    val cpg = code("""
+        |batch::retry!
+        |""".stripMargin)
+
+    inside(cpg.call.name(".*retry!").l) {
+      case batchCall :: Nil =>
+        batchCall.name shouldBe "retry!"
+        batchCall.code shouldBe "batch::retry!"
+
+        inside(batchCall.receiver.l) {
+          case (receiverCall: Call) :: Nil =>
+            receiverCall.name shouldBe Operators.fieldAccess
+            receiverCall.code shouldBe "batch.retry!"
+
+            val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
+            selfBatch.code shouldBe "self.batch"
+
+            val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
+            retry.code shouldBe "retry!"
+
+          case xs => fail(s"Expected one receiver for call, got [${xs.code.mkString(",")}]")
+        }
+
+      case xs => fail(s"Expected one method for batch.retry, got [${xs.code.mkString(",")}]")
+    }
+  }
+
+  "Call with reserved keyword as base and call name using . notation" in {
+    val cpg = code("""
+        |retry.retry!
+        |""".stripMargin)
+
+    inside(cpg.call.name(".*retry!").l) {
+      case batchCall :: Nil =>
+        batchCall.name shouldBe "retry!"
+        batchCall.code shouldBe "retry.retry!"
+
+        inside(batchCall.receiver.l) {
+          case (receiverCall: Call) :: Nil =>
+            receiverCall.name shouldBe Operators.fieldAccess
+            receiverCall.code shouldBe "retry.retry!"
+
+            val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
+            selfBatch.code shouldBe "self.retry"
+
+            val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
+            retry.code shouldBe "retry!"
+
+          case xs => fail(s"Expected one receiver for call, got [${xs.code.mkString(",")}]")
+        }
+
+      case xs => fail(s"Expected one method for batch.retry, got [${xs.code.mkString(",")}]")
+    }
+  }
+
+  "Call with reserved keyword as base and call name" in {
+    val cpg = code("""
+        |retry::retry!
+        |""".stripMargin)
+
+    inside(cpg.call.name(".*retry!").l) {
+      case batchCall :: Nil =>
+        batchCall.name shouldBe "retry!"
+        batchCall.code shouldBe "retry::retry!"
+
+        inside(batchCall.receiver.l) {
+          case (receiverCall: Call) :: Nil =>
+            receiverCall.name shouldBe Operators.fieldAccess
+            receiverCall.code shouldBe "retry.retry!"
+
+            val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
+            selfBatch.code shouldBe "self.retry"
+
+            val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
+            retry.code shouldBe "retry!"
+
+          case xs => fail(s"Expected one receiver for call, got [${xs.code.mkString(",")}]")
+        }
+
+      case xs => fail(s"Expected one method for batch.retry, got [${xs.code.mkString(",")}]")
+    }
+  }
 }


### PR DESCRIPTION
An issue was picked up where having a reserved keyword as the call on a member (e.g. `batch.retry!`) was causing a syntax error due to lexer and parser issues.

This PR handles:
 * Changed precedence of keywords in the ANTLR Lexer to come after `LOCAL_VARIABLE_IDENTIFIER`
 * Added handling to `LOCAL_VARIABLE_IDENTIFIER` tokens to determine whether a token should be marked as reserved keyword or not. We check if the previous `nonWs` token is `.`, `:` or `::`, or if the next token is `.` or `:`. If this holds, we know it cannot be a reserved keyword and is instead marked as a `LOCAL_VARIABLE_IDENTIFIER`.
 * Added debug flag to ANTLR parser to print out the parse tree. Hidden and off by default.

Resolves #4748 