### PR TITLE
[ruby] add `methodInvocationWithoutParentheses` to RETURN argumentList

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -242,6 +242,7 @@ primaryValueList
 
 primaryValueListWithAssociation
     :   (primaryValue | association)? (COMMA NL* (primaryValue | association))*
+    |   methodInvocationWithoutParentheses
     ;
 
 blockArgument

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -183,7 +183,12 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   override def visitReturnMethodInvocationWithoutParentheses(
     ctx: RubyParser.ReturnMethodInvocationWithoutParenthesesContext
   ): String = {
-    s"return ${ctx.primaryValueListWithAssociation().elements.map(visit).toList.mkString(",")}"
+    val expressions = Option(ctx.primaryValueListWithAssociation().methodInvocationWithoutParentheses()) match {
+      case Some(methodInvocation) => visit(methodInvocation) :: Nil
+      case None                   => ctx.primaryValueListWithAssociation().elements.map(visit).toList
+    }
+
+    s"return ${expressions.toList.mkString(",")}"
   }
 
   override def visitReturnWithoutArguments(ctx: RubyParser.ReturnWithoutArgumentsContext): String = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -176,7 +176,11 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
   override def visitReturnMethodInvocationWithoutParentheses(
     ctx: RubyParser.ReturnMethodInvocationWithoutParenthesesContext
   ): RubyExpression = {
-    val expressions = ctx.primaryValueListWithAssociation().elements.map(visit).toList
+    val expressions = Option(ctx.primaryValueListWithAssociation().methodInvocationWithoutParentheses()) match {
+      case Some(methodInvocation) => visit(methodInvocation) :: Nil
+      case None                   => ctx.primaryValueListWithAssociation().elements.map(visit).toList
+    }
+
     ReturnExpression(expressions)(ctx.toTextSpan)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ReturnParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/ReturnParserTests.scala
@@ -11,5 +11,6 @@ class ReturnParserTests extends RubyParserFixture with Matchers {
     test("return y(z:1)", "return y(z: 1)")
     test("return y(z=> 1)")
     test("return 1, :z => 1", "return 1,:z=> 1")
+    test("return render 1,2,3")
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -497,9 +497,12 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
         val List(ifReturnTrue: Return) = ifNode.whenTrue.isBlock.astChildren.isReturn.l
         ifReturnTrue.code shouldBe "return render json: {}, status: :internal_server_error"
 
-        val List(_, jsonArg, statusArg) = ifReturnTrue.astChildren.isCall.argument.l: @unchecked
+        val List(_, jsonArg: Block, statusArg: Literal) = ifReturnTrue.astChildren.isCall.argument.l: @unchecked
         jsonArg.argumentName shouldBe Some("json")
         jsonArg.code shouldBe "<empty>"
+
+        val List(_: Identifier, hashInitCall: Call) = jsonArg.astChildren.isCall.argument.l: @unchecked
+        hashInitCall.methodFullName shouldBe RubyOperators.hashInitializer
 
         statusArg.argumentName shouldBe Some("status")
         statusArg.code shouldBe ":internal_server_error"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
 import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -477,6 +477,37 @@ class MethodReturnTests extends RubyCode2CpgFixture(withDataFlow = true) {
           case xs => fail(s"Expected two args, got ${xs.code.mkString(",")}")
         }
       case None => fail(s"Expected at least one retrun node")
+    }
+  }
+
+  "Return with methodInvocationWithoutParentheses" in {
+    val cpg = code("""
+        |def foo()
+        | return render json: {}, status: :internal_server_error unless success
+        |end
+        |""".stripMargin)
+
+    inside(cpg.method.name("foo").body.astChildren.isControlStructure.l) {
+      case ifNode :: Nil =>
+        ifNode.controlStructureType shouldBe ControlStructureTypes.IF
+
+        val List(notCall: Call) = ifNode.condition.l: @unchecked
+        notCall.methodFullName shouldBe Operators.logicalNot
+
+        val List(ifReturnTrue: Return) = ifNode.whenTrue.isBlock.astChildren.isReturn.l
+        ifReturnTrue.code shouldBe "return render json: {}, status: :internal_server_error"
+
+        val List(_, jsonArg, statusArg) = ifReturnTrue.astChildren.isCall.argument.l: @unchecked
+        jsonArg.argumentName shouldBe Some("json")
+        jsonArg.code shouldBe "<empty>"
+
+        statusArg.argumentName shouldBe Some("status")
+        statusArg.code shouldBe ":internal_server_error"
+
+        val List(ifReturnFalse: Return) = ifNode.whenFalse.isBlock.astChildren.isReturn.l
+        ifReturnFalse.code shouldBe "return nil"
+
+      case xs => fail(s"Expected two method returns, got [${xs.code.mkString(",")}]")
     }
   }
 }


### PR DESCRIPTION
Added `methodInvocationWithoutParentheses` to `RETURN` arguments