### PR TITLE
[ruby] Changed type of the `this` param on singleton method declarations

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -374,10 +374,15 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
         createMethodTypeBindings(method, methodTypeDecl_)
 
+        val thisNodeTypeFullName = astParentFullName match {
+          case Some(fn) => s"$fn<class>"
+          case None     => Defines.Any
+        }
+
         val thisNode = newThisParameterNode(
           name = Defines.Self,
           code = thisParamCode,
-          typeFullName = astParentFullName.getOrElse(Defines.Any),
+          typeFullName = thisNodeTypeFullName,
           line = method.lineNumber,
           column = method.columnNumber
         )

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -994,4 +994,21 @@ class ClassTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected one type decl, got [${xs.code.mkString(",")}]")
     }
   }
+
+  "Self param in static method" in {
+    val cpg = code("""
+        |class Benefits < ApplicationRecord
+        |def self.save(file, backup = false)
+        |    data_path = Rails.root.join("public", "data")
+        |    full_file_name = "#{data_path}/#{file.original_filename}"
+        |    f = File.open(full_file_name, "wb+")
+        |    f.write file.read
+        |    f.close
+        |    make_backup(file, data_path, full_file_name) if backup == "true"
+        |end
+        |end
+        |""".stripMargin)
+
+    cpg.method.name("save").parameter.l.foreach(x => println(x.typeFullName))
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -207,7 +207,7 @@ class MethodTests extends RubyCode2CpgFixture {
             inside(funcF.parameter.l) {
               case thisParam :: xParam :: Nil =>
                 thisParam.code shouldBe RDefines.Self
-                thisParam.typeFullName shouldBe s"Test0.rb:$Main.C"
+                thisParam.typeFullName shouldBe s"Test0.rb:$Main.C<class>"
                 thisParam.index shouldBe 0
                 thisParam.isVariadic shouldBe false
 
@@ -241,7 +241,7 @@ class MethodTests extends RubyCode2CpgFixture {
             inside(funcF.parameter.l) {
               case thisParam :: xParam :: Nil =>
                 thisParam.code shouldBe RDefines.Self
-                thisParam.typeFullName shouldBe s"Test0.rb:$Main.C"
+                thisParam.typeFullName shouldBe s"Test0.rb:$Main.C<class>"
                 thisParam.index shouldBe 0
                 thisParam.isVariadic shouldBe false
 
@@ -365,7 +365,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case thisParam :: xParam :: Nil =>
               thisParam.name shouldBe RDefines.Self
               thisParam.code shouldBe "F"
-              thisParam.typeFullName shouldBe s"Test0.rb:$Main.F"
+              thisParam.typeFullName shouldBe s"Test0.rb:$Main.F<class>"
 
               xParam.name shouldBe "x"
             case xs => fail(s"Expected two parameters, got ${xs.name.mkString(", ")}")
@@ -375,7 +375,7 @@ class MethodTests extends RubyCode2CpgFixture {
             case thisParam :: xParam :: Nil =>
               thisParam.name shouldBe RDefines.Self
               thisParam.code shouldBe "F"
-              thisParam.typeFullName shouldBe s"Test0.rb:$Main.F"
+              thisParam.typeFullName shouldBe s"Test0.rb:$Main.F<class>"
 
               xParam.name shouldBe "x"
               xParam.code shouldBe "x"


### PR DESCRIPTION
Fixed an issue where the `self` param typeFullName on static methods were not including the `<class>`