### PR TITLE
Ammendment to previous `throw` statement cfg change.

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/cfg/CfgCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/cfg/CfgCreationPassTests.scala
@@ -604,7 +604,7 @@ class CppCfgCreationPassTests extends CfgTestFixture(() => new CCfgTestCpg(FileD
                                      |""".stripMargin)
       succOf("func") should contain theSameElementsAs expected(("foo()", AlwaysEdge))
       succOf("foo()") should contain theSameElementsAs expected(("throw foo()", AlwaysEdge))
-      succOf("throw foo()") should contain theSameElementsAs expected()
+      succOf("throw foo()") should contain theSameElementsAs expected(("RET", AlwaysEdge))
       succOf("bar()") should contain theSameElementsAs expected(("RET", AlwaysEdge))
     }
 
@@ -616,7 +616,7 @@ class CppCfgCreationPassTests extends CfgTestFixture(() => new CCfgTestCpg(FileD
       succOf("func") should contain theSameElementsAs expected(("true", AlwaysEdge))
       succOf("true") should contain theSameElementsAs expected(("foo()", TrueEdge), ("bar()", FalseEdge))
       succOf("foo()") should contain theSameElementsAs expected(("throw foo()", AlwaysEdge))
-      succOf("throw foo()") should contain theSameElementsAs expected()
+      succOf("throw foo()") should contain theSameElementsAs expected(("RET", AlwaysEdge))
       succOf("bar()") should contain theSameElementsAs expected(("RET", AlwaysEdge))
     }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -181,8 +181,9 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraphBuilder) {
     }
 
   protected def cfgForThrowStatement(node: ControlStructure): Cfg = {
-    val throwExprCfg = node.astChildren.find(_.order == 1).map(cfgFor).getOrElse(Cfg.empty)
-    throwExprCfg ++ Cfg(entryNode = Option(node))
+    val throwExprCfg     = node.astChildren.find(_.order == 1).map(cfgFor).getOrElse(Cfg.empty)
+    val concatedNatedCfg = throwExprCfg ++ Cfg(entryNode = Option(node))
+    concatedNatedCfg.copy(edges = concatedNatedCfg.edges ++ singleEdge(node, exitNode))
   }
 
   /** The CFG for a break/continue statements contains only the break/continue statement as a single entry node. The


### PR DESCRIPTION
In this PR https://github.com/joernio/joern/pull/4807 the CFG for
`throw` statements was changes in the way that they have no outgoing CFG
edges. Since this might break assumptions of some CFG consuming code, we
now create outgoing CFG edges from `throw` statements to the method exit
nodes.
