### PR TITLE
[ruby][bug] Arguments missing on `MemberAccessCommand`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -710,11 +710,16 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   }
 
   override def visitMemberAccessCommand(ctx: RubyParser.MemberAccessCommandContext): String = {
-    val arg        = visit(ctx.commandArgument())
+    val op =
+      if Option(ctx.AMPDOT()).isDefined then ctx.AMPDOT().getText
+      else if Option(ctx.COLON2()).isDefined then ctx.COLON2().getText
+      else ctx.DOT().getText
+
+    val args       = ctx.commandArgument.arguments.map(visit).mkString(", ")
     val methodName = visit(ctx.methodName)
     val base       = visit(ctx.primary())
 
-    s"$base.$methodName $arg"
+    s"$base$op$methodName $args"
   }
 
   override def visitConstantIdentifierVariable(ctx: RubyParser.ConstantIdentifierVariableContext): String = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -691,10 +691,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitMemberAccessCommand(ctx: RubyParser.MemberAccessCommandContext): RubyNode = {
-    val arg        = visit(ctx.commandArgument())
+    val args       = ctx.commandArgument.arguments.map(visit)
     val methodName = visit(ctx.methodName())
     val base       = visit(ctx.primary())
-    MemberCall(base, ".", methodName.text, List(arg))(ctx.toTextSpan)
+    MemberCall(base, ".", methodName.text, args)(ctx.toTextSpan)
   }
 
   override def visitConstantIdentifierVariable(ctx: RubyParser.ConstantIdentifierVariableContext): RubyNode = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithoutParenthesesParserTests.scala
@@ -10,11 +10,6 @@ class InvocationWithoutParenthesesParserTests extends RubyParserFixture with Mat
     test("foo!")
   }
 
-  // TODO: Fix
-  "fixme" ignore {
-    test("foo&.bar 1,2") // second arg seems to be missing in RubyNodeCreator
-  }
-
   "command with do block" in {
     test(
       """it 'should print 1' do
@@ -27,6 +22,8 @@ class InvocationWithoutParenthesesParserTests extends RubyParserFixture with Mat
     )
 
     test("foo&.bar")
+
+    test("foo&.bar 1, 2")
   }
 
   "method invocation without parenthesis with reserved keywords" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -878,4 +878,23 @@ class MethodTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected one call to exec, got [${xs.code.mkString(",")}]")
     }
   }
+
+  "MemberAccessCommand with two parameters" in {
+    val cpg = code("foo&.bar 1,2")
+
+    inside(cpg.call.name("bar").l) {
+      case barCall :: Nil =>
+        inside(barCall.argument.l) {
+          case _ :: (arg1: Literal) :: (arg2: Literal) :: Nil =>
+            arg1.code shouldBe "1"
+            arg1.typeFullName shouldBe RDefines.getBuiltInType(RDefines.Integer)
+
+            arg2.code shouldBe "2"
+            arg2.typeFullName shouldBe RDefines.getBuiltInType(RDefines.Integer)
+          case xs => fail(s"Expected three args, got [${xs.code.mkString(",")}]")
+        }
+
+      case xs => fail(s"Expected one call, got [${xs.code.mkString(",")}]")
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes:
 * All arguments after the first one on a `MemberAccessCommand` were missing
e.g.:
```ruby
foo&.bar 1, 2 # argument 2 would be missing here.
```