### PR TITLE
[ruby] Fix assignment parser test

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -596,9 +596,9 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
         case (idAssign, arguments) if idAssign.endsWith("=") =>
           val argNode = arguments match {
             case arg :: Nil => arg
-            case xs         => visit(ctx.commandArgument())
+            case xs         => xs.mkString(", ")
           }
-          s"$idAssign $argNode"
+          s"${idAssign.stripSuffix("=")} = $argNode"
         case _ =>
           s"${visit(identifierCtx)} ${arguments.mkString(",")}"
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
@@ -4,13 +4,10 @@ import io.joern.rubysrc2cpg.testfixtures.RubyParserFixture
 import org.scalatest.matchers.should.Matchers
 
 class AssignmentParserTests extends RubyParserFixture with Matchers {
-  "fixme" in {
-    test("a = 1, 2, 3, 4") // Going into SimpleCommand instead of an Assignment
-  }
-
   "Single assignment" in {
     test("x=1", "x = 1")
     test("hash[:sym] = s[:sym]")
+    test("a = 1, 2, 3, 4")
   }
 
   "Multiple assignment" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
@@ -4,7 +4,7 @@ import io.joern.rubysrc2cpg.testfixtures.RubyParserFixture
 import org.scalatest.matchers.should.Matchers
 
 class AssignmentParserTests extends RubyParserFixture with Matchers {
-  "fixme" ignore {
+  "fixme" in {
     test("a = 1, 2, 3, 4") // Going into SimpleCommand instead of an Assignment
   }
 


### PR DESCRIPTION
This PR fixes:
 * Assignment parser test with single value on LHS, and multiple values on RHS