### PR TITLE
Log full maven output on failure

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -42,9 +42,9 @@ object MavenDependencies {
         "The compile class path may be missing or partial.\n" +
         "Results will suffer from poor type information.\n" +
         "To fix this issue, please ensure that the below command can be executed successfully from the project root directory:\n" +
-        s"mvn $MavenCliOpts " + fetchArgs.mkString(" ") + "\n\n",
-      output
+        s"mvn $MavenCliOpts " + fetchArgs.mkString(" ") + "\n\n"
     )
+    logger.debug(s"Full maven error output:\n$output")
   }
 
   private[dependency] def get(projectDir: Path): Option[collection.Seq[String]] = {


### PR DESCRIPTION
We already do this for gradle tasks that fail, so also log the full maven output if fetching dependencies fails to make debugging easier.