### PR TITLE
[ruby] Fix Duplicate `self` References

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -180,7 +180,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   private def transformAsClosureBody(refs: List[Ast], baseStmtBlockAst: Ast) = {
     // Determine which locals are captured
     val capturedLocalNodes = baseStmtBlockAst.nodes
-      .collect { case x: NewIdentifier => x }
+      .collect { case x: NewIdentifier if x.name != Defines.Self => x } // Self identifiers are handled separately
       .distinctBy(_.name)
       .map(i => scope.lookupVariableInOuterScope(i.name))
       .filter(_.nonEmpty)


### PR DESCRIPTION
Fixed a bug where `self` identifiers are included in the capture logic, as their REF edges are handled elsewhere.

Railsgoat now returns the following
```scala
joern> cpg.identifier.count(_.refsTo.size != 1)
val res1: Int = 0
```