### PR TITLE
[php2cpg] Improve performance.

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -24,8 +24,12 @@ class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileC
   }
 
   def parseFiles(inputPaths: collection.Seq[String]): collection.Seq[(String, Option[PhpFile], String)] = {
+    // We need to keep a map between the input path and its canonical representation in
+    // order to map back the canonical file name we get from the php parser.
+    // Otherwise later on file name/path processing might get confused because the returned
+    // file paths are in no relation to the input paths.
     val canonicalToInputPath = mutable.HashMap.empty[String, String]
-    
+
     inputPaths.foreach { inputPath =>
       val canonicalPath = Path.of(inputPath).toFile.getCanonicalPath
       canonicalToInputPath.put(canonicalPath, inputPath)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -28,7 +28,7 @@ class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileC
       inputFile.canonicalPath
     }
 
-    val command = phpParseCommand(absoluteInputPaths)
+    val command = phpParseCommand(inputPaths)
 
     val (returnValue, output) = ExternalCommand.runWithMergeStdoutAndStderr(command, ".")
     returnValue match {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -12,36 +12,53 @@ import org.slf4j.LoggerFactory
 import scala.jdk.CollectionConverters.*
 
 class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser)(implicit withSchemaValidation: ValidationMode)
-    extends ForkJoinParallelCpgPass[String](cpg) {
+    extends ForkJoinParallelCpgPass[Array[String]](cpg) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   val PhpSourceFileExtensions: Set[String] = Set(".php")
 
-  override def generateParts(): Array[String] = SourceFiles
-    .determine(
-      config.inputPath,
-      PhpSourceFileExtensions,
-      ignoredFilesRegex = Option(config.ignoredFilesRegex),
-      ignoredFilesPath = Option(config.ignoredFiles)
-    )
-    .toArray
+  override def generateParts(): Array[Array[String]] = {
+    val sourceFiles = SourceFiles
+      .determine(
+        config.inputPath,
+        PhpSourceFileExtensions,
+        ignoredFilesRegex = Option(config.ignoredFilesRegex),
+        ignoredFilesPath = Option(config.ignoredFiles)
+      )
+      .toArray
 
-  override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
-    val relativeFilename = if (filename == config.inputPath) {
-      File(filename).name
-    } else {
-      File(config.inputPath).relativize(File(filename)).toString
-    }
-    parser.parseFile(filename) match {
-      case Some((parseResult, fileContent)) =>
-        diffGraph.absorb(
-          new AstCreator(relativeFilename, parseResult, fileContent, config.disableFileContent)(config.schemaValidation)
-            .createAst()
-        )
+    // We need to feed the php parser big groups of file in order
+    // to speed up the parsing. Apparently it is some sort of slow
+    // startup phase which makes single file processing prohibitively
+    // slow.
+    // On the other hand we need to be careful to not choose too big
+    // chunks because:
+    //   1. The argument length to the php executable has system
+    //      dependent limits
+    //   2. We want to make use of multiple CPU cores for the rest
+    //      of the CPG creation.
+    //
+    val parts = sourceFiles.grouped(20).toArray
+    parts
+  }
 
-      case None =>
-        logger.warn(s"Could not parse file $filename. Results will be missing!")
+  override def runOnPart(diffGraph: DiffGraphBuilder, filenames: Array[String]): Unit = {
+    parser.parseFiles(filenames).foreach { case (filename, parseResult, infoLines) =>
+      parseResult match {
+        case Some(parseResult) =>
+          val relativeFilename = if (filename == config.inputPath) {
+            File(filename).name
+          } else {
+            File(config.inputPath).relativize(File(filename)).toString
+          }
+          diffGraph.absorb(
+            new AstCreator(relativeFilename, filename, parseResult, config.disableFileContent)(config.schemaValidation)
+              .createAst()
+          )
+        case None =>
+          logger.warn(s"Could not parse file $filename. Results will be missing!")
+      }
     }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -50,6 +50,7 @@ class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser)(implicit with
           val relativeFilename = if (filename == config.inputPath) {
             File(filename).name
           } else {
+            logger.warn(s"InputPath: ${config.inputPath} filename: $filename")
             File(config.inputPath).relativize(File(filename)).toString
           }
           diffGraph.absorb(

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -50,7 +50,6 @@ class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser)(implicit with
           val relativeFilename = if (filename == config.inputPath) {
             File(filename).name
           } else {
-            logger.warn(s"InputPath: ${config.inputPath} filename: $filename")
             File(config.inputPath).relativize(File(filename)).toString
           }
           diffGraph.absorb(


### PR DESCRIPTION
This php parser we use seems to have some warmup phase in which it
has very poor performance which makes it very expensive to feed
it single files like we so far did.
This change invokes the php parser with groups of 20 files which on my
machine give ~40% performance increase for the total frontend runtime on
large projects.
Bigger groups of files strangely only show marginal performance
increases despite the fact that profiling the frontend indicates that
there is still a lot of time wasted by the large amount of individual
parser invocations.
For now we keep it like this because for bigger groups we would run into
argument length limitations which are especially a pain on systems
like Windows. Sadly the php parser does not provide means to specify
the to be parsed files other than as a list on the command line.
So there would need to be some change there first before we could
increase the groups size in a meaningful way.
