### PR TITLE
[ruby] Fix ignore regex for Ruby

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
@@ -1,4 +1,4 @@
 rubysrc2cpg {
-    ruby_ast_gen_version: "0.32.0"
+    ruby_ast_gen_version: "0.33.0"
     joern_type_stubs_version: "0.6.0"
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -21,8 +21,9 @@ final case class Config(downloadDependencies: Boolean = false, useTypeStubs: Boo
   override val astGenConfigPrefix: String       = "rubysrc2cpg"
   override val multiArchitectureBuilds: Boolean = true
 
-  this.defaultIgnoredFilesRegex = List("spec", "tests?", "vendor", "db(\\|/)migrate").flatMap { directory =>
-    List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|/)$directory($$|/)".r.unanchored)
+  this.defaultIgnoredFilesRegex = List("spec", "tests?", "vendor", "db(\\\\|/)([\\w_]*)migrate([_\\w]*)").flatMap {
+    directory =>
+      List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|/)$directory($$|/)".r.unanchored)
   }
 
   override def withDownloadDependencies(value: Boolean): Config = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/config/IgnoreRegexTest.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/config/IgnoreRegexTest.scala
@@ -1,0 +1,17 @@
+package io.joern.rubysrc2cpg.config
+
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class IgnoreRegexTest extends RubyCode2CpgFixture {
+  "File matching default ignore regex should be skipped" in {
+    val cpg = code(
+      """
+        |puts "test file"
+        |""".stripMargin,
+      "tmpdir/db/migrate/test0.rb"
+    )
+
+    cpg.file.map(_.name).contains("tmpdir/db/migrate/test0.rb") shouldBe false
+  }
+}


### PR DESCRIPTION
* Fixed ignore regex for Ruby to account for prefix or suffix on the `db/migrate` dir.
* Fixed regex passing to `ruby_ast_gen` so that it also ignores the correct directories.

Resolves #5062 