### PR TITLE
[ruby] In Pattern Variable Scoping Fix

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -348,7 +348,9 @@ object RubyIntermediateAst {
 
   final case class ArrayPattern(children: List[RubyExpression])(span: TextSpan) extends RubyExpression(span)
 
-  final case class MatchVariable()(span: TextSpan) extends RubyExpression(span)
+  final case class MatchVariable()(span: TextSpan) extends RubyExpression(span) {
+    def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier()(span)
+  }
 
   final case class NextExpression()(span: TextSpan) extends RubyExpression(span) with ControlFlowStatement
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -202,7 +202,7 @@ class CaseTests extends RubyCode2CpgFixture {
             lhs.name shouldBe "result"
 
             rhs.methodFullName shouldBe RubyOperators.arrayPatternMatch
-            rhs.code shouldBe s"${RubyOperators.arrayPatternMatch}(result)"
+            rhs.code shouldBe s"${RubyOperators.arrayPatternMatch}(<tmp-0>)"
           case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
         }
 
@@ -211,7 +211,7 @@ class CaseTests extends RubyCode2CpgFixture {
             lhs.name shouldBe "notResult"
 
             rhs.methodFullName shouldBe RubyOperators.arrayPatternMatch
-            rhs.code shouldBe s"${RubyOperators.arrayPatternMatch}(notResult)"
+            rhs.code shouldBe s"${RubyOperators.arrayPatternMatch}(<tmp-0>)"
           case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
         }
       case _ => fail(s"Expected two true branches")


### PR DESCRIPTION
Fixed an issue where the variables that the pattern extracted to were interpreted as fields instead of local variables. Also makes sure the pattern match call happens on the original expression and not on the LHS match variable.