### PR TITLE
Fix javasrc annotation resolution

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -140,8 +140,12 @@ class AstCreator(
   }
 
   private[astcreation] def defaultTypeFallback(typ: Type): String = {
+    defaultTypeFallback(code(typ))
+  }
+
+  private[astcreation] def defaultTypeFallback(typ: String): String = {
     if (disableTypeFallback) {
-      s"${Defines.UnresolvedNamespace}.${Util.stripGenericTypes(code(typ))}"
+      s"${Defines.UnresolvedNamespace}.${Util.stripGenericTypes(typ)}"
     } else
       TypeConstants.Any
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -458,8 +458,12 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
   }
 
   private[declarations] def astForAnnotationExpr(annotationExpr: AnnotationExpr): Ast = {
-    val fallbackType = s"${Defines.UnresolvedNamespace}.${annotationExpr.getNameAsString}"
-    val fullName     = expressionReturnTypeFullName(annotationExpr).getOrElse(fallbackType)
+    lazy val typ = tryWithSafeStackOverflow(annotationExpr.resolve()).toOption
+
+    val fullName = scope
+      .lookupType(annotationExpr.getNameAsString, false)
+      .orElse(tryWithSafeStackOverflow(annotationExpr.resolve()).toOption.flatMap(typeInfoCalc.fullName))
+      .getOrElse(defaultTypeFallback(annotationExpr.getNameAsString))
     typeInfoCalc.registerType(fullName)
     val code = annotationExpr.toString
     val name = annotationExpr.getName.getIdentifier

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/AnnotationTests.scala
@@ -5,6 +5,29 @@ import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
 class AnnotationTests extends JavaSrcCode2CpgFixture {
+  "annotations that cannot be resolved from imports" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |@interface TestMarker {}
+        |""".stripMargin)
+      .moreCode("""
+          |package bar;
+          |
+          |import foo.*;
+          |import bar.*;
+          |
+          |public class Bar {
+          |  @TestMarker
+          |  public void bar() {}
+          |}
+          |""".stripMargin)
+
+    "have the annotation type be resolved" in {
+      cpg.method.name("bar").annotation.fullName.l shouldBe List("foo.TestMarker")
+    }
+  }
+
   "normal value annotations" should {
     lazy val cpg = code("""
         |import some.NormalAnnotation;


### PR DESCRIPTION
`Expression.calculateResolvedType` is not supported for annotation expressions, so resolving these always failed, but this was hidden by the import fallbacks. With these changes, the annotation is resolved first (which is supported), after which we can find the type full name using the usual mechanism.