### PR TITLE
[php2cpg] Try multiple charsets when reading file content

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.5.2"
 
-val cpgVersion = "1.7.19"
+val cpgVersion = "1.7.21"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import scala.collection.mutable
+import scala.util.{Success, Try}
 
 class AstCreator(relativeFileName: String, fileName: String, phpAst: PhpFile, disableFileContent: Boolean)(implicit
   withSchemaValidation: ValidationMode
@@ -29,13 +30,33 @@ class AstCreator(relativeFileName: String, fileName: String, phpAst: PhpFile, di
   private val scope           = new Scope()(() => nextClosureName())
   private val tmpKeyPool      = new IntervalKeyPool(first = 0, last = Long.MaxValue)
   private val globalNamespace = globalNamespaceBlock()
-  private var fileContent     = Option.empty[String]
+  private val fileEncodings = List(
+    StandardCharsets.UTF_8,
+    StandardCharsets.UTF_16,
+    StandardCharsets.ISO_8859_1,
+    StandardCharsets.US_ASCII,
+    StandardCharsets.UTF_16LE,
+    StandardCharsets.UTF_16BE
+  )
+  private var fileContent = Option.empty[String]
 
   private def getNewTmpName(prefix: String = "tmp"): String = s"$prefix${tmpKeyPool.next.toString}"
 
   override def createAst(): DiffGraphBuilder = {
     if (!disableFileContent) {
       fileContent = Some(Files.readString(Path.of(fileName)))
+
+      fileContent = fileEncodings.iterator
+        .map { encoding =>
+          Try(Files.readString(Path.of(fileName), encoding))
+        }
+        .collectFirst { case Success(content) =>
+          content
+        }
+
+      if (fileContent.isEmpty) {
+        logger.warn(s"Could not parse file using any standard charsets. File content will be missing for $fileName")
+      }
     }
 
     val ast = astForPhpFile(phpAst)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -146,7 +146,7 @@ class MethodTests extends PhpCode2CpgFixture {
         fooMethod.file.head.content.substring(offsetStart, offsetEnd) shouldBe
           """function foo() {
             |  // ⦝
-            |  $x = "??⨌????????????";
+            |  $x = "🙂⨌🙂𐇐🙂🙂🙂🙂";
             |}""".stripMargin
       }
     }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -146,7 +146,7 @@ class MethodTests extends PhpCode2CpgFixture {
         fooMethod.file.head.content.substring(offsetStart, offsetEnd) shouldBe
           """function foo() {
             |  // ⦝
-            |  $x = "🙂⨌🙂𐇐🙂🙂🙂🙂";
+            |  $x = "??⨌????????????";
             |}""".stripMargin
       }
     }


### PR DESCRIPTION
There's a customer issue where reading the file content was resulting in a `MalformedInputException` being thrown. With this PR, we just try all of the Java standard charsets before emitting a warning instead of crashing: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/charset/StandardCharsets.html

I would be very surprised if we ever need the specific endianness UTF-16 variants, but since this only tries encodings until something works, I also don't think adding them to the list has much of a downside.