### PR TITLE
XTypeRecoveryConfig: don't error when being passes unknown arguments

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/PythonSrcCpgGenerator.scala
@@ -1,17 +1,14 @@
 package io.joern.console.cpgcreation
 
 import io.joern.console.FrontendConfig
-import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.frontendspecific.pysrc2cpg
 import io.joern.x2cpg.frontendspecific.pysrc2cpg.*
-import io.joern.x2cpg.passes.base.AstLinkerPass
-import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.nio.file.Path
-import scala.util.Try
 import scala.compiletime.uninitialized
+import scala.util.Try
 
 case class PythonSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
   private lazy val command: Path = if (isWin) rootPath.resolve("pysrc2cpg.bat") else rootPath.resolve("pysrc2cpg")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -164,7 +164,6 @@ abstract class X2CpgMain[T <: X2CpgConfig[T], X <: X2CpgFrontend[T]](
           run(config, frontend)
         } catch {
           case ex: Throwable =>
-            println(ex.getMessage)
             ex.printStackTrace()
             System.exit(1)
         }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -266,10 +266,7 @@ object X2Cpg {
     initialConf: R
   ): Option[R] = {
     val parser = commandLineParser(frontendSpecific)
-    val argsCorrected = args.takeWhile(_ != s"--$FrontendArgsDelimitor")
-    if (args != argsCorrected)
-      logger.info(s"Args specified after the `--$FrontendArgsDelimitor` separator will be ignored")
-    OParser.parse(parser, argsCorrected, initialConf)
+    OParser.parse(parser, args, initialConf)
   }
 
   /** Create a command line parser that can be extended to add options specific for the frontend.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -2,6 +2,7 @@ package io.joern.x2cpg
 
 import better.files.File
 import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, withErrorsToConsole}
+import io.joern.x2cpg.frontendspecific.FrontendArgsDelimitor
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
@@ -265,7 +266,10 @@ object X2Cpg {
     initialConf: R
   ): Option[R] = {
     val parser = commandLineParser(frontendSpecific)
-    OParser.parse(parser, args, initialConf)
+    val argsCorrected = args.takeWhile(_ != s"--$FrontendArgsDelimitor")
+    if (args != argsCorrected)
+      logger.info(s"Args specified after the `--$FrontendArgsDelimitor` separator will be ignored")
+    OParser.parse(parser, argsCorrected, initialConf)
   }
 
   /** Create a command line parser that can be extended to add options specific for the frontend.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/package.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/package.scala
@@ -10,4 +10,7 @@ package io.joern.x2cpg
   * Otherwise we'll end in jar hell with various incompatible versions of many different dependencies, and complex
   * issues with things like OSGI and JPMS.
   */
