### PR TITLE
[ruby] Regex Global Var Lowering 

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -249,14 +249,14 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
 
     node.target match {
       case regex @ StaticLiteral(s"${GlobalTypes.kernelPrefix}.Regexp") if node.isRegexMatch =>
-        node.arguments.headOption match {
+        val loweredRegex = node.arguments.headOption match {
           case Some(literal) => lowerRegexMatch(literal, regex, node.span)
           case None =>
             val self                = SelfIdentifier()(node.span.spanStart(Defines.Self))
             val globalDefaultString = MemberAccess(self, ".", "$_")(node.span.spanStart("$_"))
             lowerRegexMatch(globalDefaultString, regex, node.span)
         }
-        createMemberCall(node)
+        astForExpression(loweredRegex)
       // Regex on the RHS is more idiomatic, so no need to check types here.
       case literal: LiteralExpr if node.isRegexMatch =>
         node.arguments.headOption match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -257,6 +257,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
             lowerRegexMatch(globalDefaultString, regex, node.span)
         }
         createMemberCall(node)
+      // Regex on the RHS is more idiomatic, so no need to check types here.
       case literal: LiteralExpr if node.isRegexMatch =>
         node.arguments.headOption match {
           case Some(regex) => astForExpression(lowerRegexMatch(literal, regex, node.span))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -248,6 +248,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     }
 
     node.target match {
+      case _: LiteralExpr if node.isRegexMatch =>
+        // TODO: Wrap in regex block
+        createMemberCall(node)
       case _: LiteralExpr =>
         createMemberCall(node)
       case x: SimpleIdentifier if isBundledClass(x.text) =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -549,9 +549,7 @@ object RubyIntermediateAst {
   ) extends RubyExpression(span)
       with RubyCall {
 
-    def isRegexMatch: Boolean =
-      methodName == RubyOperators.regexpMatch
-        || methodName == "match" // an educated "guess" from a static analysis perspective
+    def isRegexMatch: Boolean = methodName == RubyOperators.regexpMatch
 
     override def withBlock(block: Block): RubyCallWithBlock[?] =
       MemberCallWithBlock(target, op, methodName, arguments, block)(span)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -549,7 +549,9 @@ object RubyIntermediateAst {
   ) extends RubyExpression(span)
       with RubyCall {
 
-    def isRegexMatch: Boolean = methodName == RubyOperators.regexpMatch
+    def isRegexMatch: Boolean =
+      methodName == RubyOperators.regexpMatch
+        || methodName == "match" // an educated "guess" from a static analysis perspective
 
     override def withBlock(block: Block): RubyCallWithBlock[?] =
       MemberCallWithBlock(target, op, methodName, arguments, block)(span)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -549,7 +549,7 @@ object RubyIntermediateAst {
   ) extends RubyExpression(span)
       with RubyCall {
 
-    def isRegexMatch: Boolean = op == RubyOperators.regexpMatch
+    def isRegexMatch: Boolean = methodName == RubyOperators.regexpMatch
 
     override def withBlock(block: Block): RubyCallWithBlock[?] =
       MemberCallWithBlock(target, op, methodName, arguments, block)(span)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.astcreation
 
+import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.passes.{Defines, GlobalTypes}
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
@@ -296,8 +297,8 @@ object RubyIntermediateAst {
   final case class IfExpression(
     condition: RubyExpression,
     thenClause: RubyExpression,
-    elsifClauses: List[RubyExpression],
-    elseClause: Option[RubyExpression]
+    elsifClauses: List[RubyExpression] = Nil,
+    elseClause: Option[RubyExpression] = None
   )(span: TextSpan)
       extends RubyExpression(span)
       with ControlFlowStatement
@@ -547,6 +548,9 @@ object RubyIntermediateAst {
     span: TextSpan
   ) extends RubyExpression(span)
       with RubyCall {
+
+    def isRegexMatch: Boolean = op == RubyOperators.regexpMatch
+
     override def withBlock(block: Block): RubyCallWithBlock[?] =
       MemberCallWithBlock(target, op, methodName, arguments, block)(span)
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -600,7 +600,18 @@ class RubyJsonToNodeCreator(
   private def visitIndexAccessAsSend(obj: Obj): RubyExpression = {
     val target  = visit(obj(ParserKeys.Receiver))
     val indices = obj.visitArray(ParserKeys.Arguments)
-    IndexAccess(target, indices)(obj.toTextSpan)
+    val isRegexMatch = indices.headOption.exists {
+      case x: StaticLiteral => x.typeFullName == getBuiltInType(Defines.Regexp)
+      case _                => false
+    }
+    if (isRegexMatch) {
+      // For regex match that looks like "hello"[/h(el)lo/]
+      val newProps = obj.value
+      newProps.put(ParserKeys.Name, RubyOperators.regexpMatch)
+      visitBinaryExpression(obj.copy(value = newProps))
+    } else {
+      IndexAccess(target, indices)(obj.toTextSpan)
+    }
   }
 
   private def visitInPattern(obj: Obj): RubyExpression = {
@@ -936,6 +947,15 @@ class RubyJsonToNodeCreator(
 
   private def visitSelf(obj: Obj): RubyExpression = SelfIdentifier()(obj.toTextSpan)
 
+  private def visitBinaryExpression(obj: Obj): RubyExpression = {
+    val callName = obj(ParserKeys.Name).str
+    val lhs      = visit(obj(ParserKeys.Receiver))
+    val rhs      = obj.visitArray(ParserKeys.Arguments).head
+    // Transform `match` to `=~` so that it is lowered later
+    val op = if RubyOperators.regexMethods.contains(callName) then RubyOperators.regexpMatch else callName
+    BinaryExpression(lhs, op, rhs)(obj.toTextSpan)
+  }
+
   private def visitSend(obj: Obj, isConditional: Boolean = false): RubyExpression = {
     val callName    = obj(ParserKeys.Name).str
     val hasReceiver = obj.contains(ParserKeys.Receiver)
@@ -954,11 +974,7 @@ class RubyJsonToNodeCreator(
       case x
           if BinaryOperators.isBinaryOperatorName(callName)
             || RubyOperators.regexMethods.contains(x) => // assert `match`, `sub`, or `gsub` is always for regex
-        val lhs = visit(obj(ParserKeys.Receiver))
-        val rhs = obj.visitArray(ParserKeys.Arguments).head
-        // Transform `match` to `=~` so that it is lowered later
-        val op = if RubyOperators.regexMethods.contains(x) then RubyOperators.regexpMatch else callName
-        BinaryExpression(lhs, op, rhs)(obj.toTextSpan)
+        visitBinaryExpression(obj)
       case _ if UnaryOperators.isUnaryOperatorName(callName) =>
         UnaryExpression(callName, visit(obj(ParserKeys.Receiver)))(obj.toTextSpan)
       case s"$name=" if hasReceiver => visitFieldAssignmentSend(obj, name)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -41,6 +41,8 @@ object Defines {
     val splat             = "<operator>.splat"
     val regexpMatch       = "=~"
     val regexpNotMatch    = "!~"
+    
+    val regexMethods =  Set("match", "sub", "gsub")
   }
 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -41,8 +41,8 @@ object Defines {
     val splat             = "<operator>.splat"
     val regexpMatch       = "=~"
     val regexpNotMatch    = "!~"
-    
-    val regexMethods =  Set("match", "sub", "gsub")
+
+    val regexMethods = Set("match", "sub", "gsub")
   }
 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -48,4 +48,62 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = true) {
       case xs => fail(s"One if statement expected, got [${xs.code.mkString(",")}]")
     }
   }
+
+  "Global regex related variables" should {
+
+    "be assigned to the match by the `~=` operator" in {
+
+      val cpg = code("""
+          |'hello' =~ /h(el)lo/
+          |""".stripMargin)
+
+      cpg.method.isModule.dotAst.foreach(println)
+    }
+
+    "be assigned to the match in a case equality" in {
+      val cpg = code("""
+          |case "hello"
+          |when /h(el)lo/
+          | puts $1
+          |end
+          |""".stripMargin)
+
+      cpg.method.dotAst.foreach(println)
+    }
+
+    "be assigned to the match in a match call (regex lhs)" in {
+      val cpg = code("""
+          |/h(el)lo/.match("hello")
+          |""".stripMargin)
+    }
+
+    "be assigned to the match in a match call (regex rhs)" in {
+      val cpg = code("""
+          |"hello".match(/h(el)lo/)
+          |""".stripMargin)
+    }
+
+    "be assigned to the match of the default global string in a match call (no rhs)" in {
+      val cpg = code("""
+          |$_ = "hello"
+          |/h(el)lo/ =~ # Match, updates $~, $1 = "el"
+          |""".stripMargin)
+    }
+
+    // We can only approximate this if the regex is directly in the index, otherwise it becomes expensive to
+    // perform constant propagation in order to determine all such cases
+    "be assigned to the match using string indexing" in {
+      val cpg = code("""
+          |"hello"[/h(el)lo]
+          |""".stripMargin)
+    }
+
+    "be assigned to the match using `sub` or `gsub` calls" in {
+      val cpg = code("""
+          |"hello".sub(/h(el)lo/)
+          |""".stripMargin)
+    }
+
+  }
+
 }


### PR DESCRIPTION
Lowering regex matches to reflect assignments made to global variables. The lowering becomes:
```ruby
 tmp = 'hello'.match(/h(el)lo/)
 if tmp
   $~ = tmp
   $& = tmp[0]
   tmp.begin(0)
 else 
   $~ = nil
   $& = nil
   nil
 end
```
Some heuristics to assign group matching global variables is next.