### PR TITLE
scalac: warn when type parameters are shadowed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,8 @@ ThisBuild / compile / javacOptions ++= Seq(
 ThisBuild / scalacOptions ++= Seq(
   "-deprecation", // Emit warning and location for usages of deprecated APIs.
   "--release",
-  "11"
+  "11",
+  "-Wshadow:type-parameter-shadow",
 )
 
 lazy val createDistribution = taskKey[File]("Create a complete Joern distribution")

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -74,10 +74,10 @@ class Scope {
 
   def popNamespaceScope(): NamespaceScope = popScope[NamespaceScope]()
 
-  private def popScope[ScopeType <: JavaScopeElement](): ScopeType = {
+  private def popScope[ScopeType0 <: JavaScopeElement](): ScopeType0 = {
     val scope = scopeStack.head
     scopeStack = scopeStack.tail
-    scope.asInstanceOf[ScopeType]
+    scope.asInstanceOf[ScopeType0]
   }
 
   def addTopLevelType(name: String, typeFullName: String): Unit = {


### PR DESCRIPTION
as brought up in https://github.com/joernio/joern/pull/4936 it can
lead to confusing situations if type parameters are shadowed, so for
the sake of readability and disambiguity alone we should enable this
compiler warning IMO.

That being said, I'd like to stress that it's not something
fundamentally complicated, afaics. Simple example copied from #4936:
```scala
class Example[NodeType <: Object](node: NodeType) extends AnyVal{
  def foo[NodeType](x: List[NodeType]): List[NodeType] = x
}
```

These two type parameters in your Example class are not related at all. They happen to have the same name, which only means that within `def foo` we cannot reference the `NodeType` type from the `class Example`, but apart from that there's no connection at all between them.

Semantically it's similar to something like this on the value level: the two `bar` variables are not related at all, they just happen to have the same name, and therefor we cannot reference the class-level `bar` variable from within `def baz`.
```scala
class Foo {
    val bar = 42

    def baz: Unit = {
      val bar = "123"
      ()
  }
}
```