### PR TITLE
[kotlin2cpg] Fix assertion error by locking descriptorRenderer options

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -23,4 +23,5 @@ libraryDependencies ++= Seq(
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 trapExit    := false
-Test / fork := false
+Test / fork := true
+Test / javaOptions ++= Seq("-ea")

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeRenderer.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeRenderer.scala
@@ -44,6 +44,7 @@ class TypeRenderer(val keepTypeArguments: Boolean = false) {
       case _: ErrorType => cpgUnresolvedType
       case t            => t
     }
+    opts.lock()
     new DescriptorRendererImpl(opts)
   }
 


### PR DESCRIPTION
DescriptorRendererImpl [asserts that the options are locked upon init](https://github.com/JetBrains/kotlin/blob/master/core/descriptors/src/org/jetbrains/kotlin/renderer/DescriptorRendererImpl.kt#L36). This means that the type rendering will fail anywhere with assertions enabled (`-ea` JVM option) as the options weren't being locked after setup.

In order to test this, I added `-ea` to the test javaOptions (which requires `Test/fork` to be `true`) and things fail. With the addition of `opts.lock()`, they pass. I'm not sure if there's a reason the tests were explicitly set to not fork or if there's a desire to keep the javaOpts "clean", but this was the easiest way to illustrate the error and fix.