### PR TITLE
[c#] methodFullName for extension method calls

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
@@ -4,8 +4,10 @@ import io.joern.x2cpg.Defines
 import io.joern.x2cpg.datastructures.{OverloadableScope, Scope, ScopeElement, TypedScope, TypedScopeElement}
 import io.joern.x2cpg.utils.ListUtils.singleOrNone
 import io.shiftleft.codepropertygraph.generated.nodes.DeclarationNew
+import io.joern.x2cpg.utils.ListUtils.singleOrNone
 
 import scala.collection.mutable
+import scala.reflect.ClassTag
 
 class CSharpScope(summary: CSharpProgramSummary)
     extends Scope[String, DeclarationNew, TypedScopeElement]
@@ -118,4 +120,50 @@ class CSharpScope(summary: CSharpProgramSummary)
         Option(top)
   }
 
+  /** Reduces [[typesInScope]] to contain only those types holding an extension method with the desired signature.
+    */
+  private def extensionsInScopeFor(
+    extendedType: String,
+    callName: String,
+    argTypes: List[String]
+  ): mutable.Set[CSharpType] = {
+    typesInScope
+      .map(t => t.copy(methods = t.methods.filter(matchingExtensionMethod(extendedType, callName, argTypes))))
+      .filter(_.methods.nonEmpty)
+  }
+
+  /** Builds a predicate for matching [[CSharpMethod]] with an ad-hoc description of theirs.
+    */
+  private def matchingExtensionMethod(
+    thisType: String,
+    name: String,
+    argTypes: List[String]
+  ): CSharpMethod => Boolean = { m =>
+    m.isStatic && m.name == name && m.parameterTypes.map(_._2) == thisType :: argTypes
+  }
+
+  /** Tries to find an extension method for [[baseTypeFullName]] with the given [[callName]] and [[argTypes]] in the
+    * types currently in scope.
+    *
+    * @param baseTypeFullName
+    *   the extension method's `this` argument.
+    * @param callName
+    *   the method name
+    * @param argTypes
+    *   the method's argument types, excluding `this`
+    * @return
+    *   the method metadata, together with the class name where it can be found
+    */
+  def tryResolveExtensionMethodInvocation(
+    baseTypeFullName: Option[String],
+    callName: String,
+    argTypes: List[String]
+  ): Option[(CSharpMethod, String)] = {
+    baseTypeFullName.flatMap { tfn =>
+      extensionsInScopeFor(tfn, callName, argTypes).take(2).toList match {
+        case x :: Nil => Some((x.methods.head, x.name))
+        case _        => None
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ExtensionMethodTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ExtensionMethodTests.scala
@@ -1,0 +1,108 @@
+package io.joern.csharpsrc2cpg.querying.ast
+
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
+import io.shiftleft.codepropertygraph.generated.nodes.Identifier
+import io.shiftleft.semanticcpg.language.*
+
+class ExtensionMethodTests extends CSharpCode2CpgFixture {
+
+  "nullary extension-method declaration" should {
+    val cpg = code("""
+        |class MyClass {}
+        |static class Extensions
+        |{
+        | public static void DoStuff(this MyClass myClass) {}
+        |}
+        |""".stripMargin)
+
+    "have correct properties" in {
+      inside(cpg.method.nameExact("DoStuff").l) {
+        case doStuff :: Nil =>
+          doStuff.fullName shouldBe "Extensions.DoStuff:void(MyClass)"
+          doStuff.signature shouldBe "void(MyClass)"
+          doStuff.methodReturn.typeFullName shouldBe "void"
+          doStuff.modifier.modifierType.toSet shouldBe Set(ModifierTypes.STATIC, ModifierTypes.PUBLIC)
+        case xs => fail(s"Expected single DoStuff method, but got $xs")
+      }
+    }
+
+    "have correct parameters" in {
+      inside(cpg.method.nameExact("DoStuff").parameter.sortBy(_.index).l) {
+        case myClass :: Nil =>
+          myClass.typeFullName shouldBe "MyClass"
+          myClass.code shouldBe "this MyClass myClass"
+          myClass.name shouldBe "myClass"
+        case xs => fail(s"Expected single parameter, but got $xs")
+      }
+    }
+  }
+
+  "nullary extension-method call" should {
+    val cpg = code("""
+        |var x = new MyClass();
+        |x.DoStuff();
+        |
+        |class MyClass {}
+        |static class Extensions
+        |{
+        | public static void DoStuff(this MyClass myClass) {}
+        |}
+        |""".stripMargin)
+
+    "have correct properties" in {
+      inside(cpg.call.nameExact("DoStuff").l) {
+        case doStuff :: Nil =>
+          doStuff.code shouldBe "x.DoStuff()"
+          doStuff.methodFullName shouldBe "Extensions.DoStuff:void(MyClass)"
+        case xs => fail(s"Expected single DoStuff call, but got $xs")
+      }
+    }
+
+    "have correct arguments" in {
+      inside(cpg.call.nameExact("DoStuff").argument.sortBy(_.argumentIndex).l) {
+        case (x: Identifier) :: Nil =>
+          x.argumentIndex shouldBe 0
+          x.name shouldBe "x"
+          x.typeFullName shouldBe "MyClass"
+          x.code shouldBe "x"
+        case xs => fail(s"Expected single identifier argument to DoStuff, but got $xs")
+      }
+    }
+  }
+
+  "two same-named extension methods in different namespaces" should {
+    val cpg = code("""
+        |using Version1;
+        |var x = new MyClass();
+        |x.DoStuff(0);
+        |
+        |class MyClass {}
+        |""".stripMargin)
+      .moreCode("""
+          |namespace Version1;
+          |
+          |static class Extension1
+          |{
+          | public static void DoStuff(this MyClass myClass, int z) {}
+          |}
+          |""".stripMargin)
+      .moreCode("""
+          |namespace Version2;
+          |
+          |static class Extension2
+          |{
+          | public static void DoStuff(this MyClass myClass, int z) {}
+          |}
+          |""".stripMargin)
+
+    "find the correct extension method" in {
+      inside(cpg.call.nameExact("DoStuff").l) {
+        case doStuff :: Nil =>
+          doStuff.code shouldBe "x.DoStuff(0)"
+          doStuff.methodFullName shouldBe "Version1.Extension1.DoStuff:void(MyClass,System.Int32)"
+        case xs => fail(s"Expected single DoStuff call, but got $xs")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Extension methods are syntactic sugar that underneath expand to the resolved method call, e.g.

```csharp
x = new MyClass();
x.DoStuff(); // is actually rewritten by Roslyn as MyClassExtensions.DoStuff(x);

class MyClass {}
static class MyClassExtensions {
  public static void DoStuff(this MyClass c) {}
}
```

See: [Binding Extension Methods at Compile Time
](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods#binding-extension-methods-at-compile-time)

This PR is only a first move towards "full support" (as much as it's feasible) and fixes the `methodFullName` properties of those calls. So, in `x.DoStuff()`, it's still a dynamic dispatch call with an argument `x`, but whose fullName is no longer `MyClass.DoStuff():<unresolvedSignature>` but rather `MyClassExtensions.DoStuff:void(MyClass)`. I'd like to refactor `astForInvocationExpression` a little bit more before piling more stuff into it, as it's quite large as it stands already.

