### PR TITLE
[ruby] Add handling for `BracketAssignmentExpression`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -820,6 +820,20 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
     s"$target${ctx.LBRACK.getText}$arg${ctx.RBRACK.getText}"
   }
 
+  override def visitBracketAssignmentExpression(ctx: RubyParser.BracketAssignmentExpressionContext): String = {
+    val op = ctx.assignmentOperator().getText
+
+    if (op != "=") {
+      defaultResult()
+    }
+
+    val lhsBase = visit(ctx.primaryValue())
+    val lhsArgs = Option(ctx.indexingArgumentList()).map(_.arguments).getOrElse(List()).map(visit)
+    val rhs     = visit(ctx.operatorExpression())
+
+    s"$lhsBase[${lhsArgs.mkString(",")}] $op ${rhs}"
+  }
+
   override def visitBracketedArrayLiteral(ctx: RubyParser.BracketedArrayLiteralContext): String = {
     val args = Option(ctx.indexingArgumentList()).map(_.arguments).getOrElse(List()).map(visit).mkString(",")
     s"${ctx.LBRACK.getText}$args${ctx.RBRACK.getText}"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -827,6 +827,26 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     )(ctx.toTextSpan)
   }
 
+  override def visitBracketAssignmentExpression(ctx: RubyParser.BracketAssignmentExpressionContext): RubyNode = {
+    val op = ctx.assignmentOperator().getText
+
+    if (op != "=") {
+      logger.warn(s"Unsupported assignment operator for bracket assignment expression: $op")
+      defaultResult()
+    }
+
+    val lhsBase = visit(ctx.primaryValue())
+    val lhsArgs = Option(ctx.indexingArgumentList()).map(_.arguments).getOrElse(List()).map(visit)
+
+    val lhs = IndexAccess(lhsBase, lhsArgs)(
+      ctx.toTextSpan.spanStart(s"${lhsBase.span.text}[${lhsArgs.map(_.span.text).mkString(", ")}]")
+    )
+
+    val rhs = visit(ctx.operatorExpression())
+
+    SingleAssignment(lhs, op, rhs)(ctx.toTextSpan)
+  }
+
   override def visitBracketedArrayLiteral(ctx: RubyParser.BracketedArrayLiteralContext): RubyNode = {
     ArrayLiteral(Option(ctx.indexingArgumentList()).map(_.arguments).getOrElse(List()).map(visit))(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
@@ -10,6 +10,7 @@ class AssignmentParserTests extends RubyParserFixture with Matchers {
 
   "Single assignment" in {
     test("x=1", "x = 1")
+    test("hash[:sym] = s[:sym]")
   }
 
   "Multiple assignment" in {


### PR DESCRIPTION
This PR adds: 
 * Handling for `BracketAssignmentExpression` (`foo[:id] = bar[:id]`)
 * Relevant parser test for new structure