### PR TITLE
[ruby] Revert type changes in `self` PR #4838

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -105,7 +105,7 @@ class AstCreator(
     val thisParameterNode = newThisParameterNode(
       name = Defines.Self,
       code = Defines.Self,
-      typeFullName = Defines.Any,
+      typeFullName = fullName,
       line = methodNode_.lineNumber,
       column = methodNode_.columnNumber,
       dynamicTypeHintFullName = fullName :: Nil

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -105,10 +105,9 @@ class AstCreator(
     val thisParameterNode = newThisParameterNode(
       name = Defines.Self,
       code = Defines.Self,
-      typeFullName = fullName,
+      typeFullName = Defines.Any,
       line = methodNode_.lineNumber,
-      column = methodNode_.columnNumber,
-      dynamicTypeHintFullName = fullName :: Nil
+      column = methodNode_.columnNumber
     )
     val thisParameterAst = Ast(thisParameterNode)
     scope.addToScope(Defines.Self, thisParameterNode)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -735,7 +735,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForSelfIdentifier(node: SelfIdentifier): Ast = {
     val thisIdentifier =
-      identifierNode(node, Defines.Self, code(node), Defines.Any, scope.surroundingTypeFullName.toList)
+      identifierNode(node, Defines.Self, code(node), scope.surroundingTypeFullName.getOrElse(Defines.Any))
 
     scope
       .lookupVariable(Defines.Self)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -70,10 +70,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val thisParameterNode = newThisParameterNode(
       name = Defines.Self,
       code = Defines.Self,
-      typeFullName = Defines.Any,
+      typeFullName = scope.surroundingTypeFullName.getOrElse(Defines.Any),
       line = method.lineNumber,
-      column = method.columnNumber,
-      dynamicTypeHintFullName = scope.surroundingTypeFullName.toList
+      column = method.columnNumber
     )
     val thisParameterAst = Ast(thisParameterNode)
     scope.addToScope(Defines.Self, thisParameterNode)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
@@ -51,8 +51,7 @@ class FieldAccessTests extends RubyCode2CpgFixture {
           case (self: Identifier) :: (sickDaysId: FieldIdentifier) :: Nil =>
             self.name shouldBe "self"
             self.code shouldBe "self"
-            self.typeFullName shouldBe Defines.Any
-            self.dynamicTypeHintFullName.head should endWith("PaidTimeOff")
+            self.typeFullName should endWith("PaidTimeOff")
 
             sickDaysId.canonicalName shouldBe "@sick_days_earned"
             sickDaysId.code shouldBe "sick_days_earned"


### PR DESCRIPTION
`self` parameters within the scope of methods reverts back to initial surrounding type information, and keeps `ANY` otherwise, e.g. `<main>` methods.