### PR TITLE
[jimple2cpg] Add a fixed value "Condition" to the possibleTypes property

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/expressions/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/expressions/AstForExpressionsCreator.scala
@@ -60,6 +60,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     }
 
     val call = callNode(parentUnit, binOp.toString, operatorName, operatorName, DispatchTypes.STATIC_DISPATCH)
+      .possibleTypes(List("Condition"))
 
     val args =
       astsForValue(binOp.getOp1, parentUnit) ++ astsForValue(binOp.getOp2, parentUnit)


### PR DESCRIPTION
[jimple2cpg] Add a fixed value "Condition" to the possibleTypes property of the Conditional judgment type Call, which is used to quickly determine whether a Call statement is a conditional judgment statement. At the same time, add the corresponding test case in IfGotoTests.

The reason for adding this attribute is that in joern, a conditional statement is not classified as a ControlStructure. Only the specific operator can be seen in the name. However, there are multiple operators for conditional statements, and it is impossible to quickly determine whether a Call statement is a conditional statement. The judgment method can refer to the test case