### PR TITLE
[javasrc2cpg] Fix orphan outerClass locals in constructor bodies

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -1,6 +1,6 @@
 package io.joern.javasrc2cpg
 
-import io.joern.javasrc2cpg.passes.{AstCreationPass, TypeInferencePass}
+import io.joern.javasrc2cpg.passes.{AstCreationPass, OuterClassRefPass, TypeInferencePass}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.passes.frontend.{JavaConfigFileCreationPass, MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.X2CpgFrontend
@@ -22,6 +22,7 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       astCreationPass.createAndApply()
       astCreationPass.sourceParser.cleanupDelombokOutput()
       astCreationPass.clearJavaParserCaches()
+      new OuterClassRefPass(cpg).createAndApply()
       JavaConfigFileCreationPass(cpg).createAndApply()
       if (!config.skipTypeInfPass) {
         TypeNodePass.withRegisteredTypes(astCreationPass.global.usedTypes.keys().asScala.toList, cpg).createAndApply()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -464,11 +464,7 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
                     .lineNumber(initRoot.lineNumber)
                     .columnNumber(initRoot.columnNumber)
 
-                  val refsTo = if (usedCapture.name == NameConstants.OuterClass) {
-                    scope.lookupVariable(usedCapture.name).getVariable().map(_.node)
-                  } else {
-                    Option(usedCapture.node)
-                  }
+                  val refsTo = Option.when(usedCapture.name != NameConstants.OuterClass)(usedCapture.node)
 
                   Ast(identifier).withRefEdges(identifier, refsTo.toList)
                 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/OuterClassRefPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/OuterClassRefPass.scala
@@ -1,0 +1,24 @@
+package io.joern.javasrc2cpg.passes;
+
+import io.joern.javasrc2cpg.util.NameConstants
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Method, TypeDecl}
+import io.shiftleft.passes.ForkJoinParallelCpgPass
+import io.shiftleft.semanticcpg.language.*
+
+class OuterClassRefPass(cpg: Cpg) extends ForkJoinParallelCpgPass[TypeDecl](cpg) {
+  override def generateParts(): Array[TypeDecl] = cpg.typeDecl.toArray
+
+  override def runOnPart(diffGraph: DiffGraphBuilder, typeDecl: TypeDecl): Unit = {
+    typeDecl.method.nameExact(Defines.ConstructorMethodName).foreach { constructor =>
+      constructor.ast.isIdentifier.nameExact(NameConstants.OuterClass).filter(_.refsTo.isEmpty).foreach {
+        outerClassIdentifier =>
+          constructor.parameter.nameExact(NameConstants.OuterClass).foreach { outerClassParam =>
+            diffGraph.addEdge(outerClassIdentifier, outerClassParam, EdgeTypes.REF)
+          }
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
@@ -749,6 +749,12 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
       cpg.parameter.filter(_.astIn.isEmpty).l shouldBe List()
     }
 
+    "have ref edges from the outer class identifier to the parameter" in {
+      inside(cpg.method.nameExact("<init>").filter(_.parameter.name.contains("ctxParam")).l) { case List(constructor) =>
+        constructor.ast.isIdentifier.name("outerClass").refsTo.l shouldBe constructor.parameter.name("outerClass").l
+      }
+    }
+
     "have params for captured members for both constructors" in {
       constructors.head.parameter.name.l shouldBe List("this", "outerClass", "outerParam")
       constructors.last.parameter.name.l shouldBe List("this", "ctxParam", "outerClass", "outerParam")

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
@@ -744,6 +744,11 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
     @inline def constructors =
       cpg.typeDecl.fullName("foo.Foo.enclosingMethod.Local").method.nameExact("<init>").sortBy(_.parameter.size)
 
+    "not have any orphan locals or parameters" in {
+      cpg.local.filter(_.astIn.isEmpty).l shouldBe List()
+      cpg.parameter.filter(_.astIn.isEmpty).l shouldBe List()
+    }
+
     "have params for captured members for both constructors" in {
       constructors.head.parameter.name.l shouldBe List("this", "outerClass", "outerParam")
       constructors.last.parameter.name.l shouldBe List("this", "ctxParam", "outerClass", "outerParam")
@@ -869,7 +874,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
             call.signature shouldBe "void(int)"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -940,7 +945,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.foo.Local.<init>:void()"
             call.signature shouldBe "void()"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1001,7 +1006,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
             call.signature shouldBe "void()"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1055,7 +1060,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
             call.signature shouldBe "void()"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1108,7 +1113,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
             call.signature shouldBe "void(int)"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1168,7 +1173,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void()"
             call.signature shouldBe "void()"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }
@@ -1217,7 +1222,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
           case List(call) =>
             call.methodFullName shouldBe "foo.Foo.fooMethod.Local.<init>:void(int)"
             call.signature shouldBe "void(int)"
-            pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
+          // pendingUntilFixed(call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH)
           case result => fail(s"Unexpected result ${result}")
         }
       }


### PR DESCRIPTION
If a class captures the outer class, then we lower the constructor
```
public Foo() {
  this("chained constructor call");
}
```

to
 
```
public Foo(OuterClassType outerClass) {
  this("chained constructor call", outerClass);
}
```

The implementation for this was creating an orphan `outerClass` identifier in the CPG due to a REF edge that was incorrectly added. 

This is a fix in 2 parts. The first is to remove a ref edge to an `outerClass` used capture which shouldn't have been added to the CPG.

The second is to create the correct ref edge to the `outerClass` parameter. I did it in a pass after the fact since the current implementation handles the creation of parameters for captured variables and adding arguments to constructor calls separately, both outside of the actual method scope. This means that the information required to create the correct REF edge is missing at the point where args are added to the `this` call. It should be possible to do this without the extra pass, but that would likely require significant changes to how constructor creation and calls are handled which would also take much longer.