### PR TITLE
[semanticcpg] remove `runPass`

### DIFF
--- a/console/src/main/scala/io/joern/console/Commit.scala
+++ b/console/src/main/scala/io/joern/console/Commit.scala
@@ -26,7 +26,7 @@ class Commit(opts: CommitOptions) extends LayerCreator {
         builder.absorb(opts.diffGraphBuilder)
       }
     }
-    runPass(pass, context)
+    pass.createAndApply()
     opts.diffGraphBuilder = Cpg.newDiffGraphBuilder
   }
 

--- a/console/src/main/scala/io/joern/console/Run.scala
+++ b/console/src/main/scala/io/joern/console/Run.scala
@@ -22,7 +22,7 @@ object Run {
             query.store()(builder)
           }
         }
-        runPass(pass, context)
+        pass.createAndApply()
       }
     })
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -25,10 +25,7 @@ class OssDataFlow(opts: OssDataFlowOptions)(implicit
   override val description: String = OssDataFlow.description
 
   override def create(context: LayerCreatorContext): Unit = {
-    val cpg                 = context.cpg
-    val enhancementExecList = Iterator(new ReachingDefPass(cpg, opts.maxNumberOfDefinitions))
-    enhancementExecList.zipWithIndex.foreach { case (pass, index) =>
-      runPass(pass, context, index)
-    }
+    val cpg = context.cpg
+    ReachingDefPass(cpg, opts.maxNumberOfDefinitions).createAndApply()
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/Base.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/Base.scala
@@ -32,9 +32,7 @@ class Base extends LayerCreator {
 
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
-    Base.passes(cpg).zipWithIndex.foreach { case (pass, index) =>
-      runPass(pass, context, index)
-    }
+    Base.passes(cpg).foreach(_.createAndApply())
   }
 
   // LayerCreators need one-arg constructor, because they're called by reflection from io.joern.console.Run

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/CallGraph.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/CallGraph.scala
@@ -23,9 +23,7 @@ class CallGraph extends LayerCreator {
 
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
-    CallGraph.passes(cpg).zipWithIndex.foreach { case (pass, index) =>
-      runPass(pass, context, index)
-    }
+    CallGraph.passes(cpg).foreach(_.createAndApply())
   }
 
   // LayerCreators need one-arg constructor, because they're called by reflection from io.joern.console.Run

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/ControlFlow.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/ControlFlow.scala
@@ -32,9 +32,7 @@ class ControlFlow extends LayerCreator {
 
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
-    ControlFlow.passes(cpg).zipWithIndex.foreach { case (pass, index) =>
-      runPass(pass, context, index)
-    }
+    ControlFlow.passes(cpg).foreach(_.createAndApply())
   }
 
   // LayerCreators need one-arg constructor, because they're called by reflection from io.joern.console.Run

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/TypeRelations.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/TypeRelations.scala
@@ -21,9 +21,7 @@ class TypeRelations extends LayerCreator {
 
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
-    TypeRelations.passes(cpg).zipWithIndex.foreach { case (pass, index) =>
-      runPass(pass, context, index)
-    }
+    TypeRelations.passes(cpg).foreach(_.createAndApply())
   }
 
   // Layers need one-arg constructor, because they're called by reflection from io.joern.console.Run

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
@@ -274,7 +274,7 @@ class Scan(options: ScanOptions)(implicit engineContext: EngineContext) extends 
       println("No queries matched current filter selection (total number of queries: `" + allQueries.length + "`)")
       return
     }
-    runPass(new ScanPass(context.cpg, queriesAfterFilter), context)
+    ScanPass(context.cpg, queriesAfterFilter).createAndApply()
     outputFindings(context.cpg)
 
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
@@ -1,9 +1,6 @@
 package io.shiftleft.semanticcpg.layers
 
-import better.files.File
-import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.Overlays
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -34,10 +31,6 @@ abstract class LayerCreator {
         Overlays.appendOverlayName(context.cpg, overlayName)
       }
     }
-  }
-
-  protected def runPass(pass: CpgPassBase, context: LayerCreatorContext, index: Int = 0): Unit = {
-    pass.createAndApply()
   }
 
   def create(context: LayerCreatorContext): Unit


### PR DESCRIPTION
By happenstance, noticed `runPass` was not really doing much, and then saw this recent PR https://github.com/joernio/joern/pull/4821. Since I didn't have anything worst to do, decided to follow @maltek's suggestion here and remove it.