### PR TITLE
ExtendedCfgNodeMethods: rename type parameter

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExtendedCfgNodeMethods.scala
@@ -10,7 +10,7 @@ import io.shiftleft.semanticcpg.language.*
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
-class ExtendedCfgNodeMethods[NodeType <: CfgNode](val node: NodeType) extends AnyVal {
+class ExtendedCfgNodeMethods[CfgNodeType <: CfgNode](val node: CfgNodeType) extends AnyVal {
 
   /** Convert to nearest AST node
     */


### PR DESCRIPTION
@tajobe has been doing some byte code surgery in order to create a Kotlin interoperability layer and found an interesting edge case when type parameters are shadowed.

---

Taking a simpler example, consider the following Scala code:

```scala
class Example[NodeType <: Object](node: NodeType) extends AnyVal{
  def foo[NodeType](x: List[NodeType]): List[NodeType] = x
}
```

When decompiling the `foo` method, we'll find the following:

```
public static <NodeType extends java.lang.Object, NodeType extends java.lang.Object> scala.collection.immutable.List<NodeType> foo$extension(java.lang.Object, scala.collection.immutable.List<NodeType>);
    descriptor: (Ljava/lang/Object;Lscala/collection/immutable/List;)Lscala/collection/immutable/List;
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC
    Code:
      stack=3, locals=2, args_size=2
         0: getstatic     #18                 // Field Example$.MODULE$:LExample$;
         3: aload_0
         4: aload_1
         5: invokevirtual #25                 // Method Example$.foo$extension:(Ljava/lang/Object;Lscala/collection/immutable/List;)Lscala/collection/immutable/List;
         8: areturn
    Signature: #23                          // <NodeType:Ljava/lang/Object;NodeType:Ljava/lang/Object;>(Ljava/lang/Object;Lscala/collection/immutable/List<TNodeType;>;)Lscala/collection/immutable/List<TNodeType;>;
```

&nbsp;
Notice how `NodeType` (the type parameter) occurs twice in the definition of `foo$extension`. Apparently the JVM (assuming Oracle as canonical) is designed to accept this when loading/linking, but guarantees nothing if the byte code is interpreted through reflection/etc, cf. https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-4.html#jvms-4.7.9:

> Oracle's Java Virtual Machine implementation does not check the well-formedness of Signature attributes during class loading or linking. Instead, Signature attributes are checked by methods of the Java SE Platform class libraries which expose generic signatures of classes, interfaces, constructors, methods, and fields. Examples include getGenericSuperclass in Class and toGenericString in java.lang.reflect.Executable.

This byte code poses a problem that is trivially fixed if we prevent shadowing by just renaming one of the type parameters, e.g.

```scala
class Example[CfgNodeType <: Object](node: CfgNodeType) extends AnyVal{
  def foo[NodeType](x: List[NodeType]): List[NodeType] = x
}
```

resulting in

```
public static <NodeType extends java.lang.Object, CfgNodeType extends java.lang.Object> scala.collection.immutable.List<NodeType> foo$extension(java.lang.Object, scala.collection.immutable.List<NodeType>);
    descriptor: (Ljava/lang/Object;Lscala/collection/immutable/List;)Lscala/collection/immutable/List;
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC
    Code:
      stack=3, locals=2, args_size=2
         0: getstatic     #18                 // Field Example$.MODULE$:LExample$;
         3: aload_0
         4: aload_1
         5: invokevirtual #25                 // Method Example$.foo$extension:(Ljava/lang/Object;Lscala/collection/immutable/List;)Lscala/collection/immutable/List;
         8: areturn
    Signature: #23                          // <NodeType:Ljava/lang/Object;CfgNodeType:Ljava/lang/Object;>(Ljava/lang/Object;Lscala/collection/immutable/List<TNodeType;>;)Lscala/collection/immutable/List<TNodeType;>;
```

---

Compiling Joern with `-Wshadow:type-parameter-shadow` only warns about 2 sites: the one in this PR and another one buried in javasrc2cpg. The latter is not public-facing, so I won't even bother proposing to change it at this point.

This rename is purely syntactical and seems to easily solve a bigger hurdle. Wdyt?




