### PR TITLE
[ruby] Splat operator fixes

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -96,10 +96,9 @@ multipleLeftHandSideItem
     ;
 
 multipleRightHandSide
-    :   operatorExpressionList (COMMA splattingRightHandSide)?
-    |   splattingRightHandSide
+    :   (operatorExpressionList | splattingRightHandSide) (COMMA (operatorExpressionList | splattingRightHandSide))*
     ;
-     
+
 splattingRightHandSide
     :   splattingArgument
     ;

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -83,8 +83,7 @@ multipleLeftHandSideExceptPacking
     ;
 
 packingLeftHandSide
-    :   STAR leftHandSide?
-    |   STAR leftHandSide (COMMA multipleLeftHandSideItem)*
+    :   STAR leftHandSide? (COMMA multipleLeftHandSideItem)*
     ;
 
 groupedLeftHandSide

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -560,12 +560,10 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   }
 
   override def visitMultipleRightHandSide(ctx: RubyParser.MultipleRightHandSideContext): String = {
-    val rhsStmts = ctx.children.asScala
-      .collect {
-        case x: RubyParser.SplattingRightHandSideContext => visit(x) :: Nil
-        case x: RubyParser.OperatorExpressionListContext => (x.operatorExpression.asScala.map(visit).toList)
-      }
-      .flatten
+    val rhsStmts = ctx.children.asScala.collect {
+      case x: RubyParser.SplattingRightHandSideContext => visit(x) :: Nil
+      case x: RubyParser.OperatorExpressionListContext => (x.operatorExpression.asScala.map(visit).toList)
+    }.flatten
 
     if rhsStmts.nonEmpty then rhsStmts.mkString(", ")
     else defaultResult()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -583,7 +583,12 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   }
 
   override def visitPackingLeftHandSide(ctx: RubyParser.PackingLeftHandSideContext): RubyNode = {
-    val splatNode = SplattingRubyNode(visit(ctx.leftHandSide))(ctx.toTextSpan)
+    val splatNode = Option(ctx.leftHandSide()) match {
+      case Some(lhs) => SplattingRubyNode(visit(ctx.leftHandSide))(ctx.toTextSpan)
+      case None =>
+        SplattingRubyNode(MandatoryParameter("_")(ctx.toTextSpan.spanStart("_")))(ctx.toTextSpan.spanStart("*_"))
+    }
+
     Option(ctx.multipleLeftHandSideItem()).map(_.asScala.map(visit).toList).getOrElse(List.empty) match {
       case Nil => splatNode
       case xs  => StatementList(splatNode +: xs)(ctx.toTextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
@@ -5,10 +5,8 @@ import org.scalatest.matchers.should.Matchers
 
 class AssignmentParserTests extends RubyParserFixture with Matchers {
   "fixme" ignore {
-    test("a = b, *c, d")   // Syntax error
-    test("*, a = b")       // Syntax error
-    test("*, x, y, z = f") // Syntax error
-    test("a = b, *c, d")   // Syntax error
+    test("a = b, *c, d") // Syntax error
+    test("a = b, *c, d") // Syntax error
   }
 
   "Single assignment" in {
@@ -45,6 +43,8 @@ class AssignmentParserTests extends RubyParserFixture with Matchers {
     test("a, b, c, *s = f")
     test("*s, x, y, z = f")
     test("a = b 1 rescue 2")
+    test("*, a = b")
+    test("*, x, y, z = f")
   }
 
   "Destructured Assignment" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/AssignmentParserTests.scala
@@ -4,11 +4,6 @@ import io.joern.rubysrc2cpg.testfixtures.RubyParserFixture
 import org.scalatest.matchers.should.Matchers
 
 class AssignmentParserTests extends RubyParserFixture with Matchers {
-  "fixme" ignore {
-    test("a = b, *c, d") // Syntax error
-    test("a = b, *c, d") // Syntax error
-  }
-
   "Single assignment" in {
     test("x=1", "x = 1")
     test("hash[:sym] = s[:sym]")
@@ -55,6 +50,7 @@ class AssignmentParserTests extends RubyParserFixture with Matchers {
     test("*a, b, c = 1, 2, 3, 4")
     test("a, b, c = 1, 2, *list")
     test("a, b, c = 1, *list")
+    test("a = b, *c, d")
   }
 
   "Class Constant Assign" in {


### PR DESCRIPTION
* Updated ANTLR grammar to allow for the `splat` operator to be in the middle of a multiple assignment LHS
* Updated ANTLR grammar to allow for multiple `splat` operators at different positions of a multiple assignment RHS