### PR TITLE
[ruby] General Maintenance & Cleanup Pt. 1

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -21,7 +21,7 @@ class AstCreator(
   protected val programSummary: RubyProgramSummary = RubyProgramSummary(),
   val enableFileContents: Boolean = false,
   val fileContent: String = "",
-  val rootNode: Option[RubyNode] = None
+  val rootNode: Option[RubyExpression] = None
 )(implicit withSchemaValidation: ValidationMode)
     extends AstCreatorBase(fileName)
     with AstCreatorHelper
@@ -31,7 +31,7 @@ class AstCreator(
     with AstForFunctionsCreator
     with AstForTypesCreator
     with AstSummaryVisitor
-    with AstNodeBuilder[RubyNode, AstCreator] {
+    with AstNodeBuilder[RubyExpression, AstCreator] {
 
   val tmpGen: FreshNameGenerator[String] = FreshNameGenerator(i => s"<tmp-$i>")
 
@@ -45,7 +45,7 @@ class AstCreator(
 
   protected var parseLevel: AstParseLevel = AstParseLevel.FULL_AST
 
-  override protected def offset(node: RubyNode): Option[(Int, Int)] = node.offset
+  override protected def offset(node: RubyExpression): Option[(Int, Int)] = node.offset
 
   protected val relativeFileName: String =
     projectRoot

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -27,6 +27,7 @@ class AstCreator(
     with AstCreatorHelper
     with AstForStatementsCreator
     with AstForExpressionsCreator
+    with AstForControlStructuresCreator
     with AstForFunctionsCreator
     with AstForTypesCreator
     with AstSummaryVisitor

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -5,7 +5,7 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   InstanceFieldIdentifier,
   MemberAccess,
   RubyFieldIdentifier,
-  RubyNode
+  RubyExpression
 }
 import io.joern.rubysrc2cpg.datastructures.{BlockScope, FieldDecl}
 import io.joern.rubysrc2cpg.passes.Defines
@@ -42,12 +42,12 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     }
   }
 
-  override def column(node: RubyNode): Option[Int]    = node.column
-  override def columnEnd(node: RubyNode): Option[Int] = node.columnEnd
-  override def line(node: RubyNode): Option[Int]      = node.line
-  override def lineEnd(node: RubyNode): Option[Int]   = node.lineEnd
+  override def column(node: RubyExpression): Option[Int]    = node.column
+  override def columnEnd(node: RubyExpression): Option[Int] = node.columnEnd
+  override def line(node: RubyExpression): Option[Int]      = node.line
+  override def lineEnd(node: RubyExpression): Option[Int]   = node.lineEnd
 
-  override def code(node: RubyNode): String = shortenCode(node.text)
+  override def code(node: RubyExpression): String = shortenCode(node.text)
 
   protected def isBuiltin(x: String): Boolean            = kernelFunctions.contains(x)
   protected def prefixAsKernelDefined(x: String): String = s"$kernelPrefix$pathSep$x"
@@ -55,7 +55,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def isBundledClass(x: String): Boolean       = GlobalTypes.bundledClasses.contains(x)
   protected def pathSep                                  = "."
 
-  private def astForFieldInstance(name: String, node: RubyNode & RubyFieldIdentifier): Ast = {
+  private def astForFieldInstance(name: String, node: RubyExpression & RubyFieldIdentifier): Ast = {
     val identName = node match {
       case _: InstanceFieldIdentifier => Defines.Self
       case _: ClassFieldIdentifier    => scope.surroundingTypeFullName.map(_.split("[.]").last).getOrElse(Defines.Any)
@@ -70,7 +70,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     )
   }
 
-  protected def handleVariableOccurrence(node: RubyNode): Ast = {
+  protected def handleVariableOccurrence(node: RubyExpression): Ast = {
     val name       = code(node)
     val identifier = identifierNode(node, name, name, Defines.Any)
     val typeRef    = scope.tryResolveTypeReference(name)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
@@ -1,0 +1,172 @@
+package io.joern.rubysrc2cpg.astcreation
+
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
+  BinaryExpression,
+  CaseExpression,
+  ControlFlowExpression,
+  DoWhileExpression,
+  ElseClause,
+  ForExpression,
+  IfExpression,
+  MemberCall,
+  NextExpression,
+  RescueExpression,
+  RubyNode,
+  SimpleIdentifier,
+  SingleAssignment,
+  SplattingRubyNode,
+  StatementList,
+  UnaryExpression,
+  Unknown,
+  UnlessExpression,
+  UntilExpression,
+  WhenClause,
+  WhileExpression
+}
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
+
+trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+
+  protected def astForControlStructureExpression(node: ControlFlowExpression): Ast = node match {
+    case node: WhileExpression   => astForWhileStatement(node)
+    case node: DoWhileExpression => astForDoWhileStatement(node)
+    case node: UntilExpression   => astForUntilStatement(node)
+    case node: CaseExpression    => blockAst(NewBlock(), astsForCaseExpression(node).toList)
+    case node: IfExpression      => astForIfExpression(node)
+    case node: UnlessExpression  => astForUnlessStatement(node)
+    case node: ForExpression     => astForForExpression(node)
+    case node: RescueExpression  => astForRescueExpression(node)
+    case node: NextExpression    => astForNextExpression(node)
+  }
+
+  private def astForWhileStatement(node: WhileExpression): Ast = {
+    val conditionAst = astForExpression(node.condition)
+    val bodyAsts     = astsForStatement(node.body)
+    whileAst(Some(conditionAst), bodyAsts, Option(code(node)), line(node), column(node))
+  }
+
+  private def astForDoWhileStatement(node: DoWhileExpression): Ast = {
+    val conditionAst = astForExpression(node.condition)
+    val bodyAsts     = astsForStatement(node.body)
+    doWhileAst(Some(conditionAst), bodyAsts, Option(code(node)), line(node), column(node))
+  }
+
+  // `until T do B` is lowered as `while !T do B`
+  private def astForUntilStatement(node: UntilExpression): Ast = {
+    val notCondition = astForExpression(UnaryExpression("!", node.condition)(node.condition.span))
+    val bodyAsts     = astsForStatement(node.body)
+    whileAst(Some(notCondition), bodyAsts, Option(code(node)), line(node), column(node))
+  }
+
+  // Recursively lowers into a ternary conditional call
+  private def astForIfExpression(node: IfExpression): Ast = {
+    def builder(node: IfExpression, conditionAst: Ast, thenAst: Ast, elseAsts: List[Ast]): Ast = {
+      // We want to make sure there's always an «else» clause in a ternary operator.
+      // The default value is a `nil` literal.
+      val elseAsts_ = if (elseAsts.isEmpty) {
+        List(astForNilBlock)
+      } else {
+        elseAsts
+      }
+
+      val call = callNode(node, code(node), Operators.conditional, Operators.conditional, DispatchTypes.STATIC_DISPATCH)
+      callAst(call, conditionAst :: thenAst :: elseAsts_)
+    }
+
+    foldIfExpression(builder)(node)
+  }
+
+  // `unless T do B` is lowered as `if !T then B`
+  private def astForUnlessStatement(node: UnlessExpression): Ast = {
+    val notConditionAst = astForExpression(UnaryExpression("!", node.condition)(node.condition.span))
+    val thenAst = node.trueBranch match
+      case stmtList: StatementList => astForStatementList(stmtList)
+      case _                       => astForStatementList(StatementList(List(node.trueBranch))(node.trueBranch.span))
+    val elseAsts = node.falseBranch.map(astForElseClause).toList
+    val ifNode   = controlStructureNode(node, ControlStructureTypes.IF, code(node))
+    controlStructureAst(ifNode, Some(notConditionAst), thenAst :: elseAsts)
+  }
+
+  protected def astForElseClause(node: RubyNode): Ast = {
+    node match
+      case elseNode: ElseClause =>
+        elseNode.thenClause match
+          case stmtList: StatementList => astForStatementList(stmtList)
+          case node =>
+            logger.warn(s"Expecting statement list in ${code(node)} ($relativeFileName), skipping")
+            astForUnknown(node)
+      case elseNode =>
+        logger.warn(s"Expecting else clause in ${code(elseNode)} ($relativeFileName), skipping")
+        astForUnknown(elseNode)
+  }
+
+  private def astForForExpression(node: ForExpression): Ast = {
+    val forEachNode  = controlStructureNode(node, ControlStructureTypes.FOR, code(node))
+    val doBodyAst    = astsForStatement(node.doBlock)
+    val iteratorNode = astForExpression(node.forVariable)
+    val iterableNode = astForExpression(node.iterableVariable)
+    Ast(forEachNode).withChild(iteratorNode).withChild(iterableNode).withChildren(doBodyAst)
+  }
+
+  protected def astsForCaseExpression(node: CaseExpression): Seq[Ast] = {
+    // TODO: Clean up the below
+    def goCase(expr: Option[SimpleIdentifier]): List[RubyNode] = {
+      val elseThenClause: Option[RubyNode] = node.elseClause.map(_.asInstanceOf[ElseClause].thenClause)
+      val whenClauses                      = node.whenClauses.map(_.asInstanceOf[WhenClause])
+      val ifElseChain = whenClauses.foldRight[Option[RubyNode]](elseThenClause) {
+        (whenClause: WhenClause, restClause: Option[RubyNode]) =>
+          // We translate multiple match expressions into an or expression.
+          //
+          // A single match expression is compared using `.===` to the case target expression if it is present
+          // otherwise it is treated as a conditional.
+          //
+          // There may be a splat as the last match expression,
+          // `case y when *x then c end` or
+          // `case when *x then c end`
+          // which is translated to `x.include? y` and `x.any?` conditions respectively
+
+          val conditions = whenClause.matchExpressions.map { mExpr =>
+            expr.map(e => BinaryExpression(mExpr, "===", e)(mExpr.span)).getOrElse(mExpr)
+          } ++ whenClause.matchSplatExpression.iterator.flatMap {
+            case splat @ SplattingRubyNode(exprList) =>
+              expr
+                .map { e =>
+                  List(MemberCall(exprList, ".", "include?", List(e))(splat.span))
+                }
+                .getOrElse {
+                  List(MemberCall(exprList, ".", "any?", List())(splat.span))
+                }
+            case e =>
+              logger.warn(s"Unrecognised RubyNode (${e.getClass}) in case match splat expression")
+              List(Unknown()(e.span))
+          }
+          // There is always at least one match expression or a splat
+          // will become an unknown in condition at the end
+          val condition = conditions.init.foldRight(conditions.last) { (cond, condAcc) =>
+            BinaryExpression(cond, "||", condAcc)(whenClause.span)
+          }
+          val conditional = IfExpression(
+            condition,
+            whenClause.thenClause.asStatementList,
+            List(),
+            restClause.map { els => ElseClause(els.asStatementList)(els.span) }
+          )(node.span)
+          Some(conditional)
+      }
+      ifElseChain.iterator.toList
+    }
+    def generatedNode: StatementList = node.expression
+      .map { e =>
+        val tmp = SimpleIdentifier(None)(e.span.spanStart(this.tmpGen.fresh))
+        StatementList(
+          List(SingleAssignment(tmp, "=", e)(e.span)) ++
+            goCase(Some(tmp))
+        )(node.span)
+      }
+      .getOrElse(StatementList(goCase(None))(node.span))
+    astsForStatement(generatedNode)
+  }
+
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -37,7 +37,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     *   a method declaration with additional refs and types if specified.
     */
   protected def astForMethodDeclaration(
-    node: RubyNode & ProcedureDeclaration,
+    node: RubyExpression & ProcedureDeclaration,
     isClosure: Boolean = false,
     isSingletonObjectMethod: Boolean = false
   ): Seq[Ast] = {
@@ -237,7 +237,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   }
 
   // TODO: remaining cases
-  protected def astForParameter(node: RubyNode, index: Int): Ast = {
+  protected def astForParameter(node: RubyExpression, index: Int): Ast = {
     node match {
       case node: (MandatoryParameter | OptionalParameter) =>
         val parameterIn = parameterInNode(
@@ -299,11 +299,11 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     }
   }
 
-  private def generateTextSpan(node: RubyNode, text: String): TextSpan = {
+  private def generateTextSpan(node: RubyExpression, text: String): TextSpan = {
     TextSpan(node.span.line, node.span.column, node.span.lineEnd, node.span.columnEnd, node.span.offset, text)
   }
 
-  protected def statementForOptionalParam(node: OptionalParameter): RubyNode = {
+  protected def statementForOptionalParam(node: OptionalParameter): RubyExpression = {
     val defaultExprNode = node.defaultExpression
 
     IfExpression(
@@ -485,13 +485,13 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     }
   }
 
-  private def astForParameters(parameters: List[RubyNode]): List[Ast] = {
+  private def astForParameters(parameters: List[RubyExpression]): List[Ast] = {
     parameters.zipWithIndex.map { case (parameterNode, index) =>
       astForParameter(parameterNode, index + 1)
     }
   }
 
-  private def statementListForOptionalParams(params: List[RubyNode]): StatementList = {
+  private def statementListForOptionalParams(params: List[RubyExpression]): StatementList = {
     StatementList(
       params
         .collect { case x: OptionalParameter =>
@@ -502,7 +502,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   }
 
   private def astForMethodBody(
-    body: RubyNode,
+    body: RubyExpression,
     optionalStatementList: StatementList,
     returnLastExpression: Boolean = true
   ): Ast = {
@@ -531,7 +531,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     }
   }
 
-  private def astForConstructorMethodBody(body: RubyNode, optionalStatementList: StatementList): Ast = {
+  private def astForConstructorMethodBody(body: RubyExpression, optionalStatementList: StatementList): Ast = {
     if (this.parseLevel == AstParseLevel.SIGNATURES) {
       Ast()
     } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -5,24 +5,17 @@ import io.joern.rubysrc2cpg.datastructures.BlockScope
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, ModifierTypes}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewControlStructure, NewMethod, NewMethodRef, NewTypeDecl}
 
 trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astsForStatement(node: RubyNode): Seq[Ast] = {
     baseAstCache.clear() // A safe approximation on where to reset the cache
-    node match
-      case node: WhileExpression            => astForWhileStatement(node) :: Nil
-      case node: DoWhileExpression          => astForDoWhileStatement(node) :: Nil
-      case node: UntilExpression            => astForUntilStatement(node) :: Nil
-      case node: IfExpression               => astForIfStatement(node) :: Nil
-      case node: UnlessExpression           => astForUnlessStatement(node) :: Nil
-      case node: ForExpression              => astForForExpression(node) :: Nil
+    node match {
+      case node: IfExpression               => astForIfStatement(node)
       case node: CaseExpression             => astsForCaseExpression(node)
       case node: StatementList              => astForStatementList(node) :: Nil
-      case node: SimpleCallWithBlock        => astForCallWithBlock(node) :: Nil
-      case node: MemberCallWithBlock        => astForCallWithBlock(node) :: Nil
       case node: ReturnExpression           => astForReturnStatement(node) :: Nil
       case node: AnonymousTypeDeclaration   => astForAnonymousTypeDeclaration(node) :: Nil
       case node: TypeDeclaration            => astForClassDeclaration(node)
@@ -34,33 +27,16 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case node: BreakStatement             => astForBreakStatement(node) :: Nil
       case node: SingletonStatementList     => astForSingletonStatementList(node)
       case _                                => astForExpression(node) :: Nil
+    }
   }
 
-  private def astForWhileStatement(node: WhileExpression): Ast = {
-    val conditionAst = astForExpression(node.condition)
-    val bodyAsts     = astsForStatement(node.body)
-    whileAst(Some(conditionAst), bodyAsts, Option(code(node)), line(node), column(node))
-  }
-
-  private def astForDoWhileStatement(node: DoWhileExpression): Ast = {
-    val conditionAst = astForExpression(node.condition)
-    val bodyAsts     = astsForStatement(node.body)
-    doWhileAst(Some(conditionAst), bodyAsts, Option(code(node)), line(node), column(node))
-  }
-
-  // `until T do B` is lowered as `while !T do B`
-  private def astForUntilStatement(node: UntilExpression): Ast = {
-    val notCondition = astForExpression(UnaryExpression("!", node.condition)(node.condition.span))
-    val bodyAsts     = astsForStatement(node.body)
-    whileAst(Some(notCondition), bodyAsts, Option(code(node)), line(node), column(node))
-  }
-
-  private def astForIfStatement(node: IfExpression): Ast = {
+  private def astForIfStatement(node: IfExpression): Seq[Ast] = {
     def builder(node: IfExpression, conditionAst: Ast, thenAst: Ast, elseAsts: List[Ast]): Ast = {
       val ifNode = controlStructureNode(node, ControlStructureTypes.IF, code(node))
       controlStructureAst(ifNode, Some(conditionAst), thenAst :: elseAsts)
     }
-    foldIfExpression(builder)(node)
+
+    foldIfExpression(builder)(node) :: Nil
   }
 
   /** Registers the currently set access modifier for the current type (until it is reset later).
@@ -106,126 +82,12 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
             Nil
   }
 
-  private def astForElseClause(node: RubyNode): Ast = {
-    node match
-      case elseNode: ElseClause =>
-        elseNode.thenClause match
-          case stmtList: StatementList => astForStatementList(stmtList)
-          case node =>
-            logger.warn(s"Expecting statement list in ${code(node)} ($relativeFileName), skipping")
-            astForUnknown(node)
-      case elseNode =>
-        logger.warn(s"Expecting else clause in ${code(elseNode)} ($relativeFileName), skipping")
-        astForUnknown(elseNode)
-  }
-
-  // `unless T do B` is lowered as `if !T then B`
-  private def astForUnlessStatement(node: UnlessExpression): Ast = {
-    val notConditionAst = astForExpression(UnaryExpression("!", node.condition)(node.condition.span))
-    val thenAst = node.trueBranch match
-      case stmtList: StatementList => astForStatementList(stmtList)
-      case _                       => astForStatementList(StatementList(List(node.trueBranch))(node.trueBranch.span))
-    val elseAsts = node.falseBranch.map(astForElseClause).toList
-    val ifNode   = controlStructureNode(node, ControlStructureTypes.IF, code(node))
-    controlStructureAst(ifNode, Some(notConditionAst), thenAst :: elseAsts)
-  }
-
-  private def astForForExpression(node: ForExpression): Ast = {
-    val forEachNode  = controlStructureNode(node, ControlStructureTypes.FOR, code(node))
-    val doBodyAst    = astsForStatement(node.doBlock)
-    val iteratorNode = astForExpression(node.forVariable)
-    val iterableNode = astForExpression(node.iterableVariable)
-    Ast(forEachNode).withChild(iteratorNode).withChild(iterableNode).withChildren(doBodyAst)
-  }
-
-  protected def astsForCaseExpression(node: CaseExpression): Seq[Ast] = {
-    def goCase(expr: Option[SimpleIdentifier]): List[RubyNode] = {
-      val elseThenClause: Option[RubyNode] = node.elseClause.map(_.asInstanceOf[ElseClause].thenClause)
-      val whenClauses                      = node.whenClauses.map(_.asInstanceOf[WhenClause])
-      val ifElseChain = whenClauses.foldRight[Option[RubyNode]](elseThenClause) {
-        (whenClause: WhenClause, restClause: Option[RubyNode]) =>
-          // We translate multiple match expressions into an or expression.
-          //
-          // A single match expression is compared using `.===` to the case target expression if it is present
-          // otherwise it is treated as a conditional.
-          //
-          // There may be a splat as the last match expression,
-          // `case y when *x then c end` or
-          // `case when *x then c end`
-          // which is translated to `x.include? y` and `x.any?` conditions respectively
-
-          val conditions = whenClause.matchExpressions.map { mExpr =>
-            expr.map(e => BinaryExpression(mExpr, "===", e)(mExpr.span)).getOrElse(mExpr)
-          } ++ (whenClause.matchSplatExpression.iterator.flatMap {
-            case splat @ SplattingRubyNode(exprList) =>
-              expr
-                .map { e =>
-                  List(MemberCall(exprList, ".", "include?", List(e))(splat.span))
-                }
-                .getOrElse {
-                  List(MemberCall(exprList, ".", "any?", List())(splat.span))
-                }
-            case e =>
-              logger.warn(s"Unrecognised RubyNode (${e.getClass}) in case match splat expression")
-              List(Unknown()(e.span))
-          })
-          // There is always at least one match expression or a splat
-          // a splat will become an unknown in condition at the end
-          val condition = conditions.init.foldRight(conditions.last) { (cond, condAcc) =>
-            BinaryExpression(cond, "||", condAcc)(whenClause.span)
-          }
-          val conditional = IfExpression(
-            condition,
-            whenClause.thenClause.asStatementList,
-            List(),
-            restClause.map { els => ElseClause(els.asStatementList)(els.span) }
-          )(node.span)
-          Some(conditional)
-      }
-      ifElseChain.iterator.toList
-    }
-    def generatedNode: StatementList = node.expression
-      .map { e =>
-        val tmp = SimpleIdentifier(None)(e.span.spanStart(this.tmpGen.fresh))
-        StatementList(
-          List(SingleAssignment(tmp, "=", e)(e.span)) ++
-            goCase(Some(tmp))
-        )(node.span)
-      }
-      .getOrElse(StatementList(goCase(None))(node.span))
-    astsForStatement(generatedNode)
-  }
-
   protected def astForStatementList(node: StatementList): Ast = {
     val block = blockNode(node)
     scope.pushNewScope(BlockScope(block))
     val statementAsts = node.statements.flatMap(astsForStatement)
     scope.popScope()
     blockAst(block, statementAsts)
-  }
-
-  /* `foo(<args>) do <params> <stmts> end` is lowered as a METHOD node shaped like so:
-   * ```
-   * <method_ref> = def <lambda>0(<params>)
-   *   <stmts>
-   * end
-   * foo(<args>, <method_ref>)
-   * ```
-   */
-  protected def astForCallWithBlock[C <: RubyCall](node: RubyNode & RubyCallWithBlock[C]): Ast = {
-    val Seq(typeRef, _)  = astForDoBlock(node.block): @unchecked
-    val typeRefDummyNode = typeRef.root.map(DummyNode(_)(node.span)).toList
-
-    // Create call with argument referencing the MethodRef
-    val callWithLambdaArg = node.withoutBlock match {
-      case x: SimpleCall => astForSimpleCall(x.copy(arguments = x.arguments ++ typeRefDummyNode)(x.span))
-      case x: MemberCall => astForMemberCall(x.copy(arguments = x.arguments ++ typeRefDummyNode)(x.span))
-      case x =>
-        logger.warn(s"Unhandled call-with-block type ${code(x)}, creating anonymous method structures only")
-        Ast()
-    }
-
-    callWithLambdaArg
   }
 
   protected def astForDoBlock(block: Block & RubyNode): Seq[Ast] = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -143,16 +143,17 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     val classBody =
       node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
 
-    def handleDefaultConstructor(bodyAsts: Seq[Ast]): Seq[Ast] = bodyAsts match {
-      case bodyAsts if scope.shouldGenerateDefaultConstructor && this.parseLevel == AstParseLevel.FULL_AST =>
+    val classBodyAsts = {
+      val bodyAsts = classBody.statements.flatMap(astsForStatement)
+      if (scope.shouldGenerateDefaultConstructor && this.parseLevel == AstParseLevel.FULL_AST) {
         val bodyStart  = classBody.span.spanStart()
         val initBody   = StatementList(List())(bodyStart)
         val methodDecl = astForMethodDeclaration(MethodDeclaration(Defines.Initialize, List(), initBody)(bodyStart))
         methodDecl ++ bodyAsts
-      case bodyAsts => bodyAsts
+      } else {
+        bodyAsts
+      }
     }
-
-    val classBodyAsts = handleDefaultConstructor(classBody.statements.flatMap(astsForStatement))
 
     val fields = node match {
       case classDecl: ClassDeclaration   => classDecl.fields

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable
 
 trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  protected def astForClassDeclaration(node: RubyNode & TypeDeclaration): Seq[Ast] = {
+  protected def astForClassDeclaration(node: RubyExpression & TypeDeclaration): Seq[Ast] = {
     node.name match
       case name: SimpleIdentifier => astForSimpleNamedClassDeclaration(node, name)
       case name =>
@@ -28,7 +28,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         astForUnknown(node) :: Nil
   }
 
-  private def getBaseClassName(node: RubyNode): String = {
+  private def getBaseClassName(node: RubyExpression): String = {
     node match
       case simpleIdentifier: SimpleIdentifier =>
         simpleIdentifier.text
@@ -46,7 +46,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
   }
 
   private def astForSimpleNamedClassDeclaration(
-    node: RubyNode & TypeDeclaration,
+    node: RubyExpression & TypeDeclaration,
     nameIdentifier: SimpleIdentifier
   ): Seq[Ast] = {
     val className    = nameIdentifier.text
@@ -252,7 +252,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     node.fieldNames.flatMap(astsForSingleFieldDeclaration(node, _))
   }
 
-  private def astsForSingleFieldDeclaration(node: FieldsDeclaration, nameNode: RubyNode): Seq[Ast] = {
+  private def astsForSingleFieldDeclaration(node: FieldsDeclaration, nameNode: RubyExpression): Seq[Ast] = {
     nameNode match
       case nameAsSymbol: StaticLiteral if nameAsSymbol.isSymbol =>
         val fieldName   = nameAsSymbol.innerText.prepended('@')

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import flatgraph.DiffGraphApplier
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{RubyNode, StatementList}
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{RubyExpression, StatementList}
 import io.joern.rubysrc2cpg.datastructures.{RubyField, RubyMethod, RubyProgramSummary, RubyStubbedType, RubyType}
 import io.joern.rubysrc2cpg.parser.RubyNodeCreator
 import io.joern.rubysrc2cpg.passes.Defines

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.datastructures
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{RubyFieldIdentifier, RubyNode}
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{RubyFieldIdentifier, RubyExpression}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.x2cpg.datastructures.{NamespaceLikeScope, TypedScopeElement}
 import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
@@ -16,7 +16,7 @@ case class FieldDecl(
   typeFullName: String,
   isStatic: Boolean,
   isInitialized: Boolean,
-  node: RubyNode & RubyFieldIdentifier
+  node: RubyExpression & RubyFieldIdentifier
 ) extends TypedScopeElement
 
 /** A type-like scope with a full name.

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -1016,7 +1016,5 @@ class ClassTests extends RubyCode2CpgFixture {
         |end
         |end
         |""".stripMargin)
-
-    cpg.method.name("save").parameter.l.foreach(x => println(x.typeFullName))
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -425,7 +425,6 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "Generate correct parameters" in {
-      cpg.method.isLambda.dotAst.l.foreach(println)
       inside(cpg.method.isLambda.parameter.l) {
         case _ :: aParam :: tmp0Param :: dParam :: eParam :: tmp1Param :: hParam :: iParam :: Nil =>
           aParam.name shouldBe "a"


### PR DESCRIPTION
* Reduced redundant match done by `AstForTypesCreator->handleDefaultConstructor`
* Refactored control structure handling into `AstForControlStructuresCreator`
* Re-named `RubyNode` to `RubyExpression` as most-if-not-all Ruby constructs can be evaluated to some value, even statements (assignments, control structures, method definitions, etc. all return a value), and added `RubyStatement` to try to subtly define constructs that stand on their own more often that not -> this will be more fleshed out in Pt. 2
* Noted areas where more clean-up and refactoring is required, but want to keep this diff small-ish