### PR TITLE
[ruby] `FieldsDeclaration` in `included do` block

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -32,16 +32,24 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     *   the name of the entity.
     * @param counter
     *   an optional counter, used to create unique instances in the case of redefinitions.
+    * @param isAccessorMethod
+    *   flag for whether the fullName is for accessor-like method lowering
     * @return
     *   a unique full name.
     */
-  protected def computeFullName(name: String, counter: Option[Int] = None): String = {
+  protected def computeFullName(
+    name: String,
+    counter: Option[Int] = None,
+    isAccessorMethod: Boolean = false
+  ): String = {
+    val surroundingName =
+      if isAccessorMethod then scope.surroundingTypeFullName.head else scope.surroundingScopeFullName.head
     val candidate = counter match {
-      case Some(cnt) => s"${scope.surroundingScopeFullName.head}.$name$cnt"
-      case None      => s"${scope.surroundingScopeFullName.head}.$name"
+      case Some(cnt) => s"$surroundingName.$name$cnt"
+      case None      => s"$surroundingName.$name"
     }
     if (usedFullNames.contains(candidate)) {
-      computeFullName(name, counter.map(_ + 1).orElse(Option(0)))
+      computeFullName(name, counter.map(_ + 1).orElse(Option(0)), isAccessorMethod)
     } else {
       usedFullNames.add(candidate)
       candidate

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -239,8 +239,14 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         val simpleIdent = node.toSimpleIdentifier
         val simpleCall  = SimpleCall(simpleIdent, List.empty)(simpleIdent.span)
         astForReturnExpression(ReturnExpression(List(simpleCall))(node.span)) :: Nil
+      case node: FieldsDeclaration =>
+        val nilReturnSpan    = node.span.spanStart("return nil")
+        val nilReturnLiteral = StaticLiteral(Defines.NilClass)(nilReturnSpan)
+        astsForFieldDeclarations(node) ++ astsForImplicitReturnStatement(nilReturnLiteral)
       case node =>
-        logger.warn(s" not supported yet: ${node.text} (${node.getClass.getSimpleName}), only generating statement")
+        logger.warn(
+          s" not supported yet: ${node.text} (${node.getClass.getSimpleName}), only generating statement (${this.relativeFileName})"
+        )
         astsForStatement(node).toList
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -286,7 +286,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         node.span.spanStart(s"return $fieldName")
       )
     )(node.span.spanStart(code))
-    astForMethodDeclaration(methodDecl)
+    astForMethodDeclaration(methodDecl, isAccessorMethod = true)
   }
 
   // creates a `def <name>=(x) { <fieldName> = x }` METHOD, for <fieldName> = @<name>
@@ -303,7 +303,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       MandatoryParameter("x")(node.span.spanStart("x")) :: Nil,
       StatementList(assignment :: Nil)(node.span.spanStart(s"return $fieldName"))
     )(node.span.spanStart(code))
-    astForMethodDeclaration(methodDecl)
+    astForMethodDeclaration(methodDecl, isAccessorMethod = true)
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -1115,4 +1115,50 @@ class ClassTests extends RubyCode2CpgFixture {
       }
     }
   }
+
+  "Multiple FieldsDeclaration in included" should {
+    val cpg = code("""
+        |class Foo
+        |  included do
+        |     attr_accessor :bar
+        |     attr_reader :baz
+        |  end
+        |end
+        |""".stripMargin)
+
+    "Create required getters and setters directly under TYPE_DECL" in {
+      inside(cpg.typeDecl.name("Foo").astChildren.isMethod.name("(bar=?|baz)").l) {
+        case barGetter :: barSetter :: bazGetter :: Nil =>
+          barGetter.name shouldBe "bar"
+          barGetter.fullName shouldBe "Test0.rb:<main>.Foo.bar"
+
+          barSetter.name shouldBe "bar="
+          barSetter.fullName shouldBe "Test0.rb:<main>.Foo.bar="
+
+          bazGetter.name shouldBe "baz"
+          bazGetter.fullName shouldBe "Test0.rb:<main>.Foo.baz"
+        case xs => fail(s"Expected three method defs for getter and setter, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "Create required TYPE_DECL nodes directly under class TYPE_DECL" in {
+      inside(cpg.typeDecl.name("Foo").astChildren.isTypeDecl.name("(bar=?|baz)").l) {
+        case barGetter :: barSetter :: bazGetter :: Nil =>
+          barGetter.name shouldBe "bar"
+          barSetter.name shouldBe "bar="
+          bazGetter.name shouldBe "baz"
+        case xs => fail(s"Expected two type decls, got [${xs.code.mkString(",")}]")
+      }
+    }
+
+    "Create required MEMBER nodes directly under class TYPE_DECL" in {
+      inside(cpg.typeDecl.name("Foo").astChildren.isMember.name("(bar=?|baz)").l) {
+        case barGetter :: barSetter :: bazGetter :: Nil =>
+          barGetter.name shouldBe "bar"
+          barSetter.name shouldBe "bar="
+          bazGetter.name shouldBe "baz"
+        case xs => fail(s"Expected two member nodes, got [${xs.code.mkString(",")}]")
+      }
+    }
+  }
 }


### PR DESCRIPTION
* Moved getters and setters defined in the `included do` block to directly under the class/module `TYPE_DECL`
* Added implicit return for `FieldsDeclaration` (We generate the AST for the `FieldsDeclaration` and add an implicit `return nil` afterwards)

Partially resolves #5118 