### PR TITLE
C# - update usage of SourceFiles.determine

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -68,7 +68,7 @@ object CSharpProgramSummary {
   }
 
   def fromExternalJsons(paths: Set[String]): NamespaceToTypeMap = {
-    val jsonFiles = SourceFiles.determine(paths, Set(".json"))(VisitOptions.default)
+    val jsonFiles = paths.flatMap(SourceFiles.determine(_, Set(".json"))(VisitOptions.default)).toList
     val inputStreams = jsonFiles.flatMap { path =>
       Try(java.io.FileInputStream(path)) match {
         case Success(stream) => Some(stream)


### PR DESCRIPTION
#5169 was open before #5180. The latter got merged first and thus the former would break the build.

This is just the most straightforward patch to get out of this situation immediately.