### PR TITLE
[kotlin2cpg] Fix "nacked" call representation.

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForExpressionsCreator.scala
@@ -11,9 +11,11 @@ import io.joern.x2cpg.utils.NodeBuilders
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.NewMethodRef
+import org.jetbrains.kotlin.descriptors.{DescriptorVisibilities, FunctionDescriptor}
 import org.jetbrains.kotlin.lexer.KtToken
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.BindingContext
 
 import scala.jdk.CollectionConverters.*
 
@@ -456,21 +458,52 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       else s"$methodFqName:$explicitSignature"
     val (fullName, signature) = typeInfoProvider.fullNameWithSignature(expr, (explicitFullName, explicitSignature))
 
+    val bindingContext = typeInfoProvider.bindingContext
+    val call           = bindingContext.get(BindingContext.CALL, expr.getCalleeExpression)
+    val resolvedCall   = bindingContext.get(BindingContext.RESOLVED_CALL, call)
+
+    val dispatchType =
+      if (resolvedCall == null) {
+        DispatchTypes.STATIC_DISPATCH
+      } else {
+        if (resolvedCall.getDispatchReceiver == null) {
+          DispatchTypes.STATIC_DISPATCH
+        } else {
+          resolvedCall.getResultingDescriptor match {
+            case functionDescriptor: FunctionDescriptor
+                if functionDescriptor.getVisibility == DescriptorVisibilities.PRIVATE =>
+              DispatchTypes.STATIC_DISPATCH
+            case _ =>
+              DispatchTypes.DYNAMIC_DISPATCH
+          }
+        }
+      }
+
     // TODO: add test case to confirm whether the ANY fallback makes sense (could be void)
     val returnType = registerType(typeInfoProvider.expressionType(expr, TypeConstants.any))
-    val node = callNode(
-      expr,
-      expr.getText,
-      referencedName,
-      fullName,
-      DispatchTypes.STATIC_DISPATCH,
-      Some(signature),
-      Some(returnType)
-    )
+    val node = callNode(expr, expr.getText, referencedName, fullName, dispatchType, Some(signature), Some(returnType))
+
     val annotationsAsts = annotations.map(astForAnnotationEntry)
     val astWithAnnotations =
-      callAst(withArgumentIndex(node, argIdx).argumentName(argNameMaybe), argAsts.toList)
-        .withChildren(annotationsAsts)
+      if (dispatchType == DispatchTypes.STATIC_DISPATCH) {
+        callAst(withArgumentIndex(node, argIdx).argumentName(argNameMaybe), argAsts.toList)
+          .withChildren(annotationsAsts)
+      } else {
+        val receiverNode = identifierNode(
+          expr,
+          Constants.this_,
+          Constants.this_,
+          typeInfoProvider.typeFullName(resolvedCall.getDispatchReceiver.getType)
+        )
+
+        callAst(
+          withArgumentIndex(node, argIdx).argumentName(argNameMaybe),
+          argAsts.toList,
+          base = Some(Ast(receiverNode))
+        )
+          .withChildren(annotationsAsts)
+      }
+
     List(astWithAnnotations)
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/DefaultTypeInfoProvider.scala
@@ -52,7 +52,7 @@ import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.DescriptorUtils.getSuperclassDescriptors
 import org.jetbrains.kotlin.resolve.`lazy`.descriptors.LazyClassDescriptor
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedClassDescriptor
-import org.jetbrains.kotlin.types.TypeUtils
+import org.jetbrains.kotlin.types.{KotlinType, TypeUtils}
 import org.jetbrains.kotlin.types.error.ErrorType
 import org.slf4j.LoggerFactory
 
@@ -323,6 +323,10 @@ class DefaultTypeInfoProvider(environment: KotlinCoreEnvironment, typeRenderer: 
       .getOrElse(defaultValue)
   }
 
