### PR TITLE
[ruby] Visibility Access Modifiers

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -68,7 +68,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case ProtectedModifier() => ModifierTypes.PROTECTED
       case PublicModifier()    => ModifierTypes.PUBLIC
     }
-    pushAccessModifier(modifier)
+    popAccessModifier()          // pop off the current modifier in scope
+    pushAccessModifier(modifier) // push new one on
     Nil
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -5,7 +5,7 @@ import io.joern.rubysrc2cpg.datastructures.BlockScope
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, ModifierTypes}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewControlStructure, NewMethod, NewMethodRef, NewTypeDecl}
 
 trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
@@ -25,6 +25,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case node: AnonymousTypeDeclaration   => astForAnonymousTypeDeclaration(node) :: Nil
     case node: TypeDeclaration            => astForClassDeclaration(node)
     case node: FieldsDeclaration          => astsForFieldDeclarations(node)
+    case node: AccessModifier             => registerAccessModifier(node)
     case node: MethodDeclaration          => astForMethodDeclaration(node)
     case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node)
     case node: MultipleAssignment         => node.assignments.map(astForExpression)
@@ -57,6 +58,18 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       controlStructureAst(ifNode, Some(conditionAst), thenAst :: elseAsts)
     }
     foldIfExpression(builder)(node)
