### PR TITLE
[c#] support setter assignments via += et al assignments

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/PropertySetterTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/PropertySetterTests.scala
@@ -112,8 +112,7 @@ class PropertySetterTests extends CSharpCode2CpgFixture {
       inside(cpg.call.nameExact("set_MyProperty").l) {
         case setter :: Nil =>
           setter.code shouldBe "m.MyProperty = 3"
-          // FIXME: signature
-          setter.methodFullName shouldBe "MyData.set_MyProperty:System.Void(MyData,System.Int32)"
+          setter.methodFullName shouldBe "MyData.set_MyProperty:System.Void(System.Int32)"
           setter.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
         case xs => fail(s"Expected single call to set_MyProperty, but got $xs")
       }
@@ -152,8 +151,7 @@ class PropertySetterTests extends CSharpCode2CpgFixture {
       inside(cpg.call.nameExact("set_MyProperty").l) {
         case setter :: Nil =>
           setter.code shouldBe "m.MyProperty = 3"
-          // FIXME: signature
-          setter.methodFullName shouldBe "MyData.set_MyProperty:System.Void(MyData,System.Int32)"
+          setter.methodFullName shouldBe "MyData.set_MyProperty:System.Void(System.Int32)"
           setter.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
         case xs => fail(s"Expected single call to set_MyProperty, but got $xs")
       }
@@ -189,8 +187,7 @@ class PropertySetterTests extends CSharpCode2CpgFixture {
       inside(cpg.call.nameExact("set_MyProperty").l) {
         case setter :: Nil =>
           setter.code shouldBe "this.MyProperty = 3"
-          // FIXME: signature
-          setter.methodFullName shouldBe "MyData.set_MyProperty:System.Void(MyData,System.Int32)"
+          setter.methodFullName shouldBe "MyData.set_MyProperty:System.Void(System.Int32)"
           setter.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
         case xs => fail(s"Expected single call to set_MyProperty, but got $xs")
       }


### PR DESCRIPTION
Handles setters involving `+=`, `*=`, etc assignments with the obvious lowering. Previously, only straightforward `=` assignments were handled. E.g. `x.MyProperty += 0` is handled as `x.set_MyProperty(x.get_MyProperty() + 0)`.

Note: Built on top of #5294 (hence the larger diff.)