### PR TITLE
[dataflowengineoss] Fix PassThroughMapping criteria for same-call named arguments

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
@@ -64,8 +64,8 @@ class ExpressionMethods[NodeType <: Expression](val node: NodeType) extends AnyV
           srcIndex == node.argumentIndex && dstName == tgt.argumentName.get
         case FlowMapping(ParameterNode(srcIndex, _), ParameterNode(dstIndex, _)) =>
           srcIndex == node.argumentIndex && dstIndex == tgt.argumentIndex
-        case PassThroughMapping if tgt.argumentIndex == node.argumentIndex || tgt.argumentIndex == -1 => true
-        case _                                                                                        => false
+        case PassThroughMapping => node.argumentIndex == tgt.argumentIndex && node.argumentName == tgt.argumentName
+        case _                  => false
       }
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -1028,7 +1028,7 @@ class NoCrossTaintDataFlowTest1
         |""".stripMargin)
     val source = cpg.literal.lineNumber(3, 4)
     val sink   = cpg.call("print").argument
-    sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
+    sink.reachableByFlows(source).map(flowToResultPairs).sorted shouldBe List(
       List(("a = 1", 3), ("bar.foo(b, X = a)", 5), ("c = bar.foo(b, X = a)", 5), ("print(c)", 6)),
       List(("b = 2", 4), ("bar.foo(b, X = a)", 5), ("c = bar.foo(b, X = a)", 5), ("print(c)", 6))
     )


### PR DESCRIPTION
It's been observed some time ago that `PassThroughMapping` wasn't behaving as expected when there were named arguments involved. For instance, see the first two added unit-tests: they were failing while the semantics for `foo` were `0->0, PassThroughMapping`.

The criteria for `hasDefinedFlowTo` was, in the same vein of #5000, not taking into account the fact that named arguments share the same index, even if their argument names are different.