### PR TITLE
[c#] getter access is get_* call

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/PropertyGetterTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/PropertyGetterTests.scala
@@ -1,6 +1,8 @@
 package io.joern.csharpsrc2cpg.querying.ast
 
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language.*
 
 class PropertyGetterTests extends CSharpCode2CpgFixture {
@@ -16,12 +18,14 @@ class PropertyGetterTests extends CSharpCode2CpgFixture {
     }
 
     "have System.Console.Out correctly set" in {
-      inside(cpg.fieldAccess.code("System.Console.Out").l) {
+      inside(cpg.call.code("System.Console.Out").l) {
         case consoleOut :: Nil =>
+          consoleOut.name shouldBe "get_Out"
+          consoleOut.methodFullName shouldBe "System.Console.get_Out:System.IO.TextWriter()"
+          consoleOut.argument shouldBe empty
+          consoleOut.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
           consoleOut.typeFullName shouldBe "System.IO.TextWriter"
-          consoleOut.fieldIdentifier.canonicalName.l shouldBe List("Out")
-        case xs =>
-          fail(s"Expected single fieldAccess for Console.Out, but got $xs")
+        case xs => fail(s"Expected single call for System.Console.Out, but got $xs")
       }
     }
   }
@@ -39,30 +43,74 @@ class PropertyGetterTests extends CSharpCode2CpgFixture {
           writeLine.code shouldBe "System.Console.Out.WriteLine(\"X\")"
           writeLine.methodFullName shouldBe "System.IO.TextWriter.WriteLine:System.Void(System.String)"
           writeLine.typeFullName shouldBe "System.Void"
-        case xs =>
-          fail(s"Expected single WriteLine call, but got $xs")
+        case xs => fail(s"Expected single WriteLine call, but got $xs")
       }
     }
 
-    "have correct properties for System.Console" in {
-      inside(cpg.fieldAccess.code("System.Console").l) {
-        case sysConsole :: Nil =>
-          sysConsole.fieldIdentifier.canonicalName.l shouldBe List("Console")
-          sysConsole.typeFullName shouldBe "System.Console"
-        case xs =>
-          fail(s"Expected single fieldAccess for System.Console, but got $xs")
+    "have correct arguments for WriteLine" in {
+      inside(cpg.call.nameExact("WriteLine").argument.sortBy(_.argumentIndex).l) {
+        case (receiver: Call) :: (literal: Literal) :: Nil =>
+          receiver.argumentIndex shouldBe 0
+          receiver.code shouldBe "System.Console.Out"
+          receiver.name shouldBe "get_Out"
+          receiver.typeFullName shouldBe "System.IO.TextWriter"
+
+          literal.argumentIndex shouldBe 1
+          literal.code shouldBe "\"X\""
+          literal.typeFullName shouldBe "System.String"
+        case xs => fail(s"Expected two arguments for WriteLine, but got $xs")
       }
     }
 
     "have correct properties for System.Console.Out" in {
-      inside(cpg.fieldAccess.code("System.Console.Out").l) {
+      inside(cpg.call.code("System.Console.Out").l) {
         case out :: Nil =>
-          out.code shouldBe "System.Console.Out"
+          out.name shouldBe "get_Out"
           out.typeFullName shouldBe "System.IO.TextWriter"
+          out.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+          out.methodFullName shouldBe "System.Console.get_Out:System.IO.TextWriter()"
         case xs =>
-          fail(s"Expected single fieldAccess for System.Console.Out, but got $xs")
+          fail(s"Expected single call for System.Console.Out, but got $xs")
       }
+    }
+
+    "have correct arguments for System.Console.Out" in {
+      cpg.call.code("System.Console.out").argument shouldBe empty
     }
   }
 
+  "`ConsoleKeyInfo.KeyChar` being assigned to a variable" should {
+    val cpg = code("""
+        |using System;
+        |var x = new ConsoleKeyInfo();
+        |var y = x.KeyChar;
+        |""".stripMargin)
+
+    "have variable correctly typed" in {
+      cpg.assignment.target.isIdentifier.nameExact("x").typeFullName.l shouldBe List("System.ConsoleKeyInfo")
+      cpg.assignment.target.isIdentifier.nameExact("y").typeFullName.l shouldBe List("System.Char")
+    }
+
+    "have correct properties for KeyChar call" in {
+      inside(cpg.call.code("x.KeyChar").l) {
+        case keyChar :: Nil =>
+          keyChar.name shouldBe "get_KeyChar"
+          keyChar.methodFullName shouldBe "System.ConsoleKeyInfo.get_KeyChar:System.Char(System.ConsoleKeyInfo)"
+          keyChar.typeFullName shouldBe "System.Char"
+          keyChar.signature shouldBe "System.Char(System.ConsoleKeyInfo)"
+        case xs => fail(s"Expected single call to KeyChar, but got $xs")
+      }
+    }
+
+    "have correct arguments for KeyChar call" in {
+      inside(cpg.call.code("x.KeyChar").argument.sortBy(_.argumentIndex).l) {
+        case (x: Identifier) :: Nil =>
+          x.typeFullName shouldBe "System.ConsoleKeyInfo"
+          x.code shouldBe "x"
+          x.name shouldBe "x"
+          x.argumentIndex shouldBe 0
+        case xs => fail(s"Expected single identifier argument to KeyChar, but got $xs")
+      }
+    }
+  }
 }


### PR DESCRIPTION
Reworks property accesses into method calls. For instance, 
* `System.Console.Out` is no longer a field access (to `Out`) but a static (because `Out` is a static property) call `System.Console.get_Out()`.
* `x.KeyChar`, where `x` has type `System.ConsoleKeyInfo`, is no longer a field access but a dynamic (because `KeyChar` is not static) call `System.ConsoleKeyInfo.get_KeyChar(x)`.