+  }
+
+  /** Registers the currently set access modifier for the current type (until it is reset later).
+    */
+  private def registerAccessModifier(node: AccessModifier): Seq[Ast] = {
+    val modifier = node match {
+      case PrivateModifier()   => ModifierTypes.PRIVATE
+      case ProtectedModifier() => ModifierTypes.PROTECTED
+      case PublicModifier()    => ModifierTypes.PUBLIC
+    }
+    pushAccessModifier(modifier)
+    Nil
   }
 
   // Rewrites a nested `if T_1 then E_1 elsif T_2 then E_2 elsif ... elsif T_n then E_n else E_{n+1}`

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -51,6 +51,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   ): Seq[Ast] = {
     val className    = nameIdentifier.text
     val inheritsFrom = node.baseClass.map(getBaseClassName).toList
+    pushAccessModifier(ModifierTypes.PUBLIC)
 
     /** Pushes new NamespaceScope onto scope stack and populates AST_PARENT_FULL_NAME and AST_PARENT_TYPE for TypeDecls
       * that are declared in a namespace
@@ -64,7 +65,6 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     def populateAstParentValues(typeDecl: NewTypeDecl, astParentFullName: String): NewTypeDecl = {
       val namespaceBlockFullName = s"${scope.surroundingScopeFullName.getOrElse("")}.$astParentFullName"
       scope.pushNewScope(NamespaceScope(namespaceBlockFullName))
-      pushAccessModifier(ModifierTypes.PUBLIC)
 
       val namespaceBlock =
         NewNamespaceBlock().name(astParentFullName).fullName(astParentFullName).filename(relativeFileName)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -63,7 +63,8 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       */
     def populateAstParentValues(typeDecl: NewTypeDecl, astParentFullName: String): NewTypeDecl = {
       val namespaceBlockFullName = s"${scope.surroundingScopeFullName.getOrElse("")}.$astParentFullName"
-      scope.pushNewScope(NamespaceScope(s"${scope.surroundingScopeFullName.getOrElse("")}.$astParentFullName"))
+      scope.pushNewScope(NamespaceScope(namespaceBlockFullName))
+      pushAccessModifier(ModifierTypes.PUBLIC)
 
       val namespaceBlock =
         NewNamespaceBlock().name(astParentFullName).fullName(astParentFullName).filename(relativeFileName)
@@ -197,7 +198,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     (typeDeclAst :: singletonTypeDeclAst :: Nil).foreach(Ast.storeInDiffGraph(_, diffGraph))
 
     if shouldPopAdditionalScope then scope.popScope()
-
+    popAccessModifier()
     prefixAst :: bodyMemberCallAst :: Nil
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.astcreation
 
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.AllowedTypeDeclarationChild
 import io.joern.rubysrc2cpg.passes.{Defines, GlobalTypes}
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 
@@ -384,6 +385,14 @@ object RubyIntermediateAst {
   final case class RaiseCall(target: RubyNode, arguments: List[RubyNode])(span: TextSpan)
       extends RubyNode(span)
       with RubyCall
+
+  sealed trait AccessModifier extends AllowedTypeDeclarationChild
+
+  final case class PublicModifier()(span: TextSpan) extends RubyNode(span) with AccessModifier
+
+  final case class PrivateModifier()(span: TextSpan) extends RubyNode(span) with AccessModifier
+
+  final case class ProtectedModifier()(span: TextSpan) extends RubyNode(span) with AccessModifier
 
   /** Represents standalone `proc { ... }` or `lambda { ... }` expressions
     */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -730,10 +730,13 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   override def visitLocalIdentifierVariable(ctx: RubyParser.LocalIdentifierVariableContext): RubyNode = {
     // Sometimes pseudo variables aren't given precedence in the parser, so we double-check here
     ctx.getText match {
-      case "nil"   => StaticLiteral(getBuiltInType(Defines.NilClass))(ctx.toTextSpan)
-      case "true"  => StaticLiteral(getBuiltInType(Defines.TrueClass))(ctx.toTextSpan)
-      case "false" => StaticLiteral(getBuiltInType(Defines.FalseClass))(ctx.toTextSpan)
-      case _       => SimpleIdentifier()(ctx.toTextSpan)
+      case "nil"       => StaticLiteral(getBuiltInType(Defines.NilClass))(ctx.toTextSpan)
+      case "true"      => StaticLiteral(getBuiltInType(Defines.TrueClass))(ctx.toTextSpan)
+      case "false"     => StaticLiteral(getBuiltInType(Defines.FalseClass))(ctx.toTextSpan)
+      case "public"    => PublicModifier()(ctx.toTextSpan)
+      case "private"   => PrivateModifier()(ctx.toTextSpan)
+      case "protected" => ProtectedModifier()(ctx.toTextSpan)
+      case _           => SimpleIdentifier()(ctx.toTextSpan)
     }
   }
 
@@ -1173,7 +1176,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     }
 
     val (allowedTypeDeclChildren, nonAllowedTypeDeclChildren) = nonInitStmts.partition {
-      case x: AllowedTypeDeclarationChild => true
+      case _: AllowedTypeDeclarationChild => true
       case _                              => false
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
@@ -1,0 +1,89 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.joern.rubysrc2cpg.passes.Defines
+import io.shiftleft.semanticcpg.language.*
+
+class AccessModifierTests extends RubyCode2CpgFixture {
+
+  "methods defined on the <main> level are private" in {
+    val cpg = code("""
+        |def foo
+        |end
+        |""".stripMargin)
+
+    cpg.method("foo").head.isPrivate.size shouldBe 1
+  }
+
+  "a method should be public by default, with the `initialize` default constructor private" in {
+    val cpg = code("""
+        |class Foo
+        | def bar
+        | end
+        |end
+        |""".stripMargin)
+
+    cpg.method("bar").head.isPublic.size shouldBe 1
+    cpg.method(Defines.Initialize).head.isPrivate.size shouldBe 1
+    cpg.method(Defines.TypeDeclBody).head.isPrivate.size shouldBe 1
+  }
+
+  "an access modifier should affect the visibility of subsequent method definitions" in {
+    val cpg = code("""
+        |class Foo
+        | def bar
+        | end
+        |
+        | private
+        |
+        | def baz
+        | end
+        |
+        | def faz
+        | end
+        |
+        |end
+        |
+        |class Baz
+        | def test1
+        | end
+        |
+        | protected
+        |
+        | def test2
+        | end
+        |end
+        |""".stripMargin)
+
+    cpg.method("bar").head.isPublic.size shouldBe 1
+
+    cpg.method("baz").head.isPrivate.size shouldBe 1
+    cpg.method("faz").head.isPrivate.size shouldBe 1
+
+    cpg.method("test1").head.isPublic.size shouldBe 1
+    cpg.method("test2").head.isProtected.size shouldBe 1
+  }
+
+  "nested types should 'remember' their access modifier mode according to scope" in {
+    val cpg = code("""
+        |class Foo
+        | private
+        |
+        | class Bar
+        |
+        |   public
+        |   def baz
+        |   end
+        |
+        | end
+        |
+        | def test
+        | end
+        |end
+        |""".stripMargin)
+
+    cpg.method("baz").isPublic.size shouldBe 1
+    cpg.method("test").isPrivate.size shouldBe 1
+  }
+
+}


### PR DESCRIPTION
* Handles various access modifiers private/public/protected
* Also considers file-level methods are private and initialize methods cannot be anything other than private
* Accounts for nested types where their modifiers are separate from surrounding type