### PR TITLE
[ruby] Lower Array Creation for In Pattern Match

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -63,6 +63,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     case node: AccessModifier                   => astForSimpleIdentifier(node.toSimpleIdentifier)
     case node: ArrayPattern                     => astForArrayPattern(node)
     case node: DummyNode                        => Ast(node.node)
+    case node: DummyAst                         => node.ast
     case node: Unknown                          => astForUnknown(node)
     case x =>
       logger.warn(s"Unhandled expression of type ${x.getClass.getSimpleName}")

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.passes.{Defines, GlobalTypes}
+import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 
 import java.util.Objects
@@ -620,6 +621,10 @@ object RubyIntermediateAst {
   /** A dummy class for wrapping around `NewNode` and allowing it to integrate with RubyNode classes.
     */
   final case class DummyNode(node: NewNode)(span: TextSpan) extends RubyExpression(span)
+
+  /** A dummy class for wrapping around `Ast` and allowing it to integrate with RubyNode classes.
+    */
+  final case class DummyAst(ast: Ast)(span: TextSpan) extends RubyExpression(span)
 
   final case class UnaryExpression(op: String, expression: RubyExpression)(span: TextSpan) extends RubyExpression(span)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -1,6 +1,5 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.*
@@ -115,11 +114,11 @@ class CaseTests extends RubyCode2CpgFixture {
 
     val block @ List(_) = cpg.method.name("class_for").block.astChildren.isBlock.l
 
-    val List(assign)   = block.astChildren.assignment.l;
+    val assign         = block.astChildren.assignment.head
     val List(lhs, rhs) = assign.argument.l
 
     lhs.start.isIdentifier.name.l shouldBe List("<tmp-0>")
-    rhs.start.isCall.code.l shouldBe List("[type, location]")
+    rhs.start.isBlock.code.l shouldBe List("[type, location]") // array lowering
 
     val headIf @ List(_)        = block.astChildren.isControlStructure.l
     val ifStmts @ List(_, _, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;
@@ -165,11 +164,11 @@ class CaseTests extends RubyCode2CpgFixture {
 
     val block @ List(_) = cpg.method.name("class_for").block.astChildren.isBlock.l
 
-    val List(assign, _, _) = block.astChildren.assignment.l;
-    val List(lhs, rhs)     = assign.argument.l
+    val assign         = block.astChildren.assignment.head
+    val List(lhs, rhs) = assign.argument.l
 
     lhs.start.isIdentifier.name.l shouldBe List("<tmp-0>")
-    rhs.start.isCall.code.l shouldBe List("[type, location]")
+    rhs.start.isBlock.code.l shouldBe List("[type, location]") // where the array lowering happens
 
     val headIf @ List(_)     = block.astChildren.isControlStructure.l
     val ifStmts @ List(_, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;


### PR DESCRIPTION
Pattern match array creation is now lowered so that both reads and writes assign array indices to where each element much be read and written from.