### PR TITLE
[ruby] BackRef and Multi-Assign Args

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -58,6 +58,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     case node: RubyCallWithBlock[_]             => astForCallWithBlock(node)
     case node: SelfIdentifier                   => astForSelfIdentifier(node)
     case node: StatementList                    => astForStatementList(node)
+    case node: MultipleAssignment               => blockAst(blockNode(node), astsForStatement(node).toList)
     case node: ReturnExpression                 => astForReturnExpression(node)
     case node: AccessModifier                   => astForSimpleIdentifier(node.toSimpleIdentifier)
     case node: ArrayPattern                     => astForArrayPattern(node)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -205,7 +205,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val methodAst = node.method match {
       case m: ProcedureDeclaration => astsForStatement(m)
-      case x                       => logger.warn(s"Unhandled method reference from AST type ${x.getClass}"); Nil
+      case x                       =>
+        // Not sure how we should represent dynamically setting access modifiers based on method refs
+        logger.debug(s"Unhandled method reference from AST type ${x.getClass}")
+        Nil
     }
 
     popAccessModifier()

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonHelpers.scala
@@ -1,21 +1,14 @@
 package io.joern.rubysrc2cpg.parser
 
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
-  AliasStatement,
   AllowedTypeDeclarationChild,
   ArrayLiteral,
-  ArrayParameter,
   ClassFieldIdentifier,
-  ControlFlowStatement,
   DefaultMultipleAssignment,
   FieldsDeclaration,
-  ForExpression,
-  IfExpression,
   MemberAccess,
   MethodDeclaration,
-  ProcParameter,
   ProcedureDeclaration,
-  RubyCall,
   RubyExpression,
   RubyFieldIdentifier,
   SelfIdentifier,
@@ -31,10 +24,8 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   TypeDeclBodyCall,
   UnaryExpression
 }
-import io.joern.rubysrc2cpg.parser.RubyJsonHelpers.nilLiteral
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
-import io.shiftleft.codepropertygraph.generated.nodes.Unknown
 import org.slf4j.LoggerFactory
 import upickle.core.*
 import upickle.default.*

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -232,7 +232,7 @@ class RubyJsonToNodeCreator(
 
   private def visitArrayPatternWithTail(obj: Obj): RubyExpression = defaultResult(Option(obj.toTextSpan))
 
-  private def visitBackRef(obj: Obj): RubyExpression = defaultResult(Option(obj.toTextSpan))
+  private def visitBackRef(obj: Obj): RubyExpression = SimpleIdentifier()(obj.toTextSpan)
 
   private def visitBegin(obj: Obj): RubyExpression = {
     StatementList(obj.visitArray(ParserKeys.Body))(obj.toTextSpan)
@@ -495,7 +495,10 @@ class RubyJsonToNodeCreator(
     ForExpression(forVariable, iterableVariable, doBlock)(obj.toTextSpan)
   }
 
-  private def visitForwardArg(obj: Obj): RubyExpression = defaultResult(Option(obj.toTextSpan))
+  private def visitForwardArg(obj: Obj): RubyExpression = {
+    logger.warn("Forward arg unhandled")
+    defaultResult(Option(obj.toTextSpan))
+  }
 
   // Note: Forward args should probably be handled more explicitly, but this should preserve flows if the same
   // identifier is used in latter forwarding
@@ -1102,7 +1105,9 @@ class RubyJsonToNodeCreator(
 
   private def visitTrue(obj: Obj): RubyExpression = StaticLiteral(getBuiltInType(Defines.TrueClass))(obj.toTextSpan)
 
-  private def visitUnDefine(obj: Obj): RubyExpression = defaultResult(Option(obj.toTextSpan))
+  private def visitUnDefine(obj: Obj): RubyExpression = {
+    defaultResult(Option(obj.toTextSpan))
+  }
 
   private def visitUnlessExpression(obj: Obj): RubyExpression = {
     defaultResult(Option(obj.toTextSpan))


### PR DESCRIPTION
* Multiple assignments may be given as arguments to calls and such, thus they are now handled under `astForExpression` as a block containing the multiple assignments
* BackRef's from regexs are handled as `self.$&`
* Lowered the warning level for non-method nodes as access modifier arguments