### PR TITLE
[console] fix kotlin's extension

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -52,7 +52,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
     new BinaryFrontend("jvm", Languages.JAVA, "Java/Dalvik Bytecode Frontend (based on SOOT's jimple)")
   def ghidra: Frontend = new BinaryFrontend("ghidra", Languages.GHIDRA, "ghidra reverse engineering frontend")
   def kotlin: SourceBasedFrontend =
-    new SourceBasedFrontend("kotlin", Languages.KOTLIN, "Kotlin Source Frontend", "kotlin")
+    new SourceBasedFrontend("kotlin", Languages.KOTLIN, "Kotlin Source Frontend", "kt")
   def python: SourceBasedFrontend =
     new SourceBasedFrontend("python", Languages.PYTHONSRC, "Python Source Frontend", "py")
   def golang: SourceBasedFrontend = new SourceBasedFrontend("golang", Languages.GOLANG, "Golang Source Frontend", "go")


### PR DESCRIPTION
Trying to `importCode.kotlin.fromString(...)` from the REPL would silently fail as no files would be parsed, since the temporary file suffix would be `.kotlin`, and thus unrecognised.