### PR TITLE
[c2cpg] Defer method decl handling

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -1,6 +1,7 @@
 package io.joern.c2cpg
 
 import io.joern.c2cpg.passes.{AstCreationPass, PreprocessorPass, TypeDeclNodePass}
+import io.joern.c2cpg.passes.FunctionDeclNodePass
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
@@ -21,6 +22,8 @@ class C2Cpg extends X2CpgFrontend[Config] {
       new MetaDataPass(cpg, Languages.NEWC, config.inputPath).createAndApply()
       val astCreationPass = new AstCreationPass(cpg, config, report)
       astCreationPass.createAndApply()
+      new FunctionDeclNodePass(cpg, astCreationPass.unhandledMethodDeclarations())(config.schemaValidation)
+        .createAndApply()
       TypeNodePass.withRegisteredTypes(astCreationPass.typesSeen(), cpg).createAndApply()
       new TypeDeclNodePass(cpg)(config.schemaValidation).createAndApply()
       report.print()

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -4,7 +4,6 @@ import io.joern.c2cpg.Config
 import io.joern.x2cpg.datastructures.Scope
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
-import io.joern.x2cpg.datastructures.Global
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
@@ -19,7 +18,7 @@ import scala.collection.mutable
   */
 class AstCreator(
   val filename: String,
-  val global: Global,
+  val global: CGlobal,
   val config: Config,
   val cdtAst: IASTTranslationUnit,
   val file2OffsetTable: ConcurrentHashMap[String, Array[Int]]

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -107,11 +107,10 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   }
 
   // Sadly, there is no predefined List / Enum of this within Eclipse CDT:
-  private val reservedTypeKeywords: List[String] =
+  private val ReservedTypeKeywords: List[String] =
     List(
       "const",
       "static",
-      "volatile",
       "restrict",
       "extern",
       "typedef",
@@ -125,11 +124,13 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       "class"
     )
 
+  private val KeepTypeKeywords: List[String] = List("unsigned", "volatile")
+
   protected def cleanType(rawType: String, stripKeywords: Boolean = true): String = {
     if (rawType == Defines.Any) return rawType
     val tpe =
       if (stripKeywords) {
-        reservedTypeKeywords.foldLeft(rawType) { (cur, repl) =>
+        ReservedTypeKeywords.foldLeft(rawType) { (cur, repl) =>
           if (cur.contains(s"$repl ")) {
             dereferenceTypeFullName(cur.replace(s"$repl ", ""))
           } else {
@@ -140,28 +141,54 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         rawType
       }
     StringUtils.normalizeSpace(tpe) match {
-      case ""                                                                      => Defines.Any
-      case t if t.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType") => Defines.Any
+      case "" =>
+        Defines.Any
+      case t if t.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType") =>
+        Defines.Any
       case t if t.contains(" ->") && t.contains("}::") =>
-        fixQualifiedName(t.substring(t.indexOf("}::") + 3, t.indexOf(" ->")))
+        replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t.substring(t.indexOf("}::") + 3, t.indexOf(" ->"))))
       case t if t.contains(" ->") =>
-        fixQualifiedName(t.substring(0, t.indexOf(" ->")))
+        replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t.substring(0, t.indexOf(" ->"))))
       case t if t.contains("( ") =>
-        fixQualifiedName(t.substring(0, t.indexOf("( ")))
-      case t if t.contains("?")                        => Defines.Any
-      case t if t.contains("#")                        => Defines.Any
-      case t if t.contains("::{") || t.contains("}::") => Defines.Any
+        replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t.substring(0, t.indexOf("( "))))
+      case t if t.contains("?") =>
+        Defines.Any
+      case t if t.contains("#") =>
+        Defines.Any
+      case t if t.contains("::{") || t.contains("}::") =>
+        Defines.Any
       case t if t.contains("{") && t.contains("}") =>
         val beforeBracket = t.substring(0, t.indexOf("{"))
         val afterBracket  = t.substring(t.indexOf("}") + 1)
         val anonType      = s"${uniqueName("type", "", "")._1}$beforeBracket$afterBracket"
