### PR TITLE
[kotlin2cpg] Dispose the environment as soon as it's not needed

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -21,6 +21,7 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.utils.IOUtils
 import org.jetbrains.kotlin.cli.jvm.compiler.{KotlinCoreEnvironment, KotlinToJVMBytecodeCompiler}
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.slf4j.LoggerFactory
@@ -224,6 +225,8 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] with UsesService {
       val bindingContext = createBindingContext(environment)
       val astCreator     = new AstCreationPass(sourceFiles, bindingContext, cpg)(config.schemaValidation)
       astCreator.createAndApply()
+      
+      Disposer.dispose(environment.getProjectEnvironment.getParentDisposable)
 
       val kotlinAstCreatorTypes = astCreator.usedTypes()
       TypeNodePass.withRegisteredTypes(kotlinAstCreatorTypes, cpg).createAndApply()

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -225,7 +225,7 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] with UsesService {
       val bindingContext = createBindingContext(environment)
       val astCreator     = new AstCreationPass(sourceFiles, bindingContext, cpg)(config.schemaValidation)
       astCreator.createAndApply()
-      
+
       Disposer.dispose(environment.getProjectEnvironment.getParentDisposable)
 
       val kotlinAstCreatorTypes = astCreator.usedTypes()


### PR DESCRIPTION
We were observing some OOM exceptions when providing large .jars to kotlin2cpg's classpath. Profiling the memory usage, it was clear it kept growing between multiple same-process invocations.

Below are two such graphs. They were obtained by:
* including a ~350MB .jar in kotlin2cpg's test resources
* setting the flag `withDefaultJars=true` by default
* running the kotlin2cpg tests

Before:
<img width="1438" alt="Screenshot 2024-11-06 at 14 22 40" src="https://github.com/user-attachments/assets/a344c2e8-885d-402f-bfcc-d07cf8b74840">

After:
<img width="1437" alt="Screenshot 2024-11-06 at 14 23 31" src="https://github.com/user-attachments/assets/520ba4a8-d2dd-4ea2-9871-e969a00a0ff6">
