### PR TITLE
[c#] support top-level method declarations

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -410,7 +410,10 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     Seq(methodAst(methodNode_, thisNode +: params, body, methodReturn, modifiers))
   }
 
-  protected def astForMethodDeclaration(methodDecl: DotNetNodeInfo): Seq[Ast] = {
+  protected def astForMethodDeclaration(
+    methodDecl: DotNetNodeInfo,
+    extraModifiers: List[NewModifier] = Nil
+  ): Seq[Ast] = {
     val name = nameFromNode(methodDecl)
     val params = methodDecl
       .json(ParserKeys.ParameterList)
@@ -440,7 +443,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       if (!jsonBody.isNull && parseLevel == AstParseLevel.FULL_AST) astForBlock(createDotNetNodeInfo(jsonBody))
       else Ast(blockNode(methodDecl)) // Creates an empty block
     scope.popScope()
-    val modifiers = astForModifiers(methodDecl).flatMap(_.nodes).collect { case x: NewModifier => x }
+    val modifiers = astForModifiers(methodDecl).flatMap(_.nodes).collect { case x: NewModifier => x } ++ extraModifiers
     val thisNode =
       if (!modifiers.exists(_.modifierType == ModifierTypes.STATIC)) astForThisParameter(methodDecl)
       else Ast()

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -226,6 +226,8 @@ object DotNetJsonAst {
 
   object ReturnStatement extends JumpStatement
 
+  object LocalFunctionStatement extends DeclarationExpr with BaseStmt
+
   object AwaitExpression extends BaseExpr
 
   object PropertyDeclaration extends DeclarationExpr


### PR DESCRIPTION
Top-level method declarations, i.e. method declarations outside of class declarations, are lowered (following Roslyn's approach) as local functions to the implicit `main` method created for the file they are found in. Their node kind -- `LocalFunctionStatement` -- is shared for local/inner method declarations, and support for these is also in the works.