### PR TITLE
[ruby] Regex Match Defines `$N` Vars

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -222,7 +222,11 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       } else {
         code(n)
       }
-      val call = callNode(n, callCode, n.methodName, XDefines.DynamicCallUnknownFullName, dispatchType)
+      val call = if (n.isRegexMatch || RubyOperators.regexMethods(n.methodName)) {
+        callNode(n, callCode, n.methodName, s"${getBuiltInType(Defines.Regexp)}.match", dispatchType)
+      } else {
+        callNode(n, callCode, n.methodName, XDefines.DynamicCallUnknownFullName, dispatchType)
+      }
       if methodFullName != XDefines.DynamicCallUnknownFullName then call.possibleTypes(Seq(methodFullName))
       if (isStatic) {
         callAst(call, argumentAsts, base = Option(baseAst)).copy(receiverEdges = Nil)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language.*
 
-class RegexTests extends RubyCode2CpgFixture(withPostProcessing = true) {
+class RegexTests extends RubyCode2CpgFixture(withPostProcessing = false) {
 
   "Global regex related variables" should {
 
@@ -23,12 +23,13 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = true) {
       val tmpTarget = tmpInit.target.asInstanceOf[Identifier]
       tmpTarget.name shouldBe s"<tmp-$tmpNo>"
       val tmpSource = tmpInit.source.asInstanceOf[Call]
-      tmpSource.code shouldBe s"$expectedSubject.match(/h(el)lo/)"
+      tmpSource.code shouldBe s"/h(el)lo/.match($expectedSubject)"
       tmpSource.name shouldBe "match"
+      tmpSource.methodFullName shouldBe "__core.Kernel.Regexp.match"
 
       // Now test for the lowered global variable assignments
       val ifStmt = cpg.controlStructure.last
-      inside(ifStmt.whenTrue.assignment.l) { case tildeAsgn :: amperAsgn :: Nil =>
+      inside(ifStmt.whenTrue.assignment.l) { case tildeAsgn :: amperAsgn :: match1Asgn :: Nil =>
         tildeAsgn.code shouldBe s"$$~ = <tmp-$tmpNo>"
         val taSource = tildeAsgn.source.asInstanceOf[Identifier]
         taSource.name shouldBe s"<tmp-$tmpNo>"
@@ -46,6 +47,15 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         val aaTarget = amperAsgn.target.asInstanceOf[Call]
         aaTarget.methodFullName shouldBe Operators.fieldAccess
         aaTarget.code shouldBe "self.$&"
+
+        match1Asgn.code shouldBe s"$$1 = <tmp-$tmpNo>[1]"
+        val match1AsgnSource = match1Asgn.source.asInstanceOf[Call]
+        match1AsgnSource.methodFullName shouldBe Operators.indexAccess
+        match1AsgnSource.code shouldBe s"<tmp-$tmpNo>[1]"
+
+        val match1AsgnTarget = match1Asgn.target.asInstanceOf[Call]
+        match1AsgnTarget.methodFullName shouldBe Operators.indexAccess
+        match1AsgnTarget.code shouldBe "$[1]"
       }
       inside(ifStmt.whenFalse.assignment.l) { case tildeAsgn :: amperAsgn :: Nil =>
         tildeAsgn.code shouldBe "$~ = nil"


### PR DESCRIPTION
This PR implements the other component of regex matching defining global variables. In Ruby, `$1`, `$2`, etc. correspond to the group matched in the last match. This is synonymous to how a `MatchData` object could refer to these matches.

This PR models these `nref` objects to `$[1]` and, during a match lowering, defines them to the corresponding index position of the lowered temp match object, i.e., `$[1] = <tmp-0>[1]` where `N` is determined by the number of opening parenthesis (simple heuristic).

Additionally, the lowered `match` calls have their `methodFullName` defined for convenient policy/semantic definition creation.