### PR TITLE
[c#] add `external-summary-paths` option

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
@@ -36,25 +36,12 @@ class CSharpSrc2Cpg extends X2CpgFrontend[Config] {
         val astGenResult = new DotNetAstGenRunner(config).execute(tmpDir)
         val astCreators  = CSharpSrc2Cpg.processAstGenRunnerResults(astGenResult.parsedFiles, config)
         // Pre-parse the AST creators for high level structures
-        val internalProgramSummary = ConcurrentTaskUtil
-          .runUsingThreadPool(astCreators.map(x => () => x.summarize()).iterator)
-          .flatMap {
-            case Failure(exception) => logger.warn(s"Unable to pre-parse C# file, skipping - ", exception); None
-            case Success(summary)   => Option(summary)
-          }
-          .foldLeft(CSharpProgramSummary(imports = CSharpProgramSummary.initialImports))(_ ++= _)
-
-        val builtinSummary = if (config.useBuiltinSummaries) {
-          CSharpProgramSummary(
-            mutable.Map
-              .fromSpecific(CSharpProgramSummary.BuiltinTypes.view.filterKeys(internalProgramSummary.imports(_)))
-              .result()
-          )
-        } else {
-          CSharpProgramSummary()
-        }
-
+        val internalProgramSummary = summarizeAstCreators(astCreators)
+        // Load built-in and/or external summaries for missing imports
+        val builtinSummary            = createBuiltinSummary(config, internalProgramSummary)
         val internalAndBuiltinSummary = internalProgramSummary ++= builtinSummary
+        val externalSummary           = createExternalSummary(config, internalAndBuiltinSummary)
+        val localSummary              = internalAndBuiltinSummary ++= externalSummary
 
         val hash = HashUtil.sha256(astCreators.map(_.parserResult).map(x => Paths.get(x.fullPath)))
         new MetaDataPass(cpg, Languages.CSHARPSRC, config.inputPath, Option(hash)).createAndApply()
@@ -63,14 +50,55 @@ class CSharpSrc2Cpg extends X2CpgFrontend[Config] {
         new DependencyPass(cpg, buildFiles(config), packageIds.add).createAndApply()
         // If "download dependencies" is enabled, then fetch dependencies and resolve their symbols for additional types
         val programSummary = if (config.downloadDependencies) {
-          DependencyDownloader(cpg, config, internalAndBuiltinSummary, packageIds.toSet).download()
+          DependencyDownloader(cpg, config, localSummary, packageIds.toSet).download()
         } else {
-          internalAndBuiltinSummary
+          localSummary
         }
         new AstCreationPass(cpg, astCreators.map(_.withSummary(programSummary)), report).createAndApply()
         TypeNodePass.withTypesFromCpg(cpg).createAndApply()
         report.print()
       }
+    }
+  }
+
+  private def summarizeAstCreators(astCreators: Seq[AstCreator]): CSharpProgramSummary = {
+    ConcurrentTaskUtil
+      .runUsingThreadPool(astCreators.map(x => () => x.summarize()).iterator)
+      .flatMap {
+        case Failure(exception) =>
+          logger.warn(s"Unable to pre-parse C# file, skipping - ", exception)
+          None
+        case Success(summary) => Option(summary)
+      }
+      .foldLeft(CSharpProgramSummary(imports = CSharpProgramSummary.initialImports))(_ ++= _)
+  }
+
+  private def createBuiltinSummary(config: Config, internalSummary: CSharpProgramSummary): CSharpProgramSummary = {
+    if (config.useBuiltinSummaries) {
+      CSharpProgramSummary(
+        mutable.Map
+          .fromSpecific(CSharpProgramSummary.BuiltinTypes.view.filterKeys(internalSummary.imports))
+          .result()
+      )
+    } else {
+      CSharpProgramSummary()
+    }
+  }
+
+  private def createExternalSummary(config: Config, internalSummary: CSharpProgramSummary): CSharpProgramSummary = {
+    if (config.externalSummaryPaths.nonEmpty) {
+      CSharpProgramSummary(
+        mutable.Map
+          .fromSpecific(
+            CSharpProgramSummary
+              .fromExternalJsons(config.externalSummaryPaths)
+              .view
+              .filterKeys(internalSummary.imports)
+          )
+          .result()
+      )
+    } else {
+      CSharpProgramSummary()
     }
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -11,8 +11,11 @@ import scopt.OParser
 
 import java.nio.file.Paths
 
-final case class Config(downloadDependencies: Boolean = false, useBuiltinSummaries: Boolean = true)
-    extends X2CpgConfig[Config]
+final case class Config(
+  downloadDependencies: Boolean = false,
+  useBuiltinSummaries: Boolean = true,
+  externalSummaryPaths: Set[String] = Set.empty
+) extends X2CpgConfig[Config]
     with DependencyDownloadConfig[Config]
     with TypeRecoveryParserConfig[Config]
     with AstGenConfig[Config] {
@@ -26,6 +29,10 @@ final case class Config(downloadDependencies: Boolean = false, useBuiltinSummari
 
   def withUseBuiltinSummaries(value: Boolean): Config = {
     copy(useBuiltinSummaries = value).withInheritedFields(this)
+  }
+
+  def withExternalSummaryPaths(paths: Set[String]): Config = {
+    copy(externalSummaryPaths = paths).withInheritedFields(this)
   }
 
 }
@@ -42,7 +49,10 @@ object Frontend {
       XTypeRecoveryConfig.parserOptionsForParserConfig,
       opt[Unit]("disable-builtin-summaries")
         .text("do not use the built-in type summaries")
-        .action((_, c) => c.withUseBuiltinSummaries(false))
+        .action((_, c) => c.withUseBuiltinSummaries(false)),
+      opt[Seq[String]]("external-summary-paths")
+        .text("where to look for external type summaries produced by DotNetAstGen (comma-separated list of paths)")
+        .action((paths, c) => c.withExternalSummaryPaths(c.externalSummaryPaths ++ paths))
     )
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -1,6 +1,8 @@
 package io.joern.csharpsrc2cpg.datastructures
 
+import better.files.File.VisitOptions
 import io.joern.csharpsrc2cpg.Constants
+import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, OverloadableMethod, ProgramSummary, TypeLike}
 import org.slf4j.LoggerFactory
 import upickle.core.LinkedHashMap
@@ -65,6 +67,30 @@ object CSharpProgramSummary {
     }
   }
 
