### PR TITLE
[c2cpg] Improvements for range-based for-statement and local code fields

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -700,15 +700,16 @@ class AstCreationPassTests extends AstC2CpgSuite {
       )
       inside(cpg.method.nameExact("method").controlStructure.l) { case List(forStmt) =>
         forStmt.controlStructureType shouldBe ControlStructureTypes.FOR
-        inside(forStmt.astChildren.order(1).l) { case List(ident: Identifier) =>
-          ident.code shouldBe "list"
-        }
-        inside(forStmt.astChildren.order(2).l) { case List(x: Local) =>
+        inside(forStmt.astChildren.isLocal.l) { case List(x: Local) =>
           x.name shouldBe "x"
           x.typeFullName shouldBe "int"
           x.code shouldBe "int x"
         }
-        inside(forStmt.astChildren.order(3).l) { case List(block: Block) =>
+        // for the expected orders see CfgCreator.cfgForForStatement
+        inside(forStmt.astChildren.order(2).l) { case List(ident: Identifier) =>
+          ident.code shouldBe "list"
+        }
+        inside(forStmt.astChildren.order(5).l) { case List(block: Block) =>
           block.astChildren.isCall.code.l shouldBe List("z = x")
         }
       }
@@ -726,7 +727,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
       )
       inside(cpg.method.nameExact("method").controlStructure.l) { case List(forStmt) =>
         forStmt.controlStructureType shouldBe ControlStructureTypes.FOR
-        forStmt.astChildren.isCall.code.l shouldBe List(
+        forStmt.astChildren.isBlock.astChildren.isCall.code.l shouldBe List(
           "anonymous_tmp_0 = foo",
           "a = anonymous_tmp_0[0]",
           "b = anonymous_tmp_0[1]"
@@ -819,7 +820,7 @@ class AstCreationPassTests extends AstC2CpgSuite {
       """.stripMargin)
       val List(forLoop)        = cpg.controlStructure.l
       val List(conditionBlock) = forLoop.condition.collectAll[Block].l
-      conditionBlock.argumentIndex shouldBe 2
+      conditionBlock.order shouldBe 2
       val List(assignmentCall, greaterCall) = conditionBlock.astChildren.collectAll[Call].l
       assignmentCall.argumentIndex shouldBe 1
       assignmentCall.code shouldBe "b = something()"

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/ControlStructureTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/ControlStructureTests.scala
@@ -92,26 +92,26 @@ class ControlStructureTests extends C2CpgSuite(FileDefaults.CppExt) {
     "should be correct for for-loop with multiple assignments" in {
       inside(cpg.controlStructure.l) { case List(forLoop) =>
         forLoop.controlStructureType shouldBe ControlStructureTypes.FOR
-        inside(forLoop.astChildren.order(1).l) { case List(assignmentBlock) =>
-          inside(assignmentBlock.astChildren.l) { case List(localX, localY, assignmentX, assignmentY) =>
-            localX.code shouldBe "int x"
-            localX.order shouldBe 1
-            localY.code shouldBe "int y"
-            localY.order shouldBe 2
+        inside(forLoop.astChildren.isLocal.l) { case List(localX, localY) =>
+          localX.code shouldBe "int x"
+          localY.code shouldBe "int y"
+        }
+        inside(forLoop.astChildren.order(3).l) { case List(assignmentBlock) =>
+          inside(assignmentBlock.astChildren.l) { case List(assignmentX, assignmentY) =>
             assignmentX.code shouldBe "x=1"
-            assignmentX.order shouldBe 3
+            assignmentX.order shouldBe 1
             assignmentY.code shouldBe "y=1"
-            assignmentY.order shouldBe 4
+            assignmentY.order shouldBe 2
           }
         }
         inside(forLoop.condition.l) { case List(x) =>
           x.code shouldBe "x"
-          x.order shouldBe 2
+          x.order shouldBe 4
         }
-        inside(forLoop.astChildren.order(3).l) { case List(updateX) =>
+        inside(forLoop.astChildren.order(5).l) { case List(updateX) =>
           updateX.code shouldBe "--x"
         }
-        inside(forLoop.astChildren.order(4).l) { case List(loopBody) =>
+        inside(forLoop.astChildren.order(6).l) { case List(loopBody) =>
           loopBody.astChildren.isCall.head.code shouldBe "bar()"
         }
       }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/TemplateTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/TemplateTypeTests.scala
@@ -29,7 +29,7 @@ class TemplateTypeTests extends C2CpgSuite(fileSuffix = FileDefaults.CppExt) {
           typeDeclA.aliasTypeFullName shouldBe Option("X<int>")
           typeDeclB.name shouldBe "B"
           typeDeclB.fullName shouldBe "B"
-          typeDeclB.aliasTypeFullName shouldBe Option("Y<int, char>")
+          typeDeclB.aliasTypeFullName shouldBe Option("Y<int,char>")
       }
     }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/LocalQueryTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/LocalQueryTests.scala
@@ -7,79 +7,97 @@ import io.shiftleft.semanticcpg.language.*
   */
 class LocalQueryTests extends C2CpgSuite {
 
-  private val cpg = code("""
-    | struct node {
-    |   int value;
-    |   struct node *next;
-    | };
-    |
-    | void free_list(struct node *head) {
-    |   struct node *q;
-    |   for (struct node *p = head; p != NULL; p = q) {
-    |     q = p->next;
-    |     free(p);
-    |   }
-    | }
-    | 
-    | int flow(int p0) {
-    |   int a = p0;
-    |   int b = a;
-    |   int c = 0x31;
-    |   int z = b + c;
-    |   z++;
-    |   int x = z;
-    |   return x;
-    | }
-    | 
-    | void test() {
-    |   static int a, b, c;
-    |   wchar_t *foo;
-    |   int d[10], e = 1;
-    | }
-    | """.stripMargin)
-
-  "should allow to query for all locals" in {
-    cpg.local.name.toSetMutable shouldBe Set("a", "b", "c", "e", "d", "z", "x", "q", "p", "foo")
-  }
-
-  "should prove correct (name, type) pairs for locals" in {
-    inside(cpg.method.name("free_list").local.l) { case List(q, p) =>
-      q.name shouldBe "q"
-      q.typeFullName shouldBe "node*"
-      q.code shouldBe "struct node* q"
-      p.name shouldBe "p"
-      p.typeFullName shouldBe "node*"
-      p.code shouldBe "struct node* p"
+  "local query example 1" should {
+    "allow to query for the local" in {
+      val cpg = code(
+        """
+        |void foo() {
+        |  static const Foo::Bar bar{};
+        |}
+        |""".stripMargin,
+        "test.cpp"
+      )
+      val List(barLocal) = cpg.method.name("foo").local.l
+      barLocal.name shouldBe "bar"
+      barLocal.typeFullName shouldBe "Foo.Bar"
+      barLocal.code shouldBe "static const Foo.Bar bar"
     }
   }
 
-  "should prove correct (name, type, code) pairs for locals" in {
-    inside(cpg.method.name("test").local.l) { case List(a, b, c, foo, d, e) =>
-      a.name shouldBe "a"
-      a.typeFullName shouldBe "int"
-      a.code shouldBe "static int a"
-      b.name shouldBe "b"
-      b.typeFullName shouldBe "int"
-      b.code shouldBe "static int b"
-      c.name shouldBe "c"
-      c.typeFullName shouldBe "int"
-      c.code shouldBe "static int c"
-      foo.name shouldBe "foo"
-      foo.typeFullName shouldBe "wchar_t*"
-      foo.code shouldBe "wchar_t* foo"
-      d.name shouldBe "d"
-      d.typeFullName shouldBe "int[10]"
-      d.code shouldBe "int[10] d"
-      e.name shouldBe "e"
-      e.typeFullName shouldBe "int"
-      e.code shouldBe "int e"
+  "local query example 2" should {
+    val cpg = code("""
+        | struct node {
+        |   int value;
+        |   struct node *next;
+        | };
+        |
+        | void free_list(struct node *head) {
+        |   struct node *q;
+        |   for (struct node *p = head; p != NULL; p = q) {
+        |     q = p->next;
+        |     free(p);
+        |   }
+        | }
+        |
+        | int flow(int p0) {
+        |   int a = p0;
+        |   int b = a;
+        |   int c = 0x31;
+        |   int z = b + c;
+        |   z++;
+        |   int x = z;
+        |   return x;
+        | }
+        |
+        | void test() {
+        |   static int a, b, c;
+        |   wchar_t *foo;
+        |   int d[10], e = 1;
+        | }
+        | """.stripMargin)
+
+    "should allow to query for all locals" in {
+      cpg.local.name.toSetMutable shouldBe Set("a", "b", "c", "e", "d", "z", "x", "q", "p", "foo")
+    }
+
+    "should prove correct (name, type) pairs for locals" in {
+      inside(cpg.method.name("free_list").local.l) { case List(q, p) =>
+        q.name shouldBe "q"
+        q.typeFullName shouldBe "node*"
+        q.code shouldBe "struct node* q"
+        p.name shouldBe "p"
+        p.typeFullName shouldBe "node*"
+        p.code shouldBe "struct node* p"
+      }
+    }
+
+    "should prove correct (name, type, code) pairs for locals" in {
+      inside(cpg.method.name("test").local.l) { case List(a, b, c, foo, d, e) =>
+        a.name shouldBe "a"
+        a.typeFullName shouldBe "int"
+        a.code shouldBe "static int a"
+        b.name shouldBe "b"
+        b.typeFullName shouldBe "int"
+        b.code shouldBe "static int b"
+        c.name shouldBe "c"
+        c.typeFullName shouldBe "int"
+        c.code shouldBe "static int c"
+        foo.name shouldBe "foo"
+        foo.typeFullName shouldBe "wchar_t*"
+        foo.code shouldBe "wchar_t* foo"
+        d.name shouldBe "d"
+        d.typeFullName shouldBe "int[10]"
+        d.code shouldBe "int[10] d"
+        e.name shouldBe "e"
+        e.typeFullName shouldBe "int"
+        e.code shouldBe "int e"
+      }
+    }
+
+    "should allow finding filenames by local regex" in {
+      val filename = cpg.local.name("a*").file.name.headOption
+      filename should not be empty
+      filename.head.endsWith(".c") shouldBe true
     }
   }
-
-  "should allow finding filenames by local regex" in {
-    val filename = cpg.local.name("a*").file.name.headOption
-    filename should not be empty
-    filename.head.endsWith(".c") shouldBe true
-  }
-
 }


### PR DESCRIPTION
- range-based for-statement blocks had multiple outgoing CFG edges because the children were not wrapped into blocks.
- code fields for locals from NamedTypeSpecifiers now preserve static and const modifier