### PR TITLE
[dataflowengineoss] replace `extraFlows` with `semantics`

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -12,14 +12,10 @@ object OssDataFlow {
   def defaultOpts = new OssDataFlowOptions()
 }
 
-class OssDataFlowOptions(
-  var maxNumberOfDefinitions: Int = 4000,
-  var extraFlows: List[FlowSemantic] = List.empty[FlowSemantic]
-) extends LayerCreatorOptions {}
+class OssDataFlowOptions(var maxNumberOfDefinitions: Int = 4000, var semantics: Semantics = DefaultSemantics())
+    extends LayerCreatorOptions {}
 
-class OssDataFlow(opts: OssDataFlowOptions)(implicit
-  val semantics: Semantics = DefaultSemantics().plus(opts.extraFlows)
-) extends LayerCreator {
+class OssDataFlow(opts: OssDataFlowOptions)(implicit val semantics: Semantics = opts.semantics) extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description

--- a/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/testfixtures/SemanticTestCpg.scala
+++ b/dataflowengineoss/src/test/scala/io/joern/dataflowengineoss/testfixtures/SemanticTestCpg.scala
@@ -3,7 +3,7 @@ package io.joern.dataflowengineoss.testfixtures
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, FullNameSemantics}
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, FullNameSemantics, Semantics}
 import io.joern.x2cpg.testfixtures.TestCpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
