### PR TITLE
[ruby] Ignore "Throwaway" AST Structures

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -92,16 +92,20 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
   protected def astForDoBlock(block: Block & RubyExpression): Seq[Ast] = {
     // Create closure structures: [MethodDecl, TypeRef, MethodRef]
-    val methodName = nextClosureName()
+    if (closureToRefs.contains(block)) {
+      closureToRefs(block)
+    } else {
+      val methodName = nextClosureName()
 
-    val methodAstsWithRefs = block.body match {
-      case x: Block =>
-        astForMethodDeclaration(x.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
-      case _ =>
-        astForMethodDeclaration(block.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
+      val methodAstsWithRefs = block.body match {
+        case x: Block =>
+          astForMethodDeclaration(x.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
+        case _ =>
+          astForMethodDeclaration(block.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
+      }
+      closureToRefs.put(block, methodAstsWithRefs)
+      methodAstsWithRefs
     }
-
-    methodAstsWithRefs
   }
 
   protected def astForReturnExpression(node: ReturnExpression): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -401,7 +401,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     inside(cpg.local.l) {
-      case jfsOutsideLocal :: hashInsideLocal :: jfsCapturedLocal :: tmp0 :: tmp1 :: Nil =>
+      case jfsOutsideLocal :: hashInsideLocal :: tmp0 :: jfsCapturedLocal :: tmp1 :: Nil =>
         jfsOutsideLocal.closureBindingId shouldBe None
         hashInsideLocal.closureBindingId shouldBe None
         jfsCapturedLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.jfs")
@@ -412,7 +412,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     inside(cpg.method.isLambda.local.l) {
-      case hashLocal :: jfsLocal :: _ :: Nil =>
+      case hashLocal :: _ :: jfsLocal :: Nil =>
         hashLocal.closureBindingId shouldBe None
         jfsLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.jfs")
       case xs => fail(s"Expected 3 locals in lambda, got ${xs.code.mkString(",")}")


### PR DESCRIPTION
Sometimes AST trees would be thrown away, specifically when long chained expressions would be compressed into temporary cache variables. Sometimes the ASTs that are thrown away, have nodes directly written to the diff graph. This only happens with expressions, and closures typically write directly to the diff graph.

This PR minimizes what is written directly to the diff graph from function creation, and extends `x2cpg.Ast` to also include `CAPTURE` edges. This also introduces `closureToRefs` map to track which `Block` nodes already have live method ASTs in the diff graph.