-package object frontendspecific
+package object frontendspecific {
+  // Special string used to separate joern-parse opts from frontend-specific opts
+  val FrontendArgsDelimitor = "--frontend-args"
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -29,9 +29,14 @@ object XTypeRecoveryConfig {
 
   def parse(cmdLineArgs: Seq[String]): XTypeRecoveryConfig = {
     OParser
-      .parse(parserOptions, cmdLineArgs, XTypeRecoveryConfig(), new DefaultOParserSetup {
-        override def errorOnUnknownArgument = false
-      })
+      .parse(
+        parserOptions,
+        cmdLineArgs,
+        XTypeRecoveryConfig(),
+        new DefaultOParserSetup {
+          override def errorOnUnknownArgument = false
+        }
+      )
       .getOrElse(
         throw new RuntimeException(
           s"unable to parse XTypeRecoveryConfig from commandline arguments ${cmdLineArgs.mkString(" ")}"
@@ -75,7 +80,7 @@ object XTypeRecoveryConfig {
             logger.warn(s"Large iteration count of $x will take a while to terminate")
           }
           success
-        },
+        }
     )
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -264,10 +264,6 @@ object XTypeRecovery {
     */
   def isDummyType(typ: String): Boolean = DummyTokens.exists(typ.contains)
 
-  @deprecated("please use XTypeRecoveryConfig.parserOptionsForParserConfig", since = "2.0.415")
-  def parserOptions[R <: X2CpgConfig[R] & TypeRecoveryParserConfig[R]]: OParser[?, R] =
-    XTypeRecoveryConfig.parserOptionsForParserConfig
-
   // The below are convenience calls for accessing type properties, one day when this pass uses `Tag` nodes instead of
   // the symbol table then perhaps this would work out better
   implicit class AllNodeTypesFromNodeExt(x: StoredNode) {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -1,30 +1,21 @@
 package io.joern.x2cpg.passes.frontend
 
 import io.joern.x2cpg.{Defines, X2CpgConfig}
-import io.shiftleft.codepropertygraph.generated.{
-  Cpg,
-  DispatchTypes,
-  EdgeTypes,
-  NodeTypes,
-  Operators,
-  Properties,
-  PropertyNames
-}
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.passes.{CpgPass, CpgPassBase, ForkJoinParallelCpgPass}
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.importresolver.*
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.{Assignment, FieldAccess}
 import org.slf4j.{Logger, LoggerFactory}
-import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
-import scopt.OParser
+import scopt.{DefaultOParserSetup, OParser}
 
 import java.util.regex.Pattern
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
 import scala.util.matching.Regex
+import scala.util.{Failure, Success, Try}
 
 /** @param iterations
   *   the number of iterations to run.
@@ -38,7 +29,9 @@ object XTypeRecoveryConfig {
 
   def parse(cmdLineArgs: Seq[String]): XTypeRecoveryConfig = {
     OParser
-      .parse(parserOptions, cmdLineArgs, XTypeRecoveryConfig())
+      .parse(parserOptions, cmdLineArgs, XTypeRecoveryConfig(), new DefaultOParserSetup {
+        override def errorOnUnknownArgument = false
+      })
       .getOrElse(
         throw new RuntimeException(
           s"unable to parse XTypeRecoveryConfig from commandline arguments ${cmdLineArgs.mkString(" ")}"
@@ -82,7 +75,7 @@ object XTypeRecoveryConfig {
             logger.warn(s"Large iteration count of $x will take a while to terminate")
           }
           success
-        }
+        },
     )
   }
 
@@ -103,8 +96,7 @@ class XTypeRecoveryState(val config: XTypeRecoveryConfig = XTypeRecoveryConfig()
 
 object XTypeRecoveryPassGenerator {
   private def linkMembersToTheirRefs(cpg: Cpg, builder: DiffGraphBuilder): Unit = {
-    import io.joern.x2cpg.passes.frontend.XTypeRecovery.AllNodeTypesFromIteratorExt
-    import io.joern.x2cpg.passes.frontend.XTypeRecovery.AllNodeTypesFromNodeExt
+    import io.joern.x2cpg.passes.frontend.XTypeRecovery.{AllNodeTypesFromIteratorExt, AllNodeTypesFromNodeExt}
 
     def getFieldBaseTypes(fieldAccess: FieldAccess): Iterator[TypeDecl] = {
       fieldAccess
@@ -304,8 +296,7 @@ abstract class RecoverForXCompilationUnit[CompilationUnitType <: AstNode](
   state: XTypeRecoveryState
 ) extends Runnable {
 
-  import io.joern.x2cpg.passes.frontend.XTypeRecovery.AllNodeTypesFromNodeExt
-  import io.joern.x2cpg.passes.frontend.XTypeRecovery.AllNodeTypesFromIteratorExt
+  import io.joern.x2cpg.passes.frontend.XTypeRecovery.{AllNodeTypesFromIteratorExt, AllNodeTypesFromNodeExt}
 
   protected val logger: Logger = LoggerFactory.getLogger(getClass)
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
@@ -38,4 +38,8 @@ class X2CpgTests extends AnyWordSpec with Matchers {
       }
     }
   }
+
+//  "argument parsing" should {
+//    "ignore all arguments after `--frontend-arguments`"
+//  }
 }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
@@ -38,8 +38,4 @@ class X2CpgTests extends AnyWordSpec with Matchers {
       }
     }
   }
-
-//  "argument parsing" should {
-//    "ignore all arguments after `--frontend-arguments`"
-//  }
 }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
@@ -4,6 +4,7 @@ import better.files.File
 import io.joern.console.cpgcreation.{CpgGenerator, cpgGeneratorForLanguage, guessLanguage}
 import io.joern.console.{FrontendConfig, InstallConfig}
 import io.joern.joerncli.CpgBasedTool.newCpgCreatedString
+import io.joern.x2cpg.frontendspecific.FrontendArgsDelimitor
 import io.shiftleft.codepropertygraph.generated.Languages
 
 import scala.collection.mutable
@@ -11,8 +12,6 @@ import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
 object JoernParse {
-  // Special string used to separate joern-parse opts from frontend-specific opts
-  val ArgsDelimitor           = "--frontend-args"
   val DefaultCpgOutFile       = "cpg.bin"
   var generator: CpgGenerator = scala.compiletime.uninitialized
 
@@ -64,7 +63,7 @@ object JoernParse {
     note("Misc")
     help("help").text("display this help message")
 
-    note(s"Args specified after the $ArgsDelimitor separator will be passed to the front-end verbatim")
+    note(s"Args specified after the $FrontendArgsDelimitor separator will be passed to the front-end verbatim")
   }
 
   private def run(args: Array[String]): Try[String] = {


### PR DESCRIPTION
as discussed in https://github.com/joernio/joern/issues/4896, we
currently fail hard when the user passes additional frontend
arguments, which we forward to XTypeRecoveryConfig.parse

With this case we still print a warning, but at least don't error.
Potentially better would be to filter out everything _but_ the
expected arguments in this case...

simple test case: foo.sc:
```
@main def main() = {
  importCode.python("tests/code/pythonsrc/simple.py",
args=List("--exclude-regex", "test*"))
}
```

```
sbt stage
./joern --script foo.sc
```
