### PR TITLE
[ruby] Fix NPE when creating Ast on empty source files

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -59,8 +59,10 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
           case Success(astCreator) => Option(astCreator)
         }
         .filter(x => {
-          if x.fileContent.isBlank then logger.warn(s"File content empty, skipping - ${x.fileName}")
-          x.fileContent.nonEmpty
+          if x.fileContent.isBlank then
+            logger.info(s"File content empty, skipping - ${x.fileName}")
+
+          !x.fileContent.isBlank
         })
 
       // Pre-parse the AST creators for high level structures

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -59,8 +59,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
           case Success(astCreator) => Option(astCreator)
         }
         .filter(x => {
-          if x.fileContent.isBlank then
-            logger.info(s"File content empty, skipping - ${x.fileName}")
+          if x.fileContent.isBlank then logger.info(s"File content empty, skipping - ${x.fileName}")
 
           !x.fileContent.isBlank
         })

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -58,6 +58,11 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
           case Failure(exception)  => logger.warn(s"Could not parse file, skipping - ", exception); None
           case Success(astCreator) => Option(astCreator)
         }
+        .filter(x => {
+          if x.fileContent.isBlank then logger.warn(s"File content empty, skipping - ${x.fileName}")
+          x.fileContent.nonEmpty
+        })
+
       // Pre-parse the AST creators for high level structures
       val internalProgramSummary = ConcurrentTaskUtil
         .runUsingThreadPool(astCreators.map(x => () => x.summarize()).iterator)


### PR DESCRIPTION
This PR:
 * added a filter on the `RubySrc2Cpg` to filter out source files that are empty. Added a warning log if there is an empty file.