### PR TITLE
[javasrc2cpg] Fix record accessor call receiver in pattern matches

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
@@ -109,7 +109,7 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
           fieldTypeFullName.orElse(Option(defaultTypeFallback()))
         )
 
-        val fieldAccessorAst = callAst(fieldAccessorCall, lhsAst :: Nil)
+        val fieldAccessorAst = callAst(fieldAccessorCall, Nil, Option(lhsAst))
 
         val patternInitWithRef = if (requiresTemporaryVariable) {
           val patternInitWithRef = initAndRefAstsForPatternInitializer(patternExpr, fieldAccessorAst)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
@@ -1337,7 +1337,7 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
               valueCall.code shouldBe "((Box) o).value()"
               valueCall.typeFullName shouldBe "java.lang.String"
 
-              inside(valueCall.argument.l) { case List(boxCast: Call) =>
+              inside(valueCall.receiver.l) { case List(boxCast: Call) =>
                 boxCast.name shouldBe Operators.cast
                 boxCast.code shouldBe "(Box) o"
                 boxCast.typeFullName shouldBe "box.Box"


### PR DESCRIPTION
When pattern matching on, for example, a `record Foo(String value){}`, the field accessor call `Foo foo; foo.value()` was being created with `foo` as an argument and not a receiver which, in turn, breaks dataflows. This PR fixes this. I only updated one unit test to demonstrate this, but will use `X.receiver` consistently when redoing the unit tests for the new pattern variable initialization representation.