### PR TITLE
[ruby] Bitwise Assignment Operators

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -222,7 +222,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       "|"   -> Operators.or,
       "^"   -> Operators.xor,
 //      "<<"  -> Operators.shiftLeft,  Note: Generally Ruby abstracts this as an append operator based on the LHS
-      ">>" -> Operators.logicalShiftRight
+      ">>" -> Operators.arithmeticShiftRight
     )
 
   protected val AssignmentOperatorNames: Map[String, String] = Map(
@@ -233,8 +233,9 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     "/="  -> Operators.assignmentDivision,
     "%="  -> Operators.assignmentModulo,
     "**=" -> Operators.assignmentExponentiation,
-    // Strictly speaking, `a ||= b` means `a || a = b`, but I reckon we wouldn't gain much representing it that way.
-    "||=" -> Operators.assignmentOr,
-    "&&=" -> Operators.assignmentAnd
+    "|="  -> Operators.assignmentOr,
+    "&="  -> Operators.assignmentAnd,
+    "<<=" -> Operators.assignmentShiftLeft,
+    ">>=" -> Operators.assignmentArithmeticShiftRight
   )
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/BooleanLogicTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/BooleanLogicTests.scala
@@ -161,4 +161,28 @@ class BooleanLogicTests extends RubyCode2CpgFixture {
     four.code shouldBe "4"
   }
 
+  "bitwise AND/OR assignments should parse correctly" in {
+    val cpg = code(
+      """
+        |x = 1
+        |x &= 0
+        |x |= 1
+        |x >>= 1
+        |x <<= 2
+        |""".stripMargin)
+
+    cpg.call.name.foreach(println)
+  }
+
+  "shift left/right assignments should parse correctly" in {
+    val cpg = code(
+      """
+        |x = 1
+        |x >>= 1
+        |x <<= 2
+        |""".stripMargin)
+
+    cpg.call.name.foreach(println)
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/BooleanLogicTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/BooleanLogicTests.scala
@@ -161,28 +161,4 @@ class BooleanLogicTests extends RubyCode2CpgFixture {
     four.code shouldBe "4"
   }
 
-  "bitwise AND/OR assignments should parse correctly" in {
-    val cpg = code(
-      """
-        |x = 1
-        |x &= 0
-        |x |= 1
-        |x >>= 1
-        |x <<= 2
-        |""".stripMargin)
-
-    cpg.call.name.foreach(println)
-  }
-
-  "shift left/right assignments should parse correctly" in {
-    val cpg = code(
-      """
-        |x = 1
-        |x >>= 1
-        |x <<= 2
-        |""".stripMargin)
-
-    cpg.call.name.foreach(println)
-  }
-
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -505,4 +505,36 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected two args, found [${xs.code.mkString(",")}]")
     }
   }
+
+  "bitwise AND/OR assignments should parse correctly" in {
+    val cpg = code("""
+        |x = 1
+        |x &= 0
+        |x |= 1
+        |""".stripMargin)
+
+    inside(cpg.assignment.l) { case _ :: and :: or :: Nil =>
+      and.name shouldBe Operators.assignmentAnd
+      and.code shouldBe "x &= 0"
+
+      or.name shouldBe Operators.assignmentOr
+      or.code shouldBe "x |= 1"
+    }
+  }
+
+  "shift left/right assignments should parse correctly" in {
+    val cpg = code("""
+        |x = 1
+        |x >>= 1
+        |x <<= 2
+        |""".stripMargin)
+
+    inside(cpg.assignment.l) { case _ :: sr :: sl :: Nil =>
+      sr.name shouldBe Operators.assignmentArithmeticShiftRight
+      sr.code shouldBe "x >>= 1"
+
+      sl.name shouldBe Operators.assignmentShiftLeft
+      sl.code shouldBe "x <<= 2"
+    }
+  }
 }


### PR DESCRIPTION
Added handling for `|=`, `&=`, `<<=`, and `>>=`

Resolves #5067