-        anonType.replace(" ", "")
-      case t if t.startsWith("[") && t.endsWith("]")       => Defines.Any
-      case t if t.contains(Defines.QualifiedNameSeparator) => fixQualifiedName(t)
-      case t if t.startsWith("unsigned ")                  => "unsigned " + t.substring(9).replace(" ", "")
-      case t if t.contains("[") && t.contains("]")         => t.replace(" ", "")
-      case t if t.contains("*")                            => t.replace(" ", "")
-      case someType                                        => someType
+        replaceWhitespaceAfterTypeKeyword(anonType)
+      case t if t.startsWith("[") && t.endsWith("]") =>
+        Defines.Any
+      case t if t.contains(Defines.QualifiedNameSeparator) =>
+        replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t))
+      case t if KeepTypeKeywords.exists(k => t.startsWith(s"$k ")) =>
+        replaceWhitespaceAfterTypeKeyword(t)
+      case t if t.contains("[") && t.contains("]") =>
+        replaceWhitespaceAfterTypeKeyword(t)
+      case t if t.contains("*") =>
+        replaceWhitespaceAfterTypeKeyword(t)
+      case someType =>
+        someType
+    }
+  }
+
+  private def replaceWhitespaceAfterTypeKeyword(tpe: String): String = {
+    if (KeepTypeKeywords.exists(k => tpe.startsWith(s"$k "))) {
+      KeepTypeKeywords.foldLeft(tpe) { (cur, repl) =>
+        val prefix = s"$repl "
+        if (cur.startsWith(prefix)) {
+          prefix + cur.substring(prefix.length).replace(" ", "")
+        } else {
+          cur
+        }
+      }
+    } else {
+      tpe.replace(" ", "")
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -149,39 +149,20 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         rawType
       }
     StringUtils.normalizeSpace(tpe) match {
-      case "" =>
-        Defines.Any
-      case t if t.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType") =>
-        Defines.Any
-      case t if t.contains(" ->") && t.contains("}::") =>
-        replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t.substring(t.indexOf("}::") + 3, t.indexOf(" ->"))))
-      case t if t.contains(" ->") =>
-        replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t.substring(0, t.indexOf(" ->"))))
-      case t if t.contains("( ") =>
-        replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t.substring(0, t.indexOf("( "))))
-      case t if t.contains("?") =>
-        Defines.Any
-      case t if t.contains("#") =>
-        Defines.Any
-      case t if t.contains("::{") || t.contains("}::") =>
-        Defines.Any
-      case t if t.contains("{") && t.contains("}") =>
-        val beforeBracket = t.substring(0, t.indexOf("{"))
-        val afterBracket  = t.substring(t.indexOf("}") + 1)
-        val anonType      = s"${uniqueName("type", "", "")._1}$beforeBracket$afterBracket"
-        replaceWhitespaceAfterTypeKeyword(anonType)
-      case t if t.startsWith("[") && t.endsWith("]") =>
-        Defines.Any
-      case t if t.contains(Defines.QualifiedNameSeparator) =>
-        replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t))
-      case t if KeepTypeKeywords.exists(k => t.startsWith(s"$k ")) =>
-        replaceWhitespaceAfterTypeKeyword(t)
-      case t if t.contains("[") && t.contains("]") =>
-        replaceWhitespaceAfterTypeKeyword(t)
-      case t if t.contains("*") =>
-        replaceWhitespaceAfterTypeKeyword(t)
-      case someType =>
-        someType
+      case ""                                                                      => Defines.Any
+      case t if t.startsWith("[") && t.endsWith("]")                               => Defines.Array
+      case t if t.contains("->")                                                   => Defines.Function
+      case t if t.contains("?")                                                    => Defines.Any
+      case t if t.contains("#")                                                    => Defines.Any
+      case t if t.contains("::{") || t.contains("}::")                             => Defines.Any
+      case t if t.contains("{") || t.contains("}")                                 => Defines.Any
+      case t if t.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType") => Defines.Any
+      case t if t.contains("( ") => replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t.substring(0, t.indexOf("( "))))
+      case t if t.contains(Defines.QualifiedNameSeparator) => replaceWhitespaceAfterTypeKeyword(fixQualifiedName(t))
+      case t if KeepTypeKeywords.exists(k => t.startsWith(s"$k ")) => replaceWhitespaceAfterTypeKeyword(t)
+      case t if t.contains("[") && t.contains("]")                 => replaceWhitespaceAfterTypeKeyword(t)
+      case t if t.contains("*")                                    => replaceWhitespaceAfterTypeKeyword(t)
+      case someType                                                => someType
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -106,6 +106,14 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     fixedTypeName
   }
 
