### PR TITLE
[ruby] Handle implicit multi-assignment returns

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -176,9 +176,12 @@ object RubyIntermediateAst {
       extends RubyExpression(span)
       with MethodParameter
 
-  final case class GroupedParameter(name: String, tmpParam: RubyExpression, multipleAssignment: RubyExpression)(
-    span: TextSpan
-  ) extends RubyExpression(span)
+  final case class GroupedParameter(
+    name: String,
+    tmpParam: RubyExpression,
+    multipleAssignment: GroupedParameterDesugaring
+  )(span: TextSpan)
+      extends RubyExpression(span)
       with MethodParameter
 
   sealed trait CollectionParameter extends MethodParameter
@@ -193,9 +196,17 @@ object RubyIntermediateAst {
       extends RubyExpression(span)
       with RubyStatement
 
-  final case class MultipleAssignment(assignments: List[SingleAssignment])(span: TextSpan)
+  trait MultipleAssignment extends RubyStatement {
+    def assignments: List[SingleAssignment]
+  }
+
+  final case class DefaultMultipleAssignment(assignments: List[SingleAssignment])(span: TextSpan)
       extends RubyExpression(span)
-      with RubyStatement
+      with MultipleAssignment
+
+  final case class GroupedParameterDesugaring(assignments: List[SingleAssignment])(span: TextSpan)
+      extends RubyExpression(span)
+      with MultipleAssignment
 
   final case class SplattingRubyNode(target: RubyExpression)(span: TextSpan) extends RubyExpression(span)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -464,7 +464,7 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
     GroupedParameter(
       tmpMandatoryParam.span.text,
       tmpMandatoryParam,
-      MultipleAssignment(singleAssignments.toList)(ctx.toTextSpan)
+      GroupedParameterDesugaring(singleAssignments)(ctx.toTextSpan)
     )(ctx.toTextSpan)
   }
 
@@ -607,7 +607,7 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
     } else {
       defaultAssignments
     }
-    MultipleAssignment(assignments)(ctx.toTextSpan)
+    DefaultMultipleAssignment(assignments)(ctx.toTextSpan)
   }
 
   override def visitMultipleLeftHandSide(ctx: RubyParser.MultipleLeftHandSideContext): RubyExpression = {
@@ -627,7 +627,7 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
 
   override def visitPackingLeftHandSide(ctx: RubyParser.PackingLeftHandSideContext): RubyExpression = {
     val splatNode = Option(ctx.leftHandSide()) match {
-      case Some(lhs) => SplattingRubyNode(visit(ctx.leftHandSide))(ctx.toTextSpan)
+      case Some(lhs) => SplattingRubyNode(visit(lhs))(ctx.toTextSpan)
       case None =>
         SplattingRubyNode(MandatoryParameter("_")(ctx.toTextSpan.spanStart("_")))(ctx.toTextSpan.spanStart("*_"))
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -382,4 +382,25 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected 3 assignments, got ${xs.code.mkString(",")}")
     }
   }
+
+  "multi-assignments as a return value" should {
+
+    val cpg = code("""
+        |def f
+        | a, b = 1, 2 # => return [1, 2]
+        |end
+        |""".stripMargin)
+
+    "create an explicit return of the LHS values as an array" in {
+      val arrayLiteral = cpg.method.name("f").methodReturn.toReturn.astChildren.isCall.head
+
+      arrayLiteral.name shouldBe Operators.arrayInitializer
+      arrayLiteral.methodFullName shouldBe Operators.arrayInitializer
+      arrayLiteral.code shouldBe "a, b = 1, 2"
+
+      arrayLiteral.astChildren.isIdentifier.code.l shouldBe List("a", "b")
+    }
+
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -474,5 +474,10 @@ class DoBlockTests extends RubyCode2CpgFixture {
         case xs => fail(s"Expected 4 assignments, got [${xs.code.mkString(", ")}]")
       }
     }
+
+    "Return nil and not the desugaring" in {
+      val nilLiteral = cpg.method.isLambda.methodReturn.toReturn.astChildren.isLiteral.head
+      nilLiteral.code shouldBe "return nil"
+    }
   }
 }


### PR DESCRIPTION
* Handles implicit returns of multi-assignments by returning an array of the LHS assignment targets.
* For implicit returns of multi-assignments created as desugaring of splatted parameters, returns `nil` as per what is evaluated in the Ruby interpreter.

Example illustration of the target code in this PR
```ruby
def f
 a, b = 1, 2 
end
f() # => [1, 2]

g = lambda {  |a, (b, c), *d, e, (f, *g), **h, &i| 
  # (b, c) is assigned <tmp-0> and (f, *g) is assigned <tmp-1>
  # This explicitly de-sugars b,c and f, g a multi-assignments to parameters at their target positions. i.e.
  # b, c = *<tmp-0>
  # f, g* = *<tmp-1>
  # but the last assignment here should be be returned
}
g.call(1, 2, 3, 4, 5, 6, 7, 8, 9) # => nil
```