### PR TITLE
[c2cpg] Added MSVC support

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -51,7 +51,7 @@ object C2Cpg {
   private val EscapedFileSeparator = Pattern.quote(java.io.File.separator)
 
   val DefaultIgnoredFolders: List[Regex] = List(
-    "\\..*".r,
+    s"(.*[$EscapedFileSeparator])?\\..*".r,
     s"(.*[$EscapedFileSeparator])?tests?[$EscapedFileSeparator].*".r,
     s"(.*[$EscapedFileSeparator])?CMakeFiles[$EscapedFileSeparator].*".r
   )

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -16,6 +16,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTNamespaceAlias
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 import java.nio.file.Paths
+import scala.collection.mutable
 
 trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -191,7 +192,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     // We only handle un-parsable macros here for now
     val isFromMacroExpansion = statement.getProblem.getNodeLocations.exists(_.isInstanceOf[IASTMacroExpansionLocation])
     val asts = if (isFromMacroExpansion) {
-      new CdtParser(config, List.empty)
+      new CdtParser(config, mutable.LinkedHashSet.empty)
         .parse(statement.getRawSignature, Paths.get(statement.getContainingFilename)) match
         case Some(node) => node.getDeclarations.toIndexedSeq.flatMap(astsForDeclaration)
         case None       => Seq.empty

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -15,6 +15,7 @@ import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContent
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{NoSuchFileException, Path}
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.Failure
 import scala.util.Success
@@ -42,7 +43,7 @@ object CdtParser {
 
 }
 
-class CdtParser(config: Config, compilationDatabase: List[CommandObject])
+class CdtParser(config: Config, compilationDatabase: mutable.LinkedHashSet[CommandObject])
     extends ParseProblemsLogger
     with PreprocessorStatementsLogger {
 
@@ -85,7 +86,7 @@ class CdtParser(config: Config, compilationDatabase: List[CommandObject])
       if (FileDefaults.isCPPFile(file.toString)) parserConfig.systemIncludePathsCPP
       else parserConfig.systemIncludePathsC
     val fileSpecificDefines  = parserConfig.definedSymbolsPerFile.getOrElse(file.toString, Map.empty)
-    val fileSpecificIncludes = parserConfig.includesPerFile.getOrElse(file.toString, List.empty)
+    val fileSpecificIncludes = parserConfig.includesPerFile.getOrElse(file.toString, mutable.LinkedHashSet.empty)
     new ScannerInfo(
       (definedSymbols ++ fileSpecificDefines).asJava,
       fileSpecificIncludes.toArray ++ (includePaths ++ additionalIncludes).map(_.toString).toArray

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
@@ -3,41 +3,29 @@ package io.joern.c2cpg.parser
 import org.eclipse.cdt.core.index.IIndexFileLocation
 import org.eclipse.cdt.core.parser.FileContent
 import org.eclipse.cdt.internal.core.parser.IMacroDictionary
-import org.eclipse.cdt.internal.core.parser.scanner.{InternalFileContent, InternalFileContentProvider}
+import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContent
+import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContentProvider
 import org.slf4j.LoggerFactory
 
 import java.util.concurrent.ConcurrentHashMap
 
 class CustomFileContentProvider(headerFileFinder: HeaderFileFinder) extends InternalFileContentProvider {
 
-  private val headerCache: ConcurrentHashMap[String, InternalFileContent] = new ConcurrentHashMap()
-  private val missingHeaderFiles: ConcurrentHashMap[String, Boolean]      = new ConcurrentHashMap()
-
   private val logger = LoggerFactory.getLogger(classOf[CustomFileContentProvider])
+  private val headerCache: ConcurrentHashMap[String, InternalFileContent] = new ConcurrentHashMap()
 
   private def loadContent(path: String): InternalFileContent = {
     val maybeFullPath = if (!getInclusionExists(path)) { headerFileFinder.find(path) }
     else { Option(path) }
-    maybeFullPath
-      .map { foundPath =>
-        headerCache.computeIfAbsent(
-          foundPath,
-          _ => {
-            logger.debug(s"Loading header file '$foundPath'")
-            FileContent.createForExternalFileLocation(foundPath).asInstanceOf[InternalFileContent]
-          }
-        )
-      }
-      .getOrElse {
-        missingHeaderFiles.computeIfAbsent(
-          path,
-          _ => {
-            logger.debug(s"Cannot find header file '$path'")
-            true
-          }
-        )
-        null
-      }
+    maybeFullPath.map { foundPath =>
+      headerCache.computeIfAbsent(
+        foundPath,
+        _ => {
+          logger.debug(s"Loading header file '$foundPath'")
+          FileContent.createForExternalFileLocation(foundPath).asInstanceOf[InternalFileContent]
+        }
+      )
+    }.orNull
   }
 
   override def getContentForInclusion(path: String, macroDictionary: IMacroDictionary): InternalFileContent =

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
@@ -1,55 +1,43 @@
 package io.joern.c2cpg.parser
 
-import io.joern.c2cpg.parser.CustomFileContentProvider.missingHeaderFiles
-import io.shiftleft.utils.IOUtils
 import org.eclipse.cdt.core.index.IIndexFileLocation
+import org.eclipse.cdt.core.parser.FileContent
 import org.eclipse.cdt.internal.core.parser.IMacroDictionary
 import org.eclipse.cdt.internal.core.parser.scanner.{InternalFileContent, InternalFileContentProvider}
 import org.slf4j.LoggerFactory
 
-import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
-
-object CustomFileContentProvider {
-  private val headerFileToLines: ConcurrentHashMap[String, Array[Char]] = new ConcurrentHashMap()
-  private val missingHeaderFiles: ConcurrentHashMap[String, Boolean]    = new ConcurrentHashMap()
-}
 
 class CustomFileContentProvider(headerFileFinder: HeaderFileFinder) extends InternalFileContentProvider {
 
-  import io.joern.c2cpg.parser.CustomFileContentProvider.headerFileToLines
+  private val headerCache: ConcurrentHashMap[String, InternalFileContent] = new ConcurrentHashMap()
+  private val missingHeaderFiles: ConcurrentHashMap[String, Boolean]      = new ConcurrentHashMap()
 
   private val logger = LoggerFactory.getLogger(classOf[CustomFileContentProvider])
 
   private def loadContent(path: String): InternalFileContent = {
-    val maybeFullPath = if (!getInclusionExists(path)) {
-      headerFileFinder.find(path)
-    } else {
-      Option(path)
-    }
+    val maybeFullPath = if (!getInclusionExists(path)) { headerFileFinder.find(path) }
+    else { Option(path) }
     maybeFullPath
       .map { foundPath =>
-        val p = Paths.get(foundPath)
-        val content = headerFileToLines.computeIfAbsent(
+        headerCache.computeIfAbsent(
           foundPath,
           _ => {
             logger.debug(s"Loading header file '$foundPath'")
-            IOUtils.readLinesInFile(p).mkString("\n").toArray
+            FileContent.createForExternalFileLocation(foundPath).asInstanceOf[InternalFileContent]
           }
         )
-        CdtParser.loadLinesAsFileContent(p, content)
       }
       .getOrElse {
         missingHeaderFiles.computeIfAbsent(
           path,
           _ => {
-            logger.debug(s"Cannot find header file for '$path'")
+            logger.debug(s"Cannot find header file '$path'")
             true
           }
         )
         null
       }
-
   }
 
   override def getContentForInclusion(path: String, macroDictionary: IMacroDictionary): InternalFileContent =

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
@@ -5,14 +5,15 @@ import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CommandObject
 import io.joern.c2cpg.utils.IncludeAutoDiscovery
 
 import java.nio.file.{Path, Paths}
+import scala.collection.mutable
 
 object ParserConfig {
 
   def empty: ParserConfig =
     ParserConfig(
-      Set.empty,
-      Set.empty,
-      Set.empty,
+      mutable.LinkedHashSet.empty,
+      mutable.LinkedHashSet.empty,
+      mutable.LinkedHashSet.empty,
       Map.empty,
       Map.empty,
       Map.empty,
@@ -20,7 +21,7 @@ object ParserConfig {
       logPreprocessor = false
     )
 
-  def fromConfig(config: Config, compilationDatabase: List[CommandObject]): ParserConfig = {
+  def fromConfig(config: Config, compilationDatabase: mutable.LinkedHashSet[CommandObject]): ParserConfig = {
     val compilationDatabaseDefines = compilationDatabase.map { c =>
       c.compiledFile() -> c.defines().toMap
     }.toMap
@@ -28,7 +29,7 @@ object ParserConfig {
       c.compiledFile() -> c.includes()
     }.toMap
     ParserConfig(
-      config.includePaths.map(Paths.get(_).toAbsolutePath),
+      mutable.LinkedHashSet.from(config.includePaths.map(Paths.get(_).toAbsolutePath)),
       IncludeAutoDiscovery.discoverIncludePathsC(config),
       IncludeAutoDiscovery.discoverIncludePathsCPP(config),
       config.defines.map { define =>
@@ -49,12 +50,12 @@ object ParserConfig {
 }
 
 case class ParserConfig(
-  userIncludePaths: Set[Path],
-  systemIncludePathsC: Set[Path],
-  systemIncludePathsCPP: Set[Path],
+  userIncludePaths: mutable.LinkedHashSet[Path],
+  systemIncludePathsC: mutable.LinkedHashSet[Path],
+  systemIncludePathsCPP: mutable.LinkedHashSet[Path],
   definedSymbols: Map[String, String],
   definedSymbolsPerFile: Map[String, Map[String, String]],
-  includesPerFile: Map[String, List[String]],
+  includesPerFile: Map[String, mutable.LinkedHashSet[String]],
   logProblems: Boolean,
   logPreprocessor: Boolean
 )

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -4,22 +4,26 @@ import io.joern.c2cpg.C2Cpg.DefaultIgnoredFolders
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.astcreation.AstCreator
 import io.joern.c2cpg.astcreation.CGlobal
-import io.joern.c2cpg.parser.{CdtParser, FileDefaults}
+import io.joern.c2cpg.parser.CdtParser
+import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.parser.JSONCompilationDatabaseParser
 import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CommandObject
-import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.utils.Report
 import io.joern.x2cpg.utils.TimeUtils
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.passes.ForkJoinParallelCpgPass
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
-import org.slf4j.{Logger, LoggerFactory}
-
-import scala.util.matching.Regex
-import scala.util.{Failure, Success, Try}
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.matching.Regex
 
 class AstCreationPass(cpg: Cpg, config: Config, report: Report = new Report())
     extends ForkJoinParallelCpgPass[String](cpg) {
@@ -29,8 +33,8 @@ class AstCreationPass(cpg: Cpg, config: Config, report: Report = new Report())
   private val global                                                  = new CGlobal()
   private val file2OffsetTable: ConcurrentHashMap[String, Array[Int]] = new ConcurrentHashMap()
 
-  private val compilationDatabase: List[CommandObject] =
-    config.compilationDatabase.map(JSONCompilationDatabaseParser.parse).getOrElse(List.empty)
+  private val compilationDatabase: mutable.LinkedHashSet[CommandObject] =
+    config.compilationDatabase.map(JSONCompilationDatabaseParser.parse).getOrElse(mutable.LinkedHashSet.empty)
 
   private val parser: CdtParser = new CdtParser(config, compilationDatabase)
 
@@ -71,7 +75,7 @@ class AstCreationPass(cpg: Cpg, config: Config, report: Report = new Report())
     }
     SourceFiles
       .filterFiles(
-        compilationDatabase.map(_.compiledFile()),
+        compilationDatabase.map(_.compiledFile()).toList,
         config.inputPath,
         ignoredDefaultRegex = Option(DefaultIgnoredFolders),
         ignoredFilesRegex = Option(config.ignoredFilesRegex),

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/PreprocessorPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/PreprocessorPass.scala
@@ -14,6 +14,7 @@ import org.eclipse.cdt.core.dom.ast.{
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths
+import scala.collection.mutable
 import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
 import scala.collection.parallel.immutable.ParIterable
 
@@ -21,8 +22,8 @@ class PreprocessorPass(config: Config) {
 
   private val logger = LoggerFactory.getLogger(classOf[PreprocessorPass])
 
-  private val compilationDatabase: List[CommandObject] =
-    config.compilationDatabase.map(JSONCompilationDatabaseParser.parse).getOrElse(List.empty)
+  private val compilationDatabase: mutable.LinkedHashSet[CommandObject] =
+    config.compilationDatabase.map(JSONCompilationDatabaseParser.parse).getOrElse(mutable.LinkedHashSet.empty)
 
   private val parser = new CdtParser(config, compilationDatabase)
 
@@ -45,7 +46,7 @@ class PreprocessorPass(config: Config) {
     }
     SourceFiles
       .filterFiles(
-        compilationDatabase.map(_.compiledFile()),
+        compilationDatabase.map(_.compiledFile()).toList,
         config.inputPath,
         ignoredDefaultRegex = Option(DefaultIgnoredFolders),
         ignoredFilesRegex = Option(config.ignoredFilesRegex),

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -88,10 +88,9 @@ object IncludeAutoDiscovery {
   private def extractMSVCIncludePaths(resolvedInstallationPath: String): Set[Path] = {
     ExternalCommand.run(VcVarsCommand, resolvedInstallationPath, Map("VSCMD_DEBUG" -> "3")) match {
       case Success(results) =>
-        val includesLine = results.find(_.startsWith("INCLUDE="))
-        val includesString =
-          includesLine.find(_.startsWith("INCLUDE=")).map(include => include.replaceFirst("INCLUDE=", ""))
-        val includes = includesString.map(line => line.split(";").toSet.map(p => Paths.get(p.trim).toRealPath()))
+        val includesLine   = results.find(_.startsWith("INCLUDE="))
+        val includesString = includesLine.map(_.replaceFirst("INCLUDE=", ""))
+        val includes       = includesString.map(_.split(";").toSet.map(p => Paths.get(p.trim).toRealPath()))
         includes.getOrElse(Set.empty)
       case Failure(exception) =>
         logger.warn(s"Unable to discover MSVC system include paths.", exception)

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/JSONCompilationDatabaseParserTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/JSONCompilationDatabaseParserTests.scala
@@ -110,16 +110,16 @@ class JSONCompilationDatabaseParserTests extends AnyWordSpec with Matchers {
         commandJsonFile.writeText(content)
 
         val commandObjects = JSONCompilationDatabaseParser.parse(commandJsonFile.pathAsString)
-        commandObjects.map(_.compiledFile()) shouldBe List(
+        commandObjects.map(_.compiledFile()) shouldBe Set(
           Paths.get("/home/user/llvm/build/file.cc").toString,
           Paths.get("/home/user/llvm/build/file2.cc").toString
         )
-        commandObjects.flatMap(_.defines()) shouldBe List(
+        commandObjects.flatMap(_.defines()) shouldBe Set(
           ("SOMEDEFA", "With spaces, quotes and \\-es."),
           ("SOMEDEFB", "\"With spaces, quotes and \\-es.\""),
           ("SOMEDEFC", "")
         )
-        commandObjects.flatMap(_.includes()) shouldBe List("/usr/include", "./include", "/home/user/project/includes")
+        commandObjects.flatMap(_.includes()) shouldBe Set("/usr/include", "./include", "/home/user/project/includes")
       }
     }
   }


### PR DESCRIPTION
This adds support for MSVC system header discovery via `--with-include-auto-discovery`.

1) Ask `vswhere.exe` for the actual MSVC installation path (https://github.com/microsoft/vswhere, included in every installation as of Visual Studio 2017).
2) Call `vcvars64.bat` to set the `INCLUDE` environment variable.
3) Use that to configure CDT.

Also in this PR (disovered during testing the MSVC stuff):
- fixed the `DefaultIgnoredFolders` regex for paths containing dot folders.
- proper thread-safe header file caching (caching the actual parse result and not only the plain code) using `createForExternalFileLocation` and `resetForTranslationUnit()`.