### PR TITLE
[ruby] Conflicting local nodes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -175,7 +175,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val capturedLocalNodes = baseStmtBlockAst.nodes
       .collect { case x: NewIdentifier => x }
       .distinctBy(_.name)
-      .map(i => scope.lookupLambdaVariable(i.name))
+      .map(i => scope.lookupVariableInOuterScope(i.name))
       .filter(_.nonEmpty)
       .flatten
       .toSet

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -92,7 +92,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     // Consider which variables are captured from the outer scope
     val stmtBlockAst = if (isClosure || isSingletonObjectMethod) {
       val baseStmtBlockAst = astForMethodBody(node.body, optionalStatementList)
-      transformAsClosureBody(refs, baseStmtBlockAst, fullName)
+      transformAsClosureBody(refs, baseStmtBlockAst)
     } else {
       if (methodName == Defines.TypeDeclBody) {
         val stmtList = node.body.asInstanceOf[StatementList]
@@ -170,12 +170,12 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     if isClosure || isSingletonObjectMethod then refs else createMethodRefPointer(method) :: Nil
   }
 
-  private def transformAsClosureBody(refs: List[Ast], baseStmtBlockAst: Ast, methodFullName: String) = {
+  private def transformAsClosureBody(refs: List[Ast], baseStmtBlockAst: Ast) = {
     // Determine which locals are captured
     val capturedLocalNodes = baseStmtBlockAst.nodes
       .collect { case x: NewIdentifier => x }
       .distinctBy(_.name)
-      .map(i => scope.lookupLambdaVariable(i.name, methodFullName))
+      .map(i => scope.lookupLambdaVariable(i.name))
       .filter(_.nonEmpty)
       .flatten
       .toSet

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -126,14 +126,10 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
   }
 
   def lookupLambdaVariable(identifier: String, methodFullName: String): List[DeclarationNew] = {
-    stack.collect {
+    stack.drop(1).collect {
       case scopeElement if scopeElement.variables.contains(identifier) =>
-        scopeElement.scopeNode match {
-          case x: MethodScope if x.fullName != methodFullName => Option(scopeElement.variables(identifier))
-          case x: MethodScope                                 => None
-          case _                                              => Option(scopeElement.variables(identifier))
-        }
-    }.flatten
+        scopeElement.variables(identifier)
+    }
   }
 
   def addRequire(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -125,7 +125,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     }
   }
 
-  def lookupLambdaVariable(identifier: String, methodFullName: String): List[DeclarationNew] = {
+  def lookupLambdaVariable(identifier: String): List[DeclarationNew] = {
     stack.drop(1).collect {
       case scopeElement if scopeElement.variables.contains(identifier) =>
         scopeElement.variables(identifier)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -11,7 +11,7 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 import java.io.File as JFile
 import scala.collection.mutable
-import scala.reflect.ClassTag
+import scala.reflect.{ClassTag, classTag}
 import scala.util.Try
 
 class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
@@ -123,6 +123,17 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
           case None => super.addToScope(identifier, variable)
         }
     }
+  }
+
+  def lookupLambdaVariable(identifier: String, methodFullName: String): List[DeclarationNew] = {
+    stack.collect {
+      case scopeElement if scopeElement.variables.contains(identifier) =>
+        scopeElement.scopeNode match {
+          case x: MethodScope if x.fullName != methodFullName => Option(scopeElement.variables(identifier))
+          case x: MethodScope                                 => None
+          case _                                              => Option(scopeElement.variables(identifier))
+        }
+    }.flatten
   }
 
   def addRequire(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -125,7 +125,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     }
   }
 
-  def lookupLambdaVariable(identifier: String): List[DeclarationNew] = {
+  def lookupVariableInOuterScope(identifier: String): List[DeclarationNew] = {
     stack.drop(1).collect {
       case scopeElement if scopeElement.variables.contains(identifier) =>
         scopeElement.variables(identifier)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -11,7 +11,7 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 import java.io.File as JFile
 import scala.collection.mutable
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.ClassTag
 import scala.util.Try
 
 class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Method}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
@@ -288,5 +288,30 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         }
       case xs => fail(s"Expected three lambdas, got ${xs.size} lambdas instead")
     }
+  }
+
+  "Local node" in {
+    val cpg = code("""
+                     | def get_pto_schedule
+                     |    begin
+                     |       schedules = current_user.paid_time_off.schedule
+                     |       jfs = []
+                     |       schedules.each do |s|
+                     |          hash = Hash.new
+                     |          hash[:id] = s[:id]
+                     |          hash[:title] = s[:event_name]
+                     |          hash[:start] = s[:date_begin]
+                     |          hash[:end] = s[:date_end]
+                     |          jfs << hash
+                     |       end
+                     |    rescue
+                     |    end
+                     |    respond_to do |format|
+                     |       format.json { render json: jfs.to_json }
+                     |    end
+                     |  end
+                     |""".stripMargin)
+
+    cpg.method.name("get_pto_schedule").dotAst.l.foreach(println)
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Method}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
@@ -289,5 +289,4 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected three lambdas, got ${xs.size} lambdas instead")
     }
   }
-
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -290,28 +290,4 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
     }
   }
 
-  "Local node" in {
-    val cpg = code("""
-                     | def get_pto_schedule
-                     |    begin
-                     |       schedules = current_user.paid_time_off.schedule
-                     |       jfs = []
-                     |       schedules.each do |s|
-                     |          hash = Hash.new
-                     |          hash[:id] = s[:id]
-                     |          hash[:title] = s[:event_name]
-                     |          hash[:start] = s[:date_begin]
-                     |          hash[:end] = s[:date_end]
-                     |          jfs << hash
-                     |       end
-                     |    rescue
-                     |    end
-                     |    respond_to do |format|
-                     |       format.json { render json: jfs.to_json }
-                     |    end
-                     |  end
-                     |""".stripMargin)
-
-    cpg.method.name("get_pto_schedule").dotAst.l.foreach(println)
-  }
 }


### PR DESCRIPTION
This PR fixes an issue where 2 `LOCAL` nodes were being created in `LAMBDA` blocks, even when the variable was only defined in the scope of the `LAMBDA` block.