### PR TITLE
[ruby] Add `commandTernaryExpression` to `command`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -141,8 +141,8 @@ methodInvocationWithoutParentheses
     ;
 
 command
-    :   operatorExpression
-        # operatorExpressionCommand
+    :   operatorExpression QMARK NL* operatorExpression NL* COLON NL* operatorExpression
+        # commandTernaryOperatorExpression
     |   primary NL? (AMPDOT | DOT | COLON2) methodName commandArgument
         # memberAccessCommand
     |   methodIdentifier commandArgument

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -141,7 +141,9 @@ methodInvocationWithoutParentheses
     ;
 
 command
-    :   primary NL? (AMPDOT | DOT | COLON2) methodName commandArgument
+    :   operatorExpression
+        # operatorExpressionCommand
+    |   primary NL? (AMPDOT | DOT | COLON2) methodName commandArgument
         # memberAccessCommand
     |   methodIdentifier commandArgument
         # simpleCommand

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -711,6 +711,10 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
     }
   }
 
+  override def visitOperatorExpressionCommand(ctx: RubyParser.OperatorExpressionCommandContext): RubyNode = {
+    visit(ctx.operatorExpression())
+  }
+
   override def visitConstantIdentifierVariable(ctx: RubyParser.ConstantIdentifierVariableContext): RubyNode = {
     SimpleIdentifier()(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -147,6 +147,18 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
         Unknown()(ctx.toTextSpan)
   }
 
+  override def visitCommandTernaryOperatorExpression(ctx: CommandTernaryOperatorExpressionContext): RubyNode = {
+    val condition = visit(ctx.operatorExpression(0))
+    val thenBody  = visit(ctx.operatorExpression(1))
+    val elseBody  = visit(ctx.operatorExpression(2))
+    IfExpression(
+      condition,
+      thenBody,
+      List.empty,
+      Option(ElseClause(StatementList(elseBody :: Nil)(elseBody.span))(elseBody.span))
+    )(ctx.toTextSpan)
+  }
+
   override def visitTernaryOperatorExpression(ctx: RubyParser.TernaryOperatorExpressionContext): RubyNode = {
     val condition = visit(ctx.operatorExpression(0))
     val thenBody  = visit(ctx.operatorExpression(1))
@@ -711,10 +723,6 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
       val methodName = visit(ctx.methodName())
       MemberCall(base, ".", methodName.text, args)(ctx.toTextSpan)
     }
-  }
-
-  override def visitOperatorExpressionCommand(ctx: RubyParser.OperatorExpressionCommandContext): RubyNode = {
-    visit(ctx.operatorExpression())
   }
 
   override def visitConstantIdentifierVariable(ctx: RubyParser.ConstantIdentifierVariableContext): RubyNode = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -573,4 +573,38 @@ class ControlStructureTests extends RubyCode2CpgFixture {
     }
   }
 
+  "Ternary if" in {
+    val cpg = code("""
+        |class Api::V1::UsersController < ApplicationController
+        |  def index
+        |    respond_with @user.admin ? User.all : @user
+        |  end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.method.name("index").l) {
+      case indexMethod :: Nil =>
+        inside(indexMethod.call.name(Operators.conditional).l) {
+          case ternary :: Nil =>
+            ternary.code shouldBe "@user.admin ? User.all : @user"
+
+            inside(ternary.argument.l) {
+              case condition :: (leftOpt: Block) :: (rightOpt: Block) :: Nil =>
+                condition.code shouldBe "@user.admin"
+                condition.ast.isFieldIdentifier.code.l shouldBe List("@user", "admin")
+
+                leftOpt.ast.fieldAccess.code.head shouldBe "User.all"
+                leftOpt.ast.isFieldIdentifier.code.l shouldBe List("User", "all")
+
+                rightOpt.ast.fieldAccess.code.head shouldBe "self.@user"
+                rightOpt.ast.isFieldIdentifier.code.head shouldBe "@user"
+
+              case xs => fail(s"Expected two arguments, got ${xs.code.mkString(",")}")
+            }
+          case xs => fail(s"Expected one call for ternary, got ${xs.code.mkString(",")}")
+        }
+      case xs => fail(s"Expected one method, got ${xs.name.mkString(",")}")
+    }
+  }
+
 }


### PR DESCRIPTION
Added `commandTernaryExpression` to `command` in the ANTLR grammar for situations like the given test case where we have a `ternaryExpression` as a parameter to a parenthesisless call