### PR TITLE
[ruby] Fixed issue where implicit require generates floating node

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
@@ -126,12 +126,12 @@ class ImplicitRequirePass(cpg: Cpg, externalTypes: Seq[TypeImportInfo] = Nil)
           }
           .collectFirst {
             // ignore an import to a file that defines the type
-            case TypeImportInfoWithProvidence(TypeImportInfo(_, importPath), _) if importPath != currPath =>
-              importPath -> createRequireCall(builder, importPath)
+            case TypeImportInfoWithProvidence(TypeImportInfo(_, importPath), _) if importPath != currPath => importPath
           }
       }
-      .distinctBy { case (importPath, _) => importPath }
-      .foreach { case (_, requireCall) =>
+      .distinct
+      .foreach { importPath =>
+        val requireCall = createRequireCall(builder, importPath)
         requireCall.order(currOrder)
         builder.addEdge(moduleMethod.block, requireCall, EdgeTypes.AST)
         currOrder += 1


### PR DESCRIPTION
The implicit `require` call node creation is now deferred until the AST parent is presented.