### PR TITLE
[ruby] Access Modifier Names in Expr

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -446,13 +446,21 @@ object RubyIntermediateAst {
       extends RubyExpression(span)
       with RubyCall
 
-  sealed trait AccessModifier extends AllowedTypeDeclarationChild
+  sealed trait AccessModifier extends AllowedTypeDeclarationChild {
+    def toSimpleIdentifier: SimpleIdentifier
+  }
 
-  final case class PublicModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier
+  final case class PublicModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier {
+    override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span)
+  }
 
-  final case class PrivateModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier
+  final case class PrivateModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier {
+    override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span)
+  }
 
-  final case class ProtectedModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier
+  final case class ProtectedModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier {
+    override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span)
+  }
 
   /** Represents standalone `proc { ... }` or `lambda { ... }` expressions
     */

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
@@ -2,6 +2,8 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.rubysrc2cpg.passes.Defines
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.semanticcpg.language.*
 
 class AccessModifierTests extends RubyCode2CpgFixture {
@@ -84,6 +86,22 @@ class AccessModifierTests extends RubyCode2CpgFixture {
 
     cpg.method("baz").isPublic.size shouldBe 1
     cpg.method("test").isPrivate.size shouldBe 1
+  }
+
+  "an identifier sharing the same name as an access modifier in an unambiguous spot should not be confused" in {
+    val cpg = code("""
+        |  def message_params
+        |    {
+        |      private: @private
+        |    }
+        |  end
+        |""".stripMargin)
+
+    val privateKey  = cpg.literal(":private").head
+    val indexAccess = privateKey.astParent.asInstanceOf[Call]
+    indexAccess.name shouldBe Operators.indexAccess
+    indexAccess.methodFullName shouldBe Operators.indexAccess
+    indexAccess.code shouldBe "<tmp-0>[:private]"
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -30,7 +30,7 @@ class HashTests extends RubyCode2CpgFixture {
 
     val List(assocCall) = hashCall.inCall.astSiblings.assignment.l
     val List(x, one)    = assocCall.argument.l
-    x.code shouldBe "<tmp-0>[x]"
+    x.code shouldBe "<tmp-0>[:x]"
     one.code shouldBe "1"
   }
 


### PR DESCRIPTION
* Fixed issue where access modifiers in expression positions would be unhandled
* Handling identifiers on LHS of associations as symbols