### PR TITLE
Add proper support for java record classes

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -150,6 +150,10 @@ class AstCreator(
     TypeConstants.Any
   }
 
+  private[astcreation] def isResolvedTypeFullName(typeFullName: String): Boolean = {
+    typeFullName != TypeConstants.Any && !typeFullName.startsWith(Defines.UnresolvedNamespace)
+  }
+
   /** Custom printer that omits comments. To be used by [[code]] */
   private val codePrinterOptions = new DefaultPrinterConfiguration()
     .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS))
@@ -368,8 +372,10 @@ class AstCreator(
     case _                       => None
   }
 
-  def argumentTypesForMethodLike(maybeResolvedMethodLike: Try[ResolvedMethodLikeDeclaration]): Option[List[String]] = {
-    maybeResolvedMethodLike.toOption
+  def argumentTypesForMethodLike(
+    maybeResolvedMethodLike: Option[ResolvedMethodLikeDeclaration]
+  ): Option[List[String]] = {
+    maybeResolvedMethodLike
       .flatMap(calcParameterTypes(_, ResolvedTypeParametersMap.empty()))
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -2,13 +2,17 @@ package io.joern.javasrc2cpg.astcreation.declarations
 
 import com.github.javaparser.ast.body.{
   AnnotationDeclaration,
+  AnnotationMemberDeclaration,
   BodyDeclaration,
   ClassOrInterfaceDeclaration,
+  CompactConstructorDeclaration,
   ConstructorDeclaration,
   EnumConstantDeclaration,
+  EnumDeclaration,
   FieldDeclaration,
   InitializerDeclaration,
   MethodDeclaration,
+  RecordDeclaration,
   TypeDeclaration,
   VariableDeclarator
 }
@@ -57,9 +61,6 @@ import scala.jdk.CollectionConverters.*
 import scala.util.{Success, Try}
 import com.github.javaparser.ast.expr.ObjectCreationExpr
 import com.github.javaparser.ast.stmt.LocalClassDeclarationStmt
-import com.github.javaparser.ast.body.AnnotationMemberDeclaration
-import com.github.javaparser.ast.body.CompactConstructorDeclaration
-import com.github.javaparser.ast.body.EnumDeclaration
 import io.joern.javasrc2cpg.scope.Scope.ScopeVariable
 import com.github.javaparser.ast.Node
 import com.github.javaparser.resolution.types.ResolvedReferenceType
@@ -117,7 +118,7 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
       methodDeclaration.getNameAsString
     }.toSet
 
-    scope.pushTypeDeclScope(typeDeclRoot, scope.isEnclosingScopeStatic, declaredMethodNames)
+    scope.pushTypeDeclScope(typeDeclRoot, scope.isEnclosingScopeStatic, declaredMethodNames, Nil)
     val memberAsts = astsForTypeDeclMembers(expr, body, isInterface = false, typeFullName)
 
     val localDecls    = scope.localDeclsInScope
@@ -173,7 +174,16 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
       createTypeDeclNode(typeDeclaration, astParentType, astParentFullName, isInterface, fullNameOverride)
 
     val declaredMethodNames = typeDeclaration.getMethods.asScala.map(_.getNameAsString).toSet
-    scope.pushTypeDeclScope(typeDeclRoot, typeDeclaration.isStatic, declaredMethodNames)
+
+    val (recordParameters, recordParameterAsts) = typeDeclaration match {
+      case recordDeclaration: RecordDeclaration =>
+        val parameters = recordDeclaration.getParameters.asScala.toList
+        val asts       = astsForRecordParameters(recordDeclaration, typeDeclRoot.fullName)
+        (parameters, asts)
+      case _ => (Nil, Nil)
+    }
+
+    scope.pushTypeDeclScope(typeDeclRoot, typeDeclaration.isStatic, declaredMethodNames, recordParameters)
     addTypeDeclTypeParamsToScope(typeDeclaration)
 
     val annotationAsts = typeDeclaration.getAnnotations.asScala.map(astForAnnotationExpr)
@@ -182,6 +192,7 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
       case enumDeclaration: EnumDeclaration => enumDeclaration.getEntries.asScala.toList
       case _                                => Nil
     }
+
     val memberAsts =
       astsForTypeDeclMembers(
         typeDeclaration,
@@ -194,6 +205,7 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     val lambdaMethods = scope.lambdaMethodsInScope
 
     val typeDeclAst = Ast(typeDeclRoot)
+      .withChildren(recordParameterAsts)
       .withChildren(memberAsts)
       .withChildren(annotationAsts)
       .withChildren(localDecls)
@@ -226,6 +238,32 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     }
 
     typeDeclAst
+  }
+
+  private def astsForRecordParameters(recordDeclaration: RecordDeclaration, recordTypeFullName: String): List[Ast] = {
+    val explicitMethodNames = recordDeclaration.getMethods.asScala.map(_.getNameAsString).toSet
+
+    recordDeclaration.getParameters.asScala.toList.flatMap { parameter =>
+      val parameterName = parameter.getNameAsString
+      val parameterTypeFullName = tryWithSafeStackOverflow {
+        val typ = parameter.getType
+        scope
+          .lookupScopeType(typ.asString())
+          .map(_.typeFullName)
+          .orElse(typeInfoCalc.fullName(typ))
+          .getOrElse(defaultTypeFallback(typ))
+      }.toOption.getOrElse(defaultTypeFallback())
+
+      val parameterMember = memberNode(parameter, parameterName, code(parameter), parameterTypeFullName)
+      val privateModifier = newModifierNode(ModifierTypes.PRIVATE)
+      val memberAst       = Ast(parameterMember).withChild(Ast(privateModifier))
+
+      val accessorMethodAst = Option.unless(explicitMethodNames.contains(parameterName))(
+        astForRecordParameterAccessor(parameter, recordTypeFullName, parameterName, parameterTypeFullName)
+      )
+
+      memberAst :: accessorMethodAst.toList
+    }
   }
 
   private def bindingTypeForReferenceType(typ: ResolvedReferenceType): Option[JavaparserBindingDeclType] = {
@@ -343,19 +381,35 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     }
 
     val constructorAstMap = astsForConstructors(
-      members.collect { case constructor: ConstructorDeclaration =>
-        constructor
+      members.collect {
+        case constructor: ConstructorDeclaration        => constructor
+        case constructor: CompactConstructorDeclaration => constructor
       },
       instanceFields
     )
 
     val membersAsts = membersAstPairs.flatMap {
-      case (constructor: ConstructorDeclaration, _) =>
-        constructorAstMap.get(constructor)
-      case (_, asts) => asts
+      case (constructor: ConstructorDeclaration, _)        => constructorAstMap.get(constructor)
+      case (constructor: CompactConstructorDeclaration, _) => constructorAstMap.get(constructor)
+      case (_, asts)                                       => asts
     }
 
-    val defaultConstructorAst = Option.when(!(isInterface || members.exists(_.isInstanceOf[ConstructorDeclaration]))) {
+    val hasCanonicalConstructor = scope.enclosingTypeDecl.get.recordParameters match {
+      case Nil => members.exists(member => member.isConstructorDeclaration || member.isCompactConstructorDeclaration)
+
+      case recordParameters =>
+        members.collect {
+          case compactConstructorDeclaration: CompactConstructorDeclaration => compactConstructorDeclaration
+
+          case constructorDeclaration: ConstructorDeclaration
+              if constructorDeclaration.getParameters.asScala
+                .map(_.getType)
+                .toList
+                .equals(recordParameters.map(_.getType)) =>
+            constructorDeclaration
+        }.nonEmpty
+    }
+    val defaultConstructorAst = Option.when(!(isInterface || hasCanonicalConstructor)) {
       astForDefaultConstructor(originNode, instanceFields)
     }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -59,7 +59,7 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     val expressionTypeFullName =
       expressionReturnTypeFullName(call).orElse(getTypeFullName(expectedReturnType)).map(typeInfoCalc.registerType)
 
-    val argumentTypes = argumentTypesForMethodLike(maybeResolvedCall)
+    val argumentTypes = argumentTypesForMethodLike(maybeResolvedCall.toOption)
     val returnType = maybeResolvedCall
       .map { resolvedCall =>
         typeInfoCalc.fullName(resolvedCall.getReturnType, ResolvedTypeParametersMap.empty())
@@ -232,7 +232,7 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
       scope.addLocalDecl(anonymousClassDecl)
     }
 
-    val argumentTypes = argumentTypesForMethodLike(maybeResolvedExpr)
+    val argumentTypes = argumentTypesForMethodLike(maybeResolvedExpr.toOption)
 
     val allocNode = newOperatorCallNode(
       Operators.alloc,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -71,7 +71,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
       .find { identifier => identifier.name == NameConstants.This || identifier.name == NameConstants.Super }
       .map { _ =>
         val typeFullName = scope.enclosingTypeDecl.fullName
-        Ast(thisNodeForMethod(typeFullName, line(expr)))
+        Ast(thisNodeForMethod(typeFullName, line(expr), column(expr)))
       }
       .toList
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -459,7 +459,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
 
       case Success(resolvedMethod) =>
         val returnType = tryWithSafeStackOverflow(resolvedMethod.getReturnType).toOption.flatMap(typeInfoCalc.fullName)
-        val parameterTypes = argumentTypesForMethodLike(Success(resolvedMethod))
+        val parameterTypes = argumentTypesForMethodLike(Option(resolvedMethod))
         composeSignature(returnType, parameterTypes, resolvedMethod.getNumberOfParams)
     }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
@@ -100,7 +100,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
     // TODO Handle super
     val maybeResolved = tryWithSafeStackOverflow(stmt.resolve())
     val args          = argAstsForCall(stmt, maybeResolved, stmt.getArguments)
-    val argTypes      = argumentTypesForMethodLike(maybeResolved)
+    val argTypes      = argumentTypesForMethodLike(maybeResolved.toOption)
 
     // TODO: We can do better than defaultTypeFallback() for the fallback type by looking at the enclosing
     //  type decl name or `extends X` name for `this` and `super` calls respectively.

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
@@ -1,5 +1,6 @@
 package io.joern.javasrc2cpg.scope
 
+import com.github.javaparser.ast.body.Parameter
 import com.github.javaparser.ast.expr.TypePatternExpr
 import io.joern.javasrc2cpg.scope.Scope.*
 import io.joern.javasrc2cpg.scope.JavaScopeElement.*
@@ -175,7 +176,8 @@ object JavaScopeElement {
     override val isStatic: Boolean,
     private[scope] val capturedVariables: Map[String, CapturedVariable],
     outerClassType: Option[String],
-    val declaredMethodNames: Set[String]
+    val declaredMethodNames: Set[String],
+    val recordParameters: List[Parameter]
   )(implicit disableTypeFallback: Boolean)
       extends JavaScopeElement(disableTypeFallback)
       with TypeDeclContainer

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -1,5 +1,6 @@
 package io.joern.javasrc2cpg.scope
 
+import com.github.javaparser.ast.body.Parameter
 import com.github.javaparser.ast.expr.TypePatternExpr
 import io.joern.javasrc2cpg.astcreation.ExpectedType
 import io.joern.javasrc2cpg.scope.Scope.*
@@ -40,7 +41,12 @@ class Scope(implicit val withSchemaValidation: ValidationMode, val disableTypeFa
     scopeStack = new FieldDeclScope(isStatic, name) :: scopeStack
   }
 
-  def pushTypeDeclScope(typeDecl: NewTypeDecl, isStatic: Boolean, methodNames: Set[String] = Set.empty): Unit = {
+  def pushTypeDeclScope(
+    typeDecl: NewTypeDecl,
+    isStatic: Boolean,
+    methodNames: Set[String] = Set.empty,
+    recordParameters: List[Parameter] = Nil
+  ): Unit = {
     val captures = getCapturesForNewScope(isStatic)
     val outerClassType = scopeStack.takeUntil(_.isInstanceOf[TypeDeclScope]) match {
       case Nil => None
@@ -58,7 +64,8 @@ class Scope(implicit val withSchemaValidation: ValidationMode, val disableTypeFa
           }
           .flatten
     }
-    scopeStack = new TypeDeclScope(typeDecl, isStatic, captures, outerClassType, methodNames) :: scopeStack
+    scopeStack =
+      new TypeDeclScope(typeDecl, isStatic, captures, outerClassType, methodNames, recordParameters) :: scopeStack
   }
 
   def pushNamespaceScope(namespace: NewNamespaceBlock): Unit = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
@@ -19,7 +19,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
       param.order shouldBe 0
       param.index shouldBe 0
       param.lineNumber shouldBe Some(3)
-      param.columnNumber shouldBe None
+      param.columnNumber shouldBe Some(3)
       param.typeFullName shouldBe "Foo"
       param.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/RecordTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/RecordTests.scala
@@ -1,0 +1,605 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier, Literal, Method, Return}
+import io.shiftleft.semanticcpg.language.*
+
+class RecordTests extends JavaSrcCode2CpgFixture {
+
+  "a record with a compact constructor" should {
+    val cpg = code("""
+                       |package foo;
+                       |
+                       |record Foo(String value) {
+                       |  public Foo {
+                       |    System.out.println(value);
+                       |  }
+                       |}
+                       |""".stripMargin)
+
+    "have the correct representation for the compact constructor" in {
+      inside(cpg.method.nameExact("<init>").l) { case List(constructor) =>
+        constructor.fullName shouldBe "foo.Foo.<init>:void(java.lang.String)"
+
+        inside(constructor.parameter.l) { case List(thisParam, valueParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+
+          valueParam.name shouldBe "value"
+          valueParam.typeFullName shouldBe "java.lang.String"
+
+          inside(constructor.body.astChildren.l) { case List(valueAssign: Call, printlnCall: Call) =>
+            valueAssign.name shouldBe Operators.assignment
+            valueAssign.methodFullName shouldBe Operators.assignment
+            valueAssign.typeFullName shouldBe "java.lang.String"
+            valueAssign.code shouldBe "this.value = value"
+
+            inside(valueAssign.argument.l) { case List(fieldAccess: Call, valueIdentifier: Identifier) =>
+              fieldAccess.name shouldBe Operators.fieldAccess
+              fieldAccess.code shouldBe "this.value"
+              fieldAccess.typeFullName shouldBe "java.lang.String"
+
+              inside(fieldAccess.argument.l) {
+                case List(thisIdentifier: Identifier, valueFieldIdentifier: FieldIdentifier) =>
+                  thisIdentifier.name shouldBe "this"
+                  thisIdentifier.typeFullName shouldBe "foo.Foo"
+                  thisIdentifier.refsTo.l shouldBe List(thisParam)
+
+                  valueFieldIdentifier.canonicalName shouldBe "value"
+              }
+
+              valueIdentifier.name shouldBe "value"
+              valueIdentifier.typeFullName shouldBe "java.lang.String"
+              valueIdentifier.refsTo.l shouldBe List(valueParam)
+            }
+
+            printlnCall.name shouldBe "println"
+            printlnCall.code shouldBe "System.out.println(value)"
+            inside(printlnCall.argument.l) { case List(_, valueIdentifier: Identifier) =>
+              valueIdentifier.name shouldBe "value"
+              valueIdentifier.refsTo.l shouldBe List(valueParam)
+            }
+          }
+        }
+      }
+    }
+
+    "have a private field for the parameter" in {
+      inside(cpg.member.l) { case List(valueMember) =>
+        valueMember.name shouldBe "value"
+        valueMember.code shouldBe "String value"
+        valueMember.typeFullName shouldBe "java.lang.String"
+        valueMember.modifier.modifierType.l shouldBe List(ModifierTypes.PRIVATE)
+      }
+    }
+
+    "have a public accessor method for the parameter" in {
+      inside(cpg.method.name("value").l) { case List(valueMethod: Method) =>
+        valueMethod.name shouldBe "value"
+        valueMethod.fullName shouldBe "foo.Foo.value:java.lang.String()"
+        valueMethod.code shouldBe "public String value()"
+        valueMethod.lineNumber shouldBe Some(4)
+        valueMethod.columnNumber shouldBe Some(12)
+
+        val methodReturn = valueMethod.methodReturn
+        methodReturn.typeFullName shouldBe "java.lang.String"
+        methodReturn.lineNumber shouldBe Some(4)
+        methodReturn.columnNumber shouldBe Some(12)
+
+        inside(valueMethod.parameter.l) { case List(thisParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+          thisParam.lineNumber shouldBe Some(4)
+          thisParam.columnNumber shouldBe Some(12)
+        }
+
+        inside(valueMethod.body.astChildren.l) { case List(returnStmt: Return) =>
+          returnStmt.code shouldBe "return this.value"
+          returnStmt.lineNumber shouldBe Some(4)
+          returnStmt.columnNumber shouldBe Some(12)
+
+          inside(returnStmt.astChildren.l) { case List(fieldAccess: Call) =>
+            fieldAccess.name shouldBe Operators.fieldAccess
+            fieldAccess.methodFullName shouldBe Operators.fieldAccess
+            fieldAccess.code shouldBe "this.value"
+            fieldAccess.typeFullName shouldBe "java.lang.String"
+            fieldAccess.lineNumber shouldBe Some(4)
+            fieldAccess.columnNumber shouldBe Some(12)
+
+            inside(fieldAccess.argument.l) { case List(thisIdentifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              thisIdentifier.name shouldBe "this"
+              thisIdentifier.code shouldBe "this"
+              thisIdentifier.typeFullName shouldBe "foo.Foo"
+              thisIdentifier.refsTo.l shouldBe cpg.method.name("value").parameter.l
+              thisIdentifier.lineNumber shouldBe Some(4)
+              thisIdentifier.columnNumber shouldBe Some(12)
+
+              fieldIdentifier.canonicalName shouldBe "value"
+              fieldIdentifier.code shouldBe "value"
+              fieldIdentifier.lineNumber shouldBe Some(4)
+              fieldIdentifier.columnNumber shouldBe Some(12)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  "a record with an explicit non-canonical constructor" should {
+    val cpg = code("""
+                       |package foo;
+                       |
+                       |record Foo(String value) {
+                       |    public Foo() {
+                       |        this.value = "value";
+                       |    }
+                       |}
+                       |""".stripMargin)
+
+    "have the correct constructors" in {
+      inside(cpg.method.nameExact("<init>").sortBy(_.parameter.size).l) {
+        case List(explicitConstructor, canonicalConstructor) =>
+          explicitConstructor.fullName shouldBe "foo.Foo.<init>:void()"
+
+          inside(explicitConstructor.parameter.l) { case List(thisParam) =>
+            thisParam.name shouldBe "this"
+            thisParam.typeFullName shouldBe "foo.Foo"
+
+            inside(explicitConstructor.body.astChildren.l) { case List(valueAssign: Call) =>
+              valueAssign.name shouldBe Operators.assignment
+              valueAssign.methodFullName shouldBe Operators.assignment
+              valueAssign.typeFullName shouldBe "java.lang.String"
+              valueAssign.code shouldBe "this.value = \"value\""
+
+              inside(valueAssign.argument.l) { case List(fieldAccess: Call, valueLiteral: Literal) =>
+                fieldAccess.name shouldBe Operators.fieldAccess
+                fieldAccess.code shouldBe "this.value"
+                fieldAccess.typeFullName shouldBe "java.lang.String"
+
+                inside(fieldAccess.argument.l) {
+                  case List(thisIdentifier: Identifier, valueFieldIdentifier: FieldIdentifier) =>
+                    thisIdentifier.name shouldBe "this"
+                    thisIdentifier.typeFullName shouldBe "foo.Foo"
+                    thisIdentifier.refsTo.l shouldBe List(thisParam)
+
+                    valueFieldIdentifier.canonicalName shouldBe "value"
+                }
+
+                valueLiteral.typeFullName shouldBe "java.lang.String"
+                valueLiteral.code shouldBe "\"value\""
+              }
+            }
+          }
+
+          canonicalConstructor.fullName shouldBe "foo.Foo.<init>:void(java.lang.String)"
+
+          inside(canonicalConstructor.parameter.l) { case List(thisParam, valueParam) =>
+            thisParam.name shouldBe "this"
+            thisParam.typeFullName shouldBe "foo.Foo"
+
+            valueParam.name shouldBe "value"
+            valueParam.typeFullName shouldBe "java.lang.String"
+
+            inside(canonicalConstructor.body.astChildren.l) { case List(valueAssign: Call) =>
+              valueAssign.name shouldBe Operators.assignment
+              valueAssign.methodFullName shouldBe Operators.assignment
+              valueAssign.typeFullName shouldBe "java.lang.String"
+              valueAssign.code shouldBe "this.value = value"
+
+              inside(valueAssign.argument.l) { case List(fieldAccess: Call, valueIdentifier: Identifier) =>
+                fieldAccess.name shouldBe Operators.fieldAccess
+                fieldAccess.code shouldBe "this.value"
+                fieldAccess.typeFullName shouldBe "java.lang.String"
+
+                inside(fieldAccess.argument.l) {
+                  case List(thisIdentifier: Identifier, valueFieldIdentifier: FieldIdentifier) =>
+                    thisIdentifier.name shouldBe "this"
+                    thisIdentifier.typeFullName shouldBe "foo.Foo"
+                    thisIdentifier.refsTo.l shouldBe List(thisParam)
+
+                    valueFieldIdentifier.canonicalName shouldBe "value"
+                }
+
+                valueIdentifier.name shouldBe "value"
+                valueIdentifier.typeFullName shouldBe "java.lang.String"
+                valueIdentifier.refsTo.l shouldBe List(valueParam)
+              }
+            }
+          }
+      }
+    }
+
+    "have a private field for the parameter" in {
+      inside(cpg.member.l) { case List(valueMember) =>
+        valueMember.name shouldBe "value"
+        valueMember.code shouldBe "String value"
+        valueMember.typeFullName shouldBe "java.lang.String"
+        valueMember.modifier.modifierType.l shouldBe List(ModifierTypes.PRIVATE)
+      }
+    }
+
+    "have a public accessor method for the parameter" in {
+      inside(cpg.method.name("value").l) { case List(valueMethod: Method) =>
+        valueMethod.name shouldBe "value"
+        valueMethod.fullName shouldBe "foo.Foo.value:java.lang.String()"
+        valueMethod.code shouldBe "public String value()"
+        valueMethod.lineNumber shouldBe Some(4)
+        valueMethod.columnNumber shouldBe Some(12)
+
+        val methodReturn = valueMethod.methodReturn
+        methodReturn.typeFullName shouldBe "java.lang.String"
+        methodReturn.lineNumber shouldBe Some(4)
+        methodReturn.columnNumber shouldBe Some(12)
+
+        inside(valueMethod.parameter.l) { case List(thisParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+          thisParam.lineNumber shouldBe Some(4)
+          thisParam.columnNumber shouldBe Some(12)
+        }
+
+        inside(valueMethod.body.astChildren.l) { case List(returnStmt: Return) =>
+          returnStmt.code shouldBe "return this.value"
+          returnStmt.lineNumber shouldBe Some(4)
+          returnStmt.columnNumber shouldBe Some(12)
+
+          inside(returnStmt.astChildren.l) { case List(fieldAccess: Call) =>
+            fieldAccess.name shouldBe Operators.fieldAccess
+            fieldAccess.methodFullName shouldBe Operators.fieldAccess
+            fieldAccess.code shouldBe "this.value"
+            fieldAccess.typeFullName shouldBe "java.lang.String"
+            fieldAccess.lineNumber shouldBe Some(4)
+            fieldAccess.columnNumber shouldBe Some(12)
+
+            inside(fieldAccess.argument.l) { case List(thisIdentifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              thisIdentifier.name shouldBe "this"
+              thisIdentifier.code shouldBe "this"
+              thisIdentifier.typeFullName shouldBe "foo.Foo"
+              thisIdentifier.refsTo.l shouldBe cpg.method.name("value").parameter.l
+              thisIdentifier.lineNumber shouldBe Some(4)
+              thisIdentifier.columnNumber shouldBe Some(12)
+
+              fieldIdentifier.canonicalName shouldBe "value"
+              fieldIdentifier.code shouldBe "value"
+              fieldIdentifier.lineNumber shouldBe Some(4)
+              fieldIdentifier.columnNumber shouldBe Some(12)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  "a record with an explicit canonical constructor" should {
+    val cpg = code("""
+                       |package foo;
+                       |
+                       |record Foo(String value) {
+                       |    public Foo(String value) {
+                       |        System.out.println(value);
+                       |        this.value = value;
+                       |    }
+                       |}
+                       |""".stripMargin)
+
+    "have the correct constructor" in {
+      inside(cpg.method.nameExact("<init>").l) { case List(constructor) =>
+        constructor.fullName shouldBe "foo.Foo.<init>:void(java.lang.String)"
+
+        inside(constructor.parameter.l) { case List(thisParam, valueParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+
+          valueParam.name shouldBe "value"
+          valueParam.typeFullName shouldBe "java.lang.String"
+
+          inside(constructor.body.astChildren.l) { case List(printlnCall: Call, valueAssign: Call) =>
+            printlnCall.name shouldBe "println"
+            printlnCall.code shouldBe "System.out.println(value)"
+
+            valueAssign.name shouldBe Operators.assignment
+            valueAssign.methodFullName shouldBe Operators.assignment
+            valueAssign.typeFullName shouldBe "java.lang.String"
+            valueAssign.code shouldBe "this.value = value"
+
+            inside(valueAssign.argument.l) { case List(fieldAccess: Call, valueIdentifier: Identifier) =>
+              fieldAccess.name shouldBe Operators.fieldAccess
+              fieldAccess.code shouldBe "this.value"
+              fieldAccess.typeFullName shouldBe "java.lang.String"
+
+              inside(fieldAccess.argument.l) {
+                case List(thisIdentifier: Identifier, valueFieldIdentifier: FieldIdentifier) =>
+                  thisIdentifier.name shouldBe "this"
+                  thisIdentifier.typeFullName shouldBe "foo.Foo"
+                  thisIdentifier.refsTo.l shouldBe List(thisParam)
+
+                  valueFieldIdentifier.canonicalName shouldBe "value"
+              }
+
+              valueIdentifier.name shouldBe "value"
+              valueIdentifier.typeFullName shouldBe "java.lang.String"
+              valueIdentifier.refsTo.l shouldBe List(valueParam)
+            }
+          }
+        }
+      }
+    }
+
+    "have a private field for the parameter" in {
+      inside(cpg.member.l) { case List(valueMember) =>
+        valueMember.name shouldBe "value"
+        valueMember.code shouldBe "String value"
+        valueMember.typeFullName shouldBe "java.lang.String"
+        valueMember.modifier.modifierType.l shouldBe List(ModifierTypes.PRIVATE)
+      }
+    }
+
+    "have a public accessor method for the parameter" in {
+      inside(cpg.method.name("value").l) { case List(valueMethod: Method) =>
+        valueMethod.name shouldBe "value"
+        valueMethod.fullName shouldBe "foo.Foo.value:java.lang.String()"
+        valueMethod.code shouldBe "public String value()"
+        valueMethod.lineNumber shouldBe Some(4)
+        valueMethod.columnNumber shouldBe Some(12)
+
+        val methodReturn = valueMethod.methodReturn
+        methodReturn.typeFullName shouldBe "java.lang.String"
+        methodReturn.lineNumber shouldBe Some(4)
+        methodReturn.columnNumber shouldBe Some(12)
+
+        inside(valueMethod.parameter.l) { case List(thisParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+          thisParam.lineNumber shouldBe Some(4)
+          thisParam.columnNumber shouldBe Some(12)
+        }
+
+        inside(valueMethod.body.astChildren.l) { case List(returnStmt: Return) =>
+          returnStmt.code shouldBe "return this.value"
+          returnStmt.lineNumber shouldBe Some(4)
+          returnStmt.columnNumber shouldBe Some(12)
+
+          inside(returnStmt.astChildren.l) { case List(fieldAccess: Call) =>
+            fieldAccess.name shouldBe Operators.fieldAccess
+            fieldAccess.methodFullName shouldBe Operators.fieldAccess
+            fieldAccess.code shouldBe "this.value"
+            fieldAccess.typeFullName shouldBe "java.lang.String"
+            fieldAccess.lineNumber shouldBe Some(4)
+            fieldAccess.columnNumber shouldBe Some(12)
+
+            inside(fieldAccess.argument.l) { case List(thisIdentifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              thisIdentifier.name shouldBe "this"
+              thisIdentifier.code shouldBe "this"
+              thisIdentifier.typeFullName shouldBe "foo.Foo"
+              thisIdentifier.refsTo.l shouldBe cpg.method.name("value").parameter.l
+              thisIdentifier.lineNumber shouldBe Some(4)
+              thisIdentifier.columnNumber shouldBe Some(12)
+
+              fieldIdentifier.canonicalName shouldBe "value"
+              fieldIdentifier.code shouldBe "value"
+              fieldIdentifier.lineNumber shouldBe Some(4)
+              fieldIdentifier.columnNumber shouldBe Some(12)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  "a record with a generic parameter" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |record Foo<T>(T value) {}
+        |""".stripMargin)
+
+    "have the correct default canonical constructor" in {
+      inside(cpg.method.nameExact("<init>").l) { case List(constructor) =>
+        constructor.fullName shouldBe "foo.Foo.<init>:void(java.lang.Object)"
+
+        inside(constructor.parameter.l) { case List(thisParam, valueParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+
+          valueParam.name shouldBe "value"
+          valueParam.typeFullName shouldBe "java.lang.Object"
+
+          inside(constructor.body.astChildren.l) { case List(valueAssign: Call) =>
+            valueAssign.name shouldBe Operators.assignment
+            valueAssign.methodFullName shouldBe Operators.assignment
+            valueAssign.typeFullName shouldBe "java.lang.Object"
+            valueAssign.code shouldBe "this.value = value"
+
+            inside(valueAssign.argument.l) { case List(fieldAccess: Call, valueIdentifier: Identifier) =>
+              fieldAccess.name shouldBe Operators.fieldAccess
+              fieldAccess.code shouldBe "this.value"
+              fieldAccess.typeFullName shouldBe "java.lang.Object"
+
+              inside(fieldAccess.argument.l) {
+                case List(thisIdentifier: Identifier, valueFieldIdentifier: FieldIdentifier) =>
+                  thisIdentifier.name shouldBe "this"
+                  thisIdentifier.typeFullName shouldBe "foo.Foo"
+                  thisIdentifier.refsTo.l shouldBe List(thisParam)
+
+                  valueFieldIdentifier.canonicalName shouldBe "value"
+              }
+
+              valueIdentifier.name shouldBe "value"
+              valueIdentifier.typeFullName shouldBe "java.lang.Object"
+              valueIdentifier.refsTo.l shouldBe List(valueParam)
+            }
+          }
+        }
+      }
+    }
+
+    "have a private field for the parameter" in {
+      inside(cpg.member.l) { case List(valueMember) =>
+        valueMember.name shouldBe "value"
+        valueMember.code shouldBe "T value"
+        valueMember.typeFullName shouldBe "java.lang.Object"
+        valueMember.modifier.modifierType.l shouldBe List(ModifierTypes.PRIVATE)
+      }
+    }
+
+    "have a public accessor method for the parameter" in {
+      inside(cpg.method.name("value").l) { case List(valueMethod: Method) =>
+        valueMethod.name shouldBe "value"
+        valueMethod.fullName shouldBe "foo.Foo.value:java.lang.Object()"
+        valueMethod.code shouldBe "public T value()"
+        valueMethod.lineNumber shouldBe Some(4)
+        valueMethod.columnNumber shouldBe Some(15)
+
+        val methodReturn = valueMethod.methodReturn
+        methodReturn.typeFullName shouldBe "java.lang.Object"
+        methodReturn.lineNumber shouldBe Some(4)
+        methodReturn.columnNumber shouldBe Some(15)
+
+        inside(valueMethod.parameter.l) { case List(thisParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+          thisParam.lineNumber shouldBe Some(4)
+          thisParam.columnNumber shouldBe Some(15)
+        }
+
+        inside(valueMethod.body.astChildren.l) { case List(returnStmt: Return) =>
+          returnStmt.code shouldBe "return this.value"
+          returnStmt.lineNumber shouldBe Some(4)
+          returnStmt.columnNumber shouldBe Some(15)
+
+          inside(returnStmt.astChildren.l) { case List(fieldAccess: Call) =>
+            fieldAccess.name shouldBe Operators.fieldAccess
+            fieldAccess.methodFullName shouldBe Operators.fieldAccess
+            fieldAccess.code shouldBe "this.value"
+            fieldAccess.typeFullName shouldBe "java.lang.Object"
+            fieldAccess.lineNumber shouldBe Some(4)
+            fieldAccess.columnNumber shouldBe Some(15)
+
+            inside(fieldAccess.argument.l) { case List(thisIdentifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              thisIdentifier.name shouldBe "this"
+              thisIdentifier.code shouldBe "this"
+              thisIdentifier.typeFullName shouldBe "foo.Foo"
+              thisIdentifier.refsTo.l shouldBe cpg.method.name("value").parameter.l
+              thisIdentifier.lineNumber shouldBe Some(4)
+              thisIdentifier.columnNumber shouldBe Some(15)
+
+              fieldIdentifier.canonicalName shouldBe "value"
+              fieldIdentifier.code shouldBe "value"
+              fieldIdentifier.lineNumber shouldBe Some(4)
+              fieldIdentifier.columnNumber shouldBe Some(15)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  "a simple record with no explicit body" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |record Foo(String value) {}
+        |""".stripMargin)
+
+    "have the correct default canonical constructor" in {
+      inside(cpg.method.nameExact("<init>").l) { case List(constructor) =>
+        constructor.fullName shouldBe "foo.Foo.<init>:void(java.lang.String)"
+
+        inside(constructor.parameter.l) { case List(thisParam, valueParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+
+          valueParam.name shouldBe "value"
+          valueParam.typeFullName shouldBe "java.lang.String"
+
+          inside(constructor.body.astChildren.l) { case List(valueAssign: Call) =>
+            valueAssign.name shouldBe Operators.assignment
+            valueAssign.methodFullName shouldBe Operators.assignment
+            valueAssign.typeFullName shouldBe "java.lang.String"
+            valueAssign.code shouldBe "this.value = value"
+
+            inside(valueAssign.argument.l) { case List(fieldAccess: Call, valueIdentifier: Identifier) =>
+              fieldAccess.name shouldBe Operators.fieldAccess
+              fieldAccess.code shouldBe "this.value"
+              fieldAccess.typeFullName shouldBe "java.lang.String"
+
+              inside(fieldAccess.argument.l) {
+                case List(thisIdentifier: Identifier, valueFieldIdentifier: FieldIdentifier) =>
+                  thisIdentifier.name shouldBe "this"
+                  thisIdentifier.typeFullName shouldBe "foo.Foo"
+                  thisIdentifier.refsTo.l shouldBe List(thisParam)
+
+                  valueFieldIdentifier.canonicalName shouldBe "value"
+              }
+
+              valueIdentifier.name shouldBe "value"
+              valueIdentifier.typeFullName shouldBe "java.lang.String"
+              valueIdentifier.refsTo.l shouldBe List(valueParam)
+            }
+          }
+        }
+      }
+    }
+
+    "have a private field for the parameter" in {
+      inside(cpg.member.l) { case List(valueMember) =>
+        valueMember.name shouldBe "value"
+        valueMember.code shouldBe "String value"
+        valueMember.typeFullName shouldBe "java.lang.String"
+        valueMember.modifier.modifierType.l shouldBe List(ModifierTypes.PRIVATE)
+      }
+    }
+
+    "have a public accessor method for the parameter" in {
+      inside(cpg.method.name("value").l) { case List(valueMethod: Method) =>
+        valueMethod.name shouldBe "value"
+        valueMethod.fullName shouldBe "foo.Foo.value:java.lang.String()"
+        valueMethod.code shouldBe "public String value()"
+        valueMethod.lineNumber shouldBe Some(4)
+        valueMethod.columnNumber shouldBe Some(12)
+
+        val methodReturn = valueMethod.methodReturn
+        methodReturn.typeFullName shouldBe "java.lang.String"
+        methodReturn.lineNumber shouldBe Some(4)
+        methodReturn.columnNumber shouldBe Some(12)
+
+        inside(valueMethod.parameter.l) { case List(thisParam) =>
+          thisParam.name shouldBe "this"
+          thisParam.typeFullName shouldBe "foo.Foo"
+          thisParam.lineNumber shouldBe Some(4)
+          thisParam.columnNumber shouldBe Some(12)
+        }
+
+        inside(valueMethod.body.astChildren.l) { case List(returnStmt: Return) =>
+          returnStmt.code shouldBe "return this.value"
+          returnStmt.lineNumber shouldBe Some(4)
+          returnStmt.columnNumber shouldBe Some(12)
+
+          inside(returnStmt.astChildren.l) { case List(fieldAccess: Call) =>
+            fieldAccess.name shouldBe Operators.fieldAccess
+            fieldAccess.methodFullName shouldBe Operators.fieldAccess
+            fieldAccess.code shouldBe "this.value"
+            fieldAccess.typeFullName shouldBe "java.lang.String"
+            fieldAccess.lineNumber shouldBe Some(4)
+            fieldAccess.columnNumber shouldBe Some(12)
+
+            inside(fieldAccess.argument.l) { case List(thisIdentifier: Identifier, fieldIdentifier: FieldIdentifier) =>
+              thisIdentifier.name shouldBe "this"
+              thisIdentifier.code shouldBe "this"
+              thisIdentifier.typeFullName shouldBe "foo.Foo"
+              thisIdentifier.refsTo.l shouldBe cpg.method.name("value").parameter.l
+              thisIdentifier.lineNumber shouldBe Some(4)
+              thisIdentifier.columnNumber shouldBe Some(12)
+
+              fieldIdentifier.canonicalName shouldBe "value"
+              fieldIdentifier.code shouldBe "value"
+              fieldIdentifier.lineNumber shouldBe Some(4)
+              fieldIdentifier.columnNumber shouldBe Some(12)
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds proper support for java records by introducing the following:

### Create fields for record parameters

```
record Foo(Bar bar, Baz baz) {}
```
will have the fields
```
private Bar bar;
private Baz baz;
```

### Create implicit getters for record parameters
```
record Foo(Bar bar, Baz baz) {}
```
will have the getter methods
```
public Bar bar() { return this.bar; }
public Baz baz() { return this.baz; }
```
### Correct default constructors for records

The correct canonical constructor which initializes the record fields is created instead of the default empty constructor. For example:
```
record Foo(Bar bar, Baz baz) {} 
```
will have the constructor 
```
public Foo(Bar bar, Baz baz) {
  this.bar = bar;
  this.baz = baz;
}
```

### Support for CompactConstructorDeclarations

```
record Foo(Bar bar, Baz baz) {
  public Foo {
    sink(bar)
  }
}
```
will have the constructor
```
public Foo(Bar bar, Baz baz) {
  this.bar = bar;
  this.baz = baz;
  sink(bar);
}
```