### PR TITLE
[ruby] Implicit Imports: Additional Types & Qualified Names

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/DependencyPass.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.passes
 
+import flatgraph.DiffGraphBuilder
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{ConfigFile, NewDependency}
 import io.shiftleft.passes.ForkJoinParallelCpgPass
@@ -11,6 +12,18 @@ import io.shiftleft.semanticcpg.language.*
   *   the graph.
   */
 class DependencyPass(cpg: Cpg) extends ForkJoinParallelCpgPass[ConfigFile](cpg) {
+
+  /** Adds all necessary initial core gems.
+    */
+  override def init(): Unit = {
+    val diffGraph = Cpg.newDiffGraphBuilder
+    DependencyPass.CORE_GEMS
+      .map { coreGemName =>
+        NewDependency().name(coreGemName).version(DependencyPass.CORE_GEM_VERSION)
+      }
+      .foreach(diffGraph.addNode)
+    flatgraph.DiffGraphApplier.applyDiff(cpg.graph, diffGraph)
+  }
 
   /** @return
     *   the Gemfiles, while preferring `Gemfile.lock` files if present.
@@ -87,4 +100,108 @@ class DependencyPass(cpg: Cpg) extends ForkJoinParallelCpgPass[ConfigFile](cpg) 
     }
   }
 
+}
+
+object DependencyPass {
+  val CORE_GEM_VERSION: String = "3.0.0"
+  // Scraped from: https://ruby-doc.org/stdlib-$CORE_GEM_VERSION/
+  // These gems require explicit import but no entry required in `Gemsfile`
+  val CORE_GEMS: Set[String] = Set(
+    "abbrev",
+    "base64",
+    "benchmark",
+    "bigdecimal",
+    "bundler",
+    "cgi",
+    "coverage",
+    "csv",
+    "date",
+    "dbm",
+    "debug",
+    "delegate",
+    "did_you_mean",
+    "digest",
+    "drb",
+    "English",
+    "erb",
+    "etc",
+    "extmk",
+    "fcntl",
+    "fiddle",
+    "fileutils",
+    "find",
+    "forwardable",
+    "gdbm",
+    "getoptlong",
+    "io/console",
+    "io/nonblock",
+    "io/wait",
+    "ipaddr",
+    "irb",
+    "json",
+    "logger",
+    "matrix",
+    "minitest",
+    "mkmf",
+    "monitor",
+    "mutex_m",
+    "net/ftp",
+    "net/http",
+    "net/imap",
+    "net/pop",
+    "net/protocol",
+    "net/smtp",
+    "nkf",
+    "objspace",
+    "observer",
+    "open-uri",
+    "open3",
+    "openssl",
+    "optparse",
+    "ostruct",
+    "pathname",
+    "power_assert",
+    "pp",
+    "prettyprint",
+    "prime",
+    "pstore",
+    "psych",
+    "pty",
+    "racc",
+    "racc/parser",
+    "rake",
+    "rbs",
+    "readline",
+    "readline",
+    "reline",
+    "resolv",
+    "resolv-replace",
+    "rexml",
+    "rinda",
+    "ripper",
+    "rss",
+    "rubygems",
+    "securerandom",
+    "set",
+    "shellwords",
+    "singleton",
+    "socket",
+    "stringio",
+    "strscan",
+    "syslog",
+    "tempfile",
+    "test-unit",
+    "time",
+    "timeout",
+    "tmpdir",
+    "tracer",
+    "tsort",
+    "typeprof",
+    "un",
+    "uri",
+    "weakref",
+    "win32ole",
+    "yaml",
+    "zlib"
+  )
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
-import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
+import io.joern.rubysrc2cpg.passes.{DependencyPass, Defines as RubyDefines}
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Identifier}
 import io.shiftleft.semanticcpg.language.*
 import io.joern.rubysrc2cpg.passes.Defines.Main
@@ -14,7 +14,7 @@ class DependencyTests extends RubyCode2CpgFixture {
     val cpg = code(DependencyTests.GEMFILELOCK, "Gemfile.lock")
 
     "result in dependency nodes of the set packages" in {
-      inside(cpg.dependency.nameNot(RubyDefines.Resolver).l) {
+      inside(cpg.dependency.nameNot(RubyDefines.Resolver).versionNot(DependencyPass.CORE_GEM_VERSION).l) {
         case aruba :: bcrypt :: betterErrors :: Nil =>
           aruba.name shouldBe "aruba"
           aruba.version shouldBe "0.14.12"
@@ -36,7 +36,7 @@ class DependencyTests extends RubyCode2CpgFixture {
     val cpg = code(DependencyTests.GEMFILE, "Gemfile")
 
     "result in dependency nodes of the set packages" in {
-      inside(cpg.dependency.nameNot(RubyDefines.Resolver).l) {
+      inside(cpg.dependency.nameNot(RubyDefines.Resolver).versionNot(DependencyPass.CORE_GEM_VERSION).l) {
         case aruba :: bcrypt :: coffeeRails :: Nil =>
           aruba.name shouldBe "aruba"
           aruba.version shouldBe "2.5.1"
@@ -59,7 +59,10 @@ class DependencyTests extends RubyCode2CpgFixture {
 
     "be preferred over a normal Gemfile" in {
       // Our Gemfile.lock specifies exact versions whereas the Gemfile does not
-      cpg.dependency.nameNot(RubyDefines.Resolver).forall(d => !d.version.isBlank) shouldBe true
+      cpg.dependency
+        .nameNot(RubyDefines.Resolver)
+        .versionNot(DependencyPass.CORE_GEM_VERSION)
+        .forall(d => !d.version.isBlank) shouldBe true
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -496,10 +496,8 @@ class ImportWithAutoloadedExternalGemsTests extends RubyCode2CpgFixture(withPost
       "encoder.rb"
     )
 
-    ImplicitRequirePass(
-      cpg,
-      TypeImportInfo("Base64", "base64.Base64", "base64") :: TypeImportInfo("Bar.Foo", "x.y.Bar.Foo", "foobar") :: Nil
-    ).createAndApply()
+    ImplicitRequirePass(cpg, TypeImportInfo("Base64", "base64") :: TypeImportInfo("Bar", "foobar") :: Nil)
+      .createAndApply()
     ImportsPass(cpg).createAndApply()
 
     "result in require statement of the file containing the symbol" in {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
@@ -183,8 +183,12 @@ object ImplicitRequirePass {
     *   true if the type is autoloadable from the given filename.
     */
   def isAutoloadable(typeName: String, fileName: String): Boolean = {
-    val strippedFileName = normalizePath(fileName)
-    typeName == strippedFileName || typeName == CaseUtils.toCamelCase(strippedFileName, true, '_', '-')
+    // We use lowercase as something like `openssl` and `OpenSSL` don't give obvious clues where capitalisation occurs
+    val strippedFileName  = normalizePath(fileName).toLowerCase
+    val lowerCaseTypeName = typeName.toLowerCase
+    lowerCaseTypeName == strippedFileName.toLowerCase || lowerCaseTypeName == CaseUtils
+      .toCamelCase(strippedFileName, true, '_', '-')
+      .toLowerCase
   }
 
   private def normalizePath(path: String): String = path.replace("\\", "/").stripSuffix(".rb")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
@@ -47,7 +47,7 @@ class ImplicitRequirePass(cpg: Cpg, externalTypes: Seq[TypeImportInfo] = Nil)
         // This match is insensitive to camel case, i.e, foo_bar will match type FooBar.
         val fileName = typeDecl.filename.split(Array('/', '\\')).last.stripSuffix(".rb")
         val typeName = typeDecl.name
-        typeName == fileName || typeName == CaseUtils.toCamelCase(fileName, true, '_', '-')
+        ImplicitRequirePass.isAutoloadable(typeName, fileName)
       }
       .map { typeDecl =>
         val typeImportInfo = TypeImportInfo(typeDecl.name, normalizePath(typeDecl.filename))
@@ -175,4 +175,16 @@ class ImplicitRequirePass(cpg: Cpg, externalTypes: Seq[TypeImportInfo] = Nil)
     }
   }
 
