### PR TITLE
[sarif] Make SarifConfig Mutable in REPL

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -233,7 +233,7 @@ trait BridgeBase extends InteractiveShell with ScriptExecution with PluginHandli
     }
     builder ++= config.runBefore
     builder ++= "import _root_.io.shiftleft.semanticcpg.sarif.SarifConfig"
-      :: "implicit val sarifConfig: SarifConfig = SarifConfig(semanticVersion = version)"
+      :: "implicit var sarifConfig: SarifConfig = SarifConfig(semanticVersion = version)"
       :: Nil
     builder.result()
   }


### PR DESCRIPTION
Just discovered the latest addition to #5256 of the sarif config was `val` and would not be able to be redefined for tools extending the REPL.