### PR TITLE
[c#] fix anonymous types' fullname

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
@@ -108,7 +108,7 @@ class AstCreator(
 
     val topLevelStmtAsts = {
       scope.pushNewScope(TypeScope(classFullName))
-      scope.pushNewScope(MethodScope(composeMethodScopeName(mainFullName)))
+      scope.pushNewScope(MethodScope(mainFullName))
       argsParameters.foreach(x => scope.addToScope(x.name, x))
 
       val asts = topLevelStmts.flatMap(astForNode)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -2,6 +2,7 @@ package io.joern.csharpsrc2cpg.astcreation
 
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
 import io.joern.csharpsrc2cpg.parser.{DotNetJsonAst, DotNetNodeInfo, ParserKeys}
+import io.joern.csharpsrc2cpg.utils.Utils.{withoutSignature}
 import io.joern.csharpsrc2cpg.{CSharpDefines, Constants, astcreation}
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
@@ -44,7 +45,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   protected def astFullName(node: DotNetNodeInfo): String = {
     scope.surroundingScopeFullName match
-      case Some(fullName) => s"$fullName.${nameFromNode(node)}"
+      case Some(fullName) => s"${withoutSignature(fullName)}.${nameFromNode(node)}"
       case _              => nameFromNode(node)
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -10,7 +10,8 @@ import io.joern.csharpsrc2cpg.utils.Utils.{
   composeGetterName,
   composeMethodFullName,
   composeMethodLikeSignature,
-  composeSetterName
+  composeSetterName,
+  withoutSignature
 }
 import io.joern.x2cpg.utils.NodeBuilders.{newMethodReturnNode, newModifierNode}
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
@@ -669,7 +670,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
 
   def astForAnonymousObjectCreationExpression(anonObjExpr: DotNetNodeInfo): Seq[Ast] = {
     val typeDeclName     = nextAnonymousTypeName()
-    val typeDeclFullName = s"${scope.surroundingScopeFullName.getOrElse(Defines.Any)}.${typeDeclName}"
+    val typeDeclFullName = s"${withoutSignature(scope.surroundingScopeFullName.getOrElse(Defines.Any))}.${typeDeclName}"
 
     val _typeDeclNode = typeDeclNode(
       anonObjExpr,

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/Utils.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/Utils.scala
@@ -30,12 +30,13 @@ object Utils {
     s"${sanitizedFileName}_Program"
   }
 
-  /** Strips the signature part from [[methodFullName]].
+  /** Strips the signature part from [[fullName]].
     *
     * Useful when handling nested methods, as method full names include signatures. To avoid a nested method's full name
     * containing both its parent's signature and its own, we remove the parent's signature when entering its scope.
     */
-  def composeMethodScopeName(methodFullName: String): String =
-    methodFullName.split(':').head
+  def withoutSignature(fullName: String): String = fullName.split(':').toList match
+    case fn :: sig :: Nil => fn
+    case _                => fullName
 
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
@@ -288,7 +288,7 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
     "create a TypeDecl node" in {
       inside(cpg.method("Main").astChildren.isTypeDecl.l) {
         case anonType :: Nil =>
-          anonType.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>0"
+          anonType.fullName shouldBe "HelloWorld.Program.Main.<anon>0"
           anonType.astParentType shouldBe "METHOD"
           anonType.astParentFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[])"
         case _ => fail("No TypeDecl node for anonymous object found")
@@ -297,7 +297,7 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
 
     "propagate type to the LHS" in {
       inside(cpg.method("Main").astChildren.isBlock.astChildren.isLocal.nameExact("Foo").l) { case loc :: Nil =>
-        loc.typeFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>0"
+        loc.typeFullName shouldBe "HelloWorld.Program.Main.<anon>0"
       }
     }
 
@@ -338,7 +338,7 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
     "create a TypeDecl node" in {
       inside(cpg.method("Main").astChildren.isTypeDecl.l) {
         case anonType :: Nil =>
-          anonType.fullName shouldBe "Foo.Bar.Main:System.Void().<anon>0"
+          anonType.fullName shouldBe "Foo.Bar.Main.<anon>0"
           anonType.astParentType shouldBe "METHOD"
           anonType.astParentFullName shouldBe "Foo.Bar.Main:System.Void()"
         case _ => fail("No TypeDecl node for anonymous object found")
@@ -347,7 +347,7 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
 
     "propagate type to the LHS" in {
       inside(cpg.method("Main").astChildren.isBlock.astChildren.isLocal.nameExact("Fred").l) { case loc :: Nil =>
-        loc.typeFullName shouldBe "Foo.Bar.Main:System.Void().<anon>0"
+        loc.typeFullName shouldBe "Foo.Bar.Main.<anon>0"
       }
     }
 
@@ -380,11 +380,11 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
     "have correct attributes" in {
       inside(cpg.method("Main").astChildren.isTypeDecl.l) {
         case anonType :: anonType2 :: Nil =>
-          anonType.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>0"
+          anonType.fullName shouldBe "HelloWorld.Program.Main.<anon>0"
           anonType.astParentType shouldBe "METHOD"
           anonType.astParentFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[])"
 
-          anonType2.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>1"
+          anonType2.fullName shouldBe "HelloWorld.Program.Main.<anon>1"
           anonType2.astParentType shouldBe "METHOD"
           anonType2.astParentFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[])"
         case _ => fail("There should be exactly 2 anonymous types present")
@@ -394,8 +394,8 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
     "propagate type to the LHS" in {
       inside(cpg.method("Main").astChildren.isBlock.astChildren.isLocal.l) {
         case loc :: loc2 :: Nil =>
-          loc.typeFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>0"
-          loc2.typeFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<anon>1"
+          loc.typeFullName shouldBe "HelloWorld.Program.Main.<anon>0"
+          loc2.typeFullName shouldBe "HelloWorld.Program.Main.<anon>1"
         case _ => fail("Exactly two locals should be present")
       }
     }


### PR DESCRIPTION
The synthetic TYPE_DECL for anonymous objects contained in its full name the surrounding method's signature part. See TypeDeclTests. They are already numbered, so I don't think a conflict should arise from this, and we get to keep uniform full names.

Also changed the approach wrt `composeMethodScopeName`: while trying to support nested methods, noticed we should have the surrounding method's full name, including its signature, as that is later needed for creating the `AST` edge that will place the nested method "inside" its parent method. Thus, instead of pushing MethodScopes without signatures, we make sure that the current method's fullName doesn't contain its parent's signature.