### PR TITLE
fix tab-completion in distribution

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -133,15 +133,15 @@ Universal/mappings ++= sbt.Path.directory(new File("joern-cli/src/main/resources
 
 // remove module-info.class from dependency jars - a hacky workaround for a scala3 compiler bug
 // see https://github.com/scala/scala3/issues/20421
-val moduleInfoLocation = "/module-info.class"
+val moduleInfoLocation = "module-info.class"
 Universal/mappings := (Universal/mappings).value.collect {
   case (jar, location)
       if location.startsWith("lib")
       && location.endsWith(".jar")
-      && FileUtils.jarContainsEntry(jar, moduleInfoLocation, onlyAtRootLevel = true) =>
+      && FileUtils.jarContainsEntryInRoot(jar, moduleInfoLocation) =>
     val newJar = target.value / "without-module-info" / jar.getName()
     IO.copyFile(jar, newJar)
-    FileUtils.removeJarEntry(newJar, moduleInfoLocation, onlyAtRootLevel = true)
+    FileUtils.removeJarEntryFromRoot(newJar, moduleInfoLocation)
     streams.value.log.info(s"workaround for scala completion bug: including a modified version of $jar without the $moduleInfoLocation entry: $newJar")
     newJar -> location
   case other =>

--- a/project/FileUtils.scala
+++ b/project/FileUtils.scala
@@ -19,27 +19,22 @@ object FileUtils {
     }
   }
 
-  /** checks if the given jar contains the given entry */
-  def jarContainsEntry(jar: File, entry: String, onlyAtRootLevel: Boolean = false): Boolean = {
+  /** checks if the given jar contains the given entry in the root directory
+    */
+  def jarContainsEntryInRoot(jar: File, entry: String): Boolean = {
     val zipFs = FileSystems.newFileSystem(jar.toPath)
     val result = zipFs.getRootDirectories.asScala.exists { zipRootDir =>
-      val iterable =
-        if (onlyAtRootLevel) Files.list(zipRootDir)
-        else Files.walk(zipRootDir)
-      iterable.iterator.asScala.exists(_.toString == entry)
+      Files.list(zipRootDir).iterator.asScala.exists(_.getFileName.toString == entry)
     }
     zipFs.close()
     result
   }
 
-  /** removes the given entry from the given jar */
-  def removeJarEntry(jar: File, entry: String, onlyAtRootLevel: Boolean = false): Unit = {
+  /** removes the given entry from the given jar, only at root level */
+  def removeJarEntryFromRoot(jar: File, entry: String): Unit = {
     val zipFs = FileSystems.newFileSystem(jar.toPath)
     zipFs.getRootDirectories.forEach { zipRootDir =>
-      val iterable =
-        if (onlyAtRootLevel) Files.list(zipRootDir)
-        else Files.walk(zipRootDir)
-      iterable.filter(_.toString == entry).forEach(Files.delete(_))
+      Files.list(zipRootDir).filter(_.getFileName.toString == entry).forEach(Files.delete(_))
     }
     zipFs.close()
   }


### PR DESCRIPTION
the `removeModuleInfoFromJars` hack only get's triggered for
`Universal/stage` - our release uses `Universal/packageBin` and that
doesn't seem to reuse anything related that we could trigger on
unfortunately...
So I thought it's easiest to just add the same hack to the start
script...

fixes https://github.com/joernio/joern/issues/4625