### PR TITLE
Introducing Joern Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Joern - The Bug Hunter's Workbench
 [![Joern SBT](https://index.scala-lang.org/joernio/joern/latest.svg)](https://index.scala-lang.org/joernio/joern)
 [![Github All Releases](https://img.shields.io/github/downloads/joernio/joern/total.svg)](https://github.com/joernio/joern/releases/)
 [![Gitter](https://img.shields.io/badge/-Discord-lime?style=for-the-badge&logo=discord&logoColor=white&color=black)](https://discord.com/invite/vv4MH284Hc)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Joern%20Guru-006BFF)](https://gurubase.io/g/joern)
 
 Joern is a platform for analyzing source code, bytecode, and binary
 executables. It generates code property graphs (CPGs), a graph


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Joern Guru](https://gurubase.io/g/joern) to Gurubase. Joern Guru uses the data from this repo and data from the [docs](https://docs.joern.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Joern Guru", which highlights that Joern now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Joern Guru in Gurubase, just let me know that's totally fine.
