### PR TITLE
external commands (astgen, php-parser etc.): fix and consolidate base dir

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -140,9 +140,10 @@ object PhpParser {
   }
 
   private def defaultPhpParserBin: String = {
-    val dir      = Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).toAbsolutePath.toString
-    val fixedDir = new java.io.File(dir.substring(0, dir.indexOf("php2cpg"))).toString
-    Paths.get(fixedDir, "php2cpg", "bin", "php-parser", "php-parser.php").toAbsolutePath.toString
+    val packagePath = Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).toAbsolutePath.toString
+    ExternalCommand
+      .executableDir(packagePath)
+      .resolve("php-parser/php-parser.php")
   }
 
   private def configOverrideOrDefaultPath(

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -140,8 +140,7 @@ object PhpParser {
   }
 
   private def defaultPhpParserBin: String = {
-    val packagePath =
-      Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).toAbsolutePath.toString
+    val packagePath = Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
     ExternalCommand
       .executableDir(packagePath)
       .resolve("php-parser/php-parser.php")

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -145,6 +145,7 @@ object PhpParser {
     ExternalCommand
       .executableDir(packagePath)
       .resolve("php-parser/php-parser.php")
+      .toString
   }
 
   private def configOverrideOrDefaultPath(

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -140,7 +140,8 @@ object PhpParser {
   }
 
   private def defaultPhpParserBin: String = {
-    val packagePath = Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).toAbsolutePath.toString
+    val packagePath =
+      Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).toAbsolutePath.toString
     ExternalCommand
       .executableDir(packagePath)
       .resolve("php-parser/php-parser.php")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
@@ -46,21 +46,11 @@ object AstGenRunner {
     packagePath: URL
   )
 
-  def executableDir(implicit metaData: AstGenProgramMetaData): String = {
-    val dir        = metaData.packagePath.toString
-    val indexOfLib = dir.lastIndexOf("lib")
-    val fixedDir = if (indexOfLib != -1) {
-      new java.io.File(dir.substring("file:".length, indexOfLib)).toString
-    } else {
-      val indexOfTarget = dir.lastIndexOf("target")
-      if (indexOfTarget != -1) {
-        new java.io.File(dir.substring("file:".length, indexOfTarget)).toString
-      } else {
-        "."
-      }
-    }
-    Paths.get(fixedDir, "/bin/astgen").toAbsolutePath.toString
-  }
+  def executableDir(implicit metaData: AstGenProgramMetaData): String =
+    ExternalCommand
+      .executableDir(metaData.packagePath.toString)
+      .resolve("astgen")
+      .toString
 
   def hasCompatibleAstGenVersion(compatibleVersion: String)(implicit metaData: AstGenProgramMetaData): Boolean = {
     ExternalCommand.run(s"$metaData.name -version", ".").toOption.map(_.mkString.strip()) match {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
@@ -48,7 +48,7 @@ object AstGenRunner {
 
   def executableDir(implicit metaData: AstGenProgramMetaData): String =
     ExternalCommand
-      .executableDir(metaData.packagePath.toString)
+      .executableDir(Paths.get(metaData.packagePath.toURI))
       .resolve("astgen")
       .toString
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -56,11 +56,11 @@ trait ExternalCommand {
 
 object ExternalCommand extends ExternalCommand {
 
-  /** Finds the absolute path to the executable directory (e.g. `/path/to/javasrc2cpg/bin`).
-   * Based on the package path of a loaded classfile based on some (potentially flakey?) filename heuristics.
-   * Context: we want to be able to invoke the x2cpg frontends from any directory, not just their install directory,
-   * and then invoke other executables, like astgen, php-parser et al. 
-   * */
+  /** Finds the absolute path to the executable directory (e.g. `/path/to/javasrc2cpg/bin`). Based on the package path
+    * of a loaded classfile based on some (potentially flakey?) filename heuristics. Context: we want to be able to
+    * invoke the x2cpg frontends from any directory, not just their install directory, and then invoke other
+    * executables, like astgen, php-parser et al.
+    */
   def executableDir(packagePath: String): Path = {
     val dir        = packagePath
     val indexOfLib = dir.lastIndexOf("lib")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -79,6 +79,6 @@ object ExternalCommand extends ExternalCommand {
         Paths.get(".")
       }
 
-    fixedDir.resolve("/bin/").toAbsolutePath
+    fixedDir.resolve("bin/").toAbsolutePath
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -1,6 +1,7 @@
 package io.joern.x2cpg.utils
 
 import java.io.File
+import java.net.URL
 import java.nio.file.{Path, Paths}
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.sys.process.{Process, ProcessLogger}
@@ -61,19 +62,22 @@ object ExternalCommand extends ExternalCommand {
     * invoke the x2cpg frontends from any directory, not just their install directory, and then invoke other
     * executables, like astgen, php-parser et al.
     */
-  def executableDir(packagePath: String): Path = {
-    val dir        = packagePath
-    val indexOfLib = dir.lastIndexOf("lib")
-    val fixedDir = if (indexOfLib != -1) {
-      new java.io.File(dir.substring(0, indexOfLib)).toString
-    } else {
-      val indexOfTarget = dir.lastIndexOf("target")
-      if (indexOfTarget != -1) {
-        new java.io.File(dir.substring(0, indexOfTarget)).toString
+  def executableDir(packagePath: Path): Path = {
+    val fixedDir = 
+      if (packagePath.toString.contains("lib")) {
+        var dir = packagePath
+        while (dir.toString.contains("lib")) 
+          dir = dir.getParent
+        dir
+      } else if (packagePath.toString.contains("target")) {
+        var dir = packagePath
+        while (dir.toString.contains("target")) 
+          dir = dir.getParent
+        dir
       } else {
-        "."
+        Paths.get(".")
       }
-    }
-    Paths.get(fixedDir, "/bin/").toAbsolutePath
+
+    fixedDir.resolve("/bin/").toAbsolutePath
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -65,11 +65,11 @@ object ExternalCommand extends ExternalCommand {
     val dir        = packagePath
     val indexOfLib = dir.lastIndexOf("lib")
     val fixedDir = if (indexOfLib != -1) {
-      new java.io.File(dir.substring("file:".length, indexOfLib)).toString
+      new java.io.File(dir.substring(0, indexOfLib)).toString
     } else {
       val indexOfTarget = dir.lastIndexOf("target")
       if (indexOfTarget != -1) {
-        new java.io.File(dir.substring("file:".length, indexOfTarget)).toString
+        new java.io.File(dir.substring(0, indexOfTarget)).toString
       } else {
         "."
       }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -63,15 +63,16 @@ object ExternalCommand extends ExternalCommand {
     * executables, like astgen, php-parser et al.
     */
   def executableDir(packagePath: Path): Path = {
-    val fixedDir = 
-      if (packagePath.toString.contains("lib")) {
-        var dir = packagePath
-        while (dir.toString.contains("lib")) 
+    val packagePathAbsolute = packagePath.toAbsolutePath
+    val fixedDir =
+      if (packagePathAbsolute.toString.contains("lib")) {
+        var dir = packagePathAbsolute
+        while (dir.toString.contains("lib"))
           dir = dir.getParent
         dir
-      } else if (packagePath.toString.contains("target")) {
-        var dir = packagePath
-        while (dir.toString.contains("target")) 
+      } else if (packagePathAbsolute.toString.contains("target")) {
+        var dir = packagePathAbsolute
+        while (dir.toString.contains("target"))
           dir = dir.getParent
         dir
       } else {


### PR DESCRIPTION
The logic to guess the base dir of the installation is quite fiddly but
works for our use cases for astgen. PhpParser implemented something similar, but
not quite - and it failed for buildbot.

On buildbot the installation path for php2cpg is
`/worker/sptestV2-php2cpg/build/x2cpg-internal/php2cpg/target/universal/stage`
which (prior to this PR) leads to an invalid derived php-parser name
and the following error:
```
2024-09-25 09:30:08.623 ERROR Invalid path for PhpParserBin: /worker/sptestV2-/php2cpg/bin/php-parser/php-parser.php
```