### PR TITLE
[javasrc2cpg] Populate generic signatures roughly following the class file signature format

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -10,7 +10,8 @@ libraryDependencies ++= Seq(
   "org.projectlombok"       % "lombok"                        % Versions.lombok,
   "org.scala-lang.modules" %% "scala-parallel-collections"    % Versions.scalaParallel,
   "org.scala-lang.modules" %% "scala-parser-combinators"      % Versions.scalaParserCombinators,
-  "net.lingala.zip4j"       % "zip4j"                         % Versions.zip4j
+  "net.lingala.zip4j"       % "zip4j"                         % Versions.zip4j,
+  "org.ow2.asm"             % "asm"                           % Versions.asm,
 )
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -27,7 +27,7 @@ import com.github.javaparser.resolution.declarations.{
 import com.github.javaparser.resolution.types.ResolvedType
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
-import io.joern.javasrc2cpg.astcreation.declarations.AstForDeclarationsCreator
+import io.joern.javasrc2cpg.astcreation.declarations.{AstForDeclarationsCreator, BinarySignatureCalculator}
 import io.joern.javasrc2cpg.astcreation.expressions.AstForExpressionsCreator
 import io.joern.javasrc2cpg.astcreation.statements.AstForStatementsCreator
 import io.joern.javasrc2cpg.scope.Scope
@@ -107,6 +107,7 @@ class AstCreator(
   private[astcreation] val typeInfoCalc: TypeInfoCalculator =
     TypeInfoCalculator(global, symbolSolver, keepTypeArguments)
   private[astcreation] val bindingTableCache = mutable.HashMap.empty[String, BindingTable]
+  private[astcreation] val binarySignatureCalculator: BinarySignatureCalculator = new BinarySignatureCalculator(scope)
 
   private[astcreation] val tempNameProvider: TemporaryNameProvider = new TemporaryNameProvider
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/BinarySignatureCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/BinarySignatureCalculator.scala
@@ -6,34 +6,149 @@ import com.github.javaparser.ast.`type`.{
   PrimitiveType,
   Type,
   TypeParameter,
+  UnknownType,
+  VarType,
   VoidType,
   WildcardType
 }
 import com.github.javaparser.ast.body.{
   AnnotationDeclaration,
+  CallableDeclaration,
   ClassOrInterfaceDeclaration,
+  CompactConstructorDeclaration,
+  ConstructorDeclaration,
+  EnumConstantDeclaration,
   EnumDeclaration,
   MethodDeclaration,
+  Parameter,
   RecordDeclaration,
+  TypeDeclaration,
   VariableDeclarator
 }
+import com.github.javaparser.ast.expr.{LambdaExpr, ObjectCreationExpr, PatternExpr, TypePatternExpr}
+import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption
+import com.github.javaparser.printer.configuration.{DefaultConfigurationOption, DefaultPrinterConfiguration}
+import io.joern.javasrc2cpg.astcreation.AstCreator
 import io.joern.javasrc2cpg.astcreation.declarations.BinarySignatureCalculator.{
+  BaseTypeMap,
   javaEnumName,
   javaObjectName,
-  javaRecordName
+  javaRecordName,
+  unspecifiedType
 }
+import io.joern.javasrc2cpg.scope.Scope
+import io.joern.javasrc2cpg.scope.Scope.ScopeTypeParam
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
+import io.joern.javasrc2cpg.util.Util
 import org.objectweb.asm.signature.SignatureWriter
+import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 
 object BinarySignatureCalculator {
-  private val javaObjectName = "java/lang/Object"
-  private val javaEnumName   = "java/lang/Enum"
-  private val javaRecordName = "java/lang/Record"
+  private val javaObjectName  = "Object"
+  private val javaEnumName    = "Enum"
+  private val javaRecordName  = "Record"
+  private val unspecifiedType = "__unspecified_type"
+
+  // From https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-4.html#jvms-4.3
+  val BaseTypeMap: Map[String, Char] = Seq(
+    TypeConstants.Byte    -> 'B',
+    TypeConstants.Char    -> 'C',
+    TypeConstants.Double  -> 'D',
+    TypeConstants.Float   -> 'F',
+    TypeConstants.Int     -> 'I',
+    TypeConstants.Long    -> 'J',
+    TypeConstants.Short   -> 'S',
+    TypeConstants.Boolean -> 'Z',
+    TypeConstants.Void    -> 'V'
+  ).toMap
 }
 
-class BinarySignatureCalculator {
+class BinarySignatureCalculator(scope: Scope) {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  private val typePrinterOptions = new DefaultPrinterConfiguration()
+    .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_COMMENTS))
+    .removeOption(new DefaultConfigurationOption(ConfigOption.PRINT_JAVADOC))
+
+  private def typeToString(typ: Type): String = {
+    Util.stripGenericTypes(typ.toString(typePrinterOptions))
+  }
+
+  val unspecifiedClassType: String = {
+    val writer = SignatureWriter()
+
+    writer.visitClassType(unspecifiedType)
+    writer.visitEnd()
+
+    writer.toString
+  }
+
+  def defaultConstructorSignature(parameters: List[Parameter]): String = {
+    val writer = SignatureWriter()
+
+    parameters.foreach { param =>
+      writer.visitParameterType()
+      addType(writer, param.getType)
+    }
+
+    writer.visitReturnType()
+    addType(writer, new VoidType())
+
+    writer.toString
+  }
+
+  def recordParameterAccessorBinarySignature(parameter: Parameter): String = {
+    val writer = SignatureWriter()
+
+    writer.visitReturnType()
+    addType(writer, parameter.getType)
+
+    writer.toString
+  }
+
+  def enumEntryBinarySignature(enumEntry: EnumConstantDeclaration): String = {
+    val writer = SignatureWriter()
+
+    enumEntry.getParentNode.toScala collect { case enumDeclaration: EnumDeclaration =>
+      writer.visitClassType(enumDeclaration.getNameAsString)
+      writer.visitEnd()
+    }
+
+    writer.toString
+  }
+
+  def variableBinarySignature(typ: String): String = {
+    val writer = SignatureWriter()
+
+    BaseTypeMap.get(typ) match {
+      case Some(baseType) =>
+        writer.visitBaseType(baseType)
+
+      case None =>
+        writer.visitClassType(typ)
+        writer.visitEnd()
+    }
+
+    writer.toString
+  }
+
+  def typeDeclBinarySignature(typeDeclaration: TypeDeclaration[?]): String = {
+    typeDeclaration match {
+      case decl: AnnotationDeclaration       => annotationDecBinarySignature(decl)
+      case decl: RecordDeclaration           => recordDeclBinarySignature(decl)
+      case decl: ClassOrInterfaceDeclaration => classDeclBinarySignature(decl)
+      case decl: EnumDeclaration             => enumDeclBinarySignature(decl)
+      case decl =>
+        throw new IllegalArgumentException(
+          s"Attempting to get binary signature for unhandled type declaration $typeDeclaration"
+        )
+    }
+  }
 
   def annotationDecBinarySignature(annotationDecl: AnnotationDeclaration): String = {
     val writer = SignatureWriter()
@@ -54,11 +169,21 @@ class BinarySignatureCalculator {
     writer.visitEnd()
 
     enumDecl.getImplementedTypes.asScala.foreach(addType(writer, _))
+    writer.visitEnd()
 
     writer.toString
   }
 
-  def classDeclBinarySignature(classDecl: ClassOrInterfaceDeclaration): String = {
+  def patternVariableBinarySignature(typePatternExpr: TypePatternExpr): String = {
+    val writer = SignatureWriter()
+    addType(writer, typePatternExpr.getType)
+    writer.toString
+  }
+
+  def classDeclBinarySignature(
+    classDecl: ClassOrInterfaceDeclaration,
+    classNameOverride: Option[String] = None
+  ): String = {
     val writer = SignatureWriter()
     classDecl.getTypeParameters.asScala.foreach(addTypeParam(writer, _))
 
@@ -93,19 +218,29 @@ class BinarySignatureCalculator {
     writer.toString
   }
 
-  def methodBinarySignature(methodDecl: MethodDeclaration): String = {
+  def variableBinarySignature(variableType: Type): String = {
     val writer = SignatureWriter()
-    methodDecl.getTypeParameters.asScala.foreach(addTypeParam(writer, _))
+    addType(writer, variableType)
+    writer.toString
+  }
 
-    methodDecl.getParameters.asScala.foreach { param =>
+  def methodBinarySignature(callableDecl: CallableDeclaration[?]): String = {
+    val writer = SignatureWriter()
+    callableDecl.getTypeParameters.asScala.foreach(addTypeParam(writer, _))
+
+    callableDecl.getParameters.asScala.foreach { param =>
       writer.visitParameterType()
       addType(writer, param.getType)
     }
 
     writer.visitReturnType()
-    addType(writer, methodDecl.getType)
+    callableDecl match {
+      case methodDeclaration: MethodDeclaration => addType(writer, methodDeclaration.getType)
+      case constructorDeclaration: ConstructorDeclaration =>
+        BaseTypeMap.get(TypeConstants.Void).foreach(writer.visitBaseType(_))
+    }
 
-    methodDecl.getThrownExceptions.asScala.foreach { exception =>
+    callableDecl.getThrownExceptions.asScala.foreach { exception =>
       writer.visitExceptionType()
       addType(writer, exception)
     }
@@ -113,9 +248,18 @@ class BinarySignatureCalculator {
     writer.toString
   }
 
-  def fieldBinarySignature(variableDeclarator: VariableDeclarator): String = {
+  def lambdaMethodBinarySignature(expr: LambdaExpr): String = {
     val writer = SignatureWriter()
-    addType(writer, variableDeclarator.getType)
+
+    expr.getParameters.asScala.foreach { param =>
+      writer.visitParameterType()
+      addType(writer, param.getType)
+    }
+
+    writer.visitReturnType()
+    writer.visitClassType(unspecifiedType)
+    writer.visitEnd()
+
     writer.toString
   }
 
@@ -135,10 +279,21 @@ class BinarySignatureCalculator {
     }
   }
 
+  private def isTypeVariable(name: String): Boolean = {
+    scope.lookupScopeType(name, includeWildcards = false).exists(_.isInstanceOf[ScopeTypeParam])
+  }
+
   private def addType(writer: SignatureWriter, typ: Type): Unit = {
+    val name = typeToString(typ)
     typ match {
+      case _ if isTypeVariable(name) =>
+        writer.visitTypeVariable(typeToString(typ))
       case classOrInterface: ClassOrInterfaceType =>
-        writer.visitClassType(classOrInterface.getNameAsString)
+        val internalClassName = scope
+          .lookupScopeType(name, includeWildcards = false)
+          .map(_.name)
+          .getOrElse(name)
+        writer.visitClassType(internalClassName)
         val typeArgs = classOrInterface.getTypeArguments.toScala.map(_.asScala).getOrElse(Nil)
         typeArgs.foreach {
           case wildcardType: WildcardType =>
@@ -148,9 +303,7 @@ class BinarySignatureCalculator {
             } else if (wildcardType.getSuperType.isPresent) {
               writer.visitTypeArgument('-')
               addType(writer, wildcardType.getSuperType.get())
-            } else {
-              writer.visitTypeArgument('*')
-            }
+            } else writer.visitTypeArgument('*')
           case typeArg =>
             writer.visitTypeArgument('=')
             addType(writer, typeArg)
@@ -163,8 +316,14 @@ class BinarySignatureCalculator {
         writer.visitTypeVariable(typeParam.getNameAsString)
       case primitiveType: PrimitiveType =>
         writer.visitBaseType(primitiveType.getType.toDescriptor.charAt(0))
+      case varType: VarType =>
+        writer.visitClassType(unspecifiedType)
+        writer.visitEnd()
       case _: VoidType =>
         writer.visitBaseType('V')
+      case _: UnknownType =>
+        writer.visitClassType(unspecifiedType)
+        writer.visitEnd()
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/BinarySignatureCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/BinarySignatureCalculator.scala
@@ -15,20 +15,17 @@ import com.github.javaparser.ast.body.{
   AnnotationDeclaration,
   CallableDeclaration,
   ClassOrInterfaceDeclaration,
-  CompactConstructorDeclaration,
   ConstructorDeclaration,
   EnumConstantDeclaration,
   EnumDeclaration,
   MethodDeclaration,
   Parameter,
   RecordDeclaration,
-  TypeDeclaration,
-  VariableDeclarator
+  TypeDeclaration
 }
-import com.github.javaparser.ast.expr.{LambdaExpr, ObjectCreationExpr, PatternExpr, TypePatternExpr}
+import com.github.javaparser.ast.expr.{LambdaExpr, TypePatternExpr}
 import com.github.javaparser.printer.configuration.DefaultPrinterConfiguration.ConfigOption
 import com.github.javaparser.printer.configuration.{DefaultConfigurationOption, DefaultPrinterConfiguration}
-import io.joern.javasrc2cpg.astcreation.AstCreator
 import io.joern.javasrc2cpg.astcreation.declarations.BinarySignatureCalculator.{
   BaseTypeMap,
   javaEnumName,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/BinarySignatureCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/BinarySignatureCalculator.scala
@@ -1,0 +1,171 @@
+package io.joern.javasrc2cpg.astcreation.declarations
+
+import com.github.javaparser.ast.`type`.{
+  ArrayType,
+  ClassOrInterfaceType,
+  PrimitiveType,
+  Type,
+  TypeParameter,
+  VoidType,
+  WildcardType
+}
+import com.github.javaparser.ast.body.{
+  AnnotationDeclaration,
+  ClassOrInterfaceDeclaration,
+  EnumDeclaration,
+  MethodDeclaration,
+  RecordDeclaration,
+  VariableDeclarator
+}
+import io.joern.javasrc2cpg.astcreation.declarations.BinarySignatureCalculator.{
+  javaEnumName,
+  javaObjectName,
+  javaRecordName
+}
+import org.objectweb.asm.signature.SignatureWriter
+
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.RichOptional
+
+object BinarySignatureCalculator {
+  private val javaObjectName = "java/lang/Object"
+  private val javaEnumName   = "java/lang/Enum"
+  private val javaRecordName = "java/lang/Record"
+}
+
+class BinarySignatureCalculator {
+
+  def annotationDecBinarySignature(annotationDecl: AnnotationDeclaration): String = {
+    val writer = SignatureWriter()
+
+    writer.visitClassType(javaObjectName)
+    writer.visitEnd()
+
+    writer.toString
+  }
+
+  def enumDeclBinarySignature(enumDecl: EnumDeclaration): String = {
+    val writer = SignatureWriter()
+
+    writer.visitSuperclass()
+    writer.visitClassType(javaEnumName)
+    writer.visitTypeArgument('=')
+    writer.visitClassType(enumDecl.getNameAsString)
+    writer.visitEnd()
+
+    enumDecl.getImplementedTypes.asScala.foreach(addType(writer, _))
+
+    writer.toString
+  }
+
+  def classDeclBinarySignature(classDecl: ClassOrInterfaceDeclaration): String = {
+    val writer = SignatureWriter()
+    classDecl.getTypeParameters.asScala.foreach(addTypeParam(writer, _))
+
+    writer.visitSuperclass()
+    if (classDecl.isInterface) {
+      writer.visitClassType(javaObjectName)
+      writer.visitEnd()
+      classDecl.getExtendedTypes.asScala.foreach(addType(writer, _))
+    } else {
+      if (classDecl.getExtendedTypes.isEmpty) {
+        writer.visitClassType(javaObjectName)
+        writer.visitEnd()
+      } else {
+        classDecl.getExtendedTypes.asScala.foreach(addType(writer, _))
+      }
+      classDecl.getImplementedTypes.asScala.foreach(addType(writer, _))
+    }
+
+    writer.toString
+  }
+
+  def recordDeclBinarySignature(recordDecl: RecordDeclaration): String = {
+    val writer = SignatureWriter()
+    recordDecl.getTypeParameters.asScala.foreach(addTypeParam(writer, _))
+
+    writer.visitSuperclass()
+    writer.visitClassType(javaRecordName)
+    writer.visitEnd()
+
+    recordDecl.getImplementedTypes.asScala.foreach(addType(writer, _))
+
+    writer.toString
+  }
+
+  def methodBinarySignature(methodDecl: MethodDeclaration): String = {
+    val writer = SignatureWriter()
+    methodDecl.getTypeParameters.asScala.foreach(addTypeParam(writer, _))
+
+    methodDecl.getParameters.asScala.foreach { param =>
+      writer.visitParameterType()
+      addType(writer, param.getType)
+    }
+
+    writer.visitReturnType()
+    addType(writer, methodDecl.getType)
+
+    methodDecl.getThrownExceptions.asScala.foreach { exception =>
+      writer.visitExceptionType()
+      addType(writer, exception)
+    }
+
+    writer.toString
+  }
+
+  def fieldBinarySignature(variableDeclarator: VariableDeclarator): String = {
+    val writer = SignatureWriter()
+    addType(writer, variableDeclarator.getType)
+    writer.toString
+  }
+
+  private def addTypeParam(writer: SignatureWriter, typeParam: TypeParameter): Unit = {
+    writer.visitFormalTypeParameter(typeParam.getNameAsString())
+    writer.visitClassBound()
+    val typeBoundIt = typeParam.getTypeBound.asScala.iterator
+    if (typeBoundIt.isEmpty) {
+      writer.visitClassType(javaObjectName)
+      writer.visitEnd()
+    } else {
+      addType(writer, typeBoundIt.next)
+    }
+    typeBoundIt.foreach { typeBound =>
+      writer.visitInterfaceBound()
+      addType(writer, typeBound)
+    }
+  }
+
+  private def addType(writer: SignatureWriter, typ: Type): Unit = {
+    typ match {
+      case classOrInterface: ClassOrInterfaceType =>
+        writer.visitClassType(classOrInterface.getNameAsString)
+        val typeArgs = classOrInterface.getTypeArguments.toScala.map(_.asScala).getOrElse(Nil)
+        typeArgs.foreach {
+          case wildcardType: WildcardType =>
+            if (wildcardType.getExtendedType.isPresent) {
+              writer.visitTypeArgument('+')
+              addType(writer, wildcardType.getExtendedType.get())
+            } else if (wildcardType.getSuperType.isPresent) {
+              writer.visitTypeArgument('-')
+              addType(writer, wildcardType.getSuperType.get())
+            } else {
+              writer.visitTypeArgument('*')
+            }
+          case typeArg =>
+            writer.visitTypeArgument('=')
+            addType(writer, typeArg)
+        }
+        writer.visitEnd()
+      case arrayType: ArrayType =>
+        writer.visitArrayType()
+        addType(writer, arrayType.getElementType)
+      case typeParam: TypeParameter =>
+        writer.visitTypeVariable(typeParam.getNameAsString)
+      case primitiveType: PrimitiveType =>
+        writer.visitBaseType(primitiveType.getType.toDescriptor.charAt(0))
+      case _: VoidType =>
+        writer.visitBaseType('V')
+    }
+  }
+
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -113,7 +113,7 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     val thisIdentifier =
       identifierNode(call, NameConstants.This, NameConstants.This, typeFullName)
     scope.lookupVariable(NameConstants.This) match {
-      case SimpleVariable(ScopeParameter(thisParam)) => diffGraph.addEdge(thisIdentifier, thisParam, EdgeTypes.REF)
+      case SimpleVariable(ScopeParameter(thisParam, _)) => diffGraph.addEdge(thisIdentifier, thisParam, EdgeTypes.REF)
       case _ => // Do nothing. This shouldn't happen for valid code, but could occur in cases where methods could not be resolved
     }
     val thisAst = Ast(thisIdentifier)
@@ -150,7 +150,9 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
       inlinedAstsForObjectCreationExpr(expr, Ast(assignTarget.copy), expectedType, resetAssignmentTargetType = true)
 
     assignTarget.typeFullName(allocAndInitAst.allocAst.rootType.getOrElse(defaultTypeFallback()))
-    val tmpLocal = localNode(expr, tmpName, tmpName, assignTarget.typeFullName)
+    val genericSignature = binarySignatureCalculator.variableBinarySignature(expr.getType)
+    val tmpLocal =
+      localNode(expr, tmpName, tmpName, assignTarget.typeFullName, genericSignature = Option(genericSignature))
 
     val allocAssignCode = s"$tmpName = ${allocAndInitAst.allocAst.rootCodeOrEmpty}"
     val allocAssignCall =

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -394,10 +394,9 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
         paramNode
       }
 
-    // TODO: Use simple name for the generic signature? We need to rely on JavaParser for any information for now anyways.
     parameterNodes.foreach { paramNode =>
       scope.enclosingMethod.get
-        .addParameter(paramNode, binarySignatureCalculator.variableBinarySignature(paramNode.typeFullName))
+        .addParameter(paramNode, binarySignatureCalculator.unspecifiedClassType)
     }
 
     parameterNodes.map(Ast(_))

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -168,6 +168,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
         .fullName(lambdaMethodNode.fullName)
         .name(lambdaMethodNode.name)
         .inheritsFromTypeFullName(inheritsFromTypeFullName)
+        .genericSignature(binarySignatureCalculator.unspecifiedClassType)
     scope.addLocalDecl(Ast(lambdaTypeDeclNode))
 
     lambdaTypeDeclNode

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
@@ -152,9 +152,15 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
         )
 
       case _ =>
-        val tmpName       = tempNameProvider.next
-        val tmpType       = patternInitAst.rootType.getOrElse(TypeConstants.Object)
-        val tmpLocal      = localNode(rootNode, tmpName, tmpName, tmpType)
+        val tmpName = tempNameProvider.next
+        val tmpType = patternInitAst.rootType.getOrElse(TypeConstants.Object)
+        val tmpLocal = localNode(
+          rootNode,
+          tmpName,
+          tmpName,
+          tmpType,
+          genericSignature = Option(binarySignatureCalculator.unspecifiedClassType)
+        )
         val tmpIdentifier = identifierNode(rootNode, tmpName, tmpName, tmpType)
 
         val tmpAssignmentNode =
@@ -216,8 +222,15 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
             )
             .getOrElse(defaultTypeFallback())
         }
-        val variableTypeCode  = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
-        val patternLocal      = localNode(typePatternExpr, variableName, code(typePatternExpr), variableType)
+        val variableTypeCode = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
+        val genericSignature = binarySignatureCalculator.variableBinarySignature(typePatternExpr.getType)
+        val patternLocal = localNode(
+          typePatternExpr,
+          variableName,
+          code(typePatternExpr),
+          variableType,
+          genericSignature = Option(genericSignature)
+        )
         val patternIdentifier = identifierNode(typePatternExpr, variableName, variableName, variableType)
 
         val initializerAst = castAstIfNecessary(typePatternExpr, variableType, patternNode.getAst)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForVarDeclAndAssignsCreator.scala
@@ -138,8 +138,15 @@ trait AstForVarDeclAndAssignsCreator { this: AstCreator =>
       // Use type name with generics for code
       val localCode = s"${declaratorType.map(_.toString).getOrElse("")} ${variableDeclarator.getNameAsString}"
 
+      val genericSignature = binarySignatureCalculator.variableBinarySignature(variableDeclarator.getType)
       val local =
-        localNode(originNode, variableDeclarator.getNameAsString, localCode, typeFullName)
+        localNode(
+          originNode,
+          variableDeclarator.getNameAsString,
+          localCode,
+          typeFullName,
+          genericSignature = Option(genericSignature)
+        )
 
       scope.enclosingBlock.foreach(_.addLocal(local))
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -231,7 +231,8 @@ trait AstForForLoopsCreator { this: AstCreator =>
         iterableAsts.head
     }
 
-    val iterableName      = nextIterableName()
+    val iterableName = nextIterableName()
+    // TODO: Generic signature
     val iterableLocalNode = localNode(iterableExpression, iterableName, iterableName, iterableType.getOrElse("ANY"))
     val iterableLocalAst  = Ast(iterableLocalNode)
 
@@ -251,14 +252,16 @@ trait AstForForLoopsCreator { this: AstCreator =>
   }
 
   private def nativeForEachIdxLocalNode(lineNo: Option[Int]): NewLocal = {
-    val idxName      = nextIndexName()
-    val typeFullName = TypeConstants.Int
+    val idxName          = nextIndexName()
+    val typeFullName     = TypeConstants.Int
+    val genericSignature = binarySignatureCalculator.variableBinarySignature(TypeConstants.Int)
     val idxLocal =
       NewLocal()
         .name(idxName)
         .typeFullName(typeFullName)
         .code(idxName)
         .lineNumber(lineNo)
+        .genericSignature(genericSignature)
     scope.enclosingBlock.get.addLocal(idxLocal)
     idxLocal
   }
@@ -338,7 +341,10 @@ trait AstForForLoopsCreator { this: AstCreator =>
         Some(variable)
     }
 
+    val genericSignature =
+      maybeVariable.map(variable => binarySignatureCalculator.variableBinarySignature(variable.getType))
     val partialLocalNode = NewLocal().lineNumber(lineNo)
+    genericSignature.foreach(partialLocalNode.genericSignature(_))
 
     maybeVariable match {
       case Some(variable) =>
@@ -361,11 +367,13 @@ trait AstForForLoopsCreator { this: AstCreator =>
 
   private def iteratorLocalForForEach(lineNumber: Option[Int]): NewLocal = {
     val iteratorLocalName = nextIterableName()
+    val genericSignature  = binarySignatureCalculator.variableBinarySignature(TypeConstants.Iterator)
     NewLocal()
       .name(iteratorLocalName)
       .code(iteratorLocalName)
       .typeFullName(TypeConstants.Iterator)
       .lineNumber(lineNumber)
+      .genericSignature(genericSignature)
   }
 
   private def iteratorAssignAstForForEach(

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -231,10 +231,16 @@ trait AstForForLoopsCreator { this: AstCreator =>
         iterableAsts.head
     }
 
-    val iterableName = nextIterableName()
-    // TODO: Generic signature
-    val iterableLocalNode = localNode(iterableExpression, iterableName, iterableName, iterableType.getOrElse("ANY"))
-    val iterableLocalAst  = Ast(iterableLocalNode)
+    val iterableName     = nextIterableName()
+    val genericSignature = binarySignatureCalculator.unspecifiedClassType
+    val iterableLocalNode = localNode(
+      iterableExpression,
+      iterableName,
+      iterableName,
+      iterableType.getOrElse("ANY"),
+      genericSignature = Option(genericSignature)
+    )
+    val iterableLocalAst = Ast(iterableLocalNode)
 
     val iterableAssignNode =
       newOperatorCallNode(Operators.assignment, code = "", line = lineNo, typeFullName = iterableType)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/scope/Scope.scala
@@ -53,7 +53,6 @@ class Scope(implicit val withSchemaValidation: ValidationMode, val disableTypeFa
       case Nil => None
 
       case (head: TypeDeclScope) :: Nil =>
-        // TODO: Generic signature
         Option.unless(isStatic)(head.typeDecl.fullName)
 
       case head :: Nil =>

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericSignatureTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericSignatureTests.scala
@@ -1,0 +1,1000 @@
+package io.joern.javasrc2cpg.querying
+
+import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class GenericSignatureTests extends JavaSrcCode2CpgFixture {
+
+  "a simple example with primitive types" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  char charMember;
+        |
+        |  public void test(boolean b) {
+        |    int x;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature for locals" in {
+      cpg.local.genericSignature.l shouldBe List("I")
+    }
+
+    "have the correct generic signature for a void method with a boolean arg" in {
+      cpg.method.name("test").genericSignature.l shouldBe List("(Z)V")
+    }
+
+    "have the correct generic signature for the parameter" in {
+      cpg.member.name("charMember").genericSignature.l shouldBe List("C")
+    }
+
+    "have the correct generic signature for the type decl implicitly extending java.lang.Object" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LObject;")
+    }
+  }
+
+  "a method with parameters and a non-void return type" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public String test(Test t, Integer i) {
+        |    return null;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.name("test").genericSignature.l shouldBe List("(LTest;LInteger;)LString;")
+    }
+  }
+
+  "a method with an unresolved return type" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public Foo test(Test t) {
+        |    return null;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.name("test").genericSignature.l shouldBe List("(LTest;)LFoo;")
+    }
+  }
+
+  "a method with an unresolved parameter" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public void test(Foo f) {
+        |    return null;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.name("test").genericSignature.l shouldBe List("(LFoo;)V")
+    }
+  }
+
+  "a class extending another class" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {}
+        |""".stripMargin).moreCode("""
+        |package test;
+        |
+        |import foo.Foo;
+        |
+        |class Test extends Foo {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LFoo;")
+    }
+  }
+
+  "a class implementing an interface" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Foo {}
+        |""".stripMargin).moreCode("""
+        |package test;
+        |
+        |import foo.Foo;
+        |
+        |class Test implements Foo {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LObject;LFoo;")
+    }
+  }
+
+  "a class extending another class and implementing an interface" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {}
+        |""".stripMargin)
+      .moreCode("""
+        |package bar;
+        |
+        |interface Bar {}
+        |""".stripMargin)
+      .moreCode("""
+        |package test;
+        |
+        |import foo.Foo;
+        |import bar.Bar;
+        |
+        |class Test extends Foo implements Bar {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LFoo;LBar;")
+    }
+  }
+
+  "a class implementing multiple interfaces" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Foo {}
+        |""".stripMargin)
+      .moreCode("""
+        |package bar;
+        |
+        |interface Bar {}
+        |""".stripMargin)
+      .moreCode("""
+        |package test;
+        |
+        |import foo.Foo;
+        |import bar.Bar;
+        |
+        |class Test implements Foo, Bar {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LObject;LFoo;LBar;")
+    }
+  }
+
+  "an interface not extending another interface" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Foo {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Foo").genericSignature.l shouldBe List("LObject;")
+    }
+  }
+
+  "an interface extending another interface" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Foo {}
+        |""".stripMargin).moreCode("""
+        |package bar;
+        |
+        |import foo.Foo;
+        |
+        |interface Bar extends Foo {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Bar").genericSignature.l shouldBe List("LObject;LFoo;")
+    }
+  }
+
+  "an interface extending multiple interfaces" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |interface Foo {}
+        |""".stripMargin)
+      .moreCode("""
+        |package bar;
+        |
+        |interface Bar {}
+        |""".stripMargin)
+      .moreCode("""
+        |package test;
+        |
+        |import foo.Foo;
+        |import bar.Bar;
+        |
+        |interface Test extends Foo, Bar {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LObject;LFoo;LBar;")
+    }
+  }
+
+  "a class extending an unresolved class" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test extends Foo {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LFoo;")
+    }
+  }
+
+  "a class implementing an unresolved interface" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test implements Foo {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LObject;LFoo;")
+    }
+  }
+
+  "a resolved lambda method" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.function.Consumer;
+        |
+        |class Test {
+        |  public Consumer<String> test() {
+        |    return s -> System.out.println(s);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature for the lambda method" in {
+      cpg.method.name(".*lambda.*").genericSignature.l shouldBe List("(L__unspecified_type;)L__unspecified_type;")
+    }
+
+    "have an empty generic signature for the lambda type decl" in {
+      cpg.typeDecl.name(".*lambda.*").genericSignature.l shouldBe List("<empty>")
+    }
+  }
+
+  "a lambda method with an explicit type annotation" should {
+    val cpg = code("""
+                     |package test;
+                     |
+                     |import java.util.function.Consumer;
+                     |
+                     |class Test {
+                     |  public Consumer<String> test() {
+                     |    return (String s) -> System.out.println(s);
+                     |  }
+                     |}
+                     |""".stripMargin)
+
+    "have the correct generic signature for the lambda method" in {
+      cpg.method.name(".*lambda.*").genericSignature.l shouldBe List("(LString;)L__unspecified_type;")
+    }
+
+    "have an empty generic signature for the lambda type decl" in {
+      cpg.typeDecl.name(".*lambda.*").genericSignature.l shouldBe List("<empty>")
+    }
+  }
+
+  "an unresolved lambda method" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public Consumer<String> test() {
+        |    return s -> System.out.println(s);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature for the lambda method" in {
+      cpg.method.name(".*lambda.*").genericSignature.l shouldBe List("(L__unspecified_type;)L__unspecified_type;")
+    }
+
+    "have an empty generic signature for the lambda type decl" in {
+      cpg.typeDecl.name(".*lambda.*").genericSignature.l shouldBe List("<empty>")
+    }
+  }
+
+  "a nested class" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  class Nested {}
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.nameExact("Test$Nested").genericSignature.l shouldBe List("LObject;")
+    }
+  }
+
+  "a local class" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public void test() {
+        |    class Local {}
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Local").genericSignature.l shouldBe List("LObject;")
+    }
+  }
+
+  "an anonymous class extending a resolved class" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {}
+        |""".stripMargin).moreCode("""
+        |package test;
+        |
+        |import foo.Foo;
+        |
+        |class Test {
+        |  public void test() {
+        |    Foo f = new Foo() {};
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.nameExact("Foo$0").genericSignature.l shouldBe List("LFoo;")
+    }
+  }
+
+  "an anonymous class extending an unresolved class" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public void test() {
+        |    Foo f = new Foo() {};
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.nameExact("Foo$0").genericSignature.l shouldBe List("LFoo;")
+    }
+  }
+
+  "an anonymous class extending an unresolved class which can be resolved from imports" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import foo.Foo;
+        |
+        |class Test {
+        |  public void test() {
+        |    Foo f = new Foo() {};
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.nameExact("Foo$0").genericSignature.l shouldBe List("LFoo;")
+    }
+  }
+
+  "a local with an array type" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public void test() {
+        |    String[] items;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("items").genericSignature.l shouldBe List("[LString;")
+    }
+  }
+
+  "a generic local with a single type argument" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |class Test {
+        |  public void test() {
+        |    List<String> list;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("list").genericSignature.l shouldBe List("LList<LString;>;")
+    }
+  }
+
+  "a generic local with a single wildcard type argument" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |class Test {
+        |  public void test() {
+        |    List<?> list;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("list").genericSignature.l shouldBe List("LList<*>;")
+    }
+  }
+
+  "a generic local with a single wildcard type argument with an upper bound" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |class Test {
+        |  public void test() {
+        |    List<? extends String> list;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("list").genericSignature.l shouldBe List("LList<+LString;>;")
+    }
+  }
+
+  "a generic local with a single wildcard type argument with a lower bound" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |class Test {
+        |  public void test() {
+        |    List<? super String> list;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("list").genericSignature.l shouldBe List("LList<-LString;>;")
+    }
+  }
+
+  "a generic local with multiple type arguments" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.Map;
+        |
+        |class Test {
+        |  public void test() {
+        |    Map<String, Integer> map;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("map").genericSignature.l shouldBe List("LMap<LString;LInteger;>;")
+    }
+  }
+
+  "a generic local with nested type arguments" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |import java.util.Map;
+        |
+        |class Test {
+        |  public void test() {
+        |    Map<String, List<String>> map;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("map").genericSignature.l shouldBe List("LMap<LString;LList<LString;>;>;")
+    }
+  }
+
+  "a generic local with a type variable type from the method signature" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public <T> void test() {
+        |    T t;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("t").genericSignature.l shouldBe List("TT;")
+    }
+  }
+
+  "a generic local with a nested type variable type from the method signature" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |class Test {
+        |  public <S> void test() {
+        |    List<S> list;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("list").genericSignature.l shouldBe List("LList<TS;>;")
+    }
+  }
+
+  "a generic local with a type variable type from the class signature" should {
+    val cpg = code("""
+        |import java.util.List;
+        |
+        |public class Main <T> {
+        |    public void main(String[] args) {
+        |        T t;
+        |    }
+        |}
+        |
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("t").genericSignature.l shouldBe List("TT;")
+    }
+  }
+
+  "a generic local with a type variable type as a bound from the class signature" should {
+    val cpg = code("""
+        |import java.util.List;
+        |
+        |public class Main <T> {
+        |    public void main(String[] args) {
+        |        List<? extends T> t;
+        |    }
+        |}
+        |
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("t").genericSignature.l shouldBe List("LList<+TT;>;")
+    }
+  }
+
+  "a method with a generic return type and generic parameters" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |class Test {
+        |  public <S, T extends List> S test(T t) {}
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.name("test").genericSignature.l shouldBe List("<S:LObject;T:LList;>(TT;)TS;")
+    }
+  }
+
+  "a generic member" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |class Test {
+        |  public List<String> list;
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.member.name("list").genericSignature.l shouldBe List("LList<LString;>;")
+    }
+  }
+
+  "an enum typeDecl" should {
+    val cpg = code("""
+        |package test;
+        |
+        |enum Test {
+        |  TEST
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature for the type decl" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LEnum<LTest;>;")
+    }
+
+    "have the correct generic signature for the enum constant" in {
+      cpg.member.name("TEST").genericSignature.l shouldBe List("LTest;")
+    }
+  }
+
+  "a record typeDecl" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |record Test<T>(String value, List<T> list) {}
+        |""".stripMargin)
+
+    "have the correct generic signature for the record" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("<T:LObject;>LRecord;")
+    }
+
+    "have the correct generic signature for the record parameter fields" in {
+      cpg.member.name("value").genericSignature.l shouldBe List("LString;")
+      cpg.member.name("list").genericSignature.l shouldBe List("LList<TT;>;")
+    }
+
+    "have the correct generic signature for the default constructor" in {
+      cpg.method.nameExact("<init>").genericSignature.l shouldBe List("(LString;LList<TT;>;)V")
+    }
+
+    "have the correct generic signature for the record paramater accessors" in {
+      cpg.method.name("value").genericSignature.l shouldBe List("()LString;")
+      cpg.method.name("list").genericSignature.l shouldBe List("()LList<TT;>;")
+    }
+  }
+
+  "a type decl extending a generic type" should {
+    val cpg = code("""
+        |package bar;
+        |
+        |class Bar <T> {}
+        |""".stripMargin).moreCode("""
+        |package test;
+        |
+        |class Test extends Bar<String> {}
+        |""".stripMargin)
+
+    "have the correct generic signature for the generic class" in {
+      cpg.typeDecl.name("Bar").genericSignature.l shouldBe List("<T:LObject;>LObject;")
+    }
+
+    "have the correct generic signature for the inheriting class" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LBar<LString;>;")
+    }
+  }
+
+  "the lowering for a native foreach loop" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  void test(String[] items) {
+        |    for (String item : items) {}
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature for the synthetic iterator local" in {
+      cpg.local.nameExact("$idx0").genericSignature.l shouldBe List("I")
+    }
+
+    "have the correct generic signature for the variable local" in {
+      cpg.local.name("item").genericSignature.l shouldBe List("LString;")
+    }
+  }
+
+  "the lowering for an iterator foreach loop" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.List;
+        |
+        |class Test {
+        |  void test(List<String> items) {
+        |    for (String item : items) {}
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature for the synthetic iterator local" in {
+      cpg.local.nameExact("$iterLocal0").genericSignature.l shouldBe List("Ljava.util.Iterator;")
+    }
+
+    "have the correct generic signature for the variable local" in {
+      cpg.local.name("item").genericSignature.l shouldBe List("LString;")
+    }
+  }
+
+  "the synthetic tmp local in the block representation of a constructor invocation" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  void test() {
+        |    System.out.println(new String());
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name.foreach(println)
+      cpg.local.nameExact("$obj0").genericSignature.l shouldBe List("LString;")
+    }
+  }
+
+  "a captured local in a lambda" should {
+    val cpg = code("""
+        |package test;
+        |
+        |import java.util.function.Consumer;
+        |
+        |class Test {
+        |  public Consumer<String> test(Integer captured) {
+        |    return s -> System.out.println(captured);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("captured").genericSignature.l shouldBe List("LInteger;")
+    }
+  }
+
+  "a pattern initializer requiring a tmp local" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  public Object foo() { return null; }
+        |
+        |  public void test() {
+        |    if (foo() instanceof String s) {}
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature for the tmp local" in {
+      cpg.local.nameExact("$obj0").genericSignature.l shouldBe List("L__unspecified_type;")
+    }
+
+    "have the correct generic signature for the pattern variable local" in {
+      cpg.local.name("s").genericSignature.l shouldBe List("LString;")
+    }
+  }
+
+  "a local class with captures" should {
+    val cpg = code("""
+        |class Test<T> {
+        |  String mainField;
+        |
+        |  public void test(Integer testParam) {
+        |    class Foo {
+        |      void foo() {
+        |        System.out.println(mainField + testParam);
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature for the outerClass member" in {
+      // TODO: This should maybe be `LTest<TT;>;` instead, but the type variable <T> has no
+      //  meaning in `Foo`.
+      cpg.member.name("outerClass").genericSignature.l shouldBe List("LTest;")
+    }
+
+    "have the correct generic signature for a captured parameter member" in {
+      cpg.member.name("testParam").genericSignature.l shouldBe List("LInteger;")
+    }
+  }
+
+  "a class extending a nested class" should {
+    val cpg = code("""
+        |package test;
+        |
+        |class Test {
+        |  class Foo {}
+        |  class Bar extends Foo {}
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.nameExact("Test$Bar").genericSignature.l shouldBe List("LTest$Foo;")
+    }
+  }
+
+  "a class extending a local class" should {
+    val cpg = code("""
+        |class Test {
+        |  public void test() {
+        |    class Foo {}
+        |    class Bar extends Foo {}
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.nameExact("Bar").genericSignature.l shouldBe List("LTest.test.Foo;")
+    }
+  }
+
+  "a default constructor" should {
+    val cpg = code("""
+        |class Test {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.nameExact("<init>").genericSignature.l shouldBe List("()V")
+    }
+  }
+
+  "an explicit constructor" should {
+    val cpg = code("""
+        |class Test {
+        |  public Test(String s) {}
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.nameExact("<init>").genericSignature.l shouldBe List("(LString;)V")
+    }
+  }
+
+  "a compact constructor for a record" should {
+    val cpg = code("""
+        |record Test(String s) {
+        |  public Test {}
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.nameExact("<init>").genericSignature.l shouldBe List("(LString;)V")
+    }
+  }
+
+  "a local with an unresolved fully qualified name" should {
+    val cpg = code("""
+        |class Test {
+        |  public void test() {
+        |    foo.Foo f;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("f").genericSignature.l shouldBe List("Lfoo.Foo;")
+    }
+  }
+
+  "a local with an unresolved type which can be inferred from imports" should {
+    val cpg = code("""
+        |import foo.Foo;
+        |
+        |class Test {
+        |  public void test() {
+        |    Foo f;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("f").genericSignature.l shouldBe List("LFoo;")
+    }
+  }
+
+  "a member with an unresolved fully qualified name" should {
+    val cpg = code("""
+        |class Test {
+        |  foo.Foo f;
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.member.name("f").genericSignature.l shouldBe List("Lfoo.Foo;")
+    }
+  }
+
+  "a member with an unresolved type which can be inferred from imports" should {
+    val cpg = code("""
+        |import foo.Foo;
+        |
+        |class Test {
+        |  Foo f;
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.member.name("f").genericSignature.l shouldBe List("LFoo;")
+    }
+  }
+
+  "a method with an unresolved fully qualified return type and param" should {
+    val cpg = code("""
+        |class Test {
+        |  public foo.Foo test(bar.Bar b) {}
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.name("test").genericSignature.l shouldBe List("(Lbar.Bar;)Lfoo.Foo;")
+    }
+  }
+
+  "a method with an unresolved return type and param which can be inferred from imports" should {
+    val cpg = code("""
+        |import foo.Foo;
+        |import bar.Bar;
+        |
+        |class Test {
+        |  public Foo test(Bar b) {}
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.name("test").genericSignature.l shouldBe List("(LBar;)LFoo;")
+    }
+  }
+
+  "a type decl extending an unresolved fully qualified type" should {
+    val cpg = code("""
+        |class Test extends foo.Foo {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("Lfoo.Foo;")
+    }
+  }
+
+  "a type decl extending an unresolved type which can be inferred from imports" should {
+    val cpg = code("""
+        |import foo.Foo;
+        |import bar.Bar;
+        |
+        |class Test extends Foo {}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.typeDecl.name("Test").genericSignature.l shouldBe List("LFoo;")
+    }
+  }
+
+  "a local with a var type" should {
+    val cpg = code("""
+        |public class Test {
+        |  public void foo() {
+        |    var s = "hello";
+        |  }
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.local.name("s").genericSignature.l shouldBe List("L__unspecified_type;")
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericSignatureTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericSignatureTests.scala
@@ -689,6 +689,31 @@ class GenericSignatureTests extends JavaSrcCode2CpgFixture {
     }
   }
 
+  "the lowering for a native foreach loop with a synthetic iterator local" should {
+    val cpg = code("""
+                     |package test;
+                     |
+                     |class Test {
+                     |  String[] items() { return null; }
+                     |  void test() {
+                     |    for (String item : items()) {}
+                     |  }
+                     |}
+                     |""".stripMargin)
+
+    "have the correct generic signature for the synthetic iterator local" in {
+      cpg.local.nameExact("$iterLocal0").genericSignature.l shouldBe List("L__unspecified_type;")
+    }
+
+    "have the correct generic signature for the synthetic index local" in {
+      cpg.local.nameExact("$idx0").genericSignature.l shouldBe List("I")
+    }
+
+    "have the correct generic signature for the variable local" in {
+      cpg.local.name("item").genericSignature.l shouldBe List("LString;")
+    }
+  }
+
   "the lowering for a native foreach loop" should {
     val cpg = code("""
         |package test;
@@ -700,7 +725,7 @@ class GenericSignatureTests extends JavaSrcCode2CpgFixture {
         |}
         |""".stripMargin)
 
-    "have the correct generic signature for the synthetic iterator local" in {
+    "have the correct generic signature for the synthetic index local" in {
       cpg.local.nameExact("$idx0").genericSignature.l shouldBe List("I")
     }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericSignatureTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericSignatureTests.scala
@@ -607,6 +607,23 @@ class GenericSignatureTests extends JavaSrcCode2CpgFixture {
     }
   }
 
+  "a type parameter with multiple interface bounds" should {
+    val cpg = code("""
+        |package test;
+        |
+        |interface I1 {}
+        |interface I2 {}
+        |
+        |class Test {
+        |  public <T extends I1 & I2> void test(T t) {}
+        |}
+        |""".stripMargin)
+
+    "have the correct generic signature" in {
+      cpg.method.name("test").genericSignature.l shouldBe List("<T:LI1;:LI2;>(TT;)V")
+    }
+  }
+
   "a generic member" should {
     val cpg = code("""
         |package test;

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/ScopeTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/ScopeTests.scala
@@ -19,6 +19,7 @@ import io.joern.x2cpg.ValidationMode
 class ScopeTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   private implicit val withSchemaValidation: ValidationMode = ValidationMode.Enabled
   private implicit val disableTypeFallback: Boolean         = false
+  private val genericSignature                              = "GENERIC_SIGNATURE"
 
   behavior of "javasrc2cpg scope"
 
@@ -28,7 +29,7 @@ class ScopeTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val method   = NewMethod().name("fooMethod")
 
     val scope = new Scope()
-    scope.pushTypeDeclScope(typeDecl, isStatic = false)
+    scope.pushTypeDeclScope(typeDecl, isStatic = false, Option(genericSignature))
     scope.enclosingTypeDecl.get.addMember(member, isStatic = false)
     scope.pushMethodScope(method, ExpectedType.empty, isStatic = false)
 
@@ -59,10 +60,13 @@ class ScopeTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val scope = new Scope()
     scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
     scope.pushMethodScope(method, ExpectedType.empty, isStatic = false)
-    scope.enclosingMethod.get.addParameter(outerParameter)
+    scope.enclosingMethod.get.addParameter(outerParameter, genericSignature)
     scope.pushTypeDeclScope(innerTypeDecl, isStatic = false)
 
-    scope.lookupVariable("fooParameter") shouldBe CapturedVariable(Nil, ScopeParameter(outerParameter))
+    scope.lookupVariable("fooParameter") shouldBe CapturedVariable(
+      Nil,
+      ScopeParameter(outerParameter, genericSignature)
+    )
   }
 
   it should "find a capture chain for a captured variable in an outer-outer scope" in {
@@ -76,14 +80,14 @@ class ScopeTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val scope = new Scope()
     scope.pushTypeDeclScope(outerOuterTypeDecl, isStatic = false)
     scope.pushMethodScope(outerOuterMethod, ExpectedType.empty, isStatic = false)
-    scope.enclosingMethod.get.addParameter(outerOuterParameter)
+    scope.enclosingMethod.get.addParameter(outerOuterParameter, genericSignature)
     scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
     scope.pushMethodScope(outerMethod, ExpectedType.empty, isStatic = false)
     scope.pushTypeDeclScope(innerTypeDecl, isStatic = false)
 
     scope.lookupVariable("parameter") shouldBe CapturedVariable(
       List(outerTypeDecl),
-      ScopeParameter(outerOuterParameter)
+      ScopeParameter(outerOuterParameter, genericSignature)
     )
   }
 
@@ -98,7 +102,7 @@ class ScopeTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val scope = new Scope()
     scope.pushTypeDeclScope(outerOuterTypeDecl, isStatic = false)
     scope.pushMethodScope(outerOuterMethod, ExpectedType.empty, isStatic = false)
-    scope.enclosingMethod.get.addParameter(outerOuterParameter)
+    scope.enclosingMethod.get.addParameter(outerOuterParameter, genericSignature)
     scope.pushTypeDeclScope(outerTypeDecl, isStatic = false)
     scope.pushMethodScope(outerMethod, ExpectedType.empty, isStatic = false)
     scope.pushTypeDeclScope(innerTypeDecl, isStatic = true)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -79,15 +79,18 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     name: String,
     code: String,
     typeFullName: String,
-    dynamicTypeHints: Seq[String] = Seq()
+    dynamicTypeHints: Seq[String] = Seq(),
+    genericSignature: Option[String] = None
   ): NewMember = {
-    NewMember()
+    val member = NewMember()
       .code(code)
       .name(name)
       .typeFullName(typeFullName)
       .dynamicTypeHintFullName(dynamicTypeHints)
       .lineNumber(line(node))
       .columnNumber(column(node))
+    genericSignature.foreach(member.genericSignature(_))
+    member
   }
 
   protected def newImportNode(code: String, importedEntity: String, importedAs: String, include: Node): NewImport = {
@@ -140,7 +143,8 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     astParentType: String = "",
     astParentFullName: String = "",
     inherits: Seq[String] = Seq.empty,
-    alias: Option[String] = None
+    alias: Option[String] = None,
+    genericSignature: Option[String] = None
   ): NewTypeDecl = {
     val node_ = NewTypeDecl()
       .name(name)
@@ -157,6 +161,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     offset(node).foreach { case (offset, offsetEnd) =>
       node_.offset(offset).offsetEnd(offsetEnd)
     }
+    genericSignature.foreach(node_.genericSignature(_))
     node_
   }
 
@@ -258,15 +263,19 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     name: String,
     code: String,
     typeFullName: String,
-    closureBindingId: Option[String] = None
-  ): NewLocal =
-    NewLocal()
+    closureBindingId: Option[String] = None,
+    genericSignature: Option[String] = None
+  ): NewLocal = {
+    val local = NewLocal()
       .name(name)
       .code(code)
       .typeFullName(typeFullName)
       .closureBindingId(closureBindingId)
       .lineNumber(line(node))
       .columnNumber(column(node))
+    genericSignature.foreach(local.genericSignature(_))
+    local
+  }
 
   protected def identifierNode(
     node: Node,
@@ -296,7 +305,8 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     signature: Option[String],
     fileName: String,
     astParentType: Option[String] = None,
-    astParentFullName: Option[String] = None
+    astParentFullName: Option[String] = None,
+    genericSignature: Option[String] = None
   ): NewMethod = {
     val node_ =
       NewMethod()
@@ -312,6 +322,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
         .lineNumberEnd(lineEnd(node))
         .columnNumberEnd(columnEnd(node))
     signature.foreach { s => node_.signature(StringUtils.normalizeSpace(s)) }
+    genericSignature.foreach(node_.genericSignature(_))
     offset(node).foreach { case (offset, offsetEnd) =>
       node_.offset(offset).offsetEnd(offsetEnd)
     }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -48,6 +48,7 @@ object Versions {
   val typeSafeConfig = "1.4.3"
   val versionSort    = "1.0.11"
   val zip4j          = "2.11.5"
+  val asm            = "9.7.1"
 
   private def parseVersion(key: String): String = {
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r


### PR DESCRIPTION
The generic signatures added by this PR follow the format described in https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.9.1 and largely correspond to the generic signatures in class files with some notable differences:

### Class type signatures 
* In most cases, only the simple name for the class will be used (so `LString;` will be used instead of `Ljava/lang/String`)
* Where a qualified name is used in source, that name is used verbatim in the signature, for example `Ljava.util.List` (note the `.` were not substituted for `/`. 
* For local classes, the name of the class as it appears in the CPG is used in the signature for instances of that class (we don't follow the JVM naming scheme for these), for example `Ltestpackage.TestClass.testMethod.LocalClass;`

### Type parameter bounds
From the language specification:
```
TypeParameter:
  Identifier ClassBound {InterfaceBound}

ClassBound:
 : [ReferenceTypeSignature]

InterfaceBound:
  : ReferenceTypeSignature
```
If a type parameter only has interface bounds I1, I2, ..., then the signature should contain `<T::LI1;:...>` (note the empty class bound), but in general we won't know if a type is a class or interface without resolving the it, so the signature in the CPG will contain `<T:LI1;:...>` instead.


### Unspecified types
Where no type name is specified, the special `L__unspecified_type;` type is used in generic signatures. This happens in a few places:
* For lambda return types and lambda parameters which do not have explicit type annotations
* For locals with a `var` type, for example `var x = 42`
* For synthetic locals created for `foreach` loops, for example in `for (String item : items())`, we create a temporary `String[] $iterLocal0 = items()` local which will have an unspecified signature (`item` will still have the signature `LString;` as expected)
* For synthetic locals created for the LHS of `instanceof` expressions with pattern matching, for example in `foo() instanceof String s`, we create an `Object o = foo()` local (since the type depends on the return type of `foo`).

