### PR TITLE
[c#] fix typeFullName for fieldAccess of same-class members

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -589,6 +589,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       .map(x => (x.typeName, false))
       .orElse(byPropertyName.map(x => (x.returnType, true)))
       .orElse(byQualifiedName.map(x => (x.name, false)))
+      .map((typeName, isGetter) => (scope.tryResolveTypeReference(typeName).map(_.name).getOrElse(typeName), isGetter))
       .getOrElse((Defines.Any, false))
 
     if (isGetter) {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ClassDeclarationTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ClassDeclarationTests.scala
@@ -19,4 +19,26 @@ class ClassDeclarationTests extends CSharpCode2CpgFixture {
     }
   }
 
+  "class with member of the same type involved in a fieldAccess" should {
+    val cpg = code("""
+        |namespace Foo;
+        |class Bar
+        |{
+        | Bar Field;
+        | void DoStuff()
+        | {
+        |   var x = this.Field;
+        | }
+        |}
+        |""".stripMargin)
+
+    "have correct typeDecl properties" in {
+      cpg.typeDecl.nameExact("Bar").fullName.l shouldBe List("Foo.Bar")
+    }
+
+    "have correct member properties" in {
+      cpg.typeDecl.nameExact("Bar").member.nameExact("Field").typeFullName.l shouldBe List("Foo.Bar")
+    }
+  }
+
 }


### PR DESCRIPTION
Noticed this sample was yielding 2 TYPE_DECLs (`Bar` and `Foo.Bar`):

```c#
namespace Foo;
class Bar {
  Bar Field1;
  void DoStuff() { var x = this.Field1; }
}
```

Reason: `this.Field1` had typeFullName `Bar` only.