### PR TITLE
frontends: allow multiple `--exclude` parameters (additionally)

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/config/ConfigTests.scala
@@ -18,7 +18,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
       "--output",
       "OUTPUT",
       "--exclude",
-      "1EXCLUDE_FILE,2EXCLUDE_FILE",
+      "1EXCLUDE_FILE",
+      "--exclude",
+      "2EXCLUDE_FILE",
       "--exclude-regex",
       "EXCLUDE_REGEX",
       // Frontend-specific args

--- a/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/test/scala/io/joern/ghidra2cpg/config/ConfigTests.scala
@@ -18,7 +18,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
       "--output",
       "OUTPUT",
       "--exclude",
-      "1EXCLUDE_FILE,2EXCLUDE_FILE",
+      "1EXCLUDE_FILE",
+      "--exclude",
+      "2EXCLUDE_FILE",
       "--exclude-regex",
       "EXCLUDE_REGEX"
       // Frontend-specific args

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/config/ConfigTests.scala
@@ -18,7 +18,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
       "--output",
       "OUTPUT",
       "--exclude",
-      "1EXCLUDE_FILE,2EXCLUDE_FILE",
+      "1EXCLUDE_FILE",
+      "--exclude",
+      "2EXCLUDE_FILE",
       "--exclude-regex",
       "EXCLUDE_REGEX",
       // Frontend-specific args

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/config/ConfigTests.scala
@@ -18,7 +18,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
       "--output",
       "OUTPUT",
       "--exclude",
-      "1EXCLUDE_FILE,2EXCLUDE_FILE",
+      "1EXCLUDE_FILE",
+      "--exclude",
+      "2EXCLUDE_FILE",
       "--exclude-regex",
       "EXCLUDE_REGEX",
       // Frontend-specific args

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/config/ConfigTests.scala
@@ -22,7 +22,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
         "--output",
         "OUTPUT",
         "--exclude",
-        "1EXCLUDE_FILE,2EXCLUDE_FILE",
+        "1EXCLUDE_FILE",
+        "--exclude",
+        "2EXCLUDE_FILE",
         "--exclude-regex",
         "EXCLUDE_REGEX",
         // Frontend-specific args

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/config/ConfigTests.scala
@@ -18,7 +18,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
       "--output",
       "OUTPUT",
       "--exclude",
-      "1EXCLUDE_FILE,2EXCLUDE_FILE",
+      "1EXCLUDE_FILE",
+      "--exclude",
+      "2EXCLUDE_FILE",
       "--exclude-regex",
       "EXCLUDE_REGEX",
       // Frontend-specific args

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/config/ConfigTests.scala
@@ -18,7 +18,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
       "--output",
       "OUTPUT",
       "--exclude",
-      "1EXCLUDE_FILE,2EXCLUDE_FILE",
+      "1EXCLUDE_FILE",
+      "--exclude",
+      "2EXCLUDE_FILE",
       "--exclude-regex",
       "EXCLUDE_REGEX",
       // Frontend-specific args

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/config/ConfigTests.scala
@@ -18,7 +18,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
       "--output",
       "OUTPUT",
       "--exclude",
-      "1EXCLUDE_FILE,2EXCLUDE_FILE",
+      "1EXCLUDE_FILE",
+      "--exclude",
+      "2EXCLUDE_FILE",
       "--exclude-regex",
       "EXCLUDE_REGEX",
       // Frontend-specific args

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/config/ConfigTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/config/ConfigTests.scala
@@ -18,7 +18,9 @@ class ConfigTests extends AnyWordSpec with Matchers with Inside {
       "--output",
       "OUTPUT",
       "--exclude",
-      "1EXCLUDE_FILE,2EXCLUDE_FILE",
+      "1EXCLUDE_FILE",
+      "--exclude",
+      "2EXCLUDE_FILE",
       "--exclude-regex",
       "EXCLUDE_REGEX"
       // Frontend-specific args

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -277,8 +277,14 @@ object X2Cpg {
         .action { (x, c) =>
           c.withOutputPath(x)
         },
+
+      // previously this was supposed to be called with `,` as a separator,
+      // e.g. `--exclude foo,bar` - which (among others) has the disadvantage
+      // that under windows a `,` is treated as an argument separator
+      // better: provide this argument multiple times, i.e. `--exlude foo --exclude bar`
       opt[Seq[String]]("exclude")
-        .valueName("<file1>,<file2>,...")
+        .valueName("<file1>")
+        .unbounded()
         .action { (x, c) =>
           c.ignoredFiles = c.ignoredFiles ++ x.map(c.createPathForIgnore)
           c


### PR DESCRIPTION
previously this was supposed to be called with `,` as a separator,
e.g. `--exclude foo,bar` - which (among others) has the disadvantage
that under windows a `,` is treated as an argument separator

better: provide this argument multiple times, i.e. `--exlude foo --exclude bar`

note: the old way using commas is still supported