### PR TITLE
[c#] fix object creation involving qualified names

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -156,6 +156,10 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       case NullableType =>
         val elementTypeNode = createDotNetNodeInfo(node.json(ParserKeys.ElementType))
         nodeTypeFullName(elementTypeNode)
+      case QualifiedName =>
+        val left  = nameFromNode(createDotNetNodeInfo(node.json(ParserKeys.Left)))
+        val right = nameFromNode(createDotNetNodeInfo(node.json(ParserKeys.Right)))
+        s"$left.$right"
       case IdentifierName =>
         val typeString = nameFromNode(node)
         scope

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ObjectCreationTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ObjectCreationTests.scala
@@ -1,0 +1,48 @@
+package io.joern.csharpsrc2cpg.querying.ast
+
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.nodes.Identifier
+import io.shiftleft.semanticcpg.language.*
+
+class ObjectCreationTests extends CSharpCode2CpgFixture {
+
+  "assignment to an object creation for a known class" should {
+    val cpg = code("""
+        |using System.Text;
+        |var x = new StringBuilder();
+        |""".stripMargin)
+
+    "have correct constructor call properties" in {
+      inside(cpg.call.nameExact(Defines.ConstructorMethodName).headOption) {
+        case Some(ctor) =>
+          ctor.typeFullName shouldBe "System.Text.StringBuilder"
+          ctor.methodFullName shouldBe "System.Text.StringBuilder.<init>"
+        case None => fail(s"Expected a constructor call")
+      }
+    }
+
+    "have correct typeFullName for the assigned variable" in {
+      cpg.assignment.target.isIdentifier.nameExact("x").typeFullName.l shouldBe List("System.Text.StringBuilder")
+    }
+  }
+
+  "assignment to a fully-qualified object creation for a known class" should {
+    val cpg = code("""
+        |var x = new System.Text.StringBuilder();
+        |""".stripMargin)
+
+    "have correct constructor call properties" in {
+      inside(cpg.call.nameExact(Defines.ConstructorMethodName).headOption) {
+        case Some(ctor) =>
+          ctor.typeFullName shouldBe "System.Text.StringBuilder"
+          ctor.methodFullName shouldBe "System.Text.StringBuilder.<init>"
+        case None => fail(s"Expected a constructor CALL")
+      }
+    }
+
+    "have correct typeFullName for the assigned variable" in {
+      cpg.assignment.target.isIdentifier.nameExact("x").typeFullName.l shouldBe List("System.Text.StringBuilder")
+    }
+  }
+}


### PR DESCRIPTION
Type full names for fully-qualified object creation expressions were missing, e.g. `new System.Text.StringBuilder()` had `ANY` for typeFullName.