### PR TITLE
[c#] fix anonymous functions' fullname

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -605,8 +605,12 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     paramTypeHint: Option[String] = None
   ): Seq[Ast] = {
     // Create method declaration
-    val name     = nextClosureName()
-    val fullName = s"${scope.surroundingScopeFullName.getOrElse(Defines.UnresolvedNamespace)}.$name"
+    val name = nextClosureName()
+    val fullName = {
+      val baseType  = withoutSignature(scope.surroundingScopeFullName.getOrElse(Defines.UnresolvedNamespace))
+      val signature = Defines.UnresolvedSignature
+      composeMethodFullName(baseType, name, signature)
+    }
     // Set parameter type if necessary, which may require the type hint
     val paramType = paramTypeHint.flatMap(AstCreatorHelper.elementTypesFromCollectionType).headOption
     val paramAsts = Try(lambdaExpression.json(ParserKeys.Parameter)).toOption match {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
@@ -19,7 +19,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
       inside(cpg.method("Main").astChildren.collectAll[Method].l) {
         case anon :: Nil =>
           anon.name shouldBe "<lambda>0"
-          anon.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main.<lambda>0:<unresolvedSignature>"
 
           inside(anon.parameter.l) {
             case x :: Nil =>
@@ -37,7 +37,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
       inside(cpg.method("Main").astChildren.collectAll[TypeDecl].l) {
         case anon :: Nil =>
           anon.name shouldBe "<lambda>0"
-          anon.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main.<lambda>0:<unresolvedSignature>"
         case xs => fail(s"Expected a single anonymous type declaration, got [${xs.code.mkString(",")}]")
       }
     }
@@ -48,7 +48,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
           numbers.name shouldBe "numbers"
           numbers.typeFullName shouldBe s"${DotNetTypeMap(BuiltinTypes.Int)}[]"
 
-          closure.methodFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
+          closure.methodFullName shouldBe "HelloWorld.Program.Main.<lambda>0:<unresolvedSignature>"
           closure.referencedMethod.name shouldBe "<lambda>0"
         case xs => fail(s"Expected two `Select` call argument, got [${xs.code.mkString(",")}]")
       }
@@ -69,7 +69,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
       inside(cpg.method("Main").astChildren.collectAll[Method].l) {
         case anon :: Nil =>
           anon.name shouldBe "<lambda>0"
-          anon.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main.<lambda>0:<unresolvedSignature>"
 
           inside(anon.parameter.l) {
             case x :: y :: Nil =>
@@ -91,7 +91,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
       inside(cpg.method("Main").astChildren.collectAll[TypeDecl].l) {
         case anon :: Nil =>
           anon.name shouldBe "<lambda>0"
-          anon.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
+          anon.fullName shouldBe "HelloWorld.Program.Main.<lambda>0:<unresolvedSignature>"
         case xs => fail(s"Expected a single anonymous type declaration, got [${xs.code.mkString(",")}]")
       }
     }
@@ -102,7 +102,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
           numbers.name shouldBe "numbers"
           numbers.typeFullName shouldBe s"${DotNetTypeMap(BuiltinTypes.Int)}[]"
 
-          closure.methodFullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[]).<lambda>0"
+          closure.methodFullName shouldBe "HelloWorld.Program.Main.<lambda>0:<unresolvedSignature>"
           closure.referencedMethod.name shouldBe "<lambda>0"
         case xs => fail(s"Expected two `Select` call argument, got [${xs.code.mkString(",")}]")
       }


### PR DESCRIPTION
Uniformizes the full names for the synthetic METHODs created for anonymous functions, in the vein of #5283.

Previously they did not have a signature: now they do, albeit an `<unresolvedSignature>` only. I reckon it might be possible to improve this, but not without a big change, I fear.