@@ -12,7 +12,7 @@ import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 trait SemanticTestCpg { this: TestCpg =>
 
   protected var _withOssDataflow                = false
-  protected var _extraFlows                     = List.empty[FlowSemantic]
+  protected var _semantics: Semantics           = DefaultSemantics()
   protected implicit var context: EngineContext = EngineContext()
 
   /** Allows one to enable data-flow analysis capabilities to the TestCpg.
@@ -22,10 +22,9 @@ trait SemanticTestCpg { this: TestCpg =>
     this
   }
 
-  /** Allows one to add additional semantics to the engine context during PDG creation.
-    */
-  def withExtraFlows(value: List[FlowSemantic] = List.empty): this.type = {
-    _extraFlows = value
+  /** Allows one to provide custom semantics to the TestCpg. */
+  def withSemantics(value: Semantics): this.type = {
+    _semantics = value
     this
   }
 
@@ -35,7 +34,7 @@ trait SemanticTestCpg { this: TestCpg =>
   def applyOssDataFlow(): Unit = {
     if (_withOssDataflow) {
       val context  = new LayerCreatorContext(this)
-      val options  = new OssDataFlowOptions(extraFlows = _extraFlows)
+      val options  = new OssDataFlowOptions(semantics = _semantics)
       val dataflow = new OssDataFlow(options)
       dataflow.run(context)
       this.context = EngineContext(dataflow.semantics)
@@ -46,8 +45,8 @@ trait SemanticTestCpg { this: TestCpg =>
 
 /** Allows the tests to make use of the data-flow engine and any additional semantics.
   */
-trait SemanticCpgTestFixture(extraFlows: List[FlowSemantic] = List.empty) {
+trait SemanticCpgTestFixture(semantics: Semantics = DefaultSemantics()) {
 
-  implicit val context: EngineContext = EngineContext(DefaultSemantics().plus(extraFlows))
+  implicit val context: EngineContext = EngineContext(semantics)
 
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/FileHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/FileHandlingTests.scala
@@ -3,6 +3,8 @@ package io.joern.c2cpg.io
 import better.files.File
 import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.testfixtures.CDefaultTestCpg
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.semanticsloader.NoSemantics
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 import io.shiftleft.semanticcpg.language.*
 
@@ -36,7 +38,7 @@ class FileHandlingTests
         }
       }
         .withOssDataflow(false)
-        .withExtraFlows(List.empty)
+        .withSemantics(DefaultSemantics())
         .withPostProcessingPasses(false)
     ) {
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgSuite.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgSuite.scala
@@ -1,17 +1,18 @@
 package io.joern.c2cpg.testfixtures
 
 import io.joern.c2cpg.parser.FileDefaults
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 
 class C2CpgSuite(
   fileSuffix: String = FileDefaults.C_EXT,
   withOssDataflow: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty,
+  semantics: Semantics = DefaultSemantics(),
   withPostProcessing: Boolean = false
 ) extends Code2CpgFixture(() =>
       new CDefaultTestCpg(fileSuffix)
         .withOssDataflow(withOssDataflow)
-        .withExtraFlows(extraFlows)
+        .withSemantics(semantics)
         .withPostProcessingPasses(withPostProcessing)
     )

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/testfixtures/CSharpCode2CpgFixture.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/testfixtures/CSharpCode2CpgFixture.scala
@@ -1,8 +1,9 @@
 package io.joern.csharpsrc2cpg.testfixtures
 
 import io.joern.csharpsrc2cpg.{CSharpSrc2Cpg, Config}
+import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.Path
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend}
 import io.joern.x2cpg.{ValidationMode, X2Cpg}
@@ -16,14 +17,14 @@ import java.io.File
 class CSharpCode2CpgFixture(
   withPostProcessing: Boolean = false,
   withDataFlow: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty
+  semantics: Semantics = DefaultSemantics()
 ) extends Code2CpgFixture(() =>
       new DefaultTestCpgWithCSharp()
         .withOssDataflow(withDataFlow)
-        .withExtraFlows(extraFlows)
+        .withSemantics(semantics)
         .withPostProcessingPasses(withPostProcessing)
     )
-    with SemanticCpgTestFixture(extraFlows)
+    with SemanticCpgTestFixture(semantics)
     with Inside {
 
   implicit val resolver: ICallResolver = NoResolve

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
@@ -1,7 +1,8 @@
 package io.joern.go2cpg.testfixtures
 
 import better.files.File
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.model.GoModHelper
@@ -49,11 +50,11 @@ class DefaultTestCpgWithGo(val fileSuffix: String) extends DefaultTestCpg with S
 class GoCodeToCpgSuite(
   fileSuffix: String = ".go",
   withOssDataflow: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty
+  semantics: Semantics = DefaultSemantics()
 ) extends Code2CpgFixture(() =>
-      new DefaultTestCpgWithGo(fileSuffix).withOssDataflow(withOssDataflow).withExtraFlows(extraFlows)
+      new DefaultTestCpgWithGo(fileSuffix).withOssDataflow(withOssDataflow).withSemantics(semantics)
     )
-    with SemanticCpgTestFixture(extraFlows)
+    with SemanticCpgTestFixture(semantics)
     with Inside {
   implicit val resolver: ICallResolver = NoResolve
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SemanticTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/SemanticTests.scala
@@ -11,12 +11,14 @@ import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
 import io.joern.x2cpg.Defines
 
 class SemanticTests
-    extends JavaDataflowFixture(extraFlows =
-      List(
-        FlowSemantic.from("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
-        FlowSemantic.from(s"ext.Library.killParam:${Defines.UnresolvedSignature}(1)", List.empty),
-        FlowSemantic.from("^ext\\.Library\\.taintNone:.*", List((0, 0), (1, 1)), regex = true),
-        FlowSemantic.from("^ext\\.Library\\.taint1to2:.*", List((1, 2)), regex = true)
+    extends JavaDataflowFixture(semantics =
+      DefaultSemantics().plus(
+        List(
+          FlowSemantic.from("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
+          FlowSemantic.from(s"ext.Library.killParam:${Defines.UnresolvedSignature}(1)", List.empty),
+          FlowSemantic.from("^ext\\.Library\\.taintNone:.*", List((0, 0), (1, 1)), regex = true),
+          FlowSemantic.from("^ext\\.Library\\.taint1to2:.*", List((1, 2)), regex = true)
+        )
       )
     ) {
   behavior of "Dataflow through custom semantics"

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaDataflowFixture.scala
@@ -1,21 +1,22 @@
 package io.joern.javasrc2cpg.testfixtures
 
+import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal}
 import io.shiftleft.semanticcpg.language.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class JavaDataflowFixture(extraFlows: List[FlowSemantic] = List.empty) extends AnyFlatSpec with Matchers {
+class JavaDataflowFixture(semantics: Semantics = DefaultSemantics()) extends AnyFlatSpec with Matchers {
 
   implicit val resolver: ICallResolver           = NoResolve
   implicit lazy val engineContext: EngineContext = EngineContext()
 
   val code: String  = ""
-  lazy val cpg: Cpg = JavaSrcTestCpg().withOssDataflow().withExtraFlows(extraFlows).moreCode(code)
+  lazy val cpg: Cpg = JavaSrcTestCpg().withOssDataflow().withSemantics(semantics).moreCode(code)
 
   def getConstSourceSink(
     methodName: String,

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg.testfixtures
 
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.frontendspecific.javasrc2cpg
@@ -40,12 +41,12 @@ class JavaSrcTestCpg(enableTypeRecovery: Boolean = false)
 
 class JavaSrcCode2CpgFixture(
   withOssDataflow: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty,
+  semantics: Semantics = DefaultSemantics(),
   enableTypeRecovery: Boolean = false
 ) extends Code2CpgFixture(() =>
-      new JavaSrcTestCpg(enableTypeRecovery).withOssDataflow(withOssDataflow).withExtraFlows(extraFlows)
+      new JavaSrcTestCpg(enableTypeRecovery).withOssDataflow(withOssDataflow).withSemantics(semantics)
     )
-    with SemanticCpgTestFixture(extraFlows) {
+    with SemanticCpgTestFixture(semantics) {
 
   implicit val resolver: ICallResolver = NoResolve
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/SemanticTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/SemanticTests.scala
@@ -1,15 +1,18 @@
 package io.joern.jimple2cpg.querying.dataflow
 
+import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.jimple2cpg.testfixtures.{JimpleDataFlowCodeToCpgSuite, JimpleDataflowTestCpg}
 import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
 import io.joern.x2cpg.Defines
 
 class SemanticTests
-    extends JimpleDataFlowCodeToCpgSuite(extraFlows =
-      List(
-        FlowSemantic.from("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
-        FlowSemantic.from("java.nio.file.Paths.get:.*\\(java.lang.String,.*\\)", List.empty, regex = true)
+    extends JimpleDataFlowCodeToCpgSuite(semantics =
+      DefaultSemantics().plus(
+        List(
+          FlowSemantic.from("Test.sanitize:java.lang.String(java.lang.String)", List((0, 0), (1, 1))),
+          FlowSemantic.from("java.nio.file.Paths.get:.*\\(java.lang.String,.*\\)", List.empty, regex = true)
+        )
       )
     ) {
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleCodeToCpgFixture.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleCodeToCpgFixture.scala
@@ -1,6 +1,7 @@
 package io.joern.jimple2cpg.testfixtures
 
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.jimple2cpg.{Config, Jimple2Cpg}
 import io.joern.x2cpg.X2Cpg
@@ -23,9 +24,9 @@ trait Jimple2CpgFrontend extends LanguageFrontend {
   }
 }
 
-class JimpleCode2CpgFixture(withOssDataflow: Boolean = false, extraFlows: List[FlowSemantic] = List.empty)
-    extends Code2CpgFixture(() => new JimpleTestCpg().withOssDataflow(withOssDataflow).withExtraFlows(extraFlows))
-    with SemanticCpgTestFixture(extraFlows) {}
+class JimpleCode2CpgFixture(withOssDataflow: Boolean = false, semantics: Semantics = DefaultSemantics())
+    extends Code2CpgFixture(() => new JimpleTestCpg().withOssDataflow(withOssDataflow).withSemantics(semantics))
+    with SemanticCpgTestFixture(semantics) {}
 
 class JimpleTestCpg extends DefaultTestCpg with Jimple2CpgFrontend with SemanticTestCpg {
 

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleDataflowCodeToCpgSuite.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleDataflowCodeToCpgSuite.scala
@@ -1,15 +1,16 @@
 package io.joern.jimple2cpg.testfixtures
 
+import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
-class JimpleDataflowTestCpg(val extraFlows: List[FlowSemantic] = List.empty) extends JimpleTestCpg {
+class JimpleDataflowTestCpg(val semantics: Semantics = DefaultSemantics()) extends JimpleTestCpg {
 
   implicit val resolver: ICallResolver           = NoResolve
   implicit lazy val engineContext: EngineContext = EngineContext()
@@ -17,14 +18,14 @@ class JimpleDataflowTestCpg(val extraFlows: List[FlowSemantic] = List.empty) ext
   override def applyPasses(): Unit = {
     super.applyPasses()
     val context = new LayerCreatorContext(this)
-    val options = new OssDataFlowOptions(extraFlows = extraFlows)
+    val options = new OssDataFlowOptions(semantics = semantics)
     new OssDataFlow(options).run(context)
   }
 
 }
 
-class JimpleDataFlowCodeToCpgSuite(val extraFlows: List[FlowSemantic] = List.empty)
-    extends Code2CpgFixture(() => new JimpleDataflowTestCpg(extraFlows)) {
+class JimpleDataFlowCodeToCpgSuite(val semantics: Semantics = DefaultSemantics())
+    extends Code2CpgFixture(() => new JimpleDataflowTestCpg(semantics)) {
 
   implicit var context: EngineContext = EngineContext()
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgSuite.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgSuite.scala
@@ -1,16 +1,17 @@
 package io.joern.jssrc2cpg.testfixtures
 
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 
 class JsSrc2CpgSuite(
   fileSuffix: String = ".js",
   withOssDataflow: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty,
+  semantics: Semantics = DefaultSemantics(),
   withPostProcessing: Boolean = false
 ) extends Code2CpgFixture(() =>
       new JsSrcDefaultTestCpg(fileSuffix)
         .withOssDataflow(withOssDataflow)
-        .withExtraFlows(extraFlows)
+        .withSemantics(semantics)
         .withPostProcessingPasses(withPostProcessing)
     )

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -1,8 +1,9 @@
 package io.joern.kotlin2cpg.testfixtures
 
 import better.files.File as BFile
+import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.SemanticCpgTestFixture
 import io.joern.dataflowengineoss.testfixtures.SemanticTestCpg
 import io.joern.kotlin2cpg.Config
@@ -57,14 +58,14 @@ class KotlinCode2CpgFixture(
   withOssDataflow: Boolean = false,
   withDefaultJars: Boolean = false,
   withPostProcessing: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty
+  semantics: Semantics = DefaultSemantics()
 ) extends Code2CpgFixture(() =>
       new KotlinTestCpg(withDefaultJars)
         .withOssDataflow(withOssDataflow)
-        .withExtraFlows(extraFlows)
+        .withSemantics(semantics)
         .withPostProcessingPasses(withPostProcessing)
     )
-    with SemanticCpgTestFixture(extraFlows) {
+    with SemanticCpgTestFixture(semantics) {
 
   protected def flowToResultPairs(path: Path): List[(String, Option[Int])] = path.resultPairs()
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/testfixtures/PhpCode2CpgFixture.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/testfixtures/PhpCode2CpgFixture.scala
@@ -1,10 +1,11 @@
 package io.joern.php2cpg.testfixtures
 
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.php2cpg.{Config, Php2Cpg}
 import io.joern.x2cpg.frontendspecific.php2cpg
-import io.joern.x2cpg.testfixtures.{Code2CpgFixture, LanguageFrontend, DefaultTestCpg}
+import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
 
@@ -33,14 +34,14 @@ class PhpTestCpg extends DefaultTestCpg with PhpFrontend with SemanticTestCpg {
 
 class PhpCode2CpgFixture(
   runOssDataflow: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty,
+  semantics: Semantics = DefaultSemantics(),
   withPostProcessing: Boolean = true
 ) extends Code2CpgFixture(() =>
       new PhpTestCpg()
         .withOssDataflow(runOssDataflow)
-        .withExtraFlows(extraFlows)
+        .withSemantics(semantics)
         .withPostProcessingPasses(withPostProcessing)
     )
-    with SemanticCpgTestFixture(extraFlows) {
+    with SemanticCpgTestFixture(semantics) {
   implicit val resolver: ICallResolver = NoResolve
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/PySrc2CpgFixture.scala
@@ -4,7 +4,7 @@ import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.Path
 import io.joern.dataflowengineoss.layers.dataflows.*
 import io.joern.dataflowengineoss.queryengine.EngineContext
-import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic}
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.frontendspecific.pysrc2cpg.{
@@ -48,7 +48,7 @@ class PySrcTestCpg extends DefaultTestCpg with PythonFrontend with SemanticTestC
     new PythonTypeHintCallLinker(this).createAndApply()
     new NaiveCallLinker(this).createAndApply()
 
-    // Some of passes above create new methods, so, we
+    // Some of the passes above create new methods, so, we
     // need to run the ASTLinkerPass one more time
     new AstLinkerPass(this).createAndApply()
     applyOssDataFlow()
@@ -58,15 +58,15 @@ class PySrcTestCpg extends DefaultTestCpg with PythonFrontend with SemanticTestC
 
 class PySrc2CpgFixture(
   withOssDataflow: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty,
+  semantics: Semantics = DefaultSemantics(),
   withPostProcessing: Boolean = true
 ) extends Code2CpgFixture(() =>
       new PySrcTestCpg()
         .withOssDataflow(withOssDataflow)
-        .withExtraFlows(extraFlows)
+        .withSemantics(semantics)
         .withPostProcessingPasses(withPostProcessing)
     )
-    with SemanticCpgTestFixture(extraFlows) {
+    with SemanticCpgTestFixture(semantics) {
 
   implicit val resolver: ICallResolver = NoResolve
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -1,5 +1,6 @@
 package io.joern.pysrc2cpg.dataflow
 
+import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.toExtendedCfgNode
 import io.joern.dataflowengineoss.semanticsloader.{FlowMapping, FlowSemantic, PassThroughMapping}
 import io.joern.pysrc2cpg.PySrc2CpgFixture
@@ -63,7 +64,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |a = 20
         |print(foo(a))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List())))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("helpers.py:<module>.foo", List()))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -76,7 +77,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |a = 20
         |print(foo(a))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(0, 0)))))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(0, 0))))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -89,7 +90,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |a = 20
         |print(foo(a))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(1, 1)))))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(1, 1))))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -101,7 +102,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |from helpers import foo
         |print(foo(20))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List())))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("helpers.py:<module>.foo", List()))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -113,7 +114,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |from helpers import foo
         |print(foo(20))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(0, 0)))))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(0, 0))))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -125,7 +126,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |from helpers import foo
         |print(foo(20))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(1, 1)))))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("helpers.py:<module>.foo", List(FlowMapping(1, 1))))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -140,7 +141,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |a = 20
         |print(foo(a))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List())))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("Test0.py:<module>.foo", List()))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -155,7 +156,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |a = 20
         |print(foo(a))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(0, 0)))))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(0, 0))))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -170,7 +171,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |a = 20
         |print(foo(a))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(1, 1)))))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(1, 1))))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -184,7 +185,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |
         |print(foo(20))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List())))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("Test0.py:<module>.foo", List()))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -198,7 +199,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |
         |print(foo(20))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(0, 0)))))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(0, 0))))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -212,7 +213,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |
         |print(foo(20))
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(1, 1)))))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic("Test0.py:<module>.foo", List(FlowMapping(1, 1))))))
     val source = cpg.literal("20").l
     val sink   = cpg.call("print").argument(1).l
     val flows  = sink.reachableByFlows(source).l
