### PR TITLE
[rubysrc2cpg] Fix ImportPass.

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImportsPass.scala
@@ -9,7 +9,9 @@ import io.shiftleft.semanticcpg.language.*
 
 class ImportsPass(cpg: Cpg) extends ForkJoinParallelCpgPass[Call](cpg) {
 
-  override def generateParts(): Array[Call] = cpg.call.nameExact(ImportsPass.ImportCallNames.toSeq*).toArray
+  override def generateParts(): Array[Call] = {
+    cpg.call.nameExact(ImportsPass.ImportCallNames.toSeq*).isStatic.toArray
+  }
 
   override def runOnPart(diffGraph: DiffGraphBuilder, call: Call): Unit = {
     val importedEntity = stripQuotes(call.argument.isLiteral.code.l match {


### PR DESCRIPTION
Only static calls with import related names 'require', 'load" and so on
are linked to import nodes.
Before that we ended up with import nodes and links for calls like
`Marshal.load(...)`.
