### PR TITLE
[c#] refactor composeMethodFullName-alikes

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -378,7 +378,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     lazy val byFieldAccess = scope.tryResolveFieldAccess(fieldIdentifierName, Some(baseTypeFullName))
 
     // Getters look like fields, but are underneath `get_`-prefixed methods
-    lazy val byPropertyName = scope.tryResolveMethodInvocation(s"get_$fieldIdentifierName", Nil, Some(baseTypeFullName))
+    lazy val byPropertyName = scope.tryResolveGetterInvocation(fieldIdentifierName, Some(baseTypeFullName))
 
     // accessExpr might be a qualified name e.g. `System.Console`, in which case `System` (baseAst) is not a type
     // but a namespace. In this scenario, we look up the entire expression

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
@@ -1,6 +1,7 @@
 package io.joern.csharpsrc2cpg.datastructures
 
 import io.joern.csharpsrc2cpg.Constants
+import io.joern.csharpsrc2cpg.utils.Utils
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.datastructures.{OverloadableScope, Scope, ScopeElement, TypedScope, TypedScopeElement}
 import io.joern.x2cpg.utils.ListUtils.singleOrNone
@@ -164,5 +165,13 @@ class CSharpScope(summary: CSharpProgramSummary)
     argTypes: List[String]
   ): Option[(CSharpMethod, String)] = {
     baseTypeFullName.flatMap(extensionsInScopeFor(_, callName, argTypes).headOption).map(x => (x.methods.head, x.name))
+  }
+
+  def tryResolveGetterInvocation(
+    fieldIdentifierName: String,
+    baseTypeFullName: Option[String]
+  ): Option[CSharpMethod] = {
+    val getterMethodName = Utils.composeGetterName(fieldIdentifierName)
+    tryResolveMethodInvocation(getterMethodName, Nil, baseTypeFullName)
   }
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/Utils.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/Utils.scala
@@ -1,12 +1,24 @@
 package io.joern.csharpsrc2cpg.utils
 
+import io.joern.x2cpg.Ast
+import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterIn
+
 object Utils {
   def composeMethodLikeSignature(returnType: String, parameterTypes: collection.Seq[String]): String = {
     s"$returnType(${parameterTypes.mkString(",")})"
   }
 
+  def composeMethodLikeSignature(returnType: String, parameters: Seq[Ast] = Nil): String = {
+    composeMethodLikeSignature(
+      returnType,
+      parameters.flatMap(_.nodes.collectFirst { case x: NewMethodParameterIn => x.typeFullName })
+    )
+  }
+
   def composeMethodFullName(typeDeclFullName: String, name: String, signature: String): String = {
     s"$typeDeclFullName.$name:$signature"
   }
+
+  def composeGetterName(fieldIdentifierName: String): String = s"get_$fieldIdentifierName"
 
 }


### PR DESCRIPTION
* Introduces `CSharpScope.tryResolveGetterInvocation` that, together with `composeGetterName`, simplifies the getter lookup in `astForSimpleMemberAccessInvocation`.
* Introduces an overloaded method for `composeMethodFullName` taking in the parameter ASTs, so we don't have to get their types beforehand every time.