### PR TITLE
[c#] dotnetastgen for linux on arm is linux-arm64

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
@@ -16,8 +16,9 @@ class DotNetAstGenRunner(config: Config) extends AstGenRunnerBase(config) {
   private val logger = LoggerFactory.getLogger(getClass)
 
   // The x86 variant seems to run well enough on MacOS M-family chips, whereas the ARM build crashes
-  override val MacArm: String = MacX86
-  override val WinArm: String = WinX86
+  override val MacArm: String   = MacX86
+  override val WinArm: String   = WinX86
+  override val LinuxArm: String = "linux-arm64"
 
   override def fileFilter(file: String, out: File): Boolean = {
     file.stripSuffix(".json").replace(out.pathAsString, config.inputPath) match {


### PR DESCRIPTION
The Linux ARM version is named `dotnetastgen-linux-arm64`. However, the default suffix on `AstGenRunnerBase` for this configuration is `arm`, leading to a lookup for `dotnetastgen-linux-arm` that doesn't exist. The fix is similar to gosrc2cpg's:

https://github.com/joernio/joern/blob/bdb65e2ddd934633dedfec18bdd19d68ffd60e8d/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala#L33

credits: @tajobe 