### PR TITLE
[kotlin2cpg] Better fallback for annotation types.

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForPrimitivesCreator.scala
@@ -256,8 +256,9 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) {
       case _ =>
         typeInfoProvider
           .typeFromImports(entry.getShortName.toString, entry.getContainingKtFile)
-          .getOrElse(TypeConstants.any)
+          .getOrElse(s"${Defines.UnresolvedNamespace}.${entry.getShortName.toString}")
     })
+
     val node =
       NewAnnotation()
         .code(entry.getText)


### PR DESCRIPTION
If an annotation type full name cannot be resolved we now use
`<unresolvedNamespace>.ClassName` instead of `ANY`.
