### PR TITLE
[c#] fix `.code` property for calls with comments surrounding them

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -2,7 +2,7 @@ package io.joern.csharpsrc2cpg.astcreation
 
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
 import io.joern.csharpsrc2cpg.parser.{DotNetJsonAst, DotNetNodeInfo, ParserKeys}
-import io.joern.csharpsrc2cpg.utils.Utils.{withoutSignature}
+import io.joern.csharpsrc2cpg.utils.Utils.withoutSignature
 import io.joern.csharpsrc2cpg.{CSharpDefines, Constants, astcreation}
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
@@ -211,6 +211,12 @@ object AstCreatorHelper {
     val c = node.toString match
       case "Attribute" =>
         metaData(ParserKeys.Code).strOpt.map(x => x.takeWhile(x => x != '\n')).getOrElse("<empty>").strip()
+      // Comments may end up in the `.code` for invocations. To workaround this, we parse '\n' and take the last line.
+      // TODO: Investigate the possibility of filtering trivia(comments) with DotNetAstGen from the start. Or, if we wish
+      //  to keep comments for potential analyses, output the JSON trivia AST as well and explicitly handle it with
+      //  a dedicated DotNetNodeInfo.
+      case "InvocationExpression" =>
+        metaData(ParserKeys.Code).strOpt.map(x => x.split('\n').last).getOrElse("<empty>").strip()
       case _ =>
         metaData(ParserKeys.Code).strOpt.map(x => x.takeWhile(x => x != '\n' && x != '{')).getOrElse("<empty>").strip()
     DotNetNodeInfo(node, json, c, ln, cn, lnEnd, cnEnd)

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/CallTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/CallTests.scala
@@ -196,4 +196,35 @@ class CallTests extends CSharpCode2CpgFixture {
     }
   }
 
+  "call expression statements with surrounding comments" should {
+    val cpg = code("""
+        |/* Hey! */
+        |System.Console.WriteLine("Foo");
+        |// Hey2!
+        |System.Console.WriteLine("Bar");
+        |System.Console.WriteLine(0);
+        |// Hey3!
+        |
+        |System.Console.WriteLine(1); // Hey4!
+        |""".stripMargin)
+
+    "have correct code for call with block comment above it" in {
+      cpg.call.nameExact("WriteLine").code.headOption shouldBe Some("System.Console.WriteLine(\"Foo\")")
+    }
+
+    "have correct code for call with line comment above it" in {
+      cpg.literal("\"Bar\"").inCall.nameExact("WriteLine").code.headOption shouldBe Some(
+        "System.Console.WriteLine(\"Bar\")"
+      )
+    }
+
+    "have correct code for call with line comment below it" in {
+      cpg.literal("0").inCall.nameExact("WriteLine").code.headOption shouldBe Some("System.Console.WriteLine(0)")
+    }
+
+    "have correct code for call with line comment immediately after it (same-line)" in {
+      cpg.literal("1").inCall.nameExact("WriteLine").code.headOption shouldBe Some("System.Console.WriteLine(1)")
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes `.code` for the following statement:

```c#
// some comment
System.Console.Out.WriteLine("X");
```

in which we currently get

```scala
cpg.call.nameExact("WriteLine").head.code == "// some comment"
```