### PR TITLE
[javasrc2cpg] Have enums and records extend java.lang.Enum and java.lang.Record

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -694,6 +694,10 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
         Seq()
       }
       maybeJavaObjectType ++ inheritsFromTypeNames
+    } else if (typ.isEnumDeclaration) {
+      TypeConstants.Enum :: Nil
+    } else if (typ.isRecordDeclaration) {
+      TypeConstants.Record :: Nil
     } else {
       List.empty[String]
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -260,6 +260,8 @@ object TypeInfoCalculator {
     val Object: String   = "java.lang.Object"
     val Class: String    = "java.lang.Class"
     val Iterator: String = "java.util.Iterator"
+    val Enum: String     = "java.lang.Enum"
+    val Record: String   = "java.lang.Record"
     val Void: String     = "void"
     val Any: String      = "ANY"
   }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/EnumTests.scala
@@ -24,6 +24,10 @@ class EnumTests extends JavaSrcCode2CpgFixture {
       |}
       |""".stripMargin)
 
+  "the enum type should extends java.lang.Enum" in {
+    cpg.typeDecl.name("FuzzyBool").inheritsFromTypeFullName.l shouldBe List("java.lang.Enum")
+  }
+
   "it should parse a basic enum without values" in {
     inside(cpg.typeDecl.name(".*FuzzyBool.*").l) { case List(typeDecl) =>
       typeDecl.code shouldBe "public enum FuzzyBool"

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/RecordTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/RecordTests.scala
@@ -18,6 +18,10 @@ class RecordTests extends JavaSrcCode2CpgFixture {
                        |}
                        |""".stripMargin)
 
+    "extend java.lang.Record" in {
+      cpg.typeDecl("Foo").inheritsFromTypeFullName.l shouldBe List("java.lang.Record")
+    }
+
     "have the correct representation for the compact constructor" in {
       inside(cpg.method.nameExact("<init>").l) { case List(constructor) =>
         constructor.fullName shouldBe "foo.Foo.<init>:void(java.lang.String)"


### PR DESCRIPTION
The lowering for enum constants still needs an overhaul, but this fixes the inheritance hierarchy, at least.