### PR TITLE
ExternalCommand: more information in error conditions

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -24,8 +24,8 @@ trait ExternalCommand {
     if (stdErr.nonEmpty) logger.warn(s"subprocess stderr: ${stdErr.mkString(lineSeparator)}")
 
     result match {
-      case Success(0)                    => Success(stdOut)
-      case failure: Failure[Seq[String]] => failure
+      case Success(0)     => Success(stdOut)
+      case Failure(error) => Failure(error)
       case Success(nonZeroExitCode) =>
         val allOutput = stdOut ++ stdErr
         val message =

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -1,14 +1,18 @@
 package io.joern.x2cpg.utils
 
+import org.slf4j.LoggerFactory
+
 import java.io.File
-import java.net.URL
 import java.nio.file.{Path, Paths}
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.sys.process.{Process, ProcessLogger}
 import scala.util.{Failure, Success, Try}
 import scala.jdk.CollectionConverters.*
+import System.lineSeparator
 
 trait ExternalCommand {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   protected val IsWin: Boolean = scala.util.Properties.isWin
 
@@ -17,12 +21,18 @@ trait ExternalCommand {
   protected val shellPrefix: Seq[String] = Nil
 
   protected def handleRunResult(result: Try[Int], stdOut: Seq[String], stdErr: Seq[String]): Try[Seq[String]] = {
+    if (stdErr.nonEmpty) logger.warn(s"subprocess stderr: ${stdErr.mkString(lineSeparator)}")
+
     result match {
-      case Success(0) =>
-        Success(stdOut)
-      case _ =>
+      case Success(0)                    => Success(stdOut)
+      case failure: Failure[Seq[String]] => failure
+      case Success(nonZeroExitCode) =>
         val allOutput = stdOut ++ stdErr
-        Failure(new RuntimeException(allOutput.mkString(System.lineSeparator())))
+        val message =
+          s"""Process exited with code $nonZeroExitCode. Output:
+             |${allOutput.mkString(lineSeparator)}
+             |""".stripMargin
+        Failure(new RuntimeException(message))
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
@@ -22,7 +22,7 @@ class ExternalCommandTest extends AnyWordSpec with Matchers {
         case result: Success[_] =>
           fail(s"expected failure, but got $result")
         case Failure(exception) =>
-          exception.getMessage should include("Process exited with code 2")
+          exception.getMessage should include("Process exited with code") // exit code `2` on linux, `1` on mac...
           exception.getMessage should include("ls: cannot access '/does/not/exist': No such file or directory")
       }
     }

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
@@ -23,7 +23,7 @@ class ExternalCommandTest extends AnyWordSpec with Matchers {
           fail(s"expected failure, but got $result")
         case Failure(exception) =>
           exception.getMessage should include("Process exited with code") // exit code `2` on linux, `1` on mac...
-          exception.getMessage should include("ls: cannot access '/does/not/exist': No such file or directory")
+          exception.getMessage should include("No such file or directory") // again, different errors on mac and linux
       }
     }
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
@@ -4,6 +4,7 @@ import better.files.File
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.util.Properties.isWin
 import scala.util.{Failure, Success}
 
 class ExternalCommandTest extends AnyWordSpec with Matchers {
@@ -22,7 +23,7 @@ class ExternalCommandTest extends AnyWordSpec with Matchers {
         case result: Success[_] =>
           fail(s"expected failure, but got $result")
         case Failure(exception) =>
-          exception.getMessage should include("Process exited with code") // exit code `2` on linux, `1` on mac...
+          exception.getMessage should include("Process exited with code")  // exit code `2` on linux, `1` on mac...
           exception.getMessage should include("No such file or directory") // again, different errors on mac and linux
       }
     }
@@ -33,7 +34,10 @@ class ExternalCommandTest extends AnyWordSpec with Matchers {
           fail(s"expected failure, but got $result")
         case Failure(exception) =>
           exception.getMessage should include("""Cannot run program "/command/does/not/exist"""")
-          exception.getMessage should include("No such file or directory")
+          if (isWin)
+            exception.getMessage should include("The system cannot find the file")
+          else
+            exception.getMessage should include("No such file or directory")
       }
     }
   }


### PR DESCRIPTION
* report exit code if it's non-zero
* pass on original error (if any) rather than disregarding it
* log.warn stderr output (if any)
* add tests