### PR TITLE
[php] fix php-parser path lookup

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -141,7 +141,7 @@ object PhpParser {
 
   private def defaultPhpParserBin: String = {
     val dir      = Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).toAbsolutePath.toString
-    val fixedDir = new java.io.File(dir.substring(0, dir.indexOf("php2cpg"))).toString
+    val fixedDir = new java.io.File(dir.substring(0, dir.lastIndexOf("php2cpg"))).toString
     Paths.get(fixedDir, "php2cpg", "bin", "php-parser", "php-parser.php").toAbsolutePath.toString
   }
 


### PR DESCRIPTION
On buildbot the installation path for php2cpg is
`/worker/sptestV2-php2cpg/build/x2cpg-internal/php2cpg/target/universal/stage`
which (prior to this PR) leads to an invalid derived php-parser name
and the following error:
```
2024-09-25 09:30:08.623 ERROR Invalid path for PhpParserBin: /worker/sptestV2-/php2cpg/bin/php-parser/php-parser.php
```