### PR TITLE
[ruby] Field Call Target, Fixed Some NPE Exceptions

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -610,8 +610,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
 
   protected def astForSimpleCall(node: SimpleCall): Ast = {
     node.target match
-      case targetNode: SimpleIdentifier => astForMethodCallWithoutBlock(node, targetNode)
-      case targetNode: MemberAccess     => astForMemberCallWithoutBlock(node, targetNode)
+      case targetNode: SimpleIdentifier    => astForMethodCallWithoutBlock(node, targetNode)
+      case targetNode: RubyFieldIdentifier => astForMemberCallWithoutBlock(node, targetNode.toMemberAccess)
+      case targetNode: MemberAccess        => astForMemberCallWithoutBlock(node, targetNode)
       case targetNode =>
         logger.warn(s"Unrecognized target of call: ${targetNode.text} ($relativeFileName), skipping")
         astForUnknown(targetNode)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -262,7 +262,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         val setterAst   = Option.when(node.hasSetter)(astForSetterMethod(node, fieldName)).getOrElse(Nil)
         Seq(memberAst) ++ getterAst ++ setterAst
       case _ =>
-        logger.warn(s"Unsupported field declaration: ${nameNode.text}, skipping")
+        logger.warn(s"Unsupported field declaration: ${nameNode.text} (${nameNode.getClass}), skipping")
         Seq()
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -250,7 +250,11 @@ object RubyIntermediateAst {
 
   /** Ruby Instance or Class Variable Identifiers: `@a`, `@@a`
     */
-  sealed trait RubyFieldIdentifier extends RubyIdentifier
+  sealed trait RubyFieldIdentifier extends RubyIdentifier {
+    def toMemberAccess: MemberAccess = {
+      MemberAccess(SelfIdentifier()(span), ".", span.text)(span)
+    }
+  }
 
   sealed trait SingletonMethodIdentifier
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -478,11 +478,16 @@ class RubyJsonToNodeCreator(
     ForExpression(forVariable, iterableVariable, doBlock)(obj.toTextSpan)
   }
 
-  private def visitForwardArg(obj: Obj): RubyExpression = defaultResult(Option(obj.toTextSpan))
+  private def visitForwardArg(obj: Obj): RubyExpression = {
+    println("forward args")
+    defaultResult(Option(obj.toTextSpan))
+  }
 
-  private def visitForwardArgs(obj: Obj): RubyExpression = defaultResult(Option(obj.toTextSpan))
+  // Note: Forward args should probably be handled more explicitly, but this should preserve flows if the same
+  // identifier is used in latter forwarding
+  private def visitForwardArgs(obj: Obj): RubyExpression = MandatoryParameter("...")(obj.toTextSpan)
 
-  private def visitForwardedArgs(obj: Obj): RubyExpression = defaultResult(Option(obj.toTextSpan))
+  private def visitForwardedArgs(obj: Obj): RubyExpression = SimpleIdentifier()(obj.toTextSpan)
 
   private def visitGlobalVariable(obj: Obj): RubyExpression = {
     val span     = obj.toTextSpan
@@ -594,7 +599,7 @@ class RubyJsonToNodeCreator(
   private def visitKwOptArg(obj: Obj): RubyExpression = visitKwArg(obj)
 
   private def visitKwRestArg(obj: Obj): RubyExpression = {
-    val name = obj(ParserKeys.Value).str
+    val name = if obj.contains(ParserKeys.Value) then obj(ParserKeys.Value).str else obj.toTextSpan.text
     HashParameter(name)(obj.toTextSpan)
   }
 
@@ -647,7 +652,7 @@ class RubyJsonToNodeCreator(
 
   private def visitMethodDefinition(obj: Obj): RubyExpression = {
     val name       = obj(ParserKeys.Name).str
-    val parameters = obj(ParserKeys.Arguments).asInstanceOf[ujson.Obj].visitArray(ParserKeys.Children)
+    val parameters = visitMethodParameters(obj(ParserKeys.Arguments).asInstanceOf[ujson.Obj])
     val body = obj
       .visitOption(ParserKeys.Body)
       .map {
@@ -756,6 +761,19 @@ class RubyJsonToNodeCreator(
     val key   = visit(obj(ParserKeys.Key))
     val value = visit(obj(ParserKeys.Value))
     Association(key, value)(obj.toTextSpan)
+  }
+
+  private def visitMethodParameters(paramsNode: Obj): List[RubyExpression] = {
+    AstType.fromString(paramsNode(ParserKeys.Type).str) match {
+      case Some(AstType.Args)        => paramsNode.visitArray(ParserKeys.Children)
+      case Some(AstType.ForwardArgs) => visit(paramsNode) :: Nil
+      case Some(x) =>
+        logger.warn(s"Not explicitly handled parameter type '$x', no special handling applied")
+        visit(paramsNode) :: Nil
+      case _ =>
+        logger.error(s"Unknown JSON type used as method parameter ${paramsNode(ParserKeys.Type).str}")
+        defaultResult(Option(paramsNode.toTextSpan)) :: Nil
+    }
   }
 
   private def visitPostExpression(obj: Obj): RubyExpression = defaultResult(Option(obj.toTextSpan))
@@ -931,7 +949,7 @@ class RubyJsonToNodeCreator(
   private def visitSingletonMethodDefinition(obj: Obj): RubyExpression = {
     val base       = visit(obj(ParserKeys.Base))
     val name       = obj(ParserKeys.Name).str
-    val parameters = obj(ParserKeys.Arguments).asInstanceOf[ujson.Obj].visitArray(ParserKeys.Children)
+    val parameters = visitMethodParameters(obj(ParserKeys.Arguments).asInstanceOf[ujson.Obj])
     val body =
       obj.visitOption(ParserKeys.Body).getOrElse(StatementList(Nil)(obj.toTextSpan.spanStart("<empty>"))) match {
         case stmtList: StatementList => stmtList

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -1014,4 +1014,28 @@ class MethodTests extends RubyCode2CpgFixture {
       getLineNumberOfLambdaForCall("map") shouldBe 6
     }
   }
+
+  "Forwarded args from method to call" should {
+    val cpg = code("""
+        |def foo(...)
+        |   bar('foo', ...)
+        |end
+        |
+        |""".stripMargin)
+
+    "create a '...' parameter node" in {
+      inside(cpg.method.nameExact("foo").parameter.l) { case _ :: forwardArgs :: Nil =>
+        forwardArgs.name shouldBe "..."
+        forwardArgs.code shouldBe "(...)"
+      }
+    }
+
+    "create a '...' identifier node as a call argument" in {
+      inside(cpg.call("bar").argument.isIdentifier.l) { case _ :: forwardedArgs :: Nil =>
+        forwardedArgs.name shouldBe "..."
+        forwardedArgs.code shouldBe "..."
+        forwardedArgs.argumentIndex shouldBe 2
+      }
+    }
+  }
 }


### PR DESCRIPTION
* Convert `FieldIdentifier` nodes to `MemberAccess` if they reach AstCreator for call targets
* Handle forwarded args which were a cause for some null pointer exceptions
* Fixed `kwrestarg` null value issue, which turned out to be a `**` parameter

Resolves #5063
Resolves #5064
Resolves #5065