+  def typeFullName(typ: KotlinType): String = {
+    typeRenderer.render(typ)
+  }
+
   def expressionType(expr: KtExpression, defaultValue: String): String = {
     Option(bindingContext.get(BindingContext.EXPRESSION_TYPE_INFO, expr))
       .flatMap(tpeInfo => Option(tpeInfo.getType))
@@ -403,11 +407,8 @@ class DefaultTypeInfoProvider(environment: KotlinCoreEnvironment, typeRenderer: 
         val relevantDesc = originalDesc match {
           case typedDesc: TypeAliasConstructorDescriptorImpl =>
             typedDesc.getUnderlyingConstructorDescriptor
-          case typedDesc: FunctionDescriptor if !typedDesc.isActual =>
-            val overriddenDescriptors = typedDesc.getOverriddenDescriptors.asScala.toList
-            if (overriddenDescriptors.nonEmpty) overriddenDescriptors.head
-            else typedDesc
-          case _ => originalDesc
+          case _ =>
+            originalDesc
         }
         val returnTypeFullName =
           if (isConstructorCall(expr).getOrElse(false)) TypeConstants.void

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
@@ -13,8 +13,8 @@ import org.jetbrains.kotlin.psi.{
   KtExpression,
   KtFile,
   KtLambdaExpression,
-  KtNamedFunction,
   KtNameReferenceExpression,
+  KtNamedFunction,
   KtParameter,
   KtPrimaryConstructor,
   KtProperty,
@@ -23,10 +23,13 @@ import org.jetbrains.kotlin.psi.{
   KtTypeAlias,
   KtTypeReference
 }
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.types.KotlinType
 
 case class AnonymousObjectContext(declaration: KtElement)
 
 trait TypeInfoProvider(val typeRenderer: TypeRenderer = new TypeRenderer()) {
+  val bindingContext: BindingContext
   def isExtensionFn(fn: KtNamedFunction): Boolean
 
   def usedAsExpression(expr: KtExpression): Option[Boolean]
@@ -112,6 +115,8 @@ trait TypeInfoProvider(val typeRenderer: TypeRenderer = new TypeRenderer()) {
   def typeFullName(expr: KtCallExpression, defaultValue: String): String
 
   def typeFullName(expr: KtParameter, defaultValue: String): String
+
+  def typeFullName(typ: KotlinType): String
 
   def typeFullName(expr: KtDestructuringDeclarationEntry, defaultValue: String): String
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -1,7 +1,8 @@
 package io.joern.kotlin2cpg.querying
 
+import io.joern.kotlin2cpg.Constants
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 
@@ -593,6 +594,69 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     "should contain a CALL node with arguments with their ARGUMENT_NAME property set" in {
       val List(c: Call) = cpg.method.nameExact("f1").callIn.l
       c.argument.map(_.argumentName).flatten.l shouldBe List("two", "one")
+    }
+  }
+
+  "have correct call to overriden base class" in {
+    val cpg = code("""
+        |package somePackage
+        |class A: java.io.Closeable {
+        |    fun foo() {
+        |        close()
+        |    }
+        |    override fun close() {
+        |    }
+        |}
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact("close").l) { case List(call) =>
+      call.methodFullName shouldBe "somePackage.A.close:void()"
+      call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      inside(call.receiver.l) { case List(receiver: Identifier) =>
+        receiver.name shouldBe Constants.this_
+        receiver.typeFullName shouldBe "somePackage.A"
+      }
+      inside(call.argument.l) { case List(argument: Identifier) =>
+        argument.name shouldBe Constants.this_
+        argument.argumentIndex shouldBe 0
+      }
+    }
+  }
+
+  "have correct call to kotlin standard library function" in {
+    val cpg = code("""
+        |fun method() {
+        |  println("test")
+        |}
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact("println").l) { case List(call) =>
+      call.methodFullName shouldBe "kotlin.io.println:void(java.lang.Object)"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      call.receiver.isEmpty shouldBe true
+      inside(call.argument.l) { case List(argument: Literal) =>
+        argument.code shouldBe "\"test\""
+        argument.argumentIndex shouldBe 1
+      }
+    }
+  }
+
+  "have correct call to custom top level function" in {
+    val cpg = code("""
+        |package somePackage
+        |fun topLevelFunc() {
+        |}
+        |fun method() {
+        |  topLevelFunc()
+        |}
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact("topLevelFunc").l) { case List(call) =>
+      call.methodFullName shouldBe "somePackage.topLevelFunc:void()"
+      call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+      call.receiver.isEmpty shouldBe true
+      call.argument.isEmpty shouldBe true
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallbackTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallbackTests.scala
@@ -2,6 +2,7 @@ package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, MethodRef}
 import io.shiftleft.semanticcpg.language.*
 
 class CallbackTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
@@ -99,7 +100,12 @@ class CallbackTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       c.lineNumber shouldBe Some(10)
       c.columnNumber shouldBe Some(8)
       c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.argument.size shouldBe 1
+      c.argument.size shouldBe 2
+      inside(c.argument.l) { case List(arg1: Identifier, arg2: MethodRef) =>
+        arg1.name shouldBe "this"
+        arg1.argumentIndex shouldBe 0
+        arg2.argumentIndex shouldBe 1
+      }
     }
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -310,8 +310,8 @@ abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: V
       .withReceiverEdges(callNode, receiverRoot)
   }
 
-  def setArgumentIndices(arguments: Seq[Ast]): Unit = {
-    var currIndex = 1
+  def setArgumentIndices(arguments: Seq[Ast], start: Int = 1): Unit = {
+    var currIndex = start
     arguments.foreach { a =>
       a.root match {
         case Some(x: ExpressionNew) =>


### PR DESCRIPTION
Fix representation of "nacked" calls like `someFunc(someArg)`. These so
far have always being represented as statically dispatched which is
obviously not correct.
