### PR TITLE
[ruby] Fix Call as TypeDecl AST Child

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -203,7 +203,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         pushAccessModifier(ModifierTypes.PUBLIC)
     }
 
-    val methodAst = astsForStatement(node.method)
+    val methodAst = node.method match {
+      case m: ProcedureDeclaration => astsForStatement(m)
+      case x                       => logger.warn(s"Unhandled method reference from AST type ${x.getClass}"); Nil
+    }
 
     popAccessModifier()
     pushAccessModifier(originalAccessModifier)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -1293,4 +1293,22 @@ class ClassTests extends RubyCode2CpgFixture {
       case xs => fail(s"expected 1 type, got ${xs.size}: [${xs.code.mkString(", ")}]")
     }
   }
+
+  "`private_class_method` with unhandled argument types should not render these under the type decl" in {
+    val cpg = code("""
+        |class Foo
+        |
+        |  private_class_method %i[
+        |    filter_ignore_usable
+        |    filter_key
+        |    filter_usage
+        |    parts
+        |  ]
+        |
+        |end
+        |
+        |""".stripMargin)
+
+    cpg.typeDecl("Foo").astChildren.whereNot(_.or(_.isMethod, _.isModifier, _.isTypeDecl, _.isMember)).size shouldBe 0
+  }
 }


### PR DESCRIPTION
Fixes issue where `<body>` calls from nested types were being given as direct children to type decls. The solution pushes `<body>` calls to the next method.

Another issue was that access modifier calls did not check that the argument was actually a method. Sometimes methods could be referred to via an identifier in some data structure. This PR currently emits a warning for these cases.

Resolves #5155 