### PR TITLE
[ruby] `public` in a Method body is lowered to `SimpleCall`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -672,19 +672,8 @@ class RubyJsonToNodeCreator(
     val body = obj
       .visitOption(ParserKeys.Body)
       .map {
-        case x: StatementList =>
-          x.copy(statements = x.statements.map {
-            case _: AccessModifier =>
-              val ident = SimpleIdentifier()(x.span)
-              SimpleCall(ident, List.empty)(x.span)
-            case y => y
-          })(x.span)
-        case x: AccessModifier =>
-          val ident = SimpleIdentifier()(x.span)
-          val call  = SimpleCall(ident, List.empty)(x.span)
-          StatementList(List(call))(x.span)
-        case x =>
-          StatementList(List(x))(x.span)
+        case x: StatementList => x
+        case x                => StatementList(List(x))(x.span)
       }
       .getOrElse(StatementList(Nil)(obj.toTextSpan.spanStart("<empty>")))
     MethodDeclaration(name, parameters, body)(obj.toTextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -672,8 +672,19 @@ class RubyJsonToNodeCreator(
     val body = obj
       .visitOption(ParserKeys.Body)
       .map {
-        case x: StatementList => x
-        case x                => StatementList(List(x))(x.span)
+        case x: StatementList =>
+          x.copy(statements = x.statements.map {
+            case _: AccessModifier =>
+              val ident = SimpleIdentifier()(x.span)
+              SimpleCall(ident, List.empty)(x.span)
+            case y => y
+          })(x.span)
+        case x: AccessModifier =>
+          val ident = SimpleIdentifier()(x.span)
+          val call  = SimpleCall(ident, List.empty)(x.span)
+          StatementList(List(call))(x.span)
+        case x =>
+          StatementList(List(x))(x.span)
       }
       .getOrElse(StatementList(Nil)(obj.toTextSpan.spanStart("<empty>")))
     MethodDeclaration(name, parameters, body)(obj.toTextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -1064,4 +1064,24 @@ class MethodTests extends RubyCode2CpgFixture {
       case xs => fail(s"Expected one return, got [${xs.code.mkString(",")}]")
     }
   }
+
+  "Method call with same name as reserved keyword" in {
+    val cpg = code("""
+        |    def public
+        |      list.sort_by(&:position).filter_map { |category| category.slug if category.visible_to_public? }
+        |    end
+        |
+        |    def notifiable
+        |      public
+        |    end
+        |""".stripMargin)
+
+    inside(cpg.method.name("notifiable").body.astChildren.isReturn.astChildren.isCall.name("public").l) {
+      case publicCall :: Nil =>
+        publicCall.code shouldBe "public"
+
+        val List(selfArg) = publicCall.argument.l
+      case xs => fail(s"Expected one call, got ${xs.code.mkString(",")}")
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -1074,9 +1074,23 @@ class MethodTests extends RubyCode2CpgFixture {
         |    def notifiable
         |      public
         |    end
+        |
+        |    def not_notifiable
+        |       public
+        |       puts 1
+        |       puts 2
+        |    end
         |""".stripMargin)
 
     inside(cpg.method.name("notifiable").body.astChildren.isReturn.astChildren.isCall.name("public").l) {
+      case publicCall :: Nil =>
+        publicCall.code shouldBe "public"
+
+        val List(selfArg) = publicCall.argument.l
+      case xs => fail(s"Expected one call, got ${xs.code.mkString(",")}")
+    }
+
+    inside(cpg.method.name("not_notifiable").body.astChildren.isCall.name("public").l) {
       case publicCall :: Nil =>
         publicCall.code shouldBe "public"
 


### PR DESCRIPTION
Fixed warning where `public` was a call to a user-defined method instead of to the Ruby reserved keyword.

resolves #5109 