### PR TITLE
[javasrc2cpg] Add name mangling for pattern locals that conflict with locals in the enclosing scope

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -280,13 +280,13 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
         val scopeVariable = variables.head
         val capturedLocal = localNode(
           lambdaNode,
-          scopeVariable.name,
-          scopeVariable.name,
+          scopeVariable.mangledName,
+          scopeVariable.mangledName,
           scopeVariable.typeFullName,
           Option(closureBindingId),
           Option(scopeVariable.genericSignature)
         )
-        scope.enclosingBlock.foreach(_.addLocal(capturedLocal))
+        scope.enclosingBlock.foreach(_.addLocal(capturedLocal, scopeVariable.name))
 
         ClosureBindingEntry(scopeVariable, closureBindingNode) -> capturedLocal
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForPatternExpressionsCreator.scala
@@ -45,86 +45,6 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  trait PatternInitTreeNode(val patternExpr: PatternExpr) {
-    def getAst: Ast
-
-    def typeFullName: Option[String]
-  }
-
-  class PatternInitRoot(patternExpr: PatternExpr, ast: PatternInitAndRefAsts) extends PatternInitTreeNode(patternExpr) {
-    override def getAst: Ast = ast.get
-
-    override def typeFullName: Option[String] = ast.rootType
-  }
-
-  class PatternInitNode(
-    parentNode: PatternInitTreeNode,
-    patternExpr: PatternExpr,
-    fieldName: String,
-    fieldTypeFullName: Option[String],
-    requiresTemporaryVariable: Boolean
-  ) extends PatternInitTreeNode(patternExpr) {
-    private var cachedResult: Option[PatternInitAndRefAsts] = None
-
-    override def typeFullName: Option[String] = fieldTypeFullName
-
-    override def getAst: Ast = {
-      cachedResult.map(_.get).getOrElse {
-        val parentAst = parentNode.getAst
-        val patternTypeFullName = tryWithSafeStackOverflow(patternExpr.getType).toOption
-          .map { typ =>
-            scope
-              .lookupScopeType(typ.asString())
-              .map(_.typeFullName)
-              .orElse(typeInfoCalc.fullName(typ))
-              .getOrElse(defaultTypeFallback(typ))
-          }
-          .getOrElse(defaultTypeFallback())
-
-        val parentPatternType = getPatternTypeFullName(parentNode.patternExpr)
-        val lhsAst            = castAstIfNecessary(parentNode.patternExpr, parentPatternType, parentAst)
-
-        val signature = composeSignature(fieldTypeFullName, Option(Nil), 0)
-        val typeDeclFullName =
-          if (isResolvedTypeFullName(parentPatternType))
-            parentPatternType
-          else
-            s"${Defines.UnresolvedNamespace}.${code(parentNode.patternExpr.getType)}"
-        val methodFullName = Util.composeMethodFullName(typeDeclFullName, fieldName, signature)
-        val methodCodePrefix = lhsAst.root match {
-          case Some(call: NewCall) if call.name.startsWith("<operator") => s"(${call.code})"
-          case Some(root: AstNodeNew)                                   => root.code
-          case _                                                        => ""
-
-        }
-        val methodCode = s"$methodCodePrefix.$fieldName()"
-
-        val fieldAccessorCall = callNode(
-          patternExpr,
-          methodCode,
-          fieldName,
-          methodFullName,
-          DispatchTypes.DYNAMIC_DISPATCH,
-          Option(signature),
-          fieldTypeFullName.orElse(Option(defaultTypeFallback()))
-        )
-
-        val fieldAccessorAst = callAst(fieldAccessorCall, Nil, Option(lhsAst))
-
-        val patternInitWithRef = if (requiresTemporaryVariable) {
-          val patternInitWithRef = initAndRefAstsForPatternInitializer(patternExpr, fieldAccessorAst)
-          patternInitWithRef
-        } else {
-          PatternInitAndRefAsts(fieldAccessorAst)
-        }
-
-        cachedResult = Option(patternInitWithRef)
-
-        patternInitWithRef.get
-      }
-    }
-  }
-
   /** In the lowering for instanceof expressions with patterns like `X instanceof Foo f`, the first argument to
     * `instanceof` (in this case `X`) appears in the CPG at least 2 times:
     *   - once for the `X instanceof Foo` check
@@ -174,7 +94,7 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
 
         // Don't need to add the local to the block scope since the only identifiers referencing it are created here
         // (so a lookup for the local will never be done)
-        scope.enclosingMethod.foreach(_.putPatternLocals(tmpLocal, None))
+        scope.enclosingMethod.foreach(_.registerLocalToAddToCpg(tmpLocal))
 
         val initAst =
           callAst(tmpAssignmentNode, Ast(tmpIdentifier) :: patternInitAst :: Nil).withRefEdge(tmpIdentifier, tmpLocal)
@@ -212,6 +132,7 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
 
       case typePatternExpr: TypePatternExpr =>
         val variableName = typePatternExpr.getNameAsString
+
         val variableType = {
           tryWithSafeStackOverflow(typePatternExpr.getType).toOption
             .map(typ =>
@@ -225,15 +146,28 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
         }
         val variableTypeCode = tryWithSafeStackOverflow(code(typePatternExpr.getType)).getOrElse(variableType)
         val genericSignature = binarySignatureCalculator.variableBinarySignature(typePatternExpr.getType)
-        val patternLocal = localNode(
-          typePatternExpr,
-          variableName,
-          code(typePatternExpr),
-          variableType,
-          genericSignature = Option(genericSignature)
-        )
-        scope.enclosingMethod.get.putPatternLocals(patternLocal, Option(typePatternExpr))
-        val patternIdentifier = identifierNode(typePatternExpr, variableName, variableName, variableType)
+        val patternLocal = scope.getHoistedPatternLocals.find(local =>
+          local.name == variableName && local.typeFullName == variableType
+        ) match {
+          case Some(local) =>
+            scope.enclosingMethod.get.registerPatternLocal(typePatternExpr, local)
+            local
+          case None =>
+            val mangledName = scope.getMangledName(variableName)
+            val patternLocal = localNode(
+              typePatternExpr,
+              mangledName,
+              code(typePatternExpr),
+              variableType,
+              genericSignature = Option(genericSignature)
+            )
+            scope.enclosingBlock.get.addHoistedPatternLocal(patternLocal)
+            scope.enclosingMethod.get.registerLocalToAddToCpg(patternLocal)
+            scope.enclosingMethod.get.registerPatternLocal(typePatternExpr, patternLocal)
+            patternLocal
+        }
+
+        val patternIdentifier = identifierNode(typePatternExpr, patternLocal.name, patternLocal.name, variableType)
 
         val initializerAst = castAstIfNecessary(typePatternExpr, variableType, patternNode.getAst)
 
@@ -404,5 +338,85 @@ trait AstForPatternExpressionsCreator { this: AstCreator =>
           .getOrElse(defaultTypeFallback(typ))
       )
       .getOrElse(defaultTypeFallback())
+  }
+
+  trait PatternInitTreeNode(val patternExpr: PatternExpr) {
+    def getAst: Ast
+
+    def typeFullName: Option[String]
+  }
+
+  class PatternInitRoot(patternExpr: PatternExpr, ast: PatternInitAndRefAsts) extends PatternInitTreeNode(patternExpr) {
+    override def getAst: Ast = ast.get
+
+    override def typeFullName: Option[String] = ast.rootType
+  }
+
+  class PatternInitNode(
+    parentNode: PatternInitTreeNode,
+    patternExpr: PatternExpr,
+    fieldName: String,
+    fieldTypeFullName: Option[String],
+    requiresTemporaryVariable: Boolean
+  ) extends PatternInitTreeNode(patternExpr) {
+    private var cachedResult: Option[PatternInitAndRefAsts] = None
+
+    override def typeFullName: Option[String] = fieldTypeFullName
+
+    override def getAst: Ast = {
+      cachedResult.map(_.get).getOrElse {
+        val parentAst = parentNode.getAst
+        val patternTypeFullName = tryWithSafeStackOverflow(patternExpr.getType).toOption
+          .map { typ =>
+            scope
+              .lookupScopeType(typ.asString())
+              .map(_.typeFullName)
+              .orElse(typeInfoCalc.fullName(typ))
+              .getOrElse(defaultTypeFallback(typ))
+          }
+          .getOrElse(defaultTypeFallback())
+
+        val parentPatternType = getPatternTypeFullName(parentNode.patternExpr)
+        val lhsAst            = castAstIfNecessary(parentNode.patternExpr, parentPatternType, parentAst)
+
+        val signature = composeSignature(fieldTypeFullName, Option(Nil), 0)
+        val typeDeclFullName =
+          if (isResolvedTypeFullName(parentPatternType))
+            parentPatternType
+          else
+            s"${Defines.UnresolvedNamespace}.${code(parentNode.patternExpr.getType)}"
+        val methodFullName = Util.composeMethodFullName(typeDeclFullName, fieldName, signature)
+        val methodCodePrefix = lhsAst.root match {
+          case Some(call: NewCall) if call.name.startsWith("<operator") => s"(${call.code})"
+          case Some(root: AstNodeNew)                                   => root.code
+          case _                                                        => ""
+
+        }
+        val methodCode = s"$methodCodePrefix.$fieldName()"
+
+        val fieldAccessorCall = callNode(
+          patternExpr,
+          methodCode,
+          fieldName,
+          methodFullName,
+          DispatchTypes.DYNAMIC_DISPATCH,
+          Option(signature),
+          fieldTypeFullName.orElse(Option(defaultTypeFallback()))
+        )
+
+        val fieldAccessorAst = callAst(fieldAccessorCall, Nil, Option(lhsAst))
+
+        val patternInitWithRef = if (requiresTemporaryVariable) {
+          val patternInitWithRef = initAndRefAstsForPatternInitializer(patternExpr, fieldAccessorAst)
+          patternInitWithRef
+        } else {
+          PatternInitAndRefAsts(fieldAccessorAst)
+        }
+
+        cachedResult = Option(patternInitWithRef)
+
+        patternInitWithRef.get
+      }
+    }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -166,18 +166,12 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     scope.pushBlockScope()
     val context = new BinaryExprContext(expr, new CombinedTypeSolver())
 
-    context
-      .typePatternExprsExposedToChild(expr.getRight)
-      .asScala
-      .flatMap(pattern => scope.enclosingMethod.flatMap(_.getLocalForPattern(pattern)))
-      .foreach { local =>
-        scope.enclosingBlock.foreach(_.addLocal(local))
-      }
+    scope.addLocalsForPatternsToEnclosingBlock(context.typePatternExprsExposedToChild(expr.getRight).asScala.toList)
 
     val rhsArgs = astsForExpression(expr.getRight, expectedType)
     // TODO Fix code
     // val rhsCode = rhsArgs.headOption.flatMap(_.rootCode).getOrElse("")
-    scope.popBlockScope()
+    scope.popBlockAndHoistPatternVariables()
 
     val args = lhsArgs ++ rhsArgs
 
@@ -266,12 +260,12 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
     scope.pushBlockScope()
     scope.addLocalsForPatternsToEnclosingBlock(patternsExposedToThen)
     val thenAst = astsForExpression(expr.getThenExpr, expectedType)
-    scope.popBlockScope()
+    scope.popBlockAndHoistPatternVariables()
 
     scope.pushBlockScope()
     scope.addLocalsForPatternsToEnclosingBlock(patternsExposedToElse)
     val elseAst = astsForExpression(expr.getElseExpr, expectedType)
-    scope.popBlockScope()
+    scope.popBlockAndHoistPatternVariables()
 
     val typeFullName =
       expressionReturnTypeFullName(expr)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -269,7 +269,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
         .code(idxName)
         .lineNumber(lineNo)
         .genericSignature(genericSignature)
-    scope.enclosingBlock.get.addLocal(idxLocal)
+    scope.enclosingBlock.get.addLocal(idxLocal, idxName)
     idxLocal
   }
 
@@ -355,15 +355,17 @@ trait AstForForLoopsCreator { this: AstCreator =>
 
     maybeVariable match {
       case Some(variable) =>
-        val name = variable.getNameAsString
+        val originalName = variable.getNameAsString
+        // TODO: Name mangling
+        val mangledName = originalName
         val typeFullName =
           tryWithSafeStackOverflow(variable.getType).toOption.flatMap(typeInfoCalc.fullName).getOrElse("ANY")
         val localNode = partialLocalNode
-          .name(name)
-          .code(variable.getNameAsString)
+          .name(mangledName)
+          .code(mangledName)
           .typeFullName(typeFullName)
 
-        scope.enclosingBlock.get.addLocal(localNode)
+        scope.enclosingBlock.get.addLocal(localNode, originalName)
         localNode
 
       case None =>

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
@@ -3245,4 +3245,411 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
       }
     }
   }
+
+  "locals with mangled names" when {
+    "the mangled local appears in a vardecl after the pattern" should {
+      val cpg = code("""
+                         |class Test {
+                         |  String source() { return "data"; }
+                         |  static boolean sink(String s) { return true; }
+                         |
+                         |  static void foo(Object o) {
+                         |    if (o instanceof String value) {
+                         |      sink(value);
+                         |    }
+                         |    int value = 2;
+                         |    sink(value);
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(firstSink, secondSink) =>
+          inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
+            firstValue.name shouldBe "value"
+            firstValue.refsTo.l shouldBe cpg.local.nameExact("value").l
+          }
+          inside(secondSink.argument.argumentIndex(1).isIdentifier.l) { case List(secondValue) =>
+            secondValue.name shouldBe "value$0"
+            secondValue.refsTo.l shouldBe cpg.local.nameExact("value$0").l
+          }
+        }
+      }
+    }
+
+    "the mangled local appears in a vardecl after the pattern in a while loop" should {
+      val cpg = code("""
+                         |class Test {
+                         |  String source() { return "data"; }
+                         |  static boolean sink(String s) { return true; }
+                         |
+                         |  static void foo(Object o) {
+                         |    while (o instanceof String value) {
+                         |      sink(value);
+                         |    }
+                         |    int value = 2;
+                         |    sink(value);
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(firstSink, secondSink) =>
+          inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
+            firstValue.name shouldBe "value"
+            firstValue.refsTo.l shouldBe cpg.local.nameExact("value").l
+          }
+          inside(secondSink.argument.argumentIndex(1).isIdentifier.l) { case List(secondValue) =>
+            secondValue.name shouldBe "value$0"
+            secondValue.refsTo.l shouldBe cpg.local.nameExact("value$0").l
+          }
+        }
+      }
+    }
+
+    "the mangled local appears in a vardecl after the pattern in a for loop" should {
+      val cpg = code("""
+                         |class Test {
+                         |  String source() { return "data"; }
+                         |  static boolean sink(String s) { return true; }
+                         |
+                         |  static void foo(Object o) {
+                         |    for (;o instanceof String value;) {
+                         |      sink(value);
+                         |    }
+                         |    int value = 2;
+                         |    sink(value);
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(firstSink, secondSink) =>
+          inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
+            firstValue.name shouldBe "value"
+            firstValue.refsTo.l shouldBe cpg.local.nameExact("value").l
+          }
+          inside(secondSink.argument.argumentIndex(1).isIdentifier.l) { case List(secondValue) =>
+            secondValue.name shouldBe "value$0"
+            secondValue.refsTo.l shouldBe cpg.local.nameExact("value$0").l
+          }
+        }
+      }
+    }
+
+    "the mangled local appears in a vardecl after the pattern in a do loop" should {
+      val cpg = code("""
+                         |class Test {
+                         |  String source() { return "data"; }
+                         |  static boolean sink(String s) { return true; }
+                         |
+                         |  static void foo(Object o) {
+                         |    do {} while (o instanceof String value);
+                         |    int value = 2;
+                         |    sink(value);
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(sink) =>
+          inside(sink.argument.argumentIndex(1).isIdentifier.l) { case List(valueIdentifier) =>
+            valueIdentifier.name shouldBe "value$0"
+            valueIdentifier.refsTo.l shouldBe cpg.local.nameExact("value$0").l
+          }
+        }
+      }
+    }
+
+    "a pattern variable name needs to be mangled" should {
+      val cpg = code("""
+                         |class Test {
+                         |  String source() { return "data"; }
+                         |  static boolean sink(String s) { return true; }
+                         |
+                         |  static void foo(Object o) {
+                         |    if (o instanceof String value) {
+                         |      sink(value);
+                         |    }
+                         |    if (o instanceof Integer value) {
+                         |      sink(value);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(firstSink, secondSink) =>
+          inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
+            firstValue.name shouldBe "value"
+            firstValue.refsTo.l shouldBe cpg.local.nameExact("value").l
+          }
+          inside(secondSink.argument.argumentIndex(1).isIdentifier.l) { case List(secondValue) =>
+            secondValue.name shouldBe "value$0"
+            secondValue.refsTo.l shouldBe cpg.local.nameExact("value$0").l
+          }
+        }
+      }
+    }
+
+    "a pattern variable name in a switch needs to be mangled" should {
+      val cpg = code("""
+                       |class Test {
+                       |  String source() { return "data"; }
+                       |  static boolean sink(String s) { return true; }
+                       |
+                       |  static void foo(Object o) {
+                       |    if (o instanceof String value) {
+                       |      sink(value);
+                       |    }
+                       |    switch (o) {
+                       |      case Integer value -> sink(value);
+                       |    }
+                       |  }
+                       |}
+                       |""".stripMargin)
+
+      "have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(firstSink, secondSink) =>
+          inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
+            firstValue.name shouldBe "value"
+            firstValue.refsTo.l shouldBe cpg.local.nameExact("value").l
+          }
+          inside(secondSink.argument.argumentIndex(1).isIdentifier.l) { case List(secondValue) =>
+            secondValue.name shouldBe "value$0"
+            secondValue.refsTo.l shouldBe cpg.local.nameExact("value$0").l
+          }
+        }
+      }
+    }
+
+    "a pattern variable name in a switch does not need to be mangled" should {
+      val cpg = code("""
+                       |class Test {
+                       |  String source() { return "data"; }
+                       |  static boolean sink(String s) { return true; }
+                       |
+                       |  static void foo(Object o) {
+                       |    switch (o) {
+                       |      case Integer value -> sink(value);
+                       |      case Boolean value -> sink(value);
+                       |    }
+                       |    if (o instanceof String value) {
+                       |      sink(value);
+                       |    }
+                       |  }
+                       |}
+                       |""".stripMargin)
+
+      "not have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(firstSink, secondSink, thirdSink) =>
+          inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
+            firstValue.name shouldBe "value"
+            firstValue.refsTo.l shouldBe cpg.local.nameExact("value").typeFullName("java.lang.Integer").l
+          }
+          inside(secondSink.argument.argumentIndex(1).isIdentifier.l) { case List(secondValue) =>
+            secondValue.name shouldBe "value"
+            secondValue.refsTo.l shouldBe cpg.local.nameExact("value").typeFullName("java.lang.Boolean").l
+          }
+          inside(thirdSink.argument.argumentIndex(1).isIdentifier.l) { case List(thirdValue) =>
+            thirdValue.name shouldBe "value"
+            thirdValue.refsTo.l shouldBe cpg.local.nameExact("value").typeFullName("java.lang.String").l
+          }
+        }
+      }
+
+      "have the locals located in the correct blocks" in {
+        inside(cpg.method.name("foo").body.astChildren.l) {
+          case List(switchStmt: ControlStructure, thirdValueLocal: Local, ifStmt: ControlStructure) =>
+            switchStmt.controlStructureType shouldBe ControlStructureTypes.SWITCH
+
+            inside(switchStmt.astChildren.l) { case List(_: Identifier, bodyBlock: Block) =>
+              inside(bodyBlock.astChildren.l) {
+                case List(_: JumpTarget, firstCaseBlock: Block, _: JumpTarget, secondCaseBlock: Block) =>
+                  inside(firstCaseBlock.astChildren.l) { case List(firstValueLocal: Local, _: ControlStructure) =>
+                    firstValueLocal.name shouldBe "value"
+                    firstValueLocal.typeFullName shouldBe "java.lang.Integer"
+                  }
+                  inside(secondCaseBlock.astChildren.l) { case List(secondValueLocal: Local, _: ControlStructure) =>
+                    secondValueLocal.name shouldBe "value"
+                    secondValueLocal.typeFullName shouldBe "java.lang.Boolean"
+                  }
+              }
+            }
+
+            thirdValueLocal.name shouldBe "value"
+            thirdValueLocal.typeFullName shouldBe "java.lang.String"
+
+            ifStmt.controlStructureType shouldBe ControlStructureTypes.IF
+        }
+      }
+    }
+
+    "a variable on the rhs of a binary expression should not have a mangled name" should {
+      val cpg = code("""
+                         |class Test {
+                         |  String source() { return "data"; }
+                         |  static boolean sink(String s) { return true; }
+                         |
+                         |  static void foo(Object o) {
+                         |    if (o instanceof String value && value.isEmpty()) {
+                         |      sink(value);
+                         |    }
+                         |    if (o instanceof Integer value) {
+                         |      sink(value);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "not have the local name mangled" in {
+        inside(cpg.call.name("isEmpty").receiver.isIdentifier.l) { case List(valueIdentifier) =>
+          valueIdentifier.name shouldBe "value"
+          valueIdentifier.typeFullName shouldBe "java.lang.String"
+        }
+      }
+    }
+
+    "a variable on the rhs of a binary expression should have a mangled name" should {
+      val cpg = code("""
+                       |class Test {
+                       |  String source() { return "data"; }
+                       |  static boolean sink(String s) { return true; }
+                       |
+                       |  static void foo(Object o) {
+                       |    if (o instanceof Integer value) {
+                       |      sink(value);
+                       |    }
+                       |    if (o instanceof String value && value.isEmpty()) {
+                       |      sink(value);
+                       |    }
+                       |  }
+                       |}
+                       |""".stripMargin)
+
+      "not have the local name mangled" in {
+        inside(cpg.call.name("isEmpty").receiver.isIdentifier.l) { case List(valueIdentifier) =>
+          valueIdentifier.name shouldBe "value$0"
+          valueIdentifier.typeFullName shouldBe "java.lang.String"
+        }
+      }
+    }
+
+    "a local is defined in a sibling block" should {
+
+      val cpg = code("""
+                           |class Test {
+                           |  String source() { return "data"; }
+                           |  static boolean sink(String s) { return true; }
+                           |
+                           |  static void foo(Object o) {
+                           |    {
+                           |      if (o instanceof String value) {
+                           |        sink(value);
+                           |      }
+                           |    }
+                           |    {
+                           |      int value = 2;
+                           |      sink(value);
+                           |    }
+                           |  }
+                           |}
+                           |""".stripMargin)
+
+      "not have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(firstSink, secondSink) =>
+          inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
+            firstValue.name shouldBe "value"
+            firstValue.refsTo.l shouldBe cpg.local.nameExact("value").typeFullName("java.lang.String").l
+          }
+          inside(secondSink.argument.argumentIndex(1).isIdentifier.l) { case List(secondValue) =>
+            secondValue.name shouldBe "value"
+            secondValue.refsTo.l shouldBe cpg.local.nameExact("value").typeFullName("int").l
+          }
+        }
+      }
+    }
+
+    "a local is defined in a nested block" should {
+
+      val cpg = code("""
+                         |class Test {
+                         |  String source() { return "data"; }
+                         |  static boolean sink(String s) { return true; }
+                         |
+                         |  static void foo(Object o) {
+                         |
+                         |    if (o instanceof String value) {
+                         |      sink(value);
+                         |    }
+                         |
+                         |    {
+                         |      int value = 2;
+                         |      sink(value);
+                         |    }
+                         |  }
+                         |}
+                         |""".stripMargin)
+
+      "have the local name mangled" in {
+        inside(cpg.call.name("sink").l) { case List(firstSink, secondSink) =>
+          inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
+            firstValue.name shouldBe "value"
+            firstValue.refsTo.l shouldBe cpg.local.nameExact("value").l
+          }
+          inside(secondSink.argument.argumentIndex(1).isIdentifier.l) { case List(secondValue) =>
+            secondValue.name shouldBe "value$0"
+            secondValue.refsTo.l shouldBe cpg.local.nameExact("value$0").l
+          }
+        }
+      }
+    }
+
+    "a pattern and local variable share a name and a type" should {
+      val cpg = code("""
+                         |class Main {
+                         |    String source () { return "data"; }
+                         |    static boolean sink0 (String s){ return true; }
+                         |    static boolean sink1 (String s){ return true; }
+                         |    static boolean sink2 (String s){ return true; }
+                         |
+                         |    static void foo(Object o) {
+                         |        if (o instanceof String s) {
+                         |            sink0(s);
+                         |        }
+                         |        if (o instanceof String s) {
+                         |            sink1(s);
+                         |        }
+                         |        // This s must be initialized before using it, so it will always overwrite the value of the
+                         |        // pattern variable, hence avoiding false positives.
+                         |        String s = "safe";
+                         |        sink2(s);
+                         |    }
+                         |}
+                         |""".stripMargin)
+
+      "share the local" in {
+        val sLocal = inside(cpg.method.name("foo").local.l) { case List(sLocal) => sLocal }
+
+        sLocal.name shouldBe "s";
+        sLocal.typeFullName shouldBe "java.lang.String"
+
+        inside(cpg.call.name("sink0").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe List(sLocal)
+        }
+        inside(cpg.call.name("sink1").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe List(sLocal)
+        }
+        inside(cpg.call.name("sink2").argument.l) { case List(sIdentifier: Identifier) =>
+          sIdentifier.name shouldBe "s"
+          sIdentifier.typeFullName shouldBe "java.lang.String"
+          sIdentifier.refsTo.l shouldBe List(sLocal)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR builds on https://github.com/joernio/joern/pull/5305 and is a follow-up to https://github.com/joernio/joern/pull/5305 and adds name mangling for locals that conflict with hoisted pattern locals. Where conflicting variables have the same types as well, a single local is shared instead.
```java
static void foo(Object o) {
  if (o instanceof String value) {
    sink(value);
  }
  // mangled
  int value;
}
```
```java
static void foo(Object o) {
  if (o instanceof String value) {
    sink(value);
  }
  if (o instanceof Integer value) {
    // mangled
    sink(value);
  }
}
```
```java
static void foo(Object o) {
  switch (o) {
    case Integer value -> sink(value);
    // not mangled since the local is enclosed in a block in the body of the switch entry
    case Boolean value -> sink(value);
  }
  if (o instanceof String value) {
    // not mangled since the switch locals are all enclosed
    sink(value);
  }
}
```
```java
static void foo(Object o) {
  {
    if (o instanceof String value) {
      sink(value);
    }
  }
  {
    // not mangled since the pattern local is enclosed in the block above
    int value = 2;
    sink(value);
  }
}
```
```java
// single local shared
static void foo(Object o) {
    if (o instanceof String s) {
        sink0(s);
    }
    if (o instanceof String s) {
        sink1(s);
    }
    // This s must be initialized before using it, so it will always overwrite the value of the
    // pattern variable, hence avoiding false positives.
    String s = "safe";
    sink2(s);
}
```