### PR TITLE
Add support for THROW control structure.

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/cfg/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/cfg/CfgCreationPassTests.scala
@@ -596,5 +596,28 @@ class CppCfgCreationPassTests extends CfgTestFixture(() => new CCfgTestCpg(FileD
       succOf("c") should contain theSameElementsAs expected(("RET", AlwaysEdge))
       succOf("d") should contain theSameElementsAs expected(("RET", AlwaysEdge))
     }
+
+    "be correct for throw statement" in {
+      implicit val cpg: Cpg = code("""
+                                     |throw foo();
+                                     |bar();
+                                     |""".stripMargin)
+      succOf("func") should contain theSameElementsAs expected(("foo()", AlwaysEdge))
+      succOf("foo()") should contain theSameElementsAs expected(("throw foo()", AlwaysEdge))
+      succOf("throw foo()") should contain theSameElementsAs expected()
+      succOf("bar()") should contain theSameElementsAs expected(("RET", AlwaysEdge))
+    }
+
+    "be correct for throw statement in if-else" in {
+      implicit val cpg: Cpg = code("""
+                                     |if (true) throw foo();
+                                     |else bar();
+                                     |""".stripMargin)
+      succOf("func") should contain theSameElementsAs expected(("true", AlwaysEdge))
+      succOf("true") should contain theSameElementsAs expected(("foo()", TrueEdge), ("bar()", FalseEdge))
+      succOf("foo()") should contain theSameElementsAs expected(("throw foo()", AlwaysEdge))
+      succOf("throw foo()") should contain theSameElementsAs expected()
+      succOf("bar()") should contain theSameElementsAs expected(("RET", AlwaysEdge))
+    }
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -174,9 +174,16 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
         cfgForChildren(node)
       case ControlStructureTypes.MATCH =>
         cfgForMatchExpression(node)
+      case ControlStructureTypes.THROW =>
+        cfgForThrowStatement(node)
       case _ =>
         Cfg.empty
     }
+
+  protected def cfgForThrowStatement(node: ControlStructure): Cfg = {
+    val throwExprCfg = node.astChildren.find(_.order == 1).map(cfgFor).getOrElse(Cfg.empty)
+    throwExprCfg ++ Cfg(entryNode = Option(node))
+  }
 
   /** The CFG for a break/continue statements contains only the break/continue statement as a single entry node. The
     * fringe is empty, that is, appending another CFG to the break statement will not result in the creation of an edge


### PR DESCRIPTION
1. Added the support in the CfgCreator. A THROW control structure now
   breaks control flow.
2. Adjust c2cpg to generate such a control structure instead of a CALL
   node.