### PR TITLE
[ruby] Handle `yield` in Constructor

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -671,7 +671,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       case None =>
         logger.warn(s"Yield expression outside of method scope: ${code(node)} ($relativeFileName), skipping")
         astForUnknown(node)
-
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -67,7 +67,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     )
 
     val isSurroundedByProgramScope = scope.isSurroundedByProgramScope
-    if (isConstructor) scope.pushNewScope(ConstructorScope(fullName))
+    if (isConstructor) scope.pushNewScope(ConstructorScope(fullName, this.procParamGen.fresh))
     else scope.pushNewScope(MethodScope(fullName, this.procParamGen.fresh))
 
     val thisParameterNode = newThisParameterNode(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -55,6 +55,8 @@ case class TypeScope(fullName: String, fields: List[FieldDecl]) extends TypeLike
   */
 trait MethodLikeScope extends TypedScopeElement {
   def fullName: String
+  def procParam: Either[String, String]
+  def hasYield: Boolean
 }
 
 case class MethodScope(fullName: String, procParam: Either[String, String], hasYield: Boolean = false)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -60,7 +60,8 @@ trait MethodLikeScope extends TypedScopeElement {
 case class MethodScope(fullName: String, procParam: Either[String, String], hasYield: Boolean = false)
     extends MethodLikeScope
 
-case class ConstructorScope(fullName: String) extends MethodLikeScope
+case class ConstructorScope(fullName: String, procParam: Either[String, String], hasYield: Boolean = false)
+    extends MethodLikeScope
 
 /** Represents scope objects that map to a block node.
   */

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
@@ -117,4 +117,33 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
       case xs => fail(s"Expected one call for yield, got ${xs.code.mkString(",")}")
     }
   }
+
+  "Yield in initialize should create implicit proc parameter" in {
+    val cpg = code("""
+        |class Payload
+        |def initialize
+        |  yield(self)
+        |end
+        |end
+        |""".stripMargin)
+
+    val initMethod = cpg.method.name("initialize").head
+
+    inside(initMethod.parameter.l) {
+      case _ :: procParam :: Nil =>
+        // This seems a bit strange, but the `<body>` method is being processed first which generates a procParam
+        // for the `MethodScope` which is why the procParam for this ConstructorScope is [1] instead of [0]
+        procParam.name shouldBe "<proc-param-1>"
+        procParam.code shouldBe "&<proc-param-1>"
+        procParam.index shouldBe 1
+      case xs => fail(s"Expected two arguments, got [${xs.code.mkString(",")}]")
+    }
+
+    inside(initMethod.call.nameExact("call").argument.l) { case selfBase :: selfParam :: Nil =>
+      selfBase.code shouldBe "<proc-param-1>"
+      selfBase.argumentIndex shouldBe 0
+      selfParam.code shouldBe "self"
+      selfParam.argumentIndex shouldBe 1
+    }
+  }
 }


### PR DESCRIPTION
Added handling for `yield` in a constructor.

Resolves #5090 