### PR TITLE
Added `joern-slice` Data-Flow Script Test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,8 +101,10 @@ jobs:
           ./joern-scan /tmp/foo
           ./joern-scan --dump
       - run: |
-          mkdir /tmp/slice
+          mkdir /tmp/slice && ls -al
+          echo "Slicing!"
           ./joern-slice data-flow tests/code/javasrc/SliceTest.java -o /tmp/slice/dataflow-slice-javasrc.json
+          echo "Validating!"
           ./joern --script test-dataflow-slice.sc --param sliceFile=/tmp/slice/dataflow-slice-javasrc.json | \ 
             grep -q 'List(boolean b, b, this, s, "MALICIOUS", s, new Foo("MALICIOUS"), s, s, "SAFE", s, b, this, this, b, s, System.out)'
       - run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,7 +100,10 @@ jobs:
           ./joern --src /tmp/foo --run scan
           ./joern-scan /tmp/foo
           ./joern-scan --dump
-          #./joern-slice data-flow -o target/slice
+      - run: |
+          ./joern-slice data-flow tests/code/javasrc/SliceTest.java -o /tmp/slice/dataflow-slice-javasrc.json
+          ./joern --script test-dataflow-slice.sc --param sliceFile=/tmp/slice/dataflow-slice-javasrc.json | \ 
+            grep -q 'List(boolean b, b, this, s, "MALICIOUS", s, new Foo("MALICIOUS"), s, s, "SAFE", s, b, this, this, b, s, System.out)'
       - run: |
           cd joern-cli/target/universal/stage
           ./schema-extender/test.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,6 +101,7 @@ jobs:
           ./joern-scan /tmp/foo
           ./joern-scan --dump
       - run: |
+          mkdir /tmp/slice
           ./joern-slice data-flow tests/code/javasrc/SliceTest.java -o /tmp/slice/dataflow-slice-javasrc.json
           ./joern --script test-dataflow-slice.sc --param sliceFile=/tmp/slice/dataflow-slice-javasrc.json | \ 
             grep -q 'List(boolean b, b, this, s, "MALICIOUS", s, new Foo("MALICIOUS"), s, s, "SAFE", s, b, this, this, b, s, System.out)'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,12 +101,9 @@ jobs:
           ./joern-scan /tmp/foo
           ./joern-scan --dump
       - run: |
-          mkdir /tmp/slice && ls -al
-          echo "Slicing!"
+          mkdir /tmp/slice
           ./joern-slice data-flow tests/code/javasrc/SliceTest.java -o /tmp/slice/dataflow-slice-javasrc.json
-          echo "Validating!"
-          ./joern --script test-dataflow-slice.sc --param sliceFile=/tmp/slice/dataflow-slice-javasrc.json | \ 
-            grep -q 'List(boolean b, b, this, s, "MALICIOUS", s, new Foo("MALICIOUS"), s, s, "SAFE", s, b, this, this, b, s, System.out)'
+          ./joern --script "./test-dataflow-slice.sc" --param sliceFile=/tmp/slice/dataflow-slice-javasrc.json | grep -q 'List(boolean b, b, this, s, "MALICIOUS", s, new Foo("MALICIOUS"), s, s, "SAFE", s, b, this, this, b, s, System.out)'
       - run: |
           cd joern-cli/target/universal/stage
           ./schema-extender/test.sh

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/DataFlowSlicing.scala
@@ -2,7 +2,7 @@ package io.joern.dataflowengineoss.slicing
 
 import io.joern.dataflowengineoss.language.*
 import io.joern.x2cpg.utils.ConcurrentTaskUtil
-import io.shiftleft.codepropertygraph.generated.{Cpg, Properties}
+import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes, Properties}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
@@ -46,8 +46,9 @@ object DataFlowSlicing {
       val sliceNodes      = sinks.iterator.repeat(_.ddgIn)(_.maxDepth(config.sliceDepth).emit).dedup.l
       val sliceNodesIdSet = sliceNodes.id.toSet
       // Lazily set up the rest if the filters are satisfied
-      lazy val sliceEdges = sliceNodes.outE
-        .filter(x => sliceNodesIdSet.contains(x.dst.id()))
+      lazy val sliceEdges = sliceNodes
+        .inE(EdgeTypes.REACHING_DEF)
+        .filter(x => sliceNodesIdSet.contains(x.src.id()))
         .map { e => SliceEdge(e.src.id(), e.dst.id(), e.label) }
         .toSet
       lazy val slice = Option(DataFlowSlice(sliceNodes.map(cfgNodeToSliceNode).toSet, sliceEdges))

--- a/test-dataflow-slice.sc
+++ b/test-dataflow-slice.sc
@@ -1,0 +1,17 @@
+import upickle.default.*
+import io.shiftleft.utils.IOUtils
+import java.nio.file.Path
+import io.joern.dataflowengineoss.slicing.{DataFlowSlice, SliceEdge}
+
+@main def exec(sliceFile: String) = {
+  val jsonContent       = IOUtils.readLinesInFile(Path.of(sliceFile)).mkString
+  val dataFlowSlice = read[DataFlowSlice](jsonContent)
+  val nodeMap = dataFlowSlice.nodes.map(n => n.id -> n).toMap
+  val edges = dataFlowSlice.edges.toList
+    .map { case SliceEdge(src, dst, _) =>
+      (nodeMap(src).lineNumber, nodeMap(dst).lineNumber) -> List(nodeMap(src).code, nodeMap(dst).code).distinct
+    }
+    .sortBy(_._1)
+    .flatMap(_._2)
+  println(edges)
+}

--- a/tests/code/javasrc/SliceTest.java
+++ b/tests/code/javasrc/SliceTest.java
@@ -1,0 +1,16 @@
+
+
+public class SliceTest {
+
+    public void foo(boolean b) {
+        String s = new Foo("MALICIOUS");
+        if (b) {
+            s.setFoo("SAFE");
+        }
+        bar(b);
+    }
+
+    public void bar(String x) {
+        System.out.println(s);
+    }
+}


### PR DESCRIPTION
* Added a script that parses and creates a sensible string from a slice that can be tested against.
* Fixed a slicing bug where slicing direction was in the opposite direction of neighbour retrieval and ended up ignoring certain nodes.
* Added entry in the `test-scripts` job to run the slice script, parse the slice, and assert the expected flow with `grep`.

Resolves #4783

@mpollmeier, is this the direction we want to go? Is this test satisfactory to assert some expected behaviour with?