### PR TITLE
[javasrc2cpg] Fix orphan local class identifiers

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
@@ -744,6 +744,11 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
     @inline def constructors =
       cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local").method.nameExact("<init>").sortBy(_.parameter.size)
 
+    "not have any orphan locals or parameters" in {
+      cpg.local.filter(_.astIn.isEmpty).l shouldBe List()
+      cpg.parameter.filter(_.astIn.isEmpty).l shouldBe List()
+    }
+
     "have params for captured members for both constructors" in {
       constructors.head.parameter.name.l shouldBe List("this", "outerClass", "outerParam")
       constructors.last.parameter.name.l shouldBe List("this", "ctxParam", "outerClass", "outerParam")
@@ -869,7 +874,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
             call.signature shouldBe "void(int)"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -940,7 +945,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.foo.Local.<init>:void()"
             call.signature shouldBe "void()"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1001,7 +1006,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
             call.signature shouldBe "void()"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1055,7 +1060,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
             call.signature shouldBe "void()"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1108,7 +1113,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
             call.signature shouldBe "void(int)"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1168,7 +1173,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
             call.signature shouldBe "void()"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1217,7 +1222,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
             call.signature shouldBe "void(int)"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }


### PR DESCRIPTION
`usedCaptures` contains an `outerClass` local which exists mostly to provide type information and should not be added to the CPG. Normally this would not happen, but this caused an issue with `this()` calls in constructor bodies where the constructor has an `outerClass` parameter which should be passed through `this`, but the REF edge was instead being created to the type-info-only local. This PR fixes this issue by correctly creating the ref edge to the `outerClass` parameter instead. There's definitely a more robust way to fix this, but that would probably require significantly larger changes to how capture information is stored. 