### PR TITLE
[ruby] Alias Handling for `alias_method`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -567,7 +567,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       case EnsureClause(thenClause) => EnsureClause(reassign(lhs, op, thenClause, transform))(x.span)
       case ElsIfClause(condition, thenClause) =>
         ElsIfClause(condition, reassign(lhs, op, thenClause, transform))(x.span)
-      case ElseClause(thenClause) => ElseClause(reassign(lhs, op, thenClause, transform))(x.span)
+      case ElseClause(thenClause)  => ElseClause(reassign(lhs, op, thenClause, transform))(x.span)
+      case InClause(pattern, body) => InClause(pattern, reassign(lhs, op, body, transform))(x.span)
       case WhenClause(matchExpressions, matchSplatExpression, thenClause) =>
         WhenClause(matchExpressions, matchSplatExpression, reassign(lhs, op, thenClause, transform))(x.span)
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -314,16 +314,17 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           case ArrayParameter(_) => prefixAsKernelDefined("Array")
           case HashParameter(_)  => prefixAsKernelDefined("Hash")
         }
+        val name = node.name.stripPrefix("*")
         val parameterIn = parameterInNode(
           node = node,
-          name = node.name.stripPrefix("*"),
+          name = name,
           code = code(node),
           index = index,
           isVariadic = true,
           evaluationStrategy = EvaluationStrategies.BY_REFERENCE,
           typeFullName = Option(typeFullName)
         )
-        scope.addToScope(node.name, parameterIn)
+        scope.addToScope(name, parameterIn)
         Ast(parameterIn)
       case node: GroupedParameter =>
         val parameterIn = parameterInNode(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -316,7 +316,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         }
         val parameterIn = parameterInNode(
           node = node,
-          name = node.name,
+          name = node.name.stripPrefix("*"),
           code = code(node),
           index = index,
           isVariadic = true,


### PR DESCRIPTION
`alias_method` is a builtin call that performs a more "dynamic" version of `alias` as it makes use of symbols. This change applies the same alias lowering logic to this function as what happens with `alias` calls.

Misc additions:
* Addresses warning for `reassign` not having an exhaustive match (due to the `InClause` object)
* Strips the leading `*` from collection parameters, as these are referred to in the method body as splatted identifiers without the leading `*`.