### PR TITLE
[c2cpg] Add implicit this param + access

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -224,7 +224,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       case s: CPPASTIdExpression =>
         safeGetEvaluation(s) match {
           case Some(evaluation: EvalMemberAccess) =>
-            cleanType(evaluation.getOwnerType.toString, stripKeywords)
+            val deref = if (evaluation.isPointerDeref) "*" else ""
+            cleanType(evaluation.getOwnerType.toString + deref, stripKeywords)
           case Some(evalBinding: EvalBinding) =>
             evalBinding.getBinding match {
               case m: CPPMethod => cleanType(fullName(m.getDefinition))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -272,7 +272,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
               EvaluationStrategies.BY_VALUE,
               line(cppFunc),
               column(cppFunc),
-              owner
+              registerType(owner)
             )
             Seq(parameterNodeInfo)
           case _ => Seq.empty

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
@@ -396,6 +396,7 @@ class MethodTests extends C2CpgSuite {
       trueThisId.code shouldBe "this"
       trueThisId.isIdentifier shouldBe true
       trueThisId.asInstanceOf[Identifier].typeFullName shouldBe "A*"
+      trueThisId._refOut.l shouldBe List(implicitThisParam)
       trueVarFieldIdent.code shouldBe "var"
       trueVarFieldIdent.isFieldIdentifier shouldBe true
 
@@ -406,6 +407,7 @@ class MethodTests extends C2CpgSuite {
       thisId.code shouldBe "this"
       thisId.isIdentifier shouldBe true
       thisId.asInstanceOf[Identifier].typeFullName shouldBe "A*"
+      thisId._refOut.l shouldBe List(implicitThisParam)
       varFieldIdent.code shouldBe "var"
       varFieldIdent.isFieldIdentifier shouldBe true
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
@@ -4,6 +4,7 @@ import io.joern.c2cpg.testfixtures.C2CpgSuite
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
@@ -388,10 +389,25 @@ class MethodTests extends C2CpgSuite {
       val List(implicitThisParam) = cpg.method.name("meth").parameter.l
       implicitThisParam.name shouldBe "this"
       implicitThisParam.typeFullName shouldBe "A"
+      val List(trueVarAccess) = cpg.call.name(Operators.equals).argument.argumentIndex(1).isCall.l
+      trueVarAccess.code shouldBe "this->var"
+      trueVarAccess.name shouldBe Operators.indirectFieldAccess
+      val List(trueThisId, trueVarFieldIdent) = trueVarAccess.argument.l
+      trueThisId.code shouldBe "this"
+      trueThisId.isIdentifier shouldBe true
+      trueThisId.asInstanceOf[Identifier].typeFullName shouldBe "A*"
+      trueVarFieldIdent.code shouldBe "var"
+      trueVarFieldIdent.isFieldIdentifier shouldBe true
+
       val List(varAccess) = cpg.call.name(Operators.equals).argument.argumentIndex(2).isCall.l
       varAccess.code shouldBe "this->var"
       varAccess.name shouldBe Operators.indirectFieldAccess
-      varAccess.argument.code.l shouldBe List("this", "var")
+      val List(thisId, varFieldIdent) = varAccess.argument.l
+      thisId.code shouldBe "this"
+      thisId.isIdentifier shouldBe true
+      thisId.asInstanceOf[Identifier].typeFullName shouldBe "A*"
+      varFieldIdent.code shouldBe "var"
+      varFieldIdent.isFieldIdentifier shouldBe true
     }
   }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
@@ -381,8 +381,10 @@ class MethodTests extends C2CpgSuite {
           |  int var;
           |  void meth();
           |};
-          |void A::meth() {
-          |  assert(this->var == var);
+          |namespace Foo {
+          |  void A::meth() {
+          |    assert(this->var == var);
+          |  }
           |}""".stripMargin,
         "test.cpp"
       )

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
@@ -157,7 +157,7 @@ class ClassTypeTests extends C2CpgSuite(FileDefaults.CPP_EXT) {
 
       val List(call) = cpg.call("foo2").l
       call.methodFullName shouldBe "B.foo2:void()"
-      cpg.identifier.nameExact("b").typeFullName.l shouldBe List("B", "B")
+      cpg.fieldIdentifier.canonicalNameExact("b").inCall.code.l shouldBe List("this->b", "this->b")
     }
   }
 
@@ -173,9 +173,14 @@ class ClassTypeTests extends C2CpgSuite(FileDefaults.CPP_EXT) {
           |}""".stripMargin)
       val List(constructor) = cpg.typeDecl.nameExact("FooT").method.isConstructor.l
       constructor.signature shouldBe "Bar.Foo(std.string,Bar.SomeClass)"
-      val List(p1, p2) = constructor.parameter.l
+      val List(thisP, p1, p2) = constructor.parameter.l
+      thisP.name shouldBe "this"
+      thisP.typeFullName shouldBe "FooT"
+      thisP.index shouldBe 0
       p1.typ.fullName shouldBe "std.string"
+      p1.index shouldBe 1
       p2.typ.fullName shouldBe "Bar.SomeClass"
+      p2.index shouldBe 2
     }
   }
 


### PR DESCRIPTION
- implicit this param for CPP functions
- identifiers that are actual member accesses are now transformed, e.g., this->varname if varname is a member and we are in the corresponding context

@maltek This needs serious testing