### PR TITLE
[console] add csharpsrc

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CSharpSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CSharpSrcCpgGenerator.scala
@@ -1,0 +1,20 @@
+package io.joern.console.cpgcreation
+
+import io.joern.console.FrontendConfig
+import java.nio.file.Path
+import scala.util.Try
+
+case class CSharpSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+  private lazy val command: Path =
+    if (isWin) rootPath.resolve("csharpsrc2cpg.bat") else rootPath.resolve("csharpsrc2cpg")
+  private lazy val cmdLineArgs = config.cmdLineParams.toSeq
+
+  override def generate(inputPath: String, outputPath: String = "cpg.bin"): Try[String] = {
+    val arguments = cmdLineArgs ++ Seq(inputPath, "--output", outputPath)
+    runShellCommand(command.toString, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean = command.toFile.exists
+
+  override def isJvmBased: Boolean = true
+}

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -62,13 +62,32 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
     new JsFrontend("jssrc", Languages.JSSRC, "Javascript/Typescript Source Frontend based on astgen", "js")
   def swiftsrc: SourceBasedFrontend =
     new SwiftSrcFrontend("swiftsrc", Languages.SWIFTSRC, "Swift Source Frontend based on swiftastgen", "swift")
-  def csharp: Frontend          = new BinaryFrontend("csharp", Languages.CSHARP, "C# Source Frontend (Roslyn)")
+  def csharp: Frontend = new BinaryFrontend("csharp", Languages.CSHARP, "C# Source Frontend (Roslyn)")
+  def csharpsrc: SourceBasedFrontend =
+    new SourceBasedFrontend("csharpsrc", Languages.CSHARPSRC, "C# Source Frontend based on DotNetAstGen", "cs")
   def llvm: Frontend            = new BinaryFrontend("llvm", Languages.LLVM, "LLVM Bitcode Frontend")
   def php: SourceBasedFrontend  = new SourceBasedFrontend("php", Languages.PHP, "PHP source frontend", "php")
   def ruby: SourceBasedFrontend = SourceBasedFrontend("ruby", Languages.RUBYSRC, "Ruby source frontend", "rb")
 
   private def allFrontends: List[Frontend] =
-    List(c, cpp, ghidra, kotlin, java, jvm, javascript, jssrc, swiftsrc, golang, llvm, php, python, csharp, ruby)
+    List(
+      c,
+      cpp,
+      ghidra,
+      kotlin,
+      java,
+      jvm,
+      javascript,
+      jssrc,
+      swiftsrc,
+      golang,
+      llvm,
+      php,
+      python,
+      csharp,
+      ruby,
+      csharpsrc
+    )
 
   // this is only abstract to force people adding frontends to make a decision whether the frontend consumes binaries or source
   abstract class Frontend(val name: String, val language: String, val description: String = "")(implicit

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -19,12 +19,13 @@ package object cpgcreation {
   ): Option[CpgGenerator] = {
     lazy val conf = config.withArgs(args)
     language match {
-      case Languages.CSHARP | Languages.CSHARPSRC => Some(CSharpCpgGenerator(conf, rootPath))
-      case Languages.C | Languages.NEWC           => Some(CCpgGenerator(conf, rootPath))
-      case Languages.LLVM                         => Some(LlvmCpgGenerator(conf, rootPath))
-      case Languages.GOLANG                       => Some(GoCpgGenerator(conf, rootPath))
-      case Languages.JAVA                         => Some(JavaCpgGenerator(conf, rootPath))
-      case Languages.JAVASRC                      => Some(JavaSrcCpgGenerator(conf, rootPath))
+      case Languages.CSHARP             => Some(CSharpCpgGenerator(conf, rootPath))
+      case Languages.CSHARPSRC          => Some(CSharpSrcCpgGenerator(conf, rootPath))
+      case Languages.C | Languages.NEWC => Some(CCpgGenerator(conf, rootPath))
+      case Languages.LLVM               => Some(LlvmCpgGenerator(conf, rootPath))
+      case Languages.GOLANG             => Some(GoCpgGenerator(conf, rootPath))
+      case Languages.JAVA               => Some(JavaCpgGenerator(conf, rootPath))
+      case Languages.JAVASRC            => Some(JavaSrcCpgGenerator(conf, rootPath))
       case Languages.JSSRC | Languages.JAVASCRIPT =>
         val jssrc = JsSrcCpgGenerator(conf, rootPath)
         if (jssrc.isAvailable) Some(jssrc)


### PR DESCRIPTION
Allow the use of `importCode.csharpsrc.fromString(...)`, which proxies to `csharpsrc2cpg`.

Follows the pattern found in `JavaCpgGenerator` and `JavaSrcCpgGenerator`. I reckon there is room for improvement (i.e. refactoring) here when dealing with `commercialAvailable` and `ossAvailable`, but one step at a time.