### PR TITLE
Add support for java type pattern matching

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -43,7 +43,8 @@ import io.joern.javasrc2cpg.util.{
   BindingTable,
   BindingTableAdapterForJavaparser,
   MultiBindingTableAdapterForJavaparser,
-  NameConstants
+  NameConstants,
+  TemporaryNameProvider
 }
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.utils.OffsetUtils
@@ -104,6 +105,8 @@ class AstCreator(
   private[astcreation] val typeInfoCalc: TypeInfoCalculator =
     TypeInfoCalculator(global, symbolSolver, keepTypeArguments)
   private[astcreation] val bindingTableCache = mutable.HashMap.empty[String, BindingTable]
+
+  private[astcreation] val tempNameProvider: TemporaryNameProvider = new TemporaryNameProvider
 
   /** Entry point of AST creation. Translates a compilation unit created by JavaParser into a DiffGraph containing the
     * corresponding CPG AST.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -52,8 +52,6 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private var tempConstCount = 0
-
   private[expressions] def astForMethodCall(call: MethodCallExpr, expectedReturnType: ExpectedType): Ast = {
     val maybeResolvedCall = tryWithSafeStackOverflow(call.resolve())
     val argumentAsts      = argAstsForCall(call, maybeResolvedCall, call.getArguments)
@@ -143,8 +141,7 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
   }
 
   private[expressions] def blockAstForObjectCreationExpr(expr: ObjectCreationExpr, expectedType: ExpectedType): Ast = {
-    val tmpName = "$obj" ++ tempConstCount.toString
-    tempConstCount += 1
+    val tmpName = tempNameProvider.next
 
     // Use an untyped identifier for receiver here, create the alloc and init ASTs,
     // then use the types of those to fix the local type.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForExpressionsCreator.scala
@@ -33,6 +33,7 @@ trait AstForExpressionsCreator
     with AstForLambdasCreator
     with AstForCallExpressionsCreator
     with AstForNameExpressionsCreator
+    with AstForPatternExpressionsCreator
     with AstForVarDeclAndAssignsCreator { this: AstCreator =>
   def astsForExpression(expression: Expression, expectedType: ExpectedType): Seq[Ast] = {
     // TODO: Implement missing handlers

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
@@ -1,0 +1,137 @@
+package io.joern.javasrc2cpg.astcreation.expressions
+
+import com.github.javaparser.ast.Node
+import com.github.javaparser.ast.expr.{
+  Expression,
+  InstanceOfExpr,
+  NameExpr,
+  PatternExpr,
+  RecordPatternExpr,
+  TypePatternExpr
+}
+import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
+import io.joern.javasrc2cpg.jartypereader.model.Model.TypeConstants
+import io.joern.javasrc2cpg.scope.Scope.NewVariableNode
+import io.joern.x2cpg.Ast
+import io.joern.x2cpg.utils.AstPropertiesUtil.*
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, NewIdentifier}
+import io.joern.x2cpg.utils.NodeBuilders.*
+import io.shiftleft.codepropertygraph.generated.Operators
+
+import scala.jdk.CollectionConverters.*
+
+trait AstForPatternExpressionsCreator { this: AstCreator =>
+
+  private[astcreation] def astIdentifierAndRefsForPatternLhs(
+    rootNode: Node,
+    patternInitAst: Ast
+  ): (Ast, NewIdentifier, Option[NewVariableNode]) = {
+    patternInitAst.nodes.toList match {
+      case (identifier: NewIdentifier) :: Nil =>
+        (patternInitAst, identifier, scope.lookupVariable(identifier.name).variableNode)
+
+      case _ =>
+        val tmpName       = tempNameProvider.next
+        val tmpType       = patternInitAst.rootType.getOrElse(TypeConstants.Object)
+        val tmpLocal      = localNode(rootNode, tmpName, tmpName, tmpType)
+        val tmpIdentifier = identifierNode(rootNode, tmpName, tmpName, tmpType)
+
+        val tmpAssignmentNode =
+          newOperatorCallNode(
+            Operators.assignment,
+            s"$tmpName = ${patternInitAst.rootCodeOrEmpty}",
+            Option(tmpType),
+            line(rootNode),
+            column(rootNode)
+          )
+
+        // Don't need to add the local to the block scope since the only identifiers referencing it are created here
+        // (so a lookup for the local will never be done)
+        scope.enclosingMethod.foreach(_.addTemporaryLocal(tmpLocal))
+
+        (
+          callAst(tmpAssignmentNode, Ast(tmpIdentifier) :: patternInitAst :: Nil).withRefEdge(tmpIdentifier, tmpLocal),
+          tmpIdentifier,
+          Option(tmpLocal)
+        )
+    }
+  }
+
+  private[astcreation] def astForInstanceOfWithPattern(
+    instanceOfLhsExpr: Expression,
+    patternLhsInitAst: Ast,
+    pattern: PatternExpr
+  ): Ast = {
+    val (lhsAst, lhsIdentifier, lhsRefsTo) = astIdentifierAndRefsForPatternLhs(instanceOfLhsExpr, patternLhsInitAst)
+
+    val patternTypeFullName = {
+      tryWithSafeStackOverflow(pattern.getType).toOption
+        .flatMap(typ => scope.lookupScopeType(typ.asString()).map(_.typeFullName).orElse(typeInfoCalc.fullName(typ)))
+        .getOrElse(TypeConstants.Any)
+    }
+
+    val patternTypeRef = typeRefNode(pattern.getType, code(pattern.getType), patternTypeFullName)
+
+    val typePatterns = getTypePatterns(pattern)
+
+    typePatterns.foreach { typePatternExpr =>
+      val variableName = typePatternExpr.getNameAsString
+      val variableType = {
+        tryWithSafeStackOverflow(typePatternExpr.getType).toOption
+          .flatMap(typ => scope.lookupScopeType(typ.asString()).map(_.typeFullName).orElse(typeInfoCalc.fullName(typ)))
+          .getOrElse(TypeConstants.Any)
+      }
+      val variableTypeCode = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
+
+      val patternLocal      = localNode(typePatternExpr, variableName, code(typePatternExpr), variableType)
+      val patternIdentifier = identifierNode(typePatternExpr, variableName, variableName, variableType)
+      // TODO Handle record pattern initializers
+      val patternInitializerCastType = typeRefNode(typePatternExpr, code(typePatternExpr.getType), variableType)
+      val patternInitializerCastRhs  = lhsIdentifier.copy
+      val patternInitializerCast = newOperatorCallNode(
+        Operators.cast,
+        s"($variableTypeCode) ${lhsIdentifier.code}",
+        Option(variableType),
+        line(typePatternExpr),
+        column(typePatternExpr)
+      )
+
+      val initializerCastAst =
+        callAst(patternInitializerCast, Ast(patternInitializerCastType) :: Ast(patternInitializerCastRhs) :: Nil)
+          .withRefEdges(patternInitializerCastRhs, lhsRefsTo.toList)
+
+      val initializerAssignmentCall = newOperatorCallNode(
+        Operators.assignment,
+        s"$variableName = ${patternInitializerCast.code}",
+        Option(variableType),
+        line(typePatternExpr),
+        column(typePatternExpr)
+      )
+      val initializerAssignmentAst = callAst(
+        initializerAssignmentCall,
+        Ast(patternIdentifier) :: initializerCastAst :: Nil
+      ).withRefEdge(patternIdentifier, patternLocal)
+
+      scope.enclosingMethod.foreach { methodScope =>
+        methodScope.putPatternVariableInfo(typePatternExpr, patternLocal, initializerAssignmentAst)
+      }
+    }
+
+    val instanceOfCall = newOperatorCallNode(
+      Operators.instanceOf,
+      s"${lhsAst.rootCodeOrEmpty} instanceof ${code(pattern.getType)}",
+      Option(TypeConstants.Boolean)
+    )
+
+    callAst(instanceOfCall, lhsAst :: Ast(patternTypeRef) :: Nil)
+  }
+
+  private def getTypePatterns(expr: PatternExpr): List[TypePatternExpr] = {
+    expr match {
+      case typePatternExpr: TypePatternExpr => typePatternExpr :: Nil
+
+      case recordPatternExpr: RecordPatternExpr =>
+        recordPatternExpr.getPatternList.asScala.toList.flatMap(getTypePatterns)
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -2,6 +2,8 @@ package io.joern.javasrc2cpg.astcreation.statements
 
 import com.github.javaparser.ast.expr.{Expression, NameExpr}
 import com.github.javaparser.ast.stmt.{BlockStmt, ForEachStmt, ForStmt}
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.ForStatementContext
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver
 import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
 import io.joern.javasrc2cpg.scope.NodeTypeInfo
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
@@ -23,7 +25,6 @@ import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.Try
 
 trait AstForForLoopsCreator { this: AstCreator =>
 
@@ -44,7 +45,9 @@ trait AstForForLoopsCreator { this: AstCreator =>
     s"$IterableNamePrefix${iterableKeyPool.next}"
   }
 
-  def astForFor(stmt: ForStmt): Ast = {
+  def astsForFor(stmt: ForStmt): List[Ast] = {
+    val forContext = new ForStatementContext(stmt, new CombinedTypeSolver())
+
     val forNode =
       NewControlStructure()
         .controlStructureType(ControlStructureTypes.FOR)
@@ -59,24 +62,41 @@ trait AstForForLoopsCreator { this: AstCreator =>
       astsForExpression(_, ExpectedType.Boolean)
     }
 
-    val updateAsts = stmt.getUpdate.asScala.toList.flatMap {
-      astsForExpression(_, ExpectedType.empty)
+    val updateAsts = stmt.getUpdate.asScala.toList match {
+      case Nil => Nil
+
+      case expressions =>
+        scope.pushBlockScope()
+        scope.addLocalsForPatternsToEnclosingBlock(
+          forContext.typePatternExprsExposedToChild(expressions.head).asScala.toList
+        )
+        val updateAsts = expressions.flatMap(astsForExpression(_, ExpectedType.empty))
+        scope.popBlockScope()
+        updateAsts
     }
 
-    val stmtAsts =
-      astsForStatement(stmt.getBody)
+    val patternPartition = partitionPatternAstsByScope(forContext)
+
+    scope.pushBlockScope()
+    scope.addLocalsForPatternsToEnclosingBlock(patternPartition.patternsIntroducedToBody)
+    val bodyAst = wrapInBlockWithPrefix(patternPartition.astsAddedToBody, stmt.getBody)
+    scope.popBlockScope()
+
+    scope.addLocalsForPatternsToEnclosingBlock(patternPartition.patternsIntroducedByStatement)
 
     val ast = Ast(forNode)
       .withChildren(initAsts)
       .withChildren(compareAsts)
       .withChildren(updateAsts)
-      .withChildren(stmtAsts)
+      .withChild(bodyAst)
 
-    compareAsts.flatMap(_.root) match {
+    val astWithConditionEdge = compareAsts.flatMap(_.root) match {
       case c :: Nil =>
         ast.withConditionEdge(forNode, c)
       case _ => ast
     }
+
+    patternPartition.astsAddedBeforeStatement ++ (astWithConditionEdge :: patternPartition.astsAddedAfterStatement)
   }
 
   def astForForEach(stmt: ForEachStmt): Seq[Ast] = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForStatementsCreator.scala
@@ -1,5 +1,6 @@
 package io.joern.javasrc2cpg.astcreation.statements
 
+import com.github.javaparser.ast.expr.TypePatternExpr
 import com.github.javaparser.ast.stmt.{
   AssertStmt,
   BlockStmt,
@@ -25,6 +26,15 @@ import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
 import io.joern.x2cpg.Ast
 import org.slf4j.LoggerFactory
 import com.github.javaparser.ast.stmt.LocalClassDeclarationStmt
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.StatementContext
+import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
+import io.joern.javasrc2cpg.scope.PatternVariableInfo
+
+import java.util
+import java.util.Collections
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
 
 trait AstForStatementsCreator extends AstForSimpleStatementsCreator with AstForForLoopsCreator { this: AstCreator =>
 
@@ -35,30 +45,155 @@ trait AstForStatementsCreator extends AstForSimpleStatementsCreator with AstForF
     // case _: LocalClassDeclarationStmt  => Seq()
     // case _: LocalRecordDeclarationStmt => Seq()
     // case _: YieldStmt                  => Seq()
-    statement match {
+    val statementAsts = statement match {
       case x: ExplicitConstructorInvocationStmt =>
         Seq(astForExplicitConstructorInvocation(x))
       case x: AssertStmt                => Seq(astForAssertStatement(x))
       case x: BlockStmt                 => Seq(astForBlockStatement(x))
       case x: BreakStmt                 => Seq(astForBreakStatement(x))
       case x: ContinueStmt              => Seq(astForContinueStatement(x))
-      case x: DoStmt                    => Seq(astForDo(x))
+      case x: DoStmt                    => astsForDo(x)
       case _: EmptyStmt                 => Seq() // Intentionally skipping this
       case x: ExpressionStmt            => astsForExpression(x.getExpression, ExpectedType.Void)
       case x: ForEachStmt               => astForForEach(x)
-      case x: ForStmt                   => Seq(astForFor(x))
-      case x: IfStmt                    => Seq(astForIf(x))
+      case x: ForStmt                   => astsForFor(x)
+      case x: IfStmt                    => astsForIf(x)
       case x: LabeledStmt               => astsForLabeledStatement(x)
       case x: ReturnStmt                => Seq(astForReturnNode(x))
       case x: SwitchStmt                => Seq(astForSwitchStatement(x))
       case x: SynchronizedStmt          => Seq(astForSynchronizedStatement(x))
       case x: ThrowStmt                 => Seq(astForThrow(x))
       case x: TryStmt                   => astsForTry(x)
-      case x: WhileStmt                 => Seq(astForWhile(x))
+      case x: WhileStmt                 => astsForWhile(x)
       case x: LocalClassDeclarationStmt => Seq(astForLocalClassDeclaration(x))
       case x =>
         logger.warn(s"Attempting to generate AST for unknown statement of type ${x.getClass}")
         Seq(unknownAst(x))
+    }
+
+    val patternVariableAsts =
+      scope.enclosingMethod
+        .map { enclosingMethod => enclosingMethod.getUnaddedPatternVariableAstsAndMarkAdded() }
+        .getOrElse(Nil)
+    patternVariableAsts ++ statementAsts
+  }
+
+  private[statements] def partitionPatternAstsByScope(context: StatementContext[?]): PatternAstPartition = {
+    val patternsIntroducedByStmt =
+      Collections.newSetFromMap(new util.IdentityHashMap[TypePatternExpr, java.lang.Boolean]())
+    patternsIntroducedByStmt.addAll(context.getIntroducedTypePatterns)
+
+    val patternsIntroducedToBody =
+      Collections.newSetFromMap(new util.IdentityHashMap[TypePatternExpr, java.lang.Boolean](2))
+
+    val body = context.getWrappedNode match {
+      case ifStmt: IfStmt           => ifStmt.getThenStmt
+      case whileStmt: WhileStmt     => whileStmt.getBody
+      case forStmt: ForStmt         => forStmt.getBody
+      case forEachStmt: ForEachStmt => forEachStmt.getBody
+      case doStmt: DoStmt           => doStmt.getBody
+      case other =>
+        throw new IllegalArgumentException(
+          s"Trying to partition pattern asts for invalid node type ${other.getClass.getName}"
+        )
+    }
+    patternsIntroducedToBody.addAll(context.typePatternExprsExposedToChild(body))
+
+    val patternsIntroducedToElse =
+      Collections.newSetFromMap(new util.IdentityHashMap[TypePatternExpr, java.lang.Boolean]())
+
+    context.getWrappedNode match {
+      case ifStmt: IfStmt if ifStmt.getElseStmt.isPresent =>
+        patternsIntroducedToElse.addAll(context.typePatternExprsExposedToChild(ifStmt.getElseStmt.get()))
+      case _ => // Nothing to do in this case
+    }
+
+    val astsAddedBeforeStmt = mutable.ListBuffer[Ast]()
+    val astsAddedAfterStmt  = mutable.ListBuffer[Ast]()
+    val astsAddedToBody     = mutable.ListBuffer[Ast]()
+    val astsAddedToElse     = mutable.ListBuffer[Ast]()
+
+    val patternSet = Collections.newSetFromMap(new util.IdentityHashMap[TypePatternExpr, java.lang.Boolean]())
+
+    // patterns that are introduced or used in the comparison expression, but not introduced to the
+    // then or else blocks, or the outer scope.
+    val patternsDefinedInConditions = context.getWrappedNode
+      .match {
+        case ifStmt: IfStmt           => Seq(ifStmt.getCondition)
+        case whileStmt: WhileStmt     => Seq(whileStmt.getCondition)
+        case forEachStmt: ForEachStmt => Seq()
+        case doStmt: DoStmt           => Seq(doStmt.getCondition)
+        case forStmt: ForStmt =>
+          forStmt.getInitialization.asScala ++ forStmt.getCompare.toScala ++ forStmt.getUpdate.asScala
+      }
+      .flatMap(_.findAll(classOf[TypePatternExpr]).asScala)
+
+    patternSet.addAll(patternsDefinedInConditions.asJava)
+
+    patternSet.asScala
+      .flatMap(patternExpr => scope.enclosingMethod.flatMap(_.getPatternVariableInfo(patternExpr)))
+      .foreach {
+        case PatternVariableInfo(pattern, variableLocal, _, _, true) =>
+          scope.enclosingMethod.foreach(_.registerPatternVariableLocalToBeAddedToGraph(pattern))
+          astsAddedBeforeStmt.addOne(Ast(variableLocal))
+
+        case PatternVariableInfo(pattern, variableLocal, initializer, _, false) =>
+          if (patternsIntroducedByStmt.contains(pattern)) {
+            if (patternsIntroducedToBody.contains(pattern) || patternsIntroducedToElse.contains(pattern)) {
+              astsAddedBeforeStmt.addOne(Ast(variableLocal))
+              astsAddedBeforeStmt.addOne(initializer)
+            } else {
+              astsAddedAfterStmt.addOne(Ast(variableLocal))
+              astsAddedAfterStmt.addOne(initializer)
+            }
+          } else {
+            if (patternsIntroducedToBody.contains(pattern)) {
+              astsAddedToBody.addOne(Ast(variableLocal))
+              astsAddedToBody.addOne(initializer)
+            } else if (patternsIntroducedToElse.contains(pattern)) {
+              astsAddedToElse.addOne(Ast(variableLocal))
+              astsAddedToElse.addOne(initializer)
+            }
+          }
+          scope.enclosingMethod.foreach(_.registerPatternVariableInitializerToBeAddedToGraph(pattern))
+          scope.enclosingMethod.foreach(_.registerPatternVariableLocalToBeAddedToGraph(pattern))
+
+      }
+
+    PatternAstPartition(
+      patternsIntroducedToBody.asScala.toList,
+      patternsIntroducedToElse.asScala.toList,
+      patternsIntroducedByStmt.asScala.toList,
+      astsAddedBeforeStmt.toList,
+      astsAddedToBody.toList,
+      astsAddedToElse.toList,
+      astsAddedAfterStmt.toList
+    )
+  }
+
+  private[statements] def wrapInBlockWithPrefix(prefixAsts: List[Ast], stmt: Statement): Ast = {
+    wrapInBlockWithPrefix(prefixAsts, stmt :: Nil)
+  }
+
+  private[statements] def wrapInBlockWithPrefix(prefixAsts: List[Ast], stmts: List[Statement]): Ast = {
+    stmts match {
+      case Seq()                     => Ast(NewBlock()).withChildren(prefixAsts)
+      case Seq(blockStmt: BlockStmt) => astForBlockStatement(blockStmt, prefixAsts = prefixAsts)
+
+      case Seq(singleStmt) =>
+        val stmtAsts = astsForStatement(singleStmt)
+        stmtAsts.toList match {
+          case bodyStmt :: Nil if prefixAsts.isEmpty => bodyStmt
+          case _                                     => blockAst(blockNode(singleStmt), prefixAsts ++ stmtAsts)
+        }
+
+      case _ =>
+        val stmtsAsts = stmts.flatMap(astsForStatement)
+        stmtsAsts match {
+          case Nil                                   => Ast(NewBlock()).withChildren(prefixAsts)
+          case bodyStmt :: Nil if prefixAsts.isEmpty => bodyStmt
+          case _                                     => blockAst(blockNode(stmts.head), prefixAsts ++ stmtsAsts)
+        }
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -1,11 +1,12 @@
 package io.joern.javasrc2cpg.scope
 
+import com.github.javaparser.ast.expr.TypePatternExpr
 import io.joern.javasrc2cpg.astcreation.ExpectedType
 import io.joern.javasrc2cpg.scope.Scope.*
 import io.joern.javasrc2cpg.scope.JavaScopeElement.*
 import io.joern.javasrc2cpg.util.MultiBindingTableAdapterForJavaparser.JavaparserBindingDeclType
 import io.joern.javasrc2cpg.util.NameConstants
-import io.joern.x2cpg.Ast
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.utils.ListUtils.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.slf4j.LoggerFactory
@@ -22,7 +23,7 @@ case class NodeTypeInfo(
   isField: Boolean = false,
   isStatic: Boolean = false
 )
-class Scope {
+class Scope(implicit val withSchemaValidation: ValidationMode) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   private var scopeStack: List[JavaScopeElement] = Nil
@@ -279,6 +280,14 @@ class Scope {
       case _ => None
     }
   }
+
+  def addLocalsForPatternsToEnclosingBlock(patterns: List[TypePatternExpr]): Unit = {
+    patterns.flatMap(enclosingMethod.get.getPatternVariableInfo(_)).foreach {
+      case PatternVariableInfo(typePatternExpr, variableLocal, _, _, _) =>
+        enclosingBlock.get.addPatternLocal(variableLocal, typePatternExpr)
+    }
+  }
+
 }
 
 object Scope {
@@ -335,6 +344,11 @@ object Scope {
     val name: String         = node.name
   }
   final case class ScopeMember(override val node: NewMember, isStatic: Boolean) extends ScopeVariable {
+    val typeFullName: String = node.typeFullName
+    val name: String         = node.name
+  }
+  final case class ScopePatternVariable(override val node: NewLocal, typePatternExpr: TypePatternExpr)
+      extends ScopeVariable {
     val typeFullName: String = node.typeFullName
     val name: String         = node.name
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TemporaryNameProvider.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TemporaryNameProvider.scala
@@ -1,0 +1,14 @@
+package io.joern.javasrc2cpg.util
+
+class TemporaryNameProvider {
+
+  val tmpNamePrefix         = "$obj"
+  private var tmpIndex: Int = 0
+
+  def next: String = {
+    val name = s"$tmpNamePrefix$tmpIndex"
+    tmpIndex += 1
+    name
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
@@ -1,0 +1,2729 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Block,
+  Call,
+  ControlStructure,
+  FieldIdentifier,
+  Identifier,
+  JumpTarget,
+  Literal,
+  Local,
+  TypeRef
+}
+import io.shiftleft.semanticcpg.language.*
+
+class PatternExprTests extends JavaSrcCode2CpgFixture {
+
+  "a type pattern in an expression in an explicit constructor" should {
+    val cpg = code("""
+        |class Test {
+        |  Object foo() {
+        |    return "abc";
+        |  }
+        |
+        |  public Test() {
+        |    boolean b = foo() instanceof String s;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "parse" in {
+      cpg.call.name("foo").nonEmpty shouldBe true
+    }
+
+    "be represented correctly" in {
+      inside(cpg.method.name(".*init.*").body.astChildren.l) {
+        case List(tmpLocal: Local, sLocal: Local, sAssign: Call, bLocal: Local, bAssign: Call) =>
+          tmpLocal.name shouldBe "$obj0"
+
+          bLocal.name shouldBe "b"
+
+          // TODO should s assignment be added if it is never used
+          sAssign.code shouldBe "s = (String) $obj0"
+
+          sLocal.name shouldBe "s"
+
+          // TODO bAssign code
+          bAssign.methodFullName shouldBe Operators.assignment
+          inside(bAssign.argument.l) { case List(bIdentifier: Identifier, instanceOfCall: Call) =>
+            bIdentifier.name shouldBe "b"
+            bIdentifier.typeFullName shouldBe "boolean"
+            bIdentifier.refsTo.l shouldBe List(bLocal)
+
+            instanceOfCall.methodFullName shouldBe Operators.instanceOf
+
+            inside(instanceOfCall.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
+              tmpAssign.methodFullName shouldBe Operators.assignment
+              // TODO tmpAssign code
+
+              inside(tmpAssign.argument.l) { case List(tmpIdentifier: Identifier, fooCall: Call) =>
+                tmpIdentifier.name shouldBe "$obj0"
+                tmpIdentifier.typeFullName shouldBe "java.lang.Object"
+                tmpIdentifier.refsTo.l shouldBe List(tmpLocal)
+
+                fooCall.name shouldBe "foo"
+                fooCall.methodFullName shouldBe "Test.foo:java.lang.Object()"
+              }
+            }
+          }
+      }
+    }
+  }
+
+  "a pattern matching instanceof in a field initializer" should {
+    val cpg = code("""
+                       |import foo.Foo;
+                       |
+                       |class Test {
+                       |    public int x = Foo.FOO instanceof String s ? s.length() : -1;
+                       |}
+                       |""".stripMargin)
+      .moreCode("""
+          |package foo;
+          |
+          |public class Foo {
+          |  public Object FOO = "abc";
+          |}
+          |""".stripMargin)
+    "parse" in {
+      cpg.call.name("length").nonEmpty shouldBe true
+    }
+
+    "add the local and initialiser for the pattern variable to the <init> method" in {
+      inside(cpg.typeDecl.name("Test").method.nameExact("<init>").body.astChildren.l) {
+        case List(tmpLocal: Local, sLocal: Local, xAssign: Call) =>
+          tmpLocal.name shouldBe "$obj0"
+          tmpLocal.typeFullName shouldBe "java.lang.Object"
+
+          sLocal.name shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+
+          xAssign.methodFullName shouldBe Operators.assignment
+          // TODO xAssign code
+
+          inside(xAssign.argument.l) { case List(xFieldAccess: Call, conditionalExpr: Call) =>
+            xFieldAccess.methodFullName shouldBe Operators.fieldAccess
+            // TODO xFieldAccess test
+
+            conditionalExpr.methodFullName shouldBe Operators.conditional
+            conditionalExpr.typeFullName shouldBe "int"
+
+            inside(conditionalExpr.argument.l) { case List(instanceOfCall: Call, lengthCall: Call, minusCall: Call) =>
+              instanceOfCall.methodFullName shouldBe Operators.instanceOf
+              inside(instanceOfCall.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
+                inside(tmpAssign.argument.l) { case List(tmpIdentifier: Identifier, fooFieldAccess: Call) =>
+                  tmpIdentifier.name shouldBe "$obj0"
+                  tmpIdentifier.typeFullName shouldBe "java.lang.Object"
+                  tmpIdentifier.refsTo.l shouldBe List(tmpLocal)
+
+                  fooFieldAccess.code shouldBe "Foo.FOO"
+                }
+
+                stringType.typeFullName shouldBe "java.lang.String"
+              }
+
+              lengthCall.methodFullName shouldBe "java.lang.String.length:int()"
+              inside(lengthCall.argument.l) { case List(sAssign: Call) =>
+                sAssign.name shouldBe Operators.assignment
+
+                inside(sAssign.argument.l) { case List(sIdentifier: Identifier, oCast: Call) =>
+                  sIdentifier.name shouldBe "s"
+                  sIdentifier.refsTo.l shouldBe List(sLocal)
+
+                  oCast.code shouldBe "(String) $obj0"
+                }
+              }
+
+              minusCall.methodFullName shouldBe Operators.minus
+            }
+          }
+      }
+    }
+  }
+
+  "a pattern matching instanceof in a static field initializer" should {
+    val cpg = code("""
+                       |import foo.Foo;
+                       |
+                       |class Test {
+                       |    public static int x = Foo.FOO instanceof String s ? s.length() : -1;
+                       |}
+                       |""".stripMargin)
+      .moreCode("""
+                    |package foo;
+                    |
+                    |public class Foo {
+                    |  public Object FOO = "abc";
+                    |}
+                    |""".stripMargin)
+    "parse" in {
+      cpg.call.name("length").nonEmpty shouldBe true
+    }
+
+    "add the local and initialiser for the pattern variable to the <clinit> method" in {
+      inside(cpg.typeDecl.name("Test").method.nameExact("<clinit>").body.astChildren.l) {
+        case List(tmpLocal: Local, sLocal: Local, xAssign: Call) =>
+          tmpLocal.name shouldBe "$obj0"
+          tmpLocal.typeFullName shouldBe "java.lang.Object"
+
+          sLocal.name shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+
+          xAssign.methodFullName shouldBe Operators.assignment
+          // TODO xAssign code
+
+          inside(xAssign.argument.l) { case List(xFieldAccess: Call, conditionalExpr: Call) =>
+            xFieldAccess.methodFullName shouldBe Operators.fieldAccess
+            // TODO xFieldAccess test
+
+            conditionalExpr.methodFullName shouldBe Operators.conditional
+            conditionalExpr.typeFullName shouldBe "int"
+
+            inside(conditionalExpr.argument.l) { case List(instanceOfCall: Call, lengthCall: Call, minusCall: Call) =>
+              instanceOfCall.methodFullName shouldBe Operators.instanceOf
+              inside(instanceOfCall.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
+                inside(tmpAssign.argument.l) { case List(tmpIdentifier: Identifier, fooFieldAccess: Call) =>
+                  tmpIdentifier.name shouldBe "$obj0"
+                  tmpIdentifier.typeFullName shouldBe "java.lang.Object"
+                  tmpIdentifier.refsTo.l shouldBe List(tmpLocal)
+
+                  fooFieldAccess.code shouldBe "Foo.FOO"
+                }
+
+                stringType.typeFullName shouldBe "java.lang.String"
+              }
+
+              lengthCall.methodFullName shouldBe "java.lang.String.length:int()"
+              inside(lengthCall.argument.l) { case List(sAssign: Call) =>
+                sAssign.name shouldBe Operators.assignment
+
+                inside(sAssign.argument.l) { case List(sIdentifier: Identifier, oCast: Call) =>
+                  sIdentifier.name shouldBe "s"
+                  sIdentifier.refsTo.l shouldBe List(sLocal)
+
+                  oCast.code shouldBe "(String) $obj0"
+                }
+              }
+
+              minusCall.methodFullName shouldBe Operators.minus
+            }
+          }
+      }
+    }
+  }
+
+  "a pattern matching instanceof with a call lhs" should {
+    val cpg = code("""
+                       |class Test {
+                       |  static String foo() {
+                       |    return "Hello, world!";
+                       |  }
+                       |
+                       |  static void sink(String s) { /* Do nothing */ }
+                       |
+                       |  void test(Object o) {
+                       |    if (foo() instanceof String s && s.isEmpty()) {
+                       |      sink(s);
+                       |    }
+                       |  }
+                       |}
+                       |""".stripMargin)
+
+    "parse" in {
+      cpg.call.name("sink").size shouldBe 1
+    }
+
+    "add a tmp local for the foo call to the start of the method" in {
+      inside(cpg.method.name("test").body.astChildren.l) { case (tmpLocal: Local) :: _ =>
+        tmpLocal.name shouldBe "$obj0"
+        tmpLocal.code shouldBe "$obj0"
+        tmpLocal.typeFullName shouldBe "java.lang.String"
+      }
+    }
+
+    "create an assignment for the temporary local as the first instanceof argument" in {
+      inside(cpg.call.nameExact(Operators.instanceOf).argument.head) { case assignment: Call =>
+        assignment.name shouldBe Operators.assignment
+        assignment.typeFullName shouldBe "java.lang.String"
+        assignment.code shouldBe "$obj0 = foo()"
+
+        inside(assignment.argument.l) { case List(tmpIdentifier: Identifier, fooCall: Call) =>
+          tmpIdentifier.name shouldBe "$obj0"
+          tmpIdentifier.code shouldBe "$obj0"
+          tmpIdentifier.typeFullName shouldBe "java.lang.String"
+          tmpIdentifier.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+
+          fooCall.name shouldBe "foo"
+          fooCall.methodFullName shouldBe "Test.foo:java.lang.String()"
+          fooCall.typeFullName shouldBe "java.lang.String"
+          fooCall.code shouldBe "foo()"
+        }
+      }
+    }
+  }
+
+  "patterns in binary expressions" when {
+    "a variable is introduced to the RHS of an && expression" should {
+
+      val cpg = code("""
+                         |class Test {
+                         |  void test(Object o) {
+                         |    if (o instanceof String s && s.isEmpty()) {
+                         |      System.out.println(s);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("isEmpty").nonEmpty shouldBe true
+      }
+
+      "be represented correctly" in {
+        inside(cpg.method.name("test").body.astChildren.l) { case List(sLocal: Local, ifStmt: ControlStructure) =>
+          sLocal.name shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+          sLocal.code shouldBe "String s"
+
+          inside(ifStmt.condition.l) { case List(andCall: Call) =>
+            andCall.name shouldBe Operators.logicalAnd
+            andCall.typeFullName shouldBe TypeConstants.Boolean
+            // TODO fix code
+            // andCall.code shouldBe "o instanceof String s && (s = (String) o).isEmpty()"
+
+            inside(andCall.argument.l) { case List(instanceOfCall: Call, isEmptyCall: Call) =>
+              instanceOfCall.name shouldBe Operators.instanceOf
+              instanceOfCall.code shouldBe "o instanceof String"
+
+              inside(instanceOfCall.argument.l) { case List(oIdentifier: Identifier, stringType: TypeRef) =>
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+
+                stringType.typeFullName shouldBe "java.lang.String"
+              }
+
+              isEmptyCall.name shouldBe "isEmpty"
+              isEmptyCall.methodFullName shouldBe "java.lang.String.isEmpty:boolean()"
+              // TODO Fix code
+              // isEmptyCall.code shouldBe "(s = (String) o).isEmpty()"
+
+              inside(isEmptyCall.argument.l) { case List(sAssignment: Call) =>
+                sAssignment.name shouldBe Operators.assignment
+                // TODO Fix code
+                // sAssignment.code shouldBe "s = (String) o"
+                sAssignment.typeFullName shouldBe "java.lang.String"
+
+                inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, castCall: Call) =>
+                  sIdentifier.name shouldBe "s"
+                  sIdentifier.typeFullName shouldBe "java.lang.String"
+                  sIdentifier.refsTo.l shouldBe cpg.method.name("test").local.name("s").l
+
+                  castCall.name shouldBe Operators.cast
+                  castCall.methodFullName shouldBe Operators.cast
+                  castCall.code shouldBe "(String) o"
+
+                  inside(castCall.argument.l) { case List(innerStringType: TypeRef, innerOIdentifier: Identifier) =>
+                    innerStringType.typeFullName shouldBe "java.lang.String"
+
+                    innerOIdentifier.name shouldBe "o"
+                    innerOIdentifier.typeFullName shouldBe "java.lang.Object"
+                    innerOIdentifier.refsTo.l shouldBe cpg.method.name("test").parameter.name("o").l
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    "a variable is introduced to the RHS of an || expression" should {
+      val cpg = code("""
+                         |class Test {
+                         |  void test(Object o) {
+                         |    if (!(o instanceof String s) || s.isEmpty()) {
+                         |      System.out.println("no input found");
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("isEmpty").nonEmpty shouldBe true
+      }
+
+      "be represented correctly" in {
+        inside(cpg.method.name("test").body.astChildren.l) { case List(sLocal: Local, ifStmt: ControlStructure) =>
+          sLocal.name shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+          sLocal.code shouldBe "String s"
+
+          inside(ifStmt.condition.l) { case List(orCall: Call) =>
+            orCall.name shouldBe Operators.logicalOr
+            orCall.typeFullName shouldBe TypeConstants.Boolean
+
+            // TODO fix code
+            // orCall.code shouldBe "!(o instanceof String s) || (s = (String) o).isEmpty()"
+
+            inside(orCall.argument.l) { case List(notCall: Call, isEmptyCall: Call) =>
+              notCall.code shouldBe "!(o instanceof String s)"
+              inside(notCall.argument.l) { case List(instanceOfCall: Call) =>
+                instanceOfCall.name shouldBe Operators.instanceOf
+                instanceOfCall.code shouldBe "o instanceof String"
+
+                inside(instanceOfCall.argument.l) { case List(oIdentifier: Identifier, stringType: TypeRef) =>
+                  oIdentifier.name shouldBe "o"
+                  oIdentifier.typeFullName shouldBe "java.lang.Object"
+
+                  stringType.typeFullName shouldBe "java.lang.String"
+                }
+              }
+
+              isEmptyCall.name shouldBe "isEmpty"
+              isEmptyCall.methodFullName shouldBe "java.lang.String.isEmpty:boolean()"
+              // TODO fix code: is currently s = (String) o.isEmpty()
+              // isEmptyCall.code shouldBe "(s = (String) o).isEmpty()"
+
+              inside(isEmptyCall.argument.l) { case List(sAssignment: Call) =>
+                sAssignment.name shouldBe Operators.assignment
+                sAssignment.code shouldBe "s = (String) o"
+                sAssignment.typeFullName shouldBe "java.lang.String"
+
+                inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, castCall: Call) =>
+                  sIdentifier.name shouldBe "s"
+                  sIdentifier.typeFullName shouldBe "java.lang.String"
+                  sIdentifier.refsTo.l shouldBe cpg.method.name("test").local.name("s").l
+
+                  castCall.name shouldBe Operators.cast
+                  castCall.methodFullName shouldBe Operators.cast
+                  castCall.code shouldBe "(String) o"
+
+                  inside(castCall.argument.l) { case List(innerStringType: TypeRef, innerOIdentifier: Identifier) =>
+                    innerStringType.typeFullName shouldBe "java.lang.String"
+
+                    innerOIdentifier.name shouldBe "o"
+                    innerOIdentifier.typeFullName shouldBe "java.lang.Object"
+                    innerOIdentifier.refsTo.l shouldBe cpg.method.name("test").parameter.name("o").l
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    "a variable is introduced to the RHS of an && expression, mutated and introduced to the body of an if" should {
+      val cpg = code("""
+                         |class Test {
+                         |  static void test(Object o) {
+                         |    if (o instanceof String value && (value = "Foo").isEmpty()) {
+                         |      System.out.println(value);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("isEmpty").nonEmpty shouldBe true
+      }
+
+      "be represented correctly" in {
+        inside(cpg.method.name("test").body.astChildren.l) { case List(valueLocal: Local, ifStmt: ControlStructure) =>
+          valueLocal.name shouldBe "value"
+          valueLocal.code shouldBe "String value"
+          valueLocal.typeFullName shouldBe "java.lang.String"
+
+          // TODO Fix code
+          // ifStmt.code shouldBe "if (o instanceof String value && ((value = (String) o) = \"Foo\").isEmpty())"
+
+          inside(ifStmt.condition.l) { case List(andCall: Call) =>
+            andCall.name shouldBe Operators.logicalAnd
+            andCall.methodFullName shouldBe Operators.logicalAnd
+            // TODO Test code
+
+            inside(andCall.astChildren.l) { case List(instanceOfCall: Call, isEmptyCall: Call) =>
+              instanceOfCall.name shouldBe Operators.instanceOf
+              instanceOfCall.code shouldBe "o instanceof String"
+
+              isEmptyCall.name shouldBe "isEmpty"
+              isEmptyCall.methodFullName shouldBe "java.lang.String.isEmpty:boolean()"
+
+              inside(isEmptyCall.argument.l) { case List(fooAssignment: Call) =>
+                fooAssignment.name shouldBe Operators.assignment
+                // TODO Test code
+
+                inside(fooAssignment.argument.l) { case List(valueAssign: Call, fooLiteral: Literal) =>
+                  valueAssign.methodFullName shouldBe Operators.assignment
+                  valueAssign.code shouldBe "value = (String) o"
+
+                  inside(valueAssign.argument.l) { case List(valueIdentifier: Identifier, oCast: Call) =>
+                    valueIdentifier.name shouldBe "value"
+                    valueIdentifier.typeFullName shouldBe "java.lang.String"
+                    valueIdentifier.code shouldBe "value"
+                    valueIdentifier.refsTo.l shouldBe List(valueLocal)
+
+                    oCast.code shouldBe "(String) o"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    "a variable is introduced to the RHS of an || expression, mutated and introduced by an if" should {
+      val cpg = code("""
+                         |class Test {
+                         |  static void test(Object o) {
+                         |    if (!(o instanceof String value) || (value = "Foo").isEmpty()) {
+                         |      return;
+                         |    }
+                         |    System.out.println(value);
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("isEmpty").nonEmpty shouldBe true
+      }
+
+      "be represented correctly" in {
+        inside(cpg.method.name("test").body.astChildren.l) {
+          case List(valueLocal: Local, ifStmt: ControlStructure, printCall: Call) =>
+            valueLocal.name shouldBe "value"
+            valueLocal.code shouldBe "String value"
+            valueLocal.typeFullName shouldBe "java.lang.String"
+
+            // TODO Fix code
+            // ifStmt.code shouldBe "if (o instanceof String value && ((value = (String) o) = \"Foo\").isEmpty())"
+
+            inside(ifStmt.condition.l) { case List(orCall: Call) =>
+              orCall.name shouldBe Operators.logicalOr
+              orCall.methodFullName shouldBe Operators.logicalOr
+              // TODO Test code
+
+              inside(orCall.astChildren.l) { case List(notCall: Call, isEmptyCall: Call) =>
+                notCall.methodFullName shouldBe Operators.logicalNot
+                // TODO Test code
+
+                inside(notCall.argument.l) { case List(instanceOfCall: Call) =>
+                  instanceOfCall.name shouldBe Operators.instanceOf
+                  instanceOfCall.code shouldBe "o instanceof String"
+                }
+
+                isEmptyCall.name shouldBe "isEmpty"
+                isEmptyCall.methodFullName shouldBe "java.lang.String.isEmpty:boolean()"
+
+                inside(isEmptyCall.argument.l) { case List(fooAssignment: Call) =>
+                  fooAssignment.name shouldBe Operators.assignment
+                  // TODO Test code
+
+                  inside(fooAssignment.argument.l) { case List(valueAssign: Call, fooLiteral: Literal) =>
+                    valueAssign.methodFullName shouldBe Operators.assignment
+                    valueAssign.code shouldBe "value = (String) o"
+
+                    inside(valueAssign.argument.l) { case List(valueIdentifier: Identifier, oCast: Call) =>
+                      valueIdentifier.name shouldBe "value"
+                      valueIdentifier.typeFullName shouldBe "java.lang.String"
+                      valueIdentifier.code shouldBe "value"
+                      valueIdentifier.refsTo.l shouldBe List(valueLocal)
+
+                      oCast.code shouldBe "(String) o"
+                    }
+                  }
+                }
+              }
+            }
+
+            printCall.name shouldBe "println"
+            inside(printCall.argument.l) { case List(systemOutFieldAccess: Call, valueIdentifier: Identifier) =>
+              systemOutFieldAccess.code shouldBe "System.out"
+
+              valueIdentifier.name shouldBe "value"
+              valueIdentifier.typeFullName shouldBe "java.lang.String"
+              valueIdentifier.code shouldBe "value"
+              valueIdentifier.refsTo.l shouldBe List(valueLocal)
+            }
+        }
+      }
+    }
+  }
+
+  "patterns in ternary expressions" when {
+    "a variable is introduced to the then expression" should {
+      val cpg = code("""
+          |class Test {
+          |  void test(Object o) {
+          |    int x = o instanceof String s ? s.length() : -1;
+          |  }
+          |}
+          |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("length").nonEmpty shouldBe true
+      }
+
+      "be represented correctly" in {
+        inside(cpg.method.name("test").body.astChildren.l) { case List(sLocal: Local, xLocal: Local, xAssign: Call) =>
+          sLocal.name shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+
+          xLocal.name shouldBe "x"
+          xLocal.typeFullName shouldBe "int"
+
+          xAssign.methodFullName shouldBe Operators.assignment
+
+          inside(xAssign.argument.l) { case List(xIdentifier: Identifier, ternaryExpr: Call) =>
+            xIdentifier.name shouldBe "x"
+
+            ternaryExpr.methodFullName shouldBe Operators.conditional
+            inside(ternaryExpr.argument.l) { case List(instanceOfCall: Call, lengthCall: Call, minusCall: Call) =>
+              instanceOfCall.name shouldBe Operators.instanceOf
+              instanceOfCall.code shouldBe "o instanceof String"
+
+              // TODO Test code
+              lengthCall.name shouldBe "length"
+              lengthCall.methodFullName shouldBe "java.lang.String.length:int()"
+              inside(lengthCall.argument.l) { case List(sAssign: Call) =>
+                sAssign.methodFullName shouldBe Operators.assignment
+                sAssign.typeFullName shouldBe "java.lang.String"
+                sAssign.code shouldBe "s = (String) o"
+
+                inside(sAssign.argument.l) { case List(sIdentifier: Identifier, oCast: Call) =>
+                  sIdentifier.name shouldBe "s"
+                  sIdentifier.typeFullName shouldBe "java.lang.String"
+                  sIdentifier.refsTo.l shouldBe List(sLocal)
+
+                  oCast.name shouldBe Operators.cast
+                  oCast.code shouldBe "(String) o"
+                }
+              }
+
+              minusCall.name shouldBe Operators.minus
+            }
+          }
+        }
+      }
+    }
+
+    "a variable is introduced to the else expression" should {
+      val cpg = code("""
+                         |class Test {
+                         |  void test(Object o) {
+                         |    int x = !(o instanceof String s) ? -1: s.length();
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("length").nonEmpty shouldBe true
+      }
+
+      "be represented correctly" in {
+        inside(cpg.method.name("test").body.astChildren.l) { case List(sLocal: Local, xLocal: Local, xAssign: Call) =>
+          sLocal.name shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+
+          xLocal.name shouldBe "x"
+          xLocal.typeFullName shouldBe "int"
+
+          xAssign.methodFullName shouldBe Operators.assignment
+
+          inside(xAssign.argument.l) { case List(xIdentifier: Identifier, ternaryExpr: Call) =>
+            xIdentifier.name shouldBe "x"
+
+            ternaryExpr.methodFullName shouldBe Operators.conditional
+            inside(ternaryExpr.argument.l) { case List(notCall: Call, minusCall: Call, lengthCall: Call) =>
+              notCall.methodFullName shouldBe Operators.logicalNot
+
+              inside(notCall.argument.l) { case List(instanceOfCall: Call) =>
+                instanceOfCall.name shouldBe Operators.instanceOf
+                instanceOfCall.code shouldBe "o instanceof String"
+              }
+
+              // TODO Test code
+              lengthCall.name shouldBe "length"
+              lengthCall.methodFullName shouldBe "java.lang.String.length:int()"
+              inside(lengthCall.argument.l) { case List(sAssign: Call) =>
+                sAssign.methodFullName shouldBe Operators.assignment
+                sAssign.typeFullName shouldBe "java.lang.String"
+                sAssign.code shouldBe "s = (String) o"
+
+                inside(sAssign.argument.l) { case List(sIdentifier: Identifier, oCast: Call) =>
+                  sIdentifier.name shouldBe "s"
+                  sIdentifier.typeFullName shouldBe "java.lang.String"
+                  sIdentifier.refsTo.l shouldBe List(sLocal)
+
+                  oCast.name shouldBe Operators.cast
+                  oCast.code shouldBe "(String) o"
+                }
+              }
+
+              minusCall.name shouldBe Operators.minus
+            }
+          }
+        }
+      }
+    }
+  }
+
+  "patterns in if statements" when {
+    "a variable is introduced to the then block" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    if (o instanceof String s) {
+                         |      sink(s);
+                         |    }
+                         |  }
+                         |  static void sink(Object o) {}
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local in the then block" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.l) {
+          case List(_: Call, thenBlock: Block) =>
+            thenBlock.ast.isLocal.name("s").typeFullName.l shouldBe List("java.lang.String")
+        }
+      }
+
+      "create the s assignment in the then block" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.l) {
+          case List(_: Call, thenBlock: Block) =>
+            thenBlock.ast.isCall
+              .nameExact(Operators.assignment)
+              .where(_.argument.isIdentifier.name("s"))
+              .code
+              .l shouldBe List("s = (String) o")
+        }
+      }
+
+      "create an identifier referring to the s local as the argument for sink" in {
+        inside(cpg.call.name("sink").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+    }
+
+    "a variable is introduced to the else block" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    if (!(o instanceof String s)) {
+                         |    } else {
+                         |      sink(s);
+                         |    }
+                         |  }
+                         |  static void sink(Object o) {}
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local in the else block" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.l) {
+          case List(_: Call, _: Block, elseStructure: ControlStructure) =>
+            inside(elseStructure.astChildren.l) { case List(elseBlock: Block) =>
+              elseBlock.ast.isLocal.name("s").typeFullName.l shouldBe List("java.lang.String")
+            }
+        }
+      }
+
+      "create the s assignment in the then block" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.l) {
+          case List(_: Call, _: Block, elseStructure: ControlStructure) =>
+            inside(elseStructure.astChildren.l) { case List(elseBlock: Block) =>
+            }
+        }
+      }
+
+      "create an identifier referring to the s local as the argument for sink" in {
+        inside(cpg.call.name("sink").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+    }
+
+    "a variable is introduced to the surrounding scope" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    if (!(o instanceof String s)) {
+                         |      return;
+                         |    }
+                         |    sink(s);
+                         |  }
+                         |  static void sink(Object o) {}
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local after the if statement" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: ControlStructure, sLocal: Local, _: Call, _: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+        }
+      }
+
+      "create the s assignment before the if statement" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: ControlStructure, _: Local, assignment: Call, _: Call) =>
+            assignment.name shouldBe Operators.assignment
+            assignment.code shouldBe "s = (String) o"
+        }
+      }
+
+      "have an s identifier as the sink argument with refs to the s local" in {
+        inside(cpg.call.name("sink").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+    }
+
+    "a variable is introduced to the else block and surrounding scope" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    if (!(o instanceof String s)) {
+                         |      sink1(s);
+                         |      return;
+                         |    } else {
+                         |      sink2(s);
+                         |    }
+                         |    sink3(s);
+                         |  }
+                         |  static void sink1(Object o) {}
+                         |  static void sink2(Object o) {}
+                         |  static void sink3(Object o) {}
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local before the if statement" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(sLocal: Local, _: Call, _: ControlStructure, _: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+        }
+      }
+
+      "create the s assignment before the if statement" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: Local, assignment: Call, _: ControlStructure, _: Call) =>
+            assignment.name shouldBe Operators.assignment
+            assignment.code shouldBe "s = (String) o"
+        }
+      }
+
+      "have an s field access as the sink1 argument" in {
+        inside(cpg.call.name("sink1").argument.l) { case List(fieldAccess: Call) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.code shouldBe "this.s"
+          fieldAccess.typeFullName shouldBe "java.lang.Integer"
+        }
+      }
+
+      "have an s identifier as the sink2 argument with refs to the s local" in {
+        inside(cpg.call.name("sink2").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+
+      "have an s identifier as the sink3 argument with refs to the s local" in {
+        inside(cpg.call.name("sink3").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+    }
+  }
+
+  "patterns in while statements" when {
+    "a variable is introduced to the body" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    while (o instanceof String s) {
+                         |      sink1(s);
+                         |    }
+                         |    sink2(s);
+                         |  }
+                         |  static void sink1(Object o) {}
+                         |  static void sink2(Object o) {}
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local in the while body" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.WHILE).astChildren.l) {
+          case List(_: Call, body: Block) =>
+            inside(body.astChildren.l) { case List(sLocal: Local, _: Call, _: Call) =>
+              sLocal.name shouldBe "s"
+              sLocal.typeFullName shouldBe "java.lang.String"
+            }
+        }
+      }
+
+      "create the s assignment in the body" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.WHILE).astChildren.l) {
+          case List(_: Call, body: Block) =>
+            inside(body.astChildren.l) { case List(_: Local, assignment: Call, _: Call) =>
+              assignment.name shouldBe Operators.assignment
+              assignment.code shouldBe "s = (String) o"
+            }
+        }
+      }
+
+      "have the argument of sink1 be an s identifier with refs to the s local" in {
+        inside(cpg.call.name("sink1").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+
+      "have the argument of sink2 be a field access for s" in {
+        inside(cpg.call.name("sink2").argument.l) { case List(fieldAccess: Call) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.code shouldBe "this.s"
+          fieldAccess.typeFullName shouldBe "java.lang.Integer"
+        }
+      }
+    }
+
+    "a variable is introduced by the while" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    while (!(o instanceof String s)) {
+                         |      sink1(s);
+                         |    }
+                         |    sink2(s);
+                         |  }
+                         |  static void sink1(Object o) {}
+                         |  static void sink2(Object o) {}
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local after the while loop" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: ControlStructure, sLocal: Local, _: Call, _: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+        }
+      }
+
+      "create the s assignment after the while loop" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: ControlStructure, _: Local, assignment: Call, _: Call) =>
+            assignment.name shouldBe Operators.assignment
+            assignment.code shouldBe "s = (String) o"
+        }
+      }
+
+      "have the argument of sink1 be a field access for s" in {
+        inside(cpg.call.name("sink1").argument.l) { case List(fieldAccess: Call) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.code shouldBe "this.s"
+          fieldAccess.typeFullName shouldBe "java.lang.Integer"
+        }
+      }
+
+      "have the argument of sink2 be an s identifier with refs to the s local" in {
+        inside(cpg.call.name("sink2").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+    }
+  }
+
+  "patterns in do statements" when {
+    "a variable is introduced by the do" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    do { sink1(s); } while (!(o instanceof String s));
+                         |    sink2(s);
+                         |  }
+                         |  static void sink1(Object o) {}
+                         |  static void sink2(Object o) {}
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local after the do loop" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: ControlStructure, sLocal: Local, _: Call, _: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+        }
+      }
+
+      "create the s assignment after the do loop" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: ControlStructure, _: Local, assignment: Call, _: Call) =>
+            assignment.name shouldBe Operators.assignment
+            assignment.code shouldBe "s = (String) o"
+        }
+      }
+
+      "have the argument of sink1 be a field access for s" in {
+        inside(cpg.call.name("sink1").argument.l) { case List(fieldAccess: Call) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.code shouldBe "this.s"
+          fieldAccess.typeFullName shouldBe "java.lang.Integer"
+        }
+      }
+
+      "have the argument of sink2 be an s identifier with refs to the s local" in {
+        inside(cpg.call.name("sink2").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+
+    }
+  }
+
+  "patterns in for statements" when {
+    "a variable is introduced to the for update" should {
+      val cpg = code("""
+          |class Foo {
+          |  void foo(Object o) {
+          |    for(int i = 0; o instanceof String s && i < 42; i += s.length()) {
+          |      System.out.println(i);
+          |    }
+          |  }
+          |}
+          |""".stripMargin)
+
+      "be represented correctly" in {
+        inside(cpg.method.name("foo").body.astChildren.l) { case List(sLocal: Local, forStmt: ControlStructure) =>
+          sLocal.name shouldBe "s"
+          sLocal.code shouldBe "String s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+
+          forStmt.controlStructureType shouldBe ControlStructureTypes.FOR
+          inside(forStmt.astChildren.l) {
+            case List(iLocal: Local, iAssign: Call, condition: Call, update: Call, body: Block) =>
+              iLocal.name shouldBe "i"
+
+              iAssign.methodFullName shouldBe Operators.assignment
+              iAssign.code shouldBe "int i = 0"
+
+              condition.methodFullName shouldBe Operators.logicalAnd
+              // TODO Check LHS arg
+
+              update.methodFullName shouldBe Operators.assignmentPlus
+              inside(update.argument.l) { case List(iIdentifier: Identifier, lengthCall: Call) =>
+                iIdentifier.name shouldBe "i"
+                iIdentifier.refsTo.l shouldBe List(iLocal)
+
+                lengthCall.name shouldBe "length"
+                lengthCall.methodFullName shouldBe "java.lang.String.length:int()"
+                // TODO Test code
+                // TODO This representation is technically not correct. It's possible to
+                inside(lengthCall.argument.l) { case List(sAssignment: Call) =>
+                  sAssignment.methodFullName shouldBe Operators.assignment
+                  sAssignment.code shouldBe "s = (String) o"
+                }
+              }
+
+              inside(body.astChildren.l) { case List(printlnCall: Call) =>
+                printlnCall.code shouldBe "System.out.println(i)"
+              }
+
+          }
+        }
+      }
+    }
+
+    "a variable is introduced to the for body" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    for (; o instanceof String s;) {
+                         |      sink1(s);
+                         |    }
+                         |    sink2(s);
+                         |  }
+                         |  static void sink1(Object o) {}
+                         |  static void sink2(Object o) {}
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local in the for body" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.FOR).astChildren.l) {
+          case List(_: Call, body: Block) =>
+            inside(body.astChildren.l) { case List(sLocal: Local, _: Call, _: Call) =>
+              sLocal.name shouldBe "s"
+              sLocal.typeFullName shouldBe "java.lang.String"
+            }
+        }
+      }
+
+      "create the s assignment in the for body" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.FOR).astChildren.l) {
+          case List(_: Call, body: Block) =>
+            inside(body.astChildren.l) { case List(_: Local, assignment: Call, _: Call) =>
+              assignment.name shouldBe Operators.assignment
+              assignment.code shouldBe "s = (String) o"
+            }
+        }
+      }
+
+      "have the argument of sink1 be an s identifier with refs to the s local" in {
+        inside(cpg.call.name("sink1").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+
+      "have the argument of sink2 be a field access for s" in {
+        inside(cpg.call.name("sink2").argument.l) { case List(fieldAccess: Call) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.code shouldBe "this.s"
+          fieldAccess.typeFullName shouldBe "java.lang.Integer"
+        }
+      }
+    }
+
+    "a variable is introduced by the for" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  Integer s;
+                         |  void foo(Object o) {
+                         |    for (; !(o instanceof String s);) {
+                         |      sink1(s);
+                         |    }
+                         |    sink2(s);
+                         |  }
+                         |  static void sink1(Object o) {}
+                         |  static void sink2(Object o) {}
+                         |}
+                         |""".stripMargin)
+      "parse" in {
+        cpg.identifier.name("s").nonEmpty shouldBe true
+      }
+
+      "create the s local after the for loop" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: ControlStructure, sLocal: Local, _: Call, _: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+        }
+      }
+
+      "create the s assignment after the for loop" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(_: ControlStructure, _: Local, assignment: Call, _: Call) =>
+            assignment.name shouldBe Operators.assignment
+            assignment.code shouldBe "s = (String) o"
+        }
+      }
+
+      "have the argument of sink1 be a field access for s" in {
+        inside(cpg.call.name("sink1").argument.l) { case List(fieldAccess: Call) =>
+          fieldAccess.name shouldBe Operators.fieldAccess
+          fieldAccess.code shouldBe "this.s"
+          fieldAccess.typeFullName shouldBe "java.lang.Integer"
+        }
+      }
+
+      "have the argument of sink2 be an s identifier with refs to the s local" in {
+        inside(cpg.call.name("sink2").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe cpg.local.name("s").l
+        }
+      }
+    }
+  }
+
+  "resolved patterns in instanceof expressions" when {
+    "a type pattern is matched" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    if (o instanceof String s) {
+                         |      sink(s);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the type check" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(instanceOfCall: Call) =>
+            instanceOfCall.name shouldBe Operators.instanceOf
+            instanceOfCall.typeFullName shouldBe "boolean"
+            instanceOfCall.code shouldBe "o instanceof String"
+
+            inside(instanceOfCall.argument.l) { case List(oIdentifier: Identifier, stringType: TypeRef) =>
+              oIdentifier.name shouldBe "o"
+              oIdentifier.typeFullName shouldBe "java.lang.Object"
+              oIdentifier.code shouldBe "o"
+
+              stringType.typeFullName shouldBe "java.lang.String"
+              stringType.code shouldBe "String"
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(sLocal: Local, sAssign: Call, _: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+            sLocal.code shouldBe "String s"
+
+            sAssign.name shouldBe Operators.assignment
+            sAssign.methodFullName shouldBe Operators.assignment
+            sAssign.code shouldBe "s = (String) o"
+
+            inside(sAssign.argument.l) { case List(sIdentifier: Identifier, castExpr: Call) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.refsTo.l should contain theSameElementsAs List(sLocal)
+
+              castExpr.name shouldBe Operators.cast
+              castExpr.methodFullName shouldBe Operators.cast
+              castExpr.typeFullName shouldBe "java.lang.String"
+              castExpr.code shouldBe "(String) o"
+
+              inside(castExpr.argument.l) { case List(stringType: TypeRef, oIdentifier: Identifier) =>
+                stringType.typeFullName shouldBe "java.lang.String"
+                stringType.code shouldBe "String"
+
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l should contain theSameElementsAs cpg.method.name("foo").parameter.name("o").l
+              }
+            }
+        }
+      }
+    }
+
+    "a non-generic, non-nested record pattern is matched" should {
+      val cpg = code("""
+                         |package box;
+                         |
+                         |record Box(String value) {}
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    if (o instanceof Box(String s)) {
+                         |      sink(s);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the type check" in {
+        // Don't need to check `Box.value() instanceof String` since it must be from the declaration
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(instanceOfBox: Call) =>
+            instanceOfBox.name shouldBe Operators.instanceOf
+            instanceOfBox.methodFullName shouldBe Operators.instanceOf
+            instanceOfBox.code shouldBe "o instanceof Box"
+            instanceOfBox.typeFullName shouldBe "boolean"
+
+            inside(instanceOfBox.argument.l) { case List(oIdentifier: Identifier, boxType: TypeRef) =>
+              oIdentifier.name shouldBe "o"
+              oIdentifier.typeFullName shouldBe "java.lang.Object"
+              oIdentifier.code shouldBe "o"
+              oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+
+              boxType.typeFullName shouldBe "box.Box"
+              boxType.code shouldBe "Box"
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(sLocal: Local, sAssignment: Call, _: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+            sLocal.code shouldBe "String s"
+
+            sAssignment.name shouldBe Operators.assignment
+            sAssignment.methodFullName shouldBe Operators.assignment
+            sAssignment.typeFullName shouldBe "java.lang.String"
+            sAssignment.code shouldBe "s = ((Box) o).value()"
+
+            inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, valueCall: Call) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.refsTo.l shouldBe List(sLocal)
+
+              valueCall.name shouldBe "value"
+              valueCall.methodFullName shouldBe "box.Box.value:java.lang.String()"
+              valueCall.typeFullName shouldBe "java.lang.String"
+              valueCall.code shouldBe "((Box) o).value()"
+
+              inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                castExpr.name shouldBe Operators.cast
+                castExpr.methodFullName shouldBe Operators.cast
+                castExpr.typeFullName shouldBe "box.Box"
+                castExpr.code shouldBe "(Box) o"
+
+                inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                  boxType.typeFullName shouldBe "box.Box"
+                  boxType.code shouldBe "Box"
+
+                  oIdentifier.name shouldBe "o"
+                  oIdentifier.typeFullName shouldBe "java.lang.Object"
+                  oIdentifier.code shouldBe "o"
+                  oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                }
+              }
+            }
+        }
+      }
+    }
+
+    "a generic, non-nested record pattern is matched" should {
+      val cpg = code("""
+                         |package box;
+                         |
+                         |record Box<T>(T value) {}
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    if (o instanceof Box(String s)) {
+                         |      sink(s);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the type check" ignore {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(andCall: Call) =>
+            andCall.name shouldBe Operators.logicalAnd
+            andCall.methodFullName shouldBe Operators.logicalAnd
+            andCall.code shouldBe "o instanceof Box && ((Box) o).value() instanceof String)"
+
+            inside(andCall.argument.l) { case List(instanceOfBox: Call, instanceOfString: Call) =>
+              instanceOfBox.name shouldBe Operators.instanceOf
+              instanceOfBox.methodFullName shouldBe Operators.instanceOf
+              instanceOfBox.code shouldBe "o instanceof Box"
+              instanceOfBox.typeFullName shouldBe "boolean"
+
+              inside(instanceOfBox.argument.l) { case List(oIdentifier: Identifier, boxType: TypeRef) =>
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+
+                boxType.typeFullName shouldBe "box.Box"
+                boxType.code shouldBe "Box"
+              }
+
+              instanceOfString.name shouldBe Operators.instanceOf
+              instanceOfString.methodFullName shouldBe Operators.instanceOf
+              instanceOfString.code shouldBe "((Box) o).value() instanceof String"
+              instanceOfString.typeFullName shouldBe "boolean"
+
+              inside(instanceOfString.argument.l) { case List(valueCall: Call, stringType: TypeRef) =>
+                valueCall.name shouldBe "value"
+                valueCall.methodFullName shouldBe "box.Box.value:java.lang.String()"
+                valueCall.code shouldBe "((Box) o).value()"
+                valueCall.typeFullName shouldBe "java.lang.String"
+
+                inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                  castExpr.name shouldBe Operators.cast
+                  castExpr.methodFullName shouldBe Operators.cast
+                  castExpr.typeFullName shouldBe "box.Box"
+                  inside(castExpr.argument.l) { case List(castBoxType: TypeRef, castOIdentifier: Identifier) =>
+                    castBoxType.typeFullName shouldBe "box.Box"
+                    castBoxType.code shouldBe "Box"
+
+                    castOIdentifier.name shouldBe "o"
+                    castOIdentifier.typeFullName shouldBe "java.lang.Object"
+                    castOIdentifier.code shouldBe "o"
+                    castOIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                  }
+                }
+
+                stringType.typeFullName shouldBe "java.lang.String"
+                stringType.code shouldBe "String"
+              }
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(sLocal: Local, sAssignment: Call, _: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+            sLocal.code shouldBe "String s"
+
+            sAssignment.name shouldBe Operators.assignment
+            sAssignment.methodFullName shouldBe Operators.assignment
+            sAssignment.typeFullName shouldBe "java.lang.String"
+            sAssignment.code shouldBe "s = (String) ((Box) o).value()"
+
+            inside(sAssignment.argument.l) { case List(stringCast: Call) =>
+              stringCast.name shouldBe Operators.cast
+              stringCast.methodFullName shouldBe Operators.cast
+              stringCast.typeFullName shouldBe "java.lang.String"
+              stringCast.code shouldBe "(String) ((Box) o).value()"
+
+              inside(stringCast.argument.l) { case List(sIdentifier: Identifier, valueCall: Call) =>
+                sIdentifier.name shouldBe "s"
+                sIdentifier.typeFullName shouldBe "java.lang.String"
+                sIdentifier.code shouldBe "s"
+                sIdentifier.refsTo.l shouldBe List(sLocal)
+
+                valueCall.name shouldBe "value"
+                valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+                valueCall.typeFullName shouldBe "java.lang.Object"
+                valueCall.code shouldBe "((Box) o).value()"
+
+                inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                  castExpr.name shouldBe Operators.cast
+                  castExpr.methodFullName shouldBe Operators.cast
+                  castExpr.typeFullName shouldBe "box.Box"
+                  castExpr.code shouldBe "(Box) o"
+
+                  inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                    boxType.typeFullName shouldBe "box.Box"
+                    boxType.code shouldBe "Box"
+
+                    oIdentifier.name shouldBe "o"
+                    oIdentifier.typeFullName shouldBe "java.lang.Object"
+                    oIdentifier.code shouldBe "o"
+                    oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                  }
+                }
+              }
+            }
+        }
+      }
+    }
+
+    "a non-generic, nested record pattern is matched" should {
+
+      val cpg = code("""
+                         |package box;
+                         |
+                         |record PairBox(Pair value) {}
+                         |record Pair(String first, Integer second) {}
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    if (o instanceof PairBox(Pair (String s, Integer i))) {
+                         |      sink(s);
+                         |      sink(i);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the type check" ignore {
+        // In this case it is only necessary to check o instanceof PairBox since it is assumed the code compiles
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(instanceOfCall: Call) =>
+            instanceOfCall.name shouldBe Operators.instanceOf
+            instanceOfCall.typeFullName shouldBe "boolean"
+            instanceOfCall.code shouldBe "o instanceof PairBox"
+
+            inside(instanceOfCall.argument.l) { case List(oIdentifier: Identifier, pairBoxType: TypeRef) =>
+              oIdentifier.name shouldBe "o"
+              oIdentifier.typeFullName shouldBe "java.lang.Object"
+              oIdentifier.code shouldBe "o"
+
+              pairBoxType.typeFullName shouldBe "java.lang.String"
+              pairBoxType.code shouldBe "String"
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        val oParameter = cpg.method.name("foo").parameter.name("o").l
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(sLocal: Local, iLocal: Local, sAssign: Call, iAssign: Call, sSink: Call, iSink: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.code shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+
+            iLocal.name shouldBe "i"
+            iLocal.code shouldBe "i"
+            iLocal.typeFullName shouldBe "java.lang.Integer"
+
+            sAssign.name shouldBe Operators.assignment
+            sAssign.methodFullName shouldBe Operators.assignment
+            sAssign.typeFullName shouldBe "java.lang.String"
+            sAssign.code shouldBe "s = ((PairBox) o).value().first()"
+
+            inside(sAssign.argument.l) { case List(sIdentifier: Identifier, firstCall: Call) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.refsTo.l shouldBe List(sLocal)
+
+              firstCall.name shouldBe "first"
+              firstCall.methodFullName shouldBe "box.Pair.first:java.lang.String()"
+              firstCall.signature shouldBe "java.lang.String()"
+              firstCall.typeFullName shouldBe "java.lang.String"
+              firstCall.code shouldBe "((PairBox) o).value().first()"
+
+              inside(firstCall.argument.l) { case List(valueCall: Call) =>
+                valueCall.name shouldBe "value"
+                valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
+                valueCall.signature shouldBe "box.Pair()"
+                valueCall.typeFullName shouldBe "box.Pair"
+                valueCall.code shouldBe "((PairBox) o).value()"
+
+                inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                  castExpr.name shouldBe Operators.cast
+                  castExpr.methodFullName shouldBe Operators.cast
+                  castExpr.typeFullName shouldBe "box.PairBox"
+                  castExpr.code shouldBe "(PairBox) o"
+
+                  inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
+                    pairBoxType.typeFullName shouldBe "box.PairBox"
+                    pairBoxType.code shouldBe "PairBox"
+
+                    oIdentifier.name shouldBe "o"
+                    oIdentifier.code shouldBe "o"
+                    oIdentifier.typeFullName shouldBe "java.lang.Object"
+                    oIdentifier.refsTo.l shouldBe oParameter
+                  }
+                }
+              }
+            }
+
+            iAssign.name shouldBe Operators.assignment
+            iAssign.methodFullName shouldBe Operators.assignment
+            iAssign.typeFullName shouldBe "java.lang.Integer"
+            iAssign.code shouldBe "i = ((PairBox) o).value().second()"
+
+            inside(iAssign.argument.l) { case List(iIdentifier: Identifier, secondCall: Call) =>
+              iIdentifier.name shouldBe "i"
+              iIdentifier.code shouldBe "i"
+              iIdentifier.typeFullName shouldBe "java.lang.Integer"
+              iIdentifier.refsTo.l shouldBe List(iLocal)
+
+              secondCall.name shouldBe "second"
+              secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Integer()"
+              secondCall.signature shouldBe "java.lang.Integer()"
+              secondCall.typeFullName shouldBe "java.lang.Integer"
+              secondCall.code shouldBe "((PairBox) o).value().second()"
+
+              inside(secondCall.argument.l) { case List(valueCall: Call) =>
+                valueCall.name shouldBe "value"
+                valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
+                valueCall.signature shouldBe "box.Pair()"
+                valueCall.typeFullName shouldBe "box.Pair()"
+                valueCall.code shouldBe "((PairBox) o).value()"
+
+                inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                  castExpr.name shouldBe Operators.cast
+                  castExpr.methodFullName shouldBe Operators.cast
+                  castExpr.typeFullName shouldBe "box.PairBox"
+                  castExpr.code shouldBe "(PairBox) o"
+
+                  inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
+                    pairBoxType.typeFullName shouldBe "box.PairBox"
+                    pairBoxType.code shouldBe "PairBox"
+
+                    oIdentifier.name shouldBe "o"
+                    oIdentifier.code shouldBe "o"
+                    oIdentifier.typeFullName shouldBe "java.lang.Object"
+                    oIdentifier.refsTo.l shouldBe oParameter
+                  }
+                }
+              }
+            }
+
+            inside(sSink.argument.isIdentifier.name("s").l) { case List(sIdentifier: Identifier) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.refsTo.l shouldBe List(sLocal)
+            }
+
+            inside(iSink.argument.isIdentifier.name("i").l) { case List(iIdentifier: Identifier) =>
+              iIdentifier.name shouldBe "i"
+              iIdentifier.code shouldBe "i"
+              iIdentifier.typeFullName shouldBe "java.lang.Integer"
+              iIdentifier.refsTo.l shouldBe List(iLocal)
+            }
+        }
+      }
+    }
+
+    "a generic, nested record pattern is matched" should {
+
+      val cpg = code("""
+                         |package box;
+                         |
+                         |record Box<T>(T value) {}
+                         |record Pair<U, V>(U first, V second) {}
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    if (o instanceof Box(Pair(String s, Integer i))) {
+                         |      sink(s);
+                         |      sink(i);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the type check" ignore {
+        val oParameter = cpg.method.name("foo").parameter.name("o").l
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(firstAnd: Call) =>
+            firstAnd.name shouldBe Operators.logicalAnd
+            firstAnd.methodFullName shouldBe Operators.logicalAnd
+            firstAnd.typeFullName shouldBe "boolean"
+            firstAnd.code shouldBe "o instanceof Box(Pair(String s, Integer i)) && (((Box) o).value() instanceof Pair && (((Pair) ((Box) o).value()).first() instanceof String && ((Pair) ((Box) o).value()).second() instanceof Integer))"
+
+            inside(firstAnd.argument.l) { case List(oInstanceOfBox: Call, secondAnd: Call) =>
+              oInstanceOfBox.name shouldBe Operators.instanceOf
+              oInstanceOfBox.methodFullName shouldBe Operators.instanceOf
+              oInstanceOfBox.typeFullName shouldBe "boolean"
+              oInstanceOfBox.code shouldBe "o instanceof Box(Pair(String s, Integer i))"
+
+              inside(oInstanceOfBox.argument.l) { case List(oIdentifier: Identifier, boxType: TypeRef) =>
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l shouldBe oParameter
+
+                boxType.typeFullName shouldBe "box.Box"
+                boxType.code shouldBe "Box"
+              }
+
+              secondAnd.name shouldBe Operators.logicalAnd
+              secondAnd.methodFullName shouldBe Operators.logicalAnd
+              secondAnd.typeFullName shouldBe "boolean"
+              secondAnd.code shouldBe "((Box) o).value() instanceof Pair && (((Pair) ((Box) o).value()).first() instanceof String && ((Pair) ((Box) o).value()).second() instanceof Integer)"
+
+              inside(secondAnd.argument.l) { case List(oValueInstanceOfPair: Call, thirdAnd: Call) =>
+                oValueInstanceOfPair.name shouldBe Operators.instanceOf
+                oValueInstanceOfPair.methodFullName shouldBe Operators.instanceOf
+                oValueInstanceOfPair.typeFullName shouldBe "boolean"
+                oValueInstanceOfPair.code shouldBe "((Box) o).value() instanceof Pair"
+
+                inside(oValueInstanceOfPair.argument.l) { case List(valueCall: Call, pairType: TypeRef) =>
+                  valueCall.name shouldBe "value"
+                  valueCall.methodFullName shouldBe "box.Box.value:box.Pair()"
+                  valueCall.signature shouldBe "box.Pair()"
+                  valueCall.code shouldBe "((Box) o).value()"
+
+                  inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                    castExpr.name shouldBe Operators.cast
+                    castExpr.methodFullName shouldBe Operators.cast
+                    castExpr.typeFullName shouldBe "box.Box"
+                    castExpr.code shouldBe "(Box) o"
+
+                    inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                      boxType.typeFullName shouldBe "box.Box"
+                      boxType.code shouldBe "Box"
+
+                      oIdentifier.name shouldBe "o"
+                      oIdentifier.code shouldBe "o"
+                      oIdentifier.typeFullName shouldBe "java.lang.Object"
+                      oIdentifier.refsTo.l shouldBe oParameter
+                    }
+                  }
+
+                  pairType.typeFullName shouldBe "box.Pair"
+                  pairType.code shouldBe "Pair"
+                }
+
+                thirdAnd.name shouldBe Operators.logicalAnd
+                thirdAnd.methodFullName shouldBe Operators.logicalAnd
+                thirdAnd.typeFullName shouldBe "boolean"
+                thirdAnd.code shouldBe "((Pair) ((Box) o).value()).first() instanceof String && ((Pair) ((Box) o).value()).second() instanceof Integer"
+
+                inside(thirdAnd.argument.l) { case List(firstInstanceOfString: Call, secondInstanceOfInteger: Call) =>
+                  firstInstanceOfString.name shouldBe Operators.instanceOf
+                  firstInstanceOfString.methodFullName shouldBe Operators.instanceOf
+                  firstInstanceOfString.typeFullName shouldBe "boolean"
+                  firstInstanceOfString.code shouldBe "((Pair) ((Box) o).value()).first() instanceof String"
+
+                  inside(firstInstanceOfString.argument.l) { case List(firstCall: Call, stringType: TypeRef) =>
+                    firstCall.name shouldBe "first"
+                    firstCall.methodFullName shouldBe "box.Pair.first:java.lang.String()"
+                    firstCall.typeFullName shouldBe "java.lang.String"
+                    firstCall.code shouldBe "((Pair) ((Box) o).value()).first()"
+
+                    inside(firstCall.argument.l) { case List(pairCast: Call) =>
+                      pairCast.name shouldBe Operators.cast
+                      pairCast.methodFullName shouldBe Operators.cast
+                      pairCast.typeFullName shouldBe "box.Pair"
+                      pairCast.code shouldBe "(Pair) ((Box) o).value()"
+
+                      inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
+                        pairType.typeFullName shouldBe "box.Pair"
+                        pairType.code shouldBe "Pair"
+
+                        valueCall.name shouldBe "value"
+                        valueCall.methodFullName shouldBe "box.Box.value:box.Pair()"
+                        valueCall.typeFullName shouldBe "box.Pair"
+                        valueCall.code shouldBe "((Box) o).value()"
+
+                        inside(valueCall.argument.l) { case List(boxCast: Call) =>
+                          boxCast.name shouldBe Operators.cast
+                          boxCast.methodFullName shouldBe Operators.cast
+                          boxCast.typeFullName shouldBe "box.Box"
+                          boxCast.code shouldBe "(Box) o"
+
+                          inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                            boxType.typeFullName shouldBe "box.Box"
+                            boxType.code shouldBe "Box"
+
+                            oIdentifier.name shouldBe "o"
+                            oIdentifier.code shouldBe "o"
+                            oIdentifier.typeFullName shouldBe "java.lang.Object"
+                            oIdentifier.refsTo.l shouldBe oParameter
+                          }
+                        }
+                      }
+                    }
+
+                    stringType.typeFullName shouldBe "java.lang.String"
+                    stringType.code shouldBe "String"
+                  }
+
+                  secondInstanceOfInteger.name shouldBe Operators.instanceOf
+                  secondInstanceOfInteger.methodFullName shouldBe Operators.instanceOf
+                  secondInstanceOfInteger.typeFullName shouldBe "boolean"
+                  secondInstanceOfInteger.code shouldBe "((Pair) ((Box) o).value()).second() instanceof Integer"
+
+                  inside(secondInstanceOfInteger.argument.l) { case List(secondCall: Call, integerType: TypeRef) =>
+                    secondCall.name shouldBe "second"
+                    secondCall.methodFullName shouldBe "box.Pair.second:java.lang.String()"
+                    secondCall.typeFullName shouldBe "java.lang.Integer"
+                    secondCall.code shouldBe "((Pair) ((Box) o).value()).second()"
+
+                    inside(secondCall.argument.l) { case List(pairCast: Call) =>
+                      pairCast.name shouldBe Operators.cast
+                      pairCast.methodFullName shouldBe Operators.cast
+                      pairCast.typeFullName shouldBe "box.Pair"
+                      pairCast.code shouldBe "(Pair) ((Box) o).value()"
+
+                      inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
+                        pairType.typeFullName shouldBe "box.Pair"
+                        pairType.code shouldBe "Pair"
+
+                        valueCall.name shouldBe "value"
+                        valueCall.methodFullName shouldBe "box.Box.value:box.Pair()"
+                        valueCall.typeFullName shouldBe "box.Pair"
+                        valueCall.code shouldBe "((Box) o).value()"
+
+                        inside(valueCall.argument.l) { case List(boxCast: Call) =>
+                          boxCast.name shouldBe Operators.cast
+                          boxCast.methodFullName shouldBe Operators.cast
+                          boxCast.typeFullName shouldBe "box.Box"
+                          boxCast.code shouldBe "(Box) o"
+
+                          inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                            boxType.typeFullName shouldBe "box.Box"
+                            boxType.code shouldBe "Box"
+
+                            oIdentifier.name shouldBe "o"
+                            oIdentifier.code shouldBe "o"
+                            oIdentifier.typeFullName shouldBe "java.lang.Object"
+                            oIdentifier.refsTo.l shouldBe oParameter
+                          }
+                        }
+                      }
+                    }
+                    integerType.typeFullName shouldBe "java.lang.Integer"
+                    integerType.code shouldBe "Integer"
+                  }
+                }
+              }
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        val oParameter = cpg.method.name("foo").parameter.name("o").l
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(sLocal: Local, iLocal: Local, sAssign: Call, iAssign: Call, sSink: Call, iSink: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.code shouldBe "s"
+            sLocal.typeFullName shouldBe "java.lang.String"
+
+            iLocal.name shouldBe "i"
+            iLocal.code shouldBe "i"
+            iLocal.typeFullName shouldBe "java.lang.Integer"
+
+            sAssign.name shouldBe Operators.assignment
+            sAssign.methodFullName shouldBe Operators.assignment
+            sAssign.typeFullName shouldBe "java.lang.String"
+            sAssign.code shouldBe "s = (String) ((Pair) ((Box) o).value()).first()"
+
+            inside(sAssign.argument.l) { case List(sIdentifier: Identifier, stringCast: Call) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.refsTo.l shouldBe List(sLocal)
+
+              stringCast.name shouldBe Operators.cast
+              stringCast.methodFullName shouldBe Operators.cast
+              stringCast.typeFullName shouldBe "java.lang.String"
+              stringCast.code shouldBe "(String) ((Pair) ((Box) o).value()).first()"
+
+              inside(stringCast.argument.l) { case List(stringType: TypeRef, firstCall: Call) =>
+                stringType.typeFullName shouldBe "java.lang.String"
+                stringType.code shouldBe "String"
+
+                firstCall.name shouldBe "first"
+                firstCall.methodFullName shouldBe "box.Pair.first:java.lang.Object()"
+                firstCall.signature shouldBe "java.lang.Object()"
+                // TODO: Should this be the erased type?
+                firstCall.typeFullName shouldBe "java.lang.Object"
+                firstCall.code shouldBe "((Pair) ((Box) o).value()).first()"
+
+                inside(firstCall.argument.l) { case List(pairCast: Call) =>
+                  pairCast.name shouldBe Operators.cast
+                  pairCast.methodFullName shouldBe Operators.cast
+                  pairCast.typeFullName shouldBe "box.Pair"
+                  pairCast.code shouldBe "(Pair) ((Box) o).value()"
+
+                  inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
+                    pairType.typeFullName shouldBe "box.Pair"
+                    pairType.code shouldBe "Pair"
+
+                    valueCall.name shouldBe "value"
+                    valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+                    valueCall.signature shouldBe "java.lang.Object()"
+                    valueCall.typeFullName shouldBe "java.lang.Object"
+                    valueCall.code shouldBe "((Box) o).value()"
+
+                    inside(valueCall.argument.l) { case List(boxCast: Call) =>
+                      boxCast.name shouldBe Operators.cast
+                      boxCast.methodFullName shouldBe Operators.cast
+                      boxCast.typeFullName shouldBe "box.Box"
+                      boxCast.code shouldBe "(Box) o"
+
+                      inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                        boxType.typeFullName shouldBe "box.Box"
+                        boxType.code shouldBe "Box"
+
+                        oIdentifier.name shouldBe "o"
+                        oIdentifier.code shouldBe "o"
+                        oIdentifier.typeFullName shouldBe "java.lang.Object"
+                        oIdentifier.refsTo.l shouldBe oParameter
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            iAssign.name shouldBe Operators.assignment
+            iAssign.methodFullName shouldBe Operators.assignment
+            iAssign.typeFullName shouldBe "java.lang.Integer"
+            iAssign.code shouldBe "i = (Integer) ((Pair) ((Box) o).value()).second()"
+
+            inside(iAssign.argument.l) { case List(iIdentifier: Identifier, integerCast: Call) =>
+              iIdentifier.name shouldBe "i"
+              iIdentifier.code shouldBe "i"
+              iIdentifier.typeFullName shouldBe "java.lang.Integer"
+              iIdentifier.refsTo.l shouldBe List(iLocal)
+
+              integerCast.name shouldBe Operators.cast
+              integerCast.methodFullName shouldBe Operators.cast
+              integerCast.typeFullName shouldBe "java.lang.Integer"
+              integerCast.code shouldBe "(Integer) ((Pair) ((Box) o).value()).second()"
+
+              inside(integerCast.argument.l) { case List(integerType: TypeRef, secondCall: Call) =>
+                integerType.typeFullName shouldBe "java.lang.Integer"
+                integerType.code shouldBe "Integer"
+
+                secondCall.name shouldBe "second"
+                secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Object()"
+                secondCall.signature shouldBe "java.lang.Object()"
+                // TODO: Should this be the erased type?
+                secondCall.typeFullName shouldBe "java.lang.Object"
+                secondCall.code shouldBe "((Pair) ((Box) o).value()).second()"
+
+                inside(secondCall.argument.l) { case List(pairCast: Call) =>
+                  pairCast.name shouldBe Operators.cast
+                  pairCast.methodFullName shouldBe Operators.cast
+                  pairCast.typeFullName shouldBe "box.Pair"
+                  pairCast.code shouldBe "(Pair) ((Box) o).value()"
+
+                  inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
+                    pairType.typeFullName shouldBe "box.Pair"
+                    pairType.code shouldBe "Pair"
+
+                    valueCall.name shouldBe "value"
+                    valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+                    valueCall.signature shouldBe "java.lang.Object()"
+                    valueCall.typeFullName shouldBe "java.lang.Object"
+                    valueCall.code shouldBe "((Box) o).value()"
+
+                    inside(valueCall.argument.l) { case List(boxCast: Call) =>
+                      boxCast.name shouldBe Operators.cast
+                      boxCast.methodFullName shouldBe Operators.cast
+                      boxCast.typeFullName shouldBe "box.Box"
+                      boxCast.code shouldBe "(Box) o"
+
+                      inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                        boxType.typeFullName shouldBe "box.Box"
+                        boxType.code shouldBe "Box"
+
+                        oIdentifier.name shouldBe "o"
+                        oIdentifier.code shouldBe "o"
+                        oIdentifier.typeFullName shouldBe "java.lang.Object"
+                        oIdentifier.refsTo.l shouldBe oParameter
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        }
+      }
+    }
+  }
+
+  "resolved patterns in switch expressions" when {
+    "a type pattern is matched" should {
+      val cpg = code("""
+                         |package box;
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    switch (o) {
+                         |      case String s -> sink(s);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the variable assignment" in {
+        // TODO Should this be MATCH?
+        inside(
+          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
+        ) { case List(_: JumpTarget, instanceCheck: ControlStructure) =>
+          inside(instanceCheck.astChildren.collectAll[Call].argument.l) {
+            case List(oIdentifier: Identifier, stringType: TypeRef) =>
+              oIdentifier.name shouldBe "o"
+              oIdentifier.code shouldBe "o"
+              oIdentifier.typeFullName shouldBe "java.lang.Object"
+
+              stringType.typeFullName shouldBe "java.lang.String"
+          }
+          instanceCheck.code shouldBe "if (o instanceof String)"
+
+          inside(instanceCheck.astChildren.l) { case List(instanceOfCall: Call, statementsBlock: Block) =>
+            instanceOfCall.code shouldBe "o instanceof String"
+            inside(statementsBlock.astChildren.l) { case List(sLocal: Local, sAssign: Call, sinkCall: Call) =>
+              sLocal.name shouldBe "s"
+              sLocal.typeFullName shouldBe "java.lang.String"
+              sLocal.code shouldBe "String s"
+
+              sAssign.name shouldBe Operators.assignment
+              sAssign.methodFullName shouldBe Operators.assignment
+              sAssign.code shouldBe "s = (String) o"
+
+              inside(sAssign.argument.l) { case List(sIdentifier: Identifier, castExpr: Call) =>
+                sIdentifier.name shouldBe "s"
+                sIdentifier.typeFullName shouldBe "java.lang.String"
+                sIdentifier.code shouldBe "s"
+                sIdentifier.refsTo.l should contain theSameElementsAs List(sLocal)
+
+                castExpr.name shouldBe Operators.cast
+                castExpr.methodFullName shouldBe Operators.cast
+                castExpr.typeFullName shouldBe "java.lang.String"
+                castExpr.code shouldBe "(String) o"
+
+                inside(castExpr.argument.l) { case List(stringType: TypeRef, oIdentifier: Identifier) =>
+                  stringType.typeFullName shouldBe "java.lang.String"
+                  stringType.code shouldBe "String"
+
+                  oIdentifier.name shouldBe "o"
+                  oIdentifier.typeFullName shouldBe "java.lang.Object"
+                  oIdentifier.code shouldBe "o"
+                  oIdentifier.refsTo.l should contain theSameElementsAs cpg.method.name("foo").parameter.name("o").l
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    "a non-generic, non-nested record pattern is matched" should {
+      val cpg = code("""
+                         |package box;
+                         |
+                         |record Box(String value) {}
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    switch (o) {
+                         |      case Box(String s) -> sink(s);
+                         |      default -> {}
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        inside(
+          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
+        ) { case List(sLocal: Local, sAssignment: Call, _: Call) =>
+          sLocal.name shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+          sLocal.code shouldBe "String s"
+
+          sAssignment.name shouldBe Operators.assignment
+          sAssignment.methodFullName shouldBe Operators.assignment
+          sAssignment.typeFullName shouldBe "java.lang.String"
+          sAssignment.code shouldBe "s = ((Box) o).value()"
+
+          inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, valueCall: Call) =>
+            sIdentifier.name shouldBe "s"
+            sIdentifier.typeFullName shouldBe "java.lang.String"
+            sIdentifier.code shouldBe "s"
+            sIdentifier.refsTo.l shouldBe List(sLocal)
+
+            valueCall.name shouldBe "value"
+            valueCall.methodFullName shouldBe "box.Box.value:java.lang.String()"
+            valueCall.typeFullName shouldBe "java.lang.String"
+            valueCall.code shouldBe "((Box) o).value()"
+
+            inside(valueCall.argument.l) { case List(castExpr: Call) =>
+              castExpr.name shouldBe Operators.cast
+              castExpr.methodFullName shouldBe Operators.cast
+              castExpr.typeFullName shouldBe "box.Box"
+              castExpr.code shouldBe "(Box) o"
+
+              inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                boxType.typeFullName shouldBe "box.Box"
+                boxType.code shouldBe "Box"
+
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+              }
+            }
+          }
+        }
+      }
+    }
+
+    "a generic, non-nested record pattern is matched" should {
+      val cpg = code("""
+                         |package box;
+                         |
+                         |record Box<T>(T value) {}
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    switch (o) {
+                         |      case Box(String s) -> sink(s);
+                         |      default -> {}
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        inside(
+          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
+        ) { case List(sLocal: Local, sAssignment: Call, _: Call) =>
+          sLocal.name shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+          sLocal.code shouldBe "String s"
+
+          sAssignment.name shouldBe Operators.assignment
+          sAssignment.methodFullName shouldBe Operators.assignment
+          sAssignment.typeFullName shouldBe "java.lang.String"
+          sAssignment.code shouldBe "s = (String) ((Box) o).value()"
+
+          inside(sAssignment.argument.l) { case List(stringCast: Call) =>
+            stringCast.name shouldBe Operators.cast
+            stringCast.methodFullName shouldBe Operators.cast
+            stringCast.typeFullName shouldBe "java.lang.String"
+            stringCast.code shouldBe "(String) ((Box) o).value()"
+
+            inside(stringCast.argument.l) { case List(sIdentifier: Identifier, valueCall: Call) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.refsTo.l shouldBe List(sLocal)
+
+              valueCall.name shouldBe "value"
+              valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+              valueCall.typeFullName shouldBe "java.lang.Object"
+              valueCall.code shouldBe "((Box) o).value()"
+
+              inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                castExpr.name shouldBe Operators.cast
+                castExpr.methodFullName shouldBe Operators.cast
+                castExpr.typeFullName shouldBe "box.Box"
+                castExpr.code shouldBe "(Box) o"
+
+                inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                  boxType.typeFullName shouldBe "box.Box"
+                  boxType.code shouldBe "Box"
+
+                  oIdentifier.name shouldBe "o"
+                  oIdentifier.typeFullName shouldBe "java.lang.Object"
+                  oIdentifier.code shouldBe "o"
+                  oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    "a non-generic, nested record pattern is matched" should {
+
+      val cpg = code("""
+                         |package box;
+                         |
+                         |record PairBox(Pair value) {}
+                         |record Pair(String first, Integer second) {}
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    switch (o) {
+                         |      case PairBox(Pair(String s, Integer i)) -> { sink(s); sink(i); }
+                         |      default -> {}
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        val oParameter = cpg.method.name("foo").parameter.name("o").l
+        inside(
+          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
+        ) { case List(sLocal: Local, iLocal: Local, sAssign: Call, iAssign: Call, sinkS: Call, sinkI: Call) =>
+          sLocal.name shouldBe "s"
+          sLocal.code shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+
+          iLocal.name shouldBe "i"
+          iLocal.code shouldBe "i"
+          iLocal.typeFullName shouldBe "java.lang.Integer"
+
+          sAssign.name shouldBe Operators.assignment
+          sAssign.methodFullName shouldBe Operators.assignment
+          sAssign.typeFullName shouldBe "java.lang.String"
+          sAssign.code shouldBe "s = ((PairBox) o).value().first()"
+
+          inside(sAssign.argument.l) { case List(sIdentifier: Identifier, firstCall: Call) =>
+            sIdentifier.name shouldBe "s"
+            sIdentifier.code shouldBe "s"
+            sIdentifier.typeFullName shouldBe "java.lang.String"
+            sIdentifier.refsTo.l shouldBe List(sLocal)
+
+            firstCall.name shouldBe "first"
+            firstCall.methodFullName shouldBe "box.Pair.first:java.lang.String()"
+            firstCall.signature shouldBe "java.lang.String()"
+            firstCall.typeFullName shouldBe "java.lang.String"
+            firstCall.code shouldBe "((PairBox) o).value().first()"
+
+            inside(firstCall.argument.l) { case List(valueCall: Call) =>
+              valueCall.name shouldBe "value"
+              valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
+              valueCall.signature shouldBe "box.Pair()"
+              valueCall.typeFullName shouldBe "box.Pair()"
+              valueCall.code shouldBe "((PairBox) o).value()"
+
+              inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                castExpr.name shouldBe Operators.cast
+                castExpr.methodFullName shouldBe Operators.cast
+                castExpr.typeFullName shouldBe "box.PairBox"
+                castExpr.code shouldBe "(PairBox) o"
+
+                inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
+                  pairBoxType.typeFullName shouldBe "box.PairBox"
+                  pairBoxType.code shouldBe "PairBox"
+
+                  oIdentifier.name shouldBe "o"
+                  oIdentifier.code shouldBe "o"
+                  oIdentifier.typeFullName shouldBe "java.lang.Object"
+                  oIdentifier.refsTo.l shouldBe oParameter
+                }
+              }
+            }
+          }
+
+          iAssign.name shouldBe Operators.assignment
+          iAssign.methodFullName shouldBe Operators.assignment
+          iAssign.typeFullName shouldBe "java.lang.Integer"
+          iAssign.code shouldBe "i = ((PairBox) o).value().second()"
+
+          inside(iAssign.argument.l) { case List(iIdentifier: Identifier, secondCall: Call) =>
+            iIdentifier.name shouldBe "i"
+            iIdentifier.code shouldBe "i"
+            iIdentifier.typeFullName shouldBe "java.lang.Integer"
+            iIdentifier.refsTo.l shouldBe List(iLocal)
+
+            secondCall.name shouldBe "second"
+            secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Integer()"
+            secondCall.signature shouldBe "java.lang.Integer()"
+            secondCall.typeFullName shouldBe "java.lang.Integer"
+            secondCall.code shouldBe "((PairBox) o).value().second()"
+
+            inside(secondCall.argument.l) { case List(valueCall: Call) =>
+              valueCall.name shouldBe "value"
+              valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
+              valueCall.signature shouldBe "box.Pair()"
+              valueCall.typeFullName shouldBe "box.Pair()"
+              valueCall.code shouldBe "((PairBox) o).value()"
+
+              inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                castExpr.name shouldBe Operators.cast
+                castExpr.methodFullName shouldBe Operators.cast
+                castExpr.typeFullName shouldBe "box.PairBox"
+                castExpr.code shouldBe "(PairBox) o"
+
+                inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
+                  pairBoxType.typeFullName shouldBe "box.PairBox"
+                  pairBoxType.code shouldBe "PairBox"
+
+                  oIdentifier.name shouldBe "o"
+                  oIdentifier.code shouldBe "o"
+                  oIdentifier.typeFullName shouldBe "java.lang.Object"
+                  oIdentifier.refsTo.l shouldBe oParameter
+                }
+              }
+            }
+          }
+
+          inside(sinkS.argument.isIdentifier.name("s").l) { case List(sIdentifier: Identifier) =>
+            sIdentifier.name shouldBe "s"
+            sIdentifier.code shouldBe "s"
+            sIdentifier.typeFullName shouldBe "java.lang.String"
+            sIdentifier.refsTo.l shouldBe List(sLocal)
+          }
+
+          inside(sinkI.argument.isIdentifier.name("i").l) { case List(iIdentifier: Identifier) =>
+            iIdentifier.name shouldBe "i"
+            iIdentifier.code shouldBe "i"
+            iIdentifier.typeFullName shouldBe "java.lang.Integer"
+            iIdentifier.refsTo.l shouldBe List(iLocal)
+          }
+        }
+      }
+    }
+
+    "a generic, nested record pattern is matched" should {
+
+      val cpg = code("""
+                         |package box;
+                         |
+                         |record Box<T>(Pair value) {}
+                         |record Pair<U, V>(U first, V second) {}
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    switch (o) {
+                         |      case Box(Pair(String s, Integer i)) -> { sink(s); sink(i); }
+                         |      default -> {}
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "parse" in {
+        cpg.call.name("sink").isEmpty shouldBe false
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        val oParameter = cpg.method.name("foo").parameter.name("o").l
+        inside(
+          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
+        ) { case List(sLocal: Local, iLocal: Local, sAssign: Call, iAssign: Call, sSink: Call, iSink: Call) =>
+          sLocal.name shouldBe "s"
+          sLocal.code shouldBe "s"
+          sLocal.typeFullName shouldBe "java.lang.String"
+
+          iLocal.name shouldBe "i"
+          iLocal.code shouldBe "i"
+          iLocal.typeFullName shouldBe "java.lang.Integer"
+
+          sAssign.name shouldBe Operators.assignment
+          sAssign.methodFullName shouldBe Operators.assignment
+          sAssign.typeFullName shouldBe "java.lang.String"
+          sAssign.code shouldBe "s = (String) ((Pair) ((Box) o).value()).first()"
+
+          inside(sAssign.argument.l) { case List(sIdentifier: Identifier, stringCast: Call) =>
+            sIdentifier.name shouldBe "s"
+            sIdentifier.code shouldBe "s"
+            sIdentifier.typeFullName shouldBe "java.lang.String"
+            sIdentifier.refsTo.l shouldBe List(sLocal)
+
+            stringCast.name shouldBe Operators.cast
+            stringCast.methodFullName shouldBe Operators.cast
+            stringCast.typeFullName shouldBe "java.lang.String"
+            stringCast.code shouldBe "(String) ((Pair) ((Box) o).value()).first()"
+
+            inside(stringCast.argument.l) { case List(stringType: TypeRef, firstCall: Call) =>
+              stringType.typeFullName shouldBe "java.lang.String"
+              stringType.code shouldBe "String"
+
+              firstCall.name shouldBe "first"
+              firstCall.methodFullName shouldBe "box.Pair.first:java.lang.Object()"
+              firstCall.signature shouldBe "java.lang.Object()"
+              // TODO: Should this be the erased type?
+              firstCall.typeFullName shouldBe "java.lang.Object"
+              firstCall.code shouldBe "((Pair) ((Box) o).value()).first()"
+
+              inside(firstCall.argument.l) { case List(pairCast: Call) =>
+                pairCast.name shouldBe Operators.cast
+                pairCast.methodFullName shouldBe Operators.cast
+                pairCast.typeFullName shouldBe "box.Pair"
+                pairCast.code shouldBe "(Pair) ((Box) o).value()"
+
+                inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
+                  pairType.typeFullName shouldBe "box.Pair"
+                  pairType.code shouldBe "Pair"
+
+                  valueCall.name shouldBe "value"
+                  valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+                  valueCall.signature shouldBe "java.lang.Object()"
+                  valueCall.typeFullName shouldBe "java.lang.Object"
+                  valueCall.code shouldBe "((Box) o).value()"
+
+                  inside(valueCall.argument.l) { case List(boxCast: Call) =>
+                    boxCast.name shouldBe Operators.cast
+                    boxCast.methodFullName shouldBe Operators.cast
+                    boxCast.typeFullName shouldBe "box.Box"
+                    boxCast.code shouldBe "(Box) o"
+
+                    inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                      boxType.typeFullName shouldBe "box.Box"
+                      boxType.code shouldBe "Box"
+
+                      oIdentifier.name shouldBe "o"
+                      oIdentifier.code shouldBe "o"
+                      oIdentifier.typeFullName shouldBe "java.lang.Object"
+                      oIdentifier.refsTo.l shouldBe oParameter
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          iAssign.name shouldBe Operators.assignment
+          iAssign.methodFullName shouldBe Operators.assignment
+          iAssign.typeFullName shouldBe "java.lang.Integer"
+          iAssign.code shouldBe "i = (Integer) ((Pair) ((Box) o).value()).second()"
+
+          inside(iAssign.argument.l) { case List(iIdentifier: Identifier, integerCast: Call) =>
+            iIdentifier.name shouldBe "i"
+            iIdentifier.code shouldBe "i"
+            iIdentifier.typeFullName shouldBe "java.lang.Integer"
+            iIdentifier.refsTo.l shouldBe List(iLocal)
+
+            integerCast.name shouldBe Operators.cast
+            integerCast.methodFullName shouldBe Operators.cast
+            integerCast.typeFullName shouldBe "java.lang.Integer"
+            integerCast.code shouldBe "(Integer) ((Pair) ((Box) o).value()).second()"
+
+            inside(integerCast.argument.l) { case List(integerType: TypeRef, secondCall: Call) =>
+              integerType.typeFullName shouldBe "java.lang.Integer"
+              integerType.code shouldBe "Integer"
+
+              secondCall.name shouldBe "second"
+              secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Object()"
+              secondCall.signature shouldBe "java.lang.Object()"
+              // TODO: Should this be the erased type?
+              secondCall.typeFullName shouldBe "java.lang.Object"
+              secondCall.code shouldBe "((Pair) ((Box) o).value()).second()"
+
+              inside(secondCall.argument.l) { case List(pairCast: Call) =>
+                pairCast.name shouldBe Operators.cast
+                pairCast.methodFullName shouldBe Operators.cast
+                pairCast.typeFullName shouldBe "box.Pair"
+                pairCast.code shouldBe "(Pair) ((Box) o).value()"
+
+                inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
+                  pairType.typeFullName shouldBe "box.Pair"
+                  pairType.code shouldBe "Pair"
+
+                  valueCall.name shouldBe "value"
+                  valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+                  valueCall.signature shouldBe "java.lang.Object()"
+                  valueCall.typeFullName shouldBe "java.lang.Object"
+                  valueCall.code shouldBe "((Box) o).value()"
+
+                  inside(valueCall.argument.l) { case List(boxCast: Call) =>
+                    boxCast.name shouldBe Operators.cast
+                    boxCast.methodFullName shouldBe Operators.cast
+                    boxCast.typeFullName shouldBe "box.Box"
+                    boxCast.code shouldBe "(Box) o"
+
+                    inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                      boxType.typeFullName shouldBe "box.Box"
+                      boxType.code shouldBe "Box"
+
+                      oIdentifier.name shouldBe "o"
+                      oIdentifier.code shouldBe "o"
+                      oIdentifier.typeFullName shouldBe "java.lang.Object"
+                      oIdentifier.refsTo.l shouldBe oParameter
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          inside(sSink.argument.isIdentifier.name("s").l) { case List(sIdentifier: Identifier) =>
+            sIdentifier.name shouldBe "s"
+            sIdentifier.code shouldBe "s"
+            sIdentifier.typeFullName shouldBe "java.lang.String"
+            sIdentifier.refsTo.l shouldBe List(sLocal)
+          }
+
+          inside(iSink.argument.isIdentifier.name("i").l) { case List(iIdentifier: Identifier) =>
+            iIdentifier.name shouldBe "i"
+            iIdentifier.code shouldBe "i"
+            iIdentifier.typeFullName shouldBe "java.lang.Integer"
+            iIdentifier.refsTo.l shouldBe List(iLocal)
+          }
+        }
+      }
+    }
+  }
+
+  "unresolved patterns in instanceof expressions" when {
+
+    "the pattern is a type pattern without an import fallback" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    if (o instanceof Bar b) {
+                         |      sink(b);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the correct lowering for the type check" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(oInstanceOfBar: Call) =>
+            oInstanceOfBar.name shouldBe Operators.instanceOf
+            oInstanceOfBar.methodFullName shouldBe Operators.instanceOf
+            oInstanceOfBar.typeFullName shouldBe "boolean"
+            oInstanceOfBar.code shouldBe "o instanceof Bar"
+
+            inside(oInstanceOfBar.argument.l) { case List(oIdentifier: Identifier, barType: TypeRef) =>
+              oIdentifier.name shouldBe "o"
+              oIdentifier.code shouldBe "o"
+              oIdentifier.typeFullName shouldBe "java.lang.Object"
+              oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+
+              barType.typeFullName shouldBe "ANY"
+              barType.code shouldBe "Bar"
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(bLocal: Local, bAssign: Call, bSink: Call) =>
+            bLocal.name shouldBe "b"
+            bLocal.code shouldBe "Bar b"
+            bLocal.typeFullName shouldBe "ANY"
+
+            bAssign.name shouldBe Operators.assignment
+            bAssign.methodFullName shouldBe Operators.assignment
+            bAssign.typeFullName shouldBe "ANY"
+            bAssign.code shouldBe "b = (Bar) o"
+
+            inside(bAssign.argument.l) { case List(bIdentifier: Identifier, castCall: Call) =>
+              bIdentifier.name shouldBe "b"
+              bIdentifier.code shouldBe "b"
+              bIdentifier.typeFullName shouldBe "ANY"
+              bIdentifier.refsTo.l shouldBe List(bLocal)
+
+              castCall.name shouldBe Operators.cast
+              castCall.methodFullName shouldBe Operators.cast
+              castCall.typeFullName shouldBe "ANY"
+              castCall.code shouldBe "(Bar) o"
+
+              inside(castCall.argument.l) { case List(barType: TypeRef, oIdentifier: Identifier) =>
+                barType.code shouldBe "Bar"
+                barType.typeFullName shouldBe "ANY"
+
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+              }
+            }
+
+            bSink.argument.isIdentifier.name("b").refsTo.l shouldBe List(bLocal)
+        }
+      }
+    }
+
+    "the pattern is a type pattern with an import fallback" should {
+      val cpg = code("""
+                         |import bar.Bar;
+                         |
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    if (o instanceof Bar b) {
+                         |      sink(b);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the correct lowering for the type check" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(oInstanceOfBar: Call) =>
+            oInstanceOfBar.name shouldBe Operators.instanceOf
+            oInstanceOfBar.methodFullName shouldBe Operators.instanceOf
+            oInstanceOfBar.typeFullName shouldBe "boolean"
+            oInstanceOfBar.code shouldBe "o instanceof Bar"
+
+            inside(oInstanceOfBar.argument.l) { case List(oIdentifier: Identifier, barType: TypeRef) =>
+              oIdentifier.name shouldBe "o"
+              oIdentifier.code shouldBe "o"
+              oIdentifier.typeFullName shouldBe "java.lang.Object"
+              oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+
+              barType.typeFullName shouldBe "bar.Bar"
+              barType.code shouldBe "Bar"
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(bLocal: Local, bAssign: Call, bSink: Call) =>
+            bLocal.name shouldBe "b"
+            bLocal.code shouldBe "Bar b"
+            bLocal.typeFullName shouldBe "bar.Bar"
+
+            bAssign.name shouldBe Operators.assignment
+            bAssign.methodFullName shouldBe Operators.assignment
+            bAssign.typeFullName shouldBe "bar.Bar"
+            bAssign.code shouldBe "b = (Bar) o"
+
+            inside(bAssign.argument.l) { case List(bIdentifier: Identifier, castCall: Call) =>
+              bIdentifier.name shouldBe "b"
+              bIdentifier.code shouldBe "b"
+              bIdentifier.typeFullName shouldBe "bar.Bar"
+              bIdentifier.refsTo.l shouldBe List(bLocal)
+
+              castCall.name shouldBe Operators.cast
+              castCall.methodFullName shouldBe Operators.cast
+              castCall.typeFullName shouldBe "bar.Bar"
+              castCall.code shouldBe "(Bar) o"
+
+              inside(castCall.argument.l) { case List(barType: TypeRef, oIdentifier: Identifier) =>
+                barType.typeFullName shouldBe "bar.Bar"
+
+                oIdentifier.name shouldBe "o"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+              }
+            }
+
+            bSink.argument.isIdentifier.name("b").refsTo.l shouldBe List(bLocal)
+        }
+      }
+    }
+
+    "the pattern is a nested record pattern" should {
+      val cpg = code("""
+                         |class Foo {
+                         |  void foo(Object o) {
+                         |    if (o instanceof Bar(Baz(Qux q))) {
+                         |      sink(q);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the correct lowering for the type check" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(oInstanceOfBar: Call) =>
+            oInstanceOfBar.name shouldBe Operators.instanceOf
+            oInstanceOfBar.methodFullName shouldBe Operators.instanceOf
+            oInstanceOfBar.typeFullName shouldBe "boolean"
+            oInstanceOfBar.code shouldBe "o instanceof Bar"
+
+            inside(oInstanceOfBar.argument.l) { case List(oIdentifier: Identifier, barType: TypeRef) =>
+              oIdentifier.name shouldBe "o"
+              oIdentifier.code shouldBe "o"
+              oIdentifier.typeFullName shouldBe "java.lang.Object"
+              oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+
+              barType.typeFullName shouldBe "ANY"
+              barType.code shouldBe "Bar"
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" ignore {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(qLocal: Local, qAssign: Call, qSink: Call) =>
+            qLocal.name shouldBe "q"
+            qLocal.code shouldBe "Qux q"
+            qLocal.typeFullName shouldBe "ANY"
+
+            qAssign.name shouldBe Operators.assignment
+            qAssign.methodFullName shouldBe Operators.assignment
+            qAssign.typeFullName shouldBe "ANY"
+            qAssign.code shouldBe "q = ((Bar) o).<unresolvedField>.<unresolvedField>"
+
+            inside(qAssign.argument.l) { case List(qIdentifier: Identifier, firstFieldAccess: Call) =>
+              qIdentifier.name shouldBe "q"
+              qIdentifier.code shouldBe "q"
+              qIdentifier.typeFullName shouldBe "ANY"
+              qIdentifier.refsTo.l shouldBe List(qLocal)
+
+              firstFieldAccess.name shouldBe Operators.fieldAccess
+              firstFieldAccess.methodFullName shouldBe Operators.fieldAccess
+              firstFieldAccess.typeFullName shouldBe "ANY"
+              firstFieldAccess.code shouldBe "((Bar) o).<unresolvedField>.<unresolvedField>"
+
+              inside(firstFieldAccess.argument.l) {
+                case List(secondFieldAccess: Call, unresolvedFieldIdentifier: FieldIdentifier) =>
+                  secondFieldAccess.name shouldBe Operators.fieldAccess
+                  secondFieldAccess.methodFullName shouldBe Operators.fieldAccess
+                  secondFieldAccess.typeFullName shouldBe "ANY"
+                  secondFieldAccess.code shouldBe "((Bar) o).<unresolvedField>"
+
+                  inside(secondFieldAccess.argument.l) {
+                    case List(castExpr: Call, unresolvedFieldIdentifier: FieldIdentifier) =>
+                      castExpr.name shouldBe Operators.cast
+                      castExpr.methodFullName shouldBe Operators.cast
+                      castExpr.typeFullName shouldBe "ANY"
+                      castExpr.code shouldBe "(Bar) o"
+
+                      inside(castExpr.argument.l) { case List(barType: TypeRef, oIdentifier: Identifier) =>
+                        barType.typeFullName shouldBe "ANY"
+                        barType.code shouldBe "Bar"
+
+                        oIdentifier.name shouldBe "o"
+                        oIdentifier.code shouldBe "o"
+                        oIdentifier.typeFullName shouldBe "java.lang.Object"
+                        oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                      }
+
+                      unresolvedFieldIdentifier.canonicalName shouldBe "<unresolvedField>"
+                      unresolvedFieldIdentifier.code shouldBe "<unresolvedField>"
+                  }
+
+                  unresolvedFieldIdentifier.canonicalName shouldBe "<unresolvedField>"
+                  unresolvedFieldIdentifier.code shouldBe "<unresolvedField>"
+              }
+            }
+        }
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/ScopeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/ScopeTests.scala
@@ -14,8 +14,11 @@ import io.joern.javasrc2cpg.scope.Scope.CapturedVariable
 import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterIn
 import io.joern.javasrc2cpg.scope.Scope.ScopeParameter
 import io.joern.javasrc2cpg.scope.Scope.NotInScope
+import io.joern.x2cpg.ValidationMode
 
 class ScopeTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  private implicit val withSchemaValidation: ValidationMode = ValidationMode.Enabled
+
   behavior of "javasrc2cpg scope"
 
   it should "find a simple variable for a member" in {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,7 +19,7 @@ object Versions {
   val ghidra                 = "11.2.1_PUBLIC_20241105-7"
   val gradleTooling          = "8.3"
   val jacksonDatabind        = "2.17.0"
-  val javaParser             = "3.25.9"
+  val javaParser             = "3.26.2"
   val jlhttp                 = "3.1"
   val jRuby                  = "9.4.9.0"
   val json4s                 = "4.0.7"


### PR DESCRIPTION
This PR adds several things related to type pattern matching (which was added in Java 16 and extended to switch statements in Java 21), in particular:
* Locals for all pattern variables that appear in `instanceof` expressions or switch entry labels
* Assignments for pattern variables which are used or introduced to a block scope
* Temporary locals and assignments for the left-hand sides of `instanceof` expressions or switch conditions which are complex expressions to avoid side effects from invoking these twice

There are a few TODOs still left after this:
* Record pattern support is still missing. The code as it is now shouldn't create an invalid CPG (in the sense of throwing errors), but the `instanceof` comparison for record patterns does not consider the types of nested patterns/types and the assignment for pattern variables from record patterns is nonsense.
* There are some cases in which type pattern matching behaves in a way that cannot be trivially represented in Java code without pattern matching. In these cases, we introduce locals into scope that should not be there according to conventional java scoping rules. This means it's currently possible to have multiple locals with the same name (possibly also the same type) to exist in the same scope. The fix for this is to merge these locals where possible and to mangle names when not.
* A lot of code fields need to be updated. `javasrc2cpg` is not consistent with whether the code field should show the original code or the lowering and this is especially obvious when looking at ASTs involving pattern variables.