### PR TITLE
[pysrc2cpg] Create member writes for variables writes in class bodies.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -1,6 +1,7 @@
 package io.joern.pysrc2cpg.cpg
 
 import io.joern.pysrc2cpg.testfixtures.PySrc2CpgFixture
+import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.semanticcpg.language.*
 
 class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
@@ -107,6 +108,17 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
                        |""".stripMargin)
       cpg.method.name("method").parameter.name("x").index.head shouldBe 1
     }
+  }
+
+  "assignment in class body should result into member write on meta class object" in {
+    val cpg = code("""class Foo:
+        |   AAA = 111
+        |""".stripMargin)
+
+    val List(bodyMethod)          = cpg.method.name("<body>").l
+    val List(block)               = bodyMethod.topLevelExpressions.l
+    val List(_, memberAssignment) = block.astChildren.collectAll[Call].l
+    memberAssignment.code shouldBe "cls.AAA = AAA"
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -1187,7 +1187,7 @@ class RegexDefinedFlowsDataFlowTests
     "be found" in {
       val src = cpg.identifier("Foo").l
       val snk = cpg.call("print").l
-      snk.reachableByFlows(src).size shouldBe 2
+      snk.reachableByFlows(src).size shouldBe 3
     }
   }
   "Import statement with method ref sample four" in {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -1186,7 +1186,7 @@ class RegexDefinedFlowsDataFlowTests
         |""".stripMargin)
     "be found" in {
       val src = cpg.identifier("Foo").l
-      val snk = cpg.call("print").l
+      val snk = cpg.call("print").argument(1).l
       snk.reachableByFlows(src).size shouldBe 3
     }
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -14,6 +14,13 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
   def local: Iterator[Local] =
     method._blockViaContainsOut.local
 
+  def topLevelExpressions: Iterator[Expression] =
+    method._astOut
+      .collectAll[Block]
+      ._astOut
+      .not(_.collectAll[Local])
+      .cast[Expression]
+
   /** All control structures of this method
     */
   def controlStructure: Iterator[ControlStructure] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -128,11 +128,7 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal {
 
   @Doc(info = "Top level expressions (\"Statements\")")
   def topLevelExpressions: Iterator[Expression] =
-    traversal._astOut
-      .collectAll[Block]
-      ._astOut
-      .not(_.collectAll[Local])
-      .cast[Expression]
+    traversal.flatMap(_.topLevelExpressions)
 
   @Doc(info = "Control flow graph nodes")
   def cfgNode: Iterator[CfgNode] =


### PR DESCRIPTION
In class body functions, assignments to variables represent assignments
to members in the meta class object.
This change adds the additional statement to the class body method to
reflect this.

Also: Made `topLevelExpressions` step available for individual methods.
