### PR TITLE
[c2cpg] Implemented cached header file loading

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -30,9 +30,13 @@ object CdtParser {
     failure: Option[Throwable] = None
   )
 
-  def readFileAsFileContent(path: Path): FileContent = {
+  def loadLinesAsFileContent(path: Path, lines: Array[Char]): InternalFileContent = {
+    FileContent.create(path.toString, true, lines).asInstanceOf[InternalFileContent]
+  }
+
+  def readFileAsFileContent(path: Path): InternalFileContent = {
     val lines = IOUtils.readLinesInFile(path).mkString("\n").toArray
-    FileContent.create(path.toString, true, lines)
+    loadLinesAsFileContent(path, lines)
   }
 
 }
@@ -97,8 +101,8 @@ class CdtParser(config: Config) extends ParseProblemsLogger with PreprocessorSta
       try {
         val fileContent         = readFileAsFileContent(realPath.path)
         val fileContentProvider = new CustomFileContentProvider(headerFileFinder)
-        val lang            = createParseLanguage(realPath.path, fileContent.asInstanceOf[InternalFileContent].toString)
-        val scannerInfo     = createScannerInfo(realPath.path)
+        val lang                = createParseLanguage(realPath.path, fileContent.toString)
+        val scannerInfo         = createScannerInfo(realPath.path)
         val translationUnit = lang.getASTTranslationUnit(fileContent, scannerInfo, fileContentProvider, null, opts, log)
         val problems        = CPPVisitor.getProblems(translationUnit)
         if (parserConfig.logProblems) logProblems(problems.toList)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
@@ -1,5 +1,6 @@
 package io.joern.c2cpg.parser
 
+import io.joern.c2cpg.parser.CustomFileContentProvider.missingHeaderFiles
 import io.shiftleft.utils.IOUtils
 import org.eclipse.cdt.core.index.IIndexFileLocation
 import org.eclipse.cdt.internal.core.parser.IMacroDictionary
@@ -11,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 object CustomFileContentProvider {
   private val headerFileToLines: ConcurrentHashMap[String, Array[Char]] = new ConcurrentHashMap()
+  private val missingHeaderFiles: ConcurrentHashMap[String, Boolean]    = new ConcurrentHashMap()
 }
 
 class CustomFileContentProvider(headerFileFinder: HeaderFileFinder) extends InternalFileContentProvider {
@@ -38,7 +40,13 @@ class CustomFileContentProvider(headerFileFinder: HeaderFileFinder) extends Inte
         CdtParser.loadLinesAsFileContent(p, content)
       }
       .getOrElse {
-        logger.debug(s"Cannot find header file for '$path'")
+        missingHeaderFiles.computeIfAbsent(
+          path,
+          _ => {
+            logger.debug(s"Cannot find header file for '$path'")
+            true
+          }
+        )
         null
       }
 


### PR DESCRIPTION
Needs some testing for (very) large projects.
Caching all the header file contents may make things worse compared to (re-) reading them from disk and GC immediately/soonish. 