### PR TITLE
[cli] recover `help` functionality

### DIFF
--- a/joern-cli/src/main/scala/io/joern/joerncli/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/Predefined.scala
@@ -9,7 +9,7 @@ object Predefined {
       "import _root_.io.joern.console.*",
       "import _root_.io.joern.joerncli.console.JoernConsole.*",
       "import _root_.io.shiftleft.codepropertygraph.cpgloading.*",
-      "import _root_.io.shiftleft.codepropertygraph.generated.*",
+      "import _root_.io.shiftleft.codepropertygraph.generated.{help => _, _}",
       "import _root_.io.shiftleft.codepropertygraph.generated.nodes.*",
       "import _root_.io.joern.dataflowengineoss.language.*",
       "import _root_.io.shiftleft.semanticcpg.language.*",


### PR DESCRIPTION
Recently noticed that the `help` command was no longer working as expected, cf.

```
% ./joern

     ██╗ ██████╗ ███████╗██████╗ ███╗   ██╗
     ██║██╔═══██╗██╔════╝██╔══██╗████╗  ██║
     ██║██║   ██║█████╗  ██████╔╝██╔██╗ ██║
██   ██║██║   ██║██╔══╝  ██╔══██╗██║╚██╗██║
╚█████╔╝╚██████╔╝███████╗██║  ██║██║ ╚████║
 ╚════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝
Version: 4.0.52
Type `help` to begin


joern> help
val res0: io.shiftleft.codepropertygraph.generated.help.type = io.shiftleft.codepropertygraph.generated.package$help$@1b2f18bd
```

---

This PR hides this specific `help` object from the REPL imports, thus recovering the original behaviour. Not sure this is the ideal approach, but not being familiar with this neck of the woods, didn't want to invest too much time without consulting first.