### PR TITLE
[ruby] Fixed Argument Order on `ArgumentListContextHelper`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -727,7 +727,7 @@ class RubyNodeCreator(
   override def visitSuperWithParentheses(ctx: RubyParser.SuperWithParenthesesContext): RubyExpression = {
     val block = Option(ctx.block()).map(visit)
     val arguments =
-      Option(ctx.argumentWithParentheses()).map(_.arguments.map(visit).sortBy(x => (x.line, x.column))).getOrElse(Nil)
+      Option(ctx.argumentWithParentheses()).map(_.arguments.map(visit)).getOrElse(Nil)
     visitSuperCall(ctx, arguments, block)
   }
 
@@ -825,7 +825,6 @@ class RubyNodeCreator(
       .flatMap(_.arguments)
       .map(visit)
       .toList
-      .sortBy(x => (x.line, x.column))
     YieldExpr(arguments)(ctx.toTextSpan)
   }
 
@@ -931,10 +930,7 @@ class RubyNodeCreator(
         if (!hasArguments) {
           return SimpleObjectInstantiation(target, List.empty)(ctx.toTextSpan)
         } else {
-          return SimpleObjectInstantiation(
-            target,
-            ctx.argumentWithParentheses().arguments.map(visit).sortBy(x => (x.line, x.column))
-          )(ctx.toTextSpan)
+          return SimpleObjectInstantiation(target, ctx.argumentWithParentheses().arguments.map(visit))(ctx.toTextSpan)
         }
       } else {
         if (!hasArguments) {
@@ -946,7 +942,7 @@ class RubyNodeCreator(
             return MemberAccess(target, ctx.op.getText, methodName)(ctx.toTextSpan)
           }
         } else {
-          val args = ctx.argumentWithParentheses().arguments.map(visit).sortBy(x => (x.line, x.column))
+          val args = ctx.argumentWithParentheses().arguments.map(visit)
           return MemberCall(target, ctx.op.getText, methodName, args)(ctx.toTextSpan)
         }
       }
@@ -962,7 +958,7 @@ class RubyNodeCreator(
         if (!hasArguments) {
           return ObjectInstantiationWithBlock(target, List.empty, block)(ctx.toTextSpan)
         } else {
-          val args = ctx.argumentWithParentheses().arguments.map(visit).sortBy(x => (x.line, x.column))
+          val args = ctx.argumentWithParentheses().arguments.map(visit)
           return ObjectInstantiationWithBlock(target, args, block)(ctx.toTextSpan)
         }
       } else {
@@ -973,8 +969,7 @@ class RubyNodeCreator(
           Option(ctx.argumentWithParentheses())
             .map(_.arguments)
             .getOrElse(List())
-            .map(visit)
-            .sortBy(x => (x.line, x.column)),
+            .map(visit),
           visit(ctx.block()).asInstanceOf[Block]
         )(ctx.toTextSpan)
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesisParserTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/parser/InvocationWithParenthesisParserTests.scala
@@ -27,11 +27,11 @@ class InvocationWithParenthesisParserTests extends RubyParserFixture with Matche
     test("foo(:region)")
     test("foo(:region,)", "foo(:region)")
     test("foo(if: true)")
-    test("foo(1, 2=>3)", "foo(2=> 3,1)")
-    test("foo(1, 2=>3,)", "foo(2=> 3,1)")
+    test("foo(1, 2=>3)", "foo(1,2=> 3)")
+    test("foo(1, 2=>3,)", "foo(1,2=> 3)")
     test("foo(1=> 2,)", "foo(1=> 2)")
-    test("foo(1, kw: 2, **3)", "foo(**3,kw: 2,1)")
-    test("foo(b, **1)", "foo(**1,b)")
+    test("foo(1, kw: 2, **3)", "foo(1,kw: 2,**3)")
+    test("foo(b, **1)", "foo(b,**1)")
     test("""foo(b: if :c
         |1
         |else
@@ -52,7 +52,7 @@ class InvocationWithParenthesisParserTests extends RubyParserFixture with Matche
       "foo.bar"
     )
 
-    test("f(1, kw:2, **3)", "f(**3,kw: 2,1)")
+    test("f(1, kw:2, **3)", "f(1,kw: 2,**3)")
   }
 
   "Method with comments" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -498,9 +498,9 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     inside(cpg.call.name("render").argument.l) {
-      case _ :: (blockArg: Identifier) :: (symbolArg: Literal) :: Nil =>
-        blockArg.code shouldBe "block"
+      case _ :: (symbolArg: Literal) :: (blockArg: Identifier) :: Nil =>
         symbolArg.code shouldBe ":some_symbol"
+        blockArg.code shouldBe "block"
 
       case xs => fail(s"Expected two args, found [${xs.code.mkString(",")}]")
     }


### PR DESCRIPTION
Fixed bug introduced by https://github.com/joernio/joern/pull/4946. In this PR, the ordering was accounted for after the fact, but this appeared to have been missed in a few places as some instances in practice had mixed up orders. This uses `line` and `column` information to order arguments correctly at the `elements` call before other nodes are constructed from the result.