### PR TITLE
[c#] cleaning up around "this" and composeMethodFullName

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -197,7 +197,7 @@ object AstCreatorHelper {
       case SimpleMemberAccessExpression | MemberBindingExpression | SuppressNullableWarningExpression | Attribute =>
         nameFromIdentifier(createDotNetNodeInfo(node.json(ParserKeys.Name)))
       case ObjectCreationExpression | CastExpression => nameFromNode(createDotNetNodeInfo(node.json(ParserKeys.Type)))
-      case ThisExpression                            => "this"
+      case ThisExpression                            => Constants.This
       case _                                         => "<empty>"
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -451,7 +451,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def methodSignature(methodReturn: NewMethodReturn, params: Seq[NewMethodParameterIn]): String = {
-    s"${methodReturn.typeFullName}(${params.map(_.typeFullName).mkString(",")})"
+    composeMethodLikeSignature(methodReturn.typeFullName, params.map(_.typeFullName))
   }
 
   private def astForParameter(paramNode: DotNetNodeInfo, idx: Int, paramTypeHint: Option[String] = None): Ast = {
@@ -466,14 +466,14 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForThisParameter(methodDecl: DotNetNodeInfo): Ast = {
-    val name         = "this"
+    val name         = Constants.This
     val typeFullName = scope.surroundingTypeDeclFullName.getOrElse(Defines.Any)
     val param = parameterInNode(methodDecl, name, name, 0, false, EvaluationStrategies.BY_SHARING.name, typeFullName)
     Ast(param)
   }
 
   protected def astForThisReceiver(invocationExpr: DotNetNodeInfo, typeFullName: Option[String] = None): Ast = {
-    val name = "this"
+    val name = Constants.This
     val param = identifierNode(
       invocationExpr,
       name,

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -3,6 +3,7 @@ package io.joern.csharpsrc2cpg.astcreation
 import io.joern.csharpsrc2cpg.datastructures.{CSharpMethod, FieldDecl}
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
 import io.joern.csharpsrc2cpg.parser.{DotNetNodeInfo, ParserKeys}
+import io.joern.csharpsrc2cpg.utils.Utils.{composeMethodFullName, composeMethodLikeSignature}
 import io.joern.csharpsrc2cpg.{CSharpOperators, Constants}
 import io.joern.x2cpg.utils.NodeBuilders.{newCallNode, newIdentifierNode, newOperatorCallNode}
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
@@ -288,15 +289,16 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         (None, None, None, Seq.empty[Ast])
     }
     val methodSignature = methodMetaData match {
-      case Some(m) => s"${m.returnType}(${m.parameterTypes.filterNot(_._1 == "this").map(_._2).mkString(",")})"
-      case None    => Defines.UnresolvedSignature
+      case Some(m) =>
+        composeMethodLikeSignature(m.returnType, m.parameterTypes.filterNot(_._1 == Constants.This).map(_._2))
+      case None => Defines.UnresolvedSignature
     }
 
     val methodFullName = baseTypeFullName match {
       case Some(typeFullName) =>
-        s"$typeFullName.$callName:$methodSignature"
+        composeMethodFullName(typeFullName, callName, methodSignature)
       case _ =>
-        s"${Defines.UnresolvedNamespace}.$callName:$methodSignature"
+        composeMethodFullName(Defines.UnresolvedNamespace, callName, methodSignature)
     }
     val dispatchType = methodMetaData
       .map(_.isStatic)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
@@ -1,5 +1,6 @@
 package io.joern.csharpsrc2cpg.datastructures
 
+import io.joern.csharpsrc2cpg.Constants
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.datastructures.{OverloadableScope, Scope, ScopeElement, TypedScope, TypedScopeElement}
 import io.joern.x2cpg.utils.ListUtils.singleOrNone
@@ -38,7 +39,7 @@ class CSharpScope(summary: CSharpProgramSummary)
 
   override def isOverloadedBy(method: CSharpMethod, argTypes: List[String]): Boolean = {
     method.parameterTypes
-      .filterNot(_._1 == "this")
+      .filterNot(_._1 == Constants.This)
       .map(_._2)
       .zip(argTypes)
       .count({ case (x, y) => x != y }) == 0
@@ -62,7 +63,7 @@ class CSharpScope(summary: CSharpProgramSummary)
     .exists(x => x.scopeNode.isInstanceOf[MethodScope] || x.scopeNode.isInstanceOf[TypeLikeScope])
 
   override def tryResolveTypeReference(typeName: String): Option[CSharpType] = {
-    if (typeName == "this") {
+    if (typeName == Constants.This) {
       surroundingTypeDeclFullName.flatMap(summary.matchingTypes).headOption
     } else {
       super.tryResolveTypeReference(typeName) match


### PR DESCRIPTION
Making sure we (a) use `composeMethodFullName` every time we build a `methodFullName`; (b) use `Constants.This`.