### PR TITLE
[ruby] removed assignment operator restriction on BracketedAssignments

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -846,22 +846,14 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitBracketAssignmentExpression(ctx: RubyParser.BracketAssignmentExpressionContext): RubyNode = {
-    val op = ctx.assignmentOperator().getText
-
-    if (op != "=") {
-      logger.warn(s"Unsupported assignment operator for bracket assignment expression: $op")
-      defaultResult()
-    }
-
     val lhsBase = visit(ctx.primaryValue())
     val lhsArgs = Option(ctx.indexingArgumentList()).map(_.arguments).getOrElse(List()).map(visit)
 
     val lhs = IndexAccess(lhsBase, lhsArgs)(
       ctx.toTextSpan.spanStart(s"${lhsBase.span.text}[${lhsArgs.map(_.span.text).mkString(", ")}]")
     )
-
+    val op  = ctx.assignmentOperator().getText
     val rhs = visit(ctx.operatorExpression())
-
     SingleAssignment(lhs, op, rhs)(ctx.toTextSpan)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -289,4 +289,84 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected three lambdas, got ${xs.size} lambdas instead")
     }
   }
+
+  "Bracketed ||=" in {
+    val cpg = code("""
+        |hash[:id] ||= s[:id]
+        |""".stripMargin)
+
+    inside(cpg.call.name(Operators.assignmentOr).l) {
+      case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "hash[:id] ||= s[:id]"
+        assignmentCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+        inside(assignmentCall.argument.l) {
+          case lhs :: rhs :: Nil =>
+            lhs.code shouldBe "hash[:id]"
+            rhs.code shouldBe "s[:id]"
+          case xs => fail(s"Expected lhs and rhs arguments, got ${xs.code.mkString(",")}")
+        }
+      case xs => fail(s"Expected on assignmentOr call, got ${xs.code.mkString(",")}")
+    }
+  }
+
+  "Bracketed +=" in {
+    val cpg = code("""
+        |hash[:id] += s[:id]
+        |""".stripMargin)
+
+    inside(cpg.call.name(Operators.assignmentPlus).l) {
+      case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "hash[:id] += s[:id]"
+        assignmentCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+        inside(assignmentCall.argument.l) {
+          case lhs :: rhs :: Nil =>
+            lhs.code shouldBe "hash[:id]"
+            rhs.code shouldBe "s[:id]"
+          case xs => fail(s"Expected lhs and rhs arguments, got ${xs.code.mkString(",")}")
+        }
+      case xs => fail(s"Expected on assignmentOr call, got ${xs.code.mkString(",")}")
+    }
+  }
+
+  "Bracketed &&=" in {
+    val cpg = code("""
+        |hash[:id] &&= s[:id]
+        |""".stripMargin)
+
+    inside(cpg.call.name(Operators.assignmentAnd).l) {
+      case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "hash[:id] &&= s[:id]"
+        assignmentCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+        inside(assignmentCall.argument.l) {
+          case lhs :: rhs :: Nil =>
+            lhs.code shouldBe "hash[:id]"
+            rhs.code shouldBe "s[:id]"
+          case xs => fail(s"Expected lhs and rhs arguments, got ${xs.code.mkString(",")}")
+        }
+      case xs => fail(s"Expected on assignmentOr call, got ${xs.code.mkString(",")}")
+    }
+  }
+
+  "Bracketed /=" in {
+    val cpg = code("""
+        |hash[:id] /= s[:id]
+        |""".stripMargin)
+
+    inside(cpg.call.name(Operators.assignmentDivision).l) {
+      case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "hash[:id] /= s[:id]"
+        assignmentCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+        inside(assignmentCall.argument.l) {
+          case lhs :: rhs :: Nil =>
+            lhs.code shouldBe "hash[:id]"
+            rhs.code shouldBe "s[:id]"
+          case xs => fail(s"Expected lhs and rhs arguments, got ${xs.code.mkString(",")}")
+        }
+      case xs => fail(s"Expected on assignmentOr call, got ${xs.code.mkString(",")}")
+    }
+  }
 }


### PR DESCRIPTION
Removed `warning` log and `defaultResult` when using any assignment operator other than equals on `BracketAssignment`