### PR TITLE
[ruby] All `require`-like Calls are Static

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -601,7 +601,16 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       case _                                  => None
     }
     pathOpt.foreach(path => scope.addRequire(projectRoot.get, fileName, path, node.isRelative, node.isWildCard))
-    astForSimpleCall(node.asSimpleCall)
+
+    val callName = node.target.text
+    val requireCallNode = NewCall()
+      .name(node.target.text)
+      .code(code(node))
+      .methodFullName(getBuiltInType(callName))
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .typeFullName(Defines.Any)
+    val arguments = astForExpression(node.argument) :: Nil
+    callAst(requireCallNode, arguments)
   }
 
   protected def astForIncludeCall(node: IncludeCall): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -24,6 +24,42 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
     call.argument.where(_.argumentIndexGt(0)).code.l shouldBe List("'test'")
   }
 
+  "`require_relative 'test'` is a CALL node with an IMPORT node pointing to it" in {
+    val cpg = code("""
+        |require_relative 'test'
+        |""".stripMargin)
+    val List(importNode) = cpg.imports.l
+    importNode.importedEntity shouldBe Some("test")
+    importNode.importedAs shouldBe Some("test")
+    val List(call) = importNode.call.l
+    call.callee.name.l shouldBe List("require_relative")
+    call.argument.where(_.argumentIndexGt(0)).code.l shouldBe List("'test'")
+  }
+
+  "`load 'test'` is a CALL node with an IMPORT node pointing to it" in {
+    val cpg = code("""
+        |load 'test'
+        |""".stripMargin)
+    val List(importNode) = cpg.imports.l
+    importNode.importedEntity shouldBe Some("test")
+    importNode.importedAs shouldBe Some("test")
+    val List(call) = importNode.call.l
+    call.callee.name.l shouldBe List("load")
+    call.argument.where(_.argumentIndexGt(0)).code.l shouldBe List("'test'")
+  }
+
+  "`require_all 'test'` is a CALL node with an IMPORT node pointing to it" in {
+    val cpg = code("""
+        |require_all 'test'
+        |""".stripMargin)
+    val List(importNode) = cpg.imports.l
+    importNode.importedEntity shouldBe Some("test")
+    importNode.importedAs shouldBe Some("test")
+    val List(call) = importNode.call.l
+    call.callee.name.l shouldBe List("require_all")
+    call.argument.where(_.argumentIndexGt(0)).code.l shouldBe List("'test'")
+  }
+
   "`begin require 'test' rescue LoadError end` has a CALL node with an IMPORT node pointing to it" in {
     val cpg = code("""
                      |begin 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImportsPass.scala
@@ -9,9 +9,7 @@ import io.shiftleft.semanticcpg.language.*
 
 class ImportsPass(cpg: Cpg) extends ForkJoinParallelCpgPass[Call](cpg) {
 
-  private val importCallName: Seq[String] = Seq("require", "load", "require_relative", "require_all")
-
-  override def generateParts(): Array[Call] = cpg.call.nameExact(importCallName*).toArray
+  override def generateParts(): Array[Call] = cpg.call.nameExact(ImportsPass.ImportCallNames.toSeq*).toArray
 
   override def runOnPart(diffGraph: DiffGraphBuilder, call: Call): Unit = {
     val importedEntity = stripQuotes(call.argument.isLiteral.code.l match {
@@ -21,4 +19,8 @@ class ImportsPass(cpg: Cpg) extends ForkJoinParallelCpgPass[Call](cpg) {
     val importNode = createImportNodeAndLink(importedEntity, importedEntity, Some(call), diffGraph)
     if (call.name == "require_all") importNode.isWildcard(true)
   }
+}
+
+object ImportsPass {
+  val ImportCallNames: Set[String] = Set("require", "load", "require_relative", "require_all")
 }


### PR DESCRIPTION
* All `require`-like call names are now a set under `ImportsPass`
* These calls are now static calls with only the arguments as children

Seems related to https://github.com/joernio/joern/pull/4901