### PR TITLE
[sarif] GH Scanning: Fingerprints & Array/Position Validation

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/v2_1_0/JoernScanResultToSarifConverter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/v2_1_0/JoernScanResultToSarifConverter.scala
@@ -35,11 +35,12 @@ class JoernScanResultToSarifConverter extends ScanResultToSarifConverter {
   }
 
   protected def evidenceToCodeFlow(finding: Finding): Schema.CodeFlow = {
-    Schema.CodeFlow(threadFlows =
-      Schema.ThreadFlow(
-        finding.evidence.map(node => Schema.ThreadFlowLocation(location = nodeToLocation(node))).l
-      ) :: Nil
-    )
+    val locations = finding.evidence.map(node => Schema.ThreadFlowLocation(location = nodeToLocation(node))).l
+    if (locations.isEmpty) {
+      Schema.CodeFlow(threadFlows = Nil)
+    } else {
+      Schema.CodeFlow(threadFlows = Schema.ThreadFlow(locations) :: Nil)
+    }
   }
 
   protected def createMessage(text: String): Schema.Message = {
@@ -88,7 +89,7 @@ class JoernScanResultToSarifConverter extends ScanResultToSarifConverter {
           startColumn = n.columnNumber,
           snippet = Option(Schema.ArtifactContent(n.code))
         )
-      case _ => null
+      case _ => Schema.Region(None, None, None)
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/v2_1_0/Schema.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/v2_1_0/Schema.scala
@@ -52,7 +52,8 @@ object Schema {
     level: String,
     locations: List[Location],
     relatedLocations: List[Location],
-    codeFlows: List[CodeFlow]
+    codeFlows: List[CodeFlow],
+    partialFingerprints: Map[String, String] = Map.empty
   ) extends SarifSchema.Result
 
   final case class Run(tool: Tool, results: List[SarifSchema.Result], originalUriBaseIds: Map[String, ArtifactLocation])

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SarifTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SarifTests.scala
@@ -93,11 +93,6 @@ class SarifTests extends AnyWordSpec with Matchers {
           |      },
           |      "results":[
           |        {
-          |          "ruleId":"f1",
-          |          "message":{
-          |            "text":"Rule 1"
-          |          },
-          |          "level":"error",
           |          "locations":[
           |            {
           |              "physicalLocation":{
@@ -130,6 +125,9 @@ class SarifTests extends AnyWordSpec with Matchers {
           |              }
           |            }
           |          ],
+          |          "message":{
+          |            "text":"Rule 1"
+          |          },
           |          "codeFlows":[
           |            {
           |              "threadFlows":[
@@ -155,7 +153,9 @@ class SarifTests extends AnyWordSpec with Matchers {
           |                }
           |              ]
           |            }
-          |          ]
+          |          ],
+          |          "ruleId":"f1",
+          |          "level":"error"
           |        }
           |      ],
           |      "originalUriBaseIds":{
@@ -166,6 +166,7 @@ class SarifTests extends AnyWordSpec with Matchers {
           |    }
           |  ]
           |}
+          |
           |""".stripMargin.trim
     }
 
@@ -237,11 +238,6 @@ class SarifTests extends AnyWordSpec with Matchers {
           |      },
           |      "results":[
           |        {
-          |          "ruleId":"f1",
-          |          "message":{
-          |            "text":"<empty>"
-          |          },
-          |          "level":"warning",
           |          "locations":[
           |            {
           |              "physicalLocation":{
@@ -272,6 +268,9 @@ class SarifTests extends AnyWordSpec with Matchers {
           |              }
           |            }
           |          ],
+          |          "message":{
+          |            "text":"<empty>"
+          |          },
           |          "codeFlows":[
           |            {
           |              "threadFlows":[
@@ -296,7 +295,9 @@ class SarifTests extends AnyWordSpec with Matchers {
           |                }
           |              ]
           |            }
-          |          ]
+          |          ],
+          |          "ruleId":"f1",
+          |          "level":"warning"
           |        }
           |      ],
           |      "originalUriBaseIds":{


### PR DESCRIPTION
GitHub code scanning has strict requirements on SARIF files that need to be enforced, such as minimum elements in an array, line number > 0, etc. Some validators emit warnings on this, but GH fails the pipeline.

Additionally, GitHub makes use of fingerprinting to avoid duplication between versions.

The SARIF conversion has been adapted to accommodate the above.