### PR TITLE
[c2cpg] Fix CFG creation for INLINE calls (LOCALS with multiple AST parents)

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -1,18 +1,19 @@
 package io.joern.c2cpg.astcreation
 
+import io.joern.x2cpg.Ast
+import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  AstNodeNew,
-  ExpressionNew,
-  NewBlock,
-  NewCall,
-  NewFieldIdentifier,
-  NewNode
-}
-import io.joern.x2cpg.{Ast, AstEdge, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.nodes.AstNodeNew
+import io.shiftleft.codepropertygraph.generated.nodes.ExpressionNew
+import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
+import io.shiftleft.codepropertygraph.generated.nodes.NewCall
+import io.shiftleft.codepropertygraph.generated.nodes.NewFieldIdentifier
+import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
 import org.apache.commons.lang3.StringUtils
-import org.eclipse.cdt.core.dom.ast.{IASTMacroExpansionLocation, IASTNode, IASTPreprocessorMacroDefinition}
+import org.eclipse.cdt.core.dom.ast.IASTMacroExpansionLocation
+import org.eclipse.cdt.core.dom.ast.IASTNode
+import org.eclipse.cdt.core.dom.ast.IASTPreprocessorMacroDefinition
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
@@ -45,18 +46,15 @@ trait MacroHandler(implicit withSchemaValidation: ValidationMode) { this: AstCre
     val macroCallAst  = matchingMacro.map { case (mac, args) => createMacroCallAst(ast, node, mac, args) }
     macroCallAst match {
       case Some(callAst) =>
-        val lostLocals = ast.refEdges.collect { case AstEdge(_, dst: NewLocal) => Ast(dst) }.toList
-        val newAst     = ast.subTreeCopy(ast.root.get.asInstanceOf[AstNodeNew], argIndex = 1)
+        val newAst = ast.subTreeCopy(ast.root.get.asInstanceOf[AstNodeNew], argIndex = 1)
         // We need to wrap the copied AST as it may contain CPG nodes not being allowed
         // to be connected via AST edges under a CALL. E.g., LOCALs but only if its not already a BLOCK.
         val childAst = newAst.root match {
-          case Some(_: NewBlock) =>
-            newAst
-          case _ =>
-            val b = NewBlock().argumentIndex(1).typeFullName(registerType(Defines.Void))
-            blockAst(b, List(newAst))
+          case Some(_: NewBlock) => newAst
+          case _                 => blockAst(blockNode(node), List(newAst))
         }
-        callAst.withChildren(lostLocals).withChild(childAst)
+        setArgumentIndices(Seq(childAst))
+        callAst.withChild(childAst)
       case None => ast
     }
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/macros/MacroHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/macros/MacroHandlingTests.scala
@@ -300,6 +300,27 @@ class MacroHandlingTests extends C2CpgSuite {
   }
 
   "MacroHandlingTests10" should {
+
+    "have ast parents" in {
+      val cpg = code("""
+          |#define FFSWAP(type,a,b) do{type SWAP_tmp=b; b=a; a=SWAP_tmp;}while(0)
+          |struct elem_to_channel {
+          |    uint64_t av_position;
+          |    uint8_t syn_ele;
+          |    uint8_t elem_id;
+          |    uint8_t aac_position;
+          |};
+          |int main () {
+          |  struct elem_to_channel e2c_vec[4 * 1] = { { 0 } };
+          |  int i = 1;
+          |  FFSWAP(struct elem_to_channel, e2c_vec[i - 1], e2c_vec[i]);
+          |}
+          |""".stripMargin)
+      cpg.local.count(l => l._astIn.isEmpty) shouldBe 0
+      cpg.local.count(l => l._astIn.size == 1) shouldBe 4
+      cpg.local.count(l => l._astIn.size > 1) shouldBe 0
+    }
+
     "only have locals with exactly one ast parent" in {
       val cpg = code(
         """

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/macros/MacroHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/macros/MacroHandlingTests.scala
@@ -298,6 +298,31 @@ class MacroHandlingTests extends C2CpgSuite {
       typeNumCall.columnNumber shouldBe Some(11)
     }
   }
+
+  "MacroHandlingTests10" should {
+    "only have locals with exactly one ast parent" in {
+      val cpg = code(
+        """
+          |#define deleteReset(ptr) do { delete ptr; ptr = nullptr; } while(0)
+          |void func(void) {
+          |  int *foo = new int;
+          |  int *bar = new int;
+          |  int *baz = new int;
+          |  deleteReset(foo);
+          |  deleteReset(bar);
+          |  deleteReset(baz);
+          |}
+          |""".stripMargin,
+        "foo.cc"
+      )
+      val List(foo) = cpg.local.nameExact("foo").l
+      foo._astIn.size shouldBe 1
+      val List(bar) = cpg.local.nameExact("bar").l
+      bar._astIn.size shouldBe 1
+      val List(baz) = cpg.local.nameExact("baz").l
+      baz._astIn.size shouldBe 1
+    }
+  }
 }
 
 class CfgMacroTests extends DataFlowCodeToCpgSuite {


### PR DESCRIPTION
No more LOCALs with multiple AST parents.