### PR TITLE
[ruby] Fix Call Type for Block

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -13,7 +13,8 @@ import ujson.*
 
 class RubyJsonToNodeCreator(
   variableNameGen: FreshNameGenerator[String] = FreshNameGenerator(id => s"<tmp-$id>"),
-  procParamGen: FreshNameGenerator[Left[String, Nothing]] = FreshNameGenerator(id => Left(s"<proc-param-$id>"))
+  procParamGen: FreshNameGenerator[Left[String, Nothing]] = FreshNameGenerator(id => Left(s"<proc-param-$id>")),
+  fileName: String = ""
 ) {
 
   private val logger       = LoggerFactory.getLogger(getClass)
@@ -293,6 +294,8 @@ class RubyJsonToNodeCreator(
       case memberAccess @ MemberAccess(target, op, memberName) =>
         val memberCall = MemberCall(target, op, memberName, List.empty)(memberAccess.span)
         memberCall.withBlock(block)
+      case x: ProtectedModifier =>
+        SimpleCall(x.toSimpleIdentifier, Nil)(obj.toTextSpan).withBlock(block)
       case x =>
         logger.warn(s"Unexpected call type used for block ${x.getClass}, ignoring block")
         x

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -119,4 +119,31 @@ class ModuleTests extends RubyCode2CpgFixture {
       }
     }
   }
+
+  "Protected call with block" should {
+    val cpg = code("""
+        |module QA
+        |  trait :protected do
+        |    protected { true }
+        |  end
+        |end
+        |""".stripMargin)
+
+    "Have the correct proc arg in call" in {
+      inside(cpg.call.name("protected").argument.l) {
+        case _ :: proc :: Nil =>
+          proc.code shouldBe "<lambda>1&Proc"
+        case xs => fail(s"Expected one call for protected, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "Generate a lambda with true body" in {
+      inside(cpg.method.isLambda.l) {
+        case protectedLambda :: _ :: Nil =>
+          val List(lambdaReturn) = protectedLambda.body.astChildren.isReturn.l
+          lambdaReturn.code shouldBe "true"
+        case xs => fail(s"Expected two lambdas, got [${xs.code.mkString(",")}]")
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixed call type for block when using `protected` keyword.

Resolves #5069 