### PR TITLE
write the php parser version to the manifest for downstream usage: php2cpg

### DIFF
--- a/joern-cli/frontends/php2cpg/build.sbt
+++ b/joern-cli/frontends/php2cpg/build.sbt
@@ -36,3 +36,7 @@ Compile / compile := ((Compile / compile) dependsOn phpParseInstallTask).value
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 Global / onChangedBuildSource := ReloadOnSourceChanges
+
+/** write the php parser version to the manifest for downstream usage */
+Compile / packageBin / packageOptions +=
+  Package.ManifestAttributes(new java.util.jar.Attributes.Name("PHP-Parser-Version") -> Versions.phpParser)


### PR DESCRIPTION
others will follow once the entire chain works