### PR TITLE
[python] Include Pipfile[.lock]

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ConfigFileCreationPass.scala
@@ -19,7 +19,10 @@ class ConfigFileCreationPass(cpg: Cpg, requirementsTxt: String = "requirement.tx
     // HTM files
     extensionFilter(".htm"),
     // Requirements.txt
-    pathEndFilter(requirementsTxt)
+    pathEndFilter(requirementsTxt),
+    // Pipfile
+    pathEndFilter("Pipfile"),
+    pathEndFilter("Pipfile.lock")
   )
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/ConfigPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/ConfigPassTests.scala
@@ -12,7 +12,51 @@ class ConfigPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       c.content shouldBe "Flask==1.1.2"
       c.name shouldBe "requirements.txt"
     }
+  }
 
+  "Pipfile should be included" in {
+    val cpg = code(
+      """
+        |[[source]]
+        |url = "https://pypi.org/simple"
+        |verify_ssl = true
+        |name = "pypi"
+        |""".stripMargin,
+      "Pipfile"
+    )
+
+    val config = cpg.configFile.name("Pipfile").head
+    config.content should include("verify_ssl = true")
+  }
+
+  "Pipfile.lock should be included" in {
+    val cpg = code(
+      """
+        |{
+        |     "_meta": {
+        |        "hash": {
+        |            "sha256": "293ad83ead15eb7bfef8a768f1853fc4cfa31b32ab85ae6962a2630b57cf569b"
+        |        },
+        |        "pipfile-spec": 6,
+        |        "requires": {
+        |            "python_full_version": "3.8.18",
+        |            "python_version": "3.8"
+        |        },
+        |        "sources": [
+        |            {
+        |                "name": "pypi",
+        |                "url": "https://pypi.org/simple",
+        |                "verify_ssl": true
+        |            }
+        |        ]
+        |    }
+        |}
+        |""".stripMargin,
+    "Pipfile.lock"
+    )
+
+    val config = cpg.configFile.name("Pipfile.lock").head
+    config.content should include("\"name\": \"pypi\"")
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/ConfigPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/ConfigPassTests.scala
@@ -52,7 +52,7 @@ class ConfigPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         |    }
         |}
         |""".stripMargin,
-    "Pipfile.lock"
+      "Pipfile.lock"
     )
 
     val config = cpg.configFile.name("Pipfile.lock").head


### PR DESCRIPTION
Includes `Pipfile[.lock]` files as `CONFIG_FILE` nodes, which can be useful to extract Python+dependencies versions.