@@ -660,7 +661,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |x = {'x': 10}
         |print(1, x)
         |""".stripMargin)
-      .withExtraFlows(List(FlowSemantic(".*print", List(PassThroughMapping), true)))
+      .withSemantics(DefaultSemantics().plus(List(FlowSemantic(".*print", List(PassThroughMapping), true))))
 
     def source       = cpg.literal
     def sink         = cpg.call("print").argument.argumentIndex(2)
@@ -845,11 +846,13 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |x = 'foobar'
         |bar.foo(Baz=x)
         |""".stripMargin)
-      .withExtraFlows(
-        List(
-          // Equivalent to a single `FlowSemantic` entry with both FlowMappings
-          FlowSemantic("bar.py:<module>.foo", List(PassThroughMapping)),
-          FlowSemantic("bar.py:<module>.foo", List(FlowMapping(0, 0)))
+      .withSemantics(
+        DefaultSemantics().plus(
+          List(
+            // Equivalent to a single `FlowSemantic` entry with both FlowMappings
+            FlowSemantic("bar.py:<module>.foo", List(PassThroughMapping)),
+            FlowSemantic("bar.py:<module>.foo", List(FlowMapping(0, 0)))
+          )
         )
       )
 
@@ -865,16 +868,18 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
 class RegexDefinedFlowsDataFlowTests
     extends PySrc2CpgFixture(
       withOssDataflow = true,
-      extraFlows = List(
-        FlowSemantic.from("^path.*<module>\\.sanitizer$", List((0, 0), (1, 1)), regex = true),
-        FlowSemantic.from("^foo.*<module>\\.sanitizer.*", List((0, 0), (1, 1)), regex = true),
-        FlowSemantic.from("^foo.*\\.create_sanitizer\\.<returnValue>\\.sanitize", List((0, 0), (1, 1)), regex = true),
-        FlowSemantic
-          .from(
-            "requests.py:<module>.post",
-            List((0, 0), (1, "url", -1), (2, "body", -1), (1, "url", 1, "url"), (2, "body", 2, "body"))
-          ),
-        FlowSemantic.from("cross_taint.py:<module>.go", List((0, 0), (1, 1), (1, "a", 2, "b")))
+      semantics = DefaultSemantics().plus(
+        List(
+          FlowSemantic.from("^path.*<module>\\.sanitizer$", List((0, 0), (1, 1)), regex = true),
+          FlowSemantic.from("^foo.*<module>\\.sanitizer.*", List((0, 0), (1, 1)), regex = true),
+          FlowSemantic.from("^foo.*\\.create_sanitizer\\.<returnValue>\\.sanitize", List((0, 0), (1, 1)), regex = true),
+          FlowSemantic
+            .from(
+              "requests.py:<module>.post",
+              List((0, 0), (1, "url", -1), (2, "body", -1), (1, "url", 1, "url"), (2, "body", 2, "body"))
+            ),
+          FlowSemantic.from("cross_taint.py:<module>.go", List((0, 0), (1, 1), (1, "a", 2, "b")))
+        )
       )
     ) {
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -1,7 +1,8 @@
 package io.joern.rubysrc2cpg.testfixtures
 
+import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.Path
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.rubysrc2cpg.{Config, RubySrc2Cpg}
 import io.joern.x2cpg.ValidationMode
@@ -82,17 +83,17 @@ class RubyCode2CpgFixture(
   withDataFlow: Boolean = false,
   downloadDependencies: Boolean = false,
   disableFileContent: Boolean = true,
-  extraFlows: List[FlowSemantic] = List.empty,
+  semantics: Semantics = DefaultSemantics(),
   antlrDebugging: Boolean = false,
   antlrProfiling: Boolean = false
 ) extends Code2CpgFixture(() =>
       new DefaultTestCpgWithRuby(downloadDependencies, disableFileContent, antlrDebugging, antlrProfiling)
         .withOssDataflow(withDataFlow)
-        .withExtraFlows(extraFlows)
+        .withSemantics(semantics)
         .withPostProcessingPasses(withPostProcessing)
     )
     with Inside
-    with SemanticCpgTestFixture(extraFlows) {
+    with SemanticCpgTestFixture(semantics) {
 
   implicit val resolver: ICallResolver = NoResolve
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftSrc2CpgSuite.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftSrc2CpgSuite.scala
@@ -1,16 +1,17 @@
 package io.joern.swiftsrc2cpg.testfixtures
 
-import io.joern.dataflowengineoss.semanticsloader.FlowSemantic
+import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 
 class SwiftSrc2CpgSuite(
   fileSuffix: String = ".swift",
   withOssDataflow: Boolean = false,
-  extraFlows: List[FlowSemantic] = List.empty,
+  semantics: Semantics = DefaultSemantics(),
   withPostProcessing: Boolean = false
 ) extends Code2CpgFixture(() =>
       new SwiftDefaultTestCpg(fileSuffix)
         .withOssDataflow(withOssDataflow)
-        .withExtraFlows(extraFlows)
+        .withSemantics(semantics)
         .withPostProcessingPasses(withPostProcessing)
     )


### PR DESCRIPTION
Continuing the abstraction work from `FullNameSemantics` towards an arbitrary `Semantics`, this PR refactors the test fixtures and `OssDataFlow` layer by replacing the traditional `extraFlows: List[FlowSemantic]` by a more general `semantics: Semantics`. Whereas previously we'd just pass the `FlowSemantic` fragment that we'd like to append to `DefaultSemantics`, the caller is now responsible for building it explicitly, which right now is as simple as `DefaultSemantics().plus(<fragment to append>)`.