### PR TITLE
[ruby] Antlr Profiler

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -11,7 +11,8 @@ final case class Config(
   useDeprecatedFrontend: Boolean = false,
   downloadDependencies: Boolean = false,
   useTypeStubs: Boolean = true,
-  antlrDebug: Boolean = false
+  antlrDebug: Boolean = false,
+  antlrProfiling: Boolean = false
 ) extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config]
@@ -31,6 +32,10 @@ final case class Config(
 
   def withAntlrDebugging(value: Boolean): Config = {
     copy(antlrDebug = value).withInheritedFields(this)
+  }
+
+  def withAntlrProfiling(value: Boolean): Config = {
+    copy(antlrProfiling = value).withInheritedFields(this)
   }
 
   override def withDownloadDependencies(value: Boolean): Config = {
@@ -69,6 +74,9 @@ private object Frontend {
       opt[Unit]("antlrDebug")
         .hidden()
         .action((_, c) => c.withAntlrDebugging(true)),
+      opt[Unit]("antlrProfile")
+        .hidden()
+        .action((_, c) => c.withAntlrProfiling(true)),
       opt[Unit]("enable-file-content")
         .action((_, c) => c.withDisableFileContent(false))
         .text("Enable file content"),

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -55,7 +55,9 @@ class RubySrc2Cpg extends X2CpgFrontend[Config] {
   }
 
   private def newCreateCpgAction(cpg: Cpg, config: Config): Unit = {
-    Using.resource(new parser.ResourceManagedParser(config.antlrCacheMemLimit, config.antlrDebug)) { parser =>
+    Using.resource(
+      new parser.ResourceManagedParser(config.antlrCacheMemLimit, config.antlrDebug, config.antlrProfiling)
+    ) { parser =>
       val astCreators = ConcurrentTaskUtil
         .runUsingThreadPool(RubySrc2Cpg.generateParserTasks(parser, config, cpg.metaData.root.headOption))
         .flatMap {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -18,7 +18,8 @@ trait RubyFrontend(
   useDeprecatedFrontend: Boolean,
   withDownloadDependencies: Boolean,
   disableFileContent: Boolean,
-  antlrDebugging: Boolean
+  antlrDebugging: Boolean,
+  antlrProfiling: Boolean
 ) extends LanguageFrontend {
   override val fileSuffix: String = ".rb"
 
@@ -30,6 +31,7 @@ trait RubyFrontend(
       .withDownloadDependencies(withDownloadDependencies)
       .withDisableFileContent(disableFileContent)
       .withAntlrDebugging(antlrDebugging)
+      .withAntlrProfiling(antlrProfiling)
 
   override def execute(sourceCodeFile: File): Cpg = {
     new RubySrc2Cpg().createCpg(sourceCodeFile.getAbsolutePath).get
@@ -42,9 +44,10 @@ class DefaultTestCpgWithRuby(
   useDeprecatedFrontend: Boolean,
   downloadDependencies: Boolean = false,
   disableFileContent: Boolean = true,
-  antlrDebugging: Boolean = false
+  antlrDebugging: Boolean = false,
+  antlrProfiling: Boolean = false
 ) extends DefaultTestCpg
-    with RubyFrontend(useDeprecatedFrontend, downloadDependencies, disableFileContent, antlrDebugging)
+    with RubyFrontend(useDeprecatedFrontend, downloadDependencies, disableFileContent, antlrDebugging, antlrProfiling)
     with SemanticTestCpg {
 
   override protected def applyPasses(): Unit = {
@@ -70,14 +73,16 @@ class RubyCode2CpgFixture(
   extraFlows: List[FlowSemantic] = List.empty,
   packageTable: Option[PackageTable] = None,
   useDeprecatedFrontend: Boolean = false,
-  antlrDebugging: Boolean = false
+  antlrDebugging: Boolean = false,
+  antlrProfiling: Boolean = false
 ) extends Code2CpgFixture(() =>
       new DefaultTestCpgWithRuby(
         packageTable,
         useDeprecatedFrontend,
         downloadDependencies,
         disableFileContent,
-        antlrDebugging
+        antlrDebugging,
+        antlrProfiling
       )
         .withOssDataflow(withDataFlow)
         .withExtraFlows(extraFlows)
@@ -98,9 +103,10 @@ class RubyCfgTestCpg(
   useDeprecatedFrontend: Boolean = true,
   downloadDependencies: Boolean = false,
   disableFileContent: Boolean = true,
-  antlrDebugging: Boolean = false
+  antlrDebugging: Boolean = false,
+  antlrProfiling: Boolean = false
 ) extends CfgTestCpg
-    with RubyFrontend(useDeprecatedFrontend, downloadDependencies, disableFileContent, antlrDebugging) {
+    with RubyFrontend(useDeprecatedFrontend, downloadDependencies, disableFileContent, antlrDebugging, antlrProfiling) {
   override val fileSuffix: String = ".rb"
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyParserFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyParserFixture.scala
@@ -18,7 +18,8 @@ class RubyParserFixture
       useDeprecatedFrontend = false,
       withDownloadDependencies = false,
       disableFileContent = true,
-      antlrDebugging = false
+      antlrDebugging = false,
+      antlrProfiling = false
     )
     with TestCodeWriter
     with AnyWordSpecLike


### PR DESCRIPTION
* Added ANTLR profiling with the `--antlrProfile` frontend argument.
* If enabled, will gather parser metrics and log them right next to the file that was parsed, as well as print any syntax ambiguities.