### PR TITLE
[jssrc2cpg] Improve error handling even further

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelJsonParser.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelJsonParser.scala
@@ -19,24 +19,37 @@ object BabelJsonParser {
     fileLoc: Int
   ) extends BaseParserResult
 
-  def readFile(rootPath: Path, file: Path): Option[ParseResult] = {
-    Try {
-      val typeMapPath = Paths.get(file.toString.replace(".json", ".typemap"))
-      val typeMap = if (typeMapPath.toFile.exists()) {
-        val typeMapJsonContent = IOUtils.readEntireFile(typeMapPath)
-        val typeMapJson        = ujson.read(typeMapJsonContent)
-        typeMapJson.obj.map { case (k, v) => k.toInt -> v.str }.toMap
-      } else {
-        Map.empty[Int, String]
-      }
-      val jsonContent       = IOUtils.readEntireFile(file)
-      val json              = ujson.read(jsonContent)
-      val filename          = json("relativeName").str
-      val fullPath          = Paths.get(rootPath.toString, filename)
-      val sourceFileContent = IOUtils.readEntireFile(fullPath)
-      val fileLoc           = sourceFileContent.lines().count().toInt
-      ParseResult(filename, fullPath.toString, json, sourceFileContent, typeMap, fileLoc)
+  private def loadTypeMap(file: Path): Try[Map[Int, String]] = Try {
+    val typeMapPathString = file.toString.replaceAll("\\.[^.]*$", "") + ".typemap"
+    val typeMapPath       = Paths.get(typeMapPathString)
+    if (typeMapPath.toFile.exists()) {
+      val typeMapJsonContent = IOUtils.readEntireFile(typeMapPath)
+      val typeMapJson        = ujson.read(typeMapJsonContent)
+      typeMapJson.obj.map { case (k, v) => k.toInt -> v.str }.toMap
+    } else {
+      Map.empty
     }
-  }.toOption
+  }
+
+  private def loadJson(file: Path): Try[Value] = Try {
+    val jsonContent = IOUtils.readEntireFile(file)
+    ujson.read(jsonContent)
+  }
+
+  private def generateParserResult(rootPath: Path, json: Value, typeMap: Map[Int, String]): Try[ParseResult] = Try {
+    val filename          = json("relativeName").str
+    val fullPath          = Paths.get(rootPath.toString, filename)
+    val sourceFileContent = IOUtils.readEntireFile(fullPath)
+    val fileLoc           = sourceFileContent.lines().count().toInt
+    ParseResult(filename, fullPath.toString, json, sourceFileContent, typeMap, fileLoc)
+  }
+
+  def readFile(rootPath: Path, file: Path): Try[ParseResult] = {
+    val typeMap = loadTypeMap(file).getOrElse(Map.empty)
+    for {
+      json        <- loadJson(file)
+      parseResult <- generateParserResult(rootPath, json, typeMap)
+    } yield parseResult
+  }
 
 }


### PR DESCRIPTION
https://github.com/joernio/joern/pull/5127 made `BabelJsonParser.readFile` a bit safer by simply wrapping everything into a big try.

This PR changes that to:
 - separate Try blocks for type map loading, json loading, and parse result generation
 - forward exceptions from json loading and parse result generation to `AstCreationPass.runOnPart`, and
 - do a proper WARN logging of these exceptions