### PR TITLE
[ruby] Fix `lambda` expression parser rule

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -311,7 +311,7 @@ primaryValue
         # singletonMethodDefinition
     |   DEF definedMethodName (LPAREN parameterList? RPAREN)? EQ NL* statement
         # endlessMethodDefinition
-    |   MINUSGT (LPAREN parameterList? RPAREN)? block
+    |   MINUSGT (LPAREN? blockParameterList? RPAREN?)? block
         # lambdaExpression
 
         // Control structures

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -311,7 +311,7 @@ primaryValue
         # singletonMethodDefinition
     |   DEF definedMethodName (LPAREN parameterList? RPAREN)? EQ NL* statement
         # endlessMethodDefinition
-    |   MINUSGT (LPAREN? blockParameterList? RPAREN?)? block
+    |   MINUSGT lambdaExpressionParameterList block
         # lambdaExpression
 
         // Control structures
@@ -407,6 +407,11 @@ primaryValue
         # rangeExpression
     |   hereDoc
         # hereDocs
+    ;
+
+lambdaExpressionParameterList
+    :   LPAREN blockParameterList? RPAREN
+    |   blockParameterList?
     ;
 
 // Non-nested calls

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -689,7 +689,7 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): String = {
     val outputSb = new StringBuilder(ctx.MINUSGT.getText)
 
-    val params = Option(ctx.parameterList()).fold(List())(_.parameters).map(visit).mkString(",")
+    val params = Option(ctx.blockParameterList()).fold(List())(_.parameters).map(visit).mkString(",")
     val body   = visit(ctx.block())
 
     if params != "" then outputSb.append(s"($params)")

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -689,8 +689,11 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): String = {
     val outputSb = new StringBuilder(ctx.MINUSGT.getText)
 
-    val params = Option(ctx.blockParameterList()).fold(List())(_.parameters).map(visit).mkString(",")
-    val body   = visit(ctx.block())
+    val params = Option(ctx.lambdaExpressionParameterList().blockParameterList())
+      .fold(List())(_.parameters)
+      .map(visit)
+      .mkString(",")
+    val body = visit(ctx.block())
 
     if params != "" then outputSb.append(s"($params)")
     if body != "" then outputSb.append(s" $body")

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -768,8 +768,9 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
   }
 
   override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): RubyExpression = {
-    val parameters = Option(ctx.blockParameterList()).fold(List())(_.parameters).map(visit)
-    val body       = visit(ctx.block()).asInstanceOf[Block]
+    val parameters =
+      Option(ctx.lambdaExpressionParameterList().blockParameterList()).fold(List())(_.parameters).map(visit)
+    val body = visit(ctx.block()).asInstanceOf[Block]
     ProcOrLambdaExpr(Block(parameters, body)(ctx.toTextSpan))(ctx.toTextSpan)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -768,7 +768,7 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
   }
 
   override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): RubyExpression = {
-    val parameters = Option(ctx.parameterList()).fold(List())(_.parameters).map(visit)
+    val parameters = Option(ctx.blockParameterList()).fold(List())(_.parameters).map(visit)
     val body       = visit(ctx.block()).asInstanceOf[Block]
     ProcOrLambdaExpr(Block(parameters, body)(ctx.toTextSpan))(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ProcDefinitionParserTests.scala
@@ -5,12 +5,13 @@ import org.scalatest.matchers.should.Matchers
 
 class ProcDefinitionParserTests extends RubyParserFixture with Matchers {
   "fixme" ignore {
-    test("->a{}")                   // Syntax error
-    test("->(b, c=1, *d, e, &f){}") // Syntax error
-    test("-> (a;b) {}")             // Syntax error
+    test("-> (a;b) {}") // Syntax error
   }
 
   "one-line proc definition" in {
+    test("->a{}", "->(a) {}")
+    test("->(b, c=1, *d, e, &f){}", "->(b,c=1,*d,&f,e) {}")
+
     test("-> {}")
 
     test(

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -248,4 +248,22 @@ class LiteralTests extends RubyCode2CpgFixture {
     formatValueCall.methodFullName shouldBe Operators.formatString
   }
 
+  "-> Lambda literal" in {
+    val cpg = code("""
+        |-> (a, *b, &c) {}
+        |""".stripMargin)
+
+    inside(cpg.method.isLambda.l) {
+      case lambdaLiteral :: Nil =>
+        inside(lambdaLiteral.parameter.l) {
+          case _ :: aParam :: bParam :: cParam :: Nil =>
+            aParam.code shouldBe "a"
+            bParam.code shouldBe "*b"
+            cParam.code shouldBe "&c"
+          case xs => fail(s"Expected four parameters, got [${xs.code.mkString(",")}]")
+        }
+      case xs => fail(s"Expected one lambda, got [${xs.name.mkString(",")}]")
+    }
+  }
+
 }


### PR DESCRIPTION
Fixed `lambda` expression parser rule to allow a parameter list without parentheses