### PR TITLE
[ruby] handle `private_class_method` and `public_class_method` access modifiers

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -24,6 +24,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case node: FieldsDeclaration          => astsForFieldDeclarations(node)
       case node: AccessModifier             => registerAccessModifier(node)
       case node: MethodDeclaration          => astForMethodDeclaration(node)
+      case node: MethodAccessModifier       => astForMethodAccessModifier(node)
       case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node)
       case node: MultipleAssignment         => node.assignments.map(astForExpression)
       case node: BreakExpression            => astForBreakExpression(node) :: Nil

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -475,6 +475,10 @@ object RubyIntermediateAst {
     def toSimpleIdentifier: SimpleIdentifier
   }
 
+  sealed trait MethodAccessModifier extends AllowedTypeDeclarationChild {
+    def method: RubyExpression
+  }
+
   final case class PublicModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier {
     override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span)
   }
@@ -486,6 +490,14 @@ object RubyIntermediateAst {
   final case class ProtectedModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier {
     override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span)
   }
+
+  final case class PrivateMethodModifier(method: RubyExpression)(span: TextSpan)
+      extends RubyExpression(span)
+      with MethodAccessModifier
+
+  final case class PublicMethodModifier(method: RubyExpression)(span: TextSpan)
+      extends RubyExpression(span)
+      with MethodAccessModifier
 
   /** Represents standalone `proc { ... }` or `lambda { ... }` expressions
     */


### PR DESCRIPTION
Added handling for `private_class_method` and `public_class_method` access modifiers, making the function def that follows them have either `PRIVATE` or `PUBLIC` modifiers.

TODO: 
handle multiple args: It's possible to call `private_class_method` with a list of symbols representing function names. All the functions matching these symbols would then also have a PRIVATE access modifier.

Resolves #5061 