### PR TITLE
Add off-by-default timeout functionality to javasrc dependency fetching

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -70,5 +70,10 @@ object JavaSrc2Cpg {
           "JAVASRC_FETCH_DEPENDENCIES",
           "If set, javasrc2cpg will fetch dependencies regardless of the --fetch-dependencies flag."
         )
+    case FetchDependenciesTimeout
+        extends JavaSrcEnvVar(
+          "JAVASRC_FETCH_DEPENDENCIES_TIMEOUT",
+          "Timeout for dependency fetching in the format <length><unit>. Overrides the --fetch-dependencies-timeout flag."
+        )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -11,6 +11,7 @@ import io.joern.x2cpg.utils.server.FrontendHTTPServer
 import scopt.OParser
 
 import java.util.concurrent.ExecutorService
+import scala.concurrent.duration.Duration
 
 /** Command line configuration parameters
   */
@@ -26,7 +27,8 @@ final case class Config(
   skipTypeInfPass: Boolean = false,
   dumpJavaparserAsts: Boolean = false,
   cacheJdkTypeSolver: Boolean = false,
-  keepTypeArguments: Boolean = false
+  keepTypeArguments: Boolean = false,
+  dependencyFetchingTimeout: Option[Duration] = None
 ) extends X2CpgConfig[Config]
     with TypeRecoveryParserConfig[Config] {
   def withInferenceJarPaths(paths: Set[String]): Config = {
@@ -75,6 +77,10 @@ final case class Config(
 
   def withKeepTypeArguments(value: Boolean): Config = {
     copy(keepTypeArguments = value).withInheritedFields(this)
+  }
+
+  def withDependencyFetchingTimeout(value: Duration): Config = {
+    copy(dependencyFetchingTimeout = Option(value)).withInheritedFields(this)
   }
 }
 
@@ -133,7 +139,10 @@ private object Frontend {
       opt[Unit]("keep-type-arguments")
         .hidden()
         .action((_, c) => c.withKeepTypeArguments(true))
-        .text("Type full names of variables keep their type arguments.")
+        .text("Type full names of variables keep their type arguments."),
+      opt[String]("fetch-dependencies-timeout")
+        .action((timeoutString, c) => c.withDependencyFetchingTimeout(Duration(timeoutString)))
+        .text("Timeout for the Maven dependency fetcher in the format <length><unit>")
     )
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -4,6 +4,7 @@ import io.joern.x2cpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Path
+import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}
 
 object MavenDependencies {
@@ -47,8 +48,10 @@ object MavenDependencies {
     logger.debug(s"Full maven error output:\n$output")
   }
 
-  private[dependency] def get(projectDir: Path): Option[collection.Seq[String]] = {
-    val lines = ExternalCommand.run(fetchCommandWithOpts, projectDir.toString).toTry match {
+  private[dependency] def get(projectDir: Path, timeoutDuration: Option[Duration]): Option[collection.Seq[String]] = {
+    val lines = ExternalCommand
+      .run(fetchCommandWithOpts, projectDir.toString, timeout = timeoutDuration)
+      .toTry match {
       case Success(lines) =>
         if (lines.contains("[INFO] Build failures were ignored.")) {
           logErrors(lines.mkString(System.lineSeparator()))


### PR DESCRIPTION
Recently, a ticket was created for an issue where analyzing a java project with javasrc ran into the hour timeout and, from the logs, it looks like most of this time was spent fetching maven dependencies. Since we rely on external tools to fetch dependencies there's likely not much we can do to speed that up, but we should have a way of preventing this from timing out the full analysis. This PR adds timeout functionality to `ExternalCommand` and the `GradleDependencyFetcher` which is disabled by default, but with either a command line flag or an envvar to enable timeouts. I think the best approach would be to set a default timeout in SL and to have customers override that with the envvar option on a per-project basis (if necessary). I've included logs from some test runs below to demonstrate the usage of this feature.

For maven, the timeout applies to the whole `mvn` command and works as expected. For gradle, it's a bit trickier since we use a single init script for all the tasks (so fetching dependencies would have a separate timeout for each subproject). To keep the total timeout at the time specified, I opted to just divide the total timeout by the number of subprojects, which could be problematic for projects with many subprojects where one or a few of these have many more dependencies than the other. Solutions to this would be to use separate init scripts for each task and count down the timeout for each created script, or to figure out some way of managing the timeout outside of the gradle api calls.

It's also worth noting that results will generally be bad if dependency fetching is interrupted, but that's arguably still better than no results.

## Test Logs

### Maven

#### no timeout

```
./joern-cli/frontends/javasrc2cpg/javasrc2cpg --fetch-dependencies test-projects/shiftleft-java-demo
```

```
[INFO ] No timeout set for dependency fetching
[INFO ] got 63 Maven dependencies
```

#### 1ms timeout

```
./joern-cli/frontends/javasrc2cpg/javasrc2cpg --fetch-dependencies ~/code/test-projects/shiftleft-java-demo --fetch-dependencies-timeout 1ms
```

```
[INFO ] Using dependency fetching timeout from --fetch-dependencies-timeout flag: 1ms
[WARN ] Command timed out after timeout of 1ms: mvn --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out
[WARN ] Retrieval of compile class path via maven return with error.
The compile class path may be missing or partial.
Results will suffer from poor type information.
To fix this issue, please ensure that the below command can be executed successfully from the project root directory:
mvn MAVEN_CLI_OPTS --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out


[DEBUG] Full maven error output:
Process exited with code 1. Output:


[INFO ] got 0 Maven dependencies
```

#### 1min timeout

```
./joern-cli/frontends/javasrc2cpg/javasrc2cpg --fetch-dependencies ~/code/test-projects/shiftleft-java-demo --fetch-dependencies-timeout 1min
```

```
[INFO ] Using dependency fetching timeout from --fetch-dependencies-timeout flag: 60000ms
[INFO ] got 63 Maven dependencies
```

#### 1ms timeout envvar override

```
JAVASRC_FETCH_DEPENDENCIES_TIMEOUT=1ms ./joern-cli/frontends/javasrc2cpg/javasrc2cpg --fetch-dependencies ~/code/test-projects/shiftleft-java-demo --fetch-dependencies-timeout 1min
```

```
[INFO ] Using dependency fetching timeout from envvar: 1ms
[WARN ] Command timed out after timeout of 1ms: mvn --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out
[WARN ] Retrieval of compile class path via maven return with error.
The compile class path may be missing or partial.
Results will suffer from poor type information.
To fix this issue, please ensure that the below command can be executed successfully from the project root directory:
mvn MAVEN_CLI_OPTS --fail-never -B dependency:build-classpath -DincludeScope=compile -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dorg.slf4j.simpleLogger.logFile=System.out


[DEBUG] Full maven error output:
Process exited with code 1. Output:


[INFO ] got 0 Maven dependencies
```
### Gradle

#### no timeout

```
./joern-cli/frontends/javasrc2cpg/javasrc2cpg --fetch-dependencies test-projects/Slide
```

```
[INFO ] No timeout set for dependency fetching
...
[INFO ] Task app:x2cpgCopyDeps_oe5TBq1x resolved `124` dependency files.
```

#### 1ms timeout

```
./joern-cli/frontends/javasrc2cpg/javasrc2cpg --fetch-dependencies test-projects/Slide --fetch-dependencies-timeout 1ms
```

```
[INFO ] Using dependency fetching timeout from --fetch-dependencies-timeout flag: 1ms
...
[DEBUG] Total timeout of 1ms set and 1 subprojects found, so setting dependency fetching timeout per project to 1ms
...
[WARN ] Caught exception while executing Gradle task: Could not execute build using connection to Gradle distribution 'https://services.gradle.org/distributions/gradle-7.3.3-all.zip'.
[DEBUG] Gradle task execution stdout: 

> Task :app:x2cpgCopyDeps_OltRFM8q_androidDeps FAILED
Requesting stop of task ':app:x2cpgCopyDeps_OltRFM8q_androidDeps' as it has exceeded its configured timeout of 1ms.
1 actionable task: 1 executed

[DEBUG] Gradle task execution stderr: 

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:x2cpgCopyDeps_OltRFM8q_androidDeps'.
> Timeout has been exceeded

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```

#### 1min timeout
```
./joern-cli/frontends/javasrc2cpg/javasrc2cpg --fetch-dependencies test-projects/Slide --fetch-dependencies-timeout 1min
```

```
[INFO ] Using dependency fetching timeout from --fetch-dependencies-timeout flag: 60000ms
...
[DEBUG] Total timeout of 60000ms set and 1 subprojects found, so setting dependency fetching timeout per project to 60000ms
...
[INFO ] Task app:x2cpgCopyDeps_RhS6Govu resolved `124` dependency files.
```

#### 1ms timeout envvar override

```
JAVASRC_FETCH_DEPENDENCIES_TIMEOUT=1ms ./joern-cli/frontends/javasrc2cpg/javasrc2cpg --fetch-dependencies test-projects/Slide --fetch-dependencies-timeout 1min
```

```
[INFO ] Using dependency fetching timeout from envvar: 1ms
...
[DEBUG] Total timeout of 1ms set and 1 subprojects found, so setting dependency fetching timeout per project to 1ms
...
[DEBUG] Gradle task execution stdout: 

> Task :app:x2cpgCopyDeps_7kGDBb1H_androidDeps FAILED
Requesting stop of task ':app:x2cpgCopyDeps_7kGDBb1H_androidDeps' as it has exceeded its configured timeout of 1ms.
1 actionable task: 1 executed

[DEBUG] Gradle task execution stderr: 

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:x2cpgCopyDeps_7kGDBb1H_androidDeps'.
> Timeout has been exceeded

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 2s
```