+}
+
+object ImplicitRequirePass {
+
+  /** Determines if the given type name and its corresponding parent file name allow for the type to be autoloaded by
+    * zeitwerk.
+    * @return
+    *   true if the type is autoloadable from the given filename.
+    */
+  def isAutoloadable(typeName: String, fileName: String): Boolean = {
+    typeName == fileName || typeName == CaseUtils.toCamelCase(fileName, true, '_', '-')
+  }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
@@ -55,11 +55,9 @@ class ImplicitRequirePass(cpg: Cpg, externalTypes: Seq[TypeImportInfo] = Nil)
       }
       .l
     // Group types by symbol and add to map for quicker retrieval later
-    importableTypeInfo
-      .groupBy { case TypeImportInfoWithProvidence(typeImportInfo, _) => typeImportInfo.name }
-      .foreach { case (typeName, typeImportInfos) =>
-        typeNameToImportInfo.put(typeName, typeImportInfos)
-      }
+    typeNameToImportInfo.addAll(importableTypeInfo.groupBy { case TypeImportInfoWithProvidence(typeImportInfo, _) =>
+      typeImportInfo.name
+    })
     typeNameToImportInfo.addAll(externalTypes.map(TypeImportInfoWithProvidence(_, true)).groupBy {
       case TypeImportInfoWithProvidence(typeImportInfo, _) => typeImportInfo.name
     })


### PR DESCRIPTION
* Allows a user of the pass to add additional type identifiers to consider for implicit imports (preference to internal types, motivation is that internal types are generally loaded later which works with zeitwerk's newest-first logic)
* Handles qualified type names to be detected and imported
* Added tests and better handling for constructors
* Deduplicates require calls
* Add core gems to `DependencyPass`