### PR TITLE
[ruby] Implement `hashCode` for `RubyExpression`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -91,12 +91,11 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   protected def astForDoBlock(block: Block & RubyExpression): Seq[Ast] = {
-    // Create closure structures: [MethodDecl, TypeRef, MethodRef]
     if (closureToRefs.contains(block)) {
       closureToRefs(block).map(x => Ast(x.copy))
     } else {
       val methodName = nextClosureName()
-
+      // Create closure structures: [TypeRef, MethodRef]
       val methodRefAsts = block.body match {
         case x: Block =>
           astForMethodDeclaration(x.toMethodDeclaration(methodName, Option(block.parameters)), isClosure = true)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -34,6 +34,13 @@ object RubyIntermediateAst {
     def text: String = span.text
 
     override def hashCode(): Int = Objects.hash(span)
+
+    override def equals(obj: Any): Boolean = {
+      obj match {
+        case o: RubyExpression => o.span == span
+        case _                 => false
+      }
+    }
   }
 
   /** Ruby statements evaluate to some value (and thus are expressions), but also perform some operation, e.g.,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -1,10 +1,9 @@
 package io.joern.rubysrc2cpg.astcreation
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{AllowedTypeDeclarationChild, RubyStatement}
 import io.joern.rubysrc2cpg.passes.{Defines, GlobalTypes}
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 
-import scala.annotation.tailrec
+import java.util.Objects
 
 object RubyIntermediateAst {
 
@@ -33,6 +32,8 @@ object RubyIntermediateAst {
     def offset: Option[(Int, Int)] = span.offset
 
     def text: String = span.text
+
+    override def hashCode(): Int = Objects.hash(span)
   }
 
   /** Ruby statements evaluate to some value (and thus are expressions), but also perform some operation, e.g.,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -1000,5 +1000,15 @@ class MethodTests extends RubyCode2CpgFixture {
       cpg.typeRef.typeFullName(".*Proc").size shouldBe 5
       cpg.typeRef.whereNot(_.astParent).size shouldBe 0
     }
+
+    "resolve cached lambdas correctly" in {
+      def getLineNumberOfLambdaForCall(callName: String) =
+        cpg.call.nameExact(callName).argument.isTypeRef.typ.referencedTypeDecl.lineNumber.head
+
+      getLineNumberOfLambdaForCall("with_index") shouldBe 3
+      getLineNumberOfLambdaForCall("sort_by") shouldBe 4
+      getLineNumberOfLambdaForCall("reject") shouldBe 5
+      getLineNumberOfLambdaForCall("map") shouldBe 6
+    }
   }
 }


### PR DESCRIPTION
 `RubyExpression` nodes don't inherently consider the `span` in the calculation of its hash, so when put into any hashed context, nodes that only rely on `span` alone will collide in these contexts.