### PR TITLE
[go] Use internal fork for `goastgen`

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/build.sbt
+++ b/joern-cli/frontends/gosrc2cpg/build.sbt
@@ -37,7 +37,7 @@ lazy val GoAstgenMac      = "goastgen-macos"
 lazy val GoAstgenMacArm   = "goastgen-macos-arm64"
 
 lazy val goAstGenDlUrl = settingKey[String]("goastgen download url")
-goAstGenDlUrl := s"https://github.com/Privado-Inc/goastgen/releases/download/v${goAstGenVersion.value}/"
+goAstGenDlUrl := s"https://github.com/joernio/goastgen/releases/download/v${goAstGenVersion.value}/"
 
 def hasCompatibleAstGenVersion(goAstGenVersion: String): Boolean = {
   Try("goastgen -version".!!).toOption.map(_.strip()) match {

--- a/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/gosrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 gosrc2cpg {
-    goastgen_version: "0.17.0"
+    goastgen_version: "0.1.0"
 }


### PR DESCRIPTION
Created fork under `joernio` orginazation for `goastgen`. Updated build file to reference the new forked repository.

Resolves #4931 