### PR TITLE
[ruby] Handle `SingleAssignmentStatement`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -531,10 +531,18 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     val memberAccess = MemberAccess(node.target, ".", s"@${node.attributeName}")(
       node.span.spanStart(s"${node.target.text}.${node.attributeName}")
     )
-    val op     = Operators.assignment
+
+    val assignmentOp = node.assignmentOperator match {
+      case "+=" => Operators.assignmentPlus
+      case "-=" => Operators.assignmentMinus
+      case "/=" => Operators.assignmentDivision
+      case "*=" => Operators.assignmentMultiplication
+      case _    => Operators.assignment
+    }
+
     val lhsAst = astForFieldAccess(memberAccess, stripLeadingAt = true)
     val rhsAst = astForExpression(node.rhs)
-    val call   = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
+    val call   = callNode(node, code(node), assignmentOp, assignmentOp, DispatchTypes.STATIC_DISPATCH)
     callAst(call, Seq(lhsAst, rhsAst))
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -532,13 +532,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       node.span.spanStart(s"${node.target.text}.${node.attributeName}")
     )
 
-    val assignmentOp = node.assignmentOperator match {
-      case "+=" => Operators.assignmentPlus
-      case "-=" => Operators.assignmentMinus
-      case "/=" => Operators.assignmentDivision
-      case "*=" => Operators.assignmentMultiplication
-      case _    => Operators.assignment
-    }
+    val assignmentOp = AssignmentOperatorNames(node.assignmentOperator)
 
     val lhsAst = astForFieldAccess(memberAccess, stripLeadingAt = true)
     val rhsAst = astForExpression(node.rhs)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -180,9 +180,14 @@ object RubyIntermediateAst {
 
   final case class SplattingRubyNode(name: RubyNode)(span: TextSpan) extends RubyNode(span)
 
-  final case class AttributeAssignment(target: RubyNode, op: String, attributeName: String, rhs: RubyNode)(
-    span: TextSpan
-  ) extends RubyNode(span)
+  final case class AttributeAssignment(
+    target: RubyNode,
+    op: String,
+    attributeName: String,
+    assignmentOperator: String,
+    rhs: RubyNode
+  )(span: TextSpan)
+      extends RubyNode(span)
 
   /** Any structure that conditionally modifies the control flow of the program.
     */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -533,6 +533,10 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
     s"$lhs $op $rhs"
   }
 
+  override def visitSingleAssignmentStatement(ctx: RubyParser.SingleAssignmentStatementContext): String = {
+    rubyNodeCreator.visitSingleAssignmentStatement(ctx).span.text
+  }
+
   override def visitMultipleAssignmentStatement(ctx: RubyParser.MultipleAssignmentStatementContext): String = {
     // TODO: fixme - ctx.toTextSpan is being used for individual elements in the building of a MultipleAssignment - needs
     //  to be fixed so that individual elements span texts can be used to build MultipleAssignment on AstPrinter side.
@@ -572,12 +576,13 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   }
 
   override def visitAttributeAssignmentExpression(ctx: RubyParser.AttributeAssignmentExpressionContext): String = {
-    val lhs        = visit(ctx.primaryValue())
-    val op         = ctx.op.getText
-    val memberName = ctx.methodName().getText
-    val rhs        = visit(ctx.operatorExpression())
+    val lhs          = visit(ctx.primaryValue())
+    val op           = ctx.op.getText
+    val assignmentOp = ctx.assignmentOperator.getText
+    val memberName   = ctx.methodName().getText
+    val rhs          = visit(ctx.operatorExpression())
 
-    s"$lhs$op$memberName = $rhs"
+    s"$lhs$op$memberName $assignmentOp $rhs"
   }
 
   override def visitSimpleCommand(ctx: RubyParser.SimpleCommandContext): String = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -449,7 +449,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
           SelfIdentifier()(ctx.toTextSpan.spanStart(Defines.Self)),
           ctx.COLON2().getText,
           ctx.CONSTANT_IDENTIFIER().getText
-        )(ctx.toTextSpan.spanStart(s"self::${ctx.CONSTANT_IDENTIFIER().getText}"))
+        )(ctx.toTextSpan.spanStart(s"$Self::${ctx.CONSTANT_IDENTIFIER().getText}"))
       else if Option(ctx.variable()).isDefined then visit(ctx.variable())
       else if Option(ctx.indexingArgumentList()).isDefined then
         val target = visit(ctx.primary())

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -41,7 +41,6 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitCompoundStatement(ctx: RubyParser.CompoundStatementContext): RubyNode = {
-    val a = ctx.getStatements.map(visit)
     StatementList(ctx.getStatements.map(visit))(ctx.toTextSpan)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
@@ -5,15 +5,9 @@ import org.scalatest.matchers.should.Matchers
 
 class AssignmentParserTests extends RubyParserFixture with Matchers {
   "fixme" ignore {
-    test("A.B ||= c 1")      // Possible string issue - result is missing A.B on LHS
-    test("a[:b] ||= c 1, 2") // Possible string issue - result is missing a[:b] on LHS
-    test("A::b += 1")        // Possible string issue - result is missing + in += operator
-    test("A::B *= c d")      // Possible string issue - result is missing A::B *= on LHS
-    test("A::b *= c d")      // Possible string issue - result is missing A::B *= on LHS
-    test("a.b ||= c 1")      // Possible string issue - result is missing a.b ||= on LHS
-    test("a = b, *c, d")     // Syntax error
-    test("*, a = b")         // Syntax error
-    test("*, x, y, z = f")   // Syntax error
+    test("a = b, *c, d")   // Syntax error
+    test("*, a = b")       // Syntax error
+    test("*, x, y, z = f") // Syntax error
   }
 
   "Single assignment" in {
@@ -30,6 +24,11 @@ class AssignmentParserTests extends RubyParserFixture with Matchers {
     test("@a = 42")
     test("a&.b = 1", "a&.b= 1")
     test("c = a&.b")
+    test("a.b ||= c 1", "if a.b.nil? then a.b = c 1 end")
+    test("A.B ||= c 1", "if A.B.nil? then A.B = c 1 end")
+    test("A::b += 1")
+    test("A::b *= c d")
+    test("a[:b] ||= c 1, 2", "if a[:b].nil? then a[:b] = c 1, 2 end")
   }
 
   "Multiple assignment" in {


### PR DESCRIPTION
Fixed an issue that was missed where `SingleAssignmentStatement` wasn't being handled properly, usually where there would be some expression for the LHS and the RHS, instead of a simple variable on the LHS.