### PR TITLE
[sarif] Add Reporting Descriptors & More "Optionality"

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -2,10 +2,12 @@ package io.joern.console
 
 import better.files.*
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.sarif.SarifConfig
 import org.apache.commons.text.StringEscapeUtils
 import replpp.scripting.ScriptRunner
 
 import java.nio.file.{Files, Path}
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
@@ -232,9 +234,6 @@ trait BridgeBase extends InteractiveShell with ScriptExecution with PluginHandli
       builder += s"""openForInputPath("$name")""".stripMargin
     }
     builder ++= config.runBefore
-    builder ++= "import _root_.io.shiftleft.semanticcpg.sarif.SarifConfig"
-      :: "implicit var sarifConfig: SarifConfig = SarifConfig(semanticVersion = version)"
-      :: Nil
     builder.result()
   }
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/RunBeforeCode.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/RunBeforeCode.scala
@@ -14,8 +14,10 @@ object RunBeforeCode {
       "import _root_.io.joern.dataflowengineoss.language.*",
       "import _root_.io.shiftleft.semanticcpg.language.*",
       "import scala.jdk.CollectionConverters.*",
+      "import _root_.io.shiftleft.semanticcpg.sarif.SarifConfig",
       "implicit val resolver: ICallResolver = NoResolve",
-      "implicit val finder: NodeExtensionFinder = DefaultNodeExtensionFinder"
+      "implicit val finder: NodeExtensionFinder = DefaultNodeExtensionFinder",
+      "implicit val sarifConfig: SarifConfig = SarifConfig(semanticVersion = Option(version))"
     )
 
   val forInteractiveShell: Seq[String] = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/SarifConfig.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/SarifConfig.scala