+  protected def registerMethodDeclaration(fullName: String, methodInfo: CGlobal.MethodInfo): Unit = {
+    global.methodDeclarations.putIfAbsent(fullName, methodInfo)
+  }
+
+  protected def registerMethodDefinition(fullName: String): Unit = {
+    global.methodDefinitions.putIfAbsent(fullName, true)
+  }
+
   // Sadly, there is no predefined List / Enum of this within Eclipse CDT:
   private val ReservedTypeKeywords: List[String] =
     List(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -326,7 +326,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       case other =>
         (code(other), code(other), cleanType(typeForDeclSpecifier(other)), false)
     }
-    CGlobal.ParameterInfo(
+    new CGlobal.ParameterInfo(
       name,
       codeString,
       paramIndex,

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/CGlobal.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/CGlobal.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 object CGlobal {
 
-  case class MethodInfo(
+  final case class MethodInfo(
     name: String,
     code: String,
     fileName: String,
@@ -21,15 +21,15 @@ object CGlobal {
     parameter: Seq[ParameterInfo],
     modifier: Seq[String]
   )
-  case class ParameterInfo(
-    name: String,
+  final class ParameterInfo(
+    val name: String,
     var code: String,
-    index: Int,
+    val index: Int,
     var isVariadic: Boolean,
-    evaluationStrategy: String,
-    lineNumber: Option[Int],
-    columnNumber: Option[Int],
-    typeFullName: String
+    val evaluationStrategy: String,
+    val lineNumber: Option[Int],
+    val columnNumber: Option[Int],
+    val typeFullName: String
   )
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/CGlobal.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/CGlobal.scala
@@ -1,0 +1,43 @@
+package io.joern.c2cpg.astcreation
+
+import io.joern.x2cpg.datastructures.Global
+import java.util.concurrent.ConcurrentHashMap
+
+object CGlobal {
+
+  case class MethodInfo(
+    name: String,
+    code: String,
+    fileName: String,
+    returnType: String,
+    astParentType: String,
+    astParentFullName: String,
+    lineNumber: Option[Int],
+    columnNumber: Option[Int],
+    lineNumberEnd: Option[Int],
+    columnNumberEnd: Option[Int],
+    signature: String,
+    offset: Option[(Int, Int)],
+    parameter: Seq[ParameterInfo],
+    modifier: Seq[String]
+  )
+  case class ParameterInfo(
+    name: String,
+    var code: String,
+    index: Int,
+    var isVariadic: Boolean,
+    evaluationStrategy: String,
+    lineNumber: Option[Int],
+    columnNumber: Option[Int],
+    typeFullName: String
+  )
+
+}
+
+class CGlobal extends Global {
+  import io.joern.c2cpg.astcreation.CGlobal.MethodInfo
+
+  val methodDeclarations: ConcurrentHashMap[String, MethodInfo] = new ConcurrentHashMap()
+  val methodDefinitions: ConcurrentHashMap[String, Boolean]     = new ConcurrentHashMap()
+
+}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/Defines.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/Defines.scala
@@ -3,6 +3,8 @@ package io.joern.c2cpg.astcreation
 object Defines {
   val Any: String                    = "ANY"
   val Void: String                   = "void"
+  val Function: String               = "std.function"
+  val Array: String                  = "std.array"
   val QualifiedNameSeparator: String = "::"
   val Empty                          = "<empty>"
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -4,7 +4,6 @@ import io.joern.c2cpg.C2Cpg.DefaultIgnoredFolders
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.astcreation.AstCreator
 import io.joern.c2cpg.astcreation.CGlobal
-import io.joern.c2cpg.astcreation.Defines
 import io.joern.c2cpg.parser.{CdtParser, FileDefaults}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
@@ -30,7 +29,7 @@ class AstCreationPass(cpg: Cpg, config: Config, report: Report = new Report())
 
   private val global = new CGlobal()
 
-  def typesSeen(): List[String] = global.usedTypes.keys().asScala.filterNot(_ == Defines.Any).toList
+  def typesSeen(): List[String] = global.usedTypes.keys().asScala.toList
 
   def unhandledMethodDeclarations(): Map[String, CGlobal.MethodInfo] = {
     global.methodDeclarations.asScala.toMap -- global.methodDefinitions.asScala.keys

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -3,18 +3,19 @@ package io.joern.c2cpg.passes
 import io.joern.c2cpg.C2Cpg.DefaultIgnoredFolders
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.astcreation.AstCreator
+import io.joern.c2cpg.astcreation.CGlobal
 import io.joern.c2cpg.astcreation.Defines
 import io.joern.c2cpg.parser.{CdtParser, FileDefaults}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.utils.Report
 import io.joern.x2cpg.utils.TimeUtils
 
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 import org.slf4j.{Logger, LoggerFactory}
+
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 import scala.jdk.CollectionConverters.*
@@ -27,9 +28,13 @@ class AstCreationPass(cpg: Cpg, config: Config, report: Report = new Report())
   private val file2OffsetTable: ConcurrentHashMap[String, Array[Int]] = new ConcurrentHashMap()
   private val parser: CdtParser                                       = new CdtParser(config)
 
-  private val global = new Global()
+  private val global = new CGlobal()
 
   def typesSeen(): List[String] = global.usedTypes.keys().asScala.filterNot(_ == Defines.Any).toList
+
+  def unhandledMethodDeclarations(): Map[String, CGlobal.MethodInfo] = {
+    global.methodDeclarations.asScala.toMap -- global.methodDefinitions.asScala.keys
+  }
 
   override def generateParts(): Array[String] = {
     val sourceFileExtensions = FileDefaults.SOURCE_FILE_EXTENSIONS

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FunctionDeclNodePass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FunctionDeclNodePass.scala
@@ -120,17 +120,15 @@ class FunctionDeclNodePass(cpg: Cpg, methodDeclarations: Map[String, CGlobal.Met
     if (methodInfo.astParentType == NodeTypes.TYPE_DECL) {
       val parentTypeDecl = cpg.typeDecl.nameExact(methodInfo.astParentFullName).headOption
       parentTypeDecl
-        .map { parentNode =>
+        .map { typeDecl =>
           val functionBinding =
             NewBinding().name(normalizedName).methodFullName(normalizedFullName).signature(signature)
-          dstGraph.addEdge(parentNode, functionBinding, EdgeTypes.BINDS)
-          method.astParentFullName = parentNode.fullName
-          method.astParentType = parentNode.label
+          dstGraph.addEdge(typeDecl, functionBinding, EdgeTypes.BINDS)
           Ast(functionBinding).withRefEdge(functionBinding, method)
         }
         .getOrElse(Ast())
     } else {
-      val parentNode = typeDeclNode(
+      val typeDecl = typeDeclNode(
         normalizedName,
         normalizedFullName,
         method.filename,
@@ -141,11 +139,11 @@ class FunctionDeclNodePass(cpg: Cpg, methodDeclarations: Map[String, CGlobal.Met
         methodInfo.columnNumber,
         methodInfo.offset
       )
-      Ast.storeInDiffGraph(Ast(parentNode), dstGraph)
-      method.astParentFullName = parentNode.fullName
-      method.astParentType = parentNode.label
+      Ast.storeInDiffGraph(Ast(typeDecl), dstGraph)
+      method.astParentFullName = typeDecl.fullName
+      method.astParentType = typeDecl.label
       val functionBinding = NewBinding().name(normalizedName).methodFullName(normalizedFullName).signature(signature)
-      Ast(functionBinding).withBindsEdge(parentNode, functionBinding).withRefEdge(functionBinding, method)
+      Ast(functionBinding).withBindsEdge(typeDecl, functionBinding).withRefEdge(functionBinding, method)
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FunctionDeclNodePass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FunctionDeclNodePass.scala
@@ -1,0 +1,176 @@
+package io.joern.c2cpg.passes
+
+import io.joern.c2cpg.astcreation.CGlobal
+import io.joern.x2cpg.Ast
+import io.joern.x2cpg.Defines
+import io.joern.x2cpg.ValidationMode
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
+import io.shiftleft.codepropertygraph.generated.nodes.NewMethod
+import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterIn
+import io.shiftleft.codepropertygraph.generated.nodes.NewMethodReturn
+import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
+import io.shiftleft.codepropertygraph.generated.nodes.NewBinding
+import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.NewModifier
+import io.shiftleft.passes.CpgPass
+import io.shiftleft.semanticcpg.language.*
+import org.apache.commons.lang3.StringUtils
+
+import scala.collection.immutable.Map
+
+class FunctionDeclNodePass(cpg: Cpg, methodDeclarations: Map[String, CGlobal.MethodInfo])(implicit
+  withSchemaValidation: ValidationMode
+) extends CpgPass(cpg) {
+
+  private def methodNode(fullName: String, methodNodeInfo: CGlobal.MethodInfo): NewMethod = {
+    val node_ =
+      NewMethod()
+        .name(StringUtils.normalizeSpace(methodNodeInfo.name))
+        .code(methodNodeInfo.code)
+        .fullName(StringUtils.normalizeSpace(fullName))
+        .filename(methodNodeInfo.fileName)
+        .astParentType(methodNodeInfo.astParentType)
+        .astParentFullName(methodNodeInfo.astParentFullName)
+        .isExternal(false)
+        .lineNumber(methodNodeInfo.lineNumber)
+        .columnNumber(methodNodeInfo.columnNumber)
+        .lineNumberEnd(methodNodeInfo.lineNumberEnd)
+        .columnNumberEnd(methodNodeInfo.columnNumberEnd)
+        .signature(StringUtils.normalizeSpace(methodNodeInfo.signature))
+    methodNodeInfo.offset.foreach { case (offset, offsetEnd) =>
+      node_.offset(offset).offsetEnd(offsetEnd)
+    }
+    node_
+  }
+
+  private def parameterInNode(parameterNodeInfo: CGlobal.ParameterInfo): NewMethodParameterIn = {
+    NewMethodParameterIn()
+      .name(parameterNodeInfo.name)
+      .code(parameterNodeInfo.code)
+      .index(parameterNodeInfo.index)
+      .order(parameterNodeInfo.index)
+      .isVariadic(parameterNodeInfo.isVariadic)
+      .evaluationStrategy(parameterNodeInfo.evaluationStrategy)
+      .lineNumber(parameterNodeInfo.lineNumber)
+      .columnNumber(parameterNodeInfo.columnNumber)
+      .typeFullName(parameterNodeInfo.typeFullName)
+  }
+
+  private def methodReturnNode(typeFullName: String, line: Option[Int], column: Option[Int]): NewMethodReturn =
+    NewMethodReturn()
+      .typeFullName(typeFullName)
+      .code("RET")
+      .evaluationStrategy(EvaluationStrategies.BY_VALUE)
+      .lineNumber(line)
+      .columnNumber(column)
+
+  private def typeDeclNode(
+    name: String,
+    fullName: String,
+    filename: String,
+    code: String,
+    astParentType: String,
+    astParentFullName: String,
+    line: Option[Int],
+    column: Option[Int],
+    offset: Option[(Int, Int)]
+  ): NewTypeDecl = {
+    val node_ = NewTypeDecl()
+      .name(name)
+      .fullName(fullName)
+      .code(code)
+      .isExternal(false)
+      .filename(filename)
+      .astParentType(astParentType)
+      .astParentFullName(astParentFullName)
+      .lineNumber(line)
+      .columnNumber(column)
+    offset.foreach { case (offset, offsetEnd) =>
+      node_.offset(offset).offsetEnd(offsetEnd)
+    }
+    node_
+  }
+
+  private def methodStubAst(
+    method: NewMethod,
+    parameters: Seq[Ast],
+    methodReturn: NewMethodReturn,
+    modifier: Seq[Ast]
+  ): Ast =
+    Ast(method)
+      .withChildren(parameters)
+      .withChild(Ast(NewBlock().typeFullName(Defines.Any)))
+      .withChildren(modifier)
+      .withChild(Ast(methodReturn))
+
+  private def createFunctionTypeAndTypeDecl(
+    methodInfo: CGlobal.MethodInfo,
+    method: NewMethod,
+    methodName: String,
+    methodFullName: String,
+    signature: String,
+    dstGraph: DiffGraphBuilder
+  ): Ast = {
+    val normalizedName     = StringUtils.normalizeSpace(methodName)
+    val normalizedFullName = StringUtils.normalizeSpace(methodFullName)
+
+    if (methodInfo.astParentType == NodeTypes.TYPE_DECL) {
+      val parentTypeDecl = cpg.typeDecl.nameExact(methodInfo.astParentFullName).headOption
+      parentTypeDecl
+        .map { parentNode =>
+          val functionBinding =
+            NewBinding().name(normalizedName).methodFullName(normalizedFullName).signature(signature)
+          dstGraph.addEdge(parentNode, functionBinding, EdgeTypes.BINDS)
+          method.astParentFullName = parentNode.fullName
+          method.astParentType = parentNode.label
+          Ast(functionBinding).withRefEdge(functionBinding, method)
+        }
+        .getOrElse(Ast())
+    } else {
+      val parentNode = typeDeclNode(
+        normalizedName,
+        normalizedFullName,
+        method.filename,
+        normalizedName,
+        methodInfo.astParentType,
+        methodInfo.astParentFullName,
+        methodInfo.lineNumber,
+        methodInfo.columnNumber,
+        methodInfo.offset
+      )
+      Ast.storeInDiffGraph(Ast(parentNode), dstGraph)
+      method.astParentFullName = parentNode.fullName
+      method.astParentType = parentNode.label
+      val functionBinding = NewBinding().name(normalizedName).methodFullName(normalizedFullName).signature(signature)
+      Ast(functionBinding).withBindsEdge(parentNode, functionBinding).withRefEdge(functionBinding, method)
+    }
+  }
+
+  override def run(dstGraph: DiffGraphBuilder): Unit = {
+    methodDeclarations.foreach { case (fullName, methodNodeInfo) =>
+      val methodNode_    = methodNode(fullName, methodNodeInfo)
+      val parameterNodes = methodNodeInfo.parameter.map(p => Ast(parameterInNode(p)))
+      val stubAst =
+        methodStubAst(
+          methodNode_,
+          parameterNodes,
+          methodReturnNode(methodNodeInfo.returnType, methodNodeInfo.lineNumber, methodNodeInfo.columnNumber),
+          methodNodeInfo.modifier.map(m => Ast(NewModifier().modifierType(m)))
+        )
+      val typeDeclAst = createFunctionTypeAndTypeDecl(
+        methodNodeInfo,
+        methodNode_,
+        methodNodeInfo.name,
+        fullName,
+        methodNodeInfo.signature,
+        dstGraph
+      )
+      val ast = stubAst.merge(typeDeclAst)
+      Ast.storeInDiffGraph(ast, dstGraph)
+    }
+  }
+
+}

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -1663,10 +1663,9 @@ class AstCreationPassTests extends AstC2CpgSuite {
           |  if (getuid == 0 || someFunction == 0) {}
           |}
           |""".stripMargin)
-      val List(methodA, methodB, methodC) = cpg.method.nameNot("<global>").l
-      methodA.fullName shouldBe "getuid"
-      methodB.fullName shouldBe "someFunction"
-      methodC.fullName shouldBe "checkFunctionPointerComparison"
+      val List(methodA) = cpg.method.fullNameExact("getuid").l
+      val List(methodB) = cpg.method.fullNameExact("someFunction").l
+      val List(methodC) = cpg.method.fullNameExact("checkFunctionPointerComparison").l
       inside(cpg.call.nameExact(Operators.equals).l) { case List(callA: Call, callB: Call) =>
         val getuidRef = callA.argument(1).asInstanceOf[MethodRef]
         getuidRef.methodFullName shouldBe methodA.fullName

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/HeaderAstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/HeaderAstCreationPassTests.scala
@@ -37,20 +37,17 @@ class HeaderAstCreationPassTests extends C2CpgSuite {
 
     "de-duplicate content correctly" in {
       inside(cpg.method.nameNot(NamespaceTraversal.globalNamespaceName).sortBy(_.fullName)) {
-        case Seq(bar, foo, m1, m2, printf) =>
+        case Seq(bar, foo, m, printf) =>
           // note that we don't see bar twice even so it is contained
           // in main.h and included in main.c and we do scan both
           bar.fullName shouldBe "bar"
           bar.filename shouldBe "main.h"
           foo.fullName shouldBe "foo"
           foo.filename shouldBe "other.h"
-          // main is include twice. First time for the header file,
-          // second time for the actual implementation in the source file
-          // We do not de-duplicate this as line/column numbers differ
-          m1.fullName shouldBe "main"
-          m1.filename shouldBe "main.c"
-          m2.fullName shouldBe "main"
-          m2.filename shouldBe "main.h"
+          // main is also deduplicated. It is defined within the header file,
+          // and has an actual implementation in the source file
+          m.fullName shouldBe "main"
+          m.filename shouldBe "main.c"
           printf.fullName shouldBe "printf"
       }
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
@@ -287,14 +287,14 @@ class MethodTests extends C2CpgSuite {
           |""".stripMargin,
         "test.cpp"
       )
-      val List(m1, m2, m3, m4) = cpg.method
-        .nameExact("staticCMethodDecl", "staticCMethodDef", "staticCPPMethodDecl", "staticCPPMethodDef")
-        .isStatic
-        .l
-      m1.fullName shouldBe "staticCMethodDecl"
-      m2.fullName shouldBe "staticCMethodDef"
-      m3.fullName shouldBe "A.staticCPPMethodDecl:void()"
-      m4.fullName shouldBe "A.staticCPPMethodDef:void()"
+      val List(staticCMethodDecl)   = cpg.method.nameExact("staticCMethodDecl").isStatic.l
+      val List(staticCMethodDef)    = cpg.method.nameExact("staticCMethodDef").isStatic.l
+      val List(staticCPPMethodDecl) = cpg.method.nameExact("staticCPPMethodDecl").isStatic.l
+      val List(staticCPPMethodDef)  = cpg.method.nameExact("staticCPPMethodDef").isStatic.l
+      staticCMethodDecl.fullName shouldBe "staticCMethodDecl"
+      staticCMethodDef.fullName shouldBe "staticCMethodDef"
+      staticCPPMethodDecl.fullName shouldBe "A.staticCPPMethodDecl:void()"
+      staticCPPMethodDef.fullName shouldBe "A.staticCPPMethodDef:void()"
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/NamespaceTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/NamespaceTypeTests.scala
@@ -77,12 +77,10 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
         |              // enclosing namespaces are the global namespace, Q, and Q::V
         |{ return 0; }
         |""".stripMargin)
-      inside(cpg.method.nameNot("<global>").fullName.l) { case List(m1, f1, f2, h, m2) =>
-        m1 shouldBe "Q.V.C.m:int()"
-        f1 shouldBe "Q.V.f:int()"
-        f2 shouldBe "Q.V.f:int()"
+      inside(cpg.method.nameNot("<global>").fullName.l) { case List(f, m, h) =>
+        f shouldBe "Q.V.f:int()"
+        m shouldBe "Q.V.C.m:int()"
         h shouldBe "h:void()"
-        m2 shouldBe "Q.V.C.m:int()"
       }
 
       inside(cpg.namespaceBlock.nameNot("<global>").l) { case List(q, v) =>
@@ -162,10 +160,10 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
         namespaceX.fullName shouldBe "X"
       }
 
-      inside(cpg.method.internal.nameNot("<global>").fullName.l) { case List(f, g, h) =>
+      inside(cpg.method.internal.nameNot("<global>").fullName.l) { case List(h, f, g) =>
+        h shouldBe "h:void()"
         f shouldBe "f:void()"
         g shouldBe "A.g:void()"
-        h shouldBe "h:void()"
       }
 
       inside(cpg.call.filterNot(_.name == Operators.fieldAccess).l) { case List(f, g) =>
@@ -201,7 +199,7 @@ class NamespaceTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CPP_EXT) {
         a2.fullName shouldBe "A"
       }
 
-      inside(cpg.method.internal.nameNot("<global>").l) { case List(f1, f2, foo, bar) =>
+      inside(cpg.method.internal.nameNot("<global>").l) { case List(foo, bar, f1, f2) =>
         f1.fullName shouldBe "A.f:void(int)"
         f1.signature shouldBe "void(int)"
         f2.fullName shouldBe "A.f:void(char)"

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/TypeNodePassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/TypeNodePassTests.scala
@@ -194,6 +194,26 @@ class TypeNodePassTests extends C2CpgSuite {
         }
       }
     }
+
+    "be correct for volatile types" in {
+      val cpg = code("""
+          |void func(void) {
+          |  static volatile int **ipp;
+          |  static int *ip;
+          |  static volatile int i = 0;
+          |
+          |  ipp = &ip;
+          |  ipp = (int**) &ip;
+          |  *ipp = &i;
+          |  if (*ip != 0) {}
+          |}""".stripMargin)
+      cpg.identifier.nameExact("ipp").typeFullName.distinct.l shouldBe List("volatile int**")
+      cpg.identifier.nameExact("ip").typeFullName.distinct.l shouldBe List("int*")
+      cpg.identifier.nameExact("i").typeFullName.distinct.l shouldBe List("volatile int")
+      cpg.local.nameExact("ipp").typeFullName.l shouldBe List("volatile int**")
+      cpg.local.nameExact("ip").typeFullName.l shouldBe List("int*")
+      cpg.local.nameExact("i").typeFullName.l shouldBe List("volatile int")
+    }
   }
 
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
@@ -3,7 +3,9 @@ package io.joern.c2cpg.testfixtures
 import better.files.File
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.passes.AstCreationPass
+import io.joern.c2cpg.passes.FunctionDeclNodePass
 import io.joern.x2cpg.testfixtures.LanguageFrontend
+import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.shiftleft.codepropertygraph.generated.Cpg
 
@@ -19,6 +21,8 @@ trait AstC2CpgFrontend extends LanguageFrontend {
       .withOutputPath(pathAsString)
     val astCreationPass = new AstCreationPass(cpg, config)
     astCreationPass.createAndApply()
+    new FunctionDeclNodePass(cpg, astCreationPass.unhandledMethodDeclarations())(ValidationMode.Enabled)
+      .createAndApply()
     cpg
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/TypeNodePass.scala
@@ -1,6 +1,7 @@
 package io.joern.x2cpg.passes.frontend
 
 import io.joern.x2cpg.passes.frontend.TypeNodePass.fullToShortName
+import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{Cpg, Properties}
 import io.shiftleft.codepropertygraph.generated.nodes.NewType
 import io.shiftleft.passes.CpgPass
@@ -45,7 +46,9 @@ class TypeNodePass protected (registeredTypes: List[String], cpg: Cpg, getTypesF
     val usedTypesSet = typeDeclTypes ++ typeFullNameValues
     usedTypesSet.remove("<empty>")
     val usedTypes =
-      (usedTypesSet.filterInPlace(!_.endsWith(NamespaceTraversal.globalNamespaceName)).toArray :+ "ANY").toSet.sorted
+      (usedTypesSet
+        .filterInPlace(!_.endsWith(NamespaceTraversal.globalNamespaceName))
+        .toArray :+ Defines.Any).toSet.sorted
 
     usedTypes.foreach { typeName =>
       val shortName = fullToShortName(typeName)


### PR DESCRIPTION
For method de-duplication (CDT always copy methods from header files into the implementation files so we would end up generating CPG METHODs for both with the same fullName), we now skip over all method decls but remember their properties.
Afterwards, a new pass stubs them iff no actual method definition exists.