### PR TITLE
[c#] void always mapped to System.Void

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -280,6 +280,6 @@ object BuiltinTypes {
     String  -> "System.String",
     Dynamic -> "System.Object",
     Null    -> Null,
-    Void    -> Void
+    Void    -> "System.Void"
   )
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -92,7 +92,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val shouldBuildCtor = dynamicFields.nonEmpty && !hasExplicitCtor && parseLevel == FULL_AST
 
     if (shouldBuildCtor) {
-      val methodReturn = newMethodReturnNode(BuiltinTypes.Void, None, None, None)
+      val methodReturn = newMethodReturnNode(DotNetTypeMap(BuiltinTypes.Void), None, None, None)
       val signature    = composeMethodLikeSignature(methodReturn.typeFullName)
       val modifiers    = Seq(newModifierNode(ModifierTypes.CONSTRUCTOR), newModifierNode(ModifierTypes.INTERNAL))
       val name         = Defines.ConstructorMethodName
@@ -134,7 +134,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val shouldBuildCtor = staticFields.nonEmpty && !hasExplicitCtor && parseLevel == FULL_AST
 
     if (shouldBuildCtor) {
-      val methodReturn = newMethodReturnNode(BuiltinTypes.Void, None, None, None)
+      val methodReturn = newMethodReturnNode(DotNetTypeMap(BuiltinTypes.Void), None, None, None)
       val signature    = composeMethodLikeSignature(methodReturn.typeFullName)
       val modifiers = Seq(
         newModifierNode(ModifierTypes.CONSTRUCTOR),
@@ -355,8 +355,8 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       .toSeq
     // TODO: Decide on proper return type for constructors. No `ReturnType` key in C# JSON for constructors so just
     //  defaulted to void (same as java) for now
-    val methodReturn     = newMethodReturnNode(BuiltinTypes.Void, None, None, None)
-    val signature        = composeMethodLikeSignature(BuiltinTypes.Void, params)
+    val methodReturn     = newMethodReturnNode(DotNetTypeMap(BuiltinTypes.Void), None, None, None)
+    val signature        = composeMethodLikeSignature(DotNetTypeMap(BuiltinTypes.Void), params)
     val typeDeclFullName = scope.surroundingTypeDeclFullName.getOrElse(Defines.UnresolvedNamespace);
 
     val modifiers = (modifiersForNode(constructorDecl) :+ newModifierNode(ModifierTypes.CONSTRUCTOR))

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ExtensionMethodTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ExtensionMethodTests.scala
@@ -19,9 +19,9 @@ class ExtensionMethodTests extends CSharpCode2CpgFixture {
     "have correct properties" in {
       inside(cpg.method.nameExact("DoStuff").l) {
         case doStuff :: Nil =>
-          doStuff.fullName shouldBe "Extensions.DoStuff:void(MyClass)"
-          doStuff.signature shouldBe "void(MyClass)"
-          doStuff.methodReturn.typeFullName shouldBe "void"
+          doStuff.fullName shouldBe "Extensions.DoStuff:System.Void(MyClass)"
+          doStuff.signature shouldBe "System.Void(MyClass)"
+          doStuff.methodReturn.typeFullName shouldBe "System.Void"
           doStuff.modifier.modifierType.toSet shouldBe Set(ModifierTypes.STATIC, ModifierTypes.PUBLIC)
         case xs => fail(s"Expected single DoStuff method, but got $xs")
       }
@@ -54,7 +54,7 @@ class ExtensionMethodTests extends CSharpCode2CpgFixture {
       inside(cpg.call.nameExact("DoStuff").l) {
         case doStuff :: Nil =>
           doStuff.code shouldBe "x.DoStuff()"
-          doStuff.methodFullName shouldBe "Extensions.DoStuff:void(MyClass)"
+          doStuff.methodFullName shouldBe "Extensions.DoStuff:System.Void(MyClass)"
           doStuff.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
         case xs => fail(s"Expected single DoStuff call, but got $xs")
       }
@@ -101,7 +101,7 @@ class ExtensionMethodTests extends CSharpCode2CpgFixture {
       inside(cpg.call.nameExact("DoStuff").l) {
         case doStuff :: Nil =>
           doStuff.code shouldBe "x.DoStuff(0)"
-          doStuff.methodFullName shouldBe "Version1.Extension1.DoStuff:void(MyClass,System.Int32)"
+          doStuff.methodFullName shouldBe "Version1.Extension1.DoStuff:System.Void(MyClass,System.Int32)"
         case xs => fail(s"Expected single DoStuff call, but got $xs")
       }
     }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/InheritanceFullNameTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/InheritanceFullNameTests.scala
@@ -62,13 +62,13 @@ class InheritanceFullNameTests extends CSharpCode2CpgFixture {
 
         inside(qux.astChildren.isMethod.l) {
           case bazz :: Nil =>
-            bazz.fullName shouldBe "HelloWorld.Qux.bazz:void()"
+            bazz.fullName shouldBe "HelloWorld.Qux.bazz:System.Void()"
             qux.fullName shouldBe "HelloWorld.Qux"
             qux.inheritsFromTypeFullName shouldBe Seq("HelloWorld.Foo")
 
             inside(qux.astChildren.isMethod.l) {
               case bazz :: Nil =>
-                bazz.fullName shouldBe "HelloWorld.Qux.bazz:void()"
+                bazz.fullName shouldBe "HelloWorld.Qux.bazz:System.Void()"
               case _ => fail("There is no method named `baz` under `Qux` interface,")
             }
           case _ => fail("There is no interface named `Qux`")

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
@@ -19,7 +19,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
       inside(cpg.method("Main").astChildren.collectAll[Method].l) {
         case anon :: Nil =>
           anon.name shouldBe "<lambda>0"
-          anon.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
 
           inside(anon.parameter.l) {
             case x :: Nil =>
@@ -37,7 +37,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
       inside(cpg.method("Main").astChildren.collectAll[TypeDecl].l) {
         case anon :: Nil =>
           anon.name shouldBe "<lambda>0"
-          anon.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
         case xs => fail(s"Expected a single anonymous type declaration, got [${xs.code.mkString(",")}]")
       }
     }
@@ -48,7 +48,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
           numbers.name shouldBe "numbers"
           numbers.typeFullName shouldBe s"${DotNetTypeMap(BuiltinTypes.Int)}[]"
 
-          closure.methodFullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+          closure.methodFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
           closure.referencedMethod.name shouldBe "<lambda>0"
         case xs => fail(s"Expected two `Select` call argument, got [${xs.code.mkString(",")}]")
       }
@@ -69,7 +69,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
       inside(cpg.method("Main").astChildren.collectAll[Method].l) {
         case anon :: Nil =>
           anon.name shouldBe "<lambda>0"
-          anon.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
 
           inside(anon.parameter.l) {
             case x :: y :: Nil =>
@@ -91,7 +91,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
       inside(cpg.method("Main").astChildren.collectAll[TypeDecl].l) {
         case anon :: Nil =>
           anon.name shouldBe "<lambda>0"
-          anon.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
         case xs => fail(s"Expected a single anonymous type declaration, got [${xs.code.mkString(",")}]")
       }
     }
@@ -102,7 +102,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
           numbers.name shouldBe "numbers"
           numbers.typeFullName shouldBe s"${DotNetTypeMap(BuiltinTypes.Int)}[]"
 
-          closure.methodFullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<lambda>0"
+          closure.methodFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
           closure.referencedMethod.name shouldBe "<lambda>0"
         case xs => fail(s"Expected two `Select` call argument, got [${xs.code.mkString(",")}]")
       }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MemberTests.scala
@@ -61,20 +61,20 @@ class MemberTests extends CSharpCode2CpgFixture {
     "have a static constructor" in {
       inside(cpg.typeDecl.nameExact("Car").method.nameExact(Defines.StaticInitMethodName).l) {
         case cctor :: Nil =>
-          cctor.fullName shouldBe s"Car.${Defines.StaticInitMethodName}:void()"
+          cctor.fullName shouldBe s"Car.${Defines.StaticInitMethodName}:System.Void()"
           cctor.modifier.modifierType.toSet shouldBe Set(
             ModifierTypes.STATIC,
             ModifierTypes.CONSTRUCTOR,
             ModifierTypes.INTERNAL
           )
-          cctor.methodReturn.typeFullName shouldBe "void"
+          cctor.methodReturn.typeFullName shouldBe "System.Void"
         case xs =>
           fail(s"Expected single static constructor, but got $xs")
       }
     }
 
     "have the static member initialization inside the static constructor" in {
-      inside(cpg.method.fullNameExact(s"Car.${Defines.StaticInitMethodName}:void()").body.assignment.l) {
+      inside(cpg.method.fullNameExact(s"Car.${Defines.StaticInitMethodName}:System.Void()").body.assignment.l) {
         case assignment :: Nil =>
           assignment.target.code shouldBe "nonInitMaxSpeed"
           assignment.source.code shouldBe "200"
@@ -106,16 +106,16 @@ class MemberTests extends CSharpCode2CpgFixture {
     "have a constructor" in {
       inside(cpg.typeDecl.nameExact("Car").method.nameExact(Defines.ConstructorMethodName).l) {
         case ctor :: Nil =>
-          ctor.fullName shouldBe s"Car.${Defines.ConstructorMethodName}:void()"
+          ctor.fullName shouldBe s"Car.${Defines.ConstructorMethodName}:System.Void()"
           ctor.modifier.modifierType.toSet shouldBe Set(ModifierTypes.INTERNAL, ModifierTypes.CONSTRUCTOR)
-          ctor.methodReturn.typeFullName shouldBe "void"
+          ctor.methodReturn.typeFullName shouldBe "System.Void"
         case xs =>
           fail(s"Expected single constructor, but got $xs")
       }
     }
 
     "have the member initialization inside the constructor" in {
-      inside(cpg.method.fullNameExact(s"Car.${Defines.ConstructorMethodName}:void()").body.assignment.l) {
+      inside(cpg.method.fullNameExact(s"Car.${Defines.ConstructorMethodName}:System.Void()").body.assignment.l) {
         case assignment :: Nil =>
           assignment.target.code shouldBe "color"
           assignment.source.code shouldBe "\"red\""
@@ -136,9 +136,9 @@ class MemberTests extends CSharpCode2CpgFixture {
     "have a static constructor correctly set" in {
       inside(cpg.typeDecl.nameExact("Car").method.nameExact(Defines.StaticInitMethodName).l) {
         case cctor :: Nil =>
-          cctor.fullName shouldBe s"Car.${Defines.StaticInitMethodName}:void()"
+          cctor.fullName shouldBe s"Car.${Defines.StaticInitMethodName}:System.Void()"
           cctor.modifier.modifierType.toSet shouldBe Set(ModifierTypes.STATIC, ModifierTypes.CONSTRUCTOR)
-          cctor.methodReturn.typeFullName shouldBe "void"
+          cctor.methodReturn.typeFullName shouldBe "System.Void"
         case xs =>
           fail(s"Expected single static constructor, but got $xs")
       }
@@ -206,16 +206,16 @@ class MemberTests extends CSharpCode2CpgFixture {
     "have a constructor" in {
       inside(cpg.typeDecl.nameExact("Car").method.nameExact(Defines.ConstructorMethodName).l) {
         case ctor :: Nil =>
-          ctor.fullName shouldBe s"Car.${Defines.ConstructorMethodName}:void()"
+          ctor.fullName shouldBe s"Car.${Defines.ConstructorMethodName}:System.Void()"
           ctor.modifier.modifierType.toSet shouldBe Set(ModifierTypes.CONSTRUCTOR)
-          ctor.methodReturn.typeFullName shouldBe "void"
+          ctor.methodReturn.typeFullName shouldBe "System.Void"
         case xs =>
           fail(s"Expected single constructor, but got $xs")
       }
     }
 
     "have the member initialization inside the constructor" in {
-      inside(cpg.method.fullNameExact(s"Car.${Defines.ConstructorMethodName}:void()").body.assignment.l) {
+      inside(cpg.method.fullNameExact(s"Car.${Defines.ConstructorMethodName}:System.Void()").body.assignment.l) {
         case assignment :: Nil =>
           // TODO: test LHS: shouldn't it resemble `this.color`?
           assignment.target.code shouldBe "color"
@@ -252,9 +252,9 @@ class MemberTests extends CSharpCode2CpgFixture {
     "generate one constructor" in {
       inside(cpg.typeDecl.nameExact("Car").method.nameExact(Defines.ConstructorMethodName).l) {
         case m :: Nil =>
-          m.fullName shouldBe s"Car.${Defines.ConstructorMethodName}:void()"
+          m.fullName shouldBe s"Car.${Defines.ConstructorMethodName}:System.Void()"
           m.modifier.modifierType.l shouldBe ModifierTypes.PUBLIC :: ModifierTypes.CONSTRUCTOR :: Nil
-          m.methodReturn.typeFullName shouldBe "void"
+          m.methodReturn.typeFullName shouldBe "System.Void"
 
           inside(m.assignment.l) {
             case color :: initMaxSpeed :: Nil =>
@@ -293,9 +293,9 @@ class MemberTests extends CSharpCode2CpgFixture {
     "generate one constructor with necessary parameters" in {
       inside(cpg.typeDecl.nameExact("Car").method.nameExact(Defines.ConstructorMethodName).l) {
         case m :: Nil =>
-          m.fullName shouldBe s"Car.${Defines.ConstructorMethodName}:void(System.Int32)"
+          m.fullName shouldBe s"Car.${Defines.ConstructorMethodName}:System.Void(System.Int32)"
           m.modifier.modifierType.l shouldBe ModifierTypes.PUBLIC :: ModifierTypes.CONSTRUCTOR :: Nil
-          m.methodReturn.typeFullName shouldBe "void"
+          m.methodReturn.typeFullName shouldBe "System.Void"
 
           inside(m.assignment.l) {
             case color :: initMaxSpeed :: Nil =>

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MethodTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MethodTests.scala
@@ -11,9 +11,9 @@ class MethodTests extends CSharpCode2CpgFixture {
 
     "generate a method node with type decl parent" in {
       val x = cpg.method.nameExact("Main").head
-      x.fullName should startWith("HelloWorld.Program.Main:void")
-      x.fullName shouldBe "HelloWorld.Program.Main:void(System.String[])"
-      x.signature shouldBe "void(System.String[])"
+      x.fullName should startWith("HelloWorld.Program.Main:System.Void")
+      x.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[])"
+      x.signature shouldBe "System.Void(System.String[])"
       x.filename shouldBe "Program.cs"
       x.code shouldBe "static void Main(string[] args)"
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TopLevelStatementTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TopLevelStatementTests.scala
@@ -67,8 +67,8 @@ class TopLevelStatementTests extends CSharpCode2CpgFixture {
         |""".stripMargin)
     inside(cpg.method.nameExact("Run").l) {
       case run :: Nil =>
-        run.methodReturn.typeFullName shouldBe "void"
-        run.fullName shouldBe "Test0_cs_Program.<Main>$.Run:void()"
+        run.methodReturn.typeFullName shouldBe "System.Void"
+        run.fullName shouldBe "Test0_cs_Program.<Main>$.Run:System.Void()"
         run.modifier.modifierType.toSet shouldBe Set(ModifierTypes.STATIC, ModifierTypes.INTERNAL)
         run.parentBlock.method.l shouldBe cpg.method.fullNameExact("Test0_cs_Program.<Main>$").l
       case xs =>

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
@@ -288,16 +288,16 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
     "create a TypeDecl node" in {
       inside(cpg.method("Main").astChildren.isTypeDecl.l) {
         case anonType :: Nil =>
-          anonType.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<anon>0"
+          anonType.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>0"
           anonType.astParentType shouldBe "METHOD"
-          anonType.astParentFullName shouldBe "HelloWorld.Program.Main:void(System.String[])"
+          anonType.astParentFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[])"
         case _ => fail("No TypeDecl node for anonymous object found")
       }
     }
 
     "propagate type to the LHS" in {
       inside(cpg.method("Main").astChildren.isBlock.astChildren.isLocal.nameExact("Foo").l) { case loc :: Nil =>
-        loc.typeFullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<anon>0"
+        loc.typeFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>0"
       }
     }
 
@@ -338,16 +338,16 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
     "create a TypeDecl node" in {
       inside(cpg.method("Main").astChildren.isTypeDecl.l) {
         case anonType :: Nil =>
-          anonType.fullName shouldBe "Foo.Bar.Main:void().<anon>0"
+          anonType.fullName shouldBe "Foo.Bar.Main:System.Void().<anon>0"
           anonType.astParentType shouldBe "METHOD"
-          anonType.astParentFullName shouldBe "Foo.Bar.Main:void()"
+          anonType.astParentFullName shouldBe "Foo.Bar.Main:System.Void()"
         case _ => fail("No TypeDecl node for anonymous object found")
       }
     }
 
     "propagate type to the LHS" in {
       inside(cpg.method("Main").astChildren.isBlock.astChildren.isLocal.nameExact("Fred").l) { case loc :: Nil =>
-        loc.typeFullName shouldBe "Foo.Bar.Main:void().<anon>0"
+        loc.typeFullName shouldBe "Foo.Bar.Main:System.Void().<anon>0"
       }
     }
 
@@ -380,13 +380,13 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
     "have correct attributes" in {
       inside(cpg.method("Main").astChildren.isTypeDecl.l) {
         case anonType :: anonType2 :: Nil =>
-          anonType.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<anon>0"
+          anonType.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>0"
           anonType.astParentType shouldBe "METHOD"
-          anonType.astParentFullName shouldBe "HelloWorld.Program.Main:void(System.String[])"
+          anonType.astParentFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[])"
 
-          anonType2.fullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<anon>1"
+          anonType2.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>1"
           anonType2.astParentType shouldBe "METHOD"
-          anonType2.astParentFullName shouldBe "HelloWorld.Program.Main:void(System.String[])"
+          anonType2.astParentFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[])"
         case _ => fail("There should be exactly 2 anonymous types present")
       }
     }
@@ -394,8 +394,8 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
     "propagate type to the LHS" in {
       inside(cpg.method("Main").astChildren.isBlock.astChildren.isLocal.l) {
         case loc :: loc2 :: Nil =>
-          loc.typeFullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<anon>0"
-          loc2.typeFullName shouldBe "HelloWorld.Program.Main:void(System.String[]).<anon>1"
+          loc.typeFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>0"
+          loc2.typeFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>1"
         case _ => fail("Exactly two locals should be present")
       }
     }


### PR DESCRIPTION
When reading from the output from DotNetAstGen, `void` is always denoted as `System.Void`. However, when building the AST we often use `void` instead. The same kind of situation happens with e.g. `int` vs `System.Int32`, but in this case we always use the latter. So, for consistency, this changes it so that `System.Void` is used throughout. 