### PR TITLE
[ruby] Fixed type prefix on require paths from `ImplicitRequireResolver`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -275,7 +275,7 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
       require.methodFullName shouldBe s"$kernelPrefix.require"
 
       val strLit = require.argument(1).asInstanceOf[Literal]
-      strLit.typeFullName shouldBe s"$builtinPrefix.String"
+      strLit.typeFullName shouldBe s"$kernelPrefix.String"
     }
 
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
@@ -113,7 +113,7 @@ class ImplicitRequirePass(cpg: Cpg) extends ForkJoinParallelCpgPass[Method](cpg)
     builder.addNode(requireCallNode)
     // Create literal argument
     val pathLiteralNode =
-      NewLiteral().code(s"'$path'").typeFullName(s"$builtinPrefix.String").argumentIndex(1).order(2)
+      NewLiteral().code(s"'$path'").typeFullName(s"$kernelPrefix.String").argumentIndex(1).order(2)
     builder.addEdge(requireCallNode, pathLiteralNode, EdgeTypes.AST)
     builder.addEdge(requireCallNode, pathLiteralNode, EdgeTypes.ARGUMENT)
     requireCallNode


### PR DESCRIPTION
Fixed an issue where the type on the path for a require from the `ImplicitRequireResolver` was being set to `__core.String` instead of `__core.Kernel.String`