### PR TITLE
[ruby] `self` Param `REF` Edge

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -732,8 +732,12 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForSelfIdentifier(node: SelfIdentifier): Ast = {
     val thisIdentifier =
-      identifierNode(node, Defines.Self, code(node), scope.surroundingTypeFullName.getOrElse(Defines.Any))
-    Ast(thisIdentifier)
+      identifierNode(node, Defines.Self, code(node), Defines.Any, scope.surroundingTypeFullName.toList)
+
+    scope
+      .lookupVariable(Defines.Self)
+      .map(selfParam => Ast(thisIdentifier).withRefEdge(thisIdentifier, selfParam))
+      .getOrElse(Ast(thisIdentifier))
   }
 
   protected def astForUnknown(node: RubyNode): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -67,15 +67,16 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     if (isConstructor) scope.pushNewScope(ConstructorScope(fullName))
     else scope.pushNewScope(MethodScope(fullName, procParamGen.fresh))
 
-    val thisParameterAst = Ast(
-      newThisParameterNode(
-        name = Defines.Self,
-        code = Defines.Self,
-        typeFullName = scope.surroundingTypeFullName.getOrElse(Defines.Any),
-        line = method.lineNumber,
-        column = method.columnNumber
-      )
+    val thisParameterNode = newThisParameterNode(
+      name = Defines.Self,
+      code = Defines.Self,
+      typeFullName = Defines.Any,
+      line = method.lineNumber,
+      column = method.columnNumber,
+      dynamicTypeHintFullName = scope.surroundingTypeFullName.toList
     )
+    val thisParameterAst = Ast(thisParameterNode)
+    scope.addToScope(Defines.Self, thisParameterNode)
     val parameterAsts = thisParameterAst :: astForParameters(node.parameters)
 
     val optionalStatementList = statementListForOptionalParams(node.parameters)
@@ -365,15 +366,15 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
         createMethodTypeBindings(method, methodTypeDecl_)
 
-        val thisParameterAst = Ast(
-          newThisParameterNode(
-            name = Defines.Self,
-            code = thisParamCode,
-            typeFullName = astParentFullName.getOrElse(Defines.Any),
-            line = method.lineNumber,
-            column = method.columnNumber
-          )
+        val thisNode = newThisParameterNode(
+          name = Defines.Self,
+          code = thisParamCode,
+          typeFullName = astParentFullName.getOrElse(Defines.Any),
+          line = method.lineNumber,
+          column = method.columnNumber
         )
+        val thisParameterAst = Ast(thisNode)
+        scope.addToScope(Defines.Self, thisNode)
 
         val parameterAsts         = thisParameterAst :: astForParameters(node.parameters)
         val optionalStatementList = statementListForOptionalParams(node.parameters)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
@@ -5,6 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Id
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 import io.joern.rubysrc2cpg.passes.Defines.Main
+import io.joern.rubysrc2cpg.passes.Defines
 
 class FieldAccessTests extends RubyCode2CpgFixture {
 
@@ -50,7 +51,8 @@ class FieldAccessTests extends RubyCode2CpgFixture {
           case (self: Identifier) :: (sickDaysId: FieldIdentifier) :: Nil =>
             self.name shouldBe "self"
             self.code shouldBe "self"
-            self.typeFullName should endWith("PaidTimeOff")
+            self.typeFullName shouldBe Defines.Any
+            self.dynamicTypeHintFullName.head should endWith("PaidTimeOff")
 
             sickDaysId.canonicalName shouldBe "@sick_days_earned"
             sickDaysId.code shouldBe "sick_days_earned"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -13,6 +13,7 @@ class MethodTests extends RubyCode2CpgFixture {
   "`def f(x) = 1`" should {
     val cpg = code("""
         |def f(x) = 1
+        |f(1)
         |""".stripMargin)
 
     "be represented by a METHOD node" in {
@@ -27,6 +28,18 @@ class MethodTests extends RubyCode2CpgFixture {
       x.index shouldBe 1
       x.isVariadic shouldBe false
       x.lineNumber shouldBe Some(2)
+
+      val List(fSelf) = f.parameter.name(RDefines.Self).l
+      fSelf.index shouldBe 0
+      fSelf.isVariadic shouldBe false
+      fSelf.lineNumber shouldBe Some(2)
+      fSelf.referencingIdentifiers.size shouldBe 0
+
+      val List(mSelf) = cpg.method.isModule.parameter.name(RDefines.Self).l
+      mSelf.index shouldBe 0
+      mSelf.isVariadic shouldBe false
+      mSelf.lineNumber shouldBe Some(1)
+      mSelf.referencingIdentifiers.size shouldBe 1
     }
 
     "have a corresponding bound type" in {


### PR DESCRIPTION
Fixed issue where no `REF` edges between self params and their identifiers.