### PR TITLE
[ruby] Add handling for `(&)` param

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -258,7 +258,7 @@ primaryValueListWithAssociation
     ;
 
 blockArgument
-    :   AMP operatorExpression
+    :   AMP operatorExpression?
     ;
     
 // --------------------------------------------------------
@@ -632,7 +632,7 @@ hashParameter
     ;
 
 procParameter
-    :   AMP procParameterName
+    :   AMP procParameterName?
     ;
 
 procParameterName

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -33,7 +33,8 @@ class AstCreator(
     with AstSummaryVisitor
     with AstNodeBuilder[RubyExpression, AstCreator] {
 
-  val tmpGen: FreshNameGenerator[String] = FreshNameGenerator(i => s"<tmp-$i>")
+  val tmpGen: FreshNameGenerator[String]                      = FreshNameGenerator(i => s"<tmp-$i>")
+  val procParamGen: FreshNameGenerator[Left[String, Nothing]] = FreshNameGenerator(i => Left(s"<proc-param-$i>"))
 
   /* Used to track variable names and their LOCAL nodes.
    */
@@ -63,7 +64,7 @@ class AstCreator(
   override def createAst(): DiffGraphBuilder = {
     val astRootNode = rootNode.match {
       case Some(node) => node.asInstanceOf[StatementList]
-      case None       => new RubyNodeCreator(tmpGen).visit(programCtx).asInstanceOf[StatementList]
+      case None       => new RubyNodeCreator(tmpGen, procParamGen).visit(programCtx).asInstanceOf[StatementList]
     }
 
     val ast = astForRubyFile(astRootNode)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -26,8 +26,6 @@ import scala.collection.mutable
 
 trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  val procParamGen = FreshNameGenerator(i => Left(s"<proc-param-$i>"))
-
   /** Creates method declaration related structures.
     * @param node
     *   the node to create the AST structure from.
@@ -65,7 +63,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val isSurroundedByProgramScope = scope.isSurroundedByProgramScope
     if (isConstructor) scope.pushNewScope(ConstructorScope(fullName))
-    else scope.pushNewScope(MethodScope(fullName, procParamGen.fresh))
+    else scope.pushNewScope(MethodScope(fullName, this.procParamGen.fresh))
 
     val thisParameterNode = newThisParameterNode(
       name = Defines.Self,
@@ -371,7 +369,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             }
         }
 
-        scope.pushNewScope(MethodScope(fullName, procParamGen.fresh))
+        scope.pushNewScope(MethodScope(fullName, this.procParamGen.fresh))
         val method = methodNode(
           node = node,
           name = node.methodName,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -28,8 +28,6 @@ object Defines {
 
   val Resolver: String = "<dependency-resolver>"
 
-  val AnonymousProcParameter = "<anonymous-proc-param>"
-
   def getBuiltInType(typeInString: String) = s"${GlobalTypes.kernelPrefix}.$typeInString"
 
   object RubyOperators {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/FreshNameGenerator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/FreshNameGenerator.scala
@@ -7,4 +7,8 @@ class FreshNameGenerator[T](template: Int => T) {
     counter += 1
     name
   }
+
+  def current: T = {
+    template(counter - 1)
+  }
 }


### PR DESCRIPTION
Added handling for unnamed proc parameter:
```ruby
def foo(&)
  bar(&)
end

def bar
  yield if block_given?
end

foo do
  puts "hello"
end
```