### PR TITLE
[python] fix methodFullName for methods named ^(import).*

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -1638,4 +1638,28 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
       }
     }
   }
+
+  "external method named `import_table`" should {
+    val cpg = code("""
+        |import boto3
+        |client = boto3.client("s3")
+        |response = client.import_table()
+        |""".stripMargin)
+
+    "have correct methodFullName for `import_table" in {
+      cpg.call("import_table").l match {
+        case List(importTable) =>
+          importTable.methodFullName shouldBe "boto3.py:<module>.client.<returnValue>.import_table"
+        case result => fail(s"Expected single call to import_table, but got $result")
+      }
+    }
+
+    "provide meaningful typeFullName for `response`" in {
+      cpg.assignment.target.isIdentifier.name("response").l match {
+        case List(response) =>
+          response.typeFullName shouldBe "boto3.py:<module>.client.<returnValue>.import_table.<returnValue>"
+        case result => fail(s"Expected single assignment to response, but got $result")
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonTypeHintCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonTypeHintCallLinker.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language.*
 
 class PythonTypeHintCallLinker(cpg: Cpg) extends XTypeHintCallLinker(cpg) {
 
-  override def calls: Iterator[Call] = super.calls.nameNot("^(import).*")
+  override def calls: Iterator[Call] = super.calls.whereNot(_.isImport)
 
   override def calleeNames(c: Call): Seq[String] = super.calleeNames(c).map {
     // Python call from  a type


### PR DESCRIPTION
If a method is named `^(import).*`, e.g. `import_table()`, its `methodFullName` is never set, remaining `<unknownFullName>`. Turns out, `PythonTypeHintCallLinker` was filtering it out because of its name.

Credit for finding this edge case: @tajobe