### PR TITLE
[ruby] `raise` Calls Represented as Operator

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -39,6 +39,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     case node: SimpleCall                       => astForSimpleCall(node)
     case node: RequireCall                      => astForRequireCall(node)
     case node: IncludeCall                      => astForIncludeCall(node)
+    case node: RaiseCall                        => astForRaiseCall(node)
     case node: YieldExpr                        => astForYield(node)
     case node: RangeExpression                  => astForRange(node)
     case node: ArrayLiteral                     => astForArrayLiteral(node)
@@ -499,6 +500,12 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       node.argument.text.replaceAll("::", ".")
     ) // Maybe generate ast and get name in a more structured approach instead
     astForSimpleCall(node.asSimpleCall)
+  }
+
+  protected def astForRaiseCall(node: RaiseCall): Ast = {
+    val throwControlStruct = controlStructureNode(node, ControlStructureTypes.THROW, code(node))
+    val args               = node.arguments.map(astForExpression)
+    Ast(throwControlStruct).withChildren(args)
   }
 
   /** A yield in Ruby calls an explicit (or implicit) proc parameter and returns its value. This can be lowered as

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -381,6 +381,10 @@ object RubyIntermediateAst {
     def asSimpleCall: SimpleCall  = SimpleCall(target, arguments)(span)
   }
 
+  final case class RaiseCall(target: RubyNode, arguments: List[RubyNode])(span: TextSpan)
+      extends RubyNode(span)
+      with RubyCall
+
   /** Represents standalone `proc { ... }` or `lambda { ... }` expressions
     */
   final case class ProcOrLambdaExpr(block: Block)(span: TextSpan) extends RubyNode(span)


### PR DESCRIPTION
* Modified `raise` calls to be control structures of type `THROW`
* If a literal argument is given, this is then explicitly represented as a `StandardError.new`