### PR TITLE
[javasrc2cpg] add basic static field test

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/testfixtures/JavaSrcCodeToCpgFixture.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg.testfixtures
 
 import io.joern.dataflowengineoss.DefaultSemantics
+import io.joern.dataflowengineoss.language.Path
 import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
@@ -81,4 +82,6 @@ class JavaSrcCode2CpgFixture(
 
     (source, sink)
   }
+
+  protected def flowToResultPairs(path: Path): List[(String, Option[Int])] = path.resultPairs()
 }


### PR DESCRIPTION
Apropos #5049, includes an ignored test that stopped working after #5036. Unfortunately, such a test wasn't there before to flag this regression.

Previously, in the example's `System.out.println(CONST)` we were lowering `CONST` as `Bar.CONST`, with `Bar` an IDENTIFIER. Presently, `Bar` is a TYPE_REF and we lose this dataflow. 

Another thing to point out regarding this design change is that it's not consistent throughout. For instance, if we had written `System.out.println(Bar.CONST)` , `Bar` is here not a TYPE_REF but again an IDENTIFIER.

I'm willing to contribute patch(es) to the recovery of this flow, but would need some guidance as I've not been able to find a workaround after some initial experiments. (Thanks in advance)