### PR TITLE
[ruby] Ruby `match` to use `DynamicCallUnknownFullName`

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -223,7 +223,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
         code(n)
       }
 
-      // Regex matches are one of the few dynamic dispatch calls we fully qualify because of the lowering mechanism
       val call = callNode(n, callCode, n.methodName, XDefines.DynamicCallUnknownFullName, dispatchType)
       if methodFullName != XDefines.DynamicCallUnknownFullName then call.possibleTypes(Seq(methodFullName))
       if (isStatic) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -70,7 +70,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       astForUnknown(node)
 
   protected def astForStaticLiteral(node: StaticLiteral): Ast = {
-    Ast(literalNode(node, code(node), node.typeFullName))
+    Ast(literalNode(node, code(node), node.typeFullName, node.typeFullName :: Nil))
   }
 
   protected def astForHereDoc(node: HereDocNode): Ast = {
@@ -224,11 +224,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
       }
 
       // Regex matches are one of the few dynamic dispatch calls we fully qualify because of the lowering mechanism
-      val call = if (methodFullName == s"${prefixAsCoreType(Defines.Regexp)}.match") {
-        callNode(n, callCode, n.methodName, methodFullName, dispatchType)
-      } else {
-        callNode(n, callCode, n.methodName, XDefines.DynamicCallUnknownFullName, dispatchType)
-      }
+      val call = callNode(n, callCode, n.methodName, XDefines.DynamicCallUnknownFullName, dispatchType)
       if methodFullName != XDefines.DynamicCallUnknownFullName then call.possibleTypes(Seq(methodFullName))
       if (isStatic) {
         callAst(call, argumentAsts, base = Option(baseAst)).copy(receiverEdges = Nil)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -23,6 +23,7 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = false) {
       tmpSource.code shouldBe s"/h(el)lo/.match($expectedSubject)"
       tmpSource.name shouldBe "match"
       tmpSource.methodFullName shouldBe Defines.DynamicCallUnknownFullName
+      tmpSource.argument(0).asInstanceOf[Literal].dynamicTypeHintFullName shouldBe "__core.Regexp" :: Nil
 
       // Now test for the lowered global variable assignments
       val ifStmt = cpg.controlStructure.last

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/RegexTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.semanticcpg.language.*
@@ -21,7 +22,7 @@ class RegexTests extends RubyCode2CpgFixture(withPostProcessing = false) {
       val tmpSource = tmpInit.source.asInstanceOf[Call]
       tmpSource.code shouldBe s"/h(el)lo/.match($expectedSubject)"
       tmpSource.name shouldBe "match"
-      tmpSource.methodFullName shouldBe "__core.Regexp.match"
+      tmpSource.methodFullName shouldBe Defines.DynamicCallUnknownFullName
 
       // Now test for the lowered global variable assignments
       val ifStmt = cpg.controlStructure.last


### PR DESCRIPTION
To be consistent with other dynamic calls, adds a dynamic type hint to literals + sets `match` to be `DynamicCallUnknownFullName` to enable dynamic call resolution strategies to kick in.