### PR TITLE
[c#] laxer extension method matching

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
@@ -140,7 +140,10 @@ class CSharpScope(summary: CSharpProgramSummary)
     name: String,
     argTypes: List[String]
   ): CSharpMethod => Boolean = { m =>
-    m.isStatic && m.name == name && m.parameterTypes.map(_._2) == thisType :: argTypes
+    // TODO: we should also compare argTypes, however we first need to account for:
+    //  a) default valued parameters in CSharpMethod, to account for different arities
+    //  b) compatible/sub types, i.e. System.String should unify with System.Object.
+    m.isStatic && m.name == name && m.parameterTypes.map(_._2).headOption.contains(thisType)
   }
 
   /** Tries to find an extension method for [[baseTypeFullName]] with the given [[callName]] and [[argTypes]] in the

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ExtensionMethodTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ExtensionMethodTests.scala
@@ -195,6 +195,22 @@ class ExtensionMethodTests extends CSharpCode2CpgFixture {
 
       cpg.call.nameExact("DoStuff").callee.l shouldBe cpg.literal("2").method.l
     }
+
+    "resolve correctly if the extra argument is type-compatible with the extension method's extra parameter" in {
+      val cpg = code("""
+          |using System.Collections.Generic;
+          |
+          |var x = new List<string>();
+          |x.DoStuff(null);
+          |
+          |static class Extensions
+          |{
+          |    public static int DoStuff(this List<string> myList, object x) { return 2; }
+          |}
+          |""".stripMargin)
+
+      cpg.call.nameExact("DoStuff").callee.l shouldBe cpg.literal("2").method.l
+    }
   }
 
   "consecutive unary extension method calls" should {


### PR DESCRIPTION
Loosens extension method matching to accomodate for the current lack of support for default parameter values and type compatibility checking. These issues will likely require updates to DotNetAstGen's output. Once they have some kind of support, we should tighten this criteria again.