### PR TITLE
[c#] resolve getters in fieldAccesses

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -315,13 +315,20 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val fieldIdentifierName = nameFromNode(accessExpr)
     val baseAst             = astForNode(createDotNetNodeInfo(accessExpr.json(ParserKeys.Expression))).head
     val baseTypeFullName    = getTypeFullNameFromAstNode(baseAst)
-    val typeFullName =
-      scope
-        .tryResolveFieldAccess(fieldIdentifierName, Some(baseTypeFullName))
-        .map(_.typeName)
-        // it may happen that accessExpr is a type name e.g. `System.Console`, in which case `System` (baseAst) is not
-        // a type but a namespace. As a fallback, we also look up the full expression.
-        .getOrElse(scope.tryResolveTypeReference(accessExpr.code).map(_.name).getOrElse(Defines.Any))
+    val typeFullName = {
+      // The typical resolving mechanism
+      lazy val byFieldAccess = scope.tryResolveFieldAccess(fieldIdentifierName, Some(baseTypeFullName)).map(_.typeName)
+
+      // Getters look like fields, but are underneath `get_`-prefixed methods
+      lazy val byPropertyName =
+        scope.tryResolveMethodInvocation(s"get_$fieldIdentifierName", Nil, Some(baseTypeFullName)).map(_.returnType)
+
+      // accessExpr might be a qualified name e.g. `System.Console`, in which case `System` (baseAst) is not a type
+      // but a namespace. In this scenario, we look up the entire expression
+      lazy val byQualifiedName = scope.tryResolveTypeReference(accessExpr.code).map(_.name)
+
+      byFieldAccess.orElse(byPropertyName).orElse(byQualifiedName).getOrElse(Defines.Any)
+    }
 
     fieldAccessAst(
       baseAst,

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/PropertyGetterTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/PropertyGetterTests.scala
@@ -1,0 +1,68 @@
+package io.joern.csharpsrc2cpg.querying.ast
+
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class PropertyGetterTests extends CSharpCode2CpgFixture {
+
+  "`System.Console.Out` being assigned to a variable" should {
+    val cpg = code("""
+        |using System;
+        |var x = System.Console.Out;
+        |""".stripMargin)
+
+    "have variable correctly typed" in {
+      cpg.identifier.nameExact("x").typeFullName.l shouldBe List("System.IO.TextWriter")
+    }
+
+    "have System.Console.Out correctly set" in {
+      inside(cpg.fieldAccess.code("System.Console.Out").l) {
+        case consoleOut :: Nil =>
+          consoleOut.typeFullName shouldBe "System.IO.TextWriter"
+          consoleOut.fieldIdentifier.canonicalName.l shouldBe List("Out")
+        case xs =>
+          fail(s"Expected single fieldAccess for Console.Out, but got $xs")
+      }
+    }
+  }
+
+  "`System.Console.Out.WriteLine` call" should {
+    val cpg = code("""
+        |using System;
+        |using System.IO;
+        |System.Console.Out.WriteLine("X");
+        |""".stripMargin)
+
+    "have correct properties for WriteLine" in {
+      inside(cpg.call.nameExact("WriteLine").l) {
+        case writeLine :: Nil =>
+          writeLine.code shouldBe "System.Console.Out.WriteLine(\"X\")"
+          writeLine.methodFullName shouldBe "System.IO.TextWriter.WriteLine:System.Void(System.String)"
+          writeLine.typeFullName shouldBe "System.Void"
+        case xs =>
+          fail(s"Expected single WriteLine call, but got $xs")
+      }
+    }
+
+    "have correct properties for System.Console" in {
+      inside(cpg.fieldAccess.code("System.Console").l) {
+        case sysConsole :: Nil =>
+          sysConsole.fieldIdentifier.canonicalName.l shouldBe List("Console")
+          sysConsole.typeFullName shouldBe "System.Console"
+        case xs =>
+          fail(s"Expected single fieldAccess for System.Console, but got $xs")
+      }
+    }
+
+    "have correct properties for System.Console.Out" in {
+      inside(cpg.fieldAccess.code("System.Console.Out").l) {
+        case out :: Nil =>
+          out.code shouldBe "System.Console.Out"
+          out.typeFullName shouldBe "System.IO.TextWriter"
+        case xs =>
+          fail(s"Expected single fieldAccess for System.Console.Out, but got $xs")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
In the output of DotNetAstGen, getters are represented as `get_`-prefixed methods. So, for instance, in order to type match the expression `System.Console.Out` we should look for `System.Console.get_Out`.