### PR TITLE
[javasrc2cpg] support flows for field accesses with a TYPE_REF base node

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -147,7 +147,12 @@ class SourceToStartingPointsInMethod(
   private def usageInOtherClasses(m: Method, usageInputs: List[UsageInput]): List[StartingPointWithSource] = {
     usageInputs.flatMap { case UsageInput(src, typeDecl, astNode) =>
       m.fieldAccess
-        .where(_.argument(1).isIdentifier.typeFullNameExact(typeDecl.fullName))
+        .where(
+          _.or(
+            _.argument(1).isIdentifier.typeFullNameExact(typeDecl.fullName),
+            _.argument(1).isTypeRef.typeFullNameExact(typeDecl.fullName)
+          )
+        )
         .where { x =>
           astNode match {
             case identifier: Identifier =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -147,11 +147,9 @@ class SourceToStartingPointsInMethod(
   private def usageInOtherClasses(m: Method, usageInputs: List[UsageInput]): List[StartingPointWithSource] = {
     usageInputs.flatMap { case UsageInput(src, typeDecl, astNode) =>
       m.fieldAccess
-        .where(
-          _.or(
-            _.argument(1).isIdentifier.typeFullNameExact(typeDecl.fullName),
-            _.argument(1).isTypeRef.typeFullNameExact(typeDecl.fullName)
-          )
+        .or(
+          _.argument(1).isIdentifier.typeFullNameExact(typeDecl.fullName),
+          _.argument(1).isTypeRef.typeFullNameExact(typeDecl.fullName)
         )
         .where { x =>
           astNode match {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
@@ -5,7 +5,7 @@ import io.joern.dataflowengineoss.language.*
 import io.shiftleft.semanticcpg.language.*
 
 class NewObjectTests extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
-  
+
   "static field passed as an argument inside a same-class static method whilst being referenced by its simple name" in {
     val cpg = code("""
         |class Bar {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/dataflow/ObjectTests.scala
@@ -5,9 +5,8 @@ import io.joern.dataflowengineoss.language.*
 import io.shiftleft.semanticcpg.language.*
 
 class NewObjectTests extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
-
-  // FIXME: stopped working after https://github.com/joernio/joern/pull/5036
-  "static field passed as an argument inside a same-class static method whilst being referenced by its simple name" ignore {
+  
+  "static field passed as an argument inside a same-class static method whilst being referenced by its simple name" in {
     val cpg = code("""
         |class Bar {
         | static String CONST = "<const>";
@@ -18,7 +17,7 @@ class NewObjectTests extends JavaSrcCode2CpgFixture(withOssDataflow = true) {
     val sink   = cpg.call("println").argument(1)
     val source = cpg.literal
     sink.reachableByFlows(source).map(flowToResultPairs).l shouldBe List(
-      List(("String Bar.CONST = \"<const>\"", Some(3)), ("System.out.println(Bar.CONST)", Some(5)))
+      List(("String Bar.CONST = \"<const>\"", Some(3)), ("System.out.println(CONST)", Some(5)))
     )
   }
 


### PR DESCRIPTION
Resolves #5049 and fixes the ignored unit-test introduced in #5075 