### PR TITLE
[c#] fix erroneous not-handled-yet warning for MemberBindingExpression

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -507,21 +507,15 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     baseType: Option[String] = None
   ): Seq[Ast] = {
     val baseNode = createDotNetNodeInfo(condAccExpr.json(ParserKeys.Expression))
-    val baseAst  = astForNode(baseNode)
-
     val baseTypeFullName =
-      if (getTypeFullNameFromAstNode(baseAst).equals(Defines.Any)) baseType
-      else Option(getTypeFullNameFromAstNode(baseAst))
+      baseType.orElse(Some(getTypeFullNameFromAstNode(astForNode(baseNode)))).filterNot(_.equals(Defines.Any))
 
     Try(createDotNetNodeInfo(condAccExpr.json(ParserKeys.WhenNotNull))).toOption match {
       case Some(node) =>
         node.node match {
-          case ConditionalAccessExpression =>
-            astForConditionalAccessExpression(node, baseTypeFullName)
-          case MemberBindingExpression => astForMemberBindingExpression(node, baseTypeFullName)
-          case InvocationExpression =>
-            astForInvocationExpression(node)
-          case _ => astForNode(node)
+          case ConditionalAccessExpression => astForConditionalAccessExpression(node, baseTypeFullName)
+          case MemberBindingExpression     => astForMemberBindingExpression(node, baseTypeFullName)
+          case _                           => astForNode(node)
         }
       case None => Seq.empty[Ast]
     }


### PR DESCRIPTION
We see a few not-handled-yet warning for `MemberBindingExpression` when, in fact, it's being handled -- just not at the top-level. Given how the AST is structured, we need to pass the base type full name to this visitor, making it an helper-like visitor to be used by others. In this PR we fix these erroneous warnings by not going through the top-level `astForNode` when we already have the base type full name. Consequently, we also avoid the creation of an UNKNOWN node that was never added to the CPG.