### PR TITLE
[ruby] Add handling for multiple `Splat` args

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -229,7 +229,7 @@ argumentWithParentheses
 argumentList
     :   blockArgument
         # blockArgumentArgumentList
-    |   splattingArgument (COMMA NL* blockArgument)? (COMMA NL* operatorExpressionList)?
+    |   splattingArgument (COMMA NL* splatArgList)? (COMMA NL* blockArgument)? (COMMA NL* operatorExpressionList)?
         # splattingArgumentArgumentList
     |   operatorExpressionList (COMMA NL* associationList)? (COMMA NL* splattingArgument)? (COMMA NL* blockArgument)?
         # operatorsArgumentList
@@ -239,6 +239,10 @@ argumentList
         # arrayArgumentList
     |   command
         # singleCommandArgumentList
+    ;
+
+splatArgList
+    :   splattingArgument (COMMA NL* splattingArgument)*
     ;
 
 commandArgumentList

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/AntlrContextHelpers.scala
@@ -319,7 +319,8 @@ object AntlrContextHelpers {
       case ctx: AssociationsArgumentListContext =>
         Option(ctx.associationList()).map(_.associations).getOrElse(List.empty)
       case ctx: SplattingArgumentArgumentListContext =>
-        Option(ctx.splattingArgument()).toList ++ Option(ctx.blockArgument()).toList ++ Option(
+        val splattingArgList = Option(ctx.splatArgList).map(_.splattingArgument().asScala.toList).toList.flatten
+        Option(ctx.splattingArgument()).toList ++ splattingArgList ++ Option(ctx.blockArgument()).toList ++ Option(
           ctx.operatorExpressionList()
         ).toList
       case ctx: BlockArgumentArgumentListContext =>


### PR DESCRIPTION
Added handling for multiple splat arguments.