### PR TITLE
[dataflowengineoss] remove overriding operator semantics

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -63,7 +63,6 @@ object DefaultSemantics {
     //  some of those operators have duplicate mappings due to a typo
     //  - see https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1630
 
-    F("<operators>.assignmentExponentiation", List((2, 1), (1, 1))),
     F("<operators>.assignmentShiftLeft", List((2, 1), (1, 1))),
     F("<operators>.assignmentLogicalShiftRight", List((2, 1), (1, 1))),
     F("<operators>.assignmentArithmeticShiftRight", List((2, 1), (1, 1))),

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -64,7 +64,6 @@ object DefaultSemantics {
     //  - see https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1630
 
     F("<operators>.assignmentExponentiation", List((2, 1), (1, 1))),
-    F("<operators>.assignmentModulo", List((2, 1), (1, 1))),
     F("<operators>.assignmentShiftLeft", List((2, 1), (1, 1))),
     F("<operators>.assignmentLogicalShiftRight", List((2, 1), (1, 1))),
     F("<operators>.assignmentArithmeticShiftRight", List((2, 1), (1, 1))),

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -63,7 +63,6 @@ object DefaultSemantics {
     //  some of those operators have duplicate mappings due to a typo
     //  - see https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1630
 
-    F("<operators>.assignmentShiftLeft", List((2, 1), (1, 1))),
     F("<operators>.assignmentLogicalShiftRight", List((2, 1), (1, 1))),
     F("<operators>.assignmentArithmeticShiftRight", List((2, 1), (1, 1))),
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -68,7 +68,6 @@ object DefaultSemantics {
     F("<operators>.assignmentLogicalShiftRight", List((2, 1), (1, 1))),
     F("<operators>.assignmentArithmeticShiftRight", List((2, 1), (1, 1))),
     F("<operators>.assignmentAnd", List((2, 1), (1, 1))),
-    F("<operators>.assignmentOr", List((2, 1), (1, 1))),
 
     // Language specific operators
     PTF("<operator>.tupleLiteral"),

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -69,7 +69,6 @@ object DefaultSemantics {
     F("<operators>.assignmentArithmeticShiftRight", List((2, 1), (1, 1))),
     F("<operators>.assignmentAnd", List((2, 1), (1, 1))),
     F("<operators>.assignmentOr", List((2, 1), (1, 1))),
-    F("<operators>.assignmentXor", List((2, 1), (1, 1))),
 
     // Language specific operators
     PTF("<operator>.tupleLiteral"),

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -67,7 +67,6 @@ object DefaultSemantics {
     F("<operators>.assignmentShiftLeft", List((2, 1), (1, 1))),
     F("<operators>.assignmentLogicalShiftRight", List((2, 1), (1, 1))),
     F("<operators>.assignmentArithmeticShiftRight", List((2, 1), (1, 1))),
-    F("<operators>.assignmentAnd", List((2, 1), (1, 1))),
 
     // Language specific operators
     PTF("<operator>.tupleLiteral"),

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/DefaultSemantics.scala
@@ -60,12 +60,6 @@ object DefaultSemantics {
     F(Operators.preIncrement, List((1, 1), (1, -1))),
     F(Operators.sizeOf, List.empty[(Int, Int)]),
 
-    //  some of those operators have duplicate mappings due to a typo
-    //  - see https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1630
-
-    F("<operators>.assignmentLogicalShiftRight", List((2, 1), (1, 1))),
-    F("<operators>.assignmentArithmeticShiftRight", List((2, 1), (1, 1))),
-
     // Language specific operators
     PTF("<operator>.tupleLiteral"),
     PTF("<operator>.dictLiteral"),

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -2038,4 +2038,31 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
       )
     }
   }
+
+  "DataFlowTest75" should {
+    val cpg = code(
+      """
+        |int main(void) {
+        | int x = 5;
+        | call1(x|=2);
+        | call2(x);
+        |}
+        |""".stripMargin)
+
+    "the literal in x|=2 should taint the outer expression" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x|=2", 4), ("call1(x|=2)", 4))
+      )
+    }
+
+    "the literal in x|=2 should taint the next occurrence of x" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x|=2", 4), ("call2(x)", 5))
+      )
+    }
+  }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -2013,8 +2013,7 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
   }
 
   "DataFlowTest74" should {
-    val cpg = code(
-      """
+    val cpg = code("""
         |int main(void) {
         | int x = 5;
         | call1(x^=2);
@@ -2024,24 +2023,19 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
 
     "the literal in x^=2 should taint the outer expression" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call1")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x^=2", 4), ("call1(x^=2)", 4))
-      )
+      val sink   = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x^=2", 4), ("call1(x^=2)", 4)))
     }
 
     "the literal in x^=2 should taint the next occurrence of x" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call2")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x^=2", 4), ("call2(x)", 5))
