### PR TITLE
[ruby] Bundled Type Full Name Consistency

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -11,7 +11,6 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   MemberCall,
   RubyExpression,
   RubyFieldIdentifier,
-  RubyIdentifier,
   SelfIdentifier,
   SimpleIdentifier,
   SingleAssignment,
@@ -22,7 +21,6 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
 }
 import io.joern.rubysrc2cpg.datastructures.{BlockScope, FieldDecl}
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
 import io.joern.rubysrc2cpg.passes.GlobalTypes
 import io.joern.rubysrc2cpg.passes.GlobalTypes.{kernelFunctions, kernelPrefix}
 import io.joern.x2cpg.{Ast, ValidationMode}
@@ -72,8 +70,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   override def code(node: RubyExpression): String = shortenCode(node.text)
 
   protected def isBuiltin(x: String): Boolean            = kernelFunctions.contains(x)
-  protected def prefixAsKernelDefined(x: String): String = s"$kernelPrefix$pathSep$x"
-  protected def prefixAsBundledType(x: String): String   = s"${GlobalTypes.builtinPrefix}.$x"
+  protected def prefixAsKernelDefined(x: String): String = Defines.getBuiltInType(x)
+  protected def prefixAsBundledType(x: String): String   = Defines.getCoreType(x)
   protected def isBundledClass(x: String): Boolean       = GlobalTypes.bundledClasses.contains(x)
   protected def pathSep                                  = "."
 
@@ -217,7 +215,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         val tildeCode   = s"$$~ = $tmpName"
         val tildeAssign = SingleAssignment(globalTilde, "=", tmp)(originSpan.spanStart(tildeCode))
 
-        def intLiteral(n: Int) = StaticLiteral(getBuiltInType(Defines.Integer))(originSpan.spanStart(s"$n"))
+        def intLiteral(n: Int) = StaticLiteral(Defines.getCoreType(Defines.Integer))(originSpan.spanStart(s"$n"))
         val tmpIndex0          = IndexAccess(tmp, intLiteral(0) :: Nil)(originSpan.spanStart(s"$tmpName[0]"))
 
         val ampersandCode   = s"$$& = $tmpName[0]"
