### PR TITLE
[ruby] `ParameterList` parser fixes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -535,7 +535,7 @@ methodParameterPart
     ;
 
 parameterList
-    :   mandatoryOrOptionalParameterList (COMMA NL* arrayParameter)? (COMMA NL* hashParameter)? (COMMA NL* procParameter)?
+    :   mandatoryOrOptionalParameterList (COMMA NL* arrayParameter)? (COMMA NL* hashParameter)? (COMMA NL* procParameter)? (COMMA NL* mandatoryOrOptionalParameterList2)?
     |   arrayParameter (COMMA NL* hashParameter)? (COMMA NL* procParameter)? (COMMA NL* mandatoryOrOptionalParameterList)?
     |   hashParameter (COMMA NL* procParameter)?
     |   procParameter
@@ -544,7 +544,11 @@ parameterList
 mandatoryOrOptionalParameterList
     :   mandatoryOrOptionalParameter (COMMA NL* mandatoryOrOptionalParameter)*
     ;
-    
+
+mandatoryOrOptionalParameterList2
+    :   mandatoryOrOptionalParameter (COMMA NL* mandatoryOrOptionalParameter)*
+    ;
+
 mandatoryOrOptionalParameter
     :   mandatoryParameter
         # mandatoryMandatoryOrOptionalParameter

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -204,11 +204,12 @@ object AntlrContextHelpers {
 
   sealed implicit class ParameterListContextHelper(ctx: ParameterListContext) {
     def parameters: List[ParserRuleContext] = {
-      val mandatoryOrOptionals = Option(ctx.mandatoryOrOptionalParameterList()).map(_.parameters).getOrElse(List())
-      val arrayParameter       = Option(ctx.arrayParameter()).toList
-      val hashParameter        = Option(ctx.hashParameter()).toList
-      val procParameter        = Option(ctx.procParameter()).toList
-      mandatoryOrOptionals ++ arrayParameter ++ hashParameter ++ procParameter
+      val mandatoryOrOptionals  = Option(ctx.mandatoryOrOptionalParameterList()).map(_.parameters).getOrElse(List())
+      val arrayParameter        = Option(ctx.arrayParameter()).toList
+      val hashParameter         = Option(ctx.hashParameter()).toList
+      val procParameter         = Option(ctx.procParameter()).toList
+      val mandatoryOrOptionals2 = Option(ctx.mandatoryOrOptionalParameterList2()).toList
+      mandatoryOrOptionals ++ arrayParameter ++ hashParameter ++ procParameter ++ mandatoryOrOptionals2
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionParserTests.scala
@@ -6,7 +6,6 @@ import org.scalatest.matchers.should.Matchers
 class MethodDefinitionParserTests extends RubyParserFixture with Matchers {
   "fixme" ignore {
     test("def f(a=1, *b, c) end") // syntax error
-    test("def f(*,a) end")        // AstPrinter issue possibly
     test("""def a(...)
         |b(...)
         |end""".stripMargin) // Syntax error

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/MethodDefinitionParserTests.scala
@@ -5,13 +5,18 @@ import org.scalatest.matchers.should.Matchers
 
 class MethodDefinitionParserTests extends RubyParserFixture with Matchers {
   "fixme" ignore {
-    test("def f(a=1, *b, c) end") // syntax error
     test("""def a(...)
         |b(...)
         |end""".stripMargin) // Syntax error
   }
 
   "single line method definition" in {
+    test(
+      "def f(a=1, *b, c) end",
+      """def f(a=1,*b,c)
+        |end""".stripMargin
+    )
+
     test(
       "def foo; end",
       """def foo

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -923,4 +923,19 @@ class MethodTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected one methood, got ${xs.name.mkString(",")}")
     }
   }
+
+  "Method def with mandatory arg after splat arg" in {
+    val cpg = code("""
+        |def foo(a=1, *b, c)
+        |end
+        |""".stripMargin)
+
+    inside(cpg.method.name("foo").parameter.l) {
+      case _ :: aParam :: bParam :: cParam :: Nil =>
+        aParam.code shouldBe "a=1"
+        bParam.code shouldBe "*b"
+        cParam.code shouldBe "c"
+      case xs => fail(s"Expected 4 params, got ${xs.code.mkString(",")}")
+    }
+  }
 }


### PR DESCRIPTION
Fixed `parameterList` in ANTLR to allow for `mandatoryOrOptionalParameter` after other types of parameters