### PR TITLE
[x2cpg] Redirect stdout/stderr to tmp files

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -1,17 +1,13 @@
 package io.joern.x2cpg.utils
 
+import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 
-import java.io.BufferedReader
 import java.io.File
-import java.io.InputStreamReader
-import java.nio.file.Path
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 
 object ExternalCommand {
 
@@ -45,39 +41,27 @@ object ExternalCommand {
       .redirectErrorStream(mergeStdErrInStdOut)
     builder.environment().putAll(extraEnv.asJava)
 
-    val stdOut = scala.collection.mutable.ArrayBuffer.empty[String]
-    val stdErr = scala.collection.mutable.ArrayBuffer.empty[String]
+    val stdOutFile = File.createTempFile("x2cpg", "stdout")
+    val stdErrFile = Option.when(!mergeStdErrInStdOut)(File.createTempFile("x2cpg", "stderr"))
 
     try {
-      val process = builder.start()
+      builder.redirectOutput(stdOutFile)
+      stdErrFile.foreach(f => builder.redirectError(f))
 
-      val outputReaderThread = new Thread(() => {
-        val outputReader = new BufferedReader(new InputStreamReader(process.getInputStream))
-        outputReader.lines.iterator.forEachRemaining(stdOut.addOne)
-      })
-
-      val errorReaderThread = new Thread(() => {
-        val errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream))
-        errorReader.lines.iterator.forEachRemaining(stdErr.addOne)
-      })
-
-      outputReaderThread.start()
-      errorReaderThread.start()
-
+      val process     = builder.start()
       val returnValue = process.waitFor()
-      outputReaderThread.join()
-      errorReaderThread.join()
 
-      process.getInputStream.close()
-      process.getOutputStream.close()
-      process.getErrorStream.close()
-      process.destroy()
+      val stdOut = IOUtils.readLinesInFile(stdOutFile.toPath)
+      val stdErr = stdErrFile.map(f => IOUtils.readLinesInFile(f.toPath)).getOrElse(Seq.empty)
 
       if (stdErr.nonEmpty) logger.warn(s"subprocess stderr: ${stdErr.mkString(System.lineSeparator())}")
-      ExternalCommandResult(returnValue, stdOut.toSeq, stdErr.toSeq)
+      ExternalCommandResult(returnValue, stdOut, stdErr)
     } catch {
       case NonFatal(exception) =>
         ExternalCommandResult(1, Seq.empty, stdErr = Seq(exception.getMessage))
+    } finally {
+      stdOutFile.deleteOnExit()
+      stdErrFile.foreach(_.deleteOnExit())
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -1,7 +1,6 @@
 package io.joern.x2cpg.utils
 
 import io.shiftleft.utils.IOUtils
-import org.slf4j.LoggerFactory
 
 import java.io.File
 import java.nio.file.{Path, Paths}
@@ -10,8 +9,6 @@ import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 object ExternalCommand {
-
-  private val logger = LoggerFactory.getLogger(ExternalCommand.getClass)
 
   case class ExternalCommandResult(exitCode: Int, stdOut: Seq[String], stdErr: Seq[String]) {
     def successOption: Option[Seq[String]] = exitCode match {
@@ -53,8 +50,6 @@ object ExternalCommand {
 
       val stdOut = IOUtils.readLinesInFile(stdOutFile.toPath)
       val stdErr = stdErrFile.map(f => IOUtils.readLinesInFile(f.toPath)).getOrElse(Seq.empty)
-
-      if (stdErr.nonEmpty) logger.warn(s"subprocess stderr: ${stdErr.mkString(System.lineSeparator())}")
       ExternalCommandResult(returnValue, stdOut, stdErr)
     } catch {
       case NonFatal(exception) =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ExternalCommand.scala
@@ -60,8 +60,8 @@ object ExternalCommand {
       case NonFatal(exception) =>
         ExternalCommandResult(1, Seq.empty, stdErr = Seq(exception.getMessage))
     } finally {
-      stdOutFile.deleteOnExit()
-      stdErrFile.foreach(_.deleteOnExit())
+      stdOutFile.delete()
+      stdErrFile.foreach(_.delete())
     }
   }
 


### PR DESCRIPTION
This bypasses tty buffering and read timeouts.
Ubuntu runner time here on GH went from 27min down to 17min.