### PR TITLE
Add support for record pattern matching

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
@@ -58,7 +58,7 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
 
       case SimpleVariable(ScopePatternVariable(localNode, typePatternExpr)) =>
         scope.enclosingMethod.flatMap(_.getPatternVariableInfo(typePatternExpr)) match {
-          case Some(PatternVariableInfo(typePatternExpr, _, initializerAst, _, false)) =>
+          case Some(PatternVariableInfo(typePatternExpr, _, initializerAst, _, false, _)) =>
             scope.enclosingMethod.foreach(_.registerPatternVariableInitializerToBeAddedToGraph(typePatternExpr))
             initializerAst
           case _ =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
@@ -1,34 +1,50 @@
 package io.joern.javasrc2cpg.astcreation.expressions
 
 import com.github.javaparser.ast.Node
-import com.github.javaparser.ast.expr.{
-  Expression,
-  InstanceOfExpr,
-  NameExpr,
-  PatternExpr,
-  RecordPatternExpr,
-  TypePatternExpr
-}
-import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
+import com.github.javaparser.ast.expr.{PatternExpr, RecordPatternExpr, TypePatternExpr}
+import io.joern.javasrc2cpg.astcreation.AstCreator
 import io.joern.javasrc2cpg.jartypereader.model.Model.TypeConstants
 import io.joern.javasrc2cpg.scope.Scope.NewVariableNode
-import io.joern.x2cpg.Ast
+import io.joern.javasrc2cpg.util.Util
+import io.joern.x2cpg.{Ast, Defines}
 import io.joern.x2cpg.utils.AstPropertiesUtil.*
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, NewIdentifier}
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, NewCall, NewIdentifier}
 import io.joern.x2cpg.utils.NodeBuilders.*
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 
 import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.RichOptional
 
 trait AstForPatternExpressionsCreator { this: AstCreator =>
 
-  private[astcreation] def astIdentifierAndRefsForPatternLhs(
+  /** In the lowering for instanceof expressions with patterns like `X instanceof Foo f`, the first argument to
+    * `instanceof` (in this case `X`) appears in the CPG at least 2 times:
+    *   - once for the `X instanceof Foo` check
+    *   - once for the `Foo f = (Foo) X` assignment.
+    *
+    * If X is an identifier or field access, then this is fine. If X is a call which could have side-effects, however,
+    * then this representation could lead to incorrect behaviour.
+    *
+    * This method solves this problem by taking the CPG lowering for X as input and returning a tuple (initializerAst,
+    * referenceAst) where initializerAst should be used as the LHS arg for the first instanceof call, while referenceAst
+    * should be used for any future references to X (for example in the variable assignment or nested instanceof calls
+    * for records).
+    *
+    * If X is an identifier or field access, then initializerAst is simply the input and referenceAst is a copy of it.
+    *
+    * If X is not an identifier or field access, then a temporary variable `$objN` is created. initializerAst is then an
+    * assignment AST `$objN = X` and referenceAst is the identifier ast `$objN`.
+    */
+  private[astcreation] def initializerAndReferenceAstsForPatternInitializer(
     rootNode: Node,
     patternInitAst: Ast
-  ): (Ast, NewIdentifier, Option[NewVariableNode]) = {
-    patternInitAst.nodes.toList match {
-      case (identifier: NewIdentifier) :: Nil =>
-        (patternInitAst, identifier, scope.lookupVariable(identifier.name).variableNode)
+  ): (Ast, Ast) = {
+    patternInitAst.root match {
+      case Some(identifier: NewIdentifier) =>
+        (patternInitAst, patternInitAst.subTreeCopy(identifier))
+
+      case Some(fieldAccess: NewCall) if fieldAccess.name == Operators.fieldAccess =>
+        (patternInitAst, patternInitAst.subTreeCopy(patternInitAst.root.get.asInstanceOf[AstNodeNew]))
 
       case _ =>
         val tmpName       = tempNameProvider.next
@@ -49,23 +65,139 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
         // (so a lookup for the local will never be done)
         scope.enclosingMethod.foreach(_.addTemporaryLocal(tmpLocal))
 
-        (
-          callAst(tmpAssignmentNode, Ast(tmpIdentifier) :: patternInitAst :: Nil).withRefEdge(tmpIdentifier, tmpLocal),
-          tmpIdentifier,
-          Option(tmpLocal)
-        )
+        val initAst =
+          callAst(tmpAssignmentNode, Ast(tmpIdentifier) :: patternInitAst :: Nil).withRefEdge(tmpIdentifier, tmpLocal)
+
+        val tmpIdentifierCopy = tmpIdentifier.copy
+        val referenceAst      = Ast(tmpIdentifierCopy).withRefEdge(tmpIdentifierCopy, tmpLocal)
+
+        (initAst, referenceAst)
     }
   }
 
-  private[astcreation] def astForInstanceOfWithPattern(
-    instanceOfLhsExpr: Expression,
-    patternLhsInitAst: Ast,
-    pattern: PatternExpr
-  ): Ast = {
-    val (lhsAst, lhsIdentifier, lhsRefsTo) = astIdentifierAndRefsForPatternLhs(instanceOfLhsExpr, patternLhsInitAst)
+  private def castAstIfNecessary(patternExpr: PatternExpr, patternType: String, initializerAst: Ast): Ast = {
+    val initializerType = initializerAst.rootType
+    if (isResolvedTypeFullName(patternType) && initializerType.contains(patternType)) {
+      initializerAst
+    } else {
+      val castType = typeRefNode(patternExpr, code(patternExpr.getType), patternType)
+      val castNode =
+        newOperatorCallNode(
+          Operators.cast,
+          s"(${castType.code}) ${initializerAst.rootCodeOrEmpty}",
+          Option(patternType)
+        )
+      callAst(castNode, Ast(castType) :: initializerAst :: Nil)
+    }
+  }
 
+  private def createAndPushAssignmentForTypePattern(
+    typePatternExpr: TypePatternExpr,
+    parentInitializerAst: Ast
+  ): Unit = {
+    val variableName = typePatternExpr.getNameAsString
+    val variableType = {
+      tryWithSafeStackOverflow(typePatternExpr.getType).toOption
+        .map(typ =>
+          scope
+            .lookupScopeType(typ.asString())
+            .map(_.typeFullName)
+            .orElse(typeInfoCalc.fullName(typ))
+            .getOrElse(defaultTypeFallback(typ))
+        )
+        .getOrElse(defaultTypeFallback())
+    }
+    val variableTypeCode  = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
+    val patternLocal      = localNode(typePatternExpr, variableName, code(typePatternExpr), variableType)
+    val patternIdentifier = identifierNode(typePatternExpr, variableName, variableName, variableType)
+
+    val initializerAst = castAstIfNecessary(typePatternExpr, variableType, parentInitializerAst)
+
+    val initializerAssignmentCall = newOperatorCallNode(
+      Operators.assignment,
+      s"$variableName = ${initializerAst.rootCodeOrEmpty}",
+      Option(variableType),
+      line(typePatternExpr),
+      column(typePatternExpr)
+    )
+    val initializerAssignmentAst = callAst(initializerAssignmentCall, Ast(patternIdentifier) :: initializerAst :: Nil)
+      .withRefEdge(patternIdentifier, patternLocal)
+
+    scope.enclosingMethod.foreach { methodScope =>
+      methodScope.putPatternVariableInfo(typePatternExpr, patternLocal, initializerAssignmentAst)
+    }
+  }
+
+  private def accessorAstsForPatternList(
+    recordPatternExpr: RecordPatternExpr,
+    recordTypeFullName: String,
+    accessorReceiverAst: Ast
+  ): List[(PatternExpr, Ast)] = {
+    val resolvedRecordType = tryWithSafeStackOverflow(recordPatternExpr.getType().resolve().asReferenceType()).toOption
+
+    val patternList = recordPatternExpr.getPatternList.asScala.toList
+    val fieldNames = resolvedRecordType
+      .flatMap(_.getTypeDeclaration.toScala)
+      .map(_.getDeclaredFields.asScala.map(_.getName).toList)
+      .getOrElse(patternList.map(_ => Defines.UnknownField))
+
+    patternList.zip(fieldNames).zipWithIndex.map { case ((patternExpr, fieldName), idx) =>
+      val patternTypeFullName = tryWithSafeStackOverflow(patternExpr.getType).toOption
+        .map { typ =>
+          scope
+            .lookupScopeType(typ.asString())
+            .map(_.typeFullName)
+            .orElse(typeInfoCalc.fullName(typ))
+            .getOrElse(defaultTypeFallback(typ))
+        }
+        .getOrElse(defaultTypeFallback())
+
+      val fieldTypeFullName = resolvedRecordType
+        .flatMap(_.getTypeDeclaration.toScala)
+        .flatMap(typeDecl => tryWithSafeStackOverflow(typeDecl.getField(fieldName).getType).toOption)
+        .flatMap(typeInfoCalc.fullName)
+
+      val signature = composeSignature(fieldTypeFullName, Option(Nil), 0)
+      val typeDeclFullName =
+        if (isResolvedTypeFullName(recordTypeFullName))
+          recordTypeFullName
+        else
+          s"${Defines.UnresolvedNamespace}.${code(recordPatternExpr.getType)}"
+      val methodFullName = Util.composeMethodFullName(typeDeclFullName, fieldName, signature)
+      val methodCodePrefix = accessorReceiverAst.root match {
+        case Some(call: NewCall) if call.name.startsWith("<operator") => s"(${call.code})"
+        case Some(root: AstNodeNew)                                   => root.code
+        case _                                                        => ""
+
+      }
+      val methodCode = s"$methodCodePrefix.$fieldName()"
+
+      val fieldAccessorCall = callNode(
+        patternExpr,
+        methodCode,
+        fieldName,
+        methodFullName,
+        DispatchTypes.DYNAMIC_DISPATCH,
+        Option(signature),
+        fieldTypeFullName.orElse(Option(defaultTypeFallback()))
+      )
+
+      val lhsAst =
+        if (idx == 0)
+          accessorReceiverAst
+        else
+          accessorReceiverAst.subTreeCopy(accessorReceiverAst.root.get.asInstanceOf[AstNodeNew])
+
+      val fieldAccessorAst = callAst(fieldAccessorCall, lhsAst :: Nil)
+
+      (patternExpr, fieldAccessorAst)
+    }
+
+  }
+
+  private[astcreation] def typeCheckAstForPattern(patternExpr: PatternExpr, lhsAst: Ast): Ast = {
     val patternTypeFullName = {
-      tryWithSafeStackOverflow(pattern.getType).toOption
+      tryWithSafeStackOverflow(patternExpr.getType).toOption
         .map(typ =>
           scope
             .lookupScopeType(typ.asString())
@@ -75,74 +207,78 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
         )
     }.getOrElse(defaultTypeFallback())
 
-    val patternTypeRef = typeRefNode(pattern.getType, code(pattern.getType), patternTypeFullName)
+    val patternTypeRef = typeRefNode(patternExpr.getType, code(patternExpr.getType), patternTypeFullName)
 
-    val typePatterns = getTypePatterns(pattern)
+    patternExpr match {
+      case typePatternExpr: TypePatternExpr =>
+        val (initializerAst, referenceAst) = initializerAndReferenceAstsForPatternInitializer(typePatternExpr, lhsAst)
 
-    typePatterns.foreach { typePatternExpr =>
-      val variableName = typePatternExpr.getNameAsString
-      val variableType = {
-        tryWithSafeStackOverflow(typePatternExpr.getType).toOption
-          .map(typ =>
-            scope
-              .lookupScopeType(typ.asString())
-              .map(_.typeFullName)
-              .orElse(typeInfoCalc.fullName(typ))
-              .getOrElse(defaultTypeFallback(typ))
-          )
-          .getOrElse(defaultTypeFallback())
-      }
-      val variableTypeCode = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
+        val lhsCode = initializerAst.root match {
+          case Some(identifier: NewIdentifier)                           => identifier.code
+          case Some(call: NewCall) if call.name == Operators.fieldAccess => call.code
+          case Some(astNodeNew: AstNodeNew)                              => s"(${astNodeNew.code})"
+          case _                                                         => ""
+        }
+        val instanceOfCall = newOperatorCallNode(
+          Operators.instanceOf,
+          s"$lhsCode instanceof ${code(patternExpr.getType)}",
+          Option(TypeConstants.Boolean)
+        )
 
-      val patternLocal      = localNode(typePatternExpr, variableName, code(typePatternExpr), variableType)
-      val patternIdentifier = identifierNode(typePatternExpr, variableName, variableName, variableType)
-      // TODO Handle record pattern initializers
-      val patternInitializerCastType = typeRefNode(typePatternExpr, code(typePatternExpr.getType), variableType)
-      val patternInitializerCastRhs  = lhsIdentifier.copy
-      val patternInitializerCast = newOperatorCallNode(
-        Operators.cast,
-        s"($variableTypeCode) ${lhsIdentifier.code}",
-        Option(variableType),
-        line(typePatternExpr),
-        column(typePatternExpr)
-      )
+        createAndPushAssignmentForTypePattern(typePatternExpr, referenceAst)
 
-      val initializerCastAst =
-        callAst(patternInitializerCast, Ast(patternInitializerCastType) :: Ast(patternInitializerCastRhs) :: Nil)
-          .withRefEdges(patternInitializerCastRhs, lhsRefsTo.toList)
-
-      val initializerAssignmentCall = newOperatorCallNode(
-        Operators.assignment,
-        s"$variableName = ${patternInitializerCast.code}",
-        Option(variableType),
-        line(typePatternExpr),
-        column(typePatternExpr)
-      )
-      val initializerAssignmentAst = callAst(
-        initializerAssignmentCall,
-        Ast(patternIdentifier) :: initializerCastAst :: Nil
-      ).withRefEdge(patternIdentifier, patternLocal)
-
-      scope.enclosingMethod.foreach { methodScope =>
-        methodScope.putPatternVariableInfo(typePatternExpr, patternLocal, initializerAssignmentAst)
-      }
-    }
-
-    val instanceOfCall = newOperatorCallNode(
-      Operators.instanceOf,
-      s"${lhsAst.rootCodeOrEmpty} instanceof ${code(pattern.getType)}",
-      Option(TypeConstants.Boolean)
-    )
-
-    callAst(instanceOfCall, lhsAst :: Ast(patternTypeRef) :: Nil)
-  }
-
-  private def getTypePatterns(expr: PatternExpr): List[TypePatternExpr] = {
-    expr match {
-      case typePatternExpr: TypePatternExpr => typePatternExpr :: Nil
+        callAst(instanceOfCall, initializerAst :: Ast(patternTypeRef) :: Nil)
 
       case recordPatternExpr: RecordPatternExpr =>
-        recordPatternExpr.getPatternList.asScala.toList.flatMap(getTypePatterns)
+        val (initializerAst, referenceAst) = initializerAndReferenceAstsForPatternInitializer(patternExpr, lhsAst)
+        val lhsCode = initializerAst.root match {
+          case Some(identifier: NewIdentifier)                           => identifier.code
+          case Some(call: NewCall) if call.name == Operators.fieldAccess => call.code
+          case Some(astNode: AstNodeNew)                                 => s"(${astNode.code})"
+          case _                                                         => ""
+        }
+        val instanceOfCall = newOperatorCallNode(
+          Operators.instanceOf,
+          s"$lhsCode instanceof ${code(patternExpr.getType)}",
+          Option(TypeConstants.Boolean)
+        )
+        val topLevelInstanceOfAst = callAst(instanceOfCall, initializerAst :: Ast(patternTypeRef) :: Nil)
+
+        val recordTypeFullName = tryWithSafeStackOverflow(recordPatternExpr.getType)
+          .map(typ =>
+            scope.lookupType(code(typ)).orElse(typeInfoCalc.fullName(typ)).getOrElse(defaultTypeFallback(typ))
+          )
+          .getOrElse(defaultTypeFallback())
+
+        val recordLhsAst = castAstIfNecessary(
+          recordPatternExpr,
+          recordTypeFullName,
+          referenceAst.subTreeCopy(referenceAst.root.get.asInstanceOf[AstNodeNew])
+        )
+
+        val accessorAsts = accessorAstsForPatternList(recordPatternExpr, recordTypeFullName, recordLhsAst)
+
+        val accessorAstsWithInit = ((recordPatternExpr, topLevelInstanceOfAst) :: accessorAsts).reverse
+
+        val accumulator = typeCheckAstForPattern(accessorAstsWithInit.head._1, accessorAstsWithInit.head._2)
+
+        accessorAstsWithInit.tail.foldLeft(accumulator) { case (accumulatorAst, (childPattern, childFieldAccessor)) =>
+          val astToAdd =
+            if (childPattern.eq(recordPatternExpr))
+              childFieldAccessor
+            else
+              typeCheckAstForPattern(childPattern, childFieldAccessor)
+
+          val andNode = newOperatorCallNode(
+            Operators.logicalAnd,
+            s"(${astToAdd.rootCodeOrEmpty}) && (${accumulatorAst.rootCodeOrEmpty})",
+            Option(TypeConstants.Boolean),
+            line(childPattern),
+            column(childPattern)
+          )
+
+          callAst(andNode, astToAdd :: accumulatorAst :: Nil)
+        }
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
@@ -11,7 +11,10 @@ import io.joern.x2cpg.utils.AstPropertiesUtil.*
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNodeNew, NewCall, NewIdentifier}
 import io.joern.x2cpg.utils.NodeBuilders.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import org.slf4j.LoggerFactory
 
+import java.util
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 
@@ -33,11 +36,94 @@ class PatternInitAndRefAsts(private val initAst: Ast, private val refAst: Ast) {
 
 object PatternInitAndRefAsts {
   def apply(initAst: Ast, refAst: Ast): PatternInitAndRefAsts = new PatternInitAndRefAsts(initAst, refAst)
+
+  def apply(initAst: Ast): PatternInitAndRefAsts =
+    new PatternInitAndRefAsts(initAst, initAst.subTreeCopy(initAst.root.get.asInstanceOf[AstNodeNew]))
 }
 
 trait AstForPatternExpressionsCreator { this: AstCreator =>
 
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
+  trait PatternInitTreeNode(val patternExpr: PatternExpr) {
+    def getAst: Ast
+
+    def typeFullName: Option[String]
+  }
+
+  class PatternInitRoot(patternExpr: PatternExpr, ast: PatternInitAndRefAsts) extends PatternInitTreeNode(patternExpr) {
+    override def getAst: Ast = ast.get
+
+    override def typeFullName: Option[String] = ast.rootType
+  }
+
+  class PatternInitNode(
+    parentNode: PatternInitTreeNode,
+    patternExpr: PatternExpr,
+    fieldName: String,
+    fieldTypeFullName: Option[String],
+    requiresTemporaryVariable: Boolean
+  ) extends PatternInitTreeNode(patternExpr) {
+    private var cachedResult: Option[PatternInitAndRefAsts] = None
+
+    override def typeFullName: Option[String] = fieldTypeFullName
+
+    override def getAst: Ast = {
+      cachedResult.map(_.get).getOrElse {
+        val parentAst = parentNode.getAst
+        val patternTypeFullName = tryWithSafeStackOverflow(patternExpr.getType).toOption
+          .map { typ =>
+            scope
+              .lookupScopeType(typ.asString())
+              .map(_.typeFullName)
+              .orElse(typeInfoCalc.fullName(typ))
+              .getOrElse(defaultTypeFallback(typ))
+          }
+          .getOrElse(defaultTypeFallback())
+
+        val parentPatternType = getPatternTypeFullName(parentNode.patternExpr)
+        val lhsAst            = castAstIfNecessary(parentNode.patternExpr, parentPatternType, parentAst)
+
+        val signature = composeSignature(fieldTypeFullName, Option(Nil), 0)
+        val typeDeclFullName =
+          if (isResolvedTypeFullName(parentPatternType))
+            parentPatternType
+          else
+            s"${Defines.UnresolvedNamespace}.${code(parentNode.patternExpr.getType)}"
+        val methodFullName = Util.composeMethodFullName(typeDeclFullName, fieldName, signature)
+        val methodCodePrefix = lhsAst.root match {
+          case Some(call: NewCall) if call.name.startsWith("<operator") => s"(${call.code})"
+          case Some(root: AstNodeNew)                                   => root.code
+          case _                                                        => ""
+
+        }
+        val methodCode = s"$methodCodePrefix.$fieldName()"
+
+        val fieldAccessorCall = callNode(
+          patternExpr,
+          methodCode,
+          fieldName,
+          methodFullName,
+          DispatchTypes.DYNAMIC_DISPATCH,
+          Option(signature),
+          fieldTypeFullName.orElse(Option(defaultTypeFallback()))
+        )
+
+        val fieldAccessorAst = callAst(fieldAccessorCall, lhsAst :: Nil)
+
+        val patternInitWithRef = if (requiresTemporaryVariable) {
+          val patternInitWithRef = initAndRefAstsForPatternInitializer(patternExpr, fieldAccessorAst)
+          patternInitWithRef
+        } else {
+          PatternInitAndRefAsts(fieldAccessorAst)
+        }
+
+        cachedResult = Option(patternInitWithRef)
+
+        patternInitWithRef.get
+      }
+    }
+  }
 
   /** In the lowering for instanceof expressions with patterns like `X instanceof Foo f`, the first argument to
     * `instanceof` (in this case `X`) appears in the CPG at least 2 times:
@@ -110,174 +196,96 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
     }
   }
 
-  private def createAndPushAssignmentForTypePattern(
-    typePatternExpr: TypePatternExpr,
-    parentInitializerAst: PatternInitAndRefAsts
-  ): Unit = {
-    val variableName = typePatternExpr.getNameAsString
-    val variableType = {
-      tryWithSafeStackOverflow(typePatternExpr.getType).toOption
-        .map(typ =>
-          scope
-            .lookupScopeType(typ.asString())
-            .map(_.typeFullName)
-            .orElse(typeInfoCalc.fullName(typ))
-            .getOrElse(defaultTypeFallback(typ))
-        )
-        .getOrElse(defaultTypeFallback())
-    }
-    val variableTypeCode  = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
-    val patternLocal      = localNode(typePatternExpr, variableName, code(typePatternExpr), variableType)
-    val patternIdentifier = identifierNode(typePatternExpr, variableName, variableName, variableType)
+  private def createAndPushAssignmentForTypePattern(patternNode: PatternInitTreeNode): Unit = {
+    println(s"Pushing assignment for pattern ${code(patternNode.patternExpr)}")
+    patternNode.patternExpr match {
+      case recordPatternExpr: RecordPatternExpr =>
+        logger.warn(s"Attempting to create assignment for record pattern expr ${code(recordPatternExpr)}")
 
-    val initializerAst = castAstIfNecessary(typePatternExpr, variableType, parentInitializerAst.get)
-
-    val initializerAssignmentCall = newOperatorCallNode(
-      Operators.assignment,
-      s"$variableName = ${initializerAst.rootCodeOrEmpty}",
-      Option(variableType),
-      line(typePatternExpr),
-      column(typePatternExpr)
-    )
-    val initializerAssignmentAst = callAst(initializerAssignmentCall, Ast(patternIdentifier) :: initializerAst :: Nil)
-      .withRefEdge(patternIdentifier, patternLocal)
-
-    scope.enclosingMethod.foreach { methodScope =>
-      methodScope.putPatternVariableInfo(typePatternExpr, patternLocal, initializerAssignmentAst)
-    }
-  }
-
-  private def accessorAstsForPatternList(
-    recordPatternExpr: RecordPatternExpr,
-    recordTypeFullName: String,
-    accessorReceiverAst: PatternInitAndRefAsts
-  ): List[(PatternExpr, Ast)] = {
-    val resolvedRecordType = tryWithSafeStackOverflow(recordPatternExpr.getType().resolve().asReferenceType()).toOption
-
-    val patternList = recordPatternExpr.getPatternList.asScala.toList
-    val fieldNames = resolvedRecordType
-      .flatMap(_.getTypeDeclaration.toScala)
-      .map(_.getDeclaredFields.asScala.map(_.getName).toList)
-      .getOrElse(patternList.map(_ => Defines.UnknownField))
-
-    patternList.zip(fieldNames).zipWithIndex.map { case ((patternExpr, fieldName), idx) =>
-      val patternTypeFullName = tryWithSafeStackOverflow(patternExpr.getType).toOption
-        .map { typ =>
-          scope
-            .lookupScopeType(typ.asString())
-            .map(_.typeFullName)
-            .orElse(typeInfoCalc.fullName(typ))
-            .getOrElse(defaultTypeFallback(typ))
+      case typePatternExpr: TypePatternExpr =>
+        val variableName = typePatternExpr.getNameAsString
+        val variableType = {
+          tryWithSafeStackOverflow(typePatternExpr.getType).toOption
+            .map(typ =>
+              scope
+                .lookupScopeType(typ.asString())
+                .map(_.typeFullName)
+                .orElse(typeInfoCalc.fullName(typ))
+                .getOrElse(defaultTypeFallback(typ))
+            )
+            .getOrElse(defaultTypeFallback())
         }
-        .getOrElse(defaultTypeFallback())
+        val variableTypeCode  = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
+        val patternLocal      = localNode(typePatternExpr, variableName, code(typePatternExpr), variableType)
+        val patternIdentifier = identifierNode(typePatternExpr, variableName, variableName, variableType)
 
-      val fieldTypeFullName = resolvedRecordType
-        .flatMap(_.getTypeDeclaration.toScala)
-        .flatMap(typeDecl => tryWithSafeStackOverflow(typeDecl.getField(fieldName).getType).toOption)
-        .flatMap(typeInfoCalc.fullName)
+        val initializerAst = castAstIfNecessary(typePatternExpr, variableType, patternNode.getAst)
 
-      val lhsAst    = castAstIfNecessary(recordPatternExpr, recordTypeFullName, accessorReceiverAst.get)
-      
-      val signature = composeSignature(fieldTypeFullName, Option(Nil), 0)
-      val typeDeclFullName =
-        if (isResolvedTypeFullName(recordTypeFullName))
-          recordTypeFullName
-        else
-          s"${Defines.UnresolvedNamespace}.${code(recordPatternExpr.getType)}"
-      val methodFullName = Util.composeMethodFullName(typeDeclFullName, fieldName, signature)
-      val methodCodePrefix = lhsAst.root match {
-        case Some(call: NewCall) if call.name.startsWith("<operator") => s"(${call.code})"
-        case Some(root: AstNodeNew)                                   => root.code
-        case _                                                        => ""
+        val initializerAssignmentCall = newOperatorCallNode(
+          Operators.assignment,
+          s"$variableName = ${initializerAst.rootCodeOrEmpty}",
+          Option(variableType),
+          line(typePatternExpr),
+          column(typePatternExpr)
+        )
+        val initializerAssignmentAst =
+          callAst(initializerAssignmentCall, Ast(patternIdentifier) :: initializerAst :: Nil)
+            .withRefEdge(patternIdentifier, patternLocal)
 
-      }
-      val methodCode = s"$methodCodePrefix.$fieldName()"
+        scope.enclosingMethod.foreach { methodScope =>
+          methodScope.putPatternVariableInfo(typePatternExpr, patternLocal, initializerAssignmentAst)
+        }
 
-      val fieldAccessorCall = callNode(
-        patternExpr,
-        methodCode,
-        fieldName,
-        methodFullName,
-        DispatchTypes.DYNAMIC_DISPATCH,
-        Option(signature),
-        fieldTypeFullName.orElse(Option(defaultTypeFallback()))
-      )
-
-      val fieldAccessorAst = callAst(fieldAccessorCall, lhsAst :: Nil)
-
-      (patternExpr, fieldAccessorAst)
     }
-
   }
 
   private[astcreation] def instanceOfAstForPattern(patternExpr: PatternExpr, lhsAst: Ast): Ast = {
-    val initAst = initAndRefAstsForPatternInitializer(patternExpr, lhsAst)
-    typeCheckAstForPattern(patternExpr, initAst, isTopLevelPattern = true).get
+    val patternTreeNode = PatternInitRoot(patternExpr, initAndRefAstsForPatternInitializer(patternExpr, lhsAst))
+    val typePatternBuffer: mutable.ListBuffer[PatternInitTreeNode] = mutable.ListBuffer()
+    if (patternExpr.isTypePatternExpr) {
+      typePatternBuffer.append(patternTreeNode)
+    }
+    val typeCheckAst = typeCheckAstForPattern(patternExpr, patternTreeNode, typePatternBuffer).get
+
+    typePatternBuffer.foreach(createAndPushAssignmentForTypePattern)
+    typeCheckAst
   }
 
   private def typeCheckAstForPattern(
     patternExpr: PatternExpr,
-    initAndRefAsts: PatternInitAndRefAsts,
-    isTopLevelPattern: Boolean = false
+    parentInitNode: PatternInitTreeNode,
+    typePatternBuffer: mutable.ListBuffer[PatternInitTreeNode]
   ): Option[Ast] = {
-    val patternTypeFullName = {
-      tryWithSafeStackOverflow(patternExpr.getType).toOption
-        .map(typ =>
-          scope
-            .lookupScopeType(typ.asString())
-            .map(_.typeFullName)
-            .orElse(typeInfoCalc.fullName(typ))
-            .getOrElse(defaultTypeFallback(typ))
-        )
-    }.getOrElse(defaultTypeFallback())
+    val patternTypeFullName = getPatternTypeFullName(patternExpr)
 
-    val patternTypeRef = typeRefNode(patternExpr.getType, code(patternExpr.getType), patternTypeFullName)
+    val isInstanceOfRequired =
+      parentInitNode.isInstanceOf[PatternInitRoot]
+        || !isResolvedTypeFullName(patternTypeFullName)
+        || !parentInitNode.typeFullName.contains(patternTypeFullName)
 
-    // val initAndRefAsts = initAndRefAstsForPatternInitializer(patternExpr, lhsAst)
-
-    val initializerType   = initAndRefAsts.rootType
-    val canSkipInstanceOf = isResolvedTypeFullName(patternTypeFullName) && initializerType.contains(patternTypeFullName)
-
-    val topLevelInstanceOfAst = Option.when(isTopLevelPattern || !canSkipInstanceOf) {
-      val initializerAst = initAndRefAsts.get
-
-      val lhsCode = initializerAst.root match {
-        case Some(identifier: NewIdentifier)                           => identifier.code
-        case Some(call: NewCall) if call.name == Operators.fieldAccess => call.code
-        case Some(astNodeNew: AstNodeNew)                              => s"(${astNodeNew.code})"
-        case _                                                         => ""
-      }
-      val instanceOfCall = newOperatorCallNode(
-        Operators.instanceOf,
-        s"$lhsCode instanceof ${code(patternExpr.getType)}",
-        Option(TypeConstants.Boolean)
-      )
-      callAst(instanceOfCall, initializerAst :: Ast(patternTypeRef) :: Nil)
-    }
+    val instanceOfAst =
+      Option.when(isInstanceOfRequired)(buildInstanceOfAst(patternExpr, parentInitNode, patternTypeFullName))
 
     patternExpr match {
       case typePatternExpr: TypePatternExpr =>
-        createAndPushAssignmentForTypePattern(typePatternExpr, initAndRefAsts)
-        topLevelInstanceOfAst
+        instanceOfAst
 
       case recordPatternExpr: RecordPatternExpr =>
-        // val recordLhsAst = castAstIfNecessary(recordPatternExpr, patternTypeFullName, initAndRefAsts.get)
+        val fieldAccessorInits =
+          initNodesForRecordFieldAccessors(recordPatternExpr, patternTypeFullName, parentInitNode)
 
-        val accessorAsts = accessorAstsForPatternList(recordPatternExpr, patternTypeFullName, initAndRefAsts)
-
-        val accessorAstsWithInit =
-          (topLevelInstanceOfAst.map(ast => (recordPatternExpr, ast)).toList ++ accessorAsts).reverse
-
-        val typeCheckAsts = accessorAstsWithInit.flatMap { case (childPattern, childFieldAccessor) =>
-          if (childPattern.eq(recordPatternExpr))
-            Option((childPattern, childFieldAccessor))
-          else
-            val childFieldWithRef = initAndRefAstsForPatternInitializer(childPattern, childFieldAccessor)
-            typeCheckAstForPattern(childPattern, childFieldWithRef).map((childPattern, _))
+        val fieldInstanceOfAsts = fieldAccessorInits.flatMap { fieldInitNode =>
+          if (fieldInitNode.patternExpr.isTypePatternExpr) {
+            typePatternBuffer.append(fieldInitNode)
+          }
+          typeCheckAstForPattern(fieldInitNode.patternExpr, fieldInitNode, typePatternBuffer).map { ast =>
+            (fieldInitNode.patternExpr, ast)
+          }
         }
 
-        typeCheckAsts match {
+        (instanceOfAst.map(ast => (recordPatternExpr, ast)).toList ++ fieldInstanceOfAsts).reverse match {
           case Nil => None
+
           case accumulator :: rest =>
             val result = rest.foldLeft(accumulator._2) { case (accumulatorAst, (childPattern, astToAdd)) =>
               val andNode = newOperatorCallNode(
@@ -293,5 +301,73 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
             Option(result)
         }
     }
+  }
+
+  private def initNodesForRecordFieldAccessors(
+    recordPatternExpr: RecordPatternExpr,
+    recordTypeFullName: String,
+    parentInitNode: PatternInitTreeNode
+  ): List[PatternInitNode] = {
+    val resolvedRecordType = tryWithSafeStackOverflow(recordPatternExpr.getType().resolve().asReferenceType()).toOption
+
+    val patternList = recordPatternExpr.getPatternList.asScala.toList
+    val fieldNames = resolvedRecordType
+      .flatMap(_.getTypeDeclaration.toScala)
+      .map(_.getDeclaredFields.asScala.map(_.getName).toList)
+      .getOrElse(patternList.map(_ => Defines.UnknownField))
+
+    patternList.zip(fieldNames).map { case (childPatternExpr, fieldName) =>
+      val childTypeFullName = getPatternTypeFullName(childPatternExpr) match {
+        case typeFullName if isResolvedTypeFullName(typeFullName) => Option(typeFullName)
+        case _                                                    => None
+      }
+
+      val fieldTypeFullName = resolvedRecordType
+        .flatMap(_.getTypeDeclaration.toScala)
+        .flatMap(typeDecl => tryWithSafeStackOverflow(typeDecl.getField(fieldName).getType).toOption)
+        .flatMap(typeInfoCalc.fullName)
+
+      val childIsBranchingNode =
+        childPatternExpr.isRecordPatternExpr && childPatternExpr.asRecordPatternExpr().getPatternList.size() > 1
+      val childTypeIsResolved = childTypeFullName.exists(isResolvedTypeFullName)
+      val requiresTemporaryVariable =
+        childIsBranchingNode || !childTypeIsResolved || childTypeFullName != fieldTypeFullName
+
+      PatternInitNode(parentInitNode, childPatternExpr, fieldName, fieldTypeFullName, requiresTemporaryVariable)
+    }
+  }
+
+  private def buildInstanceOfAst(
+    patternExpr: PatternExpr,
+    parentInitNode: PatternInitTreeNode,
+    patternTypeFullName: String
+  ): Ast = {
+    val patternTypeRef = typeRefNode(patternExpr.getType, code(patternExpr.getType), patternTypeFullName)
+    val initializerAst = parentInitNode.getAst
+
+    val lhsCode = initializerAst.root match {
+      case Some(identifier: NewIdentifier)                           => identifier.code
+      case Some(call: NewCall) if call.name == Operators.fieldAccess => call.code
+      case Some(astNodeNew: AstNodeNew)                              => s"(${astNodeNew.code})"
+      case _                                                         => ""
+    }
+    val instanceOfCall = newOperatorCallNode(
+      Operators.instanceOf,
+      s"$lhsCode instanceof ${code(patternExpr.getType)}",
+      Option(TypeConstants.Boolean)
+    )
+    callAst(instanceOfCall, initializerAst :: Ast(patternTypeRef) :: Nil)
+  }
+
+  private def getPatternTypeFullName(patternExpr: PatternExpr): String = {
+    tryWithSafeStackOverflow(patternExpr.getType).toOption
+      .map(typ =>
+        scope
+          .lookupScopeType(typ.asString())
+          .map(_.typeFullName)
+          .orElse(typeInfoCalc.fullName(typ))
+          .getOrElse(defaultTypeFallback(typ))
+      )
+      .getOrElse(defaultTypeFallback())
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -346,7 +346,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val lhsAst = astsForExpression(expr.getExpression, ExpectedType.empty).head
     expr.getPattern.toScala
       .map { patternExpression =>
-        typeCheckAstForPattern(patternExpression, lhsAst)
+        instanceOfAstForPattern(patternExpression, lhsAst)
       }
       .getOrElse {
         val booleanTypeFullName = Some(TypeConstants.Boolean)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -170,7 +170,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
       .typePatternExprsExposedToChild(expr.getRight)
       .asScala
       .flatMap(pattern => scope.enclosingMethod.flatMap(_.getPatternVariableInfo(pattern)))
-      .foreach { case PatternVariableInfo(pattern, local, _, _, _) =>
+      .foreach { case PatternVariableInfo(pattern, local, _, _, _, _) =>
         scope.enclosingBlock.foreach(_.addPatternLocal(local, pattern))
       }
 
@@ -346,7 +346,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val lhsAst = astsForExpression(expr.getExpression, ExpectedType.empty).head
     expr.getPattern.toScala
       .map { patternExpression =>
-        astForInstanceOfWithPattern(expr.getExpression, lhsAst, patternExpression)
+        typeCheckAstForPattern(patternExpression, lhsAst)
       }
       .getOrElse {
         val booleanTypeFullName = Some(TypeConstants.Boolean)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
@@ -299,7 +299,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
       stmt.getEntries.asScala.flatMap(_.getLabels.asScala).exists(_.isPatternExpr)
 
     val (initializerAst, referenceAst) = if (selectorMustBeIdentifierOrFieldAccess) {
-      val initAndRefAsts =  initAndRefAstsForPatternInitializer(stmt.getSelector, selectorAst)
+      val initAndRefAsts = initAndRefAstsForPatternInitializer(stmt.getSelector, selectorAst)
       (initAndRefAsts.get, Option(initAndRefAsts.get))
     } else {
       (selectorAst, None)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
@@ -299,9 +299,8 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
       stmt.getEntries.asScala.flatMap(_.getLabels.asScala).exists(_.isPatternExpr)
 
     val (initializerAst, referenceAst) = if (selectorMustBeIdentifierOrFieldAccess) {
-      val (initializerAst, referenceAst) =
-        initializerAndReferenceAstsForPatternInitializer(stmt.getSelector, selectorAst)
-      (initializerAst, Option(referenceAst))
+      val initAndRefAsts =  initAndRefAstsForPatternInitializer(stmt.getSelector, selectorAst)
+      (initAndRefAsts.get, Option(initAndRefAsts.get))
     } else {
       (selectorAst, None)
     }
@@ -367,7 +366,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
 
     val instanceOfAst = labels.lastOption.collect { case patternExpr: PatternExpr =>
       selectorReferenceAst.map { selectorAst =>
-        typeCheckAstForPattern(patternExpr, selectorAst)
+        instanceOfAstForPattern(patternExpr, selectorAst)
       }
     }.flatten
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
@@ -295,21 +295,23 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
 
     val selectorNode = selectorAst.root.get
 
-    val selectorMustBeIdentifier = stmt.getEntries.asScala.flatMap(_.getLabels.asScala).exists(_.isPatternExpr)
+    val selectorMustBeIdentifierOrFieldAccess =
+      stmt.getEntries.asScala.flatMap(_.getLabels.asScala).exists(_.isPatternExpr)
 
-    val (selectorInitializer, selectorIdentifier, selectorRefsTo) = if (selectorMustBeIdentifier) {
-      val (init, ident, refs) = astIdentifierAndRefsForPatternLhs(stmt.getSelector, selectorAst)
-      (init, Option(ident), refs)
+    val (initializerAst, referenceAst) = if (selectorMustBeIdentifierOrFieldAccess) {
+      val (initializerAst, referenceAst) =
+        initializerAndReferenceAstsForPatternInitializer(stmt.getSelector, selectorAst)
+      (initializerAst, Option(referenceAst))
     } else {
-      (selectorAst, None, None)
+      (selectorAst, None)
     }
 
-    val entryAsts = stmt.getEntries.asScala.flatMap(astForSwitchEntry(_, selectorIdentifier, selectorRefsTo))
+    val entryAsts = stmt.getEntries.asScala.flatMap(astForSwitchEntry(_, referenceAst))
 
     val switchBodyAst = Ast(NewBlock()).withChildren(entryAsts)
 
     Ast(switchNode)
-      .withChild(selectorInitializer)
+      .withChild(initializerAst)
       .withChild(switchBodyAst)
       .withConditionEdge(switchNode, selectorNode)
   }
@@ -355,11 +357,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
     (defaultAst ++ explicitLabelAsts).toList
   }
 
-  private def astForSwitchEntry(
-    entry: SwitchEntry,
-    selectorIdentifier: Option[NewIdentifier],
-    selectorRefsTo: Option[NewVariableNode]
-  ): Seq[Ast] = {
+  private def astForSwitchEntry(entry: SwitchEntry, selectorReferenceAst: Option[Ast]): Seq[Ast] = {
     // Fallthrough to/from a pattern is a compile error, so an entry can only have a pattern label if that is
     // the only label
     val labels    = entry.getLabels.asScala.toList
@@ -368,8 +366,8 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
     val entryContext = new SwitchEntryContext(entry, new CombinedTypeSolver())
 
     val instanceOfAst = labels.lastOption.collect { case patternExpr: PatternExpr =>
-      selectorIdentifier.map { selector =>
-        astForInstanceOfWithPattern(patternExpr, Ast(selector), patternExpr)
+      selectorReferenceAst.map { selectorAst =>
+        typeCheckAstForPattern(patternExpr, selectorAst)
       }
     }.flatten
 
@@ -382,7 +380,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
       scope.addLocalsForPatternsToEnclosingBlock(patternsExposedToBody)
       val patternAstsToAdd = patternsExposedToBody
         .flatMap(typePattern => scope.enclosingMethod.get.getPatternVariableInfo(typePattern))
-        .flatMap { case PatternVariableInfo(typePatternExpr, patternLocal, initializerAst, _, _) =>
+        .flatMap { case PatternVariableInfo(typePatternExpr, patternLocal, initializerAst, _, _, _) =>
           scope.enclosingMethod.get.registerPatternVariableInitializerToBeAddedToGraph(typePatternExpr)
           scope.enclosingMethod.get.registerPatternVariableLocalToBeAddedToGraph(typePatternExpr)
           Ast(patternLocal) :: initializerAst :: Nil
@@ -413,7 +411,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
       instanceOfAst
         .map { instanceOfAst =>
           val ifNode = controlStructureNode(entry, ControlStructureTypes.IF, s"if (${instanceOfAst.rootCodeOrEmpty})")
-          labelAsts :+ Ast(ifNode).withChild(instanceOfAst).withChild(statementsAst)
+          labelAsts :+ controlStructureAst(ifNode, Option(instanceOfAst), statementsAst :: Nil)
         }
         .getOrElse(labelAsts :+ statementsAst)
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForStatementsCreator.scala
@@ -132,12 +132,15 @@ trait AstForStatementsCreator extends AstForSimpleStatementsCreator with AstForF
 
     patternSet.asScala
       .flatMap(patternExpr => scope.enclosingMethod.flatMap(_.getPatternVariableInfo(patternExpr)))
+      .toArray
+      .sortBy(_.index)
+      .reverseIterator
       .foreach {
-        case PatternVariableInfo(pattern, variableLocal, _, _, true) =>
+        case PatternVariableInfo(pattern, variableLocal, _, _, true, _) =>
           scope.enclosingMethod.foreach(_.registerPatternVariableLocalToBeAddedToGraph(pattern))
           astsAddedBeforeStmt.addOne(Ast(variableLocal))
 
-        case PatternVariableInfo(pattern, variableLocal, initializer, _, false) =>
+        case PatternVariableInfo(pattern, variableLocal, initializer, _, false, _) =>
           if (patternsIntroducedByStmt.contains(pattern)) {
             if (patternsIntroducedToBody.contains(pattern) || patternsIntroducedToElse.contains(pattern)) {
               astsAddedBeforeStmt.addOne(Ast(variableLocal))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForStatementsCreator.scala
@@ -134,7 +134,6 @@ trait AstForStatementsCreator extends AstForSimpleStatementsCreator with AstForF
       .flatMap(patternExpr => scope.enclosingMethod.flatMap(_.getPatternVariableInfo(patternExpr)))
       .toArray
       .sortBy(_.index)
-      .reverseIterator
       .foreach {
         case PatternVariableInfo(pattern, variableLocal, _, _, true, _) =>
           scope.enclosingMethod.foreach(_.registerPatternVariableLocalToBeAddedToGraph(pattern))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
@@ -71,7 +71,8 @@ case class PatternVariableInfo(
   typeVariableLocal: NewLocal,
   typeVariableInitializer: Ast,
   localAddedToAst: Boolean = false,
-  initializerAddedToAst: Boolean = false
+  initializerAddedToAst: Boolean = false,
+  index: Int
 )
 
 object JavaScopeElement {
@@ -113,6 +114,8 @@ object JavaScopeElement {
     private val temporaryLocals = mutable.ListBuffer[NewLocal]()
     private val patternVariableInfoIdentityMap: mutable.Map[TypePatternExpr, PatternVariableInfo] =
       new util.IdentityHashMap[TypePatternExpr, PatternVariableInfo]().asScala
+    // The insertion order should be preserved to ensure stable results when getting unadded variable asts
+    private var patternVariableIndex = 0
 
     def addParameter(parameter: NewMethodParameterIn): Unit = {
       addVariableToScope(ScopeParameter(parameter))
@@ -131,8 +134,9 @@ object JavaScopeElement {
     ): Unit = {
       patternVariableInfoIdentityMap.put(
         typePatternExpr,
-        PatternVariableInfo(typePatternExpr, typeVariableLocal, typeVariableInitializer)
+        PatternVariableInfo(typePatternExpr, typeVariableLocal, typeVariableInitializer, index = patternVariableIndex)
       )
+      patternVariableIndex += 1
     }
 
     def getPatternVariableInfo(typePatternExpr: TypePatternExpr): Option[PatternVariableInfo] = {
@@ -140,20 +144,21 @@ object JavaScopeElement {
     }
 
     def registerPatternVariableInitializerToBeAddedToGraph(typePatternExpr: TypePatternExpr): Unit = {
-      patternVariableInfoIdentityMap.get(typePatternExpr).foreach { case patternVariableInfo =>
-        patternVariableInfoIdentityMap.put(typePatternExpr, patternVariableInfo.copy(initializerAddedToAst = true))
+      patternVariableInfoIdentityMap.get(typePatternExpr).foreach { patternVariableInfo =>
+        patternVariableInfoIdentityMap
+          .put(typePatternExpr, patternVariableInfo.copy(initializerAddedToAst = true))
       }
     }
 
     def registerPatternVariableLocalToBeAddedToGraph(typePatternExpr: TypePatternExpr): Unit = {
-      patternVariableInfoIdentityMap.get(typePatternExpr).foreach { case patternVariableInfo =>
+      patternVariableInfoIdentityMap.get(typePatternExpr).foreach { patternVariableInfo =>
         patternVariableInfoIdentityMap.put(typePatternExpr, patternVariableInfo.copy(localAddedToAst = true))
       }
     }
 
     def getUnaddedPatternVariableAstsAndMarkAdded(): List[Ast] = {
       val result = mutable.ListBuffer[Ast]()
-      patternVariableInfoIdentityMap.values.foreach { patternInfo =>
+      patternVariableInfoIdentityMap.values.toArray.sortBy(_.index).reverseIterator.foreach { patternInfo =>
         if (!patternInfo.localAddedToAst) {
           result.addOne(Ast(patternInfo.typeVariableLocal))
           registerPatternVariableLocalToBeAddedToGraph(patternInfo.typePatternExpr)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/JavaScopeElement.scala
@@ -158,7 +158,7 @@ object JavaScopeElement {
 
     def getUnaddedPatternVariableAstsAndMarkAdded(): List[Ast] = {
       val result = mutable.ListBuffer[Ast]()
-      patternVariableInfoIdentityMap.values.toArray.sortBy(_.index).reverseIterator.foreach { patternInfo =>
+      patternVariableInfoIdentityMap.values.toArray.sortBy(_.index).foreach { patternInfo =>
         if (!patternInfo.localAddedToAst) {
           result.addOne(Ast(patternInfo.typeVariableLocal))
           registerPatternVariableLocalToBeAddedToGraph(patternInfo.typePatternExpr)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -290,7 +290,7 @@ class Scope(implicit val withSchemaValidation: ValidationMode, val disableTypeFa
 
   def addLocalsForPatternsToEnclosingBlock(patterns: List[TypePatternExpr]): Unit = {
     patterns.flatMap(enclosingMethod.get.getPatternVariableInfo(_)).foreach {
-      case PatternVariableInfo(typePatternExpr, variableLocal, _, _, _) =>
+      case PatternVariableInfo(typePatternExpr, variableLocal, _, _, _, _) =>
         enclosingBlock.get.addPatternLocal(variableLocal, typePatternExpr)
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -11,6 +11,7 @@ import com.github.javaparser.resolution.logic.InferenceVariableType
 import com.github.javaparser.resolution.model.typesystem.{LazyType, NullType}
 import com.github.javaparser.resolution.types.*
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserRecordDeclaration
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.{TypeConstants, TypeNameConstants}
 import io.joern.x2cpg.datastructures.Global
 import org.slf4j.LoggerFactory

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
@@ -43,7 +43,7 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
           bLocal.name shouldBe "b"
 
           // TODO should s assignment be added if it is never used
-          sAssign.code shouldBe "s = (String) $obj0"
+          // TODO sAssign.code shouldBe "s = (String) $obj0"
 
           sLocal.name shouldBe "s"
 
@@ -95,15 +95,11 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
 
     "add the local and initialiser for the pattern variable to the <init> method" in {
       inside(cpg.typeDecl.name("Test").method.nameExact("<init>").body.astChildren.l) {
-        case List(tmpLocal: Local, sLocal: Local, xAssign: Call) =>
-          tmpLocal.name shouldBe "$obj0"
-          tmpLocal.typeFullName shouldBe "java.lang.Object"
-
+        case List(sLocal: Local, xAssign: Call) =>
           sLocal.name shouldBe "s"
           sLocal.typeFullName shouldBe "java.lang.String"
 
           xAssign.methodFullName shouldBe Operators.assignment
-          // TODO xAssign code
 
           inside(xAssign.argument.l) { case List(xFieldAccess: Call, conditionalExpr: Call) =>
             xFieldAccess.methodFullName shouldBe Operators.fieldAccess
@@ -114,14 +110,18 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
 
             inside(conditionalExpr.argument.l) { case List(instanceOfCall: Call, lengthCall: Call, minusCall: Call) =>
               instanceOfCall.methodFullName shouldBe Operators.instanceOf
-              inside(instanceOfCall.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
-                inside(tmpAssign.argument.l) { case List(tmpIdentifier: Identifier, fooFieldAccess: Call) =>
-                  tmpIdentifier.name shouldBe "$obj0"
-                  tmpIdentifier.typeFullName shouldBe "java.lang.Object"
-                  tmpIdentifier.refsTo.l shouldBe List(tmpLocal)
+              instanceOfCall.code shouldBe "Foo.FOO instanceof String"
 
-                  fooFieldAccess.code shouldBe "Foo.FOO"
-                }
+              inside(instanceOfCall.argument.l) { case List(fooFieldAccess: Call, stringType: TypeRef) =>
+                fooFieldAccess.code shouldBe "Foo.FOO"
+
+                // TODO: Fix static field access arguments
+                // inside(fooFieldAccess.argument.l) {
+                //   case List(fooType: TypeRef, fooFieldName: FieldIdentifier) =>
+                //     fooType.typeFullName shouldBe "foo.Foo"
+
+                //     fooFieldName.canonicalName shouldBe "FOO"
+                // }
 
                 stringType.typeFullName shouldBe "java.lang.String"
               }
@@ -134,7 +134,7 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
                   sIdentifier.name shouldBe "s"
                   sIdentifier.refsTo.l shouldBe List(sLocal)
 
-                  oCast.code shouldBe "(String) $obj0"
+                // TODO oCast.code shouldBe "(String) $obj0"
                 }
               }
 
@@ -166,10 +166,7 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
 
     "add the local and initialiser for the pattern variable to the <clinit> method" in {
       inside(cpg.typeDecl.name("Test").method.nameExact("<clinit>").body.astChildren.l) {
-        case List(tmpLocal: Local, sLocal: Local, xAssign: Call) =>
-          tmpLocal.name shouldBe "$obj0"
-          tmpLocal.typeFullName shouldBe "java.lang.Object"
-
+        case List(sLocal: Local, xAssign: Call) =>
           sLocal.name shouldBe "s"
           sLocal.typeFullName shouldBe "java.lang.String"
 
@@ -185,14 +182,8 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
 
             inside(conditionalExpr.argument.l) { case List(instanceOfCall: Call, lengthCall: Call, minusCall: Call) =>
               instanceOfCall.methodFullName shouldBe Operators.instanceOf
-              inside(instanceOfCall.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
-                inside(tmpAssign.argument.l) { case List(tmpIdentifier: Identifier, fooFieldAccess: Call) =>
-                  tmpIdentifier.name shouldBe "$obj0"
-                  tmpIdentifier.typeFullName shouldBe "java.lang.Object"
-                  tmpIdentifier.refsTo.l shouldBe List(tmpLocal)
-
-                  fooFieldAccess.code shouldBe "Foo.FOO"
-                }
+              inside(instanceOfCall.argument.l) { case List(fooFieldAccess: Call, stringType: TypeRef) =>
+                fooFieldAccess.code shouldBe "Foo.FOO"
 
                 stringType.typeFullName shouldBe "java.lang.String"
               }
@@ -205,7 +196,7 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
                   sIdentifier.name shouldBe "s"
                   sIdentifier.refsTo.l shouldBe List(sLocal)
 
-                  oCast.code shouldBe "(String) $obj0"
+                // TODO oCast.code shouldBe "(String) $obj0"
                 }
               }
 
@@ -281,6 +272,10 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
 
       "parse" in {
         cpg.call.name("isEmpty").nonEmpty shouldBe true
+      }
+
+      "not have any nodes with multiple AST parents" in {
+        cpg.astNode.filter(_._astIn.size > 1).l shouldBe Nil
       }
 
       "be represented correctly" in {
@@ -1283,28 +1278,79 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         cpg.call.name("sink").isEmpty shouldBe false
       }
 
+      "have exactly one temporary local" in {
+        cpg.local.name(".*obj.*").name.l shouldBe List("$obj0")
+      }
+
       "have the correct lowering for the type check" in {
-        // Don't need to check `Box.value() instanceof String` since it must be from the declaration
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
-          case List(instanceOfBox: Call) =>
-            instanceOfBox.name shouldBe Operators.instanceOf
-            instanceOfBox.methodFullName shouldBe Operators.instanceOf
-            instanceOfBox.code shouldBe "o instanceof Box"
-            instanceOfBox.typeFullName shouldBe "boolean"
+          case List(andCall: Call) =>
+            andCall.name shouldBe Operators.logicalAnd
+            andCall.typeFullName shouldBe "boolean"
+            andCall.code shouldBe "(o instanceof Box) && (($obj0 = ((Box) o).value()) instanceof String)"
 
-            inside(instanceOfBox.argument.l) { case List(oIdentifier: Identifier, boxType: TypeRef) =>
-              oIdentifier.name shouldBe "o"
-              oIdentifier.typeFullName shouldBe "java.lang.Object"
-              oIdentifier.code shouldBe "o"
-              oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+            inside(andCall.argument.l) { case List(instanceOfBox: Call, instanceOfString: Call) =>
+              instanceOfBox.name shouldBe Operators.instanceOf
+              instanceOfBox.methodFullName shouldBe Operators.instanceOf
+              instanceOfBox.code shouldBe "o instanceof Box"
+              instanceOfBox.typeFullName shouldBe "boolean"
 
-              boxType.typeFullName shouldBe "box.Box"
-              boxType.code shouldBe "Box"
+              inside(instanceOfBox.argument.l) { case List(oIdentifier: Identifier, boxType: TypeRef) =>
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+
+                boxType.typeFullName shouldBe "box.Box"
+                boxType.code shouldBe "Box"
+              }
+
+              instanceOfString.name shouldBe Operators.instanceOf
+              instanceOfString.methodFullName shouldBe Operators.instanceOf
+              instanceOfString.code shouldBe "($obj0 = ((Box) o).value()) instanceof String"
+              instanceOfString.typeFullName shouldBe "boolean"
+
+              inside(instanceOfString.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
+                tmpAssign.name shouldBe Operators.assignment
+                tmpAssign.methodFullName shouldBe Operators.assignment
+                tmpAssign.code shouldBe "$obj0 = ((Box) o).value()"
+                tmpAssign.typeFullName shouldBe "java.lang.String"
+
+                inside(tmpAssign.argument.l) { case List(tmpIdentifier0: Identifier, valueCall: Call) =>
+                  tmpIdentifier0.name shouldBe "$obj0"
+                  tmpIdentifier0.code shouldBe "$obj0"
+                  tmpIdentifier0.typeFullName shouldBe "java.lang.String"
+                  tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+
+                  valueCall.name shouldBe "value"
+                  valueCall.methodFullName shouldBe "box.Box.value:java.lang.String()"
+                  valueCall.typeFullName shouldBe "java.lang.String"
+                  valueCall.code shouldBe "((Box) o).value()"
+
+                  inside(valueCall.argument.l) { case List(boxCast: Call) =>
+                    boxCast.name shouldBe Operators.cast
+                    boxCast.methodFullName shouldBe Operators.cast
+                    boxCast.typeFullName shouldBe "box.Box"
+                    boxCast.code shouldBe "(Box) o"
+
+                    inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                      boxType.typeFullName shouldBe "box.Box"
+
+                      oIdentifier.name shouldBe "o"
+                      oIdentifier.code shouldBe "o"
+                      oIdentifier.typeFullName shouldBe "java.lang.Object"
+                      oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                    }
+                  }
+                }
+
+                stringType.typeFullName shouldBe "java.lang.String"
+              }
             }
         }
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the variable assignment" in {
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
           case List(sLocal: Local, sAssignment: Call, _: Call) =>
             sLocal.name shouldBe "s"
@@ -1314,35 +1360,18 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
             sAssignment.name shouldBe Operators.assignment
             sAssignment.methodFullName shouldBe Operators.assignment
             sAssignment.typeFullName shouldBe "java.lang.String"
-            sAssignment.code shouldBe "s = ((Box) o).value()"
+            sAssignment.code shouldBe "s = $obj0"
 
-            inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, valueCall: Call) =>
+            inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, tmpIdentifier0: Identifier) =>
               sIdentifier.name shouldBe "s"
               sIdentifier.typeFullName shouldBe "java.lang.String"
               sIdentifier.code shouldBe "s"
               sIdentifier.refsTo.l shouldBe List(sLocal)
 
-              valueCall.name shouldBe "value"
-              valueCall.methodFullName shouldBe "box.Box.value:java.lang.String()"
-              valueCall.typeFullName shouldBe "java.lang.String"
-              valueCall.code shouldBe "((Box) o).value()"
-
-              inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                castExpr.name shouldBe Operators.cast
-                castExpr.methodFullName shouldBe Operators.cast
-                castExpr.typeFullName shouldBe "box.Box"
-                castExpr.code shouldBe "(Box) o"
-
-                inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                  boxType.typeFullName shouldBe "box.Box"
-                  boxType.code shouldBe "Box"
-
-                  oIdentifier.name shouldBe "o"
-                  oIdentifier.typeFullName shouldBe "java.lang.Object"
-                  oIdentifier.code shouldBe "o"
-                  oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
-                }
-              }
+              tmpIdentifier0.name shouldBe "$obj0"
+              tmpIdentifier0.code shouldBe "$obj0"
+              tmpIdentifier0.typeFullName shouldBe "java.lang.String"
+              tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
             }
         }
       }
@@ -1367,12 +1396,12 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         cpg.call.name("sink").isEmpty shouldBe false
       }
 
-      "have the correct lowering for the type check" ignore {
+      "have the correct lowering for the type check" in {
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
           case List(andCall: Call) =>
             andCall.name shouldBe Operators.logicalAnd
             andCall.methodFullName shouldBe Operators.logicalAnd
-            andCall.code shouldBe "o instanceof Box && ((Box) o).value() instanceof String)"
+            andCall.code shouldBe "(o instanceof Box) && (($obj0 = ((Box) o).value()) instanceof String)"
 
             inside(andCall.argument.l) { case List(instanceOfBox: Call, instanceOfString: Call) =>
               instanceOfBox.name shouldBe Operators.instanceOf
@@ -1392,27 +1421,39 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
 
               instanceOfString.name shouldBe Operators.instanceOf
               instanceOfString.methodFullName shouldBe Operators.instanceOf
-              instanceOfString.code shouldBe "((Box) o).value() instanceof String"
+              instanceOfString.code shouldBe "($obj0 = ((Box) o).value()) instanceof String"
               instanceOfString.typeFullName shouldBe "boolean"
 
-              inside(instanceOfString.argument.l) { case List(valueCall: Call, stringType: TypeRef) =>
-                valueCall.name shouldBe "value"
-                valueCall.methodFullName shouldBe "box.Box.value:java.lang.String()"
-                valueCall.code shouldBe "((Box) o).value()"
-                valueCall.typeFullName shouldBe "java.lang.String"
+              inside(instanceOfString.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
+                tmpAssign.name shouldBe Operators.assignment
+                tmpAssign.methodFullName shouldBe Operators.assignment
+                tmpAssign.code shouldBe "$obj0 = ((Box) o).value()"
+                tmpAssign.typeFullName shouldBe "java.lang.Object"
 
-                inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                  castExpr.name shouldBe Operators.cast
-                  castExpr.methodFullName shouldBe Operators.cast
-                  castExpr.typeFullName shouldBe "box.Box"
-                  inside(castExpr.argument.l) { case List(castBoxType: TypeRef, castOIdentifier: Identifier) =>
-                    castBoxType.typeFullName shouldBe "box.Box"
-                    castBoxType.code shouldBe "Box"
+                inside(tmpAssign.argument.l) { case List(tmpIdentifier0: Identifier, valueCall: Call) =>
+                  tmpIdentifier0.name shouldBe "$obj0"
+                  tmpIdentifier0.code shouldBe "$obj0"
+                  tmpIdentifier0.typeFullName shouldBe "java.lang.Object"
+                  tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
 
-                    castOIdentifier.name shouldBe "o"
-                    castOIdentifier.typeFullName shouldBe "java.lang.Object"
-                    castOIdentifier.code shouldBe "o"
-                    castOIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                  valueCall.name shouldBe "value"
+                  valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+                  valueCall.code shouldBe "((Box) o).value()"
+                  valueCall.typeFullName shouldBe "java.lang.Object"
+
+                  inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                    castExpr.name shouldBe Operators.cast
+                    castExpr.methodFullName shouldBe Operators.cast
+                    castExpr.typeFullName shouldBe "box.Box"
+                    inside(castExpr.argument.l) { case List(castBoxType: TypeRef, castOIdentifier: Identifier) =>
+                      castBoxType.typeFullName shouldBe "box.Box"
+                      castBoxType.code shouldBe "Box"
+
+                      castOIdentifier.name shouldBe "o"
+                      castOIdentifier.typeFullName shouldBe "java.lang.Object"
+                      castOIdentifier.code shouldBe "o"
+                      castOIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                    }
                   }
                 }
 
@@ -1423,7 +1464,7 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         }
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the variable assignment" in {
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
           case List(sLocal: Local, sAssignment: Call, _: Call) =>
             sLocal.name shouldBe "s"
@@ -1433,41 +1474,26 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
             sAssignment.name shouldBe Operators.assignment
             sAssignment.methodFullName shouldBe Operators.assignment
             sAssignment.typeFullName shouldBe "java.lang.String"
-            sAssignment.code shouldBe "s = (String) ((Box) o).value()"
+            sAssignment.code shouldBe "s = (String) $obj0"
 
-            inside(sAssignment.argument.l) { case List(stringCast: Call) =>
+            inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, stringCast: Call) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.refsTo.l shouldBe List(sLocal)
+
               stringCast.name shouldBe Operators.cast
               stringCast.methodFullName shouldBe Operators.cast
               stringCast.typeFullName shouldBe "java.lang.String"
-              stringCast.code shouldBe "(String) ((Box) o).value()"
+              stringCast.code shouldBe "(String) $obj0"
 
-              inside(stringCast.argument.l) { case List(sIdentifier: Identifier, valueCall: Call) =>
-                sIdentifier.name shouldBe "s"
-                sIdentifier.typeFullName shouldBe "java.lang.String"
-                sIdentifier.code shouldBe "s"
-                sIdentifier.refsTo.l shouldBe List(sLocal)
+              inside(stringCast.argument.l) { case List(stringType: TypeRef, tmpIdentifier0: Identifier) =>
+                stringType.typeFullName shouldBe "java.lang.String"
 
-                valueCall.name shouldBe "value"
-                valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
-                valueCall.typeFullName shouldBe "java.lang.Object"
-                valueCall.code shouldBe "((Box) o).value()"
-
-                inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                  castExpr.name shouldBe Operators.cast
-                  castExpr.methodFullName shouldBe Operators.cast
-                  castExpr.typeFullName shouldBe "box.Box"
-                  castExpr.code shouldBe "(Box) o"
-
-                  inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                    boxType.typeFullName shouldBe "box.Box"
-                    boxType.code shouldBe "Box"
-
-                    oIdentifier.name shouldBe "o"
-                    oIdentifier.typeFullName shouldBe "java.lang.Object"
-                    oIdentifier.code shouldBe "o"
-                    oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
-                  }
-                }
+                tmpIdentifier0.name shouldBe "$obj0"
+                tmpIdentifier0.code shouldBe "$obj0"
+                tmpIdentifier0.typeFullName shouldBe "java.lang.Object"
+                tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
               }
             }
         }
@@ -1484,7 +1510,7 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
                          |
                          |class Foo {
                          |  void foo(Object o) {
-                         |    if (o instanceof PairBox(Pair (String s, Integer i))) {
+                         |    if (o instanceof PairBox(Pair(String s, Integer i))) {
                          |      sink(s);
                          |      sink(i);
                          |    }
@@ -1496,121 +1522,202 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         cpg.call.name("sink").isEmpty shouldBe false
       }
 
-      "have the correct lowering for the type check" ignore {
-        // In this case it is only necessary to check o instanceof PairBox since it is assumed the code compiles
+      "have the correct lowering for the type check" in {
+        val oParameter = cpg.method.name("foo").parameter.name("o").l
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
-          case List(instanceOfCall: Call) =>
-            instanceOfCall.name shouldBe Operators.instanceOf
-            instanceOfCall.typeFullName shouldBe "boolean"
-            instanceOfCall.code shouldBe "o instanceof PairBox"
+          case List(firstAnd: Call) =>
+            firstAnd.name shouldBe Operators.logicalAnd
+            firstAnd.methodFullName shouldBe Operators.logicalAnd
+            firstAnd.typeFullName shouldBe "boolean"
+            firstAnd.code shouldBe "(o instanceof PairBox) && ((($obj0 = ((PairBox) o).value()) instanceof Pair) && ((($obj2 = $obj0.first()) instanceof String) && (($obj1 = $obj0.second()) instanceof Integer)))"
 
-            inside(instanceOfCall.argument.l) { case List(oIdentifier: Identifier, pairBoxType: TypeRef) =>
-              oIdentifier.name shouldBe "o"
-              oIdentifier.typeFullName shouldBe "java.lang.Object"
-              oIdentifier.code shouldBe "o"
+            inside(firstAnd.argument.l) { case List(oInstanceOfPairBox: Call, secondAnd: Call) =>
+              oInstanceOfPairBox.name shouldBe Operators.instanceOf
+              oInstanceOfPairBox.methodFullName shouldBe Operators.instanceOf
+              oInstanceOfPairBox.typeFullName shouldBe "boolean"
+              oInstanceOfPairBox.code shouldBe "o instanceof PairBox"
 
-              pairBoxType.typeFullName shouldBe "java.lang.String"
-              pairBoxType.code shouldBe "String"
+              inside(oInstanceOfPairBox.argument.l) { case List(oIdentifier: Identifier, pairBoxType: TypeRef) =>
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l shouldBe oParameter
+
+                pairBoxType.typeFullName shouldBe "box.PairBox"
+                pairBoxType.code shouldBe "PairBox"
+              }
+
+              secondAnd.name shouldBe Operators.logicalAnd
+              secondAnd.methodFullName shouldBe Operators.logicalAnd
+              secondAnd.typeFullName shouldBe "boolean"
+              secondAnd.code shouldBe "(($obj0 = ((PairBox) o).value()) instanceof Pair) && ((($obj2 = $obj0.first()) instanceof String) && (($obj1 = $obj0.second()) instanceof Integer))"
+
+              inside(secondAnd.argument.l) { case List(oValueInstanceOfPair: Call, thirdAnd: Call) =>
+                oValueInstanceOfPair.name shouldBe Operators.instanceOf
+                oValueInstanceOfPair.methodFullName shouldBe Operators.instanceOf
+                oValueInstanceOfPair.typeFullName shouldBe "boolean"
+                oValueInstanceOfPair.code shouldBe "($obj0 = ((PairBox) o).value()) instanceof Pair"
+
+                inside(oValueInstanceOfPair.argument.l) { case List(valueAssignment: Call, pairType: TypeRef) =>
+                  valueAssignment.name shouldBe Operators.assignment
+                  valueAssignment.typeFullName shouldBe "box.Pair"
+                  valueAssignment.code shouldBe "$obj0 = ((PairBox) o).value()"
+
+                  inside(valueAssignment.argument.l) { case List(tmpIdentifier0: Identifier, valueCall: Call) =>
+                    tmpIdentifier0.name shouldBe "$obj0"
+                    tmpIdentifier0.code shouldBe "$obj0"
+                    tmpIdentifier0.typeFullName shouldBe "box.Pair"
+                    tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+
+                    valueCall.name shouldBe "value"
+                    valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
+                    valueCall.signature shouldBe "box.Pair()"
+                    valueCall.code shouldBe "((PairBox) o).value()"
+
+                    inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                      castExpr.name shouldBe Operators.cast
+                      castExpr.methodFullName shouldBe Operators.cast
+                      castExpr.typeFullName shouldBe "box.PairBox"
+                      castExpr.code shouldBe "(PairBox) o"
+
+                      inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
+                        pairBoxType.typeFullName shouldBe "box.PairBox"
+                        pairBoxType.code shouldBe "PairBox"
+
+                        oIdentifier.name shouldBe "o"
+                        oIdentifier.code shouldBe "o"
+                        oIdentifier.typeFullName shouldBe "java.lang.Object"
+                        oIdentifier.refsTo.l shouldBe oParameter
+                      }
+                    }
+                  }
+
+                  pairType.typeFullName shouldBe "box.Pair"
+                  pairType.code shouldBe "Pair"
+                }
+
+                thirdAnd.name shouldBe Operators.logicalAnd
+                thirdAnd.methodFullName shouldBe Operators.logicalAnd
+                thirdAnd.typeFullName shouldBe "boolean"
+                thirdAnd.code shouldBe "(($obj2 = $obj0.first()) instanceof String) && (($obj1 = $obj0.second()) instanceof Integer)"
+
+                inside(thirdAnd.argument.l) { case List(firstInstanceOfString: Call, secondInstanceOfInteger: Call) =>
+                  firstInstanceOfString.name shouldBe Operators.instanceOf
+                  firstInstanceOfString.methodFullName shouldBe Operators.instanceOf
+                  firstInstanceOfString.typeFullName shouldBe "boolean"
+                  firstInstanceOfString.code shouldBe "($obj2 = $obj0.first()) instanceof String"
+
+                  inside(firstInstanceOfString.argument.l) { case List(tmp2Assign: Call, stringType: TypeRef) =>
+                    tmp2Assign.name shouldBe Operators.assignment
+                    tmp2Assign.methodFullName shouldBe Operators.assignment
+                    tmp2Assign.code shouldBe "$obj2 = $obj0.first()"
+                    tmp2Assign.typeFullName shouldBe "java.lang.String"
+
+                    inside(tmp2Assign.argument.l) { case List(tmpIdentifier2: Identifier, firstCall: Call) =>
+                      tmpIdentifier2.name shouldBe "$obj2"
+                      tmpIdentifier2.code shouldBe "$obj2"
+                      tmpIdentifier2.typeFullName shouldBe "java.lang.String"
+                      tmpIdentifier2.refsTo.l shouldBe cpg.local.nameExact("$obj2").l
+
+                      firstCall.name shouldBe "first"
+                      firstCall.methodFullName shouldBe "box.Pair.first:java.lang.String()"
+                      firstCall.typeFullName shouldBe "java.lang.String"
+                      firstCall.code shouldBe "$obj0.first()"
+
+                      inside(firstCall.argument.l) { case List(tmpIdentifier0: Identifier) =>
+                        tmpIdentifier0.name shouldBe "$obj0"
+                        tmpIdentifier0.code shouldBe "$obj0"
+                        tmpIdentifier0.typeFullName shouldBe "box.Pair"
+                        tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+                      }
+                    }
+
+                    stringType.typeFullName shouldBe "java.lang.String"
+                    stringType.code shouldBe "String"
+                  }
+
+                  secondInstanceOfInteger.name shouldBe Operators.instanceOf
+                  secondInstanceOfInteger.methodFullName shouldBe Operators.instanceOf
+                  secondInstanceOfInteger.typeFullName shouldBe "boolean"
+                  secondInstanceOfInteger.code shouldBe "($obj1 = $obj0.second()) instanceof Integer"
+
+                  inside(secondInstanceOfInteger.argument.l) { case List(tmp1Assign: Call, integerType: TypeRef) =>
+                    tmp1Assign.name shouldBe Operators.assignment
+                    tmp1Assign.methodFullName shouldBe Operators.assignment
+                    tmp1Assign.code shouldBe "$obj1 = $obj0.second()"
+                    tmp1Assign.typeFullName shouldBe "java.lang.Integer"
+
+                    inside(tmp1Assign.argument.l) { case List(tmpIdentifier1: Identifier, secondCall: Call) =>
+                      tmpIdentifier1.name shouldBe "$obj1"
+                      tmpIdentifier1.code shouldBe "$obj1"
+                      tmpIdentifier1.typeFullName shouldBe "java.lang.Integer"
+                      tmpIdentifier1.refsTo.l shouldBe cpg.local.nameExact("$obj1").l
+
+                      secondCall.name shouldBe "second"
+                      secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Integer()"
+                      secondCall.typeFullName shouldBe "java.lang.Integer"
+                      secondCall.code shouldBe "$obj0.second()"
+
+                      inside(secondCall.argument.l) { case List(tmpIdentifier0: Identifier) =>
+                        tmpIdentifier0.name shouldBe "$obj0"
+                        tmpIdentifier0.code shouldBe "$obj0"
+                        tmpIdentifier0.typeFullName shouldBe "box.Pair"
+                        tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+                      }
+                    }
+                    integerType.typeFullName shouldBe "java.lang.Integer"
+                    integerType.code shouldBe "Integer"
+                  }
+                }
+              }
             }
         }
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the variable assignment" in {
         val oParameter = cpg.method.name("foo").parameter.name("o").l
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
-          case List(sLocal: Local, iLocal: Local, sAssign: Call, iAssign: Call, sSink: Call, iSink: Call) =>
+          case List(sLocal: Local, sAssign: Call, iLocal: Local, iAssign: Call, sSink: Call, iSink: Call) =>
             sLocal.name shouldBe "s"
-            sLocal.code shouldBe "s"
+            sLocal.code shouldBe "String s"
             sLocal.typeFullName shouldBe "java.lang.String"
 
             iLocal.name shouldBe "i"
-            iLocal.code shouldBe "i"
+            iLocal.code shouldBe "Integer i"
             iLocal.typeFullName shouldBe "java.lang.Integer"
 
             sAssign.name shouldBe Operators.assignment
             sAssign.methodFullName shouldBe Operators.assignment
             sAssign.typeFullName shouldBe "java.lang.String"
-            sAssign.code shouldBe "s = ((PairBox) o).value().first()"
+            sAssign.code shouldBe "s = $obj2"
 
-            inside(sAssign.argument.l) { case List(sIdentifier: Identifier, firstCall: Call) =>
+            inside(sAssign.argument.l) { case List(sIdentifier: Identifier, tmpIdentifier2: Identifier) =>
               sIdentifier.name shouldBe "s"
               sIdentifier.code shouldBe "s"
               sIdentifier.typeFullName shouldBe "java.lang.String"
               sIdentifier.refsTo.l shouldBe List(sLocal)
 
-              firstCall.name shouldBe "first"
-              firstCall.methodFullName shouldBe "box.Pair.first:java.lang.String()"
-              firstCall.signature shouldBe "java.lang.String()"
-              firstCall.typeFullName shouldBe "java.lang.String"
-              firstCall.code shouldBe "((PairBox) o).value().first()"
-
-              inside(firstCall.argument.l) { case List(valueCall: Call) =>
-                valueCall.name shouldBe "value"
-                valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
-                valueCall.signature shouldBe "box.Pair()"
-                valueCall.typeFullName shouldBe "box.Pair"
-                valueCall.code shouldBe "((PairBox) o).value()"
-
-                inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                  castExpr.name shouldBe Operators.cast
-                  castExpr.methodFullName shouldBe Operators.cast
-                  castExpr.typeFullName shouldBe "box.PairBox"
-                  castExpr.code shouldBe "(PairBox) o"
-
-                  inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
-                    pairBoxType.typeFullName shouldBe "box.PairBox"
-                    pairBoxType.code shouldBe "PairBox"
-
-                    oIdentifier.name shouldBe "o"
-                    oIdentifier.code shouldBe "o"
-                    oIdentifier.typeFullName shouldBe "java.lang.Object"
-                    oIdentifier.refsTo.l shouldBe oParameter
-                  }
-                }
-              }
+              tmpIdentifier2.name shouldBe "$obj2"
+              tmpIdentifier2.code shouldBe "$obj2"
+              tmpIdentifier2.typeFullName shouldBe "java.lang.String"
+              tmpIdentifier2.refsTo.l shouldBe cpg.method("foo").local.nameExact("$obj2").l
             }
 
             iAssign.name shouldBe Operators.assignment
             iAssign.methodFullName shouldBe Operators.assignment
             iAssign.typeFullName shouldBe "java.lang.Integer"
-            iAssign.code shouldBe "i = ((PairBox) o).value().second()"
+            iAssign.code shouldBe "i = $obj1"
 
-            inside(iAssign.argument.l) { case List(iIdentifier: Identifier, secondCall: Call) =>
+            inside(iAssign.argument.l) { case List(iIdentifier: Identifier, tmpIdentifier1: Identifier) =>
               iIdentifier.name shouldBe "i"
               iIdentifier.code shouldBe "i"
               iIdentifier.typeFullName shouldBe "java.lang.Integer"
               iIdentifier.refsTo.l shouldBe List(iLocal)
 
-              secondCall.name shouldBe "second"
-              secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Integer()"
-              secondCall.signature shouldBe "java.lang.Integer()"
-              secondCall.typeFullName shouldBe "java.lang.Integer"
-              secondCall.code shouldBe "((PairBox) o).value().second()"
-
-              inside(secondCall.argument.l) { case List(valueCall: Call) =>
-                valueCall.name shouldBe "value"
-                valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
-                valueCall.signature shouldBe "box.Pair()"
-                valueCall.typeFullName shouldBe "box.Pair()"
-                valueCall.code shouldBe "((PairBox) o).value()"
-
-                inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                  castExpr.name shouldBe Operators.cast
-                  castExpr.methodFullName shouldBe Operators.cast
-                  castExpr.typeFullName shouldBe "box.PairBox"
-                  castExpr.code shouldBe "(PairBox) o"
-
-                  inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
-                    pairBoxType.typeFullName shouldBe "box.PairBox"
-                    pairBoxType.code shouldBe "PairBox"
-
-                    oIdentifier.name shouldBe "o"
-                    oIdentifier.code shouldBe "o"
-                    oIdentifier.typeFullName shouldBe "java.lang.Object"
-                    oIdentifier.refsTo.l shouldBe oParameter
-                  }
-                }
-              }
+              tmpIdentifier1.name shouldBe "$obj1"
+              tmpIdentifier1.code shouldBe "$obj1"
+              tmpIdentifier1.typeFullName shouldBe "java.lang.Integer"
+              tmpIdentifier1.refsTo.l shouldBe cpg.method("foo").local.nameExact("$obj1").l
             }
 
             inside(sSink.argument.isIdentifier.name("s").l) { case List(sIdentifier: Identifier) =>
@@ -1652,20 +1759,20 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         cpg.call.name("sink").isEmpty shouldBe false
       }
 
-      "have the correct lowering for the type check" ignore {
+      "have the correct lowering for the type check" in {
         val oParameter = cpg.method.name("foo").parameter.name("o").l
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
           case List(firstAnd: Call) =>
             firstAnd.name shouldBe Operators.logicalAnd
             firstAnd.methodFullName shouldBe Operators.logicalAnd
             firstAnd.typeFullName shouldBe "boolean"
-            firstAnd.code shouldBe "o instanceof Box(Pair(String s, Integer i)) && (((Box) o).value() instanceof Pair && (((Pair) ((Box) o).value()).first() instanceof String && ((Pair) ((Box) o).value()).second() instanceof Integer))"
+            firstAnd.code shouldBe "(o instanceof Box) && ((($obj0 = ((Box) o).value()) instanceof Pair) && ((($obj2 = ((Pair) $obj0).first()) instanceof String) && (($obj1 = ((Pair) $obj0).second()) instanceof Integer)))"
 
             inside(firstAnd.argument.l) { case List(oInstanceOfBox: Call, secondAnd: Call) =>
               oInstanceOfBox.name shouldBe Operators.instanceOf
               oInstanceOfBox.methodFullName shouldBe Operators.instanceOf
               oInstanceOfBox.typeFullName shouldBe "boolean"
-              oInstanceOfBox.code shouldBe "o instanceof Box(Pair(String s, Integer i))"
+              oInstanceOfBox.code shouldBe "o instanceof Box"
 
               inside(oInstanceOfBox.argument.l) { case List(oIdentifier: Identifier, boxType: TypeRef) =>
                 oIdentifier.name shouldBe "o"
@@ -1680,34 +1787,36 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
               secondAnd.name shouldBe Operators.logicalAnd
               secondAnd.methodFullName shouldBe Operators.logicalAnd
               secondAnd.typeFullName shouldBe "boolean"
-              secondAnd.code shouldBe "((Box) o).value() instanceof Pair && (((Pair) ((Box) o).value()).first() instanceof String && ((Pair) ((Box) o).value()).second() instanceof Integer)"
+              secondAnd.code shouldBe "(($obj0 = ((Box) o).value()) instanceof Pair) && ((($obj2 = ((Pair) $obj0).first()) instanceof String) && (($obj1 = ((Pair) $obj0).second()) instanceof Integer))"
 
               inside(secondAnd.argument.l) { case List(oValueInstanceOfPair: Call, thirdAnd: Call) =>
                 oValueInstanceOfPair.name shouldBe Operators.instanceOf
                 oValueInstanceOfPair.methodFullName shouldBe Operators.instanceOf
                 oValueInstanceOfPair.typeFullName shouldBe "boolean"
-                oValueInstanceOfPair.code shouldBe "((Box) o).value() instanceof Pair"
+                oValueInstanceOfPair.code shouldBe "($obj0 = ((Box) o).value()) instanceof Pair"
 
-                inside(oValueInstanceOfPair.argument.l) { case List(valueCall: Call, pairType: TypeRef) =>
-                  valueCall.name shouldBe "value"
-                  valueCall.methodFullName shouldBe "box.Box.value:box.Pair()"
-                  valueCall.signature shouldBe "box.Pair()"
-                  valueCall.code shouldBe "((Box) o).value()"
+                inside(oValueInstanceOfPair.argument.l) { case List(tmpAssignment: Call, pairType: TypeRef) =>
+                  inside(tmpAssignment.argument.l) { case List(tmpIdentifier0: Identifier, valueCall: Call) =>
+                    valueCall.name shouldBe "value"
+                    valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+                    valueCall.signature shouldBe "java.lang.Object()"
+                    valueCall.code shouldBe "((Box) o).value()"
 
-                  inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                    castExpr.name shouldBe Operators.cast
-                    castExpr.methodFullName shouldBe Operators.cast
-                    castExpr.typeFullName shouldBe "box.Box"
-                    castExpr.code shouldBe "(Box) o"
+                    inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                      castExpr.name shouldBe Operators.cast
+                      castExpr.methodFullName shouldBe Operators.cast
+                      castExpr.typeFullName shouldBe "box.Box"
+                      castExpr.code shouldBe "(Box) o"
 
-                    inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                      boxType.typeFullName shouldBe "box.Box"
-                      boxType.code shouldBe "Box"
+                      inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                        boxType.typeFullName shouldBe "box.Box"
+                        boxType.code shouldBe "Box"
 
-                      oIdentifier.name shouldBe "o"
-                      oIdentifier.code shouldBe "o"
-                      oIdentifier.typeFullName shouldBe "java.lang.Object"
-                      oIdentifier.refsTo.l shouldBe oParameter
+                        oIdentifier.name shouldBe "o"
+                        oIdentifier.code shouldBe "o"
+                        oIdentifier.typeFullName shouldBe "java.lang.Object"
+                        oIdentifier.refsTo.l shouldBe oParameter
+                      }
                     }
                   }
 
@@ -1718,50 +1827,44 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
                 thirdAnd.name shouldBe Operators.logicalAnd
                 thirdAnd.methodFullName shouldBe Operators.logicalAnd
                 thirdAnd.typeFullName shouldBe "boolean"
-                thirdAnd.code shouldBe "((Pair) ((Box) o).value()).first() instanceof String && ((Pair) ((Box) o).value()).second() instanceof Integer"
+                thirdAnd.code shouldBe "(($obj2 = ((Pair) $obj0).first()) instanceof String) && (($obj1 = ((Pair) $obj0).second()) instanceof Integer)"
 
                 inside(thirdAnd.argument.l) { case List(firstInstanceOfString: Call, secondInstanceOfInteger: Call) =>
                   firstInstanceOfString.name shouldBe Operators.instanceOf
                   firstInstanceOfString.methodFullName shouldBe Operators.instanceOf
                   firstInstanceOfString.typeFullName shouldBe "boolean"
-                  firstInstanceOfString.code shouldBe "((Pair) ((Box) o).value()).first() instanceof String"
+                  firstInstanceOfString.code shouldBe "($obj2 = ((Pair) $obj0).first()) instanceof String"
 
-                  inside(firstInstanceOfString.argument.l) { case List(firstCall: Call, stringType: TypeRef) =>
-                    firstCall.name shouldBe "first"
-                    firstCall.methodFullName shouldBe "box.Pair.first:java.lang.String()"
-                    firstCall.typeFullName shouldBe "java.lang.String"
-                    firstCall.code shouldBe "((Pair) ((Box) o).value()).first()"
+                  inside(firstInstanceOfString.argument.l) { case List(tmp2Assign: Call, stringType: TypeRef) =>
+                    tmp2Assign.name shouldBe Operators.assignment
+                    tmp2Assign.methodFullName shouldBe Operators.assignment
+                    tmp2Assign.code shouldBe "$obj2 = ((Pair) $obj0).first()"
+                    tmp2Assign.typeFullName shouldBe "java.lang.Object"
 
-                    inside(firstCall.argument.l) { case List(pairCast: Call) =>
-                      pairCast.name shouldBe Operators.cast
-                      pairCast.methodFullName shouldBe Operators.cast
-                      pairCast.typeFullName shouldBe "box.Pair"
-                      pairCast.code shouldBe "(Pair) ((Box) o).value()"
+                    inside(tmp2Assign.argument.l) { case List(tmpIdentifier2: Identifier, firstCall: Call) =>
+                      tmpIdentifier2.name shouldBe "$obj2"
+                      tmpIdentifier2.code shouldBe "$obj2"
+                      tmpIdentifier2.typeFullName shouldBe "java.lang.Object"
+                      tmpIdentifier2.refsTo.l shouldBe cpg.local.nameExact("$obj2").l
 
-                      inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
-                        pairType.typeFullName shouldBe "box.Pair"
-                        pairType.code shouldBe "Pair"
+                      firstCall.name shouldBe "first"
+                      firstCall.methodFullName shouldBe "box.Pair.first:java.lang.Object()"
+                      firstCall.typeFullName shouldBe "java.lang.Object"
+                      firstCall.code shouldBe "((Pair) $obj0).first()"
 
-                        valueCall.name shouldBe "value"
-                        valueCall.methodFullName shouldBe "box.Box.value:box.Pair()"
-                        valueCall.typeFullName shouldBe "box.Pair"
-                        valueCall.code shouldBe "((Box) o).value()"
+                      inside(firstCall.argument.l) { case List(pairCast: Call) =>
+                        pairCast.name shouldBe Operators.cast
+                        pairCast.methodFullName shouldBe Operators.cast
+                        pairCast.typeFullName shouldBe "box.Pair"
+                        pairCast.code shouldBe "(Pair) $obj0"
 
-                        inside(valueCall.argument.l) { case List(boxCast: Call) =>
-                          boxCast.name shouldBe Operators.cast
-                          boxCast.methodFullName shouldBe Operators.cast
-                          boxCast.typeFullName shouldBe "box.Box"
-                          boxCast.code shouldBe "(Box) o"
+                        inside(pairCast.argument.l) { case List(pairType: TypeRef, tmpIdentifier0: Identifier) =>
+                          pairType.typeFullName shouldBe "box.Pair"
 
-                          inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                            boxType.typeFullName shouldBe "box.Box"
-                            boxType.code shouldBe "Box"
-
-                            oIdentifier.name shouldBe "o"
-                            oIdentifier.code shouldBe "o"
-                            oIdentifier.typeFullName shouldBe "java.lang.Object"
-                            oIdentifier.refsTo.l shouldBe oParameter
-                          }
+                          tmpIdentifier0.name shouldBe "$obj0"
+                          tmpIdentifier0.code shouldBe "$obj0"
+                          tmpIdentifier0.typeFullName shouldBe "java.lang.Object"
+                          tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
                         }
                       }
                     }
@@ -1773,44 +1876,39 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
                   secondInstanceOfInteger.name shouldBe Operators.instanceOf
                   secondInstanceOfInteger.methodFullName shouldBe Operators.instanceOf
                   secondInstanceOfInteger.typeFullName shouldBe "boolean"
-                  secondInstanceOfInteger.code shouldBe "((Pair) ((Box) o).value()).second() instanceof Integer"
+                  secondInstanceOfInteger.code shouldBe "($obj1 = ((Pair) $obj0).second()) instanceof Integer"
 
-                  inside(secondInstanceOfInteger.argument.l) { case List(secondCall: Call, integerType: TypeRef) =>
-                    secondCall.name shouldBe "second"
-                    secondCall.methodFullName shouldBe "box.Pair.second:java.lang.String()"
-                    secondCall.typeFullName shouldBe "java.lang.Integer"
-                    secondCall.code shouldBe "((Pair) ((Box) o).value()).second()"
+                  inside(secondInstanceOfInteger.argument.l) { case List(tmp1Assign: Call, integerType: TypeRef) =>
+                    tmp1Assign.name shouldBe Operators.assignment
+                    tmp1Assign.methodFullName shouldBe Operators.assignment
+                    tmp1Assign.code shouldBe "$obj1 = ((Pair) $obj0).second()"
+                    tmp1Assign.typeFullName shouldBe "java.lang.Object"
 
-                    inside(secondCall.argument.l) { case List(pairCast: Call) =>
-                      pairCast.name shouldBe Operators.cast
-                      pairCast.methodFullName shouldBe Operators.cast
-                      pairCast.typeFullName shouldBe "box.Pair"
-                      pairCast.code shouldBe "(Pair) ((Box) o).value()"
+                    inside(tmp1Assign.argument.l) { case List(tmpIdentifier1: Identifier, secondCall: Call) =>
+                      tmpIdentifier1.name shouldBe "$obj1"
+                      tmpIdentifier1.code shouldBe "$obj1"
+                      tmpIdentifier1.typeFullName shouldBe "java.lang.Object"
+                      tmpIdentifier1.refsTo.l shouldBe cpg.local.nameExact("$obj1").l
 
-                      inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
-                        pairType.typeFullName shouldBe "box.Pair"
-                        pairType.code shouldBe "Pair"
+                      secondCall.name shouldBe "second"
+                      secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Object()"
+                      secondCall.typeFullName shouldBe "java.lang.Object"
+                      secondCall.code shouldBe "((Pair) $obj0).second()"
 
-                        valueCall.name shouldBe "value"
-                        valueCall.methodFullName shouldBe "box.Box.value:box.Pair()"
-                        valueCall.typeFullName shouldBe "box.Pair"
-                        valueCall.code shouldBe "((Box) o).value()"
+                      inside(secondCall.argument.l) { case List(pairCast: Call) =>
+                        pairCast.name shouldBe Operators.cast
+                        pairCast.methodFullName shouldBe Operators.cast
+                        pairCast.typeFullName shouldBe "box.Pair"
+                        pairCast.code shouldBe "(Pair) $obj0"
 
-                        inside(valueCall.argument.l) { case List(boxCast: Call) =>
-                          boxCast.name shouldBe Operators.cast
-                          boxCast.methodFullName shouldBe Operators.cast
-                          boxCast.typeFullName shouldBe "box.Box"
-                          boxCast.code shouldBe "(Box) o"
+                        inside(pairCast.argument.l) { case List(pairType: TypeRef, tmpIdentifier0: Identifier) =>
+                          pairType.typeFullName shouldBe "box.Pair"
+                          pairType.code shouldBe "Pair"
 
-                          inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                            boxType.typeFullName shouldBe "box.Box"
-                            boxType.code shouldBe "Box"
-
-                            oIdentifier.name shouldBe "o"
-                            oIdentifier.code shouldBe "o"
-                            oIdentifier.typeFullName shouldBe "java.lang.Object"
-                            oIdentifier.refsTo.l shouldBe oParameter
-                          }
+                          tmpIdentifier0.name shouldBe "$obj0"
+                          tmpIdentifier0.code shouldBe "$obj0"
+                          tmpIdentifier0.typeFullName shouldBe "java.lang.Object"
+                          tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
                         }
                       }
                     }
@@ -1823,22 +1921,22 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         }
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the variable assignment" in {
         val oParameter = cpg.method.name("foo").parameter.name("o").l
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
-          case List(sLocal: Local, iLocal: Local, sAssign: Call, iAssign: Call, sSink: Call, iSink: Call) =>
+          case List(sLocal: Local, sAssign: Call, iLocal: Local, iAssign: Call, sSink: Call, iSink: Call) =>
             sLocal.name shouldBe "s"
-            sLocal.code shouldBe "s"
+            sLocal.code shouldBe "String s"
             sLocal.typeFullName shouldBe "java.lang.String"
 
             iLocal.name shouldBe "i"
-            iLocal.code shouldBe "i"
+            iLocal.code shouldBe "Integer i"
             iLocal.typeFullName shouldBe "java.lang.Integer"
 
             sAssign.name shouldBe Operators.assignment
             sAssign.methodFullName shouldBe Operators.assignment
             sAssign.typeFullName shouldBe "java.lang.String"
-            sAssign.code shouldBe "s = (String) ((Pair) ((Box) o).value()).first()"
+            sAssign.code shouldBe "s = (String) $obj2"
 
             inside(sAssign.argument.l) { case List(sIdentifier: Identifier, stringCast: Call) =>
               sIdentifier.name shouldBe "s"
@@ -1849,116 +1947,42 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
               stringCast.name shouldBe Operators.cast
               stringCast.methodFullName shouldBe Operators.cast
               stringCast.typeFullName shouldBe "java.lang.String"
-              stringCast.code shouldBe "(String) ((Pair) ((Box) o).value()).first()"
+              stringCast.code shouldBe "(String) $obj2"
 
-              inside(stringCast.argument.l) { case List(stringType: TypeRef, firstCall: Call) =>
+              inside(stringCast.argument.l) { case List(stringType: TypeRef, tmpIdentifier2: Identifier) =>
                 stringType.typeFullName shouldBe "java.lang.String"
                 stringType.code shouldBe "String"
 
-                firstCall.name shouldBe "first"
-                firstCall.methodFullName shouldBe "box.Pair.first:java.lang.Object()"
-                firstCall.signature shouldBe "java.lang.Object()"
-                // TODO: Should this be the erased type?
-                firstCall.typeFullName shouldBe "java.lang.Object"
-                firstCall.code shouldBe "((Pair) ((Box) o).value()).first()"
-
-                inside(firstCall.argument.l) { case List(pairCast: Call) =>
-                  pairCast.name shouldBe Operators.cast
-                  pairCast.methodFullName shouldBe Operators.cast
-                  pairCast.typeFullName shouldBe "box.Pair"
-                  pairCast.code shouldBe "(Pair) ((Box) o).value()"
-
-                  inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
-                    pairType.typeFullName shouldBe "box.Pair"
-                    pairType.code shouldBe "Pair"
-
-                    valueCall.name shouldBe "value"
-                    valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
-                    valueCall.signature shouldBe "java.lang.Object()"
-                    valueCall.typeFullName shouldBe "java.lang.Object"
-                    valueCall.code shouldBe "((Box) o).value()"
-
-                    inside(valueCall.argument.l) { case List(boxCast: Call) =>
-                      boxCast.name shouldBe Operators.cast
-                      boxCast.methodFullName shouldBe Operators.cast
-                      boxCast.typeFullName shouldBe "box.Box"
-                      boxCast.code shouldBe "(Box) o"
-
-                      inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                        boxType.typeFullName shouldBe "box.Box"
-                        boxType.code shouldBe "Box"
-
-                        oIdentifier.name shouldBe "o"
-                        oIdentifier.code shouldBe "o"
-                        oIdentifier.typeFullName shouldBe "java.lang.Object"
-                        oIdentifier.refsTo.l shouldBe oParameter
-                      }
-                    }
-                  }
-                }
+                tmpIdentifier2.name shouldBe "$obj2"
+                tmpIdentifier2.code shouldBe "$obj2"
+                tmpIdentifier2.typeFullName shouldBe "java.lang.Object"
+                tmpIdentifier2.refsTo.l shouldBe cpg.local.nameExact("$obj2").l
               }
-            }
 
-            iAssign.name shouldBe Operators.assignment
-            iAssign.methodFullName shouldBe Operators.assignment
-            iAssign.typeFullName shouldBe "java.lang.Integer"
-            iAssign.code shouldBe "i = (Integer) ((Pair) ((Box) o).value()).second()"
+              iAssign.name shouldBe Operators.assignment
+              iAssign.methodFullName shouldBe Operators.assignment
+              iAssign.typeFullName shouldBe "java.lang.Integer"
+              iAssign.code shouldBe "i = (Integer) $obj1"
 
-            inside(iAssign.argument.l) { case List(iIdentifier: Identifier, integerCast: Call) =>
-              iIdentifier.name shouldBe "i"
-              iIdentifier.code shouldBe "i"
-              iIdentifier.typeFullName shouldBe "java.lang.Integer"
-              iIdentifier.refsTo.l shouldBe List(iLocal)
+              inside(iAssign.argument.l) { case List(iIdentifier: Identifier, integerCast: Call) =>
+                iIdentifier.name shouldBe "i"
+                iIdentifier.code shouldBe "i"
+                iIdentifier.typeFullName shouldBe "java.lang.Integer"
+                iIdentifier.refsTo.l shouldBe List(iLocal)
 
-              integerCast.name shouldBe Operators.cast
-              integerCast.methodFullName shouldBe Operators.cast
-              integerCast.typeFullName shouldBe "java.lang.Integer"
-              integerCast.code shouldBe "(Integer) ((Pair) ((Box) o).value()).second()"
+                integerCast.name shouldBe Operators.cast
+                integerCast.methodFullName shouldBe Operators.cast
+                integerCast.typeFullName shouldBe "java.lang.Integer"
+                integerCast.code shouldBe "(Integer) $obj1"
 
-              inside(integerCast.argument.l) { case List(integerType: TypeRef, secondCall: Call) =>
-                integerType.typeFullName shouldBe "java.lang.Integer"
-                integerType.code shouldBe "Integer"
+                inside(integerCast.argument.l) { case List(integerType: TypeRef, tmpIdentifier1: Identifier) =>
+                  integerType.typeFullName shouldBe "java.lang.Integer"
+                  integerType.code shouldBe "Integer"
 
-                secondCall.name shouldBe "second"
-                secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Object()"
-                secondCall.signature shouldBe "java.lang.Object()"
-                // TODO: Should this be the erased type?
-                secondCall.typeFullName shouldBe "java.lang.Object"
-                secondCall.code shouldBe "((Pair) ((Box) o).value()).second()"
-
-                inside(secondCall.argument.l) { case List(pairCast: Call) =>
-                  pairCast.name shouldBe Operators.cast
-                  pairCast.methodFullName shouldBe Operators.cast
-                  pairCast.typeFullName shouldBe "box.Pair"
-                  pairCast.code shouldBe "(Pair) ((Box) o).value()"
-
-                  inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
-                    pairType.typeFullName shouldBe "box.Pair"
-                    pairType.code shouldBe "Pair"
-
-                    valueCall.name shouldBe "value"
-                    valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
-                    valueCall.signature shouldBe "java.lang.Object()"
-                    valueCall.typeFullName shouldBe "java.lang.Object"
-                    valueCall.code shouldBe "((Box) o).value()"
-
-                    inside(valueCall.argument.l) { case List(boxCast: Call) =>
-                      boxCast.name shouldBe Operators.cast
-                      boxCast.methodFullName shouldBe Operators.cast
-                      boxCast.typeFullName shouldBe "box.Box"
-                      boxCast.code shouldBe "(Box) o"
-
-                      inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                        boxType.typeFullName shouldBe "box.Box"
-                        boxType.code shouldBe "Box"
-
-                        oIdentifier.name shouldBe "o"
-                        oIdentifier.code shouldBe "o"
-                        oIdentifier.typeFullName shouldBe "java.lang.Object"
-                        oIdentifier.refsTo.l shouldBe oParameter
-                      }
-                    }
-                  }
+                  tmpIdentifier1.name shouldBe "$obj1"
+                  tmpIdentifier1.code shouldBe "$obj1"
+                  tmpIdentifier1.typeFullName shouldBe "java.lang.Object"
+                  tmpIdentifier1.refsTo.l shouldBe cpg.local.nameExact("$obj1").l
                 }
               }
             }
@@ -2058,9 +2082,82 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         cpg.call.name("sink").isEmpty shouldBe false
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the type check" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(andCall: Call) =>
+            andCall.name shouldBe Operators.logicalAnd
+            andCall.typeFullName shouldBe "boolean"
+            andCall.code shouldBe "(o instanceof Box) && (($obj0 = ((Box) o).value()) instanceof String)"
+
+            inside(andCall.argument.l) { case List(instanceOfBox: Call, instanceOfString: Call) =>
+              instanceOfBox.name shouldBe Operators.instanceOf
+              instanceOfBox.methodFullName shouldBe Operators.instanceOf
+              instanceOfBox.code shouldBe "o instanceof Box"
+              instanceOfBox.typeFullName shouldBe "boolean"
+
+              inside(instanceOfBox.argument.l) { case List(oIdentifier: Identifier, boxType: TypeRef) =>
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+
+                boxType.typeFullName shouldBe "box.Box"
+                boxType.code shouldBe "Box"
+              }
+
+              instanceOfString.name shouldBe Operators.instanceOf
+              instanceOfString.methodFullName shouldBe Operators.instanceOf
+              instanceOfString.code shouldBe "($obj0 = ((Box) o).value()) instanceof String"
+              instanceOfString.typeFullName shouldBe "boolean"
+
+              inside(instanceOfString.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
+                tmpAssign.name shouldBe Operators.assignment
+                tmpAssign.methodFullName shouldBe Operators.assignment
+                tmpAssign.code shouldBe "$obj0 = ((Box) o).value()"
+                tmpAssign.typeFullName shouldBe "java.lang.String"
+
+                inside(tmpAssign.argument.l) { case List(tmpIdentifier0: Identifier, valueCall: Call) =>
+                  tmpIdentifier0.name shouldBe "$obj0"
+                  tmpIdentifier0.code shouldBe "$obj0"
+                  tmpIdentifier0.typeFullName shouldBe "java.lang.String"
+                  tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+
+                  valueCall.name shouldBe "value"
+                  valueCall.methodFullName shouldBe "box.Box.value:java.lang.String()"
+                  valueCall.typeFullName shouldBe "java.lang.String"
+                  valueCall.code shouldBe "((Box) o).value()"
+
+                  inside(valueCall.argument.l) { case List(boxCast: Call) =>
+                    boxCast.name shouldBe Operators.cast
+                    boxCast.methodFullName shouldBe Operators.cast
+                    boxCast.typeFullName shouldBe "box.Box"
+                    boxCast.code shouldBe "(Box) o"
+
+                    inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
+                      boxType.typeFullName shouldBe "box.Box"
+
+                      oIdentifier.name shouldBe "o"
+                      oIdentifier.code shouldBe "o"
+                      oIdentifier.typeFullName shouldBe "java.lang.Object"
+                      oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                    }
+                  }
+                }
+
+                stringType.typeFullName shouldBe "java.lang.String"
+              }
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" in {
         inside(
-          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
+          cpg.controlStructure
+            .controlStructureType(ControlStructureTypes.IF)
+            .astChildren
+            .isBlock
+            .astChildren
+            .l
         ) { case List(sLocal: Local, sAssignment: Call, _: Call) =>
           sLocal.name shouldBe "s"
           sLocal.typeFullName shouldBe "java.lang.String"
@@ -2069,35 +2166,18 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
           sAssignment.name shouldBe Operators.assignment
           sAssignment.methodFullName shouldBe Operators.assignment
           sAssignment.typeFullName shouldBe "java.lang.String"
-          sAssignment.code shouldBe "s = ((Box) o).value()"
+          sAssignment.code shouldBe "s = $obj0"
 
-          inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, valueCall: Call) =>
+          inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, tmpIdentifier0: Identifier) =>
             sIdentifier.name shouldBe "s"
             sIdentifier.typeFullName shouldBe "java.lang.String"
             sIdentifier.code shouldBe "s"
             sIdentifier.refsTo.l shouldBe List(sLocal)
 
-            valueCall.name shouldBe "value"
-            valueCall.methodFullName shouldBe "box.Box.value:java.lang.String()"
-            valueCall.typeFullName shouldBe "java.lang.String"
-            valueCall.code shouldBe "((Box) o).value()"
-
-            inside(valueCall.argument.l) { case List(castExpr: Call) =>
-              castExpr.name shouldBe Operators.cast
-              castExpr.methodFullName shouldBe Operators.cast
-              castExpr.typeFullName shouldBe "box.Box"
-              castExpr.code shouldBe "(Box) o"
-
-              inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                boxType.typeFullName shouldBe "box.Box"
-                boxType.code shouldBe "Box"
-
-                oIdentifier.name shouldBe "o"
-                oIdentifier.typeFullName shouldBe "java.lang.Object"
-                oIdentifier.code shouldBe "o"
-                oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
-              }
-            }
+            tmpIdentifier0.name shouldBe "$obj0"
+            tmpIdentifier0.code shouldBe "$obj0"
+            tmpIdentifier0.typeFullName shouldBe "java.lang.String"
+            tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
           }
         }
       }
@@ -2123,9 +2203,82 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         cpg.call.name("sink").isEmpty shouldBe false
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the type check" in {
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(andCall: Call) =>
+            andCall.name shouldBe Operators.logicalAnd
+            andCall.methodFullName shouldBe Operators.logicalAnd
+            andCall.code shouldBe "(o instanceof Box) && (($obj0 = ((Box) o).value()) instanceof String)"
+
+            inside(andCall.argument.l) { case List(instanceOfBox: Call, instanceOfString: Call) =>
+              instanceOfBox.name shouldBe Operators.instanceOf
+              instanceOfBox.methodFullName shouldBe Operators.instanceOf
+              instanceOfBox.code shouldBe "o instanceof Box"
+              instanceOfBox.typeFullName shouldBe "boolean"
+
+              inside(instanceOfBox.argument.l) { case List(oIdentifier: Identifier, boxType: TypeRef) =>
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+
+                boxType.typeFullName shouldBe "box.Box"
+                boxType.code shouldBe "Box"
+              }
+
+              instanceOfString.name shouldBe Operators.instanceOf
+              instanceOfString.methodFullName shouldBe Operators.instanceOf
+              instanceOfString.code shouldBe "($obj0 = ((Box) o).value()) instanceof String"
+              instanceOfString.typeFullName shouldBe "boolean"
+
+              inside(instanceOfString.argument.l) { case List(tmpAssign: Call, stringType: TypeRef) =>
+                tmpAssign.name shouldBe Operators.assignment
+                tmpAssign.methodFullName shouldBe Operators.assignment
+                tmpAssign.code shouldBe "$obj0 = ((Box) o).value()"
+                tmpAssign.typeFullName shouldBe "java.lang.Object"
+
+                inside(tmpAssign.argument.l) { case List(tmpIdentifier0: Identifier, valueCall: Call) =>
+                  tmpIdentifier0.name shouldBe "$obj0"
+                  tmpIdentifier0.code shouldBe "$obj0"
+                  tmpIdentifier0.typeFullName shouldBe "java.lang.Object"
+                  tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+
+                  valueCall.name shouldBe "value"
+                  valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
+                  valueCall.code shouldBe "((Box) o).value()"
+                  valueCall.typeFullName shouldBe "java.lang.Object"
+
+                  inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                    castExpr.name shouldBe Operators.cast
+                    castExpr.methodFullName shouldBe Operators.cast
+                    castExpr.typeFullName shouldBe "box.Box"
+                    inside(castExpr.argument.l) { case List(castBoxType: TypeRef, castOIdentifier: Identifier) =>
+                      castBoxType.typeFullName shouldBe "box.Box"
+                      castBoxType.code shouldBe "Box"
+
+                      castOIdentifier.name shouldBe "o"
+                      castOIdentifier.typeFullName shouldBe "java.lang.Object"
+                      castOIdentifier.code shouldBe "o"
+                      castOIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+                    }
+                  }
+                }
+
+                stringType.typeFullName shouldBe "java.lang.String"
+                stringType.code shouldBe "String"
+              }
+            }
+        }
+      }
+
+      "have the correct lowering for the variable assignment" in {
         inside(
-          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
+          cpg.controlStructure
+            .controlStructureType(ControlStructureTypes.IF)
+            .astChildren
+            .isBlock
+            .astChildren
+            .l
         ) { case List(sLocal: Local, sAssignment: Call, _: Call) =>
           sLocal.name shouldBe "s"
           sLocal.typeFullName shouldBe "java.lang.String"
@@ -2134,41 +2287,26 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
           sAssignment.name shouldBe Operators.assignment
           sAssignment.methodFullName shouldBe Operators.assignment
           sAssignment.typeFullName shouldBe "java.lang.String"
-          sAssignment.code shouldBe "s = (String) ((Box) o).value()"
+          sAssignment.code shouldBe "s = (String) $obj0"
 
-          inside(sAssignment.argument.l) { case List(stringCast: Call) =>
+          inside(sAssignment.argument.l) { case List(sIdentifier: Identifier, stringCast: Call) =>
+            sIdentifier.name shouldBe "s"
+            sIdentifier.typeFullName shouldBe "java.lang.String"
+            sIdentifier.code shouldBe "s"
+            sIdentifier.refsTo.l shouldBe List(sLocal)
+
             stringCast.name shouldBe Operators.cast
             stringCast.methodFullName shouldBe Operators.cast
             stringCast.typeFullName shouldBe "java.lang.String"
-            stringCast.code shouldBe "(String) ((Box) o).value()"
+            stringCast.code shouldBe "(String) $obj0"
 
-            inside(stringCast.argument.l) { case List(sIdentifier: Identifier, valueCall: Call) =>
-              sIdentifier.name shouldBe "s"
-              sIdentifier.typeFullName shouldBe "java.lang.String"
-              sIdentifier.code shouldBe "s"
-              sIdentifier.refsTo.l shouldBe List(sLocal)
+            inside(stringCast.argument.l) { case List(stringType: TypeRef, tmpIdentifier0: Identifier) =>
+              stringType.typeFullName shouldBe "java.lang.String"
 
-              valueCall.name shouldBe "value"
-              valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
-              valueCall.typeFullName shouldBe "java.lang.Object"
-              valueCall.code shouldBe "((Box) o).value()"
-
-              inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                castExpr.name shouldBe Operators.cast
-                castExpr.methodFullName shouldBe Operators.cast
-                castExpr.typeFullName shouldBe "box.Box"
-                castExpr.code shouldBe "(Box) o"
-
-                inside(castExpr.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                  boxType.typeFullName shouldBe "box.Box"
-                  boxType.code shouldBe "Box"
-
-                  oIdentifier.name shouldBe "o"
-                  oIdentifier.typeFullName shouldBe "java.lang.Object"
-                  oIdentifier.code shouldBe "o"
-                  oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
-                }
-              }
+              tmpIdentifier0.name shouldBe "$obj0"
+              tmpIdentifier0.code shouldBe "$obj0"
+              tmpIdentifier0.typeFullName shouldBe "java.lang.Object"
+              tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
             }
           }
         }
@@ -2197,118 +2335,217 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         cpg.call.name("sink").isEmpty shouldBe false
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the type check" in {
         val oParameter = cpg.method.name("foo").parameter.name("o").l
-        inside(
-          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
-        ) { case List(sLocal: Local, iLocal: Local, sAssign: Call, iAssign: Call, sinkS: Call, sinkI: Call) =>
-          sLocal.name shouldBe "s"
-          sLocal.code shouldBe "s"
-          sLocal.typeFullName shouldBe "java.lang.String"
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
+          case List(firstAnd: Call) =>
+            firstAnd.name shouldBe Operators.logicalAnd
+            firstAnd.methodFullName shouldBe Operators.logicalAnd
+            firstAnd.typeFullName shouldBe "boolean"
+            firstAnd.code shouldBe "(o instanceof PairBox) && ((($obj0 = ((PairBox) o).value()) instanceof Pair) && ((($obj2 = $obj0.first()) instanceof String) && (($obj1 = $obj0.second()) instanceof Integer)))"
 
-          iLocal.name shouldBe "i"
-          iLocal.code shouldBe "i"
-          iLocal.typeFullName shouldBe "java.lang.Integer"
+            inside(firstAnd.argument.l) { case List(oInstanceOfPairBox: Call, secondAnd: Call) =>
+              oInstanceOfPairBox.name shouldBe Operators.instanceOf
+              oInstanceOfPairBox.methodFullName shouldBe Operators.instanceOf
+              oInstanceOfPairBox.typeFullName shouldBe "boolean"
+              oInstanceOfPairBox.code shouldBe "o instanceof PairBox"
 
-          sAssign.name shouldBe Operators.assignment
-          sAssign.methodFullName shouldBe Operators.assignment
-          sAssign.typeFullName shouldBe "java.lang.String"
-          sAssign.code shouldBe "s = ((PairBox) o).value().first()"
+              inside(oInstanceOfPairBox.argument.l) { case List(oIdentifier: Identifier, pairBoxType: TypeRef) =>
+                oIdentifier.name shouldBe "o"
+                oIdentifier.typeFullName shouldBe "java.lang.Object"
+                oIdentifier.code shouldBe "o"
+                oIdentifier.refsTo.l shouldBe oParameter
 
-          inside(sAssign.argument.l) { case List(sIdentifier: Identifier, firstCall: Call) =>
-            sIdentifier.name shouldBe "s"
-            sIdentifier.code shouldBe "s"
-            sIdentifier.typeFullName shouldBe "java.lang.String"
-            sIdentifier.refsTo.l shouldBe List(sLocal)
+                pairBoxType.typeFullName shouldBe "box.PairBox"
+                pairBoxType.code shouldBe "PairBox"
+              }
 
-            firstCall.name shouldBe "first"
-            firstCall.methodFullName shouldBe "box.Pair.first:java.lang.String()"
-            firstCall.signature shouldBe "java.lang.String()"
-            firstCall.typeFullName shouldBe "java.lang.String"
-            firstCall.code shouldBe "((PairBox) o).value().first()"
+              secondAnd.name shouldBe Operators.logicalAnd
+              secondAnd.methodFullName shouldBe Operators.logicalAnd
+              secondAnd.typeFullName shouldBe "boolean"
+              secondAnd.code shouldBe "(($obj0 = ((PairBox) o).value()) instanceof Pair) && ((($obj2 = $obj0.first()) instanceof String) && (($obj1 = $obj0.second()) instanceof Integer))"
 
-            inside(firstCall.argument.l) { case List(valueCall: Call) =>
-              valueCall.name shouldBe "value"
-              valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
-              valueCall.signature shouldBe "box.Pair()"
-              valueCall.typeFullName shouldBe "box.Pair()"
-              valueCall.code shouldBe "((PairBox) o).value()"
+              inside(secondAnd.argument.l) { case List(oValueInstanceOfPair: Call, thirdAnd: Call) =>
+                oValueInstanceOfPair.name shouldBe Operators.instanceOf
+                oValueInstanceOfPair.methodFullName shouldBe Operators.instanceOf
+                oValueInstanceOfPair.typeFullName shouldBe "boolean"
+                oValueInstanceOfPair.code shouldBe "($obj0 = ((PairBox) o).value()) instanceof Pair"
 
-              inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                castExpr.name shouldBe Operators.cast
-                castExpr.methodFullName shouldBe Operators.cast
-                castExpr.typeFullName shouldBe "box.PairBox"
-                castExpr.code shouldBe "(PairBox) o"
+                inside(oValueInstanceOfPair.argument.l) { case List(valueAssignment: Call, pairType: TypeRef) =>
+                  valueAssignment.name shouldBe Operators.assignment
+                  valueAssignment.typeFullName shouldBe "box.Pair"
+                  valueAssignment.code shouldBe "$obj0 = ((PairBox) o).value()"
 
-                inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
-                  pairBoxType.typeFullName shouldBe "box.PairBox"
-                  pairBoxType.code shouldBe "PairBox"
+                  inside(valueAssignment.argument.l) { case List(tmpIdentifier0: Identifier, valueCall: Call) =>
+                    tmpIdentifier0.name shouldBe "$obj0"
+                    tmpIdentifier0.code shouldBe "$obj0"
+                    tmpIdentifier0.typeFullName shouldBe "box.Pair"
+                    tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
 
-                  oIdentifier.name shouldBe "o"
-                  oIdentifier.code shouldBe "o"
-                  oIdentifier.typeFullName shouldBe "java.lang.Object"
-                  oIdentifier.refsTo.l shouldBe oParameter
+                    valueCall.name shouldBe "value"
+                    valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
+                    valueCall.signature shouldBe "box.Pair()"
+                    valueCall.code shouldBe "((PairBox) o).value()"
+
+                    inside(valueCall.argument.l) { case List(castExpr: Call) =>
+                      castExpr.name shouldBe Operators.cast
+                      castExpr.methodFullName shouldBe Operators.cast
+                      castExpr.typeFullName shouldBe "box.PairBox"
+                      castExpr.code shouldBe "(PairBox) o"
+
+                      inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
+                        pairBoxType.typeFullName shouldBe "box.PairBox"
+                        pairBoxType.code shouldBe "PairBox"
+
+                        oIdentifier.name shouldBe "o"
+                        oIdentifier.code shouldBe "o"
+                        oIdentifier.typeFullName shouldBe "java.lang.Object"
+                        oIdentifier.refsTo.l shouldBe oParameter
+                      }
+                    }
+                  }
+
+                  pairType.typeFullName shouldBe "box.Pair"
+                  pairType.code shouldBe "Pair"
+                }
+
+                thirdAnd.name shouldBe Operators.logicalAnd
+                thirdAnd.methodFullName shouldBe Operators.logicalAnd
+                thirdAnd.typeFullName shouldBe "boolean"
+                thirdAnd.code shouldBe "(($obj2 = $obj0.first()) instanceof String) && (($obj1 = $obj0.second()) instanceof Integer)"
+
+                inside(thirdAnd.argument.l) { case List(firstInstanceOfString: Call, secondInstanceOfInteger: Call) =>
+                  firstInstanceOfString.name shouldBe Operators.instanceOf
+                  firstInstanceOfString.methodFullName shouldBe Operators.instanceOf
+                  firstInstanceOfString.typeFullName shouldBe "boolean"
+                  firstInstanceOfString.code shouldBe "($obj2 = $obj0.first()) instanceof String"
+
+                  inside(firstInstanceOfString.argument.l) { case List(tmp2Assign: Call, stringType: TypeRef) =>
+                    tmp2Assign.name shouldBe Operators.assignment
+                    tmp2Assign.methodFullName shouldBe Operators.assignment
+                    tmp2Assign.code shouldBe "$obj2 = $obj0.first()"
+                    tmp2Assign.typeFullName shouldBe "java.lang.String"
+
+                    inside(tmp2Assign.argument.l) { case List(tmpIdentifier2: Identifier, firstCall: Call) =>
+                      tmpIdentifier2.name shouldBe "$obj2"
+                      tmpIdentifier2.code shouldBe "$obj2"
+                      tmpIdentifier2.typeFullName shouldBe "java.lang.String"
+                      tmpIdentifier2.refsTo.l shouldBe cpg.local.nameExact("$obj2").l
+
+                      firstCall.name shouldBe "first"
+                      firstCall.methodFullName shouldBe "box.Pair.first:java.lang.String()"
+                      firstCall.typeFullName shouldBe "java.lang.String"
+                      firstCall.code shouldBe "$obj0.first()"
+
+                      inside(firstCall.argument.l) { case List(tmpIdentifier0: Identifier) =>
+                        tmpIdentifier0.name shouldBe "$obj0"
+                        tmpIdentifier0.code shouldBe "$obj0"
+                        tmpIdentifier0.typeFullName shouldBe "box.Pair"
+                        tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+                      }
+                    }
+
+                    stringType.typeFullName shouldBe "java.lang.String"
+                    stringType.code shouldBe "String"
+                  }
+
+                  secondInstanceOfInteger.name shouldBe Operators.instanceOf
+                  secondInstanceOfInteger.methodFullName shouldBe Operators.instanceOf
+                  secondInstanceOfInteger.typeFullName shouldBe "boolean"
+                  secondInstanceOfInteger.code shouldBe "($obj1 = $obj0.second()) instanceof Integer"
+
+                  inside(secondInstanceOfInteger.argument.l) { case List(tmp1Assign: Call, integerType: TypeRef) =>
+                    tmp1Assign.name shouldBe Operators.assignment
+                    tmp1Assign.methodFullName shouldBe Operators.assignment
+                    tmp1Assign.code shouldBe "$obj1 = $obj0.second()"
+                    tmp1Assign.typeFullName shouldBe "java.lang.Integer"
+
+                    inside(tmp1Assign.argument.l) { case List(tmpIdentifier1: Identifier, secondCall: Call) =>
+                      tmpIdentifier1.name shouldBe "$obj1"
+                      tmpIdentifier1.code shouldBe "$obj1"
+                      tmpIdentifier1.typeFullName shouldBe "java.lang.Integer"
+                      tmpIdentifier1.refsTo.l shouldBe cpg.local.nameExact("$obj1").l
+
+                      secondCall.name shouldBe "second"
+                      secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Integer()"
+                      secondCall.typeFullName shouldBe "java.lang.Integer"
+                      secondCall.code shouldBe "$obj0.second()"
+
+                      inside(secondCall.argument.l) { case List(tmpIdentifier0: Identifier) =>
+                        tmpIdentifier0.name shouldBe "$obj0"
+                        tmpIdentifier0.code shouldBe "$obj0"
+                        tmpIdentifier0.typeFullName shouldBe "box.Pair"
+                        tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+                      }
+                    }
+                    integerType.typeFullName shouldBe "java.lang.Integer"
+                    integerType.code shouldBe "Integer"
+                  }
                 }
               }
             }
-          }
+        }
+      }
 
-          iAssign.name shouldBe Operators.assignment
-          iAssign.methodFullName shouldBe Operators.assignment
-          iAssign.typeFullName shouldBe "java.lang.Integer"
-          iAssign.code shouldBe "i = ((PairBox) o).value().second()"
+      "have the correct lowering for the variable assignment" in {
+        val oParameter = cpg.method.name("foo").parameter.name("o").l
+        inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
+          case List(sLocal: Local, sAssign: Call, iLocal: Local, iAssign: Call, sinkS: Call, sinkI: Call) =>
+            sLocal.name shouldBe "s"
+            sLocal.code shouldBe "String s"
+            sLocal.typeFullName shouldBe "java.lang.String"
 
-          inside(iAssign.argument.l) { case List(iIdentifier: Identifier, secondCall: Call) =>
-            iIdentifier.name shouldBe "i"
-            iIdentifier.code shouldBe "i"
-            iIdentifier.typeFullName shouldBe "java.lang.Integer"
-            iIdentifier.refsTo.l shouldBe List(iLocal)
+            iLocal.name shouldBe "i"
+            iLocal.code shouldBe "Integer i"
+            iLocal.typeFullName shouldBe "java.lang.Integer"
 
-            secondCall.name shouldBe "second"
-            secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Integer()"
-            secondCall.signature shouldBe "java.lang.Integer()"
-            secondCall.typeFullName shouldBe "java.lang.Integer"
-            secondCall.code shouldBe "((PairBox) o).value().second()"
+            sAssign.name shouldBe Operators.assignment
+            sAssign.methodFullName shouldBe Operators.assignment
+            sAssign.typeFullName shouldBe "java.lang.String"
+            sAssign.code shouldBe "s = $obj2"
 
-            inside(secondCall.argument.l) { case List(valueCall: Call) =>
-              valueCall.name shouldBe "value"
-              valueCall.methodFullName shouldBe "box.PairBox.value:box.Pair()"
-              valueCall.signature shouldBe "box.Pair()"
-              valueCall.typeFullName shouldBe "box.Pair()"
-              valueCall.code shouldBe "((PairBox) o).value()"
+            inside(sAssign.argument.l) { case List(sIdentifier: Identifier, tmpIdentifier2: Identifier) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.refsTo.l shouldBe List(sLocal)
 
-              inside(valueCall.argument.l) { case List(castExpr: Call) =>
-                castExpr.name shouldBe Operators.cast
-                castExpr.methodFullName shouldBe Operators.cast
-                castExpr.typeFullName shouldBe "box.PairBox"
-                castExpr.code shouldBe "(PairBox) o"
-
-                inside(castExpr.argument.l) { case List(pairBoxType: TypeRef, oIdentifier: Identifier) =>
-                  pairBoxType.typeFullName shouldBe "box.PairBox"
-                  pairBoxType.code shouldBe "PairBox"
-
-                  oIdentifier.name shouldBe "o"
-                  oIdentifier.code shouldBe "o"
-                  oIdentifier.typeFullName shouldBe "java.lang.Object"
-                  oIdentifier.refsTo.l shouldBe oParameter
-                }
-              }
+              tmpIdentifier2.name shouldBe "$obj2"
+              tmpIdentifier2.code shouldBe "$obj2"
+              tmpIdentifier2.typeFullName shouldBe "java.lang.String"
+              tmpIdentifier2.refsTo.l shouldBe cpg.local.nameExact("$obj2").l
             }
-          }
 
-          inside(sinkS.argument.isIdentifier.name("s").l) { case List(sIdentifier: Identifier) =>
-            sIdentifier.name shouldBe "s"
-            sIdentifier.code shouldBe "s"
-            sIdentifier.typeFullName shouldBe "java.lang.String"
-            sIdentifier.refsTo.l shouldBe List(sLocal)
-          }
+            iAssign.name shouldBe Operators.assignment
+            iAssign.methodFullName shouldBe Operators.assignment
+            iAssign.typeFullName shouldBe "java.lang.Integer"
+            iAssign.code shouldBe "i = $obj1"
 
-          inside(sinkI.argument.isIdentifier.name("i").l) { case List(iIdentifier: Identifier) =>
-            iIdentifier.name shouldBe "i"
-            iIdentifier.code shouldBe "i"
-            iIdentifier.typeFullName shouldBe "java.lang.Integer"
-            iIdentifier.refsTo.l shouldBe List(iLocal)
-          }
+            inside(iAssign.argument.l) { case List(iIdentifier: Identifier, tmpIdentifier1: Identifier) =>
+              iIdentifier.name shouldBe "i"
+              iIdentifier.code shouldBe "i"
+              iIdentifier.typeFullName shouldBe "java.lang.Integer"
+              iIdentifier.refsTo.l shouldBe List(iLocal)
+
+              tmpIdentifier1.name shouldBe "$obj1"
+              tmpIdentifier1.code shouldBe "$obj1"
+              tmpIdentifier1.typeFullName shouldBe "java.lang.Integer"
+              tmpIdentifier1.refsTo.l shouldBe cpg.local.nameExact("$obj1").l
+            }
+
+            inside(sinkS.argument.isIdentifier.name("s").l) { case List(sIdentifier: Identifier) =>
+              sIdentifier.name shouldBe "s"
+              sIdentifier.code shouldBe "s"
+              sIdentifier.typeFullName shouldBe "java.lang.String"
+              sIdentifier.refsTo.l shouldBe List(sLocal)
+            }
+
+            inside(sinkI.argument.isIdentifier.name("i").l) { case List(iIdentifier: Identifier) =>
+              iIdentifier.name shouldBe "i"
+              iIdentifier.code shouldBe "i"
+              iIdentifier.typeFullName shouldBe "java.lang.Integer"
+              iIdentifier.refsTo.l shouldBe List(iLocal)
+            }
         }
       }
     }
@@ -2335,23 +2572,32 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
         cpg.call.name("sink").isEmpty shouldBe false
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the variable assignment" in {
         val oParameter = cpg.method.name("foo").parameter.name("o").l
         inside(
-          cpg.controlStructure.controlStructureType(ControlStructureTypes.SWITCH).astChildren.isBlock.astChildren.l
-        ) { case List(sLocal: Local, iLocal: Local, sAssign: Call, iAssign: Call, sSink: Call, iSink: Call) =>
+          cpg.controlStructure
+            .controlStructureType(ControlStructureTypes.SWITCH)
+            .astChildren
+            .isBlock
+            .astChildren
+            .isControlStructure
+            .astChildren
+            .isBlock
+            .astChildren
+            .l
+        ) { case List(sLocal: Local, sAssign: Call, iLocal: Local, iAssign: Call, sSink: Call, iSink: Call) =>
           sLocal.name shouldBe "s"
-          sLocal.code shouldBe "s"
+          sLocal.code shouldBe "String s"
           sLocal.typeFullName shouldBe "java.lang.String"
 
           iLocal.name shouldBe "i"
-          iLocal.code shouldBe "i"
+          iLocal.code shouldBe "Integer i"
           iLocal.typeFullName shouldBe "java.lang.Integer"
 
           sAssign.name shouldBe Operators.assignment
           sAssign.methodFullName shouldBe Operators.assignment
           sAssign.typeFullName shouldBe "java.lang.String"
-          sAssign.code shouldBe "s = (String) ((Pair) ((Box) o).value()).first()"
+          sAssign.code shouldBe "s = (String) $obj2"
 
           inside(sAssign.argument.l) { case List(sIdentifier: Identifier, stringCast: Call) =>
             sIdentifier.name shouldBe "s"
@@ -2362,60 +2608,23 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
             stringCast.name shouldBe Operators.cast
             stringCast.methodFullName shouldBe Operators.cast
             stringCast.typeFullName shouldBe "java.lang.String"
-            stringCast.code shouldBe "(String) ((Pair) ((Box) o).value()).first()"
+            stringCast.code shouldBe "(String) $obj2"
 
-            inside(stringCast.argument.l) { case List(stringType: TypeRef, firstCall: Call) =>
+            inside(stringCast.argument.l) { case List(stringType: TypeRef, tmpIdentifier2: Identifier) =>
               stringType.typeFullName shouldBe "java.lang.String"
               stringType.code shouldBe "String"
 
-              firstCall.name shouldBe "first"
-              firstCall.methodFullName shouldBe "box.Pair.first:java.lang.Object()"
-              firstCall.signature shouldBe "java.lang.Object()"
-              // TODO: Should this be the erased type?
-              firstCall.typeFullName shouldBe "java.lang.Object"
-              firstCall.code shouldBe "((Pair) ((Box) o).value()).first()"
-
-              inside(firstCall.argument.l) { case List(pairCast: Call) =>
-                pairCast.name shouldBe Operators.cast
-                pairCast.methodFullName shouldBe Operators.cast
-                pairCast.typeFullName shouldBe "box.Pair"
-                pairCast.code shouldBe "(Pair) ((Box) o).value()"
-
-                inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
-                  pairType.typeFullName shouldBe "box.Pair"
-                  pairType.code shouldBe "Pair"
-
-                  valueCall.name shouldBe "value"
-                  valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
-                  valueCall.signature shouldBe "java.lang.Object()"
-                  valueCall.typeFullName shouldBe "java.lang.Object"
-                  valueCall.code shouldBe "((Box) o).value()"
-
-                  inside(valueCall.argument.l) { case List(boxCast: Call) =>
-                    boxCast.name shouldBe Operators.cast
-                    boxCast.methodFullName shouldBe Operators.cast
-                    boxCast.typeFullName shouldBe "box.Box"
-                    boxCast.code shouldBe "(Box) o"
-
-                    inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                      boxType.typeFullName shouldBe "box.Box"
-                      boxType.code shouldBe "Box"
-
-                      oIdentifier.name shouldBe "o"
-                      oIdentifier.code shouldBe "o"
-                      oIdentifier.typeFullName shouldBe "java.lang.Object"
-                      oIdentifier.refsTo.l shouldBe oParameter
-                    }
-                  }
-                }
-              }
+              tmpIdentifier2.name shouldBe "$obj2"
+              tmpIdentifier2.code shouldBe "$obj2"
+              tmpIdentifier2.typeFullName shouldBe "java.lang.Object"
+              tmpIdentifier2.refsTo.l shouldBe cpg.local.nameExact("$obj2").l
             }
           }
 
           iAssign.name shouldBe Operators.assignment
           iAssign.methodFullName shouldBe Operators.assignment
           iAssign.typeFullName shouldBe "java.lang.Integer"
-          iAssign.code shouldBe "i = (Integer) ((Pair) ((Box) o).value()).second()"
+          iAssign.code shouldBe "i = (Integer) $obj1"
 
           inside(iAssign.argument.l) { case List(iIdentifier: Identifier, integerCast: Call) =>
             iIdentifier.name shouldBe "i"
@@ -2426,53 +2635,16 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
             integerCast.name shouldBe Operators.cast
             integerCast.methodFullName shouldBe Operators.cast
             integerCast.typeFullName shouldBe "java.lang.Integer"
-            integerCast.code shouldBe "(Integer) ((Pair) ((Box) o).value()).second()"
+            integerCast.code shouldBe "(Integer) $obj1"
 
-            inside(integerCast.argument.l) { case List(integerType: TypeRef, secondCall: Call) =>
+            inside(integerCast.argument.l) { case List(integerType: TypeRef, tmpIdentifier1: Identifier) =>
               integerType.typeFullName shouldBe "java.lang.Integer"
               integerType.code shouldBe "Integer"
 
-              secondCall.name shouldBe "second"
-              secondCall.methodFullName shouldBe "box.Pair.second:java.lang.Object()"
-              secondCall.signature shouldBe "java.lang.Object()"
-              // TODO: Should this be the erased type?
-              secondCall.typeFullName shouldBe "java.lang.Object"
-              secondCall.code shouldBe "((Pair) ((Box) o).value()).second()"
-
-              inside(secondCall.argument.l) { case List(pairCast: Call) =>
-                pairCast.name shouldBe Operators.cast
-                pairCast.methodFullName shouldBe Operators.cast
-                pairCast.typeFullName shouldBe "box.Pair"
-                pairCast.code shouldBe "(Pair) ((Box) o).value()"
-
-                inside(pairCast.argument.l) { case List(pairType: TypeRef, valueCall: Call) =>
-                  pairType.typeFullName shouldBe "box.Pair"
-                  pairType.code shouldBe "Pair"
-
-                  valueCall.name shouldBe "value"
-                  valueCall.methodFullName shouldBe "box.Box.value:java.lang.Object()"
-                  valueCall.signature shouldBe "java.lang.Object()"
-                  valueCall.typeFullName shouldBe "java.lang.Object"
-                  valueCall.code shouldBe "((Box) o).value()"
-
-                  inside(valueCall.argument.l) { case List(boxCast: Call) =>
-                    boxCast.name shouldBe Operators.cast
-                    boxCast.methodFullName shouldBe Operators.cast
-                    boxCast.typeFullName shouldBe "box.Box"
-                    boxCast.code shouldBe "(Box) o"
-
-                    inside(boxCast.argument.l) { case List(boxType: TypeRef, oIdentifier: Identifier) =>
-                      boxType.typeFullName shouldBe "box.Box"
-                      boxType.code shouldBe "Box"
-
-                      oIdentifier.name shouldBe "o"
-                      oIdentifier.code shouldBe "o"
-                      oIdentifier.typeFullName shouldBe "java.lang.Object"
-                      oIdentifier.refsTo.l shouldBe oParameter
-                    }
-                  }
-                }
-              }
+              tmpIdentifier1.name shouldBe "$obj1"
+              tmpIdentifier1.code shouldBe "$obj1"
+              tmpIdentifier1.typeFullName shouldBe "java.lang.Object"
+              tmpIdentifier1.refsTo.l shouldBe cpg.local.nameExact("$obj1").l
             }
           }
 
@@ -2648,25 +2820,46 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
 
       "have the correct lowering for the type check" in {
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.l) {
-          case List(oInstanceOfBar: Call) =>
-            oInstanceOfBar.name shouldBe Operators.instanceOf
-            oInstanceOfBar.methodFullName shouldBe Operators.instanceOf
-            oInstanceOfBar.typeFullName shouldBe "boolean"
-            oInstanceOfBar.code shouldBe "o instanceof Bar"
+          case List(firstAnd: Call) =>
+            firstAnd.name shouldBe Operators.logicalAnd
+            firstAnd.methodFullName shouldBe Operators.logicalAnd
+            firstAnd.typeFullName shouldBe "boolean"
+            firstAnd.code shouldBe "(o instanceof Bar) && ((($obj0 = ((Bar) o).<unknownField>()) instanceof Baz) && (($obj1 = ((Baz) $obj0).<unknownField>()) instanceof Qux))"
 
-            inside(oInstanceOfBar.argument.l) { case List(oIdentifier: Identifier, barType: TypeRef) =>
-              oIdentifier.name shouldBe "o"
-              oIdentifier.code shouldBe "o"
-              oIdentifier.typeFullName shouldBe "java.lang.Object"
-              oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
+            inside(firstAnd.argument.l) { case List(instanceOfBar: Call, secondAnd: Call) =>
+              instanceOfBar.name shouldBe Operators.instanceOf
+              instanceOfBar.methodFullName shouldBe Operators.instanceOf
+              instanceOfBar.code shouldBe "o instanceof Bar"
+              instanceOfBar.typeFullName shouldBe "boolean"
 
-              barType.typeFullName shouldBe "ANY"
-              barType.code shouldBe "Bar"
+              inside(secondAnd.argument.l) { case List(instanceOfBaz: Call, instanceOfQux: Call) =>
+                instanceOfBaz.name shouldBe Operators.instanceOf
+                instanceOfBaz.methodFullName shouldBe Operators.instanceOf
+                instanceOfBaz.code shouldBe "($obj0 = ((Bar) o).<unknownField>()) instanceof Baz"
+                instanceOfBaz.typeFullName shouldBe "boolean"
+
+                inside(instanceOfBaz.argument.l) { case List(tmpAssign: Call, bazType: TypeRef) =>
+                  inside(tmpAssign.argument.l) { case List(tmpIdentifier0: Identifier, fieldAccessor: Call) =>
+                    tmpIdentifier0.name shouldBe "$obj0"
+                    tmpIdentifier0.code shouldBe "$obj0"
+                    tmpIdentifier0.typeFullName shouldBe "ANY"
+                    tmpIdentifier0.refsTo.l shouldBe cpg.local.nameExact("$obj0").l
+
+                    fieldAccessor.name shouldBe "<unknownField>"
+                    fieldAccessor.methodFullName shouldBe "<unresolvedNamespace>.Bar.<unknownField>:<unresolvedSignature>(0)"
+                    fieldAccessor.typeFullName shouldBe "ANY"
+                    fieldAccessor.code shouldBe "((Bar) o).<unknownField>()"
+                  }
+
+                  bazType.typeFullName shouldBe "ANY"
+                  bazType.code shouldBe "Baz"
+                }
+              }
             }
         }
       }
 
-      "have the correct lowering for the variable assignment" ignore {
+      "have the correct lowering for the variable assignment" in {
         inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).astChildren.isBlock.astChildren.l) {
           case List(qLocal: Local, qAssign: Call, qSink: Call) =>
             qLocal.name shouldBe "q"
@@ -2676,49 +2869,23 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
             qAssign.name shouldBe Operators.assignment
             qAssign.methodFullName shouldBe Operators.assignment
             qAssign.typeFullName shouldBe "ANY"
-            qAssign.code shouldBe "q = ((Bar) o).<unresolvedField>.<unresolvedField>"
+            qAssign.code shouldBe "q = (Qux) $obj1"
 
-            inside(qAssign.argument.l) { case List(qIdentifier: Identifier, firstFieldAccess: Call) =>
+            inside(qAssign.argument.l) { case List(qIdentifier: Identifier, quxCast: Call) =>
               qIdentifier.name shouldBe "q"
               qIdentifier.code shouldBe "q"
               qIdentifier.typeFullName shouldBe "ANY"
               qIdentifier.refsTo.l shouldBe List(qLocal)
 
-              firstFieldAccess.name shouldBe Operators.fieldAccess
-              firstFieldAccess.methodFullName shouldBe Operators.fieldAccess
-              firstFieldAccess.typeFullName shouldBe "ANY"
-              firstFieldAccess.code shouldBe "((Bar) o).<unresolvedField>.<unresolvedField>"
+              quxCast.name shouldBe Operators.cast
 
-              inside(firstFieldAccess.argument.l) {
-                case List(secondFieldAccess: Call, unresolvedFieldIdentifier: FieldIdentifier) =>
-                  secondFieldAccess.name shouldBe Operators.fieldAccess
-                  secondFieldAccess.methodFullName shouldBe Operators.fieldAccess
-                  secondFieldAccess.typeFullName shouldBe "ANY"
-                  secondFieldAccess.code shouldBe "((Bar) o).<unresolvedField>"
+              inside(quxCast.argument.l) { case List(quxType: TypeRef, tmpIdentifier1: Identifier) =>
+                quxType.code shouldBe "Qux"
 
-                  inside(secondFieldAccess.argument.l) {
-                    case List(castExpr: Call, unresolvedFieldIdentifier: FieldIdentifier) =>
-                      castExpr.name shouldBe Operators.cast
-                      castExpr.methodFullName shouldBe Operators.cast
-                      castExpr.typeFullName shouldBe "ANY"
-                      castExpr.code shouldBe "(Bar) o"
-
-                      inside(castExpr.argument.l) { case List(barType: TypeRef, oIdentifier: Identifier) =>
-                        barType.typeFullName shouldBe "ANY"
-                        barType.code shouldBe "Bar"
-
-                        oIdentifier.name shouldBe "o"
-                        oIdentifier.code shouldBe "o"
-                        oIdentifier.typeFullName shouldBe "java.lang.Object"
-                        oIdentifier.refsTo.l shouldBe cpg.method.name("foo").parameter.name("o").l
-                      }
-
-                      unresolvedFieldIdentifier.canonicalName shouldBe "<unresolvedField>"
-                      unresolvedFieldIdentifier.code shouldBe "<unresolvedField>"
-                  }
-
-                  unresolvedFieldIdentifier.canonicalName shouldBe "<unresolvedField>"
-                  unresolvedFieldIdentifier.code shouldBe "<unresolvedField>"
+                tmpIdentifier1.name shouldBe "$obj1"
+                tmpIdentifier1.code shouldBe "$obj1"
+                tmpIdentifier1.typeFullName shouldBe "ANY"
+                tmpIdentifier1.refsTo.l shouldBe cpg.local.nameExact("$obj1").l
               }
             }
         }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Defines.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Defines.scala
@@ -36,4 +36,9 @@ object Defines {
 
   val LeftAngularBracket = "<"
   val Unknown            = "<unknown>"
+
+  // Used for field access calls in the lowering of pattern extractors where the field name
+  // may not be known. As an example in javasrc2cpg, the assignment for `o instanceof Foo(Bar b))` could
+  // be lowered to `Bar b = (Bar) (((Foo) o).<unknownField>)`
+  val UnknownField = "<unknownField>"
 }


### PR DESCRIPTION
This PR adds support for pattern matching with record patterns. The lowering is effectively done in 2 stages:

First, the `instanceof` check for the record pattern is created. This is represented as a series of `instanceof` checks for the whole record tree. There are lots of examples of what this lowering looks like in the unit tests but, since the resulting lowering gets rather large very quickly, I'll include a simple example here.

### Record patterns with concrete + exact types
```
record Foo(String left, Integer right) {}

class Test {
  void test(Object o) {
    if (o instanceof Foo(String s, Integer i)) {}
  }
}
```

the `instanceof` check is lowered to
```
(o instanceof Foo) && ((($obj1 = ((Foo) o).left()) instanceof String) && (($obj0 = ((Foo) o).right()) instanceof Integer))
```

The first `o instanceof Foo` call is the same we'd expect for type pattern expressions.

The next `(($obj1 = ((Foo) o).left()) instanceof String) && (($obj0 = ((Foo) o).right()) instanceof Integer)` introduces the major difference from type pattern matching. For each record pattern in the pattern tree, a temporary variable is created for each record field. In this case:

```
$obj1 = ((Foo) o).left()
$obj0 = ((Foo) o).right()
```

This is necessary to avoid doubling-up on side-effects from repeating the getter calls in nested record patterns or in the pattern variable assignment.

The assignments for these temporary variables are added to the CPG where `((Foo) o).left()`, for example, is first called and anywhere after that `((Foo) o).left()` is replaced by `$obj1`.


The assignment for the pattern variables are then
```
s = $obj1
i = $obj0
```
which look a bit silly in this case since we could've just used the `s` and `i` variables directly instead of creating the temporary variables. This is because the return type of the `left` and `right` calls already match the pattern variable types exactly. In cases where this is not true, however, the temporary variables are necessary and are cast to the correct types during the variable assignments as needed. This can be seen in the more complex example below.

### Records with generics / subtypes

```
class Bar {}
class Baz extends Bar {}

record Foo<T>(Bar left, T right) {}

class Test {
  void test(Object o) {
    if (o instanceof Foo(Baz s, Integer i)) {} 
  }
}
```
where the instanceof check and assignments are respectively lowered to
```
(o instanceof Foo) && ((($obj1 = ((Foo) o).left()) instanceof Baz) && (($obj0 = ((Foo) o).right()) instanceof Integer))

s = (Baz) $obj1
i = (Integer) $obj0
```

Separately handling the simpler case where no temporary variables are technically needed would lead to other questions. For example, the current lowering
```
($obj1 = ((Foo) o).left()) instanceof String)
s = $obj1
```
could be either simplified to
```
(s = ((Foo) o).left()) instanceof String
```
or the `instanceof` call could be omitted entirely. That would then lead to the question of when instanceof calls should even be added and I figured the extra code complexity added by dealing with this isn't justified by the results anyways (since this only applies to leaf patterns and we'd still need temporary variables for everything inbetween).

### Casts in instanceof chains for nested generics

Casts in general, but in particular in the instanceof calls, are only added when necessary. For example, in
```
record Foo(Bar foo) {}
record Bar(String bar) {}

class Test {
  public void test(Object o) {
    if (o instanceof Foo(Bar(String s))) {}
  }
} 
```

the instanceof call is lowered to
```
(o instanceof Foo) && ((($obj0 = ((Foo) o).foo()) instanceof Bar) && (($obj1 = $obj0.bar()) instanceof String))
```

where `(Foo) o` is the only cast needed since all the other types are already exact matches. However, if these types are not already exact matches as in 
```
class Parent {}
class Child extends Parent {}

record Foo<T>(T foo) {}
record Bar(Parent bar) {}

class Test {
  public void test(Object o) {
    if (o instanceof Foo(Bar(Child s))) {}
  }
} 
```

the instanceof call is lowered to 
```
(o instanceof Foo) && ((($obj0 = ((Foo) o).foo()) instanceof Bar) && (($obj1 = ((Bar) $obj0).bar()) instanceof Child))
```
where the `(Bar) $obj0` cast is needed as well.