### PR TITLE
[ruby] Fix Implicit Require Call Structure

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable
   */
 class ImplicitRequirePass(cpg: Cpg, programSummary: RubyProgramSummary) extends ForkJoinParallelCpgPass[Method](cpg) {
 
-  private val importCallName: String = "require"
+  private val importCallName: String = "require_relative"
   private val typeToPath             = mutable.Map.empty[String, String]
 
   override def init(): Unit = {
@@ -104,7 +104,7 @@ class ImplicitRequirePass(cpg: Cpg, programSummary: RubyProgramSummary) extends 
     val requireCallNode = NewCall()
       .name(importCallName)
       .code(s"$importCallName '$path'")
-      .methodFullName(s"$kernelPrefix.require")
+      .methodFullName(s"$kernelPrefix.$importCallName")
       .dispatchType(DispatchTypes.STATIC_DISPATCH)
       .typeFullName(Defines.Any)
     builder.addNode(requireCallNode)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -2,8 +2,10 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.Main
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.Literal
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.FieldAccess
 import org.scalatest.Inspectors
@@ -261,16 +263,13 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
       cpg.imports.where(_.call.file.name(".*B.rb")).size shouldBe 0
     }
 
-    "create a `require` call following the correct format" in {
+    "create a `require` call following the simplified format" in {
       val require = cpg.call("require").head
+      require.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      require.methodFullName shouldBe s"$kernelPrefix.require"
 
-      val fieldAccessRec = require.receiver.head.asInstanceOf[FieldAccess]
-      fieldAccessRec.argument(1).code shouldBe Defines.Self
-      fieldAccessRec.argument(2).code shouldBe "require"
-
-      require.argument(0).code shouldBe Defines.Self
-
-      require.argument(1).label shouldBe NodeTypes.LITERAL
+      val strLit = require.argument(1).asInstanceOf[Literal]
+      strLit.typeFullName shouldBe s"$builtinPrefix.String"
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -1,8 +1,11 @@
 package io.joern.rubysrc2cpg.querying
 
+import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.Main
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.FieldAccess
 import org.scalatest.Inspectors
 
 class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with Inspectors {
@@ -256,6 +259,18 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
 
     "not import a type from the type's defining file" in {
       cpg.imports.where(_.call.file.name(".*B.rb")).size shouldBe 0
+    }
+
+    "create a `require` call following the correct format" in {
+      val require = cpg.call("require").head
+
+      val fieldAccessRec = require.receiver.head.asInstanceOf[FieldAccess]
+      fieldAccessRec.argument(1).code shouldBe Defines.Self
+      fieldAccessRec.argument(2).code shouldBe "require"
+
+      require.argument(0).code shouldBe Defines.Self
+
+      require.argument(1).label shouldBe NodeTypes.LITERAL
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -263,10 +263,10 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
       cpg.imports.where(_.call.file.name(".*B.rb")).size shouldBe 0
     }
 
-    "create a `require` call following the simplified format" in {
-      val require = cpg.call("require").head
+    "create a `require_relative` call following the simplified format" in {
+      val require = cpg.call("require_relative").head
       require.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      require.methodFullName shouldBe s"$kernelPrefix.require"
+      require.methodFullName shouldBe s"$kernelPrefix.require_relative"
 
       val strLit = require.argument(1).asInstanceOf[Literal]
       strLit.typeFullName shouldBe s"$builtinPrefix.String"


### PR DESCRIPTION
The implicit require calls that are generated after the AST creation had an older/out-dated format and lead to identifiers not being linked via REF edges.