### PR TITLE
workaround for scala completion bug

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -131,4 +131,26 @@ generateScaladocs := {
 
 Universal / packageBin / mappings ++= sbt.Path.directory(new File("joern-cli/src/main/resources/scripts"))
 
+lazy val removeModuleInfoFromJars = taskKey[Unit]("remove module-info.class from dependency jars - a hacky workaround for a scala3 compiler bug https://github.com/scala/scala3/issues/20421")
+removeModuleInfoFromJars := {
+  import java.nio.file.{Files, FileSystems}
+  val logger = streams.value.log
+  val libDir = (Universal/stagingDirectory).value / "lib"
+
+  // remove all `/module-info.class` from all jars
+  Files.walk(libDir.toPath)
+    .filter(_.toString.endsWith(".jar"))
+    .forEach { jar =>
+      val zipFs = FileSystems.newFileSystem(jar)
+      zipFs.getRootDirectories.forEach { zipRootDir =>
+        Files.list(zipRootDir).filter(_.toString == "/module-info.class").forEach { moduleInfoClass =>
+          logger.info(s"workaround for scala completion bug: deleting $moduleInfoClass from $jar")
+          Files.delete(moduleInfoClass)
+        }
+      }
+      zipFs.close()
+    }
+}
+removeModuleInfoFromJars := removeModuleInfoFromJars.triggeredBy(Universal/stage).value
+
 maintainer := "fabs@shiftleft.io"


### PR DESCRIPTION
on stage: remove module-info.class from dependency jars - a hacky workaround for a
scala3 compiler bug: https://github.com/scala/scala3/issues/20421

Fixes https://github.com/joernio/joern/issues/4625