### PR TITLE
fix maven dependency fetching

### DIFF
--- a/joern-cli/frontends/x2cpg/build.sbt
+++ b/joern-cli/frontends/x2cpg/build.sbt
@@ -4,9 +4,10 @@ dependsOn(Projects.semanticcpg)
 
 libraryDependencies ++= Seq(
   /* Start: AST Gen Dependencies */
-  "com.lihaoyi"         %% "upickle"     % Versions.upickle,
-  "com.typesafe"         % "config"      % Versions.typeSafeConfig,
-  "com.michaelpollmeier" % "versionsort" % Versions.versionSort,
+  "com.lihaoyi"         %% "upickle"      % Versions.upickle,
+  "com.typesafe"         % "config"       % Versions.typeSafeConfig,
+  "com.michaelpollmeier" % "versionsort"  % Versions.versionSort,
+  "org.apache.commons"   % "commons-exec" % Versions.commonsExec,
   /* End: AST Gen Dependencies */
   "net.freeutils"  % "jlhttp"             % Versions.jlhttp,
   "org.gradle"     % "gradle-tooling-api" % Versions.gradleTooling % Optional,

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -14,17 +14,18 @@ object MavenDependencies {
   // also separate this from fetchCommandWithOpts to log a version that clearly separates options we provide from
   // options specified by the user via the MAVEN_CLI_OPTS environment variable, while also making it clear that this
   // environment variable is being considered.
-  private val fetchCommand =
-    s"mvn $$$MavenCliOpts --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out"
+  private val fetchArgs =
+    Vector("--fail-never", "-B", "dependency:build-classpath", "-DincludeScope=compile", "-Dorg.slf4j.simpleLogger.defaultLogLevel=info", "-Dorg.slf4j.simpleLogger.logFile=System.out")
 
   private val fetchCommandWithOpts: Seq[String] = {
     // These options suppress output, so if they're provided we won't get any results.
     // "-q" and "--quiet" are the only ones that would realistically be used.
     val optionsToStrip = Set("-h", "--help", "-q", "--quiet", "-v", "--version")
 
-    val mavenOpts         = Option(System.getenv(MavenCliOpts)).getOrElse("")
-    val mavenOptsStripped = mavenOpts.split(raw"\s").filterNot(optionsToStrip.contains).mkString(" ")
-    fetchCommand.replace(s"$$$MavenCliOpts", mavenOptsStripped).split(" ").toSeq
+    val cli = org.apache.commons.exec.CommandLine("mvn")
+    cli.addArguments(System.getenv(MavenCliOpts), false) // a null from getenv() does not add any argument
+
+    cli.toStrings.toIndexedSeq.filterNot(optionsToStrip.contains) ++ fetchArgs
   }
 
   private def logErrors(output: String): Unit = {
@@ -34,7 +35,7 @@ object MavenDependencies {
         "The compile class path may be missing or partial.\n" +
         "Results will suffer from poor type information.\n" +
         "To fix this issue, please ensure that the below command can be executed successfully from the project root directory:\n" +
-        fetchCommand + "\n\n",
+        s"mvn $MavenCliOpts " + fetchArgs.mkString(" ") + "\n\n",
       output
     )
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -15,7 +15,14 @@ object MavenDependencies {
   // options specified by the user via the MAVEN_CLI_OPTS environment variable, while also making it clear that this
   // environment variable is being considered.
   private val fetchArgs =
-    Vector("--fail-never", "-B", "dependency:build-classpath", "-DincludeScope=compile", "-Dorg.slf4j.simpleLogger.defaultLogLevel=info", "-Dorg.slf4j.simpleLogger.logFile=System.out")
+    Vector(
+      "--fail-never",
+      "-B",
+      "dependency:build-classpath",
+      "-DincludeScope=compile",
+      "-Dorg.slf4j.simpleLogger.defaultLogLevel=info",
+      "-Dorg.slf4j.simpleLogger.logFile=System.out"
+    )
 
   private val fetchCommandWithOpts: Seq[String] = {
     // These options suppress output, so if they're provided we won't get any results.

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -9,6 +9,7 @@ object Versions {
   val catsEffect             = "3.5.4"
   val cfr                    = "0.152"
   val commonsCompress        = "1.26.2"
+  val commonsExec            = "1.4.0"
   val commonsIo              = "2.16.0"
   val commonsLang            = "3.14.0"
   val commonsText            = "1.12.0"


### PR DESCRIPTION
fixes the regression from the ExternalCommand refactor, but I just couldn't leave the the env var handling as it was either. Splitting at any whitespace isn't correct (quotes!). Switching to a proper library for parsing CLI arguments instead.