### PR TITLE
[x2cpg] Replace better.File.extension

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -171,7 +171,7 @@ object SourceFiles {
   ): List[String] = files.filter(filterFile(_, inputPath, ignoredDefaultRegex, ignoredFilesRegex, ignoredFilesPath))
 
   private def hasSourceFileExtension(file: File, sourceFileExtensions: Set[String]): Boolean =
-    file.extension.exists(sourceFileExtensions.contains)
+    sourceFileExtensions.exists(ext => file.pathAsString.endsWith(ext))
 
   /** Determines a sorted list of file paths in a directory that match the specified criteria.
     *


### PR DESCRIPTION
`File.extension` does some additional checks before returning the actual extension (`isRegularFile` and `exists`). We do not need these checks as the files we operate on are returned by a file visitor traversing said files.

This shaves off plenty of time when traversing large directories.