### PR TITLE
[c#] fix top-level main's signature

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Constants.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Constants.scala
@@ -1,8 +1,9 @@
 package io.joern.csharpsrc2cpg
 
 object Constants {
-  val This: String   = "this"
-  val Global: String = "global"
+  val This: String                   = "this"
+  val Global: String                 = "global"
+  val TopLevelMainMethodName: String = "<Main>$"
 }
 
 object CSharpOperators {

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/Utils.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/Utils.scala
@@ -23,4 +23,19 @@ object Utils {
 
   def composeSetterName(fieldIdentifierName: String): String = s"set_$fieldIdentifierName"
 
+  /** Generates the fictitious class name that holds top-level statements.
+    */
+  def composeTopLevelClassName(fileName: String): String = {
+    val sanitizedFileName = fileName.replace(java.io.File.separator, "_").replace(".", "_")
+    s"${sanitizedFileName}_Program"
+  }
+
+  /** Strips the signature part from [[methodFullName]].
+    *
+    * Useful when handling nested methods, as method full names include signatures. To avoid a nested method's full name
+    * containing both its parent's signature and its own, we remove the parent's signature when entering its scope.
+    */
+  def composeMethodScopeName(methodFullName: String): String =
+    methodFullName.split(':').head
+
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TopLevelStatementTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TopLevelStatementTests.scala
@@ -14,7 +14,7 @@ class TopLevelStatementTests extends CSharpCode2CpgFixture {
 
     inside(cpg.call("WriteLine").method.l) {
       case method :: Nil =>
-        method.fullName shouldBe "Test0_cs_Program.<Main>$"
+        method.fullName shouldBe "Test0_cs_Program.<Main>$:System.Void(System.String[])"
         method.signature shouldBe "System.Void(System.String[])"
         method.typeDecl.l shouldBe cpg.typeDecl("Test0_cs_Program").l
       case xs => fail(s"Expected a method above WriteLine, but found $xs")
@@ -30,7 +30,7 @@ class TopLevelStatementTests extends CSharpCode2CpgFixture {
     )
     inside(cpg.call("WriteLine").method.l) {
       case method :: Nil =>
-        method.fullName shouldBe "MyProject_Main_cs_Program.<Main>$"
+        method.fullName shouldBe "MyProject_Main_cs_Program.<Main>$:System.Void(System.String[])"
         method.signature shouldBe "System.Void(System.String[])"
         method.typeDecl.l shouldBe cpg.typeDecl("MyProject_Main_cs_Program").l
       case xs => fail(s"Expected a method above WriteLine, but found $xs")
@@ -44,7 +44,7 @@ class TopLevelStatementTests extends CSharpCode2CpgFixture {
     inside(cpg.parameter("args").l) {
       case args :: Nil =>
         args.typeFullName shouldBe "System.String[]"
-        args.method.fullName shouldBe "Test0_cs_Program.<Main>$"
+        args.method.fullName shouldBe "Test0_cs_Program.<Main>$:System.Void(System.String[])"
       case xs => fail(s"Expected single parameter named `args`, but found $xs")
     }
   }
@@ -70,7 +70,9 @@ class TopLevelStatementTests extends CSharpCode2CpgFixture {
         run.methodReturn.typeFullName shouldBe "System.Void"
         run.fullName shouldBe "Test0_cs_Program.<Main>$.Run:System.Void()"
         run.modifier.modifierType.toSet shouldBe Set(ModifierTypes.STATIC, ModifierTypes.INTERNAL)
-        run.parentBlock.method.l shouldBe cpg.method.fullNameExact("Test0_cs_Program.<Main>$").l
+        run.parentBlock.method.l shouldBe cpg.method
+          .fullNameExact("Test0_cs_Program.<Main>$:System.Void(System.String[])")
+          .l
       case xs =>
         fail(s"Expected single METHOD named Run, but found $xs")
     }


### PR DESCRIPTION
The fictitious `Main$` method for global statements did not conform to the full name scheme used by other methods, as it lacked the signature portion.