### PR TITLE
[ruby] Re-implemented "Ignore "Throwaway" AST Structures (#4982)"

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -26,10 +26,10 @@ import scala.collection.mutable
 
 trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  /** As expressions may be discarded, we cannot store closure ASTs in the diffgraph at the point of creation. We need
-    * to only write these at the end.
+  /** As expressions may be discarded, we cannot store closure ASTs in the diffgraph at the point of creation. So we
+    * assume every reference to this map means that the closure AST was successfully propagated.
     */
-  protected val closureToRefs = mutable.Map.empty[RubyExpression, Seq[Ast]]
+  protected val closureToRefs = mutable.Map.empty[RubyExpression, Seq[NewNode]]
 
   /** Creates method declaration related structures.
     * @param node

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -92,16 +92,20 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
   protected def astForDoBlock(block: Block & RubyExpression): Seq[Ast] = {
     // Create closure structures: [MethodDecl, TypeRef, MethodRef]
-    val methodName = nextClosureName()
+    if (closureToRefs.contains(block)) {
+      closureToRefs(block)
+    } else {
+      val methodName = nextClosureName()
 
-    val methodAstsWithRefs = block.body match {
-      case x: Block =>
-        astForMethodDeclaration(x.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
-      case _ =>
-        astForMethodDeclaration(block.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
+      val methodAstsWithRefs = block.body match {
+        case x: Block =>
+          astForMethodDeclaration(x.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
+        case _ =>
+          astForMethodDeclaration(block.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
+      }
+      closureToRefs.put(block, methodAstsWithRefs)
+      methodAstsWithRefs
     }
-
-    methodAstsWithRefs
   }
 
   protected def astForReturnExpression(node: ReturnExpression): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -93,18 +93,18 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   protected def astForDoBlock(block: Block & RubyExpression): Seq[Ast] = {
     // Create closure structures: [MethodDecl, TypeRef, MethodRef]
     if (closureToRefs.contains(block)) {
-      closureToRefs(block)
+      closureToRefs(block).map(x => Ast(x.copy))
     } else {
       val methodName = nextClosureName()
 
-      val methodAstsWithRefs = block.body match {
+      val methodRefAsts = block.body match {
         case x: Block =>
           astForMethodDeclaration(x.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
         case _ =>
           astForMethodDeclaration(block.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)
       }
-      closureToRefs.put(block, methodAstsWithRefs)
-      methodAstsWithRefs
+      closureToRefs.put(block, methodRefAsts.flatMap(_.root))
+      methodRefAsts
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -401,7 +401,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     inside(cpg.local.l) {
-      case jfsOutsideLocal :: hashInsideLocal :: jfsCapturedLocal :: tmp0 :: tmp1 :: Nil =>
+      case jfsOutsideLocal :: hashInsideLocal :: tmp0 :: jfsCapturedLocal :: tmp1 :: Nil =>
         jfsOutsideLocal.closureBindingId shouldBe None
         hashInsideLocal.closureBindingId shouldBe None
         jfsCapturedLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.jfs")
@@ -412,7 +412,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     inside(cpg.method.isLambda.local.l) {
-      case hashLocal :: jfsLocal :: _ :: Nil =>
+      case hashLocal :: _ :: jfsLocal :: Nil =>
         hashLocal.closureBindingId shouldBe None
         jfsLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.jfs")
       case xs => fail(s"Expected 3 locals in lambda, got ${xs.code.mkString(",")}")


### PR DESCRIPTION
This correctly prevents re-use of nodes that are already being used elsewhere by ensuring deep copies.