### PR TITLE
[ruby] Add `rootNode` for `RubyNodeCreator` to `AstCreator`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -2,10 +2,11 @@ package io.joern.rubysrc2cpg
 
 import better.files.File
 import io.joern.rubysrc2cpg.astcreation.AstCreator
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.StatementList
 import io.joern.rubysrc2cpg.datastructures.RubyProgramSummary
 import io.joern.rubysrc2cpg.deprecated.parser.DeprecatedRubyParser
 import io.joern.rubysrc2cpg.deprecated.parser.DeprecatedRubyParser.*
-import io.joern.rubysrc2cpg.parser.RubyParser
+import io.joern.rubysrc2cpg.parser.{RubyNodeCreator, RubyParser}
 import io.joern.rubysrc2cpg.passes.{
   AstCreationPass,
   ConfigFileCreationPass,
@@ -203,7 +204,8 @@ object RubySrc2Cpg {
               ctx,
               projectRoot,
               enableFileContents = !config.disableFileContent,
-              fileContent = fileContent
+              fileContent = fileContent,
+              rootNode = Option(new RubyNodeCreator().visit(ctx).asInstanceOf[StatementList])
             )(config.schemaValidation)
         }
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -19,7 +19,8 @@ class AstCreator(
   protected val projectRoot: Option[String] = None,
   protected val programSummary: RubyProgramSummary = RubyProgramSummary(),
   val enableFileContents: Boolean = false,
-  val fileContent: String = ""
+  val fileContent: String = "",
+  val rootNode: Option[RubyNode] = None
 )(implicit withSchemaValidation: ValidationMode)
     extends AstCreatorBase(fileName)
     with AstCreatorHelper
@@ -56,8 +57,12 @@ class AstCreator(
     relativeFileName.replaceAll(Matcher.quoteReplacement(java.io.File.separator), "/")
 
   override def createAst(): DiffGraphBuilder = {
-    val rootNode = new RubyNodeCreator().visit(programCtx).asInstanceOf[StatementList]
-    val ast      = astForRubyFile(rootNode)
+    val astRootNode = rootNode.match {
+      case Some(node) => node.asInstanceOf[StatementList]
+      case None       => new RubyNodeCreator().visit(programCtx).asInstanceOf[StatementList]
+    }
+
+    val ast = astForRubyFile(astRootNode)
     Ast.storeInDiffGraph(ast, diffGraph)
     diffGraph
   }


### PR DESCRIPTION
Added `rootNode` to `AstCreator` so that we don't generate the intermediate Ruby AST twice (once for summary, once for full AstCreationPass)