### PR TITLE
[dataflowengineoss] SemanticTestCpg doesn't rebuild semantics

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -17,8 +17,9 @@ class OssDataFlowOptions(
   var extraFlows: List[FlowSemantic] = List.empty[FlowSemantic]
 ) extends LayerCreatorOptions {}
 
-class OssDataFlow(opts: OssDataFlowOptions)(implicit s: Semantics = DefaultSemantics().plus(opts.extraFlows))
-    extends LayerCreator {
+class OssDataFlow(opts: OssDataFlowOptions)(implicit
+  val semantics: Semantics = DefaultSemantics().plus(opts.extraFlows)
+) extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/testfixtures/SemanticTestCpg.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/testfixtures/SemanticTestCpg.scala
@@ -34,10 +34,11 @@ trait SemanticTestCpg { this: TestCpg =>
     */
   def applyOssDataFlow(): Unit = {
     if (_withOssDataflow) {
-      val context = new LayerCreatorContext(this)
-      val options = new OssDataFlowOptions(extraFlows = _extraFlows)
-      new OssDataFlow(options).run(context)
-      this.context = EngineContext(DefaultSemantics().plus(_extraFlows))
+      val context  = new LayerCreatorContext(this)
+      val options  = new OssDataFlowOptions(extraFlows = _extraFlows)
+      val dataflow = new OssDataFlow(options)
+      dataflow.run(context)
+      this.context = EngineContext(dataflow.semantics)
     }
   }
 


### PR DESCRIPTION
As soon as `FullNameSemantics` started logging duplicate semantics (in #4953), it was observed that `SemanticTestCpg` was passing a fresh Semantics instance to `EngineContext` instead of passing the one used by `OssDataFlow`, cf. `SemanticTestCpg.scala:40`. By coincidence they were the same, so everything was good except for some duplicate work. Nevertheless, this patch guarantees they are the same, by exposing the semantics used by `OssDataFlow`.