### PR TITLE
[c#] lower get accessor declarations to get_* methods

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -280,12 +280,20 @@ object DotNetJsonAst {
 
   object Unknown extends DotNetParserNode
 
+  object AccessorList extends DotNetParserNode
+
+  object GetAccessorDeclaration extends DotNetParserNode
+
+  object SetAccessorDeclaration extends DotNetParserNode
+
 }
 
 /** The JSON key values, in alphabetical order.
   */
 object ParserKeys {
 
+  val AccessorList              = "AccessorList"
+  val Accessors                 = "Accessors"
   val AstRoot                   = "AstRoot"
   val Arguments                 = "Arguments"
   val ArgumentList              = "ArgumentList"
@@ -311,6 +319,7 @@ object ParserKeys {
   val ExpressionBody            = "ExpressionBody"
   val Finally                   = "Finally"
   val FileName                  = "FileName"
+  val GetAccessorDeclaration    = "GetAccessorDeclaration"
   val Identifier                = "Identifier"
   val Incrementors              = "Incrementors"
   val Initializer               = "Initializer"
@@ -333,6 +342,7 @@ object ParserKeys {
   val ParameterList             = "ParameterList"
   val Pattern                   = "Pattern"
   val Sections                  = "Sections"
+  val SetAccessorDeclaration    = "SetAccessorDeclaration"
   val SingleVariableDesignation = "SingleVariableDesignation"
   val Statement                 = "Statement"
   val Statements                = "Statements"

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberAccessTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberAccessTests.scala
@@ -6,11 +6,45 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.semanticcpg.language.*
 
 class MemberAccessTests extends CSharpCode2CpgFixture {
-  "conditional member access expressions" should {
+
+  // TODO: This test-case relies on the usage of getters, that are currently being
+  // reworked to be METHODs instead of MEMBERs. In particular, `bar?.Qux` should
+  // resemble `bar.get_Qux()`. We need to adapt astForMemberBindingExpression
+  // to accommodate this.
+  "conditional property access expressions" ignore {
     val cpg = code("""
         |namespace Foo {
         | public class Baz {
         |   public int Qux {get;}
+        | }
+        | public class Bar {
+        |   public static void Main() {
+        |     var baz = new Baz();
+        |     var a = baz?.Qux;
+        |   }
+        | }
+        |}
+        |""".stripMargin)
+
+    "have correct types both on the LHS and RHS" in {
+      inside(cpg.assignment.l.sortBy(_.lineNumber).drop(1)) {
+        case a :: Nil =>
+          inside(a.argument.l) {
+            case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+              lhs.typeFullName shouldBe BuiltinTypes.DotNetTypeMap(BuiltinTypes.Int)
+              rhs.typeFullName shouldBe BuiltinTypes.DotNetTypeMap(BuiltinTypes.Int)
+            case _ => fail("Expected 2 arguments under the assignment call.")
+          }
+        case _ => fail("Expected 1 assignment call.")
+      }
+    }
+  }
+
+  "conditional member access expressions" should {
+    val cpg = code("""
+        |namespace Foo {
+        | public class Baz {
+        |   public int Qux;
         | }
         | public class Bar {
         |   public static void Main() {
@@ -216,7 +250,11 @@ class MemberAccessTests extends CSharpCode2CpgFixture {
     }
   }
 
-  "conditional method access expression for chained fields" should {
+  // TODO: ConditionalAccessExpressions need some work to deal with nested chains.
+  // This particular test-case relies on the usage of getters, that are currently being
+  // reworked to be METHODs instead of MEMBERs.
+  // Revisit this test-case once getters are finished.
+  "conditional property access expression for chained fields" ignore {
     val cpg = code("""
       |namespace Foo {
       | public class Baz {
@@ -230,6 +268,35 @@ class MemberAccessTests extends CSharpCode2CpgFixture {
       | }
       |}
       |""".stripMargin)
+
+    "have correct types and attributes both on the LHS and RHS" in {
+      inside(cpg.assignment.l.sortBy(_.lineNumber).drop(1).l) {
+        case a :: Nil =>
+          inside(a.argument.l) {
+            case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+              lhs.typeFullName shouldBe "Foo.Baz"
+              rhs.typeFullName shouldBe "Foo.Baz"
+            case _ => fail("Expected 2 arguments under the assignment call")
+          }
+        case _ => fail("Expected 1 assignment call.")
+      }
+    }
+  }
+
+  "conditional method access expression for chained fields" should {
+    val cpg = code("""
+        |namespace Foo {
+        | public class Baz {
+        |   public Baz Qux;
+        | }
+        | public class Bar {
+        |   public static void Main() {
+        |     var baz = new Baz();
+        |     var b = baz?.Qux?.Qux;
+        |   }
+        | }
+        |}
+        |""".stripMargin)
 
     "have correct types and attributes both on the LHS and RHS" in {
       inside(cpg.assignment.l.sortBy(_.lineNumber).drop(1).l) {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberTests.scala
@@ -444,7 +444,9 @@ class MemberTests extends CSharpCode2CpgFixture {
     }
   }
 
-  "a basic class declaration with a PropertyDeclaration member" should {
+  // TODO: Getters/Setters are currently being lowered into get_/set_ methods.
+  //  Adapt this unit-test once that is finished.
+  "a basic class declaration with a PropertyDeclaration member" ignore {
     val cpg = code("""
         |public class Foo {
         | public int Bar {get; set;}
@@ -457,6 +459,28 @@ class MemberTests extends CSharpCode2CpgFixture {
           inside(fooClass.astChildren.isMember.nameExact("Bar").l) {
             case bar :: Nil =>
               bar.code shouldBe "public int Bar"
+              bar.typeFullName shouldBe "System.Int32"
+              bar.astParent shouldBe fooClass
+            case _ => fail("No member named Bar found inside Foo")
+          }
+        case _ => fail("No class named Foo found.")
+      }
+    }
+  }
+
+  "a basic class declaration with a FieldDeclaration member" should {
+    val cpg = code("""
+        |public class Foo {
+        | public int Bar;
+        |}
+        |""".stripMargin)
+
+    "create a member for Bar with appropriate properties" in {
+      inside(cpg.typeDecl.nameExact("Foo").l) {
+        case fooClass :: Nil =>
+          inside(fooClass.astChildren.isMember.nameExact("Bar").l) {
+            case bar :: Nil =>
+              bar.code shouldBe "int Bar"
               bar.typeFullName shouldBe "System.Int32"
               bar.astParent shouldBe fooClass
             case _ => fail("No member named Bar found inside Foo")


### PR DESCRIPTION
Reworks `get;` accessors to become METHODs instead of MEMBERs. At this point, we already have special logic for rewriting e.g. `Console.Out` into `Console.get_Out()` (as that's its real name, coming from DotNetAstGen), but we are still missing the same lowering for properties declared in the source-code, which are currently represented as MEMBERs. This PR turns them into get_* METHODs.

I had to ignore 3 unit-tests related to MemberBindingExpression + ConditionalAccessExpression: the original test samples for these were using getters, though they didn't have to, as can be seen by their adapted variants using traditional fields. Thus, we didn't lose on the amount of tests, only adapted them for now. Fixing all that in the same PR would make it considerably more noisy, hence the split.