### PR TITLE
[ruby] Cyclic Singleton Method AST & Bracket Invocation Fix 

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -355,6 +355,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
             expr
           }
           .getOrElse(defaultBehaviour)
+      case None if node.indices.isEmpty =>
+        astForExpression(MemberCall(node.target, ".", "[]", node.indices)(node.span))
       case None => defaultBehaviour
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -428,14 +428,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         )
         val methodTypeDecl_   = typeDeclNode(node, node.methodName, fullName, relativeFileName, code(node))
         val methodTypeDeclAst = Ast(methodTypeDecl_)
-        astParentType.orElse(scope.surroundingAstLabel).foreach { t =>
-          methodTypeDecl_.astParentType(t)
-          method.astParentType(t)
-        }
-        astParentFullName.orElse(scope.surroundingScopeFullName).foreach { fn =>
-          methodTypeDecl_.astParentFullName(fn)
-          method.astParentFullName(fn)
-        }
 
         createMethodTypeBindings(method, methodTypeDecl_)
 
@@ -466,6 +458,15 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         }
 
         scope.popScope()
+
+        astParentType.orElse(scope.surroundingAstLabel).foreach { t =>
+          methodTypeDecl_.astParentType(t)
+          method.astParentType(t)
+        }
+        astParentFullName.orElse(scope.surroundingScopeFullName).foreach { fn =>
+          methodTypeDecl_.astParentFullName(fn)
+          method.astParentFullName(fn)
+        }
 
         // The member for these types refers to the singleton class
         val member = memberForMethod(method, Option(NodeTypes.TYPE_DECL), astParentFullName.map(x => s"$x<class>"))

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -568,12 +568,19 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     }
   }
 
-  "A Set instantiated with a 'brackets' call" should {
-    val cpg = code("x = Set[]")
+  "A Set instantiation with a 'brackets' call" should {
+    val cpg = code("Set[]")
 
-    "not be interpreted as an index access" in {
-      cpg.call.nameExact("[]").size shouldBe 1
-      cpg.call.nameExact(Operators.indexAccess).size shouldBe 0
+    "be a call with name '[]'" in {
+      inside(cpg.call.nameExact("[]").l) { case bracketCall :: Nil =>
+        bracketCall.code shouldBe "(<tmp-0> = Set).[]()"
+        bracketCall.name shouldBe "[]"
+        inside(bracketCall.argument.l) { case (tmpBase: Identifier) :: Nil =>
+          tmpBase.name shouldBe "<tmp-0>"
+          tmpBase.code shouldBe "<tmp-0>"
+          tmpBase.argumentIndex shouldBe 0
+        }
+      }
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -567,4 +567,13 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
       case xs => fail(s"Expected two params, got [${xs.code.mkString(",")}]")
     }
   }
+
+  "A Set instantiated with a 'brackets' call" should {
+    val cpg = code("x = Set[]")
+
+    "not be interpreted as an index access" in {
+      cpg.call.nameExact("[]").size shouldBe 1
+      cpg.call.nameExact(Operators.indexAccess).size shouldBe 0
+    }
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -421,7 +421,6 @@ class MethodTests extends RubyCode2CpgFixture {
 
     foo.definingTypeDecl.map(_.name) shouldBe Option("C")
     foo.astParent shouldBe cpg.typeDecl("C").head
-    cpg.method.isModule.dotAst.foreach(println)
   }
 
   "A Boolean method" should {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -409,6 +409,21 @@ class MethodTests extends RubyCode2CpgFixture {
     }
   }
 
+  "Singleton methods binding to an unresolvable variable/type should bind to the next AST parent" in {
+    val cpg = code("""
+        |class C
+        | def something.foo
+        | end
+        |end
+        |""".stripMargin)
+
+    val foo = cpg.method.nameExact("foo").head
+
+    foo.definingTypeDecl.map(_.name) shouldBe Option("C")
+    foo.astParent shouldBe cpg.typeDecl("C").head
+    cpg.method.isModule.dotAst.foreach(println)
+  }
+
   "A Boolean method" should {
     val cpg = code("""
         |def exists?


### PR DESCRIPTION
* Fixed a bug where singleton methods defined on types unresolvable in scope were assigned themselves as AST parents
* Fixed a bug where bracket invocations on unresolvable types were interpreted as index accesses without an index