### PR TITLE
Add option to disable type fallbacks for javasrc2cpg

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -26,7 +26,8 @@ final case class Config(
   skipTypeInfPass: Boolean = false,
   dumpJavaparserAsts: Boolean = false,
   cacheJdkTypeSolver: Boolean = false,
-  keepTypeArguments: Boolean = false
+  keepTypeArguments: Boolean = false,
+  disableTypeFallback: Boolean = false
 ) extends X2CpgConfig[Config]
     with TypeRecoveryParserConfig[Config] {
   def withInferenceJarPaths(paths: Set[String]): Config = {
@@ -75,6 +76,10 @@ final case class Config(
 
   def withKeepTypeArguments(value: Boolean): Config = {
     copy(keepTypeArguments = value).withInheritedFields(this)
+  }
+
+  def withDisableTypeFallback(value: Boolean): Config = {
+    copy(disableTypeFallback = value).withInheritedFields(this)
   }
 }
 
@@ -133,7 +138,12 @@ private object Frontend {
       opt[Unit]("keep-type-arguments")
         .hidden()
         .action((_, c) => c.withKeepTypeArguments(true))
-        .text("Type full names of variables keep their type arguments.")
+        .text("Type full names of variables keep their type arguments."),
+      opt[Unit]("disable-type-fallback")
+        .action((_, c) => c.withDisableTypeFallback(true))
+        .text(
+          "Disables fallback to wildcard imports, unsound type inferences and the Any type (except where no better information is available)."
+        )
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -1,5 +1,6 @@
 package io.joern.javasrc2cpg.astcreation
 
+import com.github.javaparser.ast.`type`.Type
 import com.github.javaparser.ast.expr.{
   AnnotationExpr,
   BooleanLiteralExpr,
@@ -44,11 +45,12 @@ import io.joern.javasrc2cpg.util.{
   BindingTableAdapterForJavaparser,
   MultiBindingTableAdapterForJavaparser,
   NameConstants,
-  TemporaryNameProvider
+  TemporaryNameProvider,
+  Util
 }
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.utils.OffsetUtils
-import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, ValidationMode}
+import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{NewClosureBinding, NewFile, NewImport, NewNamespaceBlock}
 import org.slf4j.LoggerFactory
@@ -91,7 +93,7 @@ class AstCreator(
   val symbolSolver: JavaSymbolSolver,
   protected val keepTypeArguments: Boolean,
   val loggedExceptionCounts: scala.collection.concurrent.Map[Class[?], Int]
-)(implicit val withSchemaValidation: ValidationMode)
+)(implicit val withSchemaValidation: ValidationMode, val disableTypeFallback: Boolean)
     extends AstCreatorBase(filename)
     with AstNodeBuilder[Node, AstCreator]
     with AstForDeclarationsCreator
@@ -131,6 +133,21 @@ class AstCreator(
       case (Some(acc), Some(value)) => Some(acc :+ value)
       case _                        => None
     }
+  }
+
+  private[astcreation] def getTypeFullName(expectedType: ExpectedType): Option[String] = {
+    Option.unless(disableTypeFallback)(expectedType.fullName).flatten
+  }
+
+  private[astcreation] def defaultTypeFallback(typ: Type): String = {
+    if (disableTypeFallback) {
+      s"${Defines.UnresolvedNamespace}.${Util.stripGenericTypes(code(typ))}"
+    } else
+      TypeConstants.Any
+  }
+
+  private[astcreation] def defaultTypeFallback(): String = {
+    TypeConstants.Any
   }
 
   /** Custom printer that omits comments. To be used by [[code]] */

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -90,7 +90,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
 
     val lambdaMethodNode = createLambdaMethodNode(expr, lambdaMethodName, parametersWithoutThis, returnType)
 
-    val returnNode      = newMethodReturnNode(returnType.getOrElse(TypeConstants.Any), None, line(expr), column(expr))
+    val returnNode = newMethodReturnNode(returnType.getOrElse(defaultTypeFallback()), None, line(expr), column(expr))
     val virtualModifier = Some(newModifierNode(ModifierTypes.VIRTUAL))
     val staticModifier  = Option.when(thisParam.isEmpty)(newModifierNode(ModifierTypes.STATIC))
     val privateModifier = Some(newModifierNode(ModifierTypes.PRIVATE))
@@ -363,7 +363,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
       .zipWithIndex
       .map { case ((param, maybeType), idx) =>
         val name         = param.getNameAsString
-        val typeFullName = maybeType.getOrElse(TypeConstants.Any)
+        val typeFullName = maybeType.getOrElse(defaultTypeFallback())
         val code         = s"$typeFullName $name"
         val evalStrat =
           if (tryWithSafeStackOverflow(param.getType).toOption.exists(_.isPrimitiveType)) EvaluationStrategies.BY_VALUE

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
@@ -39,7 +39,7 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
   private[expressions] def astForNameExpr(nameExpr: NameExpr, expectedType: ExpectedType): Ast = {
     val name = nameExpr.getName.toString
     val typeFullName = expressionReturnTypeFullName(nameExpr)
-      .orElse(expectedType.fullName)
+      .orElse(getTypeFullName(expectedType))
       .map(typeInfoCalc.registerType)
 
     scope.lookupVariable(name) match {
@@ -67,7 +67,7 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
         }
 
       case SimpleVariable(variable) =>
-        val identifier = identifierNode(nameExpr, name, name, typeFullName.getOrElse(TypeConstants.Any))
+        val identifier = identifierNode(nameExpr, name, name, typeFullName.getOrElse(defaultTypeFallback()))
         val captured = variable.node match {
           case param: NewMethodParameterIn => Some(param)
           case local: NewLocal             => Some(local)
@@ -117,15 +117,15 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
         // TODO using the enclosingTypeDecl is wrong if the field was imported via a static import.
         createImplicitBaseFieldAccess(
           value.asField().isStatic,
-          typeInfoCalc.name(value.declaringType()).getOrElse(TypeConstants.Any),
-          typeInfoCalc.fullName(value.declaringType()).getOrElse(TypeConstants.Any),
+          typeInfoCalc.name(value.declaringType()).getOrElse(defaultTypeFallback()),
+          typeInfoCalc.fullName(value.declaringType()).getOrElse(defaultTypeFallback()),
           nameExpr,
           name,
-          typeFullName.getOrElse(TypeConstants.Any)
+          typeFullName.getOrElse(defaultTypeFallback())
         )
 
       case _ =>
-        Ast(identifierNode(nameExpr, name, name, typeFullName.getOrElse(TypeConstants.Any)))
+        Ast(identifierNode(nameExpr, name, name, typeFullName.getOrElse(defaultTypeFallback())))
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
@@ -66,9 +66,14 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
 
     val patternTypeFullName = {
       tryWithSafeStackOverflow(pattern.getType).toOption
-        .flatMap(typ => scope.lookupScopeType(typ.asString()).map(_.typeFullName).orElse(typeInfoCalc.fullName(typ)))
-        .getOrElse(TypeConstants.Any)
-    }
+        .map(typ =>
+          scope
+            .lookupScopeType(typ.asString())
+            .map(_.typeFullName)
+            .orElse(typeInfoCalc.fullName(typ))
+            .getOrElse(defaultTypeFallback(typ))
+        )
+    }.getOrElse(defaultTypeFallback())
 
     val patternTypeRef = typeRefNode(pattern.getType, code(pattern.getType), patternTypeFullName)
 
@@ -78,8 +83,14 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
       val variableName = typePatternExpr.getNameAsString
       val variableType = {
         tryWithSafeStackOverflow(typePatternExpr.getType).toOption
-          .flatMap(typ => scope.lookupScopeType(typ.asString()).map(_.typeFullName).orElse(typeInfoCalc.fullName(typ)))
-          .getOrElse(TypeConstants.Any)
+          .map(typ =>
+            scope
+              .lookupScopeType(typ.asString())
+              .map(_.typeFullName)
+              .orElse(typeInfoCalc.fullName(typ))
+              .getOrElse(defaultTypeFallback(typ))
+          )
+          .getOrElse(defaultTypeFallback())
       }
       val variableTypeCode = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -63,7 +63,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
             symbolSolver,
             config.keepTypeArguments,
             loggedExceptionCounts
-          )(config.schemaValidation)
+          )(config.schemaValidation, config.disableTypeFallback)
             .createAst()
         )
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -23,7 +23,7 @@ case class NodeTypeInfo(
   isField: Boolean = false,
   isStatic: Boolean = false
 )
