### PR TITLE
[jssrc2cpg] Pass excludes to astgen

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.19.0"
+    astgen_version: "3.21.0"
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -281,7 +281,7 @@ object X2Cpg {
       // previously this was supposed to be called with `,` as a separator,
       // e.g. `--exclude foo,bar` - which (among others) has the disadvantage
       // that under windows a `,` is treated as an argument separator
-      // better: provide this argument multiple times, i.e. `--exlude foo --exclude bar`
+      // better: provide this argument multiple times, i.e. `--exclude foo --exclude bar`
       opt[Seq[String]]("exclude")
         .valueName("<file1>")
         .unbounded()


### PR DESCRIPTION
This passes the ignored files and the ignored files regex down to astgen so we do not parse files matching them for nothing.

Also: removed `NODE_OPTIONS` as this is already hardcoded into the astgen build