### PR TITLE
[ruby] Fix namespace inconsistencies

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -958,6 +958,16 @@ class ClassTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
+    inside(cpg.namespaceBlock.fullNameExact("Api.V1").typeDecl.l) {
+      case mobileNamespace :: mobileClassNamespace :: Nil =>
+        mobileNamespace.name shouldBe "MobileController"
+        mobileNamespace.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
+
+        mobileClassNamespace.name shouldBe "MobileController<class>"
+        mobileClassNamespace.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController<class>"
+      case xs => fail(s"Expected two namespace blocks, got ${xs.code.mkString(",")}")
+    }
+
     inside(cpg.typeDecl.name("MobileController").l) {
       case mobileTypeDecl :: Nil =>
         mobileTypeDecl.name shouldBe "MobileController"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -910,4 +910,20 @@ class MethodTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected one call, got [${xs.code.mkString(",")}]")
     }
   }
+
+  "Method def in class defined in a namespace" in {
+    val cpg = code("""
+        |class Api::V1::MobileController
+        |  def show
+        |  end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.method.name("show").l) {
+      case showMethod :: Nil =>
+        showMethod.astParentFullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
+        showMethod.astParentType shouldBe NodeTypes.TYPE_DECL
+      case xs => fail(s"Expected one methood, got ${xs.name.mkString(",")}")
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -47,6 +47,16 @@ class ModuleTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
+    inside(cpg.namespaceBlock.fullNameExact("Api.V1").typeDecl.l) {
+      case mobileNamespace :: mobileClassNamespace :: Nil =>
+        mobileNamespace.name shouldBe "MobileController"
+        mobileNamespace.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
+
+        mobileClassNamespace.name shouldBe "MobileController<class>"
+        mobileClassNamespace.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController<class>"
+      case xs => fail(s"Expected two namespace blocks, got ${xs.code.mkString(",")}")
+    }
+
     inside(cpg.typeDecl.name("MobileController").l) {
       case mobileTypeDecl :: Nil =>
         mobileTypeDecl.name shouldBe "MobileController"


### PR DESCRIPTION
Fixed an issue where classes defined in namespaces had different fullNames for the class and singleton instance defined in the namespace. Also resolved an issue where methods defined in class defined in a namespace was not being defined under the new `TypeDecl`