### PR TITLE
[ruby] Add `IndexAccess` for `.[](index)` notation

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/antlr4/io/joern/rubysrc2cpg/parser/RubyParser.g4
@@ -117,6 +117,7 @@ methodName
     :   methodIdentifier
     |   keyword
     |   pseudoVariable
+    |   LBRACK RBRACK
     ;
 
 methodOnlyIdentifier

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyNodeCreator.scala
@@ -922,6 +922,7 @@ class RubyNodeCreator(
       Option(ctx.primaryValue()).map(_.getText).contains("Class") && Option(ctx.methodName())
         .map(_.getText)
         .contains("new")
+
     val methodName = ctx.methodName().getText
 
     if (!hasBlock) {
@@ -943,7 +944,8 @@ class RubyNodeCreator(
           }
         } else {
           val args = ctx.argumentWithParentheses().arguments.map(visit)
-          return MemberCall(target, ctx.op.getText, methodName, args)(ctx.toTextSpan)
+          if methodName == "[]" then return IndexAccess(target, args)(ctx.toTextSpan)
+          else return MemberCall(target, ctx.op.getText, methodName, args)(ctx.toTextSpan)
         }
       }
     }


### PR DESCRIPTION
Added check to `visitMemberAccessExpression` to modify `.[](index)` notation to an `IndexAccess`.