### PR TITLE
[php] Use Robust Version Checking

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -29,7 +29,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
             logger.info(s"Checking PHP installation: $version")
             VersionHelper.compare("7.1.0", version) >= 0
           case x =>
-            logger.info(s"Unable to determine PHP version string from '$x''")
+            logger.info(s"Unable to determine PHP version string from '$x'")
             false
         }
       case Failure(exception) =>

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -9,6 +9,7 @@ import io.joern.x2cpg.utils.ExternalCommand
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 import org.slf4j.LoggerFactory
+import versionsort.VersionHelper
 
 import scala.collection.mutable
 import scala.util.matching.Regex
@@ -18,17 +19,14 @@ class Php2Cpg extends X2CpgFrontend[Config] {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  // PHP 7.1.0 and above is required by Composer, which is used by PHP Parser
-  private val PhpVersionRegex = new Regex("^PHP ([78]\\.[1-9]\\.[0-9]|[9-9]\\d\\.\\d\\.\\d)")
-
   private def isPhpVersionSupported: Boolean = {
     val result = ExternalCommand.run(Seq("php", "--version"), ".").toTry
     result match {
       case Success(listString) =>
         val phpVersionStr = listString.headOption.getOrElse("")
         logger.info(s"Checking PHP installation: $phpVersionStr")
-        val matchResult = PhpVersionRegex.findFirstIn(phpVersionStr)
-        matchResult.isDefined
+        // PHP 7.1.0 and above is required by Composer, which is used by PHP Parser
+        VersionHelper.compare("7.1.0", phpVersionStr) >= 0
       case Failure(exception) =>
         logger.error(s"Failed to run php --version: ${exception.getMessage}")
         false

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -22,18 +22,15 @@ class Php2Cpg extends X2CpgFrontend[Config] {
   private def isPhpVersionSupported: Boolean = {
     val result = ExternalCommand.run(Seq("php", "--version"), ".").toTry
     result match {
-      case Success(listString) =>
+      case Success(s"PHP $version ($_" :: _) =>
         // PHP 7.1.0 and above is required by Composer, which is used by PHP Parser
-        listString.headOption.getOrElse("") match {
-          case s"PHP $version ($_" =>
-            logger.info(s"Checking PHP installation: $version")
-            VersionHelper.compare(version, "7.1.0") >= 0
-          case x =>
-            logger.info(s"Unable to determine PHP version string from '$x'")
-            false
-        }
+        logger.info(s"Checking PHP installation: $version")
+        VersionHelper.compare(version, "7.1.0") >= 0
       case Failure(exception) =>
         logger.error(s"Failed to run php --version: ${exception.getMessage}")
+        false
+      case x =>
+        logger.info(s"Unable to determine PHP version string from '$x'")
         false
     }
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -23,10 +23,15 @@ class Php2Cpg extends X2CpgFrontend[Config] {
     val result = ExternalCommand.run(Seq("php", "--version"), ".").toTry
     result match {
       case Success(listString) =>
-        val phpVersionStr = listString.headOption.getOrElse("")
-        logger.info(s"Checking PHP installation: $phpVersionStr")
         // PHP 7.1.0 and above is required by Composer, which is used by PHP Parser
-        VersionHelper.compare("7.1.0", phpVersionStr) >= 0
+        listString.headOption.getOrElse("") match {
+          case s"PHP $version ($_" =>
+            logger.info(s"Checking PHP installation: $version")
+            VersionHelper.compare("7.1.0", version) >= 0
+          case x =>
+            logger.info(s"Unable to determine PHP version string from '$x''")
+            false
+        }
       case Failure(exception) =>
         logger.error(s"Failed to run php --version: ${exception.getMessage}")
         false

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -27,7 +27,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
         listString.headOption.getOrElse("") match {
           case s"PHP $version ($_" =>
             logger.info(s"Checking PHP installation: $version")
-            VersionHelper.compare("7.1.0", version) >= 0
+            VersionHelper.compare(version, "7.1.0") >= 0
           case x =>
             logger.info(s"Unable to determine PHP version string from '$x'")
             false

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -30,7 +30,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
         logger.error(s"Failed to run php --version: ${exception.getMessage}")
         false
       case x =>
-        logger.info(s"Unable to determine PHP version string from '$x'")
+        logger.error(s"Unable to determine PHP version string from '$x'")
         false
     }
   }


### PR DESCRIPTION
 Replaced the check for the installed PHP version using Michael's `VersionHelper` instead of regex.

Resolves https://github.com/joernio/joern/issues/5320