### PR TITLE
[ruby] Implicit Require & Import Processing Tweaks

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -83,7 +83,7 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
       val programSummary = internalProgramSummary ++= dependencySummary
 
       AstCreationPass(cpg, astCreators.map(_.withSummary(programSummary))).createAndApply()
-      if (cpg.dependency.name.contains("zeitwerk")) ImplicitRequirePass(cpg, programSummary).createAndApply()
+      if (cpg.dependency.name.contains("zeitwerk")) ImplicitRequirePass(cpg).createAndApply()
       ImportsPass(cpg).createAndApply()
       if config.downloadDependencies then {
         DependencySummarySolverPass(cpg, dependencySummary).createAndApply()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ImplicitRequirePass.scala
@@ -27,13 +27,13 @@ class ImplicitRequirePass(cpg: Cpg) extends ForkJoinParallelCpgPass[Method](cpg)
       .filter { typeDecl =>
         // zeitwerk will match types that share the name of the path.
         // This match is insensitive to camel case, i.e, foo_bar will match type FooBar.
-        val fileName = typeDecl.filename.split('/').last.stripSuffix(".rb")
+        val fileName = typeDecl.filename.split(Array('/', '\\')).last.stripSuffix(".rb")
         val typeName = typeDecl.name
         typeName == fileName || typeName == CaseUtils.toCamelCase(fileName, true, '_', '-')
       }
       .l
     importableTypes.foreach { typeDecl =>
-      typeToPath.put(typeDecl.fullName, typeDecl.filename.stripSuffix(".rb"))
+      typeToPath.put(typeDecl.fullName, typeDecl.filename.replace("\\", "/").stripSuffix(".rb"))
     }
     importableTypes.groupBy(_.name).foreach { case (name, types) =>
       typeNameToFullName.put(name, types.toSet)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -268,10 +268,10 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
       cpg.imports.where(_.call.file.name(".*B.rb")).size shouldBe 0
     }
 
-    "create a `require_relative` call following the simplified format" in {
-      val require = cpg.call("require_relative").head
+    "create a `require` call following the simplified format" in {
+      val require = cpg.call("require").head
       require.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      require.methodFullName shouldBe s"$kernelPrefix.require_relative"
+      require.methodFullName shouldBe s"$kernelPrefix.require"
 
       val strLit = require.argument(1).asInstanceOf[Literal]
       strLit.typeFullName shouldBe s"$builtinPrefix.String"


### PR DESCRIPTION
* Reverted implicit requires to use `require` instead of `require_relative`
* Removed requirement for `ImplicitRequirePass` to need `programSummary` argument
* Moved import processing to post-processing