@@ -239,7 +237,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         )
       },
       elseClause = Option {
-        def nil         = StaticLiteral(getBuiltInType(Defines.NilClass))(originSpan.spanStart("nil"))
+        def nil         = StaticLiteral(Defines.getCoreType(Defines.NilClass))(originSpan.spanStart("nil"))
         val tildeCode   = s"$$~ = nil"
         val tildeAssign = SingleAssignment(globalTilde, "=", nil)(originSpan.spanStart(tildeCode))
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -70,8 +70,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   override def code(node: RubyExpression): String = shortenCode(node.text)
 
   protected def isBuiltin(x: String): Boolean            = kernelFunctions.contains(x)
-  protected def prefixAsKernelDefined(x: String): String = Defines.getBuiltInType(x)
-  protected def prefixAsBundledType(x: String): String   = Defines.getCoreType(x)
+  protected def prefixAsKernelDefined(x: String): String = Defines.prefixAsKernelDefined(x)
+  protected def prefixAsCoreType(x: String): String      = Defines.prefixAsCoreType(x)
   protected def isBundledClass(x: String): Boolean       = GlobalTypes.bundledClasses.contains(x)
   protected def pathSep                                  = "."
 
@@ -215,7 +215,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         val tildeCode   = s"$$~ = $tmpName"
         val tildeAssign = SingleAssignment(globalTilde, "=", tmp)(originSpan.spanStart(tildeCode))
 
-        def intLiteral(n: Int) = StaticLiteral(Defines.getCoreType(Defines.Integer))(originSpan.spanStart(s"$n"))
+        def intLiteral(n: Int) = StaticLiteral(Defines.prefixAsCoreType(Defines.Integer))(originSpan.spanStart(s"$n"))
         val tmpIndex0          = IndexAccess(tmp, intLiteral(0) :: Nil)(originSpan.spanStart(s"$tmpName[0]"))
 
         val ampersandCode   = s"$$& = $tmpName[0]"
@@ -237,7 +237,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         )
       },
       elseClause = Option {
-        def nil         = StaticLiteral(Defines.getCoreType(Defines.NilClass))(originSpan.spanStart("nil"))
+        def nil         = StaticLiteral(Defines.prefixAsCoreType(Defines.NilClass))(originSpan.spanStart("nil"))
         val tildeCode   = s"$$~ = nil"
         val tildeAssign = SingleAssignment(globalTilde, "=", nil)(originSpan.spanStart(tildeCode))
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
@@ -158,18 +158,18 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
     scope.addToScope(node.forVariable.span.text, iterVarLocal)
 
     val idxName  = "_idx_"
-    val idxLocal = NewLocal().name(idxName).code(idxName).typeFullName(Defines.getCoreType(Defines.Integer))
+    val idxLocal = NewLocal().name(idxName).code(idxName).typeFullName(Defines.prefixAsCoreType(Defines.Integer))
     val idxIdenAtAssign = identifierNode(
       node = collectionNode,
       name = idxName,
       code = idxName,
-      typeFullName = Defines.getCoreType(Defines.Integer)
+      typeFullName = Defines.prefixAsCoreType(Defines.Integer)
     )
 
     val idxAssignment =
       callNode(node, s"$idxName = 0", Operators.assignment, Operators.assignment, DispatchTypes.STATIC_DISPATCH)
     val idxAssignmentArgs =
-      List(Ast(idxIdenAtAssign), Ast(NewLiteral().code("0").typeFullName(Defines.getCoreType(Defines.Integer))))
+      List(Ast(idxIdenAtAssign), Ast(NewLiteral().code("0").typeFullName(Defines.prefixAsCoreType(Defines.Integer))))
     val idxAssignmentAst = callAst(idxAssignment, idxAssignmentArgs)
 
     val idxIdAtCond = idxIdenAtAssign.copy
@@ -260,7 +260,7 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
             // which is translated to `x.include? y` and `x.any?` conditions respectively
 
             val conditions = whenClause.matchExpressions.map {
-              case regex: StaticLiteral if regex.typeFullName == prefixAsBundledType(Defines.Regexp) =>
+              case regex: StaticLiteral if regex.typeFullName == prefixAsCoreType(Defines.Regexp) =>
                 expr.map(e => BinaryExpression(regex, RubyOperators.regexpMatch, e)(regex.span)).getOrElse(regex)
               case mExpr =>
                 expr.map(e => BinaryExpression(mExpr, "===", e)(mExpr.span)).getOrElse(mExpr)
@@ -303,7 +303,7 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
                     val arrAccess = {
                       val code = s"${expr.get.text}[$idx]"
                       val base = expr.get.copy()(expr.get.span.spanStart(expr.get.text))
-                      val indices = StaticLiteral(Defines.getCoreType(Defines.Integer))(
+                      val indices = StaticLiteral(Defines.prefixAsCoreType(Defines.Integer))(
                         expr.get.span.spanStart(idx.toString)
                       ) :: Nil
                       IndexAccess(base, indices)(lhs.span.spanStart(code))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForControlStructuresCreator.scala
@@ -9,7 +9,6 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   ControlFlowStatement,
   DoWhileExpression,
   DummyAst,
-  DynamicLiteral,
   ElseClause,
   ForExpression,
   IfExpression,
@@ -22,7 +21,6 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   RescueExpression,
   RubyExpression,
   SimpleIdentifier,
-  SimpleObjectInstantiation,
   SingleAssignment,
   SplattingRubyNode,
   StatementList,
@@ -34,9 +32,8 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   WhenClause,
   WhileExpression
 }
-import io.joern.rubysrc2cpg.datastructures.BlockScope
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.passes.Defines.{RubyOperators, getBuiltInType}
+import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewFieldIdentifier, NewLiteral, NewLocal}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
@@ -161,18 +158,18 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
     scope.addToScope(node.forVariable.span.text, iterVarLocal)
 
     val idxName  = "_idx_"
-    val idxLocal = NewLocal().name(idxName).code(idxName).typeFullName(Defines.getBuiltInType(Defines.Integer))
+    val idxLocal = NewLocal().name(idxName).code(idxName).typeFullName(Defines.getCoreType(Defines.Integer))
     val idxIdenAtAssign = identifierNode(
       node = collectionNode,
       name = idxName,
       code = idxName,
-      typeFullName = Defines.getBuiltInType(Defines.Integer)
+      typeFullName = Defines.getCoreType(Defines.Integer)
     )
 
     val idxAssignment =
       callNode(node, s"$idxName = 0", Operators.assignment, Operators.assignment, DispatchTypes.STATIC_DISPATCH)
     val idxAssignmentArgs =
-      List(Ast(idxIdenAtAssign), Ast(NewLiteral().code("0").typeFullName(Defines.getBuiltInType(Defines.Integer))))
+      List(Ast(idxIdenAtAssign), Ast(NewLiteral().code("0").typeFullName(Defines.getCoreType(Defines.Integer))))
     val idxAssignmentAst = callAst(idxAssignment, idxAssignmentArgs)
 
     val idxIdAtCond = idxIdenAtAssign.copy
@@ -263,7 +260,7 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
             // which is translated to `x.include? y` and `x.any?` conditions respectively
 
             val conditions = whenClause.matchExpressions.map {
-              case regex: StaticLiteral if regex.typeFullName == getBuiltInType(Defines.Regexp) =>
+              case regex: StaticLiteral if regex.typeFullName == prefixAsBundledType(Defines.Regexp) =>
                 expr.map(e => BinaryExpression(regex, RubyOperators.regexpMatch, e)(regex.span)).getOrElse(regex)
               case mExpr =>
                 expr.map(e => BinaryExpression(mExpr, "===", e)(mExpr.span)).getOrElse(mExpr)
@@ -304,9 +301,11 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
                 val stmts = x.children.zipWithIndex.flatMap {
                   case (lhs: MatchVariable, idx) if expr.isDefined =>
                     val arrAccess = {
-                      val code    = s"${expr.get.text}[$idx]"
-                      val base    = expr.get.copy()(expr.get.span.spanStart(expr.get.text))
-                      val indices = StaticLiteral(idx.toString)(expr.get.span.spanStart(idx.toString)) :: Nil
+                      val code = s"${expr.get.text}[$idx]"
+                      val base = expr.get.copy()(expr.get.span.spanStart(expr.get.text))
+                      val indices = StaticLiteral(Defines.getCoreType(Defines.Integer))(
+                        expr.get.span.spanStart(idx.toString)
+                      ) :: Nil
                       IndexAccess(base, indices)(lhs.span.spanStart(code))
                     }
                     val asgn = SingleAssignment(lhs, "=", arrAccess)(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -252,7 +252,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     }
 
     node.target match {
-      case regex @ StaticLiteral(s"${GlobalTypes.builtinPrefix}.${Defines.Regexp}") if node.isRegexMatch =>
+      case regex @ StaticLiteral(s"${GlobalTypes.`corePrefix`}.${Defines.Regexp}") if node.isRegexMatch =>
         val loweredRegex = node.arguments.headOption match {
           case Some(literal) => lowerRegexMatch(literal, regex, node.span)
           case None =>
@@ -841,13 +841,13 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     (node.lowerBound, node.upperBound) match {
       case (lb: StaticLiteral, ub: StaticLiteral) =>
         (lb.typeFullName, ub.typeFullName) match {
-          case (s"${GlobalTypes.builtinPrefix}.Integer", s"${GlobalTypes.builtinPrefix}.Integer") =>
+          case (s"${GlobalTypes.`corePrefix`}.Integer", s"${GlobalTypes.`corePrefix`}.Integer") =>
             generateRange(lb.span.text.toInt, ub.span.text.toInt, node.rangeOperator.exclusive)
               .map(x =>
                 StaticLiteral(lb.typeFullName)(TextSpan(lb.line, lb.column, lb.lineEnd, lb.columnEnd, None, x.toString))
               )
               .toList
-          case (s"${GlobalTypes.builtinPrefix}.String", s"${GlobalTypes.builtinPrefix}.String") =>
+          case (s"${GlobalTypes.`corePrefix`}.String", s"${GlobalTypes.`corePrefix`}.String") =>
             val lbVal = lb.span.text.replaceAll("['\"]", "")
             val ubVal = ub.span.text.replaceAll("['\"]", "")
 
@@ -999,7 +999,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
 
     val argumentAst = node.arguments.map(astForMethodCallArgument)
     val (dispatchType, methodFullName) =
-      if receiverType.startsWith(GlobalTypes.builtinPrefix) then (DispatchTypes.STATIC_DISPATCH, methodFullNameHint)
+      if receiverType.startsWith(GlobalTypes.corePrefix) then (DispatchTypes.STATIC_DISPATCH, methodFullNameHint)
       else (DispatchTypes.DYNAMIC_DISPATCH, XDefines.DynamicCallUnknownFullName)
 
     val call = callNode(node, code(node), methodName, methodFullName, dispatchType)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -311,8 +311,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         Ast() // The proc parameter is retrieved later under method AST creation
       case node: CollectionParameter =>
         val typeFullName = node match {
-          case ArrayParameter(_) => prefixAsBundledType("Array")
-          case HashParameter(_)  => prefixAsBundledType("Hash")
+          case ArrayParameter(_) => prefixAsCoreType("Array")
+          case HashParameter(_)  => prefixAsCoreType("Hash")
         }
         val name = node.name.stripPrefix("*")
         val parameterIn = parameterInNode(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -311,8 +311,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         Ast() // The proc parameter is retrieved later under method AST creation
       case node: CollectionParameter =>
         val typeFullName = node match {
-          case ArrayParameter(_) => prefixAsKernelDefined("Array")
-          case HashParameter(_)  => prefixAsKernelDefined("Hash")
+          case ArrayParameter(_) => prefixAsBundledType("Array")
+          case HashParameter(_)  => prefixAsBundledType("Hash")
         }
         val name = node.name.stripPrefix("*")
         val parameterIn = parameterInNode(

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,10 +1,10 @@
 package io.joern.rubysrc2cpg.astcreation
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{RubyStatement, *}
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.datastructures.BlockScope
 import io.joern.rubysrc2cpg.parser.RubyJsonHelpers
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
+import io.joern.rubysrc2cpg.passes.Defines.prefixAsKernelDefined
 import io.joern.x2cpg.datastructures.MethodLike
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewControlStructure}
@@ -186,7 +186,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     def elseReturnNil(span: TextSpan) = Option {
       ElseClause(
         StatementList(
-          ReturnExpression(StaticLiteral(Defines.getCoreType(Defines.NilClass))(span.spanStart("nil")) :: Nil)(
+          ReturnExpression(StaticLiteral(Defines.prefixAsCoreType(Defines.NilClass))(span.spanStart("nil")) :: Nil)(
             span.spanStart("return nil")
           ) :: Nil
         )(span.spanStart("return nil"))
@@ -217,7 +217,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case node: GroupedParameterDesugaring =>
         // If the desugaring is the last expression, then we should return nil
         val nilReturnSpan    = node.span.spanStart("return nil")
-        val nilReturnLiteral = StaticLiteral(Defines.getCoreType(Defines.NilClass))(nilReturnSpan)
+        val nilReturnLiteral = StaticLiteral(Defines.prefixAsCoreType(Defines.NilClass))(nilReturnSpan)
         astsForStatement(node) ++ astsForImplicitReturnStatement(nilReturnLiteral)
       case node: AttributeAssignment =>
         List(
@@ -232,7 +232,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         stmtList.statements.map(astForExpression)
       case StatementList(stmts) =>
         val nilReturnSpan    = node.span.spanStart("return nil")
-        val nilReturnLiteral = StaticLiteral(Defines.getCoreType(Defines.NilClass))(nilReturnSpan)
+        val nilReturnLiteral = StaticLiteral(Defines.prefixAsCoreType(Defines.NilClass))(nilReturnSpan)
         stmts.map(astForExpression) ++ astsForImplicitReturnStatement(nilReturnLiteral)
       case x: RangeExpression =>
         astForReturnRangeExpression(x) :: Nil
@@ -259,12 +259,12 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         astForReturnExpression(ReturnExpression(List(simpleCall))(node.span)) :: Nil
       case node: FieldsDeclaration =>
         val nilReturnSpan    = node.span.spanStart("return nil")
-        val nilReturnLiteral = StaticLiteral(Defines.getCoreType(Defines.NilClass))(nilReturnSpan)
+        val nilReturnLiteral = StaticLiteral(Defines.prefixAsCoreType(Defines.NilClass))(nilReturnSpan)
         astsForFieldDeclarations(node) ++ astsForImplicitReturnStatement(nilReturnLiteral)
       case node: SingletonClassDeclaration =>
         astForAnonymousTypeDeclaration(node)
         val nilReturnSpan    = node.span.spanStart("return nil")
-        val nilReturnLiteral = StaticLiteral(Defines.getCoreType(Defines.NilClass))(nilReturnSpan)
+        val nilReturnLiteral = StaticLiteral(Defines.prefixAsCoreType(Defines.NilClass))(nilReturnSpan)
         astsForImplicitReturnStatement(nilReturnLiteral)
       case node =>
         logger.warn(
@@ -285,7 +285,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   // The evaluation of a MethodDeclaration returns its name in symbol form.
   // E.g. `def f = 0` ===> `:f`
   private def astForReturnMethodDeclarationSymbolName(node: RubyExpression & ProcedureDeclaration): Ast = {
-    val literalNode_ = literalNode(node, s":${node.methodName}", prefixAsBundledType(Defines.Symbol))
+    val literalNode_ = literalNode(node, s":${node.methodName}", prefixAsCoreType(Defines.Symbol))
     val returnNode_  = returnNode(node, literalNode_.code)
     returnAst(returnNode_, Seq(Ast(literalNode_)))
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -186,7 +186,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     def elseReturnNil(span: TextSpan) = Option {
       ElseClause(
         StatementList(
-          ReturnExpression(StaticLiteral(getBuiltInType(Defines.NilClass))(span.spanStart("nil")) :: Nil)(
+          ReturnExpression(StaticLiteral(Defines.getCoreType(Defines.NilClass))(span.spanStart("nil")) :: Nil)(
             span.spanStart("return nil")
           ) :: Nil
         )(span.spanStart("return nil"))
@@ -217,7 +217,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case node: GroupedParameterDesugaring =>
         // If the desugaring is the last expression, then we should return nil
         val nilReturnSpan    = node.span.spanStart("return nil")
-        val nilReturnLiteral = StaticLiteral(Defines.NilClass)(nilReturnSpan)
+        val nilReturnLiteral = StaticLiteral(Defines.getCoreType(Defines.NilClass))(nilReturnSpan)
         astsForStatement(node) ++ astsForImplicitReturnStatement(nilReturnLiteral)
       case node: AttributeAssignment =>
         List(
@@ -232,7 +232,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         stmtList.statements.map(astForExpression)
       case StatementList(stmts) =>
         val nilReturnSpan    = node.span.spanStart("return nil")
-        val nilReturnLiteral = StaticLiteral(Defines.NilClass)(nilReturnSpan)
+        val nilReturnLiteral = StaticLiteral(Defines.getCoreType(Defines.NilClass))(nilReturnSpan)
         stmts.map(astForExpression) ++ astsForImplicitReturnStatement(nilReturnLiteral)
       case x: RangeExpression =>
         astForReturnRangeExpression(x) :: Nil
@@ -259,12 +259,12 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
         astForReturnExpression(ReturnExpression(List(simpleCall))(node.span)) :: Nil
       case node: FieldsDeclaration =>
         val nilReturnSpan    = node.span.spanStart("return nil")
-        val nilReturnLiteral = StaticLiteral(Defines.NilClass)(nilReturnSpan)
+        val nilReturnLiteral = StaticLiteral(Defines.getCoreType(Defines.NilClass))(nilReturnSpan)
         astsForFieldDeclarations(node) ++ astsForImplicitReturnStatement(nilReturnLiteral)
       case node: SingletonClassDeclaration =>
         astForAnonymousTypeDeclaration(node)
         val nilReturnSpan    = node.span.spanStart("return nil")
-        val nilReturnLiteral = StaticLiteral(Defines.NilClass)(nilReturnSpan)
+        val nilReturnLiteral = StaticLiteral(Defines.getCoreType(Defines.NilClass))(nilReturnSpan)
         astsForImplicitReturnStatement(nilReturnLiteral)
       case node =>
         logger.warn(
@@ -285,7 +285,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   // The evaluation of a MethodDeclaration returns its name in symbol form.
   // E.g. `def f = 0` ===> `:f`
   private def astForReturnMethodDeclarationSymbolName(node: RubyExpression & ProcedureDeclaration): Ast = {
-    val literalNode_ = literalNode(node, s":${node.methodName}", getBuiltInType(Defines.Symbol))
+    val literalNode_ = literalNode(node, s":${node.methodName}", prefixAsBundledType(Defines.Symbol))
     val returnNode_  = returnNode(node, literalNode_.code)
     returnAst(returnNode_, Seq(Ast(literalNode_)))
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -375,7 +375,7 @@ object RubyIntermediateAst {
   final case class TypeIdentifier(typeFullName: String)(span: TextSpan)
       extends RubyExpression(span)
       with RubyIdentifier {
-    def isBuiltin: Boolean        = typeFullName.startsWith(GlobalTypes.builtinPrefix)
+    def isBuiltin: Boolean        = typeFullName.startsWith(GlobalTypes.corePrefix)
     override def toString: String = s"TypeIdentifier(${span.text}, $typeFullName)"
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -434,12 +434,12 @@ object RubyIntermediateAst {
 
     def isStatic: Boolean = !isDynamic
 
-    def typeFullName: String = Defines.getBuiltInType(Defines.Array)
+    def typeFullName: String = Defines.getCoreType(Defines.Array)
   }
 
   sealed trait HashLike extends RubyExpression with LiteralExpr {
     def elements: List[RubyExpression]
-    def typeFullName: String = Defines.getBuiltInType(Defines.Hash)
+    def typeFullName: String = Defines.getCoreType(Defines.Hash)
   }
 
   final case class HashLiteral(elements: List[RubyExpression])(span: TextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -4,6 +4,7 @@ import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.passes.{Defines, GlobalTypes}
 import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
+import org.slf4j.LoggerFactory
 
 import java.util.Objects
 
@@ -408,6 +409,25 @@ object RubyIntermediateAst {
         case s                                    => s
       }
     }
+
+  }
+
+  object StaticLiteral {
+
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    def unapply(literal: StaticLiteral): Option[String] = {
+      val typeName = literal.typeFullName.stripPrefix(s"${GlobalTypes.corePrefix}.")
+      Some(typeName).filter(GlobalTypes.bundledClasses.contains) match {
+        case None =>
+          logger.warn(
+            s"Unapply called on static literal with type not contained within known bundled classes: ${literal.typeFullName}"
+          )
+          Some(literal.typeFullName)
+        case x => x
+      }
+
+    }
   }
 
   final case class DynamicLiteral(typeFullName: String, expressions: List[RubyExpression])(span: TextSpan)
@@ -434,12 +454,12 @@ object RubyIntermediateAst {
 
     def isStatic: Boolean = !isDynamic
 
-    def typeFullName: String = Defines.getCoreType(Defines.Array)
+    def typeFullName: String = Defines.prefixAsCoreType(Defines.Array)
   }
 
   sealed trait HashLike extends RubyExpression with LiteralExpr {
     def elements: List[RubyExpression]
-    def typeFullName: String = Defines.getCoreType(Defines.Hash)
+    def typeFullName: String = Defines.prefixAsCoreType(Defines.Hash)
   }
 
   final case class HashLiteral(elements: List[RubyExpression])(span: TextSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -1,8 +1,7 @@
 package io.joern.rubysrc2cpg.datastructures
 
 import better.files.File
-import io.joern.rubysrc2cpg.passes.GlobalTypes
-import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
+import io.joern.rubysrc2cpg.passes.{GlobalTypes, Defines as RubyDefines}
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.datastructures.*
 import io.shiftleft.codepropertygraph.generated.NodeTypes
@@ -12,6 +11,7 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import java.io.File as JFile
 import scala.collection.mutable
 import scala.reflect.ClassTag
+import scala.collection.mutable
 import scala.util.Try
 
 class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
@@ -26,17 +26,30 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     mutable.Set(RubyType(GlobalTypes.kernelPrefix, builtinMethods, List.empty))
 
   // Add some built-in methods that are significant
-  // TODO: Perhaps create an offline pre-built list of methods
   typesInScope.addAll(
     Seq(
       RubyType(
-        s"$corePrefix.Array",
-        List(RubyMethod("[]", List.empty, s"$corePrefix.Array", Option(s"$corePrefix.Array"))),
+        RubyDefines.prefixAsCoreType(RubyDefines.Array),
+        List(
+          RubyMethod(
+            "[]",
+            List.empty,
+            RubyDefines.prefixAsCoreType(RubyDefines.Array),
+            Option(RubyDefines.prefixAsCoreType(RubyDefines.Array))
+          )
+        ),
         List.empty
       ),
       RubyType(
-        s"$corePrefix.Hash",
-        List(RubyMethod("[]", List.empty, s"$corePrefix.Hash", Option(s"$corePrefix.Hash"))),
+        RubyDefines.prefixAsCoreType(RubyDefines.Hash),
+        List(
+          RubyMethod(
+            "[]",
+            List.empty,
+            RubyDefines.prefixAsCoreType(RubyDefines.Hash),
+            Option(RubyDefines.prefixAsCoreType(RubyDefines.Hash))
+          )
+        ),
         List.empty
       )
     )
@@ -361,9 +374,9 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
       .orElse {
         super.tryResolveTypeReference(normalizedTypeName) match {
           case None if GlobalTypes.kernelFunctions.contains(normalizedTypeName) =>
-            Option(RubyType(s"${GlobalTypes.kernelPrefix}.$normalizedTypeName", List.empty, List.empty))
+            Option(RubyType(RubyDefines.prefixAsKernelDefined(normalizedTypeName), List.empty, List.empty))
           case None if GlobalTypes.bundledClasses.contains(normalizedTypeName) =>
-            Option(RubyType(s"${GlobalTypes.corePrefix}.$normalizedTypeName", List.empty, List.empty))
+            Option(RubyType(RubyDefines.prefixAsCoreType(normalizedTypeName), List.empty, List.empty))
           case None =>
             None
           case x => x

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -2,9 +2,9 @@ package io.joern.rubysrc2cpg.datastructures
 
 import better.files.File
 import io.joern.rubysrc2cpg.passes.GlobalTypes
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.x2cpg.Defines
-import io.joern.x2cpg.datastructures.{TypedScopeElement, *}
+import io.joern.x2cpg.datastructures.*
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{DeclarationNew, NewLocal, NewMethodParameterIn}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
@@ -30,13 +30,13 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
   typesInScope.addAll(
     Seq(
       RubyType(
-        s"$builtinPrefix.Array",
-        List(RubyMethod("[]", List.empty, s"$builtinPrefix.Array", Option(s"$builtinPrefix.Array"))),
+        s"$corePrefix.Array",
+        List(RubyMethod("[]", List.empty, s"$corePrefix.Array", Option(s"$corePrefix.Array"))),
         List.empty
       ),
       RubyType(
-        s"$builtinPrefix.Hash",
-        List(RubyMethod("[]", List.empty, s"$builtinPrefix.Hash", Option(s"$builtinPrefix.Hash"))),
+        s"$corePrefix.Hash",
+        List(RubyMethod("[]", List.empty, s"$corePrefix.Hash", Option(s"$corePrefix.Hash"))),
         List.empty
       )
     )
@@ -363,7 +363,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
           case None if GlobalTypes.kernelFunctions.contains(normalizedTypeName) =>
             Option(RubyType(s"${GlobalTypes.kernelPrefix}.$normalizedTypeName", List.empty, List.empty))
           case None if GlobalTypes.bundledClasses.contains(normalizedTypeName) =>
-            Option(RubyType(s"${GlobalTypes.builtinPrefix}.$normalizedTypeName", List.empty, List.empty))
+            Option(RubyType(s"${GlobalTypes.corePrefix}.$normalizedTypeName", List.empty, List.empty))
           case None =>
             None
           case x => x

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonHelpers.scala
@@ -25,7 +25,7 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   UnaryExpression
 }
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.passes.Defines.getCoreType
+import io.joern.rubysrc2cpg.passes.Defines.prefixAsCoreType
 import org.slf4j.LoggerFactory
 import upickle.core.*
 import upickle.default.*
@@ -68,7 +68,7 @@ object RubyJsonHelpers {
   }
 
   protected def nilLiteral(span: TextSpan): StaticLiteral =
-    StaticLiteral(getCoreType(Defines.NilClass))(span.spanStart("nil"))
+    StaticLiteral(prefixAsCoreType(Defines.NilClass))(span.spanStart("nil"))
 
   def createClassBodyAndFields(
     obj: ujson.Obj
@@ -321,7 +321,7 @@ object RubyJsonHelpers {
 
   def infinityUpperBound(obj: ujson.Obj): MemberAccess =
     MemberAccess(
-      SimpleIdentifier(Option(getCoreType(Defines.Float)))(obj.toTextSpan.spanStart("Float")),
+      SimpleIdentifier(Option(prefixAsCoreType(Defines.Float)))(obj.toTextSpan.spanStart("Float")),
       "::",
       "INFINITY"
     )(obj.toTextSpan.spanStart("Float::INFINITY"))
@@ -330,7 +330,7 @@ object RubyJsonHelpers {
     UnaryExpression(
       "-",
       MemberAccess(
-        SimpleIdentifier(Option(getCoreType(Defines.Float)))(obj.toTextSpan.spanStart("Float")),
+        SimpleIdentifier(Option(prefixAsCoreType(Defines.Float)))(obj.toTextSpan.spanStart("Float")),
         "::",
         "INFINITY"
       )(obj.toTextSpan.spanStart("Float::INFINITY"))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonHelpers.scala
@@ -25,7 +25,7 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   UnaryExpression
 }
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.passes.Defines.getBuiltInType
+import io.joern.rubysrc2cpg.passes.Defines.getCoreType
 import org.slf4j.LoggerFactory
 import upickle.core.*
 import upickle.default.*
@@ -68,7 +68,7 @@ object RubyJsonHelpers {
   }
 
   protected def nilLiteral(span: TextSpan): StaticLiteral =
-    StaticLiteral(getBuiltInType(Defines.NilClass))(span.spanStart("nil"))
+    StaticLiteral(getCoreType(Defines.NilClass))(span.spanStart("nil"))
 
   def createClassBodyAndFields(
     obj: ujson.Obj
@@ -321,7 +321,7 @@ object RubyJsonHelpers {
 
   def infinityUpperBound(obj: ujson.Obj): MemberAccess =
     MemberAccess(
-      SimpleIdentifier(Option(getBuiltInType(Defines.Float)))(obj.toTextSpan.spanStart("Float")),
+      SimpleIdentifier(Option(getCoreType(Defines.Float)))(obj.toTextSpan.spanStart("Float")),
       "::",
       "INFINITY"
     )(obj.toTextSpan.spanStart("Float::INFINITY"))
@@ -330,7 +330,7 @@ object RubyJsonHelpers {
     UnaryExpression(
       "-",
       MemberAccess(
-        SimpleIdentifier(Option(getBuiltInType(Defines.Float)))(obj.toTextSpan.spanStart("Float")),
+        SimpleIdentifier(Option(getCoreType(Defines.Float)))(obj.toTextSpan.spanStart("Float")),
         "::",
         "INFINITY"
       )(obj.toTextSpan.spanStart("Float::INFINITY"))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -1,11 +1,11 @@
 package io.joern.rubysrc2cpg.parser
 
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{RubyExpression, *}
+import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.parser.AstType.Send
 import io.joern.rubysrc2cpg.parser.RubyJsonHelpers.*
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.{NilClass, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.rubysrc2cpg.utils.FreshNameGenerator
 import io.joern.x2cpg.frontendspecific.rubysrc2cpg.ImportsPass
 import io.joern.x2cpg.frontendspecific.rubysrc2cpg.ImportsPass.ImportCallNames
@@ -851,7 +851,7 @@ class RubyJsonToNodeCreator(
       case Nil => RaiseCall(target, List.empty)(obj.toTextSpan)
       case (argument: StaticLiteral) :: Nil =>
         val simpleErrorId =
-          SimpleIdentifier(Option(s"$builtinPrefix.StandardError"))(argument.span.spanStart("StandardError"))
+          SimpleIdentifier(Option(s"$corePrefix.StandardError"))(argument.span.spanStart("StandardError"))
         val implicitSimpleErrInst = SimpleObjectInstantiation(simpleErrorId, argument :: Nil)(
           argument.span.spanStart(s"StandardError.new(${argument.text})")
         )

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -36,13 +36,13 @@ object Defines {
 
   val Resolver: String = "<dependency-resolver>"
 
-  def getBuiltInType(typeInString: String): String = {
+  def prefixAsKernelDefined(typeInString: String): String = {
     if (GlobalTypes.bundledClasses.contains(typeInString))
       logger.warn(s"Type '$typeInString' is considered a 'core' type, not a 'Kernel-contained' type")
     s"${GlobalTypes.kernelPrefix}.$typeInString"
   }
 
-  def getCoreType(typeInString: String): String = {
+  def prefixAsCoreType(typeInString: String): String = {
     if (!GlobalTypes.bundledClasses.contains(typeInString))
       logger.warn(s"Type '$typeInString' not considered a 'core' type")
     s"${GlobalTypes.corePrefix}.$typeInString"
@@ -61,9 +61,9 @@ object Defines {
 }
 
 object GlobalTypes {
-  val Kernel        = "Kernel"
-  val corePrefix = "__core"
-  val kernelPrefix  = s"$corePrefix.$Kernel"
+  val Kernel       = "Kernel"
+  val corePrefix   = "__core"
+  val kernelPrefix = s"$corePrefix.$Kernel"
 
   /** Source: https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html
     */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -1,6 +1,10 @@
 package io.joern.rubysrc2cpg.passes
 
+import org.slf4j.LoggerFactory
+
 object Defines {
+
+  private val logger = LoggerFactory.getLogger(getClass)
 
   val Any: String          = "ANY"
   val Defined: String      = "defined"
@@ -32,7 +36,17 @@ object Defines {
 
   val Resolver: String = "<dependency-resolver>"
 
-  def getBuiltInType(typeInString: String) = s"${GlobalTypes.kernelPrefix}.$typeInString"
+  def getBuiltInType(typeInString: String): String = {
+    if (GlobalTypes.bundledClasses.contains(typeInString))
+      logger.warn(s"Type '$typeInString' is considered a 'core' type, not a 'Kernel-contained' type")
+    s"${GlobalTypes.kernelPrefix}.$typeInString"
+  }
+
+  def getCoreType(typeInString: String): String = {
+    if (!GlobalTypes.bundledClasses.contains(typeInString))
+      logger.warn(s"Type '$typeInString' not considered a 'core' type")
+    s"${GlobalTypes.builtinPrefix}.$typeInString"
+  }
 
   object RubyOperators {
     val backticks: String = "<operator>.backticks"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -45,7 +45,7 @@ object Defines {
   def getCoreType(typeInString: String): String = {
     if (!GlobalTypes.bundledClasses.contains(typeInString))
       logger.warn(s"Type '$typeInString' not considered a 'core' type")
-    s"${GlobalTypes.builtinPrefix}.$typeInString"
+    s"${GlobalTypes.corePrefix}.$typeInString"
   }
 
   object RubyOperators {
@@ -62,8 +62,8 @@ object Defines {
 
 object GlobalTypes {
   val Kernel        = "Kernel"
-  val builtinPrefix = "__core"
-  val kernelPrefix  = s"$builtinPrefix.$Kernel"
+  val corePrefix = "__core"
+  val kernelPrefix  = s"$corePrefix.$Kernel"
 
   /** Source: https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/function.html
     */

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -1,12 +1,11 @@
 package io.joern.rubysrc2cpg.passes
 
 import io.joern.rubysrc2cpg.passes.Defines.Main
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.joern.x2cpg.Defines as XDefines
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
-import io.shiftleft.semanticcpg.language.importresolver.*
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.importresolver.*
 
 import scala.collection.immutable.List
 
@@ -89,8 +88,8 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate function return types" in {
       inside(cpg.method.name("func2?").l) {
         case func :: func2 :: Nil =>
-          func.methodReturn.typeFullName shouldBe s"$kernelPrefix.String"
-          func2.methodReturn.typeFullName shouldBe s"$kernelPrefix.String"
+          func.methodReturn.typeFullName shouldBe s"$builtinPrefix.String"
+          func2.methodReturn.typeFullName shouldBe s"$builtinPrefix.String"
         case xs => fail(s"Expected 2 functions, got [${xs.name.mkString(",")}]")
       }
     }
@@ -98,7 +97,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate return type to identifier c" in {
       inside(cpg.identifier.name("c").l) {
         case cIdent :: Nil =>
-          cIdent.typeFullName shouldBe s"$kernelPrefix.String"
+          cIdent.typeFullName shouldBe s"$builtinPrefix.String"
         case xs => fail(s"Expected one identifier for c, got [${xs.name.mkString(",")}]")
       }
     }
@@ -136,7 +135,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
         case funcAssignment :: constructAssignment :: tmpAssignment :: Nil =>
           inside(funcAssignment.argument.l) {
             case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe s"$kernelPrefix.String"
+              lhs.typeFullName shouldBe s"$builtinPrefix.String"
             case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}] ")
           }
 
@@ -257,9 +256,9 @@ class RubyExternalTypeRecoveryTests
 
     "resolve 'x' and 'y' locally under foo.rb" in {
       val Some(x) = cpg.identifier("x").where(_.file.name(".*foo.*")).headOption: @unchecked
-      x.typeFullName shouldBe s"$kernelPrefix.Integer"
+      x.typeFullName shouldBe s"$builtinPrefix.Integer"
       val Some(y) = cpg.identifier("y").where(_.file.name(".*foo.*")).headOption: @unchecked
-      y.typeFullName shouldBe s"$kernelPrefix.String"
+      y.typeFullName shouldBe s"$builtinPrefix.String"
     }
 
     "resolve 'FooModule.x' and 'FooModule.y' field access primitive types correctly" in {
@@ -270,9 +269,9 @@ class RubyExternalTypeRecoveryTests
         .name("z")
         .l
       z1.typeFullName shouldBe "ANY"
-      z1.dynamicTypeHintFullName shouldBe Seq(s"$kernelPrefix.Integer", s"$kernelPrefix.String")
+      z1.dynamicTypeHintFullName shouldBe Seq(s"$builtinPrefix.Integer", s"$builtinPrefix.String")
       z2.typeFullName shouldBe "ANY"
-      z2.dynamicTypeHintFullName shouldBe Seq(s"$kernelPrefix.Integer", s"$kernelPrefix.String")
+      z2.dynamicTypeHintFullName shouldBe Seq(s"$builtinPrefix.Integer", s"$builtinPrefix.String")
     }
 
     "resolve 'FooModule.d' field access object types correctly" ignore {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.passes
 
 import io.joern.rubysrc2cpg.passes.Defines.Main
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{corePrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.semanticcpg.language.*
@@ -88,8 +88,8 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate function return types" in {
       inside(cpg.method.name("func2?").l) {
         case func :: func2 :: Nil =>
-          func.methodReturn.typeFullName shouldBe s"$builtinPrefix.String"
-          func2.methodReturn.typeFullName shouldBe s"$builtinPrefix.String"
+          func.methodReturn.typeFullName shouldBe s"$corePrefix.String"
+          func2.methodReturn.typeFullName shouldBe s"$corePrefix.String"
         case xs => fail(s"Expected 2 functions, got [${xs.name.mkString(",")}]")
       }
     }
@@ -97,7 +97,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate return type to identifier c" in {
       inside(cpg.identifier.name("c").l) {
         case cIdent :: Nil =>
-          cIdent.typeFullName shouldBe s"$builtinPrefix.String"
+          cIdent.typeFullName shouldBe s"$corePrefix.String"
         case xs => fail(s"Expected one identifier for c, got [${xs.name.mkString(",")}]")
       }
     }
@@ -135,7 +135,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
         case funcAssignment :: constructAssignment :: tmpAssignment :: Nil =>
           inside(funcAssignment.argument.l) {
             case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe s"$builtinPrefix.String"
+              lhs.typeFullName shouldBe s"$corePrefix.String"
             case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}] ")
           }
 
@@ -256,9 +256,9 @@ class RubyExternalTypeRecoveryTests
 
     "resolve 'x' and 'y' locally under foo.rb" in {
       val Some(x) = cpg.identifier("x").where(_.file.name(".*foo.*")).headOption: @unchecked
-      x.typeFullName shouldBe s"$builtinPrefix.Integer"
+      x.typeFullName shouldBe s"$corePrefix.Integer"
       val Some(y) = cpg.identifier("y").where(_.file.name(".*foo.*")).headOption: @unchecked
-      y.typeFullName shouldBe s"$builtinPrefix.String"
+      y.typeFullName shouldBe s"$corePrefix.String"
     }
 
     "resolve 'FooModule.x' and 'FooModule.y' field access primitive types correctly" in {
@@ -269,9 +269,9 @@ class RubyExternalTypeRecoveryTests
         .name("z")
         .l
       z1.typeFullName shouldBe "ANY"
-      z1.dynamicTypeHintFullName shouldBe Seq(s"$builtinPrefix.Integer", s"$builtinPrefix.String")
+      z1.dynamicTypeHintFullName shouldBe Seq(s"$corePrefix.Integer", s"$corePrefix.String")
       z2.typeFullName shouldBe "ANY"
-      z2.dynamicTypeHintFullName shouldBe Seq(s"$builtinPrefix.Integer", s"$builtinPrefix.String")
+      z2.dynamicTypeHintFullName shouldBe Seq(s"$corePrefix.Integer", s"$corePrefix.String")
     }
 
     "resolve 'FooModule.d' field access object types correctly" ignore {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -59,9 +59,9 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
 
     "resolve 'print' and 'puts' StubbedRubyType calls" in {
       val List(printCall) = cpg.call("print").l
-      printCall.methodFullName shouldBe s"$kernelPrefix.print"
+      printCall.methodFullName shouldBe Defines.prefixAsKernelDefined("print")
       val List(maxCall) = cpg.call("puts").l
-      maxCall.methodFullName shouldBe s"$kernelPrefix.puts"
+      maxCall.methodFullName shouldBe Defines.prefixAsKernelDefined("puts")
     }
 
     "present the declared method name when a built-in with the same name is used in the same compilation unit" in {
@@ -88,8 +88,8 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate function return types" in {
       inside(cpg.method.name("func2?").l) {
         case func :: func2 :: Nil =>
-          func.methodReturn.typeFullName shouldBe s"$corePrefix.String"
-          func2.methodReturn.typeFullName shouldBe s"$corePrefix.String"
+          func.methodReturn.typeFullName shouldBe Defines.prefixAsCoreType("String")
+          func2.methodReturn.typeFullName shouldBe Defines.prefixAsCoreType("String")
         case xs => fail(s"Expected 2 functions, got [${xs.name.mkString(",")}]")
       }
     }
@@ -97,7 +97,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate return type to identifier c" in {
       inside(cpg.identifier.name("c").l) {
         case cIdent :: Nil =>
-          cIdent.typeFullName shouldBe s"$corePrefix.String"
+          cIdent.typeFullName shouldBe Defines.prefixAsCoreType("String")
         case xs => fail(s"Expected one identifier for c, got [${xs.name.mkString(",")}]")
       }
     }
@@ -135,7 +135,7 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
         case funcAssignment :: constructAssignment :: tmpAssignment :: Nil =>
           inside(funcAssignment.argument.l) {
             case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe s"$corePrefix.String"
+              lhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
             case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}] ")
           }
 
@@ -256,9 +256,9 @@ class RubyExternalTypeRecoveryTests
 
     "resolve 'x' and 'y' locally under foo.rb" in {
       val Some(x) = cpg.identifier("x").where(_.file.name(".*foo.*")).headOption: @unchecked
-      x.typeFullName shouldBe s"$corePrefix.Integer"
+      x.typeFullName shouldBe Defines.prefixAsCoreType("Integer")
       val Some(y) = cpg.identifier("y").where(_.file.name(".*foo.*")).headOption: @unchecked
-      y.typeFullName shouldBe s"$corePrefix.String"
+      y.typeFullName shouldBe Defines.prefixAsCoreType("String")
     }
 
     "resolve 'FooModule.x' and 'FooModule.y' field access primitive types correctly" in {
@@ -269,9 +269,9 @@ class RubyExternalTypeRecoveryTests
         .name("z")
         .l
       z1.typeFullName shouldBe "ANY"
-      z1.dynamicTypeHintFullName shouldBe Seq(s"$corePrefix.Integer", s"$corePrefix.String")
+      z1.dynamicTypeHintFullName shouldBe Seq(Defines.prefixAsCoreType("Integer"), Defines.prefixAsCoreType("String"))
       z2.typeFullName shouldBe "ANY"
-      z2.dynamicTypeHintFullName shouldBe Seq(s"$corePrefix.Integer", s"$corePrefix.String")
+      z2.dynamicTypeHintFullName shouldBe Seq(Defines.prefixAsCoreType("Integer"), Defines.prefixAsCoreType("String"))
     }
 
     "resolve 'FooModule.d' field access object types correctly" ignore {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{corePrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines as XDefines
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Local}
@@ -99,7 +99,7 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (foo: Literal) :: Nil =>
       foo.code shouldBe "foo"
-      foo.typeFullName shouldBe s"$builtinPrefix.String"
+      foo.typeFullName shouldBe s"$corePrefix.String"
     }
   }
 
@@ -116,10 +116,10 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (x: Literal) :: (y: Literal) :: Nil =>
       x.code shouldBe ":x"
-      x.typeFullName shouldBe s"$builtinPrefix.Symbol"
+      x.typeFullName shouldBe s"$corePrefix.Symbol"
 
       y.code shouldBe ":y"
-      y.typeFullName shouldBe s"$builtinPrefix.Symbol"
+      y.typeFullName shouldBe s"$corePrefix.Symbol"
     }
   }
 
@@ -159,7 +159,7 @@ class ArrayTests extends RubyCode2CpgFixture {
       yFmtStrLit.code shouldBe "23"
 
       zLit.code shouldBe "z"
-      zLit.typeFullName shouldBe s"$builtinPrefix.String"
+      zLit.typeFullName shouldBe s"$corePrefix.String"
     }
   }
 
@@ -171,8 +171,8 @@ class ArrayTests extends RubyCode2CpgFixture {
     inside(cpg.call.nameExact("[]").l) {
       case bracketCall :: Nil =>
         bracketCall.name shouldBe "[]"
-        bracketCall.methodFullName shouldBe s"$builtinPrefix.Array.[]"
-        bracketCall.typeFullName shouldBe s"$builtinPrefix.Array"
+        bracketCall.methodFullName shouldBe s"$corePrefix.Array.[]"
+        bracketCall.typeFullName shouldBe s"$corePrefix.Array"
 
         inside(bracketCall.argument.l) {
           case _ :: one :: two :: three :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -99,7 +99,7 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (foo: Literal) :: Nil =>
       foo.code shouldBe "foo"
-      foo.typeFullName shouldBe s"$kernelPrefix.String"
+      foo.typeFullName shouldBe s"$builtinPrefix.String"
     }
   }
 
@@ -116,10 +116,10 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (x: Literal) :: (y: Literal) :: Nil =>
       x.code shouldBe ":x"
-      x.typeFullName shouldBe s"$kernelPrefix.Symbol"
+      x.typeFullName shouldBe s"$builtinPrefix.Symbol"
 
       y.code shouldBe ":y"
-      y.typeFullName shouldBe s"$kernelPrefix.Symbol"
+      y.typeFullName shouldBe s"$builtinPrefix.Symbol"
     }
   }
 
@@ -135,10 +135,10 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (xFmt: Call) :: (yFmt: Call) :: (zLit: Literal) :: Nil =>
       xFmt.name shouldBe Operators.formatString
-      xFmt.typeFullName shouldBe Defines.getBuiltInType(Defines.String)
+      xFmt.typeFullName shouldBe Defines.getCoreType(Defines.String)
 
       yFmt.name shouldBe Operators.formatString
-      yFmt.typeFullName shouldBe Defines.getBuiltInType(Defines.String)
+      yFmt.typeFullName shouldBe Defines.getCoreType(Defines.String)
 
       val List(xFmtStr, xAddFmtStr) = xFmt.astChildren.isCall.l
       xFmtStr.name shouldBe Operators.formattedValue
@@ -159,7 +159,7 @@ class ArrayTests extends RubyCode2CpgFixture {
       yFmtStrLit.code shouldBe "23"
 
       zLit.code shouldBe "z"
-      zLit.typeFullName shouldBe s"$kernelPrefix.String"
+      zLit.typeFullName shouldBe s"$builtinPrefix.String"
     }
   }
 
@@ -197,12 +197,12 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (test1Fmt: Call) :: (test2: Literal) :: Nil =>
       test1Fmt.name shouldBe Operators.formatString
-      test1Fmt.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+      test1Fmt.typeFullName shouldBe Defines.getCoreType(Defines.Symbol)
       test1Fmt.code shouldBe "test_#{1}"
 
       val List(test1FmtLit, test1FmtSymbol) = test1Fmt.astChildren.isCall.l
       test1FmtSymbol.name shouldBe Operators.formattedValue
-      test1FmtSymbol.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+      test1FmtSymbol.typeFullName shouldBe Defines.getCoreType(Defines.Symbol)
       test1FmtSymbol.code shouldBe "#{1}"
 
       test1FmtLit.name shouldBe Operators.formattedValue
@@ -211,7 +211,7 @@ class ArrayTests extends RubyCode2CpgFixture {
       test1FmtFinal.code shouldBe "test_"
 
       test2.code shouldBe ":test_2"
-      test2.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+      test2.typeFullName shouldBe Defines.getCoreType(Defines.Symbol)
     }
   }
 
@@ -288,7 +288,7 @@ class ArrayTests extends RubyCode2CpgFixture {
         splatArgOne.code shouldBe "*::ApplicationSettingsHelper.visible_attributes"
 
         symbolArg.code shouldBe ":can_create_organization"
-        symbolArg.typeFullName shouldBe Defines.getBuiltInType(Defines.Symbol)
+        symbolArg.typeFullName shouldBe Defines.getCoreType(Defines.Symbol)
 
         splatArgTwo.methodFullName shouldBe RubyOperators.splat
         splatArgTwo.code shouldBe "*::ApplicationSettingsHelper.some_other_attributes"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -2,12 +2,15 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{corePrefix, kernelPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+
 import io.joern.x2cpg.Defines as XDefines
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal, Local}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes.Assignment
 
 class ArrayTests extends RubyCode2CpgFixture {
@@ -99,7 +102,7 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (foo: Literal) :: Nil =>
       foo.code shouldBe "foo"
-      foo.typeFullName shouldBe s"$corePrefix.String"
+      foo.typeFullName shouldBe Defines.prefixAsCoreType("String")
     }
   }
 
@@ -116,10 +119,10 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (x: Literal) :: (y: Literal) :: Nil =>
       x.code shouldBe ":x"
-      x.typeFullName shouldBe s"$corePrefix.Symbol"
+      x.typeFullName shouldBe Defines.prefixAsCoreType("Symbol")
 
       y.code shouldBe ":y"
-      y.typeFullName shouldBe s"$corePrefix.Symbol"
+      y.typeFullName shouldBe Defines.prefixAsCoreType("Symbol")
     }
   }
 
@@ -135,10 +138,10 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (xFmt: Call) :: (yFmt: Call) :: (zLit: Literal) :: Nil =>
       xFmt.name shouldBe Operators.formatString
-      xFmt.typeFullName shouldBe Defines.getCoreType(Defines.String)
+      xFmt.typeFullName shouldBe Defines.prefixAsCoreType(Defines.String)
 
       yFmt.name shouldBe Operators.formatString
-      yFmt.typeFullName shouldBe Defines.getCoreType(Defines.String)
+      yFmt.typeFullName shouldBe Defines.prefixAsCoreType(Defines.String)
 
       val List(xFmtStr, xAddFmtStr) = xFmt.astChildren.isCall.l
       xFmtStr.name shouldBe Operators.formattedValue
@@ -159,7 +162,7 @@ class ArrayTests extends RubyCode2CpgFixture {
       yFmtStrLit.code shouldBe "23"
 
       zLit.code shouldBe "z"
-      zLit.typeFullName shouldBe s"$corePrefix.String"
+      zLit.typeFullName shouldBe Defines.prefixAsCoreType("String")
     }
   }
 
@@ -171,8 +174,8 @@ class ArrayTests extends RubyCode2CpgFixture {
     inside(cpg.call.nameExact("[]").l) {
       case bracketCall :: Nil =>
         bracketCall.name shouldBe "[]"
-        bracketCall.methodFullName shouldBe s"$corePrefix.Array.[]"
-        bracketCall.typeFullName shouldBe s"$corePrefix.Array"
+        bracketCall.methodFullName shouldBe s"${Defines.prefixAsCoreType("Array")}.[]"
+        bracketCall.typeFullName shouldBe Defines.prefixAsCoreType("Array")
 
         inside(bracketCall.argument.l) {
           case _ :: one :: two :: three :: Nil =>
@@ -197,12 +200,12 @@ class ArrayTests extends RubyCode2CpgFixture {
 
     inside(asgns.map(_.source)) { case (test1Fmt: Call) :: (test2: Literal) :: Nil =>
       test1Fmt.name shouldBe Operators.formatString
-      test1Fmt.typeFullName shouldBe Defines.getCoreType(Defines.Symbol)
+      test1Fmt.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Symbol)
       test1Fmt.code shouldBe "test_#{1}"
 
       val List(test1FmtLit, test1FmtSymbol) = test1Fmt.astChildren.isCall.l
       test1FmtSymbol.name shouldBe Operators.formattedValue
-      test1FmtSymbol.typeFullName shouldBe Defines.getCoreType(Defines.Symbol)
+      test1FmtSymbol.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Symbol)
       test1FmtSymbol.code shouldBe "#{1}"
 
       test1FmtLit.name shouldBe Operators.formattedValue
@@ -211,7 +214,7 @@ class ArrayTests extends RubyCode2CpgFixture {
       test1FmtFinal.code shouldBe "test_"
 
       test2.code shouldBe ":test_2"
-      test2.typeFullName shouldBe Defines.getCoreType(Defines.Symbol)
+      test2.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Symbol)
     }
   }
 
@@ -288,7 +291,7 @@ class ArrayTests extends RubyCode2CpgFixture {
         splatArgOne.code shouldBe "*::ApplicationSettingsHelper.visible_attributes"
 
         symbolArg.code shouldBe ":can_create_organization"
-        symbolArg.typeFullName shouldBe Defines.getCoreType(Defines.Symbol)
+        symbolArg.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Symbol)
 
         splatArgTwo.methodFullName shouldBe RubyOperators.splat
         splatArgTwo.code shouldBe "*::ApplicationSettingsHelper.some_other_attributes"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -71,7 +71,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     val List(atan2) = cpg.call.name("atan2").l
     atan2.lineNumber shouldBe Some(3)
     atan2.code shouldBe "Math.atan2(1, 1)"
-    atan2.methodFullName shouldBe s"${GlobalTypes.corePrefix}.Math.atan2"
+    atan2.methodFullName shouldBe s"${RubyDefines.prefixAsCoreType("Math")}.atan2"
     atan2.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
     val List(mathRec: Call) = atan2.receiver.l: @unchecked
@@ -79,7 +79,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     mathRec.typeFullName shouldBe Defines.Any
     mathRec.code shouldBe s"Math.atan2"
 
-    mathRec.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"${GlobalTypes.corePrefix}.Math"
+    mathRec.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe RubyDefines.prefixAsCoreType("Math")
     mathRec.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "atan2"
   }
 
@@ -357,7 +357,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
   "a call with a quoted regex literal should have a literal receiver" in {
     val cpg          = code("%r{^/}.freeze()")
     val regexLiteral = cpg.call.nameExact("freeze").receiver.fieldAccess.argument(1).head.asInstanceOf[Literal]
-    regexLiteral.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.Regexp)
+    regexLiteral.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Regexp)
     regexLiteral.code shouldBe "%r{^/}"
   }
 
@@ -516,10 +516,10 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         sentryAssoc.code shouldBe "[:sentry_issue_identifier]"
 
         strLiteral.code shouldBe "\"1234\""
-        strLiteral.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.String)
+        strLiteral.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.String)
 
         numericLiteral.code shouldBe "10"
-        numericLiteral.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.Integer)
+        numericLiteral.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Integer)
       case xs => fail(s"Expected 6 parameters for call, got [${xs.code.mkString(", ")}]")
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -357,7 +357,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
   "a call with a quoted regex literal should have a literal receiver" in {
     val cpg          = code("%r{^/}.freeze()")
     val regexLiteral = cpg.call.nameExact("freeze").receiver.fieldAccess.argument(1).head.asInstanceOf[Literal]
-    regexLiteral.typeFullName shouldBe s"$kernelPrefix.Regexp"
+    regexLiteral.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.Regexp)
     regexLiteral.code shouldBe "%r{^/}"
   }
 
@@ -516,10 +516,10 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         sentryAssoc.code shouldBe "[:sentry_issue_identifier]"
 
         strLiteral.code shouldBe "\"1234\""
-        strLiteral.typeFullName shouldBe RubyDefines.getBuiltInType(RubyDefines.String)
+        strLiteral.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.String)
 
         numericLiteral.code shouldBe "10"
-        numericLiteral.typeFullName shouldBe RubyDefines.getBuiltInType(RubyDefines.Integer)
+        numericLiteral.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.Integer)
       case xs => fail(s"Expected 6 parameters for call, got [${xs.code.mkString(", ")}]")
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -71,7 +71,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     val List(atan2) = cpg.call.name("atan2").l
     atan2.lineNumber shouldBe Some(3)
     atan2.code shouldBe "Math.atan2(1, 1)"
-    atan2.methodFullName shouldBe s"${GlobalTypes.builtinPrefix}.Math.atan2"
+    atan2.methodFullName shouldBe s"${GlobalTypes.corePrefix}.Math.atan2"
     atan2.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
 
     val List(mathRec: Call) = atan2.receiver.l: @unchecked
@@ -79,7 +79,7 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
     mathRec.typeFullName shouldBe Defines.Any
     mathRec.code shouldBe s"Math.atan2"
 
-    mathRec.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"${GlobalTypes.builtinPrefix}.Math"
+    mathRec.argument(1).asInstanceOf[TypeRef].typeFullName shouldBe s"${GlobalTypes.corePrefix}.Math"
     mathRec.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "atan2"
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -747,7 +747,7 @@ class ClassTests extends RubyCode2CpgFixture {
 
     "create the `StandardError` local variable" in {
       cpg.local.nameExact("some_variable").dynamicTypeHintFullName.toList shouldBe List(
-        s"${GlobalTypes.builtinPrefix}.StandardError"
+        s"${GlobalTypes.corePrefix}.StandardError"
       )
     }
 
@@ -962,7 +962,7 @@ class ClassTests extends RubyCode2CpgFixture {
           inside(bodyMethod.block.astChildren.l) {
             case (one: Literal) :: Nil =>
               one.code shouldBe "1"
-              one.typeFullName shouldBe s"${GlobalTypes.builtinPrefix}.Integer"
+              one.typeFullName shouldBe s"${GlobalTypes.corePrefix}.Integer"
             case xs => fail(s"Expected one literal, got [${xs.code.mkString(",")}]")
           }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -747,7 +747,7 @@ class ClassTests extends RubyCode2CpgFixture {
 
     "create the `StandardError` local variable" in {
       cpg.local.nameExact("some_variable").dynamicTypeHintFullName.toList shouldBe List(
-        s"${GlobalTypes.corePrefix}.StandardError"
+        RubyDefines.prefixAsCoreType("StandardError")
       )
     }
 
@@ -962,7 +962,7 @@ class ClassTests extends RubyCode2CpgFixture {
           inside(bodyMethod.block.astChildren.l) {
             case (one: Literal) :: Nil =>
               one.code shouldBe "1"
-              one.typeFullName shouldBe s"${GlobalTypes.corePrefix}.Integer"
+              one.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
             case xs => fail(s"Expected one literal, got [${xs.code.mkString(",")}]")
           }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -962,7 +962,7 @@ class ClassTests extends RubyCode2CpgFixture {
           inside(bodyMethod.block.astChildren.l) {
             case (one: Literal) :: Nil =>
               one.code shouldBe "1"
-              one.typeFullName shouldBe s"${GlobalTypes.kernelPrefix}.Integer"
+              one.typeFullName shouldBe s"${GlobalTypes.builtinPrefix}.Integer"
             case xs => fail(s"Expected one literal, got [${xs.code.mkString(",")}]")
           }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -398,7 +398,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
           inside(forEachNode.astChildren.l) {
             case (idxLocal: Local) :: (iVarLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
               idxLocal.name shouldBe "_idx_"
-              idxLocal.typeFullName shouldBe Defines.getBuiltInType(Defines.Integer)
+              idxLocal.typeFullName shouldBe Defines.getCoreType(Defines.Integer)
 
               iVarLocal.name shouldBe "i"
 
@@ -436,7 +436,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
           inside(forEachNode.astChildren.l) {
             case (idxLocal: Local) :: (iVarLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
               idxLocal.name shouldBe "_idx_"
-              idxLocal.typeFullName shouldBe Defines.getBuiltInType(Defines.Integer)
+              idxLocal.typeFullName shouldBe Defines.getCoreType(Defines.Integer)
 
               iVarLocal.name shouldBe "i"
 
@@ -674,7 +674,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
         inside(forEachNode.astChildren.l) {
           case (idxLocal: Local) :: (numLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
             idxLocal.name shouldBe "_idx_"
-            idxLocal.typeFullName shouldBe Defines.getBuiltInType(Defines.Integer)
+            idxLocal.typeFullName shouldBe Defines.getCoreType(Defines.Integer)
 
             numLocal.name shouldBe "num"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -398,7 +398,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
           inside(forEachNode.astChildren.l) {
             case (idxLocal: Local) :: (iVarLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
               idxLocal.name shouldBe "_idx_"
-              idxLocal.typeFullName shouldBe Defines.getCoreType(Defines.Integer)
+              idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
 
               iVarLocal.name shouldBe "i"
 
@@ -436,7 +436,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
           inside(forEachNode.astChildren.l) {
             case (idxLocal: Local) :: (iVarLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
               idxLocal.name shouldBe "_idx_"
-              idxLocal.typeFullName shouldBe Defines.getCoreType(Defines.Integer)
+              idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
 
               iVarLocal.name shouldBe "i"
 
@@ -674,7 +674,7 @@ class ControlStructureTests extends RubyCode2CpgFixture {
         inside(forEachNode.astChildren.l) {
           case (idxLocal: Local) :: (numLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
             idxLocal.name shouldBe "_idx_"
-            idxLocal.typeFullName shouldBe Defines.getCoreType(Defines.Integer)
+            idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
 
             numLocal.name shouldBe "num"
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.{Initialize, Main, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -273,7 +273,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
               newCall.name shouldBe Initialize
               newCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
-              newCall.dynamicTypeHintFullName should contain(s"$builtinPrefix.Array.$Initialize")
+              newCall.dynamicTypeHintFullName should contain(s"$corePrefix.Array.$Initialize")
 
               inside(newCall.argument.l) {
                 case (_: Identifier) :: (x: Identifier) :: (closure: TypeRef) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -1,7 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.{Initialize, Main, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -273,7 +272,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
               newCall.name shouldBe Initialize
               newCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
-              newCall.dynamicTypeHintFullName should contain(s"$corePrefix.Array.$Initialize")
+              newCall.dynamicTypeHintFullName should contain(s"${RubyDefines.prefixAsCoreType(s"Array")}.$Initialize")
 
               inside(newCall.argument.l) {
                 case (_: Identifier) :: (x: Identifier) :: (closure: TypeRef) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, TypeRef}
@@ -101,7 +101,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe s"$builtinPrefix.String"
+                rhs.typeFullName shouldBe s"$corePrefix.String"
               case _ => fail("Expected LHS and RHS after lowering")
             }
 
@@ -110,7 +110,7 @@ class HashTests extends RubyCode2CpgFixture {
               lhs.name shouldBe Operators.indexAccess
 
               rhs.code shouldBe "\"ade\""
-              rhs.typeFullName shouldBe s"$builtinPrefix.String"
+              rhs.typeFullName shouldBe s"$corePrefix.String"
             }
           case _ => fail("Expected 5 calls (one per item in range)")
         }
@@ -127,7 +127,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe s"$builtinPrefix.String"
+                rhs.typeFullName shouldBe s"$corePrefix.String"
               case _ => fail("Expected LHS and RHS after lowering")
             }
           case _ => fail("Expected 3 calls (one per item in range)")
@@ -175,7 +175,7 @@ class HashTests extends RubyCode2CpgFixture {
                   case _ => fail("Expected range operator for non-primitive range key")
                 }
 
-                rhs.typeFullName shouldBe s"$builtinPrefix.String"
+                rhs.typeFullName shouldBe s"$corePrefix.String"
                 rhs.code shouldBe "\"a\""
               case _ => fail("Expected LHS and RHS for association")
             }
@@ -195,8 +195,8 @@ class HashTests extends RubyCode2CpgFixture {
       case hashCall :: Nil =>
         hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
         hashCall.lineNumber shouldBe Some(2)
-        hashCall.methodFullName shouldBe s"$builtinPrefix.Hash.[]"
-        hashCall.typeFullName shouldBe s"$builtinPrefix.Hash"
+        hashCall.methodFullName shouldBe s"$corePrefix.Hash.[]"
+        hashCall.typeFullName shouldBe s"$corePrefix.Hash"
 
         inside(hashCall.astChildren.l) {
           case (_: Call) :: (_: TypeRef) :: (one: Call) :: (two: Call) :: (three: Call) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, TypeRef}
@@ -101,7 +101,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe s"$kernelPrefix.String"
+                rhs.typeFullName shouldBe s"$builtinPrefix.String"
               case _ => fail("Expected LHS and RHS after lowering")
             }
 
@@ -110,7 +110,7 @@ class HashTests extends RubyCode2CpgFixture {
               lhs.name shouldBe Operators.indexAccess
 
               rhs.code shouldBe "\"ade\""
-              rhs.typeFullName shouldBe s"$kernelPrefix.String"
+              rhs.typeFullName shouldBe s"$builtinPrefix.String"
             }
           case _ => fail("Expected 5 calls (one per item in range)")
         }
@@ -127,7 +127,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe s"$kernelPrefix.String"
+                rhs.typeFullName shouldBe s"$builtinPrefix.String"
               case _ => fail("Expected LHS and RHS after lowering")
             }
           case _ => fail("Expected 3 calls (one per item in range)")
@@ -175,7 +175,7 @@ class HashTests extends RubyCode2CpgFixture {
                   case _ => fail("Expected range operator for non-primitive range key")
                 }
 
-                rhs.typeFullName shouldBe s"$kernelPrefix.String"
+                rhs.typeFullName shouldBe s"$builtinPrefix.String"
                 rhs.code shouldBe "\"a\""
               case _ => fail("Expected LHS and RHS for association")
             }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
+import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, TypeRef}
@@ -101,7 +101,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe s"$corePrefix.String"
+                rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
               case _ => fail("Expected LHS and RHS after lowering")
             }
 
@@ -110,7 +110,7 @@ class HashTests extends RubyCode2CpgFixture {
               lhs.name shouldBe Operators.indexAccess
 
               rhs.code shouldBe "\"ade\""
-              rhs.typeFullName shouldBe s"$corePrefix.String"
+              rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
             }
           case _ => fail("Expected 5 calls (one per item in range)")
         }
@@ -127,7 +127,7 @@ class HashTests extends RubyCode2CpgFixture {
                 lhs.name shouldBe Operators.indexAccess
 
                 rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe s"$corePrefix.String"
+                rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
               case _ => fail("Expected LHS and RHS after lowering")
             }
           case _ => fail("Expected 3 calls (one per item in range)")
@@ -175,7 +175,7 @@ class HashTests extends RubyCode2CpgFixture {
                   case _ => fail("Expected range operator for non-primitive range key")
                 }
 
-                rhs.typeFullName shouldBe s"$corePrefix.String"
+                rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
                 rhs.code shouldBe "\"a\""
               case _ => fail("Expected LHS and RHS for association")
             }
@@ -195,8 +195,8 @@ class HashTests extends RubyCode2CpgFixture {
       case hashCall :: Nil =>
         hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
         hashCall.lineNumber shouldBe Some(2)
-        hashCall.methodFullName shouldBe s"$corePrefix.Hash.[]"
-        hashCall.typeFullName shouldBe s"$corePrefix.Hash"
+        hashCall.methodFullName shouldBe s"${Defines.prefixAsCoreType("Hash")}.[]"
+        hashCall.typeFullName shouldBe Defines.prefixAsCoreType("Hash")
 
         inside(hashCall.astChildren.l) {
           case (_: Call) :: (_: TypeRef) :: (one: Call) :: (two: Call) :: (three: Call) :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
+import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
@@ -26,7 +26,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               localAst.code shouldBe "a"
               callAst.code shouldBe "a = 10"
 
-              literalAst.typeFullName shouldBe s"$corePrefix.String"
+              literalAst.typeFullName shouldBe Defines.prefixAsCoreType("String")
 
               returnAst.code shouldBe "a"
             case _ =>
@@ -55,7 +55,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               inside(assignmentCall.argument.l) {
                 case lhsArg :: (rhsArg: Literal) :: Nil =>
                   lhsArg.code shouldBe "a"
-                  rhsArg.typeFullName shouldBe s"$corePrefix.String"
+                  rhsArg.typeFullName shouldBe Defines.prefixAsCoreType("String")
                 case _ => fail("Expected LHS and RHS for assignment")
               }
             case _ => fail("Expected call for assignment")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
@@ -26,7 +26,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               localAst.code shouldBe "a"
               callAst.code shouldBe "a = 10"
 
-              literalAst.typeFullName shouldBe s"$builtinPrefix.String"
+              literalAst.typeFullName shouldBe s"$corePrefix.String"
 
               returnAst.code shouldBe "a"
             case _ =>
@@ -55,7 +55,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               inside(assignmentCall.argument.l) {
                 case lhsArg :: (rhsArg: Literal) :: Nil =>
                   lhsArg.code shouldBe "a"
-                  rhsArg.typeFullName shouldBe s"$builtinPrefix.String"
+                  rhsArg.typeFullName shouldBe s"$corePrefix.String"
                 case _ => fail("Expected LHS and RHS for assignment")
               }
             case _ => fail("Expected call for assignment")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
@@ -1,6 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
@@ -26,7 +26,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               localAst.code shouldBe "a"
               callAst.code shouldBe "a = 10"
 
-              literalAst.typeFullName shouldBe s"$kernelPrefix.String"
+              literalAst.typeFullName shouldBe s"$builtinPrefix.String"
 
               returnAst.code shouldBe "a"
             case _ =>
@@ -55,7 +55,7 @@ class HereDocTests extends RubyCode2CpgFixture {
               inside(assignmentCall.argument.l) {
                 case lhsArg :: (rhsArg: Literal) :: Nil =>
                   lhsArg.code shouldBe "a"
-                  rhsArg.typeFullName shouldBe s"$kernelPrefix.String"
+                  rhsArg.typeFullName shouldBe s"$builtinPrefix.String"
                 case _ => fail("Expected LHS and RHS for assignment")
               }
             case _ => fail("Expected call for assignment")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -2,7 +2,6 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.{Initialize, Main}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{corePrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.frontendspecific.rubysrc2cpg.{ImplicitRequirePass, ImportsPass, TypeImportInfo}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
@@ -380,10 +379,10 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
     "create a `require` call following the simplified format" in {
       val require = cpg.call("require").head
       require.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      require.methodFullName shouldBe s"$kernelPrefix.require"
+      require.methodFullName shouldBe Defines.prefixAsKernelDefined("require")
 
       val strLit = require.argument(1).asInstanceOf[Literal]
-      strLit.typeFullName shouldBe s"$kernelPrefix.String"
+      strLit.typeFullName shouldBe Defines.prefixAsCoreType("String")
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.{Initialize, Main}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{corePrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.joern.x2cpg.frontendspecific.rubysrc2cpg.{ImplicitRequirePass, ImportsPass, TypeImportInfo}
 import io.shiftleft.codepropertygraph.generated.DispatchTypes

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
-import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
@@ -17,7 +17,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "123"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
+    literal.typeFullName shouldBe s"$corePrefix.Integer"
   }
 
   "`3.14` is represented by a LITERAL node" in {
@@ -28,7 +28,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3.14"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Float"
+    literal.typeFullName shouldBe s"$corePrefix.Float"
   }
 
   "`3e10` is represented by a LITERAL node" in {
@@ -39,7 +39,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3e10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Float"
+    literal.typeFullName shouldBe s"$corePrefix.Float"
   }
 
   "`12e-10` is represented by a LITERAL node" in {
@@ -50,7 +50,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "12e-10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Float"
+    literal.typeFullName shouldBe s"$corePrefix.Float"
   }
 
   "`0b01` is represented by a LITERAL node" in {
@@ -61,7 +61,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0b01"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
+    literal.typeFullName shouldBe s"$corePrefix.Integer"
   }
 
   "`0xabc` is represented by a LITERAL node" in {
@@ -72,7 +72,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0xabc"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
+    literal.typeFullName shouldBe s"$corePrefix.Integer"
   }
 
   "`true` is represented by a LITERAL node" in {
@@ -83,7 +83,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "true"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.TrueClass"
+    literal.typeFullName shouldBe s"$corePrefix.TrueClass"
   }
 
   "`false` is represented by a LITERAL node" in {
@@ -94,7 +94,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "false"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.FalseClass"
+    literal.typeFullName shouldBe s"$corePrefix.FalseClass"
   }
 
   "`nil` is represented by a LITERAL node" in {
@@ -105,7 +105,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "nil"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.NilClass"
+    literal.typeFullName shouldBe s"$corePrefix.NilClass"
   }
 
   "`'hello'` is represented by a LITERAL node" in {
@@ -116,7 +116,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "'hello'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$corePrefix.String"
   }
 
   "`'x' 'y' 'z'` is represented by a dynamic literal node call" in {
@@ -130,11 +130,11 @@ class LiteralTests extends RubyCode2CpgFixture {
 
     inside(dynamicLitCall.argument.astChildren.l) { case (x: Literal) :: (y: Literal) :: (z: Literal) :: Nil =>
       x.code shouldBe "'x'"
-      x.typeFullName shouldBe s"$builtinPrefix.String"
+      x.typeFullName shouldBe s"$corePrefix.String"
       y.code shouldBe "'y'"
-      y.typeFullName shouldBe s"$builtinPrefix.String"
+      y.typeFullName shouldBe s"$corePrefix.String"
       z.code shouldBe "'z'"
-      z.typeFullName shouldBe s"$builtinPrefix.String"
+      z.typeFullName shouldBe s"$corePrefix.String"
     }
   }
 
@@ -146,7 +146,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "\"hello\""
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$corePrefix.String"
   }
 
   "`%q(hello)` is represented by a LITERAL node" in {
@@ -157,7 +157,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%q(hello)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$corePrefix.String"
   }
 
   "`%Q(hello world)` is represented by a LITERAL node" in {
@@ -168,7 +168,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%Q(hello world)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$corePrefix.String"
   }
 
   "`%(foo \"bar\" baz)` is represented by a LITERAL node" in {
@@ -179,7 +179,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%(foo \"bar\" baz)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.String"
+    literal.typeFullName shouldBe s"$corePrefix.String"
   }
 
   """`%q<\n...\n>` is represented by a LITERAL node""" in {
@@ -195,10 +195,10 @@ class LiteralTests extends RubyCode2CpgFixture {
     firstLine.lineNumber shouldBe Some(2)
     xyz.code.trim shouldBe "xyz"
     xyz.lineNumber shouldBe Some(3)
-    xyz.typeFullName shouldBe s"$builtinPrefix.String"
+    xyz.typeFullName shouldBe s"$corePrefix.String"
     one23.code.trim shouldBe "123"
     one23.lineNumber shouldBe Some(4)
-    one23.typeFullName shouldBe s"$builtinPrefix.String"
+    one23.typeFullName shouldBe s"$corePrefix.String"
   }
 
   "`:symbol` is represented by a LITERAL node" in {
@@ -209,7 +209,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":symbol"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Symbol"
+    literal.typeFullName shouldBe s"$corePrefix.Symbol"
   }
 
   "`:'symbol'` is represented by a LITERAL node" in {
@@ -220,7 +220,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":'symbol'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Symbol"
+    literal.typeFullName shouldBe s"$corePrefix.Symbol"
   }
 
   "`/(eu|us)/` is represented by a LITERAL node" in {
@@ -231,7 +231,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/(eu|us)/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Regexp"
+    literal.typeFullName shouldBe s"$corePrefix.Regexp"
   }
 
   "`/fedora|el-|centos/` is represented by a LITERAL node" in {
@@ -242,7 +242,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/fedora|el-|centos/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$builtinPrefix.Regexp"
+    literal.typeFullName shouldBe s"$corePrefix.Regexp"
   }
 
   "`/#{os_version_regex}/` is represented by a CALL node with a string format method full name" in {
@@ -254,7 +254,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(formatValueCall) = cpg.call.code("/#.*").l
     formatValueCall.code shouldBe "/#{os_version_regex}/"
     formatValueCall.lineNumber shouldBe Some(3)
-    formatValueCall.typeFullName shouldBe s"$builtinPrefix.Regexp"
+    formatValueCall.typeFullName shouldBe s"$corePrefix.Regexp"
     formatValueCall.methodFullName shouldBe Operators.formatString
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
+import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
+import io.joern.rubysrc2cpg.passes.GlobalTypes.builtinPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
@@ -16,7 +17,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "123"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Integer"
+    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
   }
 
   "`3.14` is represented by a LITERAL node" in {
@@ -27,7 +28,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3.14"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Float"
+    literal.typeFullName shouldBe s"$builtinPrefix.Float"
   }
 
   "`3e10` is represented by a LITERAL node" in {
@@ -38,7 +39,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3e10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Float"
+    literal.typeFullName shouldBe s"$builtinPrefix.Float"
   }
 
   "`12e-10` is represented by a LITERAL node" in {
@@ -49,7 +50,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "12e-10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Float"
+    literal.typeFullName shouldBe s"$builtinPrefix.Float"
   }
 
   "`0b01` is represented by a LITERAL node" in {
@@ -60,7 +61,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0b01"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Integer"
+    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
   }
 
   "`0xabc` is represented by a LITERAL node" in {
@@ -71,7 +72,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0xabc"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Integer"
+    literal.typeFullName shouldBe s"$builtinPrefix.Integer"
   }
 
   "`true` is represented by a LITERAL node" in {
@@ -82,7 +83,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "true"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.TrueClass"
+    literal.typeFullName shouldBe s"$builtinPrefix.TrueClass"
   }
 
   "`false` is represented by a LITERAL node" in {
@@ -93,7 +94,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "false"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.FalseClass"
+    literal.typeFullName shouldBe s"$builtinPrefix.FalseClass"
   }
 
   "`nil` is represented by a LITERAL node" in {
@@ -104,7 +105,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "nil"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.NilClass"
+    literal.typeFullName shouldBe s"$builtinPrefix.NilClass"
   }
 
   "`'hello'` is represented by a LITERAL node" in {
@@ -115,7 +116,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "'hello'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`'x' 'y' 'z'` is represented by a dynamic literal node call" in {
@@ -129,11 +130,11 @@ class LiteralTests extends RubyCode2CpgFixture {
 
     inside(dynamicLitCall.argument.astChildren.l) { case (x: Literal) :: (y: Literal) :: (z: Literal) :: Nil =>
       x.code shouldBe "'x'"
-      x.typeFullName shouldBe s"$kernelPrefix.String"
+      x.typeFullName shouldBe s"$builtinPrefix.String"
       y.code shouldBe "'y'"
-      y.typeFullName shouldBe s"$kernelPrefix.String"
+      y.typeFullName shouldBe s"$builtinPrefix.String"
       z.code shouldBe "'z'"
-      z.typeFullName shouldBe s"$kernelPrefix.String"
+      z.typeFullName shouldBe s"$builtinPrefix.String"
     }
   }
 
@@ -145,7 +146,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "\"hello\""
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`%q(hello)` is represented by a LITERAL node" in {
@@ -156,7 +157,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%q(hello)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`%Q(hello world)` is represented by a LITERAL node" in {
@@ -167,7 +168,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%Q(hello world)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`%(foo \"bar\" baz)` is represented by a LITERAL node" in {
@@ -178,7 +179,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%(foo \"bar\" baz)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.String"
+    literal.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   """`%q<\n...\n>` is represented by a LITERAL node""" in {
@@ -194,10 +195,10 @@ class LiteralTests extends RubyCode2CpgFixture {
     firstLine.lineNumber shouldBe Some(2)
     xyz.code.trim shouldBe "xyz"
     xyz.lineNumber shouldBe Some(3)
-    xyz.typeFullName shouldBe s"$kernelPrefix.String"
+    xyz.typeFullName shouldBe s"$builtinPrefix.String"
     one23.code.trim shouldBe "123"
     one23.lineNumber shouldBe Some(4)
-    one23.typeFullName shouldBe s"$kernelPrefix.String"
+    one23.typeFullName shouldBe s"$builtinPrefix.String"
   }
 
   "`:symbol` is represented by a LITERAL node" in {
@@ -208,7 +209,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":symbol"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Symbol"
+    literal.typeFullName shouldBe s"$builtinPrefix.Symbol"
   }
 
   "`:'symbol'` is represented by a LITERAL node" in {
@@ -219,7 +220,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":'symbol'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Symbol"
+    literal.typeFullName shouldBe s"$builtinPrefix.Symbol"
   }
 
   "`/(eu|us)/` is represented by a LITERAL node" in {
@@ -230,7 +231,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/(eu|us)/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Regexp"
+    literal.typeFullName shouldBe s"$builtinPrefix.Regexp"
   }
 
   "`/fedora|el-|centos/` is represented by a LITERAL node" in {
@@ -241,7 +242,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/fedora|el-|centos/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$kernelPrefix.Regexp"
+    literal.typeFullName shouldBe s"$builtinPrefix.Regexp"
   }
 
   "`/#{os_version_regex}/` is represented by a CALL node with a string format method full name" in {
@@ -253,7 +254,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(formatValueCall) = cpg.call.code("/#.*").l
     formatValueCall.code shouldBe "/#{os_version_regex}/"
     formatValueCall.lineNumber shouldBe Some(3)
-    formatValueCall.typeFullName shouldBe s"$kernelPrefix.Regexp"
+    formatValueCall.typeFullName shouldBe s"$builtinPrefix.Regexp"
     formatValueCall.methodFullName shouldBe Operators.formatString
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -1,7 +1,6 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
-import io.joern.rubysrc2cpg.passes.GlobalTypes.corePrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
@@ -17,7 +16,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "123"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Integer"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
   }
 
   "`3.14` is represented by a LITERAL node" in {
@@ -28,7 +27,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3.14"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Float"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Float")
   }
 
   "`3e10` is represented by a LITERAL node" in {
@@ -39,7 +38,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "3e10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Float"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Float")
   }
 
   "`12e-10` is represented by a LITERAL node" in {
@@ -50,7 +49,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "12e-10"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Float"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Float")
   }
 
   "`0b01` is represented by a LITERAL node" in {
@@ -61,7 +60,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0b01"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Integer"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
   }
 
   "`0xabc` is represented by a LITERAL node" in {
@@ -72,7 +71,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "0xabc"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Integer"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
   }
 
   "`true` is represented by a LITERAL node" in {
@@ -83,7 +82,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "true"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.TrueClass"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("TrueClass")
   }
 
   "`false` is represented by a LITERAL node" in {
@@ -94,7 +93,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "false"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.FalseClass"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("FalseClass")
   }
 
   "`nil` is represented by a LITERAL node" in {
@@ -105,7 +104,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "nil"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.NilClass"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("NilClass")
   }
 
   "`'hello'` is represented by a LITERAL node" in {
@@ -116,7 +115,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "'hello'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.String"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
   }
 
   "`'x' 'y' 'z'` is represented by a dynamic literal node call" in {
@@ -130,11 +129,11 @@ class LiteralTests extends RubyCode2CpgFixture {
 
     inside(dynamicLitCall.argument.astChildren.l) { case (x: Literal) :: (y: Literal) :: (z: Literal) :: Nil =>
       x.code shouldBe "'x'"
-      x.typeFullName shouldBe s"$corePrefix.String"
+      x.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
       y.code shouldBe "'y'"
-      y.typeFullName shouldBe s"$corePrefix.String"
+      y.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
       z.code shouldBe "'z'"
-      z.typeFullName shouldBe s"$corePrefix.String"
+      z.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
     }
   }
 
@@ -146,7 +145,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "\"hello\""
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.String"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
   }
 
   "`%q(hello)` is represented by a LITERAL node" in {
@@ -157,7 +156,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%q(hello)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.String"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
   }
 
   "`%Q(hello world)` is represented by a LITERAL node" in {
@@ -168,7 +167,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%Q(hello world)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.String"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
   }
 
   "`%(foo \"bar\" baz)` is represented by a LITERAL node" in {
@@ -179,7 +178,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "%(foo \"bar\" baz)"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.String"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
   }
 
   """`%q<\n...\n>` is represented by a LITERAL node""" in {
@@ -195,10 +194,10 @@ class LiteralTests extends RubyCode2CpgFixture {
     firstLine.lineNumber shouldBe Some(2)
     xyz.code.trim shouldBe "xyz"
     xyz.lineNumber shouldBe Some(3)
-    xyz.typeFullName shouldBe s"$corePrefix.String"
+    xyz.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
     one23.code.trim shouldBe "123"
     one23.lineNumber shouldBe Some(4)
-    one23.typeFullName shouldBe s"$corePrefix.String"
+    one23.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
   }
 
   "`:symbol` is represented by a LITERAL node" in {
@@ -209,7 +208,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":symbol"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Symbol"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Symbol")
   }
 
   "`:'symbol'` is represented by a LITERAL node" in {
@@ -220,7 +219,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe ":'symbol'"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Symbol"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Symbol")
   }
 
   "`/(eu|us)/` is represented by a LITERAL node" in {
@@ -231,7 +230,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/(eu|us)/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Regexp"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Regexp")
   }
 
   "`/fedora|el-|centos/` is represented by a LITERAL node" in {
@@ -242,7 +241,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(literal) = cpg.literal.l
     literal.code shouldBe "/fedora|el-|centos/"
     literal.lineNumber shouldBe Some(2)
-    literal.typeFullName shouldBe s"$corePrefix.Regexp"
+    literal.typeFullName shouldBe RubyDefines.prefixAsCoreType("Regexp")
   }
 
   "`/#{os_version_regex}/` is represented by a CALL node with a string format method full name" in {
@@ -254,7 +253,7 @@ class LiteralTests extends RubyCode2CpgFixture {
     val List(formatValueCall) = cpg.call.code("/#.*").l
     formatValueCall.code shouldBe "/#{os_version_regex}/"
     formatValueCall.lineNumber shouldBe Some(3)
-    formatValueCall.typeFullName shouldBe s"$corePrefix.Regexp"
+    formatValueCall.typeFullName shouldBe RubyDefines.prefixAsCoreType("Regexp")
     formatValueCall.methodFullName shouldBe Operators.formatString
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{corePrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
@@ -156,7 +156,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
 
     val List(s: Literal) = r.astChildren.isLiteral.l
     s.code shouldBe ":g"
-    s.typeFullName shouldBe s"$builtinPrefix.Symbol"
+    s.typeFullName shouldBe s"$corePrefix.Symbol"
   }
 
   "explicit RETURN node for `\"\"` exists" in {
@@ -192,14 +192,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            twenty.typeFullName shouldBe s"$corePrefix.Integer"
 
             returnNil.code shouldBe "return nil"
             returnNil.lineNumber shouldBe Some(3)
             val List(nil: Literal) = returnNil.astChildren.l: @unchecked
             nil.code shouldBe "nil"
             nil.lineNumber shouldBe Some(3)
-            nil.typeFullName shouldBe s"$builtinPrefix.NilClass"
+            nil.typeFullName shouldBe s"$corePrefix.NilClass"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -227,14 +227,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            twenty.typeFullName shouldBe s"$corePrefix.Integer"
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(6)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(6)
-            forty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            forty.typeFullName shouldBe s"$corePrefix.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -297,14 +297,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(2)
-            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            twenty.typeFullName shouldBe s"$corePrefix.Integer"
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(2)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(2)
-            forty.typeFullName shouldBe s"$builtinPrefix.Integer"
+            forty.typeFullName shouldBe s"$corePrefix.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -430,7 +430,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
 
     inside(cpg.method.nameExact("foo").methodReturn.toReturn.astChildren.l) {
       case (heredoc: Literal) :: Nil =>
-        heredoc.typeFullName shouldBe s"$builtinPrefix.String"
+        heredoc.typeFullName shouldBe s"$corePrefix.String"
         heredoc.code should startWith("   puts \"hello\"")
       case xs => fail(s"Expected a single literal node, instead got [${xs.code.mkString(", ")}]")
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{builtinPrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
@@ -156,7 +156,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
 
     val List(s: Literal) = r.astChildren.isLiteral.l
     s.code shouldBe ":g"
-    s.typeFullName shouldBe s"$kernelPrefix.Symbol"
+    s.typeFullName shouldBe s"$builtinPrefix.Symbol"
   }
 
   "explicit RETURN node for `\"\"` exists" in {
@@ -192,14 +192,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe s"$kernelPrefix.Integer"
+            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
 
             returnNil.code shouldBe "return nil"
             returnNil.lineNumber shouldBe Some(3)
             val List(nil: Literal) = returnNil.astChildren.l: @unchecked
             nil.code shouldBe "nil"
             nil.lineNumber shouldBe Some(3)
-            nil.typeFullName shouldBe s"$kernelPrefix.NilClass"
+            nil.typeFullName shouldBe s"$builtinPrefix.NilClass"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -227,14 +227,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe s"$kernelPrefix.Integer"
+            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(6)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(6)
-            forty.typeFullName shouldBe s"$kernelPrefix.Integer"
+            forty.typeFullName shouldBe s"$builtinPrefix.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -297,14 +297,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(2)
-            twenty.typeFullName shouldBe s"$kernelPrefix.Integer"
+            twenty.typeFullName shouldBe s"$builtinPrefix.Integer"
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(2)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(2)
-            forty.typeFullName shouldBe s"$kernelPrefix.Integer"
+            forty.typeFullName shouldBe s"$builtinPrefix.Integer"
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -430,7 +430,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
 
     inside(cpg.method.nameExact("foo").methodReturn.toReturn.astChildren.l) {
       case (heredoc: Literal) :: Nil =>
-        heredoc.typeFullName shouldBe s"$kernelPrefix.String"
+        heredoc.typeFullName shouldBe s"$builtinPrefix.String"
         heredoc.code should startWith("   puts \"hello\"")
       case xs => fail(s"Expected a single literal node, instead got [${xs.code.mkString(", ")}]")
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
+import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
 import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{corePrefix, kernelPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
@@ -72,7 +72,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     r.lineNumber shouldBe Some(3)
 
     val List(c: Call) = r.astChildren.isCall.l
-    c.methodFullName shouldBe s"$kernelPrefix.puts"
+    c.methodFullName shouldBe RubyDefines.prefixAsKernelDefined("puts")
     c.lineNumber shouldBe Some(3)
     c.code shouldBe "puts x"
   }
@@ -156,7 +156,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
 
     val List(s: Literal) = r.astChildren.isLiteral.l
     s.code shouldBe ":g"
-    s.typeFullName shouldBe s"$corePrefix.Symbol"
+    s.typeFullName shouldBe RubyDefines.prefixAsCoreType("Symbol")
   }
 
   "explicit RETURN node for `\"\"` exists" in {
@@ -192,14 +192,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe s"$corePrefix.Integer"
+            twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
 
             returnNil.code shouldBe "return nil"
             returnNil.lineNumber shouldBe Some(3)
             val List(nil: Literal) = returnNil.astChildren.l: @unchecked
             nil.code shouldBe "nil"
             nil.lineNumber shouldBe Some(3)
-            nil.typeFullName shouldBe s"$corePrefix.NilClass"
+            nil.typeFullName shouldBe RubyDefines.prefixAsCoreType("NilClass")
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -227,14 +227,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe s"$corePrefix.Integer"
+            twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(6)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(6)
-            forty.typeFullName shouldBe s"$corePrefix.Integer"
+            forty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -297,14 +297,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
             val List(twenty: Literal) = return20.astChildren.l: @unchecked
             twenty.code shouldBe "20"
             twenty.lineNumber shouldBe Some(2)
-            twenty.typeFullName shouldBe s"$corePrefix.Integer"
+            twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
 
             return40.code shouldBe "40"
             return40.lineNumber shouldBe Some(2)
             val List(forty: Literal) = return40.astChildren.l: @unchecked
             forty.code shouldBe "40"
             forty.lineNumber shouldBe Some(2)
-            forty.typeFullName shouldBe s"$corePrefix.Integer"
+            forty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
           case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
         }
       case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
@@ -430,7 +430,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
 
     inside(cpg.method.nameExact("foo").methodReturn.toReturn.astChildren.l) {
       case (heredoc: Literal) :: Nil =>
-        heredoc.typeFullName shouldBe s"$corePrefix.String"
+        heredoc.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
         heredoc.code should startWith("   puts \"hello\"")
       case xs => fail(s"Expected a single literal node, instead got [${xs.code.mkString(", ")}]")
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
 import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{kernelPrefix, builtinPrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
@@ -273,7 +273,7 @@ class MethodTests extends RubyCode2CpgFixture {
           xs.name shouldBe "xs"
           xs.code shouldBe "*xs"
           xs.isVariadic shouldBe true
-          xs.typeFullName shouldBe s"$kernelPrefix.Array"
+          xs.typeFullName shouldBe s"$builtinPrefix.Array"
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }
@@ -284,7 +284,7 @@ class MethodTests extends RubyCode2CpgFixture {
           ys.name shouldBe "ys"
           ys.code shouldBe "**ys"
           ys.isVariadic shouldBe true
-          ys.typeFullName shouldBe s"$kernelPrefix.Hash"
+          ys.typeFullName shouldBe s"$builtinPrefix.Hash"
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }
@@ -973,10 +973,10 @@ class MethodTests extends RubyCode2CpgFixture {
         inside(barCall.argument.l) {
           case _ :: (arg1: Literal) :: (arg2: Literal) :: Nil =>
             arg1.code shouldBe "1"
-            arg1.typeFullName shouldBe RDefines.getBuiltInType(RDefines.Integer)
+            arg1.typeFullName shouldBe RDefines.getCoreType(RDefines.Integer)
 
             arg2.code shouldBe "2"
-            arg2.typeFullName shouldBe RDefines.getBuiltInType(RDefines.Integer)
+            arg2.typeFullName shouldBe RDefines.getCoreType(RDefines.Integer)
           case xs => fail(s"Expected three args, got [${xs.code.mkString(",")}]")
         }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -2,7 +2,6 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
 import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{kernelPrefix, corePrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
@@ -273,7 +272,7 @@ class MethodTests extends RubyCode2CpgFixture {
           xs.name shouldBe "xs"
           xs.code shouldBe "*xs"
           xs.isVariadic shouldBe true
-          xs.typeFullName shouldBe s"$corePrefix.Array"
+          xs.typeFullName shouldBe RDefines.prefixAsCoreType("Array")
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }
@@ -284,7 +283,7 @@ class MethodTests extends RubyCode2CpgFixture {
           ys.name shouldBe "ys"
           ys.code shouldBe "**ys"
           ys.isVariadic shouldBe true
-          ys.typeFullName shouldBe s"$corePrefix.Hash"
+          ys.typeFullName shouldBe RDefines.prefixAsCoreType("Hash")
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }
@@ -973,10 +972,10 @@ class MethodTests extends RubyCode2CpgFixture {
         inside(barCall.argument.l) {
           case _ :: (arg1: Literal) :: (arg2: Literal) :: Nil =>
             arg1.code shouldBe "1"
-            arg1.typeFullName shouldBe RDefines.getCoreType(RDefines.Integer)
+            arg1.typeFullName shouldBe RDefines.prefixAsCoreType(RDefines.Integer)
 
             arg2.code shouldBe "2"
-            arg2.typeFullName shouldBe RDefines.getCoreType(RDefines.Integer)
+            arg2.typeFullName shouldBe RDefines.prefixAsCoreType(RDefines.Integer)
           case xs => fail(s"Expected three args, got [${xs.code.mkString(",")}]")
         }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines as RDefines
 import io.joern.rubysrc2cpg.passes.Defines.{Main, RubyOperators}
-import io.joern.rubysrc2cpg.passes.GlobalTypes.{kernelPrefix, builtinPrefix}
+import io.joern.rubysrc2cpg.passes.GlobalTypes.{kernelPrefix, corePrefix}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, NodeTypes, Operators}
@@ -273,7 +273,7 @@ class MethodTests extends RubyCode2CpgFixture {
           xs.name shouldBe "xs"
           xs.code shouldBe "*xs"
           xs.isVariadic shouldBe true
-          xs.typeFullName shouldBe s"$builtinPrefix.Array"
+          xs.typeFullName shouldBe s"$corePrefix.Array"
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }
@@ -284,7 +284,7 @@ class MethodTests extends RubyCode2CpgFixture {
           ys.name shouldBe "ys"
           ys.code shouldBe "**ys"
           ys.isVariadic shouldBe true
-          ys.typeFullName shouldBe s"$builtinPrefix.Hash"
+          ys.typeFullName shouldBe s"$corePrefix.Hash"
         case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -1,10 +1,10 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.{Defines, GlobalTypes}
 import io.joern.rubysrc2cpg.passes.Defines.Main
+import io.joern.rubysrc2cpg.passes.{Defines, GlobalTypes}
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes.{File, Literal, NamespaceBlock}
+import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language.*
 
 class ModuleTests extends RubyCode2CpgFixture {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -1,10 +1,8 @@
 package io.joern.rubysrc2cpg.querying
 
-import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
-import io.joern.rubysrc2cpg.passes.GlobalTypes.kernelPrefix
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.semanticcpg.language.*
 
 class RegexTests extends RubyCode2CpgFixture(withPostProcessing = false) {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -25,7 +25,7 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = false) {
       val tmpSource = tmpInit.source.asInstanceOf[Call]
       tmpSource.code shouldBe s"/h(el)lo/.match($expectedSubject)"
       tmpSource.name shouldBe "match"
-      tmpSource.methodFullName shouldBe "__core.Kernel.Regexp.match"
+      tmpSource.methodFullName shouldBe "__core.Regexp.match"
 
       // Now test for the lowered global variable assignments
       val ifStmt = cpg.controlStructure.last

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -292,13 +292,13 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
 
                 inside(lhs.argument.l) {
                   case base :: (index: Literal) :: Nil =>
-                    index.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.Symbol)
+                    index.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Symbol)
                   case xs => fail(s"Expected base and index, got [${xs.code.mkString(",")}]")
                 }
 
                 inside(rhs.argument.l) {
                   case base :: (index: Literal) :: Nil =>
-                    index.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.Symbol)
+                    index.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Symbol)
                   case xs => fail(s"Expected base and index, got [${xs.code.mkString(",")}]")
                 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -2,7 +2,7 @@ package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines as RubyDefines
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 
@@ -292,13 +292,13 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
 
                 inside(lhs.argument.l) {
                   case base :: (index: Literal) :: Nil =>
-                    index.typeFullName shouldBe RubyDefines.getBuiltInType(RubyDefines.Symbol)
+                    index.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.Symbol)
                   case xs => fail(s"Expected base and index, got [${xs.code.mkString(",")}]")
                 }
 
                 inside(rhs.argument.l) {
                   case base :: (index: Literal) :: Nil =>
-                    index.typeFullName shouldBe RubyDefines.getBuiltInType(RubyDefines.Symbol)
+                    index.typeFullName shouldBe RubyDefines.getCoreType(RubyDefines.Symbol)
                   case xs => fail(s"Expected base and index, got [${xs.code.mkString(",")}]")
                 }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/ImplicitRequirePass.scala
@@ -148,7 +148,7 @@ class ImplicitRequirePass(cpg: Cpg, externalTypes: Seq[TypeImportInfo] = Nil)
     builder.addNode(requireCallNode)
     // Create literal argument
     val pathLiteralNode =
-      NewLiteral().code(s"'$path'").typeFullName(s"$kernelPrefix.String").argumentIndex(1).order(2)
+      NewLiteral().code(s"'$path'").typeFullName(s"$builtinPrefix.String").argumentIndex(1).order(2)
     builder.addEdge(requireCallNode, pathLiteralNode, EdgeTypes.AST)
     builder.addEdge(requireCallNode, pathLiteralNode, EdgeTypes.ARGUMENT)
     requireCallNode


### PR DESCRIPTION
It was recently determined that bundled types were prefixed with the `__core.Kernel` prefix which was unintended, as it should only go as far as `__core`.

This change remediates this, as well as logs a warning when a full name is attempted to be constructed in a way that will generate a bundled type with the `__core.Kernel` prefix, or if a non-bundled type will be created with a `__core` prefix.