### PR TITLE
[c#] basic support for ImplicitUsings

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -40,6 +40,11 @@ case class CSharpProgramSummary(namespaceToType: NamespaceToTypeMap, imports: Se
     )
   }
 
+  private def allImports: Set[String] = imports ++ globalImports
+
+  def appendImported(other: CSharpProgramSummary): CSharpProgramSummary =
+    this ++= other.filter(namespacePred = (ns, _) => allImports.contains(ns))
+
   /** Builds a new `CSharpProgramSummary` by filtering the current one's fields.
     *
     * @param namespacePred
@@ -61,6 +66,9 @@ case class CSharpProgramSummary(namespaceToType: NamespaceToTypeMap, imports: Se
       imports = imports.filter(importsPred),
       globalImports = globalImports.filter(globalImportsPred)
     )
+
+  def addGlobalImports(imports: Set[String]): CSharpProgramSummary =
+    copy(globalImports = globalImports ++ imports)
 
 }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/ImplicitUsingsCollector.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/ImplicitUsingsCollector.scala
@@ -1,0 +1,84 @@
+package io.joern.csharpsrc2cpg.utils
+
+import better.files.File
+import io.joern.semanticcpg.utils.SecureXmlParsing
+
+import scala.xml.{Elem, Node}
+
+/** Depending on the project type defined in `.csproj` files, different sets of global usings are turned on by default.
+  * Here we collect them all.
+  */
+object ImplicitUsingsCollector {
+
+  /** Collects implicit global imports extracted from `.csproj` files.
+    *
+    * @param buildFiles
+    *   paths to `.csproj` files
+    * @return
+    *   the list of implicitly turned on global imports
+    */
+  def collect(buildFiles: List[String]): List[String] = {
+    buildFiles.flatMap { csproj =>
+      SecureXmlParsing.parseXml(File(csproj).contentAsString) match
+        case Some(xml) => from(xml)
+        case None      => List.empty
+    }
+  }
+
+  // See https://learn.microsoft.com/en-gb/dotnet/core/project-sdk/overview#implicit-using-directives
+  private val projectTypeMapping: Map[String, List[String]] = {
+    val netSdkNamespace = List(
+      "System",
+      "System.Collections.Generic",
+      "System.IO",
+      "System.Linq",
+      "System.Net.Http",
+      "System.Threading",
+      "System.Threading.Tasks"
+    )
+    Map(
+      "Microsoft.NET.Sdk" -> netSdkNamespace,
+      "Microsoft.NET.Sdk.Web" -> netSdkNamespace.appendedAll(
+        List(
+          "System.Net.Http.Json",
+          "Microsoft.AspNetCore.Builder",
+          "Microsoft.AspNetCore.Hosting",
+          "Microsoft.AspNetCore.Http",
+          "Microsoft.AspNetCore.Routing",
+          "Microsoft.Extensions.Configuration",
+          "Microsoft.Extensions.DependencyInjection",
+          "Microsoft.Extensions.Hosting",
+          "Microsoft.Extensions.Logging"
+        )
+      ),
+      "Microsoft.NET.Sdk.Worker" -> netSdkNamespace.appendedAll(
+        List(
+          "Microsoft.Extensions.Configuration",
+          "Microsoft.Extensions.DependencyInjection",
+          "Microsoft.Extensions.Hosting",
+          "Microsoft.Extensions.Logging"
+        )
+      ),
+      "Microsoft.NET.Sdk.WindowsDesktop" -> netSdkNamespace.appendedAll(List("System.Drawing", "System.Windows.Forms"))
+    )
+  }
+
+  private def from(rootElem: Elem): List[String] = {
+    val projectType = rootElem.label match
+      case "Project" => rootElem.attribute("Sdk").flatMap(_.headOption.map(_.text))
+      case _         => None
+
+    val implicitUsingsEnabled = rootElem.child
+      .collect { case x if x.label == "PropertyGroup" => x.child }
+      .flatten
+      .collect { case x if x.label == "ImplicitUsings" => x.text }
+      .exists(x => x == "true" || x == "enable")
+
+    if (projectType.isDefined && implicitUsingsEnabled) {
+      projectTypeMapping.getOrElse(projectType.get, Nil)
+    } else {
+      Nil
+    }
+  }
+
+}

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/ProgramSummaryCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/ProgramSummaryCreator.scala
@@ -18,7 +18,7 @@ object ProgramSummaryCreator {
   def from(astCreators: Seq[AstCreator], config: Config): CSharpProgramSummary = {
     val internalSummary = summarizeAstCreators(astCreators)
     val externalSummary = buildExternalSummary(config.useBuiltinSummaries, config.externalSummaryPaths)
-    internalSummary ++= externalSummary.filter(namespacePred = (ns, _) => internalSummary.imports.contains(ns))
+    internalSummary.appendImported(externalSummary)
   }
 
   private def summarizeAstCreators(astCreators: Seq[AstCreator]): CSharpProgramSummary = {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ImplicitUsingsTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ImplicitUsingsTests.scala
@@ -1,0 +1,127 @@
+package io.joern.csharpsrc2cpg.querying.ast
+
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class ImplicitUsingsTests extends CSharpCode2CpgFixture {
+
+  "top-level WriteLine call" when {
+
+    "accompanied by a NET.Sdk csproj with ImplicitUsings set to `enable`" should {
+      val cpg = code("""
+          |Console.WriteLine("Foo");
+          |""".stripMargin)
+        .moreCode(
+          """
+            |<Project Sdk="Microsoft.NET.Sdk">
+            | <PropertyGroup>
+            |   <OutputType>Exe</OutputType>
+            |   <ImplicitUsings>enable</ImplicitUsings>
+            | </PropertyGroup>
+            |</Project>
+            |""".stripMargin,
+          fileName = "App.csproj"
+        )
+
+      "resolve WriteLine call" in {
+        cpg.call.nameExact("WriteLine").methodFullName.l shouldBe List(
+          "System.Console.WriteLine:System.Void(System.String)"
+        )
+      }
+    }
+
+    "accompanied by a NET.Sdk csproj with ImplicitUsings set to `true`" should {
+      val cpg = code("""
+          |Console.WriteLine("Foo");
+          |""".stripMargin)
+        .moreCode(
+          """
+            |<Project Sdk="Microsoft.NET.Sdk">
+            | <PropertyGroup>
+            |   <OutputType>Exe</OutputType>
+            |   <ImplicitUsings>true</ImplicitUsings>
+            | </PropertyGroup>
+            |</Project>
+            |""".stripMargin,
+          fileName = "App.csproj"
+        )
+
+      "resolve WriteLine call" in {
+        cpg.call.nameExact("WriteLine").methodFullName.l shouldBe List(
+          "System.Console.WriteLine:System.Void(System.String)"
+        )
+      }
+    }
+
+    "accompanied by a NET.Sdk csproj with ImplicitUsings omitted" should {
+      val cpg = code("""
+          |Console.WriteLine("Foo");
+          |""".stripMargin)
+        .moreCode(
+          """
+            |<Project Sdk="Microsoft.NET.Sdk">
+            | <PropertyGroup>
+            |   <OutputType>Exe</OutputType>
+            | </PropertyGroup>
+            |</Project>
+            |""".stripMargin,
+          fileName = "App.csproj"
+        )
+
+      "not resolve WriteLine call" in {
+        cpg.call.nameExact("WriteLine").methodFullName.l shouldBe List(
+          "<unresolvedNamespace>.WriteLine:<unresolvedSignature>"
+        )
+      }
+
+    }
+
+    "accompanied by a NET.Sdk csproj with ImplicitUsings set to `false`" should {
+      val cpg = code("""
+          |Console.WriteLine("Foo");
+          |""".stripMargin)
+        .moreCode(
+          """
+            |<Project Sdk="Microsoft.NET.Sdk">
+            | <PropertyGroup>
+            |   <OutputType>Exe</OutputType>
+            |   <ImplicitUsings>false</ImplicitUsings>
+            | </PropertyGroup>
+            |</Project>
+            |""".stripMargin,
+          fileName = "App.csproj"
+        )
+
+      "not resolve WriteLine call" in {
+        cpg.call.nameExact("WriteLine").methodFullName.l shouldBe List(
+          "<unresolvedNamespace>.WriteLine:<unresolvedSignature>"
+        )
+      }
+    }
+
+    "accompanied by a NET.Sdk csproj with ImplicitUsings set to `disable`" should {
+      val cpg = code("""
+          |Console.WriteLine("Foo");
+          |""".stripMargin)
+        .moreCode(
+          """
+            |<Project Sdk="Microsoft.NET.Sdk">
+            | <PropertyGroup>
+            |   <OutputType>Exe</OutputType>
+            |   <ImplicitUsings>disable</ImplicitUsings>
+            | </PropertyGroup>
+            |</Project>
+            |""".stripMargin,
+          fileName = "App.csproj"
+        )
+
+      "not resolve WriteLine call" in {
+        cpg.call.nameExact("WriteLine").methodFullName.l shouldBe List(
+          "<unresolvedNamespace>.WriteLine:<unresolvedSignature>"
+        )
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Introduces an initial mechanism to handle implicit global imports enabled by `<ImplicitUsings>` in `.csproj` files. Behind the scenes, Roslyn generates a set of `global using XXX` directives based on the project type. In this PR these directives are globally collected and included as `globalImports` to `CSharpProgramSummary`. Remaining changes are just minor refactoring tweaks.