-      )
+      val sink   = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x^=2", 4), ("call2(x)", 5)))
     }
   }
 
   "DataFlowTest75" should {
-    val cpg = code(
-      """
+    val cpg = code("""
         |int main(void) {
         | int x = 5;
         | call1(x|=2);
@@ -2051,24 +2045,19 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
 
     "the literal in x|=2 should taint the outer expression" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call1")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x|=2", 4), ("call1(x|=2)", 4))
-      )
+      val sink   = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x|=2", 4), ("call1(x|=2)", 4)))
     }
 
     "the literal in x|=2 should taint the next occurrence of x" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call2")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x|=2", 4), ("call2(x)", 5))
-      )
+      val sink   = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x|=2", 4), ("call2(x)", 5)))
     }
   }
 
   "DataFlowTest76" should {
-    val cpg = code(
-      """
+    val cpg = code("""
         |int main(void) {
         | int x = 5;
         | call1(x&=2);
@@ -2078,24 +2067,19 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
 
     "the literal in x&=2 should taint the outer expression" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call1")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x&=2", 4), ("call1(x&=2)", 4))
-      )
+      val sink   = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x&=2", 4), ("call1(x&=2)", 4)))
     }
 
     "the literal in x&=2 should taint the next occurrence of x" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call2")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x&=2", 4), ("call2(x)", 5))
-      )
+      val sink   = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x&=2", 4), ("call2(x)", 5)))
     }
   }
 
   "DataFlowTest77" should {
-    val cpg = code(
-      """
+    val cpg = code("""
         |int main(void) {
         | int x = 5;
         | call1(x<<=2);
@@ -2105,24 +2089,19 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
 
     "the literal in x<<=2 should taint the outer expression" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call1")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x<<=2", 4), ("call1(x<<=2)", 4))
-      )
+      val sink   = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x<<=2", 4), ("call1(x<<=2)", 4)))
     }
 
     "the literal in x<<=2 should taint the next occurrence of x" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call2")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x<<=2", 4), ("call2(x)", 5))
-      )
+      val sink   = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x<<=2", 4), ("call2(x)", 5)))
     }
   }
 
   "DataFlowTest78" should {
-    val cpg = code(
-      """
+    val cpg = code("""
         |int main(void) {
         | int x = 5;
         | call1(x>>=2);
@@ -2132,18 +2111,14 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
 
     "the literal in x>>=2 should taint the outer expression" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call1")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x>>=2", 4), ("call1(x>>=2)", 4))
-      )
+      val sink   = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x>>=2", 4), ("call1(x>>=2)", 4)))
     }
 
     "the literal in x>>=2 should taint the next occurrence of x" in {
       val source = cpg.literal("2")
-      val sink = cpg.call("call2")
-      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-        List(("x>>=2", 4), ("call2(x)", 5))
-      )
+      val sink   = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x>>=2", 4), ("call2(x)", 5)))
     }
   }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -2119,4 +2119,31 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
       )
     }
   }
+
+  "DataFlowTest78" should {
+    val cpg = code(
+      """
+        |int main(void) {
+        | int x = 5;
+        | call1(x>>=2);
+        | call2(x);
+        |}
+        |""".stripMargin)
+
+    "the literal in x>>=2 should taint the outer expression" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x>>=2", 4), ("call1(x>>=2)", 4))
+      )
+    }
+
+    "the literal in x>>=2 should taint the next occurrence of x" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x>>=2", 4), ("call2(x)", 5))
+      )
+    }
+  }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -1988,4 +1988,27 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
       )
     }
   }
+
+  "DataFlowTest73" should {
+    val cpg = code("""
+        |int main(void) {
+        | int x = 5;
+        | call1(x%=2);
+        | call2(x);
+        |}
+        |""".stripMargin)
+
+    "the literal in x%=2 should taint the outer expression" in {
+      val source = cpg.literal("2")
+      val sink   = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x%=2", 4), ("call1(x%=2)", 4)))
+    }
+
+    "the literal in x%=2 should taint the next occurrence of x" in {
+      val source = cpg.literal("2")
+      val sink   = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(List(("x%=2", 4), ("call2(x)", 5)))
+    }
+
+  }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -2065,4 +2065,31 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
       )
     }
   }
+
+  "DataFlowTest76" should {
+    val cpg = code(
+      """
+        |int main(void) {
+        | int x = 5;
+        | call1(x&=2);
+        | call2(x);
+        |}
+        |""".stripMargin)
+
+    "the literal in x&=2 should taint the outer expression" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x&=2", 4), ("call1(x&=2)", 4))
+      )
+    }
+
+    "the literal in x&=2 should taint the next occurrence of x" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x&=2", 4), ("call2(x)", 5))
+      )
+    }
+  }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -2011,4 +2011,31 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
     }
 
   }
+
+  "DataFlowTest74" should {
+    val cpg = code(
+      """
+        |int main(void) {
+        | int x = 5;
+        | call1(x^=2);
+        | call2(x);
+        |}
+        |""".stripMargin)
+
+    "the literal in x^=2 should taint the outer expression" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x^=2", 4), ("call1(x^=2)", 4))
+      )
+    }
+
+    "the literal in x^=2 should taint the next occurrence of x" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x^=2", 4), ("call2(x)", 5))
+      )
+    }
+  }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -2092,4 +2092,31 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
       )
     }
   }
+
+  "DataFlowTest77" should {
+    val cpg = code(
+      """
+        |int main(void) {
+        | int x = 5;
+        | call1(x<<=2);
+        | call2(x);
+        |}
+        |""".stripMargin)
+
+    "the literal in x<<=2 should taint the outer expression" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call1")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x<<=2", 4), ("call1(x<<=2)", 4))
+      )
+    }
+
+    "the literal in x<<=2 should taint the next occurrence of x" in {
+      val source = cpg.literal("2")
+      val sink = cpg.call("call2")
+      sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+        List(("x<<=2", 4), ("call2(x)", 5))
+      )
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
@@ -46,6 +46,22 @@ class SingleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink = cpg.call.name("puts").l
     sink.reachableByFlows(src).l.size shouldBe 2
   }
+  
+  "flow through **=" in {
+    val cpg = code(
+      """
+        |x = 5
+        |call1(x**=2)
+        |call2(x) 
+        |""".stripMargin)
+    
+    val source = cpg.literal("2").l
+    val call1 = cpg.call("call1")
+    val call2 = cpg.call("call2")
+    
+    call1.reachableBy(source).l shouldBe source
+    call2.reachableBy(source).l shouldBe source
+  }
 
   "Data flow through grouping expression" in {
     val cpg = code("""

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/SingleAssignmentTests.scala
@@ -46,19 +46,18 @@ class SingleAssignmentTests extends RubyCode2CpgFixture(withPostProcessing = tru
     val sink = cpg.call.name("puts").l
     sink.reachableByFlows(src).l.size shouldBe 2
   }
-  
+
   "flow through **=" in {
-    val cpg = code(
-      """
+    val cpg = code("""
         |x = 5
         |call1(x**=2)
         |call2(x) 
         |""".stripMargin)
-    
+
     val source = cpg.literal("2").l
-    val call1 = cpg.call("call1")
-    val call2 = cpg.call("call2")
-    
+    val call1  = cpg.call("call1")
+    val call2  = cpg.call("call2")
+
     call1.reachableBy(source).l shouldBe source
     call2.reachableBy(source).l shouldBe source
   }


### PR DESCRIPTION
Conflicting (i.e. same methodFullNamed) `FlowSemantics` are not currently handled by `FullNameSemantics.fromList` and silently it's the last entry that takes precedence. (Will create another PR for this shortly, that combines two such `FlowSemantics` into a single one.)

Take for example `<operators>.assignmentModulo` (as in `x%=y`). We have 2 conflicting entries for it in `DefaultSemantics`:
* `F(Operators.assignmentModulo, List((2, 1), (1, 1), (2, -1)))`
* `F("<operators>.assignmentModulo", List((2, 1), (1, 1)))`

Coincidentally, `Operators.assignmentModulo` is `"<operators>.assignmentModulo"`, so it's the latter `FlowSemantic` that ends up being used, thus preventing the `FlowMapping(2,-1)` from being considered. As such, in an expression such as `call(x%=2)`, the literal `2` doesn't taint `call`.

The same happens for the remaining operators being removed in this PR.