### PR TITLE
[c2cpg] Implemented support for JSON Compilation Database Files

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -99,9 +99,9 @@ private object Frontend {
         .text("instructs the parser to skip function and method bodies.")
         .action((_, c) => c.withSkipFunctionBodies(true)),
       opt[Unit]("no-image-locations")
-        .text(
-          "performance optimization, allows the parser not to create image-locations. An image location explains how a name made it into the translation unit. Eg: via macro expansion or preprocessor."
-        )
+        .text("""performance optimization, allows the parser not to create image-locations.
+            | An image location explains how a name made it into the translation unit.
+            | E.g., via macro expansion or preprocessor.""".stripMargin)
         .action((_, c) => c.withNoImageLocations(true)),
       opt[Unit]("with-preprocessed-files")
         .text("includes *.i files and gives them priority over their unprocessed origin source files.")
@@ -111,7 +111,12 @@ private object Frontend {
         .text("define a name")
         .action((d, c) => c.withDefines(c.defines + d)),
       opt[String]("compilation-database")
-        .text("use this compilation database file (only handles files and compile settings listed in this file")
+        .text("""enables the processing of compilation database files (e.g., compile_commands.json).
+            | This allows to automatically extract compiler options, source files, and other build information from the specified database
+            | and ensuring consistency with the build configuration.
+            | For a cmake based build such a file is generated with the environment variable CMAKE_EXPORT_COMPILE_COMMANDS being present.
+            | Clang based build are supported e.g., with https://github.com/rizsotto/Bear
+            | """.stripMargin)
         .action((d, c) => c.withCompilationDatabase(SourceFiles.toAbsolutePath(d, c.inputPath)))
     )
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -3,6 +3,7 @@ package io.joern.c2cpg
 import io.joern.c2cpg.Frontend.*
 import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import io.joern.x2cpg.utils.server.FrontendHTTPServer
+import io.joern.x2cpg.SourceFiles
 import org.slf4j.LoggerFactory
 import scopt.OParser
 
@@ -16,7 +17,8 @@ final case class Config(
   includePathsAutoDiscovery: Boolean = false,
   skipFunctionBodies: Boolean = false,
   noImageLocations: Boolean = false,
-  withPreprocessedFiles: Boolean = false
+  withPreprocessedFiles: Boolean = false,
+  compilationDatabase: Option[String] = None
 ) extends X2CpgConfig[Config] {
   def withIncludePaths(includePaths: Set[String]): Config = {
     this.copy(includePaths = includePaths).withInheritedFields(this)
@@ -56,6 +58,10 @@ final case class Config(
 
   def withPreprocessedFiles(value: Boolean): Config = {
     this.copy(withPreprocessedFiles = value).withInheritedFields(this)
+  }
+
+  def withCompilationDatabase(value: String): Config = {
+    this.copy(compilationDatabase = Some(value)).withInheritedFields(this)
   }
 }
 
@@ -103,7 +109,10 @@ private object Frontend {
       opt[String]("define")
         .unbounded()
         .text("define a name")
-        .action((d, c) => c.withDefines(c.defines + d))
+        .action((d, c) => c.withDefines(c.defines + d)),
+      opt[String]("compilation-database")
+        .text("use this compilation database file (only handles files and compile settings listed in this file")
+        .action((d, c) => c.withCompilationDatabase(SourceFiles.toAbsolutePath(d, c.inputPath)))
     )
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -42,7 +42,7 @@ class AstCreator(
   protected val usingDeclarationMappings: mutable.Map[String, String] = mutable.HashMap.empty
 
   // TypeDecls with their bindings (with their refs) for lambdas and methods are not put in the AST
-  // where the respective nodes are defined. Instead we put them under the parent TYPE_DECL in which they are defined.
+  // where the respective nodes are defined. Instead, we put them under the parent TYPE_DECL in which they are defined.
   // To achieve this we need this extra stack.
   protected val methodAstParentStack: Stack[NewNode] = new Stack()
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -191,7 +191,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     // We only handle un-parsable macros here for now
     val isFromMacroExpansion = statement.getProblem.getNodeLocations.exists(_.isInstanceOf[IASTMacroExpansionLocation])
     val asts = if (isFromMacroExpansion) {
-      new CdtParser(config).parse(statement.getRawSignature, Paths.get(statement.getContainingFilename)) match
+      new CdtParser(config, List.empty)
+        .parse(statement.getRawSignature, Paths.get(statement.getContainingFilename)) match
         case Some(node) => node.getDeclarations.toIndexedSeq.flatMap(astsForDeclaration)
         case None       => Seq.empty
     } else {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/JSONCompilationDatabaseParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/JSONCompilationDatabaseParser.scala
@@ -1,0 +1,97 @@
+package io.joern.c2cpg.parser
+
+import io.joern.x2cpg.SourceFiles
+import io.shiftleft.utils.IOUtils
+import org.slf4j.LoggerFactory
+import ujson.Value
+
+import java.nio.file.Paths
+import scala.util.Try
+
+object JSONCompilationDatabaseParser {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /** {{{
+    * 1) -D: Matches the -D flag, which is the key prefix for defining macros.
+    * 2) ([A-Za-z_][A-Za-z0-9_]+): Matches a valid macro name (which must start with a letter or underscore and can be followed by letters, numbers, or underscores).
+    * 3) (=(\\*".*"))?: Optionally matches = followed by either:
+    *  a) A quoted string: Allows for strings in quotes.
+    *  b) Any char sequence (.*") closed with a quote.
+    * }}}
+    */
+  private val defineInCommandPattern = """-D([A-Za-z_][A-Za-z0-9_]+)(=(\\*".*"))?""".r
+
+  /** {{{
+    * 1) -I: Matches the -I flag, which indicates an include directory.
+    * 2) (\S+): Matches one or more non-whitespace characters, which represent the path of the directory.
+    * }}}
+    */
+  private val includeInCommandPattern = """-I(\S+)""".r
+
+  case class CommandObject(directory: String, arguments: List[String], command: List[String], file: String) {
+
+    /** @return
+      *   the file path (guaranteed to be absolute)
+      */
+    def compiledFile(): String = SourceFiles.toAbsolutePath(file, directory)
+
+    private def nameValuePairFromDefine(define: String): (String, String) = {
+      val s = define.stripPrefix("-D")
+      if (s.contains("=")) {
+        val split = s.split("=")
+        (split.head, split(1))
+      } else {
+        (s, "")
+      }
+    }
+
+    private def pathFromInclude(include: String): String = include.stripPrefix("-I")
+
+    def includes(): List[String] = {
+      val includesFromArguments = arguments.filter(a => a.startsWith("-I")).map(pathFromInclude)
+      val includesFromCommand = command.flatMap { c =>
+        val includes = includeInCommandPattern.findAllIn(c).toList
+        includes.map(pathFromInclude)
+      }
+      includesFromArguments ++ includesFromCommand
+    }
+
+    def defines(): List[(String, String)] = {
+      val definesFromArguments = arguments.filter(a => a.startsWith("-D")).map(nameValuePairFromDefine)
+      val definesFromCommand = command.flatMap { c =>
+        val defines = defineInCommandPattern.findAllIn(c).toList
+        defines.map(nameValuePairFromDefine)
+      }
+      definesFromArguments ++ definesFromCommand
+    }
+  }
+
+  private def hasKey(node: Value, key: String): Boolean = Try(node(key)).isSuccess
+
+  private def safeArguments(obj: Value): List[String] = {
+    if (hasKey(obj, "arguments")) obj("arguments").arrOpt.map(_.toList.map(_.str)).getOrElse(List.empty)
+    else List.empty
+  }
+
+  private def safeCommand(obj: Value): List[String] = {
+    if (hasKey(obj, "command")) List(obj("command").str)
+    else List.empty
+  }
+
+  def parse(compileCommandsJson: String): List[CommandObject] = {
+    try {
+      val jsonContent       = IOUtils.readEntireFile(Paths.get(compileCommandsJson))
+      val json              = ujson.read(jsonContent)
+      val allCommandObjects = json.arr.toList
+      allCommandObjects.map { obj =>
+        CommandObject(obj("directory").str, safeArguments(obj), safeCommand(obj), obj("file").str)
+      }
+    } catch {
+      case t: Throwable =>
+        logger.warn(s"Could not parse '$compileCommandsJson'", t)
+        List.empty
+    }
+  }
+
+}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
@@ -1,6 +1,7 @@
 package io.joern.c2cpg.parser
 
 import io.joern.c2cpg.Config
+import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CommandObject
 import io.joern.c2cpg.utils.IncludeAutoDiscovery
 
 import java.nio.file.{Path, Paths}
@@ -8,21 +9,42 @@ import java.nio.file.{Path, Paths}
 object ParserConfig {
 
   def empty: ParserConfig =
-    ParserConfig(Set.empty, Set.empty, Set.empty, Map.empty, logProblems = false, logPreprocessor = false)
+    ParserConfig(
+      Set.empty,
+      Set.empty,
+      Set.empty,
+      Map.empty,
+      Map.empty,
+      Map.empty,
+      logProblems = false,
+      logPreprocessor = false
+    )
 
-  def fromConfig(config: Config): ParserConfig = ParserConfig(
-    config.includePaths.map(Paths.get(_).toAbsolutePath),
-    IncludeAutoDiscovery.discoverIncludePathsC(config),
-    IncludeAutoDiscovery.discoverIncludePathsCPP(config),
-    config.defines.map {
-      case define if define.contains("=") =>
-        val s = define.split("=")
-        s.head -> s(1)
-      case define => define -> "true"
-    }.toMap ++ DefaultDefines.DEFAULT_CALL_CONVENTIONS,
-    config.logProblems,
-    config.logPreprocessor
-  )
+  def fromConfig(config: Config, compilationDatabase: List[CommandObject]): ParserConfig = {
+    val compilationDatabaseDefines = compilationDatabase.map { c =>
+      c.compiledFile() -> c.defines().toMap
+    }.toMap
+    val includes = compilationDatabase.map { c =>
+      c.compiledFile() -> c.includes()
+    }.toMap
+    ParserConfig(
+      config.includePaths.map(Paths.get(_).toAbsolutePath),
+      IncludeAutoDiscovery.discoverIncludePathsC(config),
+      IncludeAutoDiscovery.discoverIncludePathsCPP(config),
+      config.defines.map { define =>
+        if (define.contains("=")) {
+          val split = define.split("=")
+          split.head -> split(1)
+        } else {
+          define -> ""
+        }
+      }.toMap ++ DefaultDefines.DEFAULT_CALL_CONVENTIONS,
+      compilationDatabaseDefines,
+      includes,
+      config.logProblems,
+      config.logPreprocessor
+    )
+  }
 
 }
 
@@ -31,6 +53,8 @@ case class ParserConfig(
   systemIncludePathsC: Set[Path],
   systemIncludePathsCPP: Set[Path],
   definedSymbols: Map[String, String],
+  definedSymbolsPerFile: Map[String, Map[String, String]],
+  includesPerFile: Map[String, List[String]],
   logProblems: Boolean,
   logPreprocessor: Boolean
 )

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/JSONCompilationDatabaseParserTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/JSONCompilationDatabaseParserTests.scala
@@ -1,0 +1,114 @@
+package io.joern.c2cpg.io
+
+import better.files.File
+import io.joern.c2cpg.parser.JSONCompilationDatabaseParser
+import io.joern.c2cpg.C2Cpg
+import io.joern.c2cpg.Config
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Paths
+
+class JSONCompilationDatabaseParserTests extends AnyWordSpec with Matchers {
+
+  "Parsing a simple compile_commands.json" should {
+    "generate a proper list of CommandObjects" in {
+      val content =
+        """
+          |[
+          |  { "directory": "/home/user/llvm/build",
+          |    "arguments": ["/usr/bin/clang++", "-I/usr/include", "-I./include", "-DSOMEDEFA=With spaces, quotes and \\-es.", "-c", "-o", "file.o", "file.cc"],
+          |    "file": "file.cc" },
+          |  { "directory": "/home/user/llvm/build",
+          |    "command": "/usr/bin/clang++ -I/home/user/project/includes -DSOMEDEFB=\"With spaces, quotes and \\-es.\" -DSOMEDEFC -c -o file.o file.cc",
+          |    "file": "file2.cc" }
+          |]""".stripMargin
+
+      File.usingTemporaryFile("compile_commands.json") { commandJsonFile =>
+        commandJsonFile.writeText(content)
+
+        val commandObjects = JSONCompilationDatabaseParser.parse(commandJsonFile.pathAsString)
+        commandObjects.map(_.compiledFile()) shouldBe List(
+          Paths.get("/home/user/llvm/build/file.cc").toString,
+          Paths.get("/home/user/llvm/build/file2.cc").toString
+        )
+        commandObjects.flatMap(_.defines()) shouldBe List(
+          ("SOMEDEFA", "With spaces, quotes and \\-es."),
+          ("SOMEDEFB", "\"With spaces, quotes and \\-es.\""),
+          ("SOMEDEFC", "")
+        )
+        commandObjects.flatMap(_.includes()) shouldBe List("/usr/include", "./include", "/home/user/project/includes")
+      }
+    }
+  }
+
+  private def newProjectUnderTest(): File = {
+    val dir = File.newTemporaryDirectory("c2cpgJSONCompilationDatabaseParserTests")
+
+    val mainText =
+      """
+        |int main(int argc, char *argv[]) {
+        |  print("Hello World!");
+        |}
+        |#ifdef SOMEDEFA
+        |void foo() {}
+        |#endif
+        |#ifdef SOMEDEFC
+        |void bar() {}
+        |#endif
+        |""".stripMargin
+
+    val fileA = dir / "fileA.c"
+    fileA.createIfNotExists(createParents = true)
+    fileA.writeText(mainText)
+    fileA.deleteOnExit()
+    val fileB = dir / "fileB.c"
+    fileB.createIfNotExists(createParents = true)
+    fileB.writeText(mainText)
+    fileB.deleteOnExit()
+    val fileC = dir / "fileC.c"
+    fileC.createIfNotExists(createParents = true)
+    fileC.writeText(mainText)
+    fileC.deleteOnExit()
+
+    val compilerCommands = dir / "compile_commands.json"
+    compilerCommands.createIfNotExists(createParents = true)
+    val content = s"""
+       |[
+       |  { "directory": "${dir.pathAsString}",
+       |    "arguments": ["/usr/bin/clang++", "-Irelative", "-DSOMEDEFA=With spaces, quotes and \\-es.", "-c", "-o", "fileA.o", "fileA.cc"],
+       |    "file": "fileA.c" },
+       |  { "directory": ".",
+       |    "arguments": ["/usr/bin/clang++", "-Irelative", "-DSOMEDEFB=With spaces, quotes and \\-es.", "-c", "-o", "fileB.o", "fileB.cc"],
+       |    "file": "${fileB.pathAsString}" }
+       |]""".stripMargin.replace("\\", "\\\\") // escape for tests under Windows
+    compilerCommands.writeText(content)
+    compilerCommands.deleteOnExit()
+
+    dir.deleteOnExit()
+  }
+
+  "Using a simple compile_commands.json" should {
+    "respect the files listed" in {
+      val cpgOutFile = File.newTemporaryFile("c2cpg.bin")
+      cpgOutFile.deleteOnExit()
+      val projectUnderTest = newProjectUnderTest()
+      val input            = projectUnderTest.path.toAbsolutePath.toString
+      val output           = cpgOutFile.toString
+      val config = Config()
+        .withInputPath(input)
+        .withOutputPath(output)
+        .withCompilationDatabase((File(input) / "compile_commands.json").pathAsString)
+      val c2cpg = new C2Cpg()
+      val cpg   = c2cpg.createCpg(config).get
+      cpg.file.nameNot(FileTraversal.UNKNOWN, "<includes>").name.sorted.l should contain theSameElementsAs List(
+        "fileA.c",
+        "fileB.c"
+        // fileC.c is ignored because it is not listed in the compile_commands.json
+      )
+      cpg.method.nameNot("<global>").name.sorted.l shouldBe List("foo", "main", "main")
+    }
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -106,7 +106,7 @@ object SourceFiles {
     && !ignoredFilesRegex.exists(isIgnoredByRegex(file, inputPath, _))
     && !ignoredFilesPath.exists(isIgnoredByFileList(file, _))
 
-  private def filterFiles(
+  def filterFiles(
     files: List[String],
     inputPath: String,
     ignoredDefaultRegex: Option[Seq[Regex]] = None,


### PR DESCRIPTION
Specifications e.g., here: https://clang.llvm.org/docs/JSONCompilationDatabase.html

With this, we only handle files listed there.
Additionally, defines and includes are passed to CDT on a per file level just like the actual compiler invocation.