### PR TITLE
[ruby] Added mixed-elements functionality to `BracketedArrayLiteral`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -168,6 +168,18 @@ commandWithDoBlock
     |   primary (DOT | COLON2) methodName argumentList doBlock
     ;
 
+bracketedArrayElementList
+    :   bracketedArrayElement (COMMA? NL* bracketedArrayElement)* COMMA?
+    ;
+
+bracketedArrayElement
+    :   operatorExpressionList
+    |   command
+    |   indexingArgument
+    |   associationList
+    |   splattingArgument
+    ;
+
 indexingArgumentList
     :   operatorExpressionList COMMA?
         # operatorExpressionListIndexingArgumentList
@@ -179,7 +191,7 @@ indexingArgumentList
         #indexingArgumentIndexingArgumentList
     |   associationList COMMA?
         # associationListIndexingArgumentList
-    |   splattingArgument
+    |   splattingArgument (COMMA NL* splattingArgument)*
         # splattingArgumentIndexingArgumentList
     ;
 
@@ -339,7 +351,7 @@ primaryValue
         # methodCallWithParentheses
 
         // Literals
-    |   LBRACK NL* indexingArgumentList? NL* RBRACK
+    |   LBRACK NL* bracketedArrayElementList? NL* RBRACK
         # bracketedArrayLiteral
     |   QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_START quotedNonExpandedArrayElementList? QUOTED_NON_EXPANDED_STRING_ARRAY_LITERAL_END
         # quotedNonExpandedStringArrayLiteral

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -257,13 +257,34 @@ object AntlrContextHelpers {
     }
   }
 
+  sealed implicit class BracketedArrayElementListContextHelper(ctx: BracketedArrayElementListContext) {
+    def elements: List[ParserRuleContext] = {
+      ctx.bracketedArrayElement.asScala.flatMap(_.element).toList
+    }
+  }
+
+  sealed implicit class BracketedArrayElementContextHelper(ctx: BracketedArrayElementContext) {
+    def element: List[ParserRuleContext] = {
+      ctx.children.asScala
+        .collect {
+          case x: OperatorExpressionListContext => x.operatorExpression().asScala
+          case x: CommandContext                => x :: Nil
+          case x: AssociationListContext        => x.associations
+          case x: SplattingArgumentContext      => x :: Nil
+          case x: IndexingArgumentContext       => x :: Nil
+        }
+        .toList
+        .flatten
+    }
+  }
+
   sealed implicit class IndexingArgumentListContextHelper(ctx: IndexingArgumentListContext) {
     def arguments: List[ParserRuleContext] = ctx match
       case ctx: CommandIndexingArgumentListContext => List(ctx.command())
       case ctx: OperatorExpressionListIndexingArgumentListContext =>
         ctx.operatorExpressionList().operatorExpression().asScala.toList
       case ctx: AssociationListIndexingArgumentListContext   => ctx.associationList().associations
-      case ctx: SplattingArgumentIndexingArgumentListContext => ctx.splattingArgument() :: Nil
+      case ctx: SplattingArgumentIndexingArgumentListContext => ctx.splattingArgument().asScala.toList
       case ctx: OperatorExpressionListWithSplattingArgumentIndexingArgumentListContext => ctx.splattingArgument() :: Nil
       case ctx: IndexingArgumentIndexingArgumentListContext =>
         ctx.indexingArgument().asScala.toList

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -880,7 +880,8 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   }
 
   override def visitBracketedArrayLiteral(ctx: RubyParser.BracketedArrayLiteralContext): String = {
-    val args = Option(ctx.indexingArgumentList()).map(_.arguments).getOrElse(List()).map(visit).mkString(",")
+    val args = Option(ctx.bracketedArrayElementList()).map(_.elements).getOrElse(List()).map(visit).mkString(",")
+
     s"${ctx.LBRACK.getText}$args${ctx.RBRACK.getText}"
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -1020,7 +1020,7 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
   }
 
   override def visitBracketedArrayLiteral(ctx: RubyParser.BracketedArrayLiteralContext): RubyExpression = {
-    ArrayLiteral(Option(ctx.indexingArgumentList()).map(_.arguments).getOrElse(List()).map(visit))(ctx.toTextSpan)
+    ArrayLiteral(Option(ctx.bracketedArrayElementList()).map(_.elements).getOrElse(List()).map(visit))(ctx.toTextSpan)
   }
 
   override def visitQuotedNonExpandedStringArrayLiteral(


### PR DESCRIPTION
Updated ANTLR grammar rules to allow for any number of mixed element types in an `BracketedArrayLiteral`