### PR TITLE
[ruby] Persist JRuby Script Container with Environment 

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -21,9 +21,9 @@ final case class Config(downloadDependencies: Boolean = false, useTypeStubs: Boo
   override val astGenConfigPrefix: String       = "rubysrc2cpg"
   override val multiArchitectureBuilds: Boolean = true
 
-  this.defaultIgnoredFilesRegex = List("spec", "tests?", "vendor", "db(\\\\|/)([\\w_]*)migrate([_\\w]*)").flatMap {
+  this.defaultIgnoredFilesRegex = List("spec", "tests?", "vendor", "db(\\\\|\\/)([\\w_]*)migrate([_\\w]*)").flatMap {
     directory =>
-      List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|/)$directory($$|/)".r.unanchored)
+      List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|\\/)$directory($$|\\/)".r.unanchored)
   }
 
   override def withDownloadDependencies(value: Boolean): Config = {


### PR DESCRIPTION
Persisting the lazily created JRuby execution environment and loaded global variables with cleaning up only happening at shutdown.

This removes the overhead of JRuby instantiating a Ruby environment for each RubySrc2Cpg.