### PR TITLE
[ruby] Temp Var Call `code` Fix

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -212,8 +212,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       val callCode = if (baseCode.contains("<tmp-")) {
         val rhsCode =
           if (n.methodName == "new") n.methodName
-          else code(n).replace("::", ".").takeWhile(c => c != '(' && c != ' ').split('.').last
-        s"$baseCode.$rhsCode"
+          else s"${n.methodName}(${n.arguments.map(code).mkString(", ")})"
+        s"$baseCode${n.op}$rhsCode"
       } else {
         code(n)
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -210,7 +210,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       val dispatchType = if (isStatic) DispatchTypes.STATIC_DISPATCH else DispatchTypes.DYNAMIC_DISPATCH
 
       val callCode = if (baseCode.contains("<tmp-")) {
-        val rhsCode = if (n.methodName == "new") n.methodName else code(n).replace("::", ".").split('.').last
+        val rhsCode =
+          if (n.methodName == "new") n.methodName
+          else code(n).replace("::", ".").takeWhile(c => c != '(' && c != ' ').split('.').last
         s"$baseCode.$rhsCode"
       } else {
         code(n)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -433,7 +433,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |User.find_by(auth_token: cookies[:auth_token].to_s)
         |""".stripMargin)
 
-    cpg.call("find_by").code.head shouldBe "(<tmp-0> = User).find_by"
+    cpg.call("find_by").code.head shouldBe "(<tmp-0> = User).find_by(auth_token: cookies[:auth_token].to_s)"
     cpg.call(Operators.indexAccess).code.head shouldBe "cookies[:auth_token]"
     cpg.fieldAccess
       .where(_.fieldIdentifier.canonicalNameExact("@to_s"))

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -427,4 +427,17 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
       case xs => fail(s"Expected one call for foo, got ${xs.code.mkString}")
     }
   }
+
+  "Calls separated by `tmp` should render correct `code` properties" in {
+    val cpg = code("""
+        |User.find_by(auth_token: cookies[:auth_token].to_s)
+        |""".stripMargin)
+
+    cpg.call("find_by").code.head shouldBe "(<tmp-0> = User).find_by"
+    cpg.call(Operators.indexAccess).code.head shouldBe "cookies[:auth_token]"
+    cpg.fieldAccess
+      .where(_.fieldIdentifier.canonicalNameExact("@to_s"))
+      .code
+      .head shouldBe "(<tmp-1> = cookies[:auth_token]).to_s"
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -616,7 +616,7 @@ class ClassTests extends RubyCode2CpgFixture {
         case Some(bodyCall) =>
           bodyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
           bodyCall.methodFullName shouldBe s"Test0.rb:$Main.Foo.${RubyDefines.TypeDeclBody}"
-          bodyCall.code shouldBe "(<tmp-0> = self::Foo).<body>"
+          bodyCall.code shouldBe "(<tmp-0> = self::Foo)::<body>()"
           bodyCall.receiver.isEmpty shouldBe true
           bodyCall.argument(0).code shouldBe "<tmp-0>"
         case None => fail("Expected <body> call")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -678,9 +678,9 @@ class MethodTests extends RubyCode2CpgFixture {
       inside(cpg.method.name(RDefines.Main).filename("t1.rb").block.astChildren.isCall.l) {
         case (a1: Call) :: (a2: Call) :: (a3: Call) :: (a4: Call) :: (a5: Call) :: Nil =>
           a1.code shouldBe "self.A = module A (...)"
-          a2.code shouldBe "(<tmp-0> = self::A).<body>"
+          a2.code shouldBe "(<tmp-0> = self::A)::<body>()"
           a3.code shouldBe "self.B = class B (...)"
-          a4.code shouldBe "(<tmp-1> = self::B).<body>"
+          a4.code shouldBe "(<tmp-1> = self::B)::<body>()"
           a5.code shouldBe "self.c = def c (...)"
         case xs => fail(s"Expected assignments to appear before definitions, instead got [${xs.mkString("\n")}]")
       }
@@ -795,7 +795,7 @@ class MethodTests extends RubyCode2CpgFixture {
     inside(cpg.call.name(".*retry!").l) {
       case batchCall :: Nil =>
         batchCall.name shouldBe "retry!"
-        batchCall.code shouldBe "(<tmp-0> = batch).retry!()"
+        batchCall.code shouldBe "(<tmp-0> = batch)::retry!()"
 
         inside(batchCall.receiver.l) {
           case (receiverCall: Call) :: Nil =>
@@ -851,7 +851,7 @@ class MethodTests extends RubyCode2CpgFixture {
     inside(cpg.call.name(".*retry!").l) {
       case batchCall :: Nil =>
         batchCall.name shouldBe "retry!"
-        batchCall.code shouldBe "(<tmp-0> = retry).retry!()"
+        batchCall.code shouldBe "(<tmp-0> = retry)::retry!()"
 
         inside(batchCall.receiver.l) {
           case (receiverCall: Call) :: Nil =>


### PR DESCRIPTION
Changed how the code property is constructed for temp var calls to be more robust.