### PR TITLE
[ruby] Member Access Base as Call Fix

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -226,7 +226,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
             val typeName = surroundingType.split('.').last
             TypeIdentifier(s"$surroundingType<class>")(x.span.spanStart(typeName))
           case None if scope.lookupVariable(x.text).isDefined => x
-          case None => MemberAccess(SelfIdentifier()(x.span.spanStart(Defines.Self)), ".", x.text)(x.span)
+          case None if x.text.charAt(0).isUpper => // calls have lower-case first character
+            MemberAccess(SelfIdentifier()(x.span.spanStart(Defines.Self)), ".", x.text)(x.span)
+          case None => MemberCall(SelfIdentifier()(x.span.spanStart(Defines.Self)), ".", x.text, Nil)(x.span)
         }
       case x @ MemberAccess(ma, _, _) => x.copy(target = determineMemberAccessBase(ma))(x.span)
       case _                          => target

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -283,6 +283,25 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     }
   }
 
+  "a parenthesis-less call as the base of a member access" should {
+    val cpg = code("""
+        |def f(p)
+        | src.join(",")
+        |end
+        |
+        |def src = [1, 2]
+        |""".stripMargin)
+
+    "correctly create a `src` call instead of identifier" in {
+      inside(cpg.call("src").l) {
+        case src :: Nil =>
+          src.name shouldBe "src"
+          src.methodFullName shouldBe s"Test0.rb:$Main.src"
+        case xs => fail(s"Expected exactly one `src` call, instead got [${xs.code.mkString(",")}]")
+      }
+    }
+  }
+
   "an identifier sharing the name of a previously defined method" should {
     val cpg = code("""
         |def foo()


### PR DESCRIPTION
Fixed an instance where something like `foo.bar` would represent `foo` as a `self.foo` field access instead of a `foo()` call, given that no `foo` variable is present.