### PR TITLE
Set PHP static initalizer offsets to the whole file

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -810,6 +810,14 @@ class AstCreator(relativeFileName: String, fileName: String, phpAst: PhpFile, di
         val fullName  = composeMethodFullName(StaticInitMethodName, isStatic = true)
         val ast =
           staticInitMethodAst(inits, fullName, Option(signature), TypeConstants.Void, fileName = Some(relativeFileName))
+
+        for {
+          method  <- ast.root.collect { case method: NewMethod => method }
+          content <- fileContent
+        } {
+          method.offset(0)
+          method.offsetEnd(content.length)
+        }
         Option(ast)
     }
 


### PR DESCRIPTION
This is a hack to fix an autofix issue. The `offset` and `offsetEnd` properties aren't set for the static init method since there aren't always sensible values to set these to, but since they weren't external, autofix was expecting this.

Some backend passes may be affected by this too 