### PR TITLE
[c#] allow resolving fully-qualified names without importing them first

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ListUtils.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ListUtils.scala
@@ -16,5 +16,8 @@ object ListUtils {
         case _                   => Nil
       }
     }
+
+    /** Returns the single element, or None if the list is empty or contains more than one element. */
+    def singleOrNone: Option[T] = if list.size == 1 then list.headOption else None
   }
 }


### PR DESCRIPTION
Follow up to #5205 -- the previous tests worked fine since `System` was being imported. However, we should still resolve e.g. `System.Console` when `System` is not being imported. I forgot to take into account this scenario in the previous PR.