-class Scope(implicit val withSchemaValidation: ValidationMode) {
+class Scope(implicit val withSchemaValidation: ValidationMode, val disableTypeFallback: Boolean) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   private var scopeStack: List[JavaScopeElement] = Nil

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeFallbackTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeFallbackTests.scala
@@ -1,0 +1,98 @@
+package io.joern.javasrc2cpg.queryinfieldsg
+
+import io.joern.javasrc2cpg.Config
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
+import io.shiftleft.semanticcpg.language.*
+
+class TypeFallbackTests extends JavaSrcCode2CpgFixture {
+  private val typeFallbackDisabledConfig = Config().withDisableTypeFallback(true)
+
+  "cpgs generated with type fallbacks disabled" should {
+
+    "set the type of unresolved locals to <unresolvedNamespace>.Type" in {
+      val cpg = code("""
+          |class Foo {
+          |  void foo() {
+          |    Bar b = new Bar();
+          |  }
+          |}
+          |""".stripMargin)
+        .withConfig(typeFallbackDisabledConfig)
+
+      cpg.call(".*alloc.*").typeFullName.l shouldBe List("<unresolvedNamespace>.Bar")
+      cpg.method("foo").local.name("b").typeFullName.l shouldBe List("<unresolvedNamespace>.Bar")
+    }
+
+    "set the type of call receivers to <unresolvedNamespace>.Type" in {
+      val cpg = code("""
+          |class Foo {
+          |  void foo(Bar b) {
+          |    b.bar();
+          |  }
+          |}
+          |""".stripMargin)
+        .withConfig(typeFallbackDisabledConfig)
+
+      inside(cpg.call.name("bar").l) { case List(barCall: Call) =>
+        barCall.methodFullName shouldBe "<unresolvedNamespace>.Bar.bar:<unresolvedSignature>(0)"
+
+        inside(barCall.receiver.l) { case List(bIdentifier: Identifier) =>
+          bIdentifier.name shouldBe "b"
+          bIdentifier.typeFullName shouldBe "<unresolvedNamespace>.Bar"
+        }
+      }
+    }
+
+    "set the type of unresolved parameters to <unresolvedNamespace>.Type" in {
+      val cpg = code("""
+          |class Foo {
+          |  void foo(Bar b) { }
+          |}
+          |""".stripMargin)
+        .withConfig(typeFallbackDisabledConfig)
+
+      cpg.method("foo").parameter.name("b").typeFullName.l shouldBe List("<unresolvedNamespace>.Bar")
+    }
+
+    "set the type of unresolved fields to <unresolvedNamespace>.Type" in {
+      val cpg = code("""
+          |class Foo {
+          |  Bar b;
+          |}
+          |""".stripMargin)
+        .withConfig(typeFallbackDisabledConfig)
+
+      cpg.member("b").typeFullName.l shouldBe List("<unresolvedNamespace>.Bar")
+    }
+
+    "set the type of unresolved pattern variables to <unresolvedNamespace>.Type" in {
+      val cpg = code("""
+          |class Foo {
+          |  void foo(Object o) {
+          |    if (o instanceof Bar b) {}
+          |  }
+          |}
+          |""".stripMargin)
+        .withConfig(typeFallbackDisabledConfig)
+
+      cpg.method("foo").local.name("b").typeFullName.l shouldBe List("<unresolvedNamespace>.Bar")
+    }
+
+    "not use wildcard imports as a fallback" in {
+      val cpg = code("""
+          |import testpackage.*;
+          |
+          |class Foo {
+          |  void foo() {
+          |    Bar b = new Bar();
+          |  }
+          |}
+          |""".stripMargin)
+        .withConfig(typeFallbackDisabledConfig)
+
+      cpg.call(".*alloc.*").typeFullName.l shouldBe List("<unresolvedNamespace>.Bar")
+      cpg.method("foo").local.name("b").typeFullName.l shouldBe List("<unresolvedNamespace>.Bar")
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/ScopeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/ScopeTests.scala
@@ -18,6 +18,7 @@ import io.joern.x2cpg.ValidationMode
 
 class ScopeTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   private implicit val withSchemaValidation: ValidationMode = ValidationMode.Enabled
+  private implicit val disableTypeFallback: Boolean         = false
 
   behavior of "javasrc2cpg scope"
 


### PR DESCRIPTION
This PR adds functionality to disable wildcard import handling and `expectedType` fallbacks with the `disable-type-fallback` flag and changes the behaviour of the `ANY` type fallback when this flag is set. Where a type name is available but cannot be resolved, `<unresolvedNamespace>.TypeName` will be used instead of  `ANY`. In cases where the simple name isn't available either, `ANY` is still used, but this can easily be changed in the `defaultTypeFallback()` method.