### PR TITLE
[ruby] Include `y(a)ml`, `xml`, and `erb` files

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
@@ -24,6 +24,8 @@ class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
     extensionFilter(".yaml"),
     extensionFilter(".yml"),
     // XML files
-    extensionFilter(".xml")
+    extensionFilter(".xml"),
+    // ERB files
+    extensionFilter(".erb")
   )
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
@@ -16,5 +16,14 @@ class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
     case None           => Seq()
   }
 
-  override protected val configFileFilters: List[File => Boolean] = List(validGemfilePaths.contains)
+  override protected val configFileFilters: List[File => Boolean] = List(
+    // Gemfiles
+    validGemfilePaths.contains,
+    extensionFilter(".ini"),
+    // YAML files
+    extensionFilter(".yaml"),
+    extensionFilter(".yml"),
+    // XML files
+    extensionFilter(".xml")
+  )
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -1,0 +1,48 @@
+package io.joern.rubysrc2cpg.passes
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class ConfigFileCreationPassTests extends RubyCode2CpgFixture {
+
+  "yaml files should be included" in {
+    val cpg = code(
+      """
+        |foo:
+        |  bar
+        |""".stripMargin,
+      "config.yaml"
+    )
+
+    val config = cpg.configFile.name("config.yaml").head
+    config.content should include("foo:")
+  }
+
+  "yml files should be included" in {
+    val cpg = code(
+      """
+        |foo:
+        |  bar
+        |""".stripMargin,
+      "config.yml"
+    )
+
+    val config = cpg.configFile.name("config.yml").head
+    config.content should include("foo:")
+  }
+
+  "xml files should be included" in {
+    val cpg = code(
+      """
+        |<foo>
+        |  <p>bar<p>
+        |</foo>
+        |""".stripMargin,
+      "config.xml"
+    )
+
+    val config = cpg.configFile.name("config.xml").head
+    config.content should include("<p>bar<p>")
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -45,4 +45,16 @@ class ConfigFileCreationPassTests extends RubyCode2CpgFixture {
     config.content should include("<p>bar<p>")
   }
 
+  "erb files should be included" in {
+    val cpg = code(
+      """
+        |<%= 1 + 2 %>
+        |""".stripMargin,
+      "foo.erb"
+    )
+
+    val config = cpg.configFile.name("foo.erb").head
+    config.content should include("1 + 2")
+  }
+
 }


### PR DESCRIPTION
Includes `y(a)ml`, `xml`, `erb` files as config file nodes.