### PR TITLE
[ruby] Named Arguments with Hash Rocket Syntax

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -319,6 +319,13 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     inArg.argumentName shouldBe Option("in")
   }
 
+  "Calls with named arguments using symbols and hash rocket syntax" in {
+    val cpg                      = code("render :foo => \"bar\"")
+    val List(_, barArg: Literal) = cpg.call.nameExact("render").argument.l: @unchecked
+    barArg.code shouldBe "\"bar\""
+    barArg.argumentName shouldBe Option("foo")
+  }
+
   "named parameters in parenthesis-less call with a known keyword as the association key should shadow the keyword" in {
     val cpg = code("""
         |foo retry: 3

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
@@ -104,20 +104,14 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
     inside(cpg.method.name("foo").call.nameExact("call").l) {
       case yieldCall :: Nil =>
         inside(yieldCall.argument.l) {
-          case (base: Identifier) :: (literalArg: Literal) :: (assocArg: Call) :: Nil =>
+          case (base: Identifier) :: (oneLiteral: Literal) :: (twoLiteral: Literal) :: Nil =>
             base.name shouldBe "<proc-param-0>"
             base.code shouldBe "<proc-param-0>"
 
-            literalArg.code shouldBe "1"
-            assocArg.code shouldBe (":z => 2")
-
-            assocArg.methodFullName shouldBe RubyOperators.association
-            inside(assocArg.argument.l) {
-              case (key: Literal) :: (value: Literal) :: Nil =>
-                key.code shouldBe ":z"
-                value.code shouldBe "2"
-              case xs => fail(s"Expected 2 arguments for assoc call, got ${xs.code.mkString(",")}")
-            }
+            oneLiteral.code shouldBe "1"
+            oneLiteral.argumentIndex shouldBe 1
+            twoLiteral.code shouldBe "2"
+            twoLiteral.argumentName shouldBe Some("z")
           case xs => fail(s"Expected two arguments for yieldCall, got ${xs.code.mkString(",")}")
         }
       case xs => fail(s"Expected one call for yield, got ${xs.code.mkString(",")}")


### PR DESCRIPTION
Added handling for named arguments when using hash rocket syntax with "symbol" keys.