### PR TITLE
[ruby] Fix: explicit initialize method statements and params missing

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1083,7 +1083,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
         )
       }
 
-    StatementList(otherTypeDeclChildren ++ updatedBodyMethod)(stmts.span)
+    StatementList(initMethod ++ otherTypeDeclChildren ++ updatedBodyMethod)(stmts.span)
   }
 
   override def visitClassDefinition(ctx: RubyParser.ClassDefinitionContext): RubyNode = {


### PR DESCRIPTION
This PR fixes:
 * Parameters and statements from the initialize method in a `Class` were missing, fixed by adding the `initMethod` back into the `StatementList` after moving all `nonAllowedTypeDeclChildren` to the `<body>` method.

Resolves #4812 