### PR TITLE
[Dependency Fetcher] Fix gradle dependency fetcher android detection and detect project and configuration names automatically

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -83,10 +83,10 @@ object DependencyResolver {
     projectDir: Path
   ): Option[collection.Seq[String]] = {
     logger.info("resolving Gradle dependencies at {}", projectDir)
-    val gradleProjectName   = params.forGradle.get(GradleConfigKeys.ProjectName)
-    val gradleConfiguration = params.forGradle.get(GradleConfigKeys.ConfigurationName)
+    val maybeProjectNameOverride   = params.forGradle.get(GradleConfigKeys.ProjectName)
+    val maybeConfigurationOverride = params.forGradle.get(GradleConfigKeys.ConfigurationName)
 
-    GradleDependencies.get(projectDir, gradleProjectName, gradleConfiguration) match {
+    GradleDependencies.get(projectDir, maybeProjectNameOverride, maybeConfigurationOverride) match {
       case dependenciesMap if dependenciesMap.values.exists(_.nonEmpty) =>
         Option(dependenciesMap.values.flatten.toSet.toSeq)
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -19,7 +19,6 @@ case class DependencyResolverParams(
 
 object DependencyResolver {
   private val logger                         = LoggerFactory.getLogger(getClass)
-  private val defaultGradleProjectName       = "app"
   private val defaultGradleConfigurationName = "compileClasspath"
   private val MaxSearchDepth: Int            = 4
 
@@ -31,9 +30,10 @@ object DependencyResolver {
       if (isMavenBuildFile(buildFile))
         // TODO: implement
         None
-      else if (isGradleBuildFile(buildFile))
+      else if (isGradleBuildFile(buildFile)) {
+        // TODO: Don't limit this to the default configuration name
         getCoordinatesForGradleProject(buildFile.getParent, defaultGradleConfigurationName)
-      else {
+      } else {
         logger.warn(s"Found unsupported build file $buildFile")
         Nil
       }
@@ -84,10 +84,9 @@ object DependencyResolver {
     projectDir: Path
   ): Option[collection.Seq[String]] = {
     logger.info("resolving Gradle dependencies at {}", projectDir)
-    val gradleProjectName = params.forGradle.getOrElse(GradleConfigKeys.ProjectName, defaultGradleProjectName)
-    val gradleConfiguration =
-      params.forGradle.getOrElse(GradleConfigKeys.ConfigurationName, defaultGradleConfigurationName)
-    GradleDependencies.get(projectDir, gradleProjectName, gradleConfiguration) match {
+    val gradleProjectName   = params.forGradle.get(GradleConfigKeys.ProjectName)
+    val gradleConfiguration = params.forGradle.get(GradleConfigKeys.ConfigurationName)
+    GradleDependencies.get(projectDir, None, None) match {
       case Some(deps) => Some(deps)
       case None =>
         logger.warn(s"Could not download Gradle dependencies for project at path `$projectDir`")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -69,7 +69,7 @@ object GradleDependencies {
     val projectConfigurationString = projectInfo.subprojects
       .map { case (projectNameInfo, configurationNames) =>
         val quotedConfigurationNames = configurationNames.map(name => s"\"$name\"").mkString(", ")
-        s"${projectNameInfo.projectName}: [$quotedConfigurationNames]"
+        s"\"${projectNameInfo.projectName}\": [$quotedConfigurationNames]"
       }
       .mkString(", ")
 
@@ -375,6 +375,12 @@ object GradleDependencies {
               "A missing Android SDK configuration caused gradle dependency fetching failures. Please define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file"
             )
           }
+          if (stderrStream.toString.contains("Could not compile initialization script")) {
+            val scriptContents = File(initScriptPath).contentAsString
+            logger.debug(
+              s"########## INITIALIZATION_SCRIPT ##########\n$scriptContents\n###########################################"
+            )
+          }
           logger.debug(s"Gradle task execution stdout: \n$stdoutStream")
           logger.debug(s"Gradle task execution stderr: \n$stderrStream")
           None
@@ -433,7 +439,6 @@ object GradleDependencies {
                       projectInfo.subprojects.keys.flatMap { projectNameInfo =>
                         val taskName = projectNameInfo.makeGradleTaskName(initScript.taskName)
 
-                        val x = 2
                         runGradleTask(c, taskName, initScript.destinationDir, initScriptFile.pathAsString) map { deps =>
                           val depsOutput = deps.map { d =>
                             if (!d.endsWith(aarFileExtension)) d


### PR DESCRIPTION
Before this PR , android project detection only worked for some projects, which would cause conflicts between the `android` plugin in a (java, I think) android subproject and the `java` plugin added by the init script.

The second issue this PR addresses is needing to provide a project name and configuration to the dependency fetcher (without which it would fall back to some defaults ). This is problematic for enterprise customers who would need to do this per app uploaded, but also limited the dependency fetcher to fetching dependencies for a single subproject. The new version automatically detects all projects/subprojects with dependencies, filters configuration names based on some heuristics and fetches dependencies for all of these. 

I tested these manually on some projects I found on github, so it's possible I missed some cases.