### PR TITLE
Add sourceCode accessor to nodes and traversals for accessing file content via offset

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/OffsetTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/OffsetTests.scala
@@ -90,19 +90,12 @@ class OffsetTests extends JavaSrcCode2CpgFixture {
     ).withConfig(contentEnabled)
 
     "have the first method retrievable via the offset fields" in {
-      def method    = cpg.method.name("method1").head
-      val offset    = method.offset.get
-      val offsetEnd = method.offsetEnd.get
-
-      cpg.file.name(".*Foo.java").content.head.substring(offset, offsetEnd) shouldBe method1
+      def method = cpg.method.name("method1").head
+      method.sourceCode shouldBe method1
     }
 
     "have the second method retrievable via the offset fields" in {
-      def method    = cpg.method.name("method2").head
-      val offset    = method.offset.get
-      val offsetEnd = method.offsetEnd.get
-
-      cpg.file.name(".*Foo.java").content.head.substring(offset, offsetEnd) shouldBe method2
+      inside(cpg.method.name("method2").sourceCode.l) { case List(sourceCode) => sourceCode shouldBe method2 }
     }
 
     "not have offsets set for the default constructor" in {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.Implicits.IterableOnceDeco
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode.PropertyDefaults
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.nodemethods.AstNodeMethods.lastExpressionInBlock
@@ -92,6 +93,15 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
       case expr: Expression                           => expr.code
       case call: CallRepr if !call.isInstanceOf[Call] => call.code
     }
+
+  def sourceCode: String = {
+    val maybeSourceCode = for {
+      offset      <- node.offset
+      offsetEnd   <- node.offsetEnd
+      fileContent <- node.file.headOption.map(_.content)
+    } yield fileContent.substring(offset, offsetEnd)
+    maybeSourceCode.getOrElse(PropertyDefaults.Code)
+  }
 
   def statement: AstNode =
     statementInternal(node, _.parentExpression.get)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -229,6 +229,13 @@ package object language
 
   // EvalType accessors ~
 
+  // ~ SourceCode accessors
+  implicit def singleToSourceCodeAccessorsLocal[A <: AstNode](a: A): SourceCodeAccessors[A] =
+    new SourceCodeAccessors[A](Iterator.single(a))
+  implicit def iterOnceToSourceCodeAccessorsLocal[A <: AstNode](a: IterableOnce[A]): SourceCodeAccessors[A] =
+    new SourceCodeAccessors[A](a.iterator)
+  // SourceCode accessors ~
+
   // ~ Modifier accessors
   implicit def singleToModifierAccessorsMember[A <: Member](a: A): ModifierAccessors[A] =
     new ModifierAccessors[A](Iterator.single(a))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/SourceCodeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/SourceCodeAccessors.scala
@@ -1,0 +1,45 @@
+package io.shiftleft.semanticcpg.language.types.propertyaccessors
+
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode
+import io.shiftleft.semanticcpg.language.*
+
+class SourceCodeAccessors[A <: AstNode](val traversal: Iterator[A]) extends AnyVal {
+
+  def sourceCode: Iterator[String] =
+    sourceCode(traversal)
+
+  def sourceCode(regex: String): Iterator[A] = {
+    traversal.where(sourceCode(_).filter(_.matches(regex)))
+  }
+
+  def sourceCode(regexes: String*): Iterator[A] =
+    if (regexes.isEmpty) Iterator.empty
+    else {
+      val regexes0 = regexes.map(_.r).toSet
+      traversal.where(sourceCode(_).filter(value => regexes0.exists(_.matches(value))))
+    }
+
+  def sourceCodeExact(value: String): Iterator[A] =
+    traversal.where(sourceCode(_).filter(_ == value))
+
+  def sourceCodeExact(values: String*): Iterator[A] =
+    if (values.isEmpty) Iterator.empty
+    else {
+      val valuesSet = values.to(Set)
+      traversal.where(sourceCode(_).filter(valuesSet.contains))
+    }
+
+  def sourceCodeNot(regex: String): Iterator[A] =
+    traversal.where(sourceCode(_).filterNot(_.matches(regex)))
+
+  def sourceCodeNot(regexes: String*): Iterator[A] =
+    if (regexes.isEmpty) Iterator.empty
+    else {
+      val regexes0 = regexes.map(_.r).toSet
+      traversal.where(sourceCode(_).filter(value => !regexes0.exists(_.matches(value))))
+    }
+
+  private def sourceCode(traversal: Iterator[A]): Iterator[String] =
+    traversal.map(_.sourceCode)
+
+}


### PR DESCRIPTION
Using the `offset` fields to access the source code for a node is currently quite cumbersome, so this PR adds a `sourceCode` accessor to AST nodes and traversals which is just a convenience wrapper around the logic to get the offsets, file and to do the lookup.

I decided to have `sourceCode` return a `String` instead of `Option[String]` for two reasons, but am open to changing this:
* It is consistent with the type of `file.content`
* It can be used as a drop-in replacement for `code` 
