### PR TITLE
[ruby] Alias and Method Lowering

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -32,7 +32,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     *   the name of the entity.
     * @param counter
     *   an optional counter, used to create unique instances in the case of redefinitions.
-    * @param isAccessorMethod
+    * @param useSurroundingTypeFullName
     *   flag for whether the fullName is for accessor-like method lowering
     * @return
     *   a unique full name.
@@ -40,16 +40,16 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def computeFullName(
     name: String,
     counter: Option[Int] = None,
-    isAccessorMethod: Boolean = false
+    useSurroundingTypeFullName: Boolean = false
   ): String = {
     val surroundingName =
-      if isAccessorMethod then scope.surroundingTypeFullName.head else scope.surroundingScopeFullName.head
+      if useSurroundingTypeFullName then scope.surroundingTypeFullName.head else scope.surroundingScopeFullName.head
     val candidate = counter match {
       case Some(cnt) => s"$surroundingName.$name$cnt"
       case None      => s"$surroundingName.$name"
     }
     if (usedFullNames.contains(candidate)) {
-      computeFullName(name, counter.map(_ + 1).orElse(Option(0)), isAccessorMethod)
+      computeFullName(name, counter.map(_ + 1).orElse(Option(0)), useSurroundingTypeFullName)
     } else {
       usedFullNames.add(candidate)
       candidate

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -604,14 +604,12 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   }
 
   private def shouldUseSurroundingTypeFullName: Boolean = {
-    val inBodyMethodScope = scope.surroundingScopeFullName.exists(x => x.split("[.]").takeRight(1).head == "<body>")
+    val inBodyMethodScope =
+      scope.surroundingScopeFullName.exists(x => x.split("[.]").takeRight(1).contains(Defines.TypeDeclBody))
 
     scope.surroundingAstLabel match {
-      case Some(astLabel) =>
-        val p = astLabel
-        astLabel == NodeTypes.METHOD && inBodyMethodScope
-      case None =>
-        false
+      case Some(NodeTypes.METHOD) => inBodyMethodScope
+      case _                      => false
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -286,7 +286,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         node.span.spanStart(s"return $fieldName")
       )
     )(node.span.spanStart(code))
-    astForMethodDeclaration(methodDecl, isAccessorMethod = true)
+    astForMethodDeclaration(methodDecl, useSurroundingTypeFullName = true)
   }
 
   // creates a `def <name>=(x) { <fieldName> = x }` METHOD, for <fieldName> = @<name>
@@ -303,7 +303,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       MandatoryParameter("x")(node.span.spanStart("x")) :: Nil,
       StatementList(assignment :: Nil)(node.span.spanStart(s"return $fieldName"))
     )(node.span.spanStart(code))
-    astForMethodDeclaration(methodDecl, isAccessorMethod = true)
+    astForMethodDeclaration(methodDecl, useSurroundingTypeFullName = true)
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -613,6 +613,8 @@ object RubyIntermediateAst {
 
   final case class HereDocNode(content: String)(span: TextSpan) extends RubyExpression(span)
 
-  final case class AliasStatement(oldName: String, newName: String)(span: TextSpan) extends RubyExpression(span)
+  final case class AliasStatement(oldName: String, newName: String)(span: TextSpan)
+      extends RubyExpression(span)
+      with AllowedTypeDeclarationChild
 
 }


### PR DESCRIPTION
* Moved `AliasStatement` lowering to `AstCreator`
* Added handling to ensure methods are lowered to directly under the respective `TYPE_DECL` when found in the `<body>` method.

Resolves #5116 