### PR TITLE
[ruby] Fixed Pseudo-Variables as Literals

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -290,4 +290,13 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     augeasReceiv.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "open"
   }
 
+  "`nil` keyword as a member access should be a literal" in {
+    val cpg    = code("nil.to_json")
+    val toJson = cpg.fieldAccess.codeExact("nil.to_json").head
+    val nilRec = toJson.argument(1).asInstanceOf[Literal]
+
+    nilRec.code shouldBe "nil"
+    nilRec.lineNumber shouldBe Option(1)
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -93,6 +93,9 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     val List(breakNode) = cpg.break.l
     breakNode.code shouldBe "break"
     breakNode.lineNumber shouldBe Some(8)
+
+    // `loop` is lowered as a do-while loop with a true condition
+    cpg.controlStructure.condition("true").size shouldBe 1
   }
 
   "`if-end` statement is represented by an `IF` CONTROL_STRUCTURE node" in {


### PR DESCRIPTION
Although the parser rule for picking up pseudo-variables seems fine, it may sometimes choose to represent it as a local variable. This fixes this and adds the related tests.