+  def fromExternalJsons(paths: Set[String]): NamespaceToTypeMap = {
+    val jsonFiles = SourceFiles.determine(paths, Set(".json"))(VisitOptions.default)
+    val inputStreams = jsonFiles.flatMap { path =>
+      Try(java.io.FileInputStream(path)) match {
+        case Success(stream) => Some(stream)
+        case Failure(exc) =>
+          logger.warn(s"Unable to open file: $path", exc)
+          None
+      }
+    }
+
+    if (inputStreams.isEmpty) {
+      logger.warn("No JSON files found in the provided paths.")
+      mutable.Map.empty
+    } else {
+      jsonToInitialMapping(loadAndMergeJsonStreams(inputStreams)) match {
+        case Success(mapping) => mapping
+        case Failure(exception) =>
+          logger.warn("Failed to parsed merged JSON streams", exception)
+          mutable.Map.empty
+      }
+    }
+  }
+
   /** Converts a JSON type mapping to a NamespaceToTypeMap entry.
     * @param jsonInputStream
     *   a JSON file as an input stream.
@@ -73,6 +99,30 @@ object CSharpProgramSummary {
     */
   def jsonToInitialMapping(jsonInputStream: InputStream): Try[NamespaceToTypeMap] =
     Try(read[NamespaceToTypeMap](ujson.Readable.fromByteArray(jsonInputStream.readAllBytes())))
+
+  private def loadAndMergeJsonStreams(jsonInputStreams: List[InputStream]): InputStream = {
+    val jsonObjects = for {
+      inputStream <- jsonInputStreams
+      jsonString = Source.fromInputStream(inputStream).mkString
+      jsonObject = ujson.read(jsonString).obj
+    } yield jsonObject
+
+    val mergedJson = jsonObjects
+      .reduceOption((prev, curr) => {
+        curr.keys.foreach(key => {
+          prev.updateWith(key) {
+            case Some(x) =>
+              Option(x.arr.addAll(curr.get(key).get.arr))
+            case None =>
+              Option(curr.get(key).get.arr)
+          }
+        })
+        prev
+      })
+      .getOrElse(LinkedHashMap[String, ujson.Value]())
+
+    new ByteArrayInputStream(writeToByteArray(ujson.read(mergedJson)))
+  }
 
   private def mergeBuiltInTypesJson: InputStream = {
     val classLoader      = getClass.getClassLoader
@@ -117,30 +167,7 @@ object CSharpProgramSummary {
       logger.warn("No JSON files found.")
       InputStream.nullInputStream()
     } else {
-      val mergedJsonObjects = ListBuffer[LinkedHashMap[String, ujson.Value]]()
-      for (resourcePath <- resourcePaths) {
-        val inputStream = classLoader.getResourceAsStream(resourcePath)
-        val jsonString  = Source.fromInputStream(inputStream).mkString
-        val jsonObject  = ujson.read(jsonString).obj
-        mergedJsonObjects.addOne(jsonObject)
-      }
-
-      val mergedJson: LinkedHashMap[String, ujson.Value] =
-        mergedJsonObjects
-          .reduceOption((prev, curr) => {
-            curr.keys.foreach(key => {
-              prev.updateWith(key) {
-                case Some(x) =>
-                  Option(x.arr.addAll(curr.get(key).get.arr))
-                case None =>
-                  Option(curr.get(key).get.arr)
-              }
-            })
-            prev
-          })
-          .getOrElse(LinkedHashMap[String, ujson.Value]())
-
-      new ByteArrayInputStream(writeToByteArray(ujson.read(mergedJson)))
+      loadAndMergeJsonStreams(resourcePaths.map(classLoader.getResourceAsStream))
     }
   }
 


### PR DESCRIPTION
Introduces an `external-summary-paths` option, allowing users to provide custom directories for type summaries à la `builtin_types`. Some minor refactoring otherwise.