### PR TITLE
[c#] support for top-level statements

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
@@ -1,15 +1,23 @@
 package io.joern.csharpsrc2cpg.astcreation
 
 import io.joern.csharpsrc2cpg.{CSharpDefines, Constants}
-import io.joern.csharpsrc2cpg.datastructures.{CSharpProgramSummary, CSharpScope}
+import io.joern.csharpsrc2cpg.datastructures.{CSharpProgramSummary, CSharpScope, MethodScope, TypeScope}
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
 import io.joern.csharpsrc2cpg.parser.{DotNetNodeInfo, ParserKeys}
 import io.joern.x2cpg.astgen.{AstGenNodeBuilder, ParserResult}
+import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.NodeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{NewFile, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.{DiffGraphBuilder, ModifierTypes, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  NewBlock,
+  NewFile,
+  NewMethod,
+  NewMethodParameterIn,
+  NewMethodReturn,
+  NewModifier,
+  NewTypeDecl
+}
 import org.slf4j.{Logger, LoggerFactory}
-import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
 import ujson.Value
 
 import java.math.BigInteger
@@ -48,9 +56,78 @@ class AstCreator(
   }
 
   protected def astForCompilationUnit(cu: DotNetNodeInfo): Seq[Ast] = {
-    val imports    = cu.json(ParserKeys.Usings).arr.flatMap(astForNode).toSeq
-    val memberAsts = astForMembers(cu.json(ParserKeys.Members).arr.map(createDotNetNodeInfo).toSeq)
-    imports ++ memberAsts
+    val importAsts                              = cu.json(ParserKeys.Usings).arr.flatMap(astForNode).toSeq
+    val members                                 = cu.json(ParserKeys.Members).arr.map(createDotNetNodeInfo).toSeq
+    val (globalStatements, nonGlobalStatements) = members.partition(_.node == GlobalStatement)
+    val nonGlobalStatementAsts                  = nonGlobalStatements.flatMap(astForNode)
+
+    // If there are global statements, we should treat this file as an entry-point.
+    // Roslyn implicitly wraps these statements inside the following block:
+    // ```
+    // internal class Program {
+    //   private static void <Main>$(string[] args) {
+    //      <globalStatements>
+    //   }
+    // }
+    // ```
+    // Note: there can only be one such file in a given project, but we are currently
+    // not checking this.
+    if (globalStatements.nonEmpty) {
+      importAsts ++ astForTopLevelStatements(globalStatements) ++ nonGlobalStatementAsts
+    } else {
+      importAsts ++ nonGlobalStatementAsts
+    }
+  }
+
+  private def astForTopLevelStatements(topLevelStmts: Seq[DotNetNodeInfo]): Seq[Ast] = {
+    val className     = "Program"
+    val mainName      = "<Main>$"
+    val classFullName = s"$className"
+    val mainFullName  = s"$classFullName.$mainName"
+
+    val classNode = NewTypeDecl()
+      .name(className)
+      .fullName(classFullName)
+      .filename(relativeFileName)
+
+    val classModifiers = Seq(NewModifier().modifierType(ModifierTypes.INTERNAL))
+
+    val methodNode = NewMethod()
+      .name(mainName)
+      .fullName(mainFullName)
+      .filename(relativeFileName)
+      .signature("System.Void(System.String[])")
+
+    val methodModifiers =
+      Seq(NewModifier().modifierType(ModifierTypes.STATIC), NewModifier().modifierType(ModifierTypes.PRIVATE))
+
+    val argsParameter = NewMethodParameterIn().name("args").typeFullName("System.String[]")
+    val methodBlock   = NewBlock().typeFullName("System.Void")
+    val methodReturn  = NewMethodReturn().typeFullName("System.Void")
+
+    val topLevelStmtAsts = {
+      scope.pushNewScope(TypeScope(classFullName))
+      scope.pushNewScope(MethodScope(mainFullName))
+      scope.addToScope("args", argsParameter)
+
+      val asts = topLevelStmts.flatMap(astForNode)
+
+      scope.popScope()
+      scope.popScope()
+      asts
+    }
+
+    val methodAst = Ast(methodNode)
+      .withChildren(methodModifiers.map(Ast(_)))
+      .withChild(Ast(argsParameter))
+      .withChild(Ast(methodBlock).withChildren(topLevelStmtAsts))
+      .withChild(Ast(methodReturn))
+
+    val classAst = Ast(classNode)
+      .withChildren(classModifiers.map(Ast(_)))
+      .withChild(methodAst)
+
+    Seq(classAst)
   }
 
   protected def astForMembers(members: Seq[DotNetNodeInfo]): Seq[Ast] = {

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
@@ -1,11 +1,10 @@
 package io.joern.csharpsrc2cpg.astcreation
 
-import io.joern.csharpsrc2cpg.{CSharpDefines, Constants}
+import io.joern.csharpsrc2cpg.Constants
 import io.joern.csharpsrc2cpg.datastructures.{CSharpProgramSummary, CSharpScope, MethodScope, TypeScope}
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
 import io.joern.csharpsrc2cpg.parser.{DotNetNodeInfo, ParserKeys}
 import io.joern.x2cpg.astgen.{AstGenNodeBuilder, ParserResult}
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{DiffGraphBuilder, ModifierTypes, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes.{

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
@@ -80,10 +80,11 @@ class AstCreator(
   }
 
   private def astForTopLevelStatements(topLevelStmts: Seq[DotNetNodeInfo]): Seq[Ast] = {
-    val className     = "Program"
-    val mainName      = "<Main>$"
-    val classFullName = s"$className"
-    val mainFullName  = s"$classFullName.$mainName"
+    val sanitizedFileName = relativeFileName.replace(java.io.File.separator, "_").replace(".", "_")
+    val className         = s"${sanitizedFileName}_Program"
+    val mainName          = "<Main>$"
+    val classFullName     = s"$className"
+    val mainFullName      = s"$classFullName.$mainName"
 
     val classNode = NewTypeDecl()
       .name(className)

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TopLevelStatementTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TopLevelStatementTests.scala
@@ -13,9 +13,25 @@ class TopLevelStatementTests extends CSharpCode2CpgFixture {
 
     inside(cpg.call("WriteLine").method.l) {
       case method :: Nil =>
-        method.fullName shouldBe "Program.<Main>$"
+        method.fullName shouldBe "Test0_cs_Program.<Main>$"
         method.signature shouldBe "System.Void(System.String[])"
-        method.typeDecl.l shouldBe cpg.typeDecl("Program").l
+        method.typeDecl.l shouldBe cpg.typeDecl("Test0_cs_Program").l
+      case xs => fail(s"Expected a method above WriteLine, but found $xs")
+    }
+  }
+
+  "fictitious class name when found inside a directory" in {
+    val cpg = code(
+      """
+        |System.Console.WriteLine(args);
+        |""".stripMargin,
+      "MyProject/Main.cs"
+    )
+    inside(cpg.call("WriteLine").method.l) {
+      case method :: Nil =>
+        method.fullName shouldBe "MyProject_Main_cs_Program.<Main>$"
+        method.signature shouldBe "System.Void(System.String[])"
+        method.typeDecl.l shouldBe cpg.typeDecl("MyProject_Main_cs_Program").l
       case xs => fail(s"Expected a method above WriteLine, but found $xs")
     }
   }
@@ -27,7 +43,7 @@ class TopLevelStatementTests extends CSharpCode2CpgFixture {
     inside(cpg.parameter("args").l) {
       case args :: Nil =>
         args.typeFullName shouldBe "System.String[]"
-        args.method.fullName shouldBe "Program.<Main>$"
+        args.method.fullName shouldBe "Test0_cs_Program.<Main>$"
       case xs => fail(s"Expected single parameter named `args`, but found $xs")
     }
   }
@@ -43,4 +59,5 @@ class TopLevelStatementTests extends CSharpCode2CpgFixture {
       case xs         => fail(s"Expected single TYPE_DECL named `XYZ`, but found $xs")
     }
   }
+
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TopLevelStatementTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TopLevelStatementTests.scala
@@ -1,0 +1,46 @@
+package io.joern.csharpsrc2cpg.querying.ast
+
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class TopLevelStatementTests extends CSharpCode2CpgFixture {
+
+  "WriteLine as a top-level statement should be found inside a fictitious method" in {
+    val cpg = code("""
+        |using System;
+        |Console.WriteLine("Foo");
+        |""".stripMargin)
+
+    inside(cpg.call("WriteLine").method.l) {
+      case method :: Nil =>
+        method.fullName shouldBe "Program.<Main>$"
+        method.signature shouldBe "System.Void(System.String[])"
+        method.typeDecl.l shouldBe cpg.typeDecl("Program").l
+      case xs => fail(s"Expected a method above WriteLine, but found $xs")
+    }
+  }
+
+  "free-variable `args` is in fact a method parameter" in {
+    val cpg = code("""
+        |System.Console.WriteLine(args);
+        |""".stripMargin)
+    inside(cpg.parameter("args").l) {
+      case args :: Nil =>
+        args.typeFullName shouldBe "System.String[]"
+        args.method.fullName shouldBe "Program.<Main>$"
+      case xs => fail(s"Expected single parameter named `args`, but found $xs")
+    }
+  }
+
+  "class declaration defined after top-level statements is present" in {
+    val cpg = code("""
+        |System.Console.WriteLine(args);
+        |class XYZ
+        |{
+        |}""".stripMargin)
+    inside(cpg.typeDecl("XYZ").l) {
+      case xyz :: Nil => xyz.fullName shouldBe "XYZ"
+      case xs         => fail(s"Expected single TYPE_DECL named `XYZ`, but found $xs")
+    }
+  }
+}


### PR DESCRIPTION
Adds support for top-level statements by imitating the lowering performed by Roslyn, i.e. by wrapping them inside a code block like
```csharp
internal class Program
{
  private static void <Main>$(string[] args)
  {
    <top-level-statements>
  }
}
```

I used the same names (`<Main>$` and `Program`) here, but I'm not sure if the usage of `<` or `$` is reserved in full names? If so, what would the recommended names be?

Caveat: there can only be one such file (with top-level statements), which implicitly becomes the program's entry point. In an arbitrary repo we might find more than one since this restriction is tied to a `csproj`. In other words, the "compilation unit" would ideally be a .csproj, but that would mean a large refactoring.