### PR TITLE
[test] remove leftover `println`

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ClassLoaderTypeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ClassLoaderTypeTests.scala
@@ -48,7 +48,6 @@ class ClassLoaderTypeTests extends JavaSrcCode2CpgFixture {
     }
 
     "be resolved by the system classloader (java 17)" in {
-      println(System.getProperty("java.version"))
       val cpg = code(testCode)
 
       cpg.call.name("getIconHeight").methodFullName.head.startsWith("<unresolved") shouldBe false

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/LocalTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/LocalTests.scala
@@ -71,7 +71,6 @@ class LocalTests extends PhpCode2CpgFixture {
           |  }
           |}
           |""".stripMargin)
-    println(cpg.local.name.l)
     inside(cpg.local.l) { case List(xLocal) =>
       xLocal.name shouldBe "x"
       xLocal.code shouldBe "static $x"

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeNodeTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeNodeTests.scala
@@ -29,7 +29,6 @@ class TypeNodeTests extends PhpCode2CpgFixture {
         |""".stripMargin)
 
     "have corresponding type nodes created" in {
-      println(cpg.literal.toList)
       cpg.typ.fullName.toSet shouldEqual Set("ANY", "int")
     }
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
@@ -70,8 +70,6 @@ class TypeTests extends AnyWordSpec with Matchers {
           .name(".*Base")
           .toList
 
-      cpg.typeDecl.name(".*Derived").baseTypeDecl.foreach(println)
-
       queryResult.size shouldBe 1
     }
 


### PR DESCRIPTION
While waiting for another PR job to conclude, noticed some "garbage" in the logs. Tidying them up a little bit...