### PR TITLE
[ruby] Use `try/catch/else/finally controlStructureNode` for `RescueExpression`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -340,7 +340,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     inside(cpg.method("test1").controlStructure.l) {
       case tryStruct :: rescue1Struct :: rescue2Struct :: rescue3Struct :: elseStruct :: ensureStruct :: Nil =>
         tryStruct.controlStructureType shouldBe ControlStructureTypes.TRY
-        val List(body, _, _, _, _, _) = tryStruct.astChildren.l
+        val body = tryStruct.astChildren.head
         body.ast.isLiteral.code.l shouldBe List("1")
 
         rescue1Struct.controlStructureType shouldBe ControlStructureTypes.CATCH
@@ -376,7 +376,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     inside(cpg.method("test2").controlStructure.l) {
       case tryStruct :: defaultElseStruct :: ensureStruct :: Nil =>
         tryStruct.controlStructureType shouldBe ControlStructureTypes.TRY
-        val List(body, _, _) = tryStruct.astChildren.l
+        val body = tryStruct.astChildren.head
         body.ast.isLiteral.code.l shouldBe List("1")
 
         defaultElseStruct.controlStructureType shouldBe ControlStructureTypes.ELSE

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -523,20 +523,16 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "Should be represented as a TRY structure" in {
-      inside(cpg.method.name("foo").tryBlock.l) {
-        case tryBlock :: Nil =>
-          tryBlock.controlStructureType shouldBe ControlStructureTypes.TRY
+      inside(cpg.method.name("foo").controlStructure.l) {
+        case tryStruct :: ensureStruct :: Nil =>
+          tryStruct.controlStructureType shouldBe ControlStructureTypes.TRY
+          val body = tryStruct.astChildren.head
+          body.ast.isLiteral.code.l shouldBe List("1")
 
-          inside(tryBlock.astChildren.l) {
-            case body :: ensureBody :: Nil =>
-              body.ast.isLiteral.code.l shouldBe List("1")
-              body.order shouldBe 1
+          ensureStruct.controlStructureType shouldBe ControlStructureTypes.FINALLY
+          ensureStruct.ast.isLiteral.code.l shouldBe List("2")
 
-              ensureBody.ast.isLiteral.code.l shouldBe List("2")
-              ensureBody.order shouldBe 3
-            case xs => fail(s"Expected body and ensureBody, got ${xs.code.mkString(", ")} instead")
-          }
-        case xs => fail(s"Expected one method, found ${xs.method.name.mkString(", ")} instead")
+        case xs => fail(s"Expected two structures, got ${xs.code.mkString(",")}")
       }
     }
   }


### PR DESCRIPTION
Updated AST generation for `RescueExpression` to use `try/catch/else/finally controlStructureNode` types.