### PR TITLE
[c#] add `disable-builtin-summaries`

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
@@ -44,11 +44,15 @@ class CSharpSrc2Cpg extends X2CpgFrontend[Config] {
           }
           .foldLeft(CSharpProgramSummary(imports = CSharpProgramSummary.initialImports))(_ ++= _)
 
-        val builtinSummary = CSharpProgramSummary(
-          mutable.Map
-            .fromSpecific(CSharpProgramSummary.BuiltinTypes.view.filterKeys(internalProgramSummary.imports(_)))
-            .result()
-        )
+        val builtinSummary = if (config.useBuiltinSummaries) {
+          CSharpProgramSummary(
+            mutable.Map
+              .fromSpecific(CSharpProgramSummary.BuiltinTypes.view.filterKeys(internalProgramSummary.imports(_)))
+              .result()
+          )
+        } else {
+          CSharpProgramSummary()
+        }
 
         val internalAndBuiltinSummary = internalProgramSummary ++= builtinSummary
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -11,7 +11,7 @@ import scopt.OParser
 
 import java.nio.file.Paths
 
-final case class Config(downloadDependencies: Boolean = false)
+final case class Config(downloadDependencies: Boolean = false, useBuiltinSummaries: Boolean = true)
     extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config]
@@ -22,6 +22,10 @@ final case class Config(downloadDependencies: Boolean = false)
 
   override def withDownloadDependencies(value: Boolean): Config = {
     copy(downloadDependencies = value).withInheritedFields(this)
+  }
+
+  def withUseBuiltinSummaries(value: Boolean): Config = {
+    copy(useBuiltinSummaries = value).withInheritedFields(this)
   }
 
 }
@@ -35,7 +39,10 @@ object Frontend {
     OParser.sequence(
       programName("csharpsrc2cpg"),
       DependencyDownloadConfig.parserOptions,
-      XTypeRecoveryConfig.parserOptionsForParserConfig
+      XTypeRecoveryConfig.parserOptionsForParserConfig,
+      opt[Unit]("disable-builtin-summaries")
+        .text("do not use the built-in type summaries")
+        .action((_, c) => c.withUseBuiltinSummaries(false))
     )
   }
 


### PR DESCRIPTION
Adds support for ignoring `builtin_types` in C#. This is a preliminary step toward enabling users to supply their own custom `builtin_types`, and thus avoid name clashes.