### PR TITLE
markus/koltinBugfixes

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
@@ -713,15 +713,19 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       scope.addToScope(expr.getName, node)
       val localAst = Ast(node)
 
-      val rhsAsts       = astsForExpression(expr.getDelegateExpressionOrInitializer, Some(2))
-      val identifier    = identifierNode(elem, elem.getText, elem.getText, typeFullName)
-      val identifierAst = astWithRefEdgeMaybe(identifier.name, identifier)
-      val assignmentNode =
-        NodeBuilders.newOperatorCallNode(Operators.assignment, expr.getText, None, line(expr), column(expr))
-      val call =
-        callAst(assignmentNode, List(identifierAst) ++ rhsAsts)
-          .withChildren(annotations.map(astForAnnotationEntry))
-      Seq(localAst, call)
+      if (expr.getDelegateExpressionOrInitializer != null) {
+        val rhsAsts       = astsForExpression(expr.getDelegateExpressionOrInitializer, Some(2))
+        val identifier    = identifierNode(elem, elem.getText, elem.getText, typeFullName)
+        val identifierAst = astWithRefEdgeMaybe(identifier.name, identifier)
+        val assignmentNode =
+          NodeBuilders.newOperatorCallNode(Operators.assignment, expr.getText, None, line(expr), column(expr))
+        val call =
+          callAst(assignmentNode, List(identifierAst) ++ rhsAsts)
+            .withChildren(annotations.map(astForAnnotationEntry))
+        Seq(localAst, call)
+      } else {
+        Seq(localAst)
+      }
     }
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameRenderer.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/NameRenderer.scala
@@ -1,6 +1,6 @@
 package io.joern.kotlin2cpg.types
 
-import io.joern.kotlin2cpg.types.NameRenderer.BuiltinTypeTranslationTable
+import io.joern.kotlin2cpg.types.NameRenderer.{BuiltinTypeTranslationTable, logger}
 import io.joern.x2cpg.Defines
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
 import org.jetbrains.kotlin.descriptors.impl.TypeAliasConstructorDescriptor
@@ -16,11 +16,14 @@ import org.jetbrains.kotlin.descriptors.{
 import org.jetbrains.kotlin.name.FqNameUnsafe
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.error.ErrorClassDescriptor
+import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
 object NameRenderer {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   private val BuiltinTypeTranslationTable = mutable.HashMap(
     "kotlin.Unit"         -> "void",
     "kotlin.Boolean"      -> "boolean",
@@ -111,6 +114,13 @@ class NameRenderer {
           } else {
             Some(upperBoundTypeFns.flatten.mkString("&"))
           }
+        case null =>
+          // We do not expect this because to my understanding a typ should always have a constructor
+          // descriptor.
+          logger.warn(
+            s"Found type without constructor descriptor. Typ: $typ Constructor class: ${typ.getConstructor.getClass}"
+          )
+          None
       }
 
     javaFullName

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LocalTests.scala
@@ -25,4 +25,20 @@ class LocalTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       l2.typeFullName shouldBe "int"
     }
   }
+
+  "CPG for local declaration without initialization" should {
+    val cpg = code("""
+                     |fun main() {
+                     |  var x: Int
+                     |}
+                     |""".stripMargin)
+
+    "contain LOCAL node for `x`" in {
+      val List(l1) = cpg.local("x").l
+      l1.code shouldBe "x"
+      l1.name shouldBe "x"
+      l1.typeFullName shouldBe "int"
+    }
+  }
+
 }


### PR DESCRIPTION
- **Fix handling of lambda functions wrapped by constructs like labels.**
- **Handle case where a type constructor has no declaration descriptor.**
- **Fix broken CPG in case of variable declaration without initialization.**
