### PR TITLE
[QueryDB][docs] Fix comment in UseAfterFree query

### DIFF
--- a/querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
+++ b/querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala
@@ -236,7 +236,7 @@ object UseAfterFree extends QueryBundle {
           |  if (cond) {
           |    free(x);
           |    if (cond2)
-          |      return x; // not post-dominated by free call
+          |      return x; // doesn't post-dominate the free call
           |    x = NULL;
           |  }
           |  return x;


### PR DESCRIPTION
In the file `querydb/src/main/scala/io/joern/scanners/c/UseAfterFree.scala`, the free-follows-value-reuse query has a comment in the "the query does not match" examples. The comment states that the `return x` is not post-dominated by the free call, I believe this is not what the author meant as this statement is not relevant to what the query is doing. This could confuse users. I believe the author wanted to write the following comment instead `return x doesn't post-dominate the free call`.