### PR TITLE
[ruby] Add `primaryValueListWithAssociation` to `RETURN` ANTLR rule

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -128,13 +128,13 @@ methodInvocationWithoutParentheses
         # commandMethodInvocationWithoutParentheses
     |   chainedCommandWithDoBlock ((DOT | COLON2) methodName commandArgumentList)?
         # chainedMethodInvocationWithoutParentheses
-    |   RETURN primaryValueList
+    |   RETURN primaryValueListWithAssociation
         # returnMethodInvocationWithoutParentheses
     |   BREAK primaryValueList
         # breakMethodInvocationWithoutParentheses
     |   NEXT primaryValueList
         # nextMethodInvocationWithoutParentheses
-    |   YIELD yieldValueList
+    |   YIELD primaryValueListWithAssociation
         # yieldMethodInvocationWithoutParentheses
     ;
 
@@ -240,7 +240,7 @@ primaryValueList
     :   primaryValue (COMMA NL* primaryValue)*
     ;
 
-yieldValueList
+primaryValueListWithAssociation
     :   (primaryValue | association)? (COMMA NL* (primaryValue | association))*
     ;
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -162,7 +162,7 @@ object AntlrContextHelpers {
     }
   }
 
-  sealed implicit class YieldValueListContextHelper(ctx: YieldValueListContext) {
+  sealed implicit class PrimaryValueListWithAssociationContextHelper(ctx: PrimaryValueListWithAssociationContext) {
     def elements: List[ParserRuleContext] = {
       ctx.children.asScala.collect {
         case x: PrimaryValueContext => x

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -180,7 +180,7 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   override def visitReturnMethodInvocationWithoutParentheses(
     ctx: RubyParser.ReturnMethodInvocationWithoutParenthesesContext
   ): String = {
-    s"return ${ctx.primaryValueList().primaryValue().asScala.map(visit).toList.mkString(ls)}"
+    s"return ${ctx.primaryValueListWithAssociation().elements.map(visit).toList.mkString(",")}"
   }
 
   override def visitReturnWithoutArguments(ctx: RubyParser.ReturnWithoutArgumentsContext): String = {
@@ -719,7 +719,7 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   override def visitYieldMethodInvocationWithoutParentheses(
     ctx: RubyParser.YieldMethodInvocationWithoutParenthesesContext
   ): String = {
-    val args = ctx.yieldValueList().elements.map(visit).mkString(",")
+    val args = ctx.primaryValueListWithAssociation().elements.map(visit).mkString(",")
     s"${ctx.YIELD.getText} $args"
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -174,7 +174,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   override def visitReturnMethodInvocationWithoutParentheses(
     ctx: RubyParser.ReturnMethodInvocationWithoutParenthesesContext
   ): RubyNode = {
-    val expressions = ctx.primaryValueList().primaryValue().asScala.map(visit).toList
+    val expressions = ctx.primaryValueListWithAssociation().elements.map(visit).toList
     ReturnExpression(expressions)(ctx.toTextSpan)
   }
 
@@ -748,7 +748,7 @@ class RubyNodeCreator extends RubyParserBaseVisitor[RubyNode] {
   override def visitYieldMethodInvocationWithoutParentheses(
     ctx: RubyParser.YieldMethodInvocationWithoutParenthesesContext
   ): RubyNode = {
-    val arguments = ctx.yieldValueList().elements.map(visit).toList
+    val arguments = ctx.primaryValueListWithAssociation().elements.map(visit).toList
     YieldExpr(arguments)(ctx.toTextSpan)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ReturnParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ReturnParserTests.scala
@@ -4,16 +4,12 @@ import io.joern.rubysrc2cpg.testfixtures.RubyParserFixture
 import org.scalatest.matchers.should.Matchers
 
 class ReturnParserTests extends RubyParserFixture with Matchers {
-  "fixme" ignore {
-    test("return y :z=> 1")
-    test("return 1, :z => 1")
-  }
-
   "Standalone return statement" in {
     test("return")
     test("return ::X.y()", "return self::X.y()")
     test("return(0)", "return 0")
     test("return y(z:1)", "return y(z: 1)")
     test("return y(z=> 1)")
+    test("return 1, :z => 1", "return 1,:z=> 1")
   }
 }


### PR DESCRIPTION
Added `primaryValueListWithAssociation` to `RETURN` ANTLR rule to allow associations to be used in return statements.