### PR TITLE
[c#] Bump `DotNetAstGen`

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 csharpsrc2cpg {
-    dotnetastgen_version: "0.34.0"
+    dotnetastgen_version: "0.35.0"
 }


### PR DESCRIPTION
Uses new version of `DotNetAstGen` that uses a parallelized version. Credits to @ricekot

https://github.com/joernio/DotNetAstGen/pull/26