### PR TITLE
[ruby] Lower Array Creation for All Arrays

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -403,7 +403,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       `return Bar.new`, lowered to
       `return {Bar tmp = Bar.<alloc>(); tmp.<init>(); tmp}`
      */
-    val block = blockNode(node)
+    val block = blockNode(node, node.text, Defines.Any)
     scope.pushNewScope(BlockScope(block))
 
     val tmpName     = this.tmpGen.fresh
@@ -705,23 +705,54 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   protected def astForArrayLiteral(node: ArrayLiteral): Ast = {
-    val arguments = if (node.text.startsWith("%")) {
-      val argumentsType =
-        if (node.isStringArray) getBuiltInType(Defines.String)
-        else getBuiltInType(Defines.Symbol)
-      node.elements.map {
-        case element @ StaticLiteral(_)               => StaticLiteral(argumentsType)(element.span)
-        case element @ DynamicLiteral(_, expressions) => DynamicLiteral(argumentsType, expressions)(element.span)
-        case element                                  => element
-      }
-    } else {
-      node.elements
+    val arrayInitCall = {
+      val base = SimpleIdentifier()(node.span.spanStart(Defines.Array))
+      astForExpression(SimpleObjectInstantiation(base, Nil)(node.span))
     }
-    val argumentAsts = arguments.map(astForExpression)
+    if (node.elements.isEmpty) {
+      arrayInitCall
+    } else {
+      val tmp = this.tmpGen.fresh
 
-    val call =
-      callNode(node, code(node), Operators.arrayInitializer, Operators.arrayInitializer, DispatchTypes.STATIC_DISPATCH)
-    callAst(call, argumentAsts)
+      def tmpRubyNode(tmpNode: Option[RubyExpression] = None) =
+        SimpleIdentifier()(tmpNode.map(_.span).getOrElse(node.span).spanStart(tmp))
+
+      def tmpAst(tmpNode: Option[RubyExpression] = None) = astForSimpleIdentifier(tmpRubyNode(tmpNode))
+
+      val block = blockNode(node, node.text, Defines.Any)
+      scope.pushNewScope(BlockScope(block))
+      val tmpLocal = NewLocal().name(tmp).code(tmp)
+      scope.addToScope(tmp, tmpLocal)
+
+      val arguments = if (node.text.startsWith("%")) {
+        val argumentsType =
+          if (node.isStringArray) getBuiltInType(Defines.String)
+          else getBuiltInType(Defines.Symbol)
+        node.elements.map {
+          case element @ StaticLiteral(_)               => StaticLiteral(argumentsType)(element.span)
+          case element @ DynamicLiteral(_, expressions) => DynamicLiteral(argumentsType, expressions)(element.span)
+          case element                                  => element
+        }
+      } else {
+        node.elements
+      }
+      val argumentAsts = arguments.zipWithIndex.map { case (arg, idx) =>
+        val indices     = StaticLiteral(getBuiltInType(Defines.Integer))(arg.span.spanStart(idx.toString)) :: Nil
+        val base        = tmpRubyNode(Option(arg))
+        val indexAccess = IndexAccess(base, indices)(arg.span.spanStart(s"${base.text}[$idx]"))
+        val assignment =
+          SingleAssignment(indexAccess, "=", arg)(arg.span.spanStart(s"${indexAccess.text} = ${arg.text}"))
+        astForExpression(assignment)
+      }
+
+      val assignment =
+        callNode(node, code(node), Operators.assignment, Operators.assignment, DispatchTypes.STATIC_DISPATCH)
+      val tmpAssignment = callAst(assignment, tmpAst() :: arrayInitCall :: Nil)
+      val tmpRetAst     = tmpAst(node.elements.lastOption)
+
+      scope.popScope()
+      blockAst(block, tmpAssignment +: argumentAsts :+ tmpRetAst)
+    }
   }
 
   protected def astForHashLiteral(node: HashLike): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ArrayTests.scala
@@ -120,7 +120,7 @@ class ArrayTests extends RubyCode2CpgFixture(withPostProcessing = true, withData
     val source     = cpg.literal.code("b").l
     val sink       = cpg.call.name("puts").argument(1).l
     val List(flow) = sink.reachableByFlows(source).map(flowToResultPairs).distinct.sortBy(_.length).l
-    flow shouldBe List(("%w[b c]", 2), ("a = %w[b c]", 2), ("puts a", 3))
+    flow shouldBe List(("<tmp-1>[0] = b", 2), ("<tmp-1>", 2), ("a = %w[b c]", 2), ("puts a", 3))
   }
 
   "flow through %i array" in {
@@ -134,11 +134,8 @@ class ArrayTests extends RubyCode2CpgFixture(withPostProcessing = true, withData
     val sink       = cpg.call.name("puts").argument(1).l
     val List(flow) = sink.reachableByFlows(source).map(flowToResultPairs).distinct.sortBy(_.length).l
     flow shouldBe List(
-      (
-        """|%i[b
-           |    c]""".stripMargin,
-        2
-      ),
+      ("<tmp-1>[0] = :b", 2),
+      ("<tmp-1>", 2),
       (
         """|a = %i[b
            |    c]""".stripMargin,

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -5,140 +5,162 @@ import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines as XDefines
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Local}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
 
 class ArrayTests extends RubyCode2CpgFixture {
 
-  "`[]` is represented by an `arrayInitializer` operator call" in {
+  "`[]` is represented by an alloc constructor call" in {
     val cpg = code("""
                      |[]
                      |""".stripMargin)
 
-    val List(arrayCall) = cpg.call.l
+    val List(arrayCall) = cpg.call.name("initialize").l
 
-    arrayCall.methodFullName shouldBe Operators.arrayInitializer
+    arrayCall.methodFullName shouldBe XDefines.DynamicCallUnknownFullName
     arrayCall.code shouldBe "[]"
     arrayCall.lineNumber shouldBe Some(2)
+    inside(arrayCall.argument.l) { case callBase :: Nil =>
+      callBase.code shouldBe "<tmp-0>"
+    }
+
+    inside(arrayCall.astSiblings.l) { case (_: Local) :: (asgnCall: Call) :: (_: Identifier) :: Nil =>
+      val asgn = asgnCall.asInstanceOf[Assignment]
+      val rhs  = asgn.source.asInstanceOf[Call]
+      rhs.methodFullName shouldBe Operators.alloc
+      rhs.code shouldBe "[]"
+    }
   }
 
-  "`[1]` is represented by an `arrayInitializer` operator call with arguments `1`" in {
+  "`[1]` is represented by an alloc call with arguments `1`" in {
     val cpg = code("""
                      |[1]
                      |""".stripMargin)
 
-    val List(arrayCall) = cpg.call.l
+    val List(arrayCall) = cpg.call.name("initialize").l
 
-    arrayCall.methodFullName shouldBe Operators.arrayInitializer
+    arrayCall.methodFullName shouldBe XDefines.DynamicCallUnknownFullName
     arrayCall.code shouldBe "[1]"
     arrayCall.lineNumber shouldBe Some(2)
+    inside(arrayCall.argument.l) { case callBase :: Nil =>
+      callBase.code shouldBe "<tmp-0>"
+    }
 
-    val List(one) = arrayCall.argument.l
+    inside(arrayCall.parentBlock.parentBlock.lastOption) { case Some(loweringBlock: Block) =>
+      val asgn = loweringBlock.astChildren.assignment.last
+      val lhs  = asgn.target.asInstanceOf[Call]
+      lhs.methodFullName shouldBe Operators.indexAccess
+      lhs.code shouldBe "<tmp-1>[0]"
 
-    one.code shouldBe "1"
+      val rhs = asgn.source.asInstanceOf[Literal]
+      rhs.code shouldBe "1"
+    }
   }
 
-  "`[1,2,]` is represented by an `arrayInitializer` operator call with arguments `1`, `2`" in {
+  "`[1,2,]` is represented by an alloc call with arguments `1`, `2`" in {
     val cpg = code("""
                      |[1,2,]
                      |""".stripMargin)
 
-    val List(arrayCall) = cpg.call.l
+    inside(cpg.block.codeExact("[1,2,]").astChildren.assignment.where(_.source.isLiteral).l) {
+      case asgn1 :: asgn2 :: Nil =>
+        asgn1.code shouldBe "<tmp-1>[0] = 1"
+        asgn1.source.asInstanceOf[Literal].code shouldBe "1"
 
-    arrayCall.methodFullName shouldBe Operators.arrayInitializer
-    arrayCall.code shouldBe "[1,2,]"
-    arrayCall.lineNumber shouldBe Some(2)
-
-    val List(one, two) = arrayCall.argument.l
-
-    one.code shouldBe "1"
-    two.code shouldBe "2"
+        asgn2.code shouldBe "<tmp-1>[1] = 2"
+        asgn2.source.asInstanceOf[Literal].code shouldBe "2"
+    }
   }
 
-  "`%w{}` is represented by an `arrayInitializer` operator call" in {
+  "`%w{}` is represented by an alloc call" in {
     val cpg = code("""
                      |%w{}
                      |""".stripMargin)
 
-    val List(arrayCall) = cpg.call.l
+    val List(arrayCall) = cpg.block.codeExact("%w{}").l
 
-    arrayCall.methodFullName shouldBe Operators.arrayInitializer
     arrayCall.code shouldBe "%w{}"
     arrayCall.lineNumber shouldBe Some(2)
-    arrayCall.argument.isEmpty shouldBe true
+    arrayCall.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).isEmpty shouldBe true
   }
 
-  "`%w?foo?` is represented by an `arrayInitializer` operator call with arguments 'foo'" in {
+  "`%w?foo?` is represented by an alloc call with arguments 'foo'" in {
     val cpg = code("""
                      |%w?foo?
                      |""".stripMargin)
 
-    val List(arrayCall) = cpg.call.name(Operators.arrayInitializer).l
+    val List(arrayCall, _) = cpg.block.codeExact("%w?foo?").l
 
     arrayCall.code shouldBe "%w?foo?"
     arrayCall.lineNumber shouldBe Some(2)
+    val asgns = arrayCall.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
 
-    val List(foo) = arrayCall.argument.isLiteral.l
-    foo.code shouldBe "foo"
-    foo.typeFullName shouldBe s"$kernelPrefix.String"
+    inside(asgns.map(_.source)) { case (foo: Literal) :: Nil =>
+      foo.code shouldBe "foo"
+      foo.typeFullName shouldBe s"$kernelPrefix.String"
+    }
   }
 
-  "`%i(x y)` is represented by an `arrayInitializer` operator call with arguments `:x`, `:y`" in {
+  "`%i(x y)` is represented by an alloc call with arguments `:x`, `:y`" in {
     val cpg = code("""
                      |%i(x y)
                      |""".stripMargin)
 
-    val List(arrayCall) = cpg.call.name(Operators.arrayInitializer).l
+    val List(arrayCall, _) = cpg.block.codeExact("%i(x y)").l
 
     arrayCall.code shouldBe "%i(x y)"
     arrayCall.lineNumber shouldBe Some(2)
+    val asgns = arrayCall.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
 
-    val List(x, y) = arrayCall.argument.isLiteral.l
-    x.code shouldBe ":x"
-    x.typeFullName shouldBe y.typeFullName
+    inside(asgns.map(_.source)) { case (x: Literal) :: (y: Literal) :: Nil =>
+      x.code shouldBe ":x"
+      x.typeFullName shouldBe s"$kernelPrefix.Symbol"
 
-    y.code shouldBe ":y"
-    y.typeFullName shouldBe s"$kernelPrefix.Symbol"
+      y.code shouldBe ":y"
+      y.typeFullName shouldBe s"$kernelPrefix.Symbol"
+    }
   }
 
-  "%W is represented an `arrayInitializer` operator call" in {
+  "%W is represented an alloc call" in {
     val cpg = code("""%W(x#{1 + 3} y#{23} z)
         |""".stripMargin)
 
-    val List(arrayCall) = cpg.call.name(Operators.arrayInitializer).l
+    val List(arrayCall, _) = cpg.block.codeExact("%W(x#{1 + 3} y#{23} z)").l
 
     arrayCall.code shouldBe "%W(x#{1 + 3} y#{23} z)"
     arrayCall.lineNumber shouldBe Some(1)
+    val asgns = arrayCall.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
 
-    val List(xFmt, yFmt) = arrayCall.argument.isCall.l
-    xFmt.name shouldBe Operators.formatString
-    xFmt.typeFullName shouldBe Defines.getBuiltInType(Defines.String)
+    inside(asgns.map(_.source)) { case (xFmt: Call) :: (yFmt: Call) :: (zLit: Literal) :: Nil =>
+      xFmt.name shouldBe Operators.formatString
+      xFmt.typeFullName shouldBe Defines.getBuiltInType(Defines.String)
 
-    yFmt.name shouldBe Operators.formatString
-    yFmt.typeFullName shouldBe Defines.getBuiltInType(Defines.String)
+      yFmt.name shouldBe Operators.formatString
+      yFmt.typeFullName shouldBe Defines.getBuiltInType(Defines.String)
 
-    val List(xFmtStr, xAddFmtStr) = xFmt.astChildren.isCall.l
-    xFmtStr.name shouldBe Operators.formattedValue
-    xAddFmtStr.name shouldBe Operators.formattedValue
+      val List(xFmtStr, xAddFmtStr) = xFmt.astChildren.isCall.l
+      xFmtStr.name shouldBe Operators.formattedValue
+      xAddFmtStr.name shouldBe Operators.formattedValue
 
-    val List(xFmtStrAdd) = xAddFmtStr.astChildren.isCall.l
-    xFmtStrAdd.name shouldBe Operators.addition
+      val List(xFmtStrAdd) = xAddFmtStr.astChildren.isCall.l
+      xFmtStrAdd.name shouldBe Operators.addition
 
-    val List(lhs, rhs) = xFmtStrAdd.argument.l
-    lhs.code shouldBe "1"
-    rhs.code shouldBe "3"
+      val List(lhs, rhs) = xFmtStrAdd.argument.l
+      lhs.code shouldBe "1"
+      rhs.code shouldBe "3"
 
-    val List(yFmtStr, yFmt23) = yFmt.astChildren.isCall.l
-    yFmtStr.name shouldBe Operators.formattedValue
-    yFmt23.name shouldBe Operators.formattedValue
+      val List(yFmtStr, yFmt23) = yFmt.astChildren.isCall.l
+      yFmtStr.name shouldBe Operators.formattedValue
+      yFmt23.name shouldBe Operators.formattedValue
 
-    val List(yFmtStrLit: Literal) = yFmt23.argument.l: @unchecked
-    yFmtStrLit.code shouldBe "23"
+      val List(yFmtStrLit: Literal) = yFmt23.argument.l: @unchecked
+      yFmtStrLit.code shouldBe "23"
 
-    val List(zLit) = arrayCall.argument.isLiteral.l
-    zLit.code shouldBe "z"
-    zLit.typeFullName shouldBe s"$kernelPrefix.String"
+      zLit.code shouldBe "z"
+      zLit.typeFullName shouldBe s"$kernelPrefix.String"
+    }
   }
 
   "an implicit array constructor (Array::[]) should be lowered to an array initializer" in {
@@ -167,28 +189,30 @@ class ArrayTests extends RubyCode2CpgFixture {
   "%I array" in {
     val cpg = code("%I(test_#{1} test_2)")
 
-    val List(arrayCall) = cpg.call.name(Operators.arrayInitializer).l
-    arrayCall.lineNumber shouldBe Some(1)
+    val List(arrayCall, _) = cpg.block.codeExact("%I(test_#{1} test_2)").l
+
     arrayCall.code shouldBe "%I(test_#{1} test_2)"
+    arrayCall.lineNumber shouldBe Some(1)
+    val asgns = arrayCall.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
 
-    val List(test1Fmt) = arrayCall.argument.isCall.l
-    test1Fmt.name shouldBe Operators.formatString
-    test1Fmt.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
-    test1Fmt.code shouldBe "test_#{1}"
+    inside(asgns.map(_.source)) { case (test1Fmt: Call) :: (test2: Literal) :: Nil =>
+      test1Fmt.name shouldBe Operators.formatString
+      test1Fmt.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+      test1Fmt.code shouldBe "test_#{1}"
 
-    val List(test1FmtLit, test1FmtSymbol) = test1Fmt.astChildren.isCall.l
-    test1FmtSymbol.name shouldBe Operators.formattedValue
-    test1FmtSymbol.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
-    test1FmtSymbol.code shouldBe "#{1}"
+      val List(test1FmtLit, test1FmtSymbol) = test1Fmt.astChildren.isCall.l
+      test1FmtSymbol.name shouldBe Operators.formattedValue
+      test1FmtSymbol.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+      test1FmtSymbol.code shouldBe "#{1}"
 
-    test1FmtLit.name shouldBe Operators.formattedValue
+      test1FmtLit.name shouldBe Operators.formattedValue
 
-    val List(test1FmtFinal: Literal) = test1FmtLit.argument.l: @unchecked
-    test1FmtFinal.code shouldBe "test_"
+      val List(test1FmtFinal: Literal) = test1FmtLit.argument.l: @unchecked
+      test1FmtFinal.code shouldBe "test_"
 
-    val List(test2) = arrayCall.argument.isLiteral.l
-    test2.code shouldBe ":test_2"
-    test2.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+      test2.code shouldBe ":test_2"
+      test2.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+    }
   }
 
   "shift-left operator interpreted as a call (append)" in {
@@ -208,57 +232,71 @@ class ArrayTests extends RubyCode2CpgFixture {
   "Array bodies with mixed elements" in {
     val cpg = code("[1, 2 => 1, 2 => 3]")
 
-    inside(cpg.call.name(Operators.arrayInitializer).argument.l) {
-      case (argLit: Literal) :: (argAssoc: Call) :: (argAssoc2: Call) :: Nil =>
-        argLit.code shouldBe "1"
+    val List(arrayCall, _) = cpg.block.codeExact("[1, 2 => 1, 2 => 3]").l
 
-        argAssoc.code shouldBe "2 => 1"
-        argAssoc.methodFullName shouldBe Defines.RubyOperators.association
+    arrayCall.code shouldBe "[1, 2 => 1, 2 => 3]"
+    arrayCall.lineNumber shouldBe Some(1)
+    val asgns = arrayCall.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
 
-        argAssoc2.code shouldBe "2 => 3"
-        argAssoc2.methodFullName shouldBe Defines.RubyOperators.association
-      case xs => fail(s"Expected two elements for array init, got ${xs.code.mkString(",")}")
+    inside(asgns.map(_.source)) { case (argLit: Literal) :: (argAssoc: Call) :: (argAssoc2: Call) :: Nil =>
+      argLit.code shouldBe "1"
+
+      argAssoc.code shouldBe "2 => 1"
+      argAssoc.methodFullName shouldBe Defines.RubyOperators.association
+
+      argAssoc2.code shouldBe "2 => 3"
+      argAssoc2.methodFullName shouldBe Defines.RubyOperators.association
     }
   }
 
   "Array with mixed elements" in {
     val cpg = code("""
-                     |[
-                     |   *::ApplicationSettingsHelper.visible_attributes,
-                     |   { default_branch_protection_defaults: [
-                     |     :allow_force_push,
-                     |     :developer_can_initial_push,
-                     |     {
-                     |       allowed_to_merge: [:access_level],
-                     |       allowed_to_push: [:access_level]
-                     |      }
-                     |   ] },
-                     |   :can_create_organization,
-                     |   *::ApplicationSettingsHelper.some_other_attributes,
-                     |]
-                     |""".stripMargin)
+        |[
+        |   *::ApplicationSettingsHelper.visible_attributes,
+        |   { default_branch_protection_defaults: [
+        |     :allow_force_push,
+        |     :developer_can_initial_push,
+        |     {
+        |       allowed_to_merge: [:access_level],
+        |       allowed_to_push: [:access_level]
+        |      }
+        |   ] },
+        |   :can_create_organization,
+        |   *::ApplicationSettingsHelper.some_other_attributes,
+        |]
+        |""".stripMargin)
 
-    cpg.call.name(Operators.arrayInitializer).headOption match {
-      case Some(arrayInit) =>
-        inside(arrayInit.argument.l) {
-          case (splatArgOne: Call) :: (hashLiteralArg: Block) :: (symbolArg: Literal) :: (splatArgTwo: Call) :: Nil =>
-            splatArgOne.methodFullName shouldBe RubyOperators.splat
-            splatArgOne.code shouldBe "*::ApplicationSettingsHelper.visible_attributes"
+    val List(arrayCall, _) = cpg.block
+      .codeExact("""[
+        |   *::ApplicationSettingsHelper.visible_attributes,
+        |   { d...""".stripMargin)
+      .l
 
-            symbolArg.code shouldBe ":can_create_organization"
-            symbolArg.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+    arrayCall.code shouldBe
+      """[
+        |   *::ApplicationSettingsHelper.visible_attributes,
+        |   { d...""".stripMargin
+    arrayCall.lineNumber shouldBe Some(2)
+    val asgns = arrayCall.astChildren
+      .collect { case x: Call if x.name == Operators.assignment => x.asInstanceOf[Assignment] }
+      .where(_.target.isCall.nameExact(Operators.indexAccess))
+      .l
 
-            splatArgTwo.methodFullName shouldBe RubyOperators.splat
-            splatArgTwo.code shouldBe "*::ApplicationSettingsHelper.some_other_attributes"
+    inside(asgns.map(_.source)) {
+      case (splatArgOne: Call) :: (hashLiteralArg: Block) :: (symbolArg: Literal) :: (splatArgTwo: Call) :: Nil =>
+        splatArgOne.methodFullName shouldBe RubyOperators.splat
+        splatArgOne.code shouldBe "*::ApplicationSettingsHelper.visible_attributes"
 
-            val List(hashInitAssignment: Call, _) =
-              hashLiteralArg.astChildren.isCall.name(Operators.assignment).l: @unchecked
-            val List(_: Identifier, hashInitCall: Call) = hashInitAssignment.argument.l: @unchecked
-            hashInitCall.methodFullName shouldBe RubyOperators.hashInitializer
+        symbolArg.code shouldBe ":can_create_organization"
+        symbolArg.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
 
-          case xs => fail(s"Expected 4 arguments, got [${xs.code.mkString(",")}]")
-        }
-      case None => fail("Expected one call for head arrayInit")
+        splatArgTwo.methodFullName shouldBe RubyOperators.splat
+        splatArgTwo.code shouldBe "*::ApplicationSettingsHelper.some_other_attributes"
+
+        val List(hashInitAssignment: Call, _) =
+          hashLiteralArg.astChildren.isCall.name(Operators.assignment).l: @unchecked
+        val List(_: Identifier, hashInitCall: Call) = hashInitAssignment.argument.l: @unchecked
+        hashInitCall.methodFullName shouldBe RubyOperators.hashInitializer
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -403,13 +403,11 @@ class DoBlockTests extends RubyCode2CpgFixture {
                      |  end
                      |""".stripMargin)
 
-    inside(cpg.local.l) {
-      case jfsOutsideLocal :: schedules :: hashInsideLocal :: tmp0 :: jfsCapturedLocal :: Nil =>
+    inside(cpg.local.nameNot("<tmp-\\d>").l) {
+      case jfsOutsideLocal :: schedules :: hashInsideLocal :: jfsCapturedLocal :: Nil =>
         jfsOutsideLocal.closureBindingId shouldBe None
         hashInsideLocal.closureBindingId shouldBe None
         jfsCapturedLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.jfs")
-
-        tmp0.name shouldBe "<tmp-0>"
       case xs => fail(s"Expected 6 locals, got ${xs.code.mkString(",")}")
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -103,8 +103,8 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     r.code shouldBe "[]"
     r.lineNumber shouldBe Some(3)
 
-    val List(c: Call) = r.astChildren.isCall.l
-    c.methodFullName shouldBe Operators.arrayInitializer
+    val List(arr: Block) = r.astChildren.isBlock.l
+    arr.code shouldBe "[]"
   }
 
   "implicit RETURN node for index access exists" in {


### PR DESCRIPTION
All arrays are initialized via a block at each specific index access the element is positioned, e.g. `a = [1, 2]` becomes
```
a = {
 <tmp-0> = Array.new
 <tmp-0>[0] = 1
 <tmp-0>[1] = 2
 <tmp-0>
}
```