### PR TITLE
[ruby] Incorrect class names

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -66,11 +66,14 @@ object RubyIntermediateAst {
     def bodyMemberCall: Option[TypeDeclBodyCall]
   }
 
+  final case class NamespaceDeclaration(namespaceParts: List[String])(span: TextSpan) extends RubyNode(span)
+
   final case class ModuleDeclaration(
     name: RubyNode,
     body: RubyNode,
     fields: List[RubyNode & RubyFieldIdentifier],
-    bodyMemberCall: Option[TypeDeclBodyCall]
+    bodyMemberCall: Option[TypeDeclBodyCall],
+    namespaceDeclaration: Option[NamespaceDeclaration]
   )(span: TextSpan)
       extends RubyNode(span)
       with TypeDeclaration {
@@ -82,7 +85,8 @@ object RubyIntermediateAst {
     baseClass: Option[RubyNode],
     body: RubyNode,
     fields: List[RubyNode & RubyFieldIdentifier],
-    bodyMemberCall: Option[TypeDeclBodyCall]
+    bodyMemberCall: Option[TypeDeclBodyCall],
+    namespaceDeclaration: Option[NamespaceDeclaration]
   )(span: TextSpan)
       extends RubyNode(span)
       with TypeDeclaration

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -6,8 +6,9 @@ import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
-import io.joern.rubysrc2cpg.passes.Defines.{Main, TypeDeclBody, Initialize}
+import io.joern.rubysrc2cpg.passes.Defines.{Initialize, Main, TypeDeclBody}
 import io.joern.rubysrc2cpg.passes.GlobalTypes
+import io.shiftleft.codepropertygraph.generated.NodeTypes
 
 class ClassTests extends RubyCode2CpgFixture {
 
@@ -948,6 +949,39 @@ class ClassTests extends RubyCode2CpgFixture {
 
         case xs => fail(s"Expected body method and init method, got [${xs.code.mkString(",")}]")
       }
+    }
+  }
+
+  "fixme" in {
+    val cpg = code("""
+        |class Api::V1::MobileController
+        |end
+        |""".stripMargin)
+
+    inside(cpg.typeDecl.name("MobileController").l) {
+      case mobileTypeDecl :: Nil =>
+        mobileTypeDecl.name shouldBe "MobileController"
+        mobileTypeDecl.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
+        mobileTypeDecl.astParentFullName shouldBe "Api.V1"
+        mobileTypeDecl.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
+
+      case xs => fail(s"Expected one class decl, got [${xs.code.mkString(",")}]")
+    }
+  }
+
+  "Namespace scope is popping properly" in {
+    val cpg = code("""
+        |class Foo::Bar
+        |end
+        |
+        |class Baz
+        |end
+        |""".stripMargin)
+
+    inside(cpg.typeDecl.name("Baz").l) {
+      case bazTypeDecl :: Nil =>
+        bazTypeDecl.fullName shouldBe "Test0.rb:<main>.Baz"
+      case xs => fail(s"Expected one type decl, got [${xs.code.mkString(",")}]")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.Main
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.semanticcpg.language.*
 
 class ModuleTests extends RubyCode2CpgFixture {
@@ -39,4 +40,20 @@ class ModuleTests extends RubyCode2CpgFixture {
     m.method.name.l shouldBe List(Defines.TypeDeclBody)
   }
 
+  "Module defined in Namespace" in {
+    val cpg = code("""
+        |module Api::V1::MobileController
+        |end
+        |""".stripMargin)
+
+    inside(cpg.typeDecl.name("MobileController").l) {
+      case mobileTypeDecl :: Nil =>
+        mobileTypeDecl.name shouldBe "MobileController"
+        mobileTypeDecl.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
+        mobileTypeDecl.astParentFullName shouldBe "Api.V1"
+        mobileTypeDecl.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
+
+      case xs => fail(s"Expected one class decl, got [${xs.code.mkString(",")}]")
+    }
+  }
 }


### PR DESCRIPTION
This PR includes:
 * Fixed an issue where classes/modules defined in a namespace (e.g. `Api::V1:Controller`) would have incorrect class names.
 * Added `NamespaceDeclaration` node for classes/modules defined in Namespace