### PR TITLE
[ruby] Add handling for `beginless` and `endless` range expressions

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -169,10 +169,10 @@ commandWithDoBlock
     ;
 
 indexingArgumentList
-    :   command
-        # commandIndexingArgumentList
-    |   operatorExpressionList COMMA?
+    :   operatorExpressionList COMMA?
         # operatorExpressionListIndexingArgumentList
+    |   command
+        # commandIndexingArgumentList
     |   operatorExpressionList COMMA splattingArgument
         # operatorExpressionListWithSplattingArgumentIndexingArgumentList
     |   (indexingArgument COMMA? NL*)*
@@ -403,12 +403,12 @@ primaryValue
         # logicalAndExpression
     |   primaryValue orOperator=BAR2        NL* primaryValue
         # logicalOrExpression
+    |   primaryValue rangeOperator NL* primaryValue
+        # boundedRangeExpression
     |   primaryValue rangeOperator
         # endlessRangeExpression
     |   rangeOperator primaryValue
         # beginlessRangeExpression
-    |   primaryValue rangeOperator NL* primaryValue
-        # boundedRangeExpression
     |   hereDoc
         # hereDocs
     ;

--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -403,8 +403,12 @@ primaryValue
         # logicalAndExpression
     |   primaryValue orOperator=BAR2        NL* primaryValue
         # logicalOrExpression
-    |   primaryValue rangeOperator          NL* primaryValue
-        # rangeExpression
+    |   primaryValue rangeOperator
+        # endlessRangeExpression
+    |   rangeOperator primaryValue
+        # beginlessRangeExpression
+    |   primaryValue rangeOperator NL* primaryValue
+        # boundedRangeExpression
     |   hereDoc
         # hereDocs
     ;

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -926,12 +926,26 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
     s"${ctx.QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_START.getText}$elementsString${ctx.QUOTED_NON_EXPANDED_SYMBOL_ARRAY_LITERAL_END.getText}"
   }
 
-  override def visitRangeExpression(ctx: RubyParser.RangeExpressionContext): String = {
+  override def visitBoundedRangeExpression(ctx: RubyParser.BoundedRangeExpressionContext): String = {
     val lowerBound = visit(ctx.primaryValue(0))
     val upperBound = visit(ctx.primaryValue(1))
     val op         = visit(ctx.rangeOperator())
 
     s"$lowerBound$op$upperBound"
+  }
+
+  override def visitEndlessRangeExpression(ctx: RubyParser.EndlessRangeExpressionContext): String = {
+    val lowerBound = visit(ctx.primaryValue)
+    val op         = ctx.rangeOperator().getText
+
+    s"$lowerBound${op}Float::INFINITY"
+  }
+
+  override def visitBeginlessRangeExpression(ctx: RubyParser.BeginlessRangeExpressionContext): String = {
+    val upperBound = visit(ctx.primaryValue)
+    val op         = ctx.rangeOperator().getText
+
+    s"-Float::INFINITY$op$upperBound"
   }
 
   override def visitRangeOperator(ctx: RubyParser.RangeOperatorContext): String = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1077,10 +1077,43 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
     }
   }
 
-  override def visitRangeExpression(ctx: RubyParser.RangeExpressionContext): RubyExpression = {
+  override def visitBoundedRangeExpression(ctx: RubyParser.BoundedRangeExpressionContext): RubyExpression = {
     RangeExpression(
       visit(ctx.primaryValue(0)),
       visit(ctx.primaryValue(1)),
+      visit(ctx.rangeOperator()).asInstanceOf[RangeOperator]
+    )(ctx.toTextSpan)
+  }
+
+  override def visitEndlessRangeExpression(ctx: RubyParser.EndlessRangeExpressionContext): RubyExpression = {
+    val infinityUpperBound =
+      MemberAccess(
+        SimpleIdentifier(Option(getBuiltInType(Defines.Float)))(ctx.toTextSpan.spanStart("Float")),
+        "::",
+        "INFINITY"
+      )(ctx.toTextSpan.spanStart("Float::INFINITY"))
+
+    RangeExpression(
+      visit(ctx.primaryValue),
+      infinityUpperBound,
+      visit(ctx.rangeOperator()).asInstanceOf[RangeOperator]
+    )(ctx.toTextSpan)
+  }
+
+  override def visitBeginlessRangeExpression(ctx: RubyParser.BeginlessRangeExpressionContext): RubyExpression = {
+    val lowerBoundInfinity =
+      UnaryExpression(
+        "-",
+        MemberAccess(
+          SimpleIdentifier(Option(getBuiltInType(Defines.Float)))(ctx.toTextSpan.spanStart("Float")),
+          "::",
+          "INFINITY"
+        )(ctx.toTextSpan.spanStart("Float::INFINITY"))
+      )(ctx.toTextSpan.spanStart("-Float::INFINITY"))
+
+    RangeExpression(
+      lowerBoundInfinity,
+      visit(ctx.primaryValue),
       visit(ctx.rangeOperator()).asInstanceOf[RangeOperator]
     )(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RangeParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/RangeParserTests.scala
@@ -4,14 +4,8 @@ import io.joern.rubysrc2cpg.testfixtures.RubyParserFixture
 import org.scalatest.matchers.should.Matchers
 
 class RangeParserTests extends RubyParserFixture with Matchers {
-  "fixme" ignore {
-    test("""0...
-        |; a...
-        |; c
-        |""".stripMargin) // Syntax error
-  }
-
   "Range Operator" in {
+    test("0..", "0..Float::INFINITY")
     test("1..2")
     test(
       """0..
@@ -24,5 +18,15 @@ class RangeParserTests extends RubyParserFixture with Matchers {
         |a..b
         |c""".stripMargin
     )
+    test(
+      """0..
+        |;
+        |2..
+        |""".stripMargin,
+      """0..Float::INFINITY
+        |2..Float::INFINITY""".stripMargin
+    )
+    test("..2", "-Float::INFINITY..2")
+    test("...3", "-Float::INFINITY...3")
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RangeTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RangeTests.scala
@@ -23,4 +23,31 @@ class RangeTests extends RubyCode2CpgFixture {
     upperBound.code shouldBe "1"
   }
 
+  "`0..` is represented by a `range` operator call with infinity upperbound" in {
+    val cpg         = code("0..")
+    val List(range) = cpg.call(Operators.range).l
+
+    range.methodFullName shouldBe Operators.range
+    range.code shouldBe "0.."
+    range.lineNumber shouldBe Some(1)
+
+    val List(lowerBound, upperBound) = range.argument.l
+
+    lowerBound.code shouldBe "0"
+    upperBound.code shouldBe "Float::INFINITY"
+  }
+
+  "`..0` is represented by a `range` operator call with infinity lowerbound" in {
+    val cpg         = code("..0")
+    val List(range) = cpg.call(Operators.range).l
+
+    range.methodFullName shouldBe Operators.range
+    range.code shouldBe "..0"
+    range.lineNumber shouldBe Some(1)
+
+    val List(lowerBound, upperBound) = range.argument.l
+
+    lowerBound.code shouldBe "-Float::INFINITY"
+    upperBound.code shouldBe "0"
+  }
 }


### PR DESCRIPTION
Added parser rules and lowering for `beginless` and `endless` range expressions. 
```ruby
# beginless expression
(..0) -> (-Float::INFINITY..0)

# endless expression
(0..) -> (0..Float::INFINITY)
```