### PR TITLE
[sarif] Safe URI Construction

### DIFF
--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SarifTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SarifTests.scala
@@ -346,6 +346,7 @@ object SarifTests {
       .name("Foo")
       .lineNumber(2)
       .code("public foo()")
+      .filename("not compliant uri")
     val finding = NewFinding()
       .evidence(Iterator.single(method))
       .keyValuePairs(


### PR DESCRIPTION
In the case where an unexpected string in placed in the `filename` property, default to attempting URI construction within a `Try` and returning a `None` on failure