### PR TITLE
[ruby] Fix lifting of Field Statements

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -90,7 +90,7 @@ object RubySrc2Cpg {
   def postProcessingPasses(cpg: Cpg, config: Config): List[CpgPassBase] = {
     val implicitRequirePass = if (cpg.dependency.name.contains("zeitwerk")) ImplicitRequirePass(cpg) :: Nil else Nil
     implicitRequirePass ++ List(ImportsPass(cpg), RubyImportResolverPass(cpg)) ++
-      new RubyTypeRecoveryPassGenerator(cpg, config = XTypeRecoveryConfig(iterations = 2))
+      new RubyTypeRecoveryPassGenerator(cpg, config = XTypeRecoveryConfig(iterations = 4))
         .generate() ++ List(new RubyTypeHintCallLinker(cpg), new NaiveCallLinker(cpg), new AstLinkerPass(cpg))
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -90,7 +90,7 @@ object RubySrc2Cpg {
   def postProcessingPasses(cpg: Cpg, config: Config): List[CpgPassBase] = {
     val implicitRequirePass = if (cpg.dependency.name.contains("zeitwerk")) ImplicitRequirePass(cpg) :: Nil else Nil
     implicitRequirePass ++ List(ImportsPass(cpg), RubyImportResolverPass(cpg)) ++
-      new RubyTypeRecoveryPassGenerator(cpg, config = XTypeRecoveryConfig(iterations = 4))
+      new RubyTypeRecoveryPassGenerator(cpg, config = XTypeRecoveryConfig(iterations = 2))
         .generate() ++ List(new RubyTypeHintCallLinker(cpg), new NaiveCallLinker(cpg), new AstLinkerPass(cpg))
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -174,6 +174,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
       }
     }
   }
+
 }
 
 class RubyExternalTypeRecoveryTests

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -937,9 +937,7 @@ class ClassTests extends RubyCode2CpgFixture {
           }
 
           inside(bodyMethod.block.astChildren.l) {
-            case (barInit: Call) :: (one: Literal) :: Nil =>
-              barInit.code shouldBe "bar = nil"
-
+            case (one: Literal) :: Nil =>
               one.code shouldBe "1"
               one.typeFullName shouldBe s"${GlobalTypes.kernelPrefix}.Integer"
             case xs => fail(s"Expected one literal, got [${xs.code.mkString(",")}]")
@@ -1017,4 +1015,5 @@ class ClassTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
   }
+
 }


### PR DESCRIPTION
Fixed lifting of field statements, previously was lifting out any `SingleAssignments` that were inside of methods causing variables to be registered at fields when they shouldn't have been.

Resolves #5092 