### PR TITLE
[c2cpg] Some performance fixes

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -1,6 +1,7 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.c2cpg.Config
+import io.joern.c2cpg.parser.HeaderFileFinder
 import io.joern.x2cpg.datastructures.Scope
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
@@ -21,6 +22,7 @@ class AstCreator(
   val global: CGlobal,
   val config: Config,
   val cdtAst: IASTTranslationUnit,
+  val headerFileFinder: HeaderFileFinder,
   val file2OffsetTable: ConcurrentHashMap[String, Array[Int]]
 )(implicit withSchemaValidation: ValidationMode)
     extends AstCreatorBase(filename)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -289,7 +289,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     // We only handle un-parsable macros here for now
     val isFromMacroExpansion = statement.getProblem.getNodeLocations.exists(_.isInstanceOf[IASTMacroExpansionLocation])
     val asts = if (isFromMacroExpansion) {
-      new CdtParser(config, mutable.LinkedHashSet.empty)
+      new CdtParser(config, headerFileFinder, mutable.LinkedHashSet.empty)
         .parse(statement.getRawSignature, Paths.get(statement.getContainingFilename)) match
         case Some(node) => node.getDeclarations.toIndexedSeq.flatMap(astsForDeclaration)
         case None       => Seq.empty

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -36,23 +36,24 @@ object CdtParser {
 
   private def readFileAsFileContent(file: File, lines: Option[Array[Char]] = None): FileContent = {
     val codeLines = lines.getOrElse(IOUtils.readLinesInFile(file.path).mkString("\n").toArray)
-    val isSource  = FileDefaults.hasSourceFileExtension(file.pathAsString)
-    FileContent.create(file.pathAsString, isSource, codeLines)
+    FileContent.create(file.pathAsString, true, codeLines)
   }
 
 }
 
-class CdtParser(config: Config, compilationDatabase: mutable.LinkedHashSet[CommandObject])
-    extends ParseProblemsLogger
+class CdtParser(
+  config: Config,
+  headerFileFinder: HeaderFileFinder,
+  compilationDatabase: mutable.LinkedHashSet[CommandObject]
+) extends ParseProblemsLogger
     with PreprocessorStatementsLogger {
 
   import io.joern.c2cpg.parser.CdtParser.*
 
-  private val headerFileFinder = new HeaderFileFinder(config.inputPath)
-  private val parserConfig     = ParserConfig.fromConfig(config, compilationDatabase)
-  private val definedSymbols   = parserConfig.definedSymbols
-  private val includePaths     = parserConfig.userIncludePaths
-  private val log              = new DefaultLogService
+  private val parserConfig   = ParserConfig.fromConfig(config, compilationDatabase)
+  private val definedSymbols = parserConfig.definedSymbols
+  private val includePaths   = parserConfig.userIncludePaths
+  private val log            = new DefaultLogService
 
   // enables parsing of code behind disabled preprocessor defines:
   private var opts: Int = ILanguage.OPTION_PARSE_INACTIVE_CODE

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -2,13 +2,20 @@ package io.joern.c2cpg.parser
 
 import better.files.*
 import io.joern.c2cpg.C2Cpg.DefaultIgnoredFolders
+import io.joern.c2cpg.Config
 import io.joern.x2cpg.SourceFiles
 import org.jline.utils.Levenshtein
 
-class HeaderFileFinder(root: String) {
+class HeaderFileFinder(config: Config) {
 
   private val nameToPathMap: Map[String, List[String]] = SourceFiles
-    .determine(root, FileDefaults.HeaderFileExtensions, ignoredDefaultRegex = Option(DefaultIgnoredFolders))
+    .determine(
+      config.inputPath,
+      FileDefaults.HeaderFileExtensions,
+      ignoredDefaultRegex = Option(DefaultIgnoredFolders),
+      ignoredFilesRegex = Option(config.ignoredFilesRegex),
+      ignoredFilesPath = Option(config.ignoredFiles)
+    )
     .map { p =>
       val file = File(p)
       (file.name, file.pathAsString)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/PreprocessorPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/PreprocessorPass.scala
@@ -3,6 +3,7 @@ package io.joern.c2cpg.passes
 import io.joern.c2cpg.C2Cpg.DefaultIgnoredFolders
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.parser.{CdtParser, FileDefaults}
+import io.joern.c2cpg.parser.HeaderFileFinder
 import io.joern.c2cpg.parser.JSONCompilationDatabaseParser
 import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CommandObject
 import io.joern.x2cpg.SourceFiles
@@ -25,7 +26,8 @@ class PreprocessorPass(config: Config) {
   private val compilationDatabase: mutable.LinkedHashSet[CommandObject] =
     config.compilationDatabase.map(JSONCompilationDatabaseParser.parse).getOrElse(mutable.LinkedHashSet.empty)
 
-  private val parser = new CdtParser(config, compilationDatabase)
+  private val headerFileFinder = new HeaderFileFinder(config)
+  private val parser           = new CdtParser(config, headerFileFinder, compilationDatabase)
 
   private def sourceFilesFromDirectory(): ParIterable[String] = {
     SourceFiles


### PR DESCRIPTION
- only use one instance of HeaderFileFinder during the whole parse process and CPG generation (no need to initialize this more than once)
- respect file exclusions during header file search

Reduces runtime on polarphp by ~10sec on my machine.