@@ -30,10 +30,10 @@ import java.net.URI
   */
 case class SarifConfig(
   toolName: String = "Joern",
-  toolFullName: String = "Joern - The Bug Hunter's Workbench",
-  toolInformationUri: URI = URI("https://joern.io"),
-  organization: String = "Joern.io",
-  semanticVersion: String = "0.0.1",
+  toolFullName: Option[String] = Option("Joern - The Bug Hunter's Workbench"),
+  toolInformationUri: Option[URI] = Option(URI("https://joern.io")),
+  organization: Option[String] = Option("Joern.io"),
+  semanticVersion: Option[String] = None,
   sarifVersion: SarifVersion = SarifVersion.V2_1_0,
   resultConverter: ScanResultToSarifConverter = JoernScanResultToSarifConverter(),
   customSerializers: List[Serializer[?]] = SarifSchema.serializers

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/ScanResultToSarifConverter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/ScanResultToSarifConverter.scala
@@ -1,11 +1,19 @@
 package io.shiftleft.semanticcpg.sarif
 
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.semanticcpg.sarif.SarifSchema.Result
+import io.shiftleft.semanticcpg.sarif.SarifSchema.{ReportingDescriptor, Result}
 
 /** A component that converts a CPG finding to some version of SARIF.
   */
 trait ScanResultToSarifConverter {
+
+  /** Given a finding, will extract any rule data and create a SARIF ReportingDescriptor
+    * @param finding
+    *   the finding to convert.
+    * @return
+    *   a SARIF compliant reporting descriptor object if possible.
+    */
+  def convertFindingToReportingDescriptor(finding: Finding): Option[ReportingDescriptor]
 
   /** Given a finding, will convert it to the SARIF specified result.
     * @param finding

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/v2_1_0/Schema.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/v2_1_0/Schema.scala
@@ -21,7 +21,7 @@ object Schema {
   final case class ArtifactLocation(uri: Option[URI] = None, uriBaseId: Option[String] = Option("PROJECT_ROOT"))
       extends SarifSchema.ArtifactLocation
 
-  final case class CodeFlow(message: Option[Message] = None, threadFlows: List[ThreadFlow]) extends SarifSchema.CodeFlow
+  final case class CodeFlow(threadFlows: List[ThreadFlow], message: Option[Message] = None) extends SarifSchema.CodeFlow
 
   final case class Location(physicalLocation: PhysicalLocation) extends SarifSchema.Location
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/v2_1_0/Schema.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/v2_1_0/Schema.scala
@@ -21,11 +21,11 @@ object Schema {
   final case class ArtifactLocation(uri: Option[URI] = None, uriBaseId: Option[String] = Option("PROJECT_ROOT"))
       extends SarifSchema.ArtifactLocation
 
-  final case class CodeFlow(message: Message, threadFlows: List[ThreadFlow]) extends SarifSchema.CodeFlow
+  final case class CodeFlow(message: Option[Message] = None, threadFlows: List[ThreadFlow]) extends SarifSchema.CodeFlow
 
   final case class Location(physicalLocation: PhysicalLocation) extends SarifSchema.Location
 
-  final case class Message(text: String) extends SarifSchema.Message
+  final case class Message(text: String, markdown: Option[String] = None) extends SarifSchema.Message
 
   final case class PhysicalLocation(artifactLocation: ArtifactLocation, region: Region)
       extends SarifSchema.PhysicalLocation
@@ -37,6 +37,14 @@ object Schema {
     endColumn: Option[Int] = None,
     snippet: Option[ArtifactContent] = None
   ) extends SarifSchema.Region
+
+  final case class ReportingDescriptor(
+    id: String,
+    name: String,
+    shortDescription: Option[Message] = None,
+    fullDescription: Option[Message] = None,
+    helpUri: Option[URI] = None
+  ) extends SarifSchema.ReportingDescriptor
 
   final case class Result(
     ruleId: String,
@@ -58,10 +66,11 @@ object Schema {
 
   final case class ToolComponent(
     name: String,
-    fullName: String,
-    organization: String,
-    semanticVersion: String,
-    informationUri: URI
+    fullName: Option[String] = None,
+    organization: Option[String] = None,
+    semanticVersion: Option[String] = None,
+    informationUri: Option[URI] = None,
+    rules: List[SarifSchema.ReportingDescriptor] = Nil
   ) extends SarifSchema.ToolComponent
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SarifTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SarifTests.scala
@@ -22,8 +22,8 @@ class SarifTests extends AnyWordSpec with Matchers {
       run.results shouldBe Nil
       val tool = run.tool.driver
       tool.name shouldBe "Joern"
-      tool.fullName shouldBe "Joern - The Bug Hunter's Workbench"
-      tool.organization shouldBe "Joern.io"
+      tool.fullName shouldBe Option("Joern - The Bug Hunter's Workbench")
+      tool.organization shouldBe Option("Joern.io")
     }
   }
 
@@ -34,13 +34,25 @@ class SarifTests extends AnyWordSpec with Matchers {
     createValidFindingNode(cpg)
 
     "create a valid SARIF result" in {
-      val sarif   = cpg.finding.toSarif()
-      val results = sarif.runs.head.results
+      val sarif = cpg.finding.toSarif()
+      val run   = sarif.runs.head
+      val rules = run.tool.driver.rules
+
+      rules.size shouldBe 1
+      val rule = rules.head
+      rule.id shouldBe "f1"
+      rule.name shouldBe "Rule 1"
+      rule.shortDescription shouldBe None
+      rule.fullDescription.map(_.text) shouldBe Some("something bad happened")
+      rule.helpUri shouldBe None
+
+      val results = run.results
       results.size shouldBe 1
+
       val result = results.head
 
       result.ruleId shouldBe "f1"
-      result.message.text shouldBe "Finding 1"
+      result.message.text shouldBe "Rule 1"
       result.level shouldBe "error"
 
       val region = result.locations.head.physicalLocation.region
@@ -52,7 +64,7 @@ class SarifTests extends AnyWordSpec with Matchers {
       artifactLocation.uri.map(_.toString) shouldBe Some("Bar.java")
 
       result.codeFlows.size shouldBe 1
-      result.codeFlows.head.message.text shouldBe "something bad happened"
+      result.codeFlows.head.message shouldBe None
     }
 
     "create a valid SARIF JSON" in {
@@ -68,14 +80,23 @@ class SarifTests extends AnyWordSpec with Matchers {
           |          "fullName":"Joern - The Bug Hunter's Workbench",
           |          "organization":"Joern.io",
           |          "semanticVersion":"0.0.1",
-          |          "informationUri":"https://joern.io"
+          |          "informationUri":"https://joern.io",
+          |          "rules":[
+          |            {
+          |              "id":"f1",
+          |              "name":"Rule 1",
+          |              "fullDescription":{
+          |                "text":"something bad happened"
+          |              }
+          |            }
+          |          ]
           |        }
           |      },
           |      "results":[
           |        {
           |          "ruleId":"f1",
           |          "message":{
-          |            "text":"Finding 1"
+          |            "text":"Rule 1"
           |          },
           |          "level":"error",
           |          "locations":[
@@ -112,9 +133,6 @@ class SarifTests extends AnyWordSpec with Matchers {
           |          ],
           |          "codeFlows":[
           |            {
-          |              "message":{
-          |                "text":"something bad happened"
-          |              },
           |              "threadFlows":[
           |                {
           |                  "locations":[
@@ -161,8 +179,19 @@ class SarifTests extends AnyWordSpec with Matchers {
     createInvalidFindingNode(cpg)
 
     "create a valid SARIF result" in {
-      val sarif   = cpg.finding.toSarif()
-      val results = sarif.runs.head.results
+      val sarif = cpg.finding.toSarif()
+      val run   = sarif.runs.head
+      val rules = run.tool.driver.rules
+
+      rules.size shouldBe 1
+      val rule = rules.head
+      rule.id shouldBe "f1"
+      rule.name shouldBe "<empty>"
+      rule.shortDescription shouldBe None
+      rule.fullDescription.map(_.text) shouldBe Some("something bad happened")
+      rule.helpUri shouldBe None
+
+      val results = run.results
       results.size shouldBe 1
       val result = results.head
 
@@ -179,7 +208,7 @@ class SarifTests extends AnyWordSpec with Matchers {
       artifactLocation.uri.map(_.toString) shouldBe None
 
       result.codeFlows.size shouldBe 1
-      result.codeFlows.head.message.text shouldBe "something bad happened"
+      result.codeFlows.head.message shouldBe None
     }
 
     "create a valid SARIF JSON" in {
@@ -196,7 +225,16 @@ class SarifTests extends AnyWordSpec with Matchers {
           |          "fullName":"Joern - The Bug Hunter's Workbench",
           |          "organization":"Joern.io",
           |          "semanticVersion":"0.0.1",
-          |          "informationUri":"https://joern.io"
+          |          "informationUri":"https://joern.io",
+          |          "rules":[
+          |            {
+          |              "id":"f1",
+          |              "name":"<empty>",
+          |              "fullDescription":{
+          |                "text":"something bad happened"
+          |              }
+          |            }
+          |          ]
           |        }
           |      },
           |      "results":[
@@ -238,9 +276,6 @@ class SarifTests extends AnyWordSpec with Matchers {
           |          ],
           |          "codeFlows":[
           |            {
-          |              "message":{
-          |                "text":"something bad happened"
-          |              },
           |              "threadFlows":[
           |                {
           |                  "locations":[
@@ -295,7 +330,7 @@ object SarifTests {
       .keyValuePairs(
         List(
           NewKeyValuePair().key("name").value("f1"),
-          NewKeyValuePair().key("title").value("Finding 1"),
+          NewKeyValuePair().key("title").value("Rule 1"),
           NewKeyValuePair().key("description").value("something bad happened"),
           NewKeyValuePair().key("score").value("8.0")
         )

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SarifTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SarifTests.scala
@@ -76,11 +76,10 @@ class SarifTests extends AnyWordSpec with Matchers {
           |    {
           |      "tool":{
           |        "driver":{
-          |          "name":"Joern",
-          |          "fullName":"Joern - The Bug Hunter's Workbench",
           |          "organization":"Joern.io",
-          |          "semanticVersion":"0.0.1",
+          |          "name":"Joern",
           |          "informationUri":"https://joern.io",
+          |          "fullName":"Joern - The Bug Hunter's Workbench",
           |          "rules":[
           |            {
           |              "id":"f1",
@@ -221,11 +220,10 @@ class SarifTests extends AnyWordSpec with Matchers {
           |    {
           |      "tool":{
           |        "driver":{
-          |          "name":"Joern",
-          |          "fullName":"Joern - The Bug Hunter's Workbench",
           |          "organization":"Joern.io",
-          |          "semanticVersion":"0.0.1",
+          |          "name":"Joern",
           |          "informationUri":"https://joern.io",
+          |          "fullName":"Joern - The Bug Hunter's Workbench",
           |          "rules":[
           |            {
           |              "id":"f1",


### PR DESCRIPTION
* Added reporting descriptors which allow one to add more meta data to rules, and link findings to a given existing entry.
* Moved the sarif instantiation to the RunBeforeCode object which separates actions from tools deriving from Joern
* Using more "optional" properties where possible on properties which are not required by the sarif schema