### PR TITLE
[ruby] Strip Unused Parser Rules

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -210,10 +210,6 @@ splattingArgument
 operatorExpressionList
     :   operatorExpression (COMMA NL* operatorExpression)*
     ;
-    
-operatorExpressionList2
-    :   operatorExpression (COMMA NL* operatorExpression)+
-    ;
 
 argumentWithParentheses
     :   LPAREN NL* COMMA? NL* RPAREN
@@ -242,10 +238,6 @@ argumentListItem
     |   operatorExpressionList
     |   associationList
     |   blockArgument
-    ;
-
-splatArgList
-    :   splattingArgument (COMMA NL* splattingArgument)*
     ;
 
 commandArgumentList
@@ -711,23 +703,9 @@ doubleQuotedString
     :   DOUBLE_QUOTED_STRING_START doubleQuotedStringContent* DOUBLE_QUOTED_STRING_END
     ;
 
-quotedExpandedExternalCommandString
-    :   QUOTED_EXPANDED_EXTERNAL_COMMAND_LITERAL_START 
-        quotedExpandedLiteralStringContent*
-        QUOTED_EXPANDED_EXTERNAL_COMMAND_LITERAL_END
-    ;
-
 doubleQuotedStringContent
     :   DOUBLE_QUOTED_STRING_CHARACTER_SEQUENCE
     |   STRING_INTERPOLATION_BEGIN compoundStatement STRING_INTERPOLATION_END
-    ;
-
-quotedNonExpandedLiteralString
-    :   QUOTED_NON_EXPANDED_STRING_LITERAL_START NON_EXPANDED_LITERAL_CHARACTER_SEQUENCE? QUOTED_NON_EXPANDED_STRING_LITERAL_END
-    ;
-
-quotedExpandedLiteralString
-    :   QUOTED_EXPANDED_STRING_LITERAL_START quotedExpandedLiteralStringContent* QUOTED_EXPANDED_STRING_LITERAL_END
     ;
 
 quotedExpandedLiteralStringContent


### PR DESCRIPTION
There were some unused parser rules adding unnecessary complexity to the parser