### PR TITLE
Upgrade to Multi-Threaded `ruby_ast_gen`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
@@ -1,4 +1,4 @@
 rubysrc2cpg {
-    ruby_ast_gen_version: "0.31.0"
+    ruby_ast_gen_version: "0.32.0"
     joern_type_stubs_version: "0.6.0"
 }


### PR DESCRIPTION
Some stats on https://github.com/joernio/ruby_ast_gen/pull/10, however, `AstCreation` only begins to ingest parsed files once the parsing is complete instead of as files are ready, which may be required to realize further performance gains on large repositories such as `gitlab`.

Resolves [#5066](https://github.com/joernio/joern/issues/5066)