### PR TITLE
[ruby] Add handling for ArrayLiteral used directly as argument in call

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -216,10 +216,12 @@ argumentList
         # operatorsArgumentList
     |   associationList (COMMA NL* splattingArgument)? (COMMA NL* blockArgument)?
         # associationsArgumentList
+    |   LBRACK ((symbol|association) COMMA? NL*)* RBRACK
+        # arrayArgumentList
     |   command
         # singleCommandArgumentList
     ;
-    
+
 commandArgumentList
     :   associationList
     |   primaryValueList (COMMA NL* associationList)?

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -232,6 +232,11 @@ object AntlrContextHelpers {
       case ctx =>
         logger.warn(s"ArgumentWithParenthesesContextHelper - Unsupported argument type ${ctx.getClass}")
         List()
+
+    def isArrayArgumentList: Boolean = ctx match {
+      case ctx: ArgumentListArgumentWithParenthesesContext => ctx.argumentList().isArrayArgumentListContext
+      case _                                               => false
+    }
   }
 
   sealed implicit class ArgumentListContextHelper(ctx: ArgumentListContext) {
@@ -250,9 +255,16 @@ object AntlrContextHelpers {
         ).toList
       case ctx: BlockArgumentArgumentListContext =>
         Option(ctx.blockArgument()).toList
+      case ctx: ArrayArgumentListContext =>
+        val associations = ctx.association().asScala.toList
+        val symbols      = ctx.symbol().asScala.toList
+        (associations ++ symbols)
+          .sortBy(x => (x.toTextSpan.line, x.toTextSpan.column))
       case ctx =>
         logger.warn(s"ArgumentListContextHelper - Unsupported element type ${ctx.getClass.getSimpleName}")
         List()
+
+    def isArrayArgumentListContext: Boolean = ctx.isInstanceOf[ArrayArgumentListContext]
   }
 
   sealed implicit class CommandWithDoBlockContextHelper(ctx: CommandWithDoBlockContext) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -697,7 +697,9 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
     outputSb.append(identifier)
 
     val args = ctx.argumentWithParentheses().arguments.map(visit).mkString(",")
-    outputSb.append(s"($args)")
+
+    if ctx.argumentWithParentheses().isArrayArgumentList then outputSb.append(s"([$args])")
+    else outputSb.append(s"($args)")
 
     if Option(ctx.block).isDefined then outputSb.append(s" ${visit(ctx.block)}")
     outputSb.toString

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
@@ -8,6 +8,7 @@ class AssignmentParserTests extends RubyParserFixture with Matchers {
     test("a = b, *c, d")   // Syntax error
     test("*, a = b")       // Syntax error
     test("*, x, y, z = f") // Syntax error
+    test("a = b, *c, d")   // Syntax error
   }
 
   "Single assignment" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesisParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesisParserTests.scala
@@ -5,14 +5,14 @@ import org.scalatest.matchers.should.Matchers
 
 class InvocationWithParenthesisParserTests extends RubyParserFixture with Matchers {
   "fixme" ignore {
-    test("foo.()")           // syntax error
-    test("defined?(42)")     // parentheses go missing
-    test("foo([:b, :c=> 1]") // syntax error
-    test("x(&)")             // Syntax error
+    test("foo.()")       // syntax error
+    test("defined?(42)") // parentheses go missing
+    test("x(&)")         // Syntax error
   }
 
   "method invocation with parenthesis" in {
     test("foo()")
+    test("foo([:c => 1, :d])", "foo([:c=> 1,:d])")
     test(
       """foo(
         |)


### PR DESCRIPTION
Added handling where an `Array` is initialized and used directly as a paramter in a function call.