### PR TITLE
[ruby] Fixed anltr warnings on possible empty string matches

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -187,7 +187,7 @@ indexingArgumentList
         # commandIndexingArgumentList
     |   operatorExpressionList COMMA splattingArgument
         # operatorExpressionListWithSplattingArgumentIndexingArgumentList
-    |   (indexingArgument COMMA? NL*)*
+    |   indexingArgument (COMMA? NL* indexingArgument)*
         #indexingArgumentIndexingArgumentList
     |   associationList COMMA?
         # associationListIndexingArgumentList
@@ -324,7 +324,7 @@ primaryValue
         # singletonMethodDefinition
     |   DEF definedMethodName (LPAREN parameterList? RPAREN)? EQ NL* statement
         # endlessMethodDefinition
-    |   MINUSGT lambdaExpressionParameterList block
+    |   MINUSGT lambdaExpressionParameterList? block
         # lambdaExpression
 
         // Control structures
@@ -428,7 +428,7 @@ primaryValue
 
 lambdaExpressionParameterList
     :   LPAREN blockParameterList? RPAREN
-    |   blockParameterList?
+    |   blockParameterList
     ;
 
 // Non-nested calls
@@ -498,11 +498,22 @@ blockParameterList
     ;
 
 mandatoryOrOptionalOrGroupedParameterList
-    :   (mandatoryOrOptionalParameter | groupedParameterList) (COMMA NL* (mandatoryOrOptionalParameter | groupedParameterList))*
+    :   mandatoryOrOptionalOrGroupedParameter (COMMA NL* mandatoryOrOptionalOrGroupedParameter)*
+    ;
+
+mandatoryOrOptionalOrGroupedParameter
+    :   mandatoryParameter
+    |   optionalParameter
+    |   groupedParameterList
     ;
 
 mandatoryOrGroupedParameterList
-    :   (mandatoryParameter | groupedParameterList) (COMMA NL* (mandatoryParameter | groupedParameterList))*
+    :   mandatoryOrGroupedParameter (COMMA NL* mandatoryOrGroupedParameter)*
+    ;
+
+mandatoryOrGroupedParameter
+    :   mandatoryParameter
+    |   groupedParameterList
     ;
 
 groupedParameterList

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -211,12 +211,12 @@ object AntlrContextHelpers {
     ctx: MandatoryOrOptionalOrGroupedParameterListContext
   ) {
     def parameters: List[ParserRuleContext] =
-      ctx.mandatoryOrOptionalParameter().asScala.toList ++ ctx.groupedParameterList().asScala.toList
+      ctx.mandatoryOrOptionalOrGroupedParameter().asScala.toList
   }
 
   sealed implicit class MandatoryOrGroupedParameterListContextHelper(ctx: MandatoryOrGroupedParameterListContext) {
     def parameters: List[ParserRuleContext] =
-      ctx.mandatoryParameter().asScala.toList ++ ctx.groupedParameterList().asScala.toList
+      ctx.mandatoryOrGroupedParameter().asScala.toList
   }
 
   sealed implicit class GroupedParameterListContextHelper(ctx: GroupedParameterListContext) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AstPrinter.scala
@@ -694,10 +694,12 @@ class AstPrinter extends RubyParserBaseVisitor[String] {
   override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): String = {
     val outputSb = new StringBuilder(ctx.MINUSGT.getText)
 
-    val params = Option(ctx.lambdaExpressionParameterList().blockParameterList())
-      .fold(List())(_.parameters)
-      .map(visit)
-      .mkString(",")
+    val params = Option(ctx.lambdaExpressionParameterList()) match {
+      case Some(parameterList) =>
+        Option(parameterList.blockParameterList()).fold(List())(_.parameters).map(visit).mkString(",")
+      case None => ""
+    }
+
     val body = visit(ctx.block())
 
     if params != "" then outputSb.append(s"($params)")

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -772,8 +772,11 @@ class RubyNodeCreator(variableNameGen: FreshNameGenerator[String] = FreshNameGen
   }
 
   override def visitLambdaExpression(ctx: RubyParser.LambdaExpressionContext): RubyExpression = {
-    val parameters =
-      Option(ctx.lambdaExpressionParameterList().blockParameterList()).fold(List())(_.parameters).map(visit)
+    val parameters = Option(ctx.lambdaExpressionParameterList()) match {
+      case Some(parameterList) => Option(parameterList.blockParameterList()).fold(List())(_.parameters).map(visit)
+      case None                => List()
+    }
+
     val body = visit(ctx.block()).asInstanceOf[Block]
     ProcOrLambdaExpr(Block(parameters, body)(ctx.toTextSpan))(ctx.toTextSpan)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/DoBlockParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/DoBlockParserTests.scala
@@ -5,17 +5,35 @@ import org.scalatest.matchers.should.Matchers
 
 class DoBlockParserTests extends RubyParserFixture with Matchers {
   "fixme" ignore {
-    test("f { |a, (b, c), d| }") // syntax error
     test(
       "break foo arg do |bar| end"
     ) // syntax error - possibly false syntax error due to just having a code sample starting with break which our parser doesn't allow
     test("yield foo arg do |bar| end") // syntax error
     test("a.b do | ; c | end")         // syntax error
-    test("f { |a, (b, *, c)| }")
-    test("a { |b, c=1, *d, e, &f| }")
   }
 
   "Some block" in {
+    test(
+      "f { |a, (b, *, c)| }",
+      """f {
+        |{|a,(b, c, *)|}
+        |}""".stripMargin
+    )
+
+    test(
+      "a { |b, c=1, *d, e, &f| }",
+      """a {
+        |{|b,c=1,*d,&f,e|}
+        |}""".stripMargin
+    )
+
+    test(
+      "f { |a, (b, c), d| }",
+      """f {
+        |{|a,(b, c),d|}
+        |}""".stripMargin
+    )
+
     test(
       "a { |b, *c, d| }",
       """a {


### PR DESCRIPTION
Fixed some ANTLR rules to get rid of warnings for possible empty string matches.