### PR TITLE
[ruby] Implicit Return for `MethodAccessModifier`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -240,6 +240,23 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         val simpleIdent = node.toSimpleIdentifier
         val simpleCall  = SimpleCall(simpleIdent, List.empty)(simpleIdent.span)
         astForReturnExpression(ReturnExpression(List(simpleCall))(node.span)) :: Nil
+      case node: MethodAccessModifier =>
+        val simpleIdent = node.toSimpleIdentifier
+
+        val methodIdentName = node.method match {
+          case x: StaticLiteral     => x.span.text
+          case x: MethodDeclaration => x.methodName
+          case x =>
+            logger.warn(s"Unknown node type for method identifier name: ${x.getClass} (${this.relativeFileName})")
+            x.span.text
+        }
+
+        val methodIdent = SimpleIdentifier(None)(simpleIdent.span.spanStart(methodIdentName))
+
+        val simpleCall = SimpleCall(simpleIdent, List(methodIdent))(
+          simpleIdent.span.spanStart(s"${simpleIdent.span.text} ${methodIdent.span.text}")
+        )
+        astForReturnExpression(ReturnExpression(List(simpleCall))(node.span)) :: Nil
       case node: FieldsDeclaration =>
         val nilReturnSpan    = node.span.spanStart("return nil")
         val nilReturnLiteral = StaticLiteral(Defines.NilClass)(nilReturnSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -489,6 +489,7 @@ object RubyIntermediateAst {
   }
 
   sealed trait MethodAccessModifier extends AllowedTypeDeclarationChild {
+    def toSimpleIdentifier: SimpleIdentifier
     def method: RubyExpression
   }
 
@@ -506,11 +507,15 @@ object RubyIntermediateAst {
 
   final case class PrivateMethodModifier(method: RubyExpression)(span: TextSpan)
       extends RubyExpression(span)
-      with MethodAccessModifier
+      with MethodAccessModifier {
+    override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span.spanStart("private_class_method"))
+  }
 
   final case class PublicMethodModifier(method: RubyExpression)(span: TextSpan)
       extends RubyExpression(span)
-      with MethodAccessModifier
+      with MethodAccessModifier {
+    override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span.spanStart("public_class_method"))
+  }
 
   /** Represents standalone `proc { ... }` or `lambda { ... }` expressions
     */


### PR DESCRIPTION
Added implicit return handling for `MethodAccessModifiers`

Resolves #5145 