### PR TITLE
[dataflowengineoss] composable semantics

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/semanticsloader/Semantics.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/semanticsloader/Semantics.scala
@@ -2,22 +2,86 @@ package io.joern.dataflowengineoss.semanticsloader
 
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Method
+import io.shiftleft.semanticcpg.language.*
 
 trait Semantics {
 
   /** Useful for `Semantics` that benefit from having some kind of internal state tailored to the current CPG.
     */
-  def initialize(cpg: Cpg): Unit
+  def initialize(cpg: Cpg): Unit = {}
 
   def forMethod(method: Method): Option[FlowSemantic]
+
+  /** Builds a new `Semantics` whose `forMethod` behaviour first lookups in `other` and only if it fails (i.e. returns
+    * `None`) lookups in the current one.
+    */
+  def after(other: Semantics): Semantics = Semantics.compose(this, other)
 }
 
-/** The empty Semantics */
+object Semantics {
+
+  private def compose(first: Semantics, second: Semantics): Semantics = new Semantics {
+
+    override def initialize(cpg: Cpg): Unit = {
+      second.initialize(cpg)
+      first.initialize(cpg)
+    }
+
+    override def forMethod(method: Method): Option[FlowSemantic] =
+      second.forMethod(method).orElse { first.forMethod(method) }
+  }
+}
+
+/** The empty Semantics, whose `forMethod` always fails, i.e. the identity under `Semantics.after`. */
 object NoSemantics extends Semantics {
 
-  override def initialize(cpg: Cpg): Unit = {}
-
   override def forMethod(method: Method): Option[FlowSemantic] = None
+}
+
+/** The nil Semantics, whose `forMethod` always succeeds but returns the empty (nil) mapping. */
+object NilSemantics {
+
+  /** Builds a universal nil semantics. Beware this is right-absorbing under `Semantics.after`. */
+  def apply(): Semantics = new Semantics {
+    override def forMethod(method: Method): Option[FlowSemantic] = Some(FlowSemantic(method.fullName, List.empty))
+  }
+
+  /** Extensionally builds a nil semantics. */
+  def where(methodFullNames: List[String], regex: Boolean = false): Semantics =
+    FullNameSemantics.fromList(methodFullNames.map {
+      FlowSemantic(_, List.empty, regex)
+    })
+
+  /** Intensionally builds a nil semantics. */
+  def where(predicate: Method => Boolean): Semantics = new Semantics {
+    override def forMethod(method: Method): Option[FlowSemantic] = Option.when(predicate(method)) {
+      FlowSemantic(method.fullName, List.empty)
+    }
+  }
+}
+
+/** Semantics whose mappings are: 0->0, PassThroughMapping. */
+object NoCrossTaintSemantics {
+
+  /** Builds a universal no-cross-taint semantics. Beware this is right-absorbing under `Semantics.after`. */
+  def apply(): Semantics = new Semantics {
+    override def forMethod(method: Method): Option[FlowSemantic] = Some(
+      FlowSemantic(method.fullName, List(FlowMapping(0, 0), PassThroughMapping))
+    )
+  }
+
+  /** Extensionally builds a no-cross-taint semantics. */
+  def where(methodFullNames: List[String], regex: Boolean = false): Semantics =
+    FullNameSemantics.fromList(methodFullNames.map {
+      FlowSemantic(_, List(FlowMapping(0, 0), PassThroughMapping), regex)
+    })
+
+  /** Intensionally builds a no-cross-taint semantics. */
+  def where(predicate: Method => Boolean): Semantics = new Semantics {
+    override def forMethod(method: Method): Option[FlowSemantic] = Option.when(predicate(method)) {
+      FlowSemantic(method.fullName, List(FlowMapping(0, 0), PassThroughMapping))
+    }
+  }
 }
 
 case class FlowSemantic(methodFullName: String, mappings: List[FlowPath] = List.empty, regex: Boolean = false)


### PR DESCRIPTION
* Allows one to compose arbitrary `Semantics` at runtime, cf. the newly introduced `Semantics.after`, with `NoSemantics` as the identity.
* Identifies `NilSemantics`, which under the current engine seems to work as "negative semantics", removing any potential flows that would otherwise be created. I can't say I have it fully covered yet, but fwiw that's my interpretation at the moment.
* Introduces `NoCrossTaintSemantics`, which can be built both extensionally/intensionally, allowing one to, for instance, specify that an entire external library should have this kind of semantics.

`pysrc2cpg` was the frontend I used for testing them, but only because that's the frontend I was playing with. There's no other reason for not testing with other frontends.