### PR TITLE
[ruby] Fixed `Paramater without method` issue

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -1045,11 +1045,11 @@ class RubyJsonToNodeCreator(
       case Some(rhs) =>
         SingleAssignment(lhs, "=", rhs)(obj.toTextSpan)
       case None =>
-        if (obj(ParserKeys.Type).str == "ivasgn") {
-          lhs
-        } else {
+        if (AstType.fromString(obj(ParserKeys.Type).str) == AstType.LocalVariableAssign) {
           // `lvasgn` is used in exec_var for rescueExpr, which only has LHS
           MandatoryParameter(lhs.span.text)(lhs.span)
+        } else {
+          lhs
         }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -1045,8 +1045,12 @@ class RubyJsonToNodeCreator(
       case Some(rhs) =>
         SingleAssignment(lhs, "=", rhs)(obj.toTextSpan)
       case None =>
-        // `lvasgn` is used in exec_var for rescueExpr, which only has LHS
-        MandatoryParameter(lhs.span.text)(lhs.span)
+        if (obj(ParserKeys.Type).str == "ivasgn") {
+          lhs
+        } else {
+          // `lvasgn` is used in exec_var for rescueExpr, which only has LHS
+          MandatoryParameter(lhs.span.text)(lhs.span)
+        }
     }
   }
 


### PR DESCRIPTION
Fixed an issue where we were encountering a warning: `Parameter without method encountered`. This one was a bit of a rabbit hole to figure out

The following is a minimal example to reproduce the error we were having:
```ruby
class Foo
  def bar(baz, &)
    someFunc(&)
    @limit -= 100
    puts @limit.zero?
  end
end
```
1) We hit `@limit -= 100`, `@limit` here was seen as `SimpleIdent` and gets added as a variable to the scope with name `@limit`
2) We then hit `puts @limit.zero?`, which has a `FieldAccess(target=FieldIdentifier(@limit))`, where the `FieldIdentifier` is `RubyIdentifier` so it goes into `AstForExpressionsCreator::astForSimpleIdentifier`
3) When we get here, we call the `scope.lookupVariable(name)` but now it wrongly finds `@limit` in the variable scope because the `FieldIdentifier` here and `SimpleIdentifier` (from the single assignment) both have the same name, which then causes it to go into `AstCreatorHelper::handleVariableOccurrence`
4) In here, we now call `scope.findFieldInScope` because we have a `RubyFieldIdentifier`, but this returns `None` because the name `@limit` exists, but not as a field
5) We now call `scope.pushField` which `popScope()`, but everytime we pop a scope we lost all the variables within the scope.
6) Now that the variables are lost, when we call `RubyScope::procParamName`, the `flatMap(lookupVariable(_))` no longer returns the `<proc-param>` that we initially had because it got lost when we were pushing the new field

Resolves #5144 