### PR TITLE
[ruby] Rework In Pattern Match Overtainting

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
@@ -1,12 +1,49 @@
 package io.joern.rubysrc2cpg.astcreation
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{ArrayPattern, BinaryExpression, BreakExpression, CaseExpression, ControlFlowStatement, DoWhileExpression, ElseClause, ForExpression, IfExpression, InClause, IndexAccess, MatchVariable, MemberCall, NextExpression, OperatorAssignment, RescueExpression, ReturnExpression, RubyExpression, SimpleCall, SimpleIdentifier, SingleAssignment, SplattingRubyNode, StatementList, StaticLiteral, UnaryExpression, Unknown, UnlessExpression, UntilExpression, WhenClause, WhileExpression}
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
+  ArrayPattern,
+  BinaryExpression,
+  BreakExpression,
+  CaseExpression,
+  ControlFlowStatement,
+  DoWhileExpression,
+  ElseClause,
+  ForExpression,
+  IfExpression,
+  InClause,
+  IndexAccess,
+  MatchVariable,
+  MemberCall,
+  NextExpression,
+  OperatorAssignment,
+  RescueExpression,
+  ReturnExpression,
+  RubyExpression,
+  SimpleCall,
+  SimpleIdentifier,
+  SingleAssignment,
+  SplattingRubyNode,
+  StatementList,
+  StaticLiteral,
+  UnaryExpression,
+  Unknown,
+  UnlessExpression,
+  UntilExpression,
+  WhenClause,
+  WhileExpression
+}
 import io.joern.rubysrc2cpg.parser.RubyJsonHelpers
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewFieldIdentifier, NewIdentifier, NewLiteral, NewLocal}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  NewBlock,
+  NewFieldIdentifier,
+  NewIdentifier,
+  NewLiteral,
+  NewLocal
+}
 
 trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -268,8 +305,8 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
                 val stmts = x.children.zipWithIndex.flatMap {
                   case (lhs: MatchVariable, idx) if expr.isDefined =>
                     val arrAccess = {
-                      val code = s"${expr.get.text}[$idx]"
-                      val base = expr.get.copy()(expr.get.span.spanStart(expr.get.text))
+                      val code    = s"${expr.get.text}[$idx]"
+                      val base    = expr.get.copy()(expr.get.span.spanStart(expr.get.text))
                       val indices = StaticLiteral(idx.toString)(expr.get.span.spanStart(idx.toString)) :: Nil
                       IndexAccess(base, indices)(lhs.span.spanStart(code))
                     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -623,14 +623,14 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     val callNode_ =
       callNode(node, code(node), Operators.arrayInitializer, Operators.arrayInitializer, DispatchTypes.STATIC_DISPATCH)
     val childrenAst = node.children.map {
-      case x: MatchVariable if scope.lookupVariable(x.text).isEmpty => handleVariableOccurrence( x.toSimpleIdentifier)
-      case x: MatchVariable => astForExpression(x.toSimpleIdentifier)
-      case x                => astForExpression(x)
+      case x: MatchVariable if scope.lookupVariable(x.text).isEmpty => handleVariableOccurrence(x.toSimpleIdentifier)
+      case x: MatchVariable                                         => astForExpression(x.toSimpleIdentifier)
+      case x                                                        => astForExpression(x)
     }
 
     callAst(callNode_, childrenAst)
   }
-  
+
   protected def astForMandatoryParameter(node: RubyExpression): Ast = handleVariableOccurrence(node)
 
   protected def astForSimpleCall(node: SimpleCall): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -39,7 +39,6 @@ object Defines {
     val hashInitializer   = "<operator>.hashInitializer"
     val association       = "<operator>.association"
     val splat             = "<operator>.splat"
-    val arrayPatternMatch = "<operator>.arrayPatternMatch"
     val regexpMatch       = "=~"
     val regexpNotMatch    = "!~"
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -201,8 +201,8 @@ class CaseTests extends RubyCode2CpgFixture {
           case (lhs: Identifier) :: (rhs: Call) :: Nil =>
             lhs.name shouldBe "result"
 
-            rhs.methodFullName shouldBe RubyOperators.arrayPatternMatch
-            rhs.code shouldBe s"${RubyOperators.arrayPatternMatch}(<tmp-0>)"
+            rhs.methodFullName shouldBe Operators.indexAccess
+            rhs.code shouldBe s"<tmp-0>[1]"
           case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
         }
 
@@ -210,8 +210,8 @@ class CaseTests extends RubyCode2CpgFixture {
           case (lhs: Identifier) :: (rhs: Call) :: Nil =>
             lhs.name shouldBe "notResult"
 
-            rhs.methodFullName shouldBe RubyOperators.arrayPatternMatch
-            rhs.code shouldBe s"${RubyOperators.arrayPatternMatch}(<tmp-0>)"
+            rhs.methodFullName shouldBe Operators.indexAccess
+            rhs.code shouldBe s"<tmp-0>[1]"
           case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
         }
       case _ => fail(s"Expected two true branches")


### PR DESCRIPTION
This change reworks the means of extracting the variables from an array pattern match by using an index access corresponding to the location we want to extract. e.g.
```ruby
case [type, location]
in [:value, result]
  puts "#{result}"
else
  puts "else"
end
```
Accesses `result` by `<tmp-0>[1]` (where `<tmp-0> = [type, location]`)