### PR TITLE
[ruby] Add handling for command literal `%x`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -455,6 +455,17 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
     }
   }
 
+  override def visitQuotedExpandedExternalCommandLiteral(
+    ctx: RubyParser.QuotedExpandedExternalCommandLiteralContext
+  ): String = {
+    val command =
+      if ctx.quotedExpandedLiteralStringContent.asScala.nonEmpty then
+        ctx.quotedExpandedLiteralStringContent.asScala.flatMap(_.children.asScala.map(visit)).mkString("")
+      else ""
+
+    s"${ctx.QUOTED_EXPANDED_EXTERNAL_COMMAND_LITERAL_START.getText}$command${ctx.QUOTED_EXPANDED_EXTERNAL_COMMAND_LITERAL_END.getText}"
+  }
+
   override def visitDoubleQuotedString(ctx: RubyParser.DoubleQuotedStringContext): String = {
     if (!ctx.isInterpolated) {
       ctx.getText

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -388,7 +388,9 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     ctx: RubyParser.QuotedExpandedExternalCommandLiteralContext
   ): RubyNode = {
     val commandLiteral =
-      StaticLiteral(Defines.String)(ctx.quotedExpandedLiteralStringContent.asScala.toList.map(_.toTextSpan).head)
+      if ctx.quotedExpandedLiteralStringContent.asScala.nonEmpty then
+        StaticLiteral(Defines.String)(ctx.quotedExpandedLiteralStringContent.asScala.toList.map(_.toTextSpan).head)
+      else StaticLiteral(Defines.String)(ctx.toTextSpan.spanStart())
 
     SimpleCall(SimpleIdentifier()(ctx.toTextSpan.spanStart("exec")), List(commandLiteral))(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -384,6 +384,15 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     }
   }
 
+  override def visitQuotedExpandedExternalCommandLiteral(
+    ctx: RubyParser.QuotedExpandedExternalCommandLiteralContext
+  ): RubyNode = {
+    val commandLiteral =
+      StaticLiteral(Defines.String)(ctx.quotedExpandedLiteralStringContent.asScala.toList.map(_.toTextSpan).head)
+
+    SimpleCall(SimpleIdentifier()(ctx.toTextSpan.spanStart("exec")), List(commandLiteral))(ctx.toTextSpan)
+  }
+
   override def visitCurlyBracesBlock(ctx: RubyParser.CurlyBracesBlockContext): RubyNode = {
     val parameters = Option(ctx.blockParameter()).fold(List())(_.parameters).map(visit)
     val body       = visit(ctx.compoundStatement())

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/StringParserTests.scala
@@ -69,8 +69,7 @@ class StringParserTests extends RubyParserFixture with Matchers {
         |  is a number."""".stripMargin)
   }
 
-  // TODO: Unknown nodes in RubyNodeCreator
-  "Expanded `%x` external command literal" ignore {
+  "Expanded `%x` external command literal" in {
     test("%x//")
     test("%x{l#{'s'}}")
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -860,4 +860,22 @@ class MethodTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected one method for batch.retry, got [${xs.code.mkString(",")}]")
     }
   }
+
+  "%x should be represented as a call to EXEC" in {
+    val cpg = code("""
+        |%x(ls -l)
+        |""".stripMargin)
+
+    inside(cpg.call.name("exec").l) {
+      case execCall :: Nil =>
+        execCall.name shouldBe "exec"
+        inside(execCall.argument.l) {
+          case selfArg :: lsArg :: Nil =>
+            selfArg.code shouldBe "self"
+            lsArg.code shouldBe "ls -l"
+          case xs => fail(s"expected 2 arguments, got [${xs.code.mkString(",")}]")
+        }
+      case xs => println("penis")
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -875,7 +875,7 @@ class MethodTests extends RubyCode2CpgFixture {
             lsArg.code shouldBe "ls -l"
           case xs => fail(s"expected 2 arguments, got [${xs.code.mkString(",")}]")
         }
-      case xs => println("penis")
+      case xs => fail(s"Expected one call to exec, got [${xs.code.mkString(",")}]")
     }
   }
 }


### PR DESCRIPTION
This PR adds:
 * Adds handling for command literal using `%x` syntax. This is modelled to be a call to `exec` as it runs a system command.

Resolves #4816 