### PR TITLE
[c#] identify assignments in JsonAst; add operatorCallNode

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -6,7 +6,7 @@ import io.joern.csharpsrc2cpg.{CSharpDefines, Constants, astcreation}
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.{Operators, PropertyNames}
 import ujson.Value
 
 import scala.annotation.tailrec
@@ -28,15 +28,6 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         logger.warn("Key not found in json. Defaulting to a null node.")
         DotNetNodeInfo(DotNetJsonAst.Unknown, ujson.Null, "", None, None, None, None)
       }
-  }
-
-  def createCallNodeForOperator(
-    node: DotNetNodeInfo,
-    operatorMethod: String,
-    signature: Option[String] = None,
-    typeFullName: Option[String] = None
-  ): NewCall = {
-    callNode(node, node.code, operatorMethod, operatorMethod, DispatchTypes.STATIC_DISPATCH, signature, typeFullName)
   }
 
   protected def notHandledYet(node: DotNetNodeInfo): Seq[Ast] = {

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,20 +1,12 @@
 package io.joern.csharpsrc2cpg.astcreation
 
 import io.joern.csharpsrc2cpg.CSharpOperators
-import io.joern.csharpsrc2cpg.parser.DotNetNodeInfo
-import io.joern.csharpsrc2cpg.parser.ParserKeys
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
+import io.joern.csharpsrc2cpg.parser.{DotNetNodeInfo, ParserKeys}
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
+import io.shiftleft.codepropertygraph.generated.nodes.{NewFieldIdentifier, NewIdentifier, NewLiteral, NewLocal}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, ModifierTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  NewControlStructure,
-  NewFieldIdentifier,
-  NewIdentifier,
-  NewLiteral,
-  NewLocal
-}
 
 import scala.::
 import scala.util.Try
@@ -323,11 +315,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case Some(_expr: ujson.Obj) => astForNode(createDotNetNodeInfo(_expr))
       case _                      => Seq.empty[Ast]
     }
-    val throwCall = createCallNodeForOperator(
-      throwStmt,
-      CSharpOperators.throws,
-      typeFullName = Option(getTypeFullNameFromAstNode(argsAst))
-    )
+    val throwCall = operatorCallNode(throwStmt, CSharpOperators.throws, Some(getTypeFullNameFromAstNode(argsAst)))
     Seq(callAst(throwCall, argsAst))
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonAst.scala
@@ -134,27 +134,29 @@ object DotNetJsonAst {
   object LogicalNotExpression    extends UnaryExpr
   object AddressOfExpression     extends UnaryExpr
 
-  sealed trait BinaryExpr                extends BaseExpr
-  object AddExpression                   extends BinaryExpr
-  object SubtractExpression              extends BinaryExpr
-  object MultiplyExpression              extends BinaryExpr
-  object DivideExpression                extends BinaryExpr
-  object ModuloExpression                extends BinaryExpr
-  object EqualsExpression                extends BinaryExpr
-  object NotEqualsExpression             extends BinaryExpr
-  object LogicalAndExpression            extends BinaryExpr
-  object LogicalOrExpression             extends BinaryExpr
-  object AddAssignmentExpression         extends BinaryExpr
-  object SubtractAssignmentExpression    extends BinaryExpr
-  object MultiplyAssignmentExpression    extends BinaryExpr
-  object DivideAssignmentExpression      extends BinaryExpr
-  object ModuloAssignmentExpression      extends BinaryExpr
-  object AndAssignmentExpression         extends BinaryExpr
-  object OrAssignmentExpression          extends BinaryExpr
-  object ExclusiveOrAssignmentExpression extends BinaryExpr
-  object RightShiftAssignmentExpression  extends BinaryExpr
-  object LeftShiftAssignmentExpression   extends BinaryExpr
-  object SimpleAssignmentExpression      extends BinaryExpr
+  sealed trait BinaryExpr     extends BaseExpr
+  object AddExpression        extends BinaryExpr
+  object SubtractExpression   extends BinaryExpr
+  object MultiplyExpression   extends BinaryExpr
+  object DivideExpression     extends BinaryExpr
+  object ModuloExpression     extends BinaryExpr
+  object EqualsExpression     extends BinaryExpr
+  object NotEqualsExpression  extends BinaryExpr
+  object LogicalAndExpression extends BinaryExpr
+  object LogicalOrExpression  extends BinaryExpr
+
+  sealed trait AssignmentExpr            extends BinaryExpr
+  object AddAssignmentExpression         extends AssignmentExpr
+  object SubtractAssignmentExpression    extends AssignmentExpr
+  object MultiplyAssignmentExpression    extends AssignmentExpr
+  object DivideAssignmentExpression      extends AssignmentExpr
+  object ModuloAssignmentExpression      extends AssignmentExpr
+  object AndAssignmentExpression         extends AssignmentExpr
+  object OrAssignmentExpression          extends AssignmentExpr
+  object ExclusiveOrAssignmentExpression extends AssignmentExpr
+  object RightShiftAssignmentExpression  extends AssignmentExpr
+  object LeftShiftAssignmentExpression   extends AssignmentExpr
+  object SimpleAssignmentExpression      extends AssignmentExpr
 
   object GreaterThanExpression        extends BinaryExpr
   object LessThanExpression           extends BinaryExpr

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -1,7 +1,7 @@
 package io.joern.x2cpg
 
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
-import io.shiftleft.codepropertygraph.generated.nodes.Block.{PropertyDefaults => BlockDefaults}
+import io.joern.x2cpg.utils.NodeBuilders.{newMethodReturnNode, newOperatorCallNode}
+import io.shiftleft.codepropertygraph.generated.nodes.Block.PropertyDefaults as BlockDefaults
 import io.shiftleft.codepropertygraph.generated.nodes.{
   NewAnnotation,
   NewBlock,
@@ -220,6 +220,10 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     signature.foreach { s => out.signature(s) }
     typeFullName.foreach { t => out.typeFullName(t) }
     out
+  }
+
+  protected def operatorCallNode(node: Node, name: String, typeFullName: Option[String]): NewCall = {
+    newOperatorCallNode(name, code(node), typeFullName, line(node), column(node))
   }
 
   protected def returnNode(node: Node, code: String): NewReturn = {


### PR DESCRIPTION
* Identifies `AssignmentExpr` within `BinaryExpr` inside `DotNetJsonAst`. This is preparatory work for handling assignments whose LHS is a setter property, which no longer means a traditional assignment but rather a setter call.
* Replaces `createCallNodeForOperator` by a more general AstNodeBuilder `operatorCallNode` that is guaranteed to respect the `code/line/column` primitives.