### PR TITLE
[dataflowengineoss] provide FullNameSemantics.plus method

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -17,9 +17,8 @@ class OssDataFlowOptions(
   var extraFlows: List[FlowSemantic] = List.empty[FlowSemantic]
 ) extends LayerCreatorOptions {}
 
-class OssDataFlow(opts: OssDataFlowOptions)(implicit
-  s: Semantics = FullNameSemantics.fromList(DefaultSemantics().elements ++ opts.extraFlows)
-) extends LayerCreator {
+class OssDataFlow(opts: OssDataFlowOptions)(implicit s: Semantics = DefaultSemantics().plus(opts.extraFlows))
+    extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/semanticsloader/FullNameSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/semanticsloader/FullNameSemantics.scala
@@ -62,4 +62,8 @@ class FullNameSemantics private (methodToSemantic: mutable.Map[String, FlowSeman
       .mkString("\n")
   }
 
+  /** Immutably extends the current `FullNameSemantics` with `extraFlows`.
+    */
+  def plus(extraFlows: List[FlowSemantic]): FullNameSemantics = FullNameSemantics.fromList(elements ++ extraFlows)
+
 }

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/testfixtures/SemanticTestCpg.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/testfixtures/SemanticTestCpg.scala
@@ -37,7 +37,7 @@ trait SemanticTestCpg { this: TestCpg =>
       val context = new LayerCreatorContext(this)
       val options = new OssDataFlowOptions(extraFlows = _extraFlows)
       new OssDataFlow(options).run(context)
-      this.context = EngineContext(FullNameSemantics.fromList(DefaultSemantics().elements ++ _extraFlows))
+      this.context = EngineContext(DefaultSemantics().plus(_extraFlows))
     }
   }
 
@@ -47,8 +47,6 @@ trait SemanticTestCpg { this: TestCpg =>
   */
 trait SemanticCpgTestFixture(extraFlows: List[FlowSemantic] = List.empty) {
 
-  implicit val context: EngineContext = EngineContext(
-    FullNameSemantics.fromList(DefaultSemantics().elements ++ extraFlows)
-  )
+  implicit val context: EngineContext = EngineContext(DefaultSemantics().plus(extraFlows))
 
 }


### PR DESCRIPTION
Simple convenience `plus` method for extending `FullNameSemantics` with extra flows.

In general, i.e. for an arbitrary `Semantics`, such a `plus` method (or, more generally, `combine(x: A, y: A): A` for `A <: Semantics`) is not meaningful, unless we want to restrict it considerably (e.g. to a monoid), but we currently don't have any use for such restrictions.