### PR TITLE
Add tmp locals for pattern initializers to lambda method bodies

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -302,19 +302,13 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
     val bindingsToLocals      = defineCapturedVariables(lambdaMethodName, capturedVariables)
     val capturedLocalAsts     = bindingsToLocals.map(_._2).map(Ast(_))
     val closureBindingEntries = bindingsToLocals.map(_._1)
+    val temporaryLocalAsts    = scope.enclosingMethod.map(_.getTemporaryLocals).getOrElse(Nil).map(Ast(_))
 
-    body match {
-      case block: BlockStmt =>
-        val blockAst = Ast(blockNode(block))
-          .withChildren(capturedLocalAsts)
-          .withChildren(stmts)
-        LambdaBody(blockAst, closureBindingEntries)
-      case stmt =>
-        val blockAst = Ast(blockNode(stmt))
-          .withChildren(capturedLocalAsts)
-          .withChildren(stmts)
-        LambdaBody(blockAst, closureBindingEntries)
-    }
+    val blockAst = Ast(blockNode(body))
+      .withChildren(temporaryLocalAsts)
+      .withChildren(capturedLocalAsts)
+      .withChildren(stmts)
+    LambdaBody(blockAst, closureBindingEntries)
   }
 
   private def genericParamTypeMapForLambda(expectedType: ExpectedType): ResolvedTypeParametersMap = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
@@ -18,6 +18,22 @@ import io.shiftleft.semanticcpg.language.*
 
 class PatternExprTests extends JavaSrcCode2CpgFixture {
 
+  "a pattern initializer in a lambda method" should {
+    val cpg = code("""
+        |import java.util.function.Function;
+        |
+        |class Foo {
+        |  Function test() {
+        |    return o -> foo() instanceof String s ? s : null;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "not create any orphan locals" in {
+      cpg.local.exists(_._astIn.isEmpty) shouldBe false
+    }
+  }
+
   "a type pattern in an expression in an explicit constructor" should {
     val cpg = code("""
         |class Test {


### PR DESCRIPTION
While troubleshooting a customer issue, I reproduced some missing locals using the elasticsearch repo as a test project. This fixes some of the orphan locals, but there is another issue which I'm still looking into, but which is unrelated to patterns.