### PR TITLE
[c#] finish refactoring astForSimpleMemberAccess

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberTests.scala
@@ -328,7 +328,7 @@ class MemberTests extends CSharpCode2CpgFixture {
         |  int b;
         |
         |  static Car() { // static constructor
-        |     this.nonInitMaxSpeed = 2000;
+        |     nonInitMaxSpeed = 2000;
         |  }
         |
         |  public Car() {
@@ -347,7 +347,7 @@ class MemberTests extends CSharpCode2CpgFixture {
           inside(m.body.astChildren.isCall.l) {
             case staticImplicit :: staticExplicit :: Nil =>
               staticExplicit.methodFullName shouldBe Operators.assignment
-              staticExplicit.code shouldBe "this.nonInitMaxSpeed = 2000"
+              staticExplicit.code shouldBe "nonInitMaxSpeed = 2000"
 
               inside(staticExplicit.argument.fieldAccess.l) {
                 case fieldAccess :: Nil =>


### PR DESCRIPTION
* `astForSimpleMemberAccess` is now without edge cases.
* This refactoring brought up to light another edge case: classes/typeDecls found outside an explicit namespace block were not being loaded into `CSharpProgramSummary`, and thus their fields wouldn't be found later on.
* Fixes a semantically invalid unit-test code sample: `this.nonInitMaxSpeed` inside a `static` method isn't valid C# code.