### PR TITLE
[c#] initial support for replacing setter assignments with setter calls

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -132,6 +132,12 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
           .tryResolveTypeReference(typeString)
           .map(_.name)
           .orElse(BuiltinTypes.DotNetTypeMap.get(typeString))
+          .orElse(scope.findFieldInScope(typeString).map(_.typeFullName))
+          .orElse(scope.lookupVariable(typeString).flatMap {
+            case x: NewLocal             => Some(x.typeFullName)
+            case x: NewMethodParameterIn => Some(x.typeFullName)
+            case _                       => None
+          })
           .getOrElse(typeString)
       case Attribute =>
         val typeString = s"${nameFromNode(node)}Attribute"

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -91,6 +91,36 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     Operators.lessEqualsThan    -> BuiltinTypes.DotNetTypeMap(BuiltinTypes.Bool)
   )
 
+  protected val binaryOperatorsMap: Map[String, String] = Map(
+    "+"   -> Operators.addition,
+    "-"   -> Operators.subtraction,
+    "*"   -> Operators.multiplication,
+    "/"   -> Operators.division,
+    "%"   -> Operators.modulo,
+    "=="  -> Operators.equals,
+    "!="  -> Operators.notEquals,
+    "&&"  -> Operators.logicalAnd,
+    "||"  -> Operators.logicalOr,
+    "="   -> Operators.assignment,
+    "+="  -> Operators.assignmentPlus,
+    "-="  -> Operators.assignmentMinus,
+    "*="  -> Operators.assignmentMultiplication,
+    "/="  -> Operators.assignmentDivision,
+    "%="  -> Operators.assignmentModulo,
+    "&="  -> Operators.assignmentAnd,
+    "|="  -> Operators.assignmentOr,
+    "^="  -> Operators.assignmentXor,
+    ">>=" -> Operators.assignmentLogicalShiftRight,
+    "<<=" -> Operators.assignmentShiftLeft,
+    ">"   -> Operators.greaterThan,
+    "<"   -> Operators.lessThan,
+    ">="  -> Operators.greaterEqualsThan,
+    "<="  -> Operators.lessEqualsThan,
+    "|"   -> Operators.or,
+    "&"   -> Operators.and,
+    "^"   -> Operators.xor
+  )
+
   protected def nodeTypeFullName(node: DotNetNodeInfo): String = {
     node.node match {
       case NumericLiteralExpression if node.code.matches("^\\d+$") => // e.g. 200

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -196,46 +196,16 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     callAst(callNode, argsAst) :: Nil
   }
 
-  private def translateBinaryOperatorName(operatorToken: String): Option[String] = {
-    Map(
-      "+"   -> Operators.addition,
-      "-"   -> Operators.subtraction,
-      "*"   -> Operators.multiplication,
-      "/"   -> Operators.division,
-      "%"   -> Operators.modulo,
-      "=="  -> Operators.equals,
-      "!="  -> Operators.notEquals,
-      "&&"  -> Operators.logicalAnd,
-      "||"  -> Operators.logicalOr,
-      "="   -> Operators.assignment,
-      "+="  -> Operators.assignmentPlus,
-      "-="  -> Operators.assignmentMinus,
-      "*="  -> Operators.assignmentMultiplication,
-      "/="  -> Operators.assignmentDivision,
-      "%="  -> Operators.assignmentModulo,
-      "&="  -> Operators.assignmentAnd,
-      "|="  -> Operators.assignmentOr,
-      "^="  -> Operators.assignmentXor,
-      ">>=" -> Operators.assignmentLogicalShiftRight,
-      "<<=" -> Operators.assignmentShiftLeft,
-      ">"   -> Operators.greaterThan,
-      "<"   -> Operators.lessThan,
-      ">="  -> Operators.greaterEqualsThan,
-      "<="  -> Operators.lessEqualsThan,
-      "|"   -> Operators.or,
-      "&"   -> Operators.and,
-      "^"   -> Operators.xor
-    ).get(operatorToken)
-  }
-
   private def astForBinaryExpression(binaryExpr: DotNetNodeInfo): Seq[Ast] = {
     val lhsNode       = createDotNetNodeInfo(binaryExpr.json(ParserKeys.Left))
     val rhsNode       = createDotNetNodeInfo(binaryExpr.json(ParserKeys.Right))
     val operatorToken = binaryExpr.json(ParserKeys.OperatorToken)(ParserKeys.Value).str
-    val operatorName = translateBinaryOperatorName(operatorToken).getOrElse {
-      logger.warn(s"Unhandled operator '$operatorToken' for ${code(binaryExpr)}")
-      CSharpOperators.unknown
-    }
+    val operatorName = binaryOperatorsMap.getOrElse(
+      operatorToken, {
+        logger.warn(s"Unhandled operator '$operatorToken' for ${code(binaryExpr)}")
+        CSharpOperators.unknown
+      }
+    )
     binaryExpr.node match {
       case _: AssignmentExpr => astForAssignmentExpression(binaryExpr, lhsNode, operatorName, rhsNode)
       case _                 => astForRegularBinaryExpression(binaryExpr, lhsNode, operatorName, rhsNode)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
@@ -174,4 +174,12 @@ class CSharpScope(summary: CSharpProgramSummary)
     val getterMethodName = Utils.composeGetterName(fieldIdentifierName)
     tryResolveMethodInvocation(getterMethodName, Nil, baseTypeFullName)
   }
+
+  def tryResolveSetterInvocation(
+    fieldIdentifierName: String,
+    baseTypeFullName: Option[String]
+  ): Option[CSharpMethod] = {
+    val setterMethodName = Utils.composeSetterName(fieldIdentifierName)
+    tryResolveMethodInvocation(setterMethodName, Defines.Any :: Nil, baseTypeFullName)
+  }
 }


### PR DESCRIPTION
Renders setter assignments as their corresponding `set_PropertyName` calls, e.g. `x.MyProperty = y` roughly becomes `x.set_MyProperty(y)`. There are still some edges to be addressed in future PRs; in particular, we should have a general solution for building signatures so we don't keep falling for them.