### PR TITLE
semanticcpg: harden inheritance steps against loops

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -56,7 +56,7 @@ class TypeDeclTraversal(val traversal: Iterator[TypeDecl]) extends AnyVal {
   /** Direct and transitive base type declaration.
     */
   def derivedTypeDeclTransitive: Iterator[TypeDecl] =
-    traversal.repeat(_.derivedTypeDecl)(_.emitAllButFirst)
+    traversal.repeat(_.derivedTypeDecl)(_.emitAllButFirst.dedup)
 
   /** Direct base type declaration.
     */
@@ -66,7 +66,7 @@ class TypeDeclTraversal(val traversal: Iterator[TypeDecl]) extends AnyVal {
   /** Direct and transitive base type declaration.
     */
   def baseTypeDeclTransitive: Iterator[TypeDecl] =
-    traversal.repeat(_.baseTypeDecl)(_.emitAllButFirst)
+    traversal.repeat(_.baseTypeDecl)(_.emitAllButFirst.dedup)
 
   /** Traverse to alias type declarations.
     */
@@ -104,7 +104,7 @@ class TypeDeclTraversal(val traversal: Iterator[TypeDecl]) extends AnyVal {
   /** Direct and transitive alias type declarations.
     */
   def aliasTypeDeclTransitive: Iterator[TypeDecl] =
-    traversal.repeat(_.aliasTypeDecl)(_.emitAllButFirst)
+    traversal.repeat(_.aliasTypeDecl)(_.emitAllButFirst.dedup)
 
   def content: Iterator[String] = {
     traversal.flatMap(contentOnSingle)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
@@ -43,7 +43,7 @@ class TypeTraversal(val traversal: Iterator[Type]) extends AnyVal {
   /** Direct and transitive base types of the corresponding type declaration.
     */
   def baseTypeTransitive: Iterator[Type] =
-    traversal.repeat(_.baseType)(_.emitAllButFirst)
+    traversal.repeat(_.baseType)(_.emitAllButFirst.dedup)
 
   /** Direct derived types.
     */
@@ -53,7 +53,7 @@ class TypeTraversal(val traversal: Iterator[Type]) extends AnyVal {
   /** Direct and transitive derived types.
     */
   def derivedTypeTransitive: Iterator[Type] =
-    traversal.repeat(_.derivedType)(_.emitAllButFirst)
+    traversal.repeat(_.derivedType)(_.emitAllButFirst.dedup)
 
   /** Type declarations which derive from this type.
     */
@@ -68,7 +68,7 @@ class TypeTraversal(val traversal: Iterator[Type]) extends AnyVal {
   /** Direct and transitive alias types.
     */
   def aliasTypeTransitive: Iterator[Type] =
-    traversal.repeat(_.aliasType)(_.emitAllButFirst)
+    traversal.repeat(_.aliasType)(_.emitAllButFirst.dedup)
 
   def localOfType: Iterator[Local] =
     traversal._localViaEvalTypeIn


### PR DESCRIPTION
such loops are bugs that should be fixed. But they happen occasionally, and right now they lead to OOM and infinite loops. I'd prefer it if we handled that a bit more gracefully. The cost of the set in `.dedup` should be pretty low.