### PR TITLE
[pysrc2cpg] Fix captured variable linking into class scopes.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -126,12 +126,12 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
     addNodeToDiff(methodRefNode)
   }
 
-  def closureBindingNode(closureBindingId: String, closureOriginalName: String): nodes.NewClosureBinding = {
+  def closureBindingNode(closureBindingId: String): nodes.NewClosureBinding = {
     val closureBindingNode = nodes
       .NewClosureBinding()
       .closureBindingId(Some(closureBindingId))
       .evaluationStrategy(EvaluationStrategies.BY_REFERENCE)
-      .closureOriginalName(Some(closureOriginalName))
+      .closureOriginalName(None)
     addNodeToDiff(closureBindingNode)
   }
 


### PR DESCRIPTION
The linking of captured variables was not yet working if variables from
outside of a class have been captured into methods of a class.
This was the case because of a possible name clashes between those
captured variables and variables inside of the class body methods.
To avoid such clashes captures variables get a `<captured>` prefix
inside the class body methods.
This solves a long standing issue where data flows via such captured
variables were not found.
