### PR TITLE
[c2cpg] Safer CCorePlugin.log with null

### DIFF
--- a/joern-cli/frontends/c2cpg/eclipse-cdt/CCorePlugin.java
+++ b/joern-cli/frontends/c2cpg/eclipse-cdt/CCorePlugin.java
@@ -92,9 +92,11 @@ public class CCorePlugin extends Plugin {
     }
 
     public static void log(IStatus status) {
-        Throwable t = status.getException();
-        String msg = t.getMessage();
-        logger.debug(msg, t);
+        Throwable throwable;
+        if ((throwable = status.getException()) != null) {
+            String msg = throwable.getMessage();
+            logger.debug(msg, throwable);
+        }
     }
 
 }


### PR DESCRIPTION
We can release this later. Just saw null there during testing on the chromium source code again.