### PR TITLE
[kotlin2cpg] Fix field access representation.

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
@@ -341,14 +341,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     val callKind        = typeInfoProvider.bindingKind(expr)
     val isExtensionCall = callKind == CallKind.ExtensionCall
 
-    val hasThisSuperOrNameRefReceiver = expr.getReceiverExpression match {
-      case _: KtThisExpression          => true
-      case _: KtNameReferenceExpression => true
-      case _: KtSuperExpression         => true
-      case _                            => false
-    }
     val hasNameRefSelector = expr.getSelectorExpression.isInstanceOf[KtNameReferenceExpression]
-    val isFieldAccessCall  = hasThisSuperOrNameRefReceiver && hasNameRefSelector
     val isCallToSuper = expr.getReceiverExpression match {
       case _: KtSuperExpression => true
       case _                    => false
@@ -366,10 +359,10 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     val outAst =
       if (isCtorCtorCall.getOrElse(false)) {
         astForQualifiedExpressionCtor(expr, argIdx, argNameMaybe)
-      } else if (isFieldAccessCall) {
-        astForQualifiedExpressionFieldAccess(expr, argIdx, argNameMaybe)
       } else if (isExtensionCall) {
         astForQualifiedExpressionExtensionCall(expr, argIdx, argNameMaybe)
+      } else if (hasNameRefSelector) {
+        astForQualifiedExpressionFieldAccess(expr, argIdx, argNameMaybe)
       } else if (isCallToSuper) {
         astForQualifiedExpressionCallToSuper(expr, argIdx, argNameMaybe)
       } else if (noAstForReceiver) {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallsToFieldAccessTests.scala
@@ -139,4 +139,21 @@ class CallsToFieldAccessTests extends KotlinCode2CpgFixture(withOssDataflow = fa
       x.methodFullName shouldBe "mypkg.AClass.printX:void()"
     }
   }
+
+  "Field access after array/map access" should {
+    "have correct arguments" in {
+      val cpg = code("""
+          |val m = LinkedHashMap<Int, User>()
+          |val x = m[1].aaa
+          |""".stripMargin)
+
+      inside(cpg.call.methodFullNameExact(Operators.fieldAccess).argument.l) { case List(arg1, arg2) =>
+        arg1.code shouldBe "m[1]"
+        arg1.argumentIndex shouldBe 1
+        arg2.code shouldBe "aaa"
+        arg2.argumentIndex shouldBe 2
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
In case of a field access after a map/array access, the following field
access had invalid argument indicies because it triggered the code path
for dynamic receiver calls. This is now fixed.
