### PR TITLE
[x2cpg] add fieldAccessAst

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -333,27 +333,16 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val identifier = newIdentifierNode(identifierName, typeFullName)
 
-    val fieldIdentifier = NewFieldIdentifier()
-      .code(fieldIdentifierName)
-      .canonicalName(fieldIdentifierName)
-      .lineNumber(accessExpr.lineNumber)
-      .columnNumber(accessExpr.columnNumber)
-
-    val fieldAccessCode = s"$identifierName.$fieldIdentifierName"
-
-    val fieldAccess =
-      newOperatorCallNode(
-        Operators.fieldAccess,
-        fieldAccessCode,
-        Some(typeFullName).orElse(Some(Defines.Any)),
-        accessExpr.lineNumber,
-        accessExpr.columnNumber
-      )
-
-    val identifierAst = Ast(identifier)
-    val fieldIdentAst = Ast(fieldIdentifier)
-
-    Seq(callAst(fieldAccess, Seq(identifierAst, fieldIdentAst)))
+    fieldAccessAst(
+      Ast(identifier),
+      s"$identifierName.$fieldIdentifierName",
+      line(accessExpr),
+      column(accessExpr),
+      fieldIdentifierName,
+      typeFullName,
+      line(accessExpr),
+      column(accessExpr)
+    ) :: Nil
   }
 
   protected def astForElementAccessExpression(elementAccessExpression: DotNetNodeInfo): Seq[Ast] = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForNameExpressionsCreator.scala
@@ -99,9 +99,9 @@ trait AstForNameExpressionsCreator { this: AstCreator =>
       } else {
         newIdentifierNode(NameConstants.This, baseTypeDeclFullName)
       }
-    createFieldAccessAst(
+    fieldAccessAst(
       Ast(base),
-      s"${base.code}.${fieldName}",
+      s"${base.code}.$fieldName",
       line(node),
       column(node),
       fieldName,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -291,34 +291,6 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     astsForExpression(expr.getInner, expectedType)
   }
 
-  private[expressions] def createFieldAccessAst(
-    base: Ast,
-    fieldAccessCode: String,
-    fieldAccessLineNo: Option[Int],
-    fieldAccessColumnNo: Option[Int],
-    fieldName: String,
-    fieldTypeFullName: String,
-    fieldLineNo: Option[Int],
-    fieldColumnNo: Option[Int]
-  ): Ast = {
-    val callNode =
-      newOperatorCallNode(
-        Operators.fieldAccess,
-        fieldAccessCode,
-        Some(fieldTypeFullName),
-        fieldAccessLineNo,
-        fieldAccessColumnNo
-      )
-
-    val fieldIdentifierNode = NewFieldIdentifier()
-      .code(fieldName)
-      .canonicalName(fieldName)
-      .lineNumber(fieldLineNo)
-      .columnNumber(fieldColumnNo)
-
-    callAst(callNode, Seq(base, Ast(fieldIdentifierNode)))
-  }
-
   private[expressions] def astForFieldAccessExpr(expr: FieldAccessExpr, expectedType: ExpectedType): Ast = {
     val typeFullName =
       expressionReturnTypeFullName(expr)
@@ -329,7 +301,7 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     val fieldIdentifier = expr.getName
     val identifierAsts  = astsForExpression(expr.getScope, ExpectedType.empty)
 
-    createFieldAccessAst(
+    fieldAccessAst(
       identifierAsts.head,
       expr.toString,
       line(expr),

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -2,12 +2,10 @@ package io.joern.x2cpg
 
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.utils.IntervalKeyPool
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
-import io.shiftleft.codepropertygraph.generated.Cpg
+import io.joern.x2cpg.utils.NodeBuilders.{newFieldIdentifierNode, newMethodReturnNode, newOperatorCallNode}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Cpg, DiffGraphBuilder, ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, ModifierTypes}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
-import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
 
 abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: ValidationMode) {
   val diffGraph: DiffGraphBuilder = Cpg.newDiffGraphBuilder
@@ -322,6 +320,21 @@ abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: V
           currIndex = currIndex + 1
       }
     }
+  }
+
+  def fieldAccessAst(
+    base: Ast,
+    code: String,
+    lineNo: Option[Int],
+    columnNo: Option[Int],
+    fieldName: String,
+    fieldTypeFullName: String,
+    fieldLineNo: Option[Int],
+    fieldColumnNo: Option[Int]
+  ): Ast = {
+    val callNode = newOperatorCallNode(Operators.fieldAccess, code, Some(fieldTypeFullName), lineNo, columnNo)
+    val fieldIdentifierNode = newFieldIdentifierNode(fieldName, fieldLineNo, fieldColumnNo)
+    callAst(callNode, Seq(base, Ast(fieldIdentifierNode)))
   }
 
   def withIndex[T, X](nodes: Seq[T])(f: (T, Int) => X): Seq[X] =


### PR DESCRIPTION
Promotes `javasrc2cpg`'s `createFieldAccessAst` utility method to `x2cpg` and reuses it in `csharpsrc2cpg`.

Context: I have a couple of PRs in the pipeline for improving csharpsrc2cpg with some missing features (like chained member accesses and field initialisers) and am creating smaller PRs as I clean it up.