### PR TITLE
[ruby] Use `THREADSAFE` Configuration for Script Container

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
@@ -33,7 +33,7 @@ class RubyAstGenRunner(config: Config) extends AstGenRunnerBase(config) with Aut
   private val container: ScriptingContainer = {
     val cwd       = env.path.toAbsolutePath.toString
     val gemPath   = Seq(cwd, "vendor", "bundle", "jruby", "3.1.0").mkString(separator)
-    val container = new ScriptingContainer(LocalContextScope.SINGLETON, LocalVariableBehavior.TRANSIENT)
+    val container = new ScriptingContainer(LocalContextScope.THREADSAFE, LocalVariableBehavior.TRANSIENT)
     val config    = container.getProvider.getRubyInstanceConfig
     container.setCompileMode(RubyInstanceConfig.CompileMode.OFF)
     container.setNativeEnabled(false)


### PR DESCRIPTION
For many concurrent requests on the HTTP server, the current configuration bombs out. This uses the thread safe config.