### PR TITLE
[c2cpg] Make method fullNames truly unique

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -2,6 +2,7 @@ package io.joern.c2cpg
 
 import io.joern.c2cpg.passes.{AstCreationPass, PreprocessorPass, TypeDeclNodePass}
 import io.joern.c2cpg.passes.FunctionDeclNodePass
+import io.joern.c2cpg.passes.MethodFullNameUniquenessPass
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
@@ -25,10 +26,11 @@ class C2Cpg extends X2CpgFrontend[Config] {
       new MetaDataPass(cpg, Languages.NEWC, config.inputPath).createAndApply()
       val astCreationPass = new AstCreationPass(cpg, config, report)
       astCreationPass.createAndApply()
-      new FunctionDeclNodePass(cpg, astCreationPass.unhandledMethodDeclarations())(config.schemaValidation)
+      new FunctionDeclNodePass(cpg, astCreationPass.unhandledMethodDeclarations(), config)
         .createAndApply()
       TypeNodePass.withRegisteredTypes(astCreationPass.typesSeen(), cpg).createAndApply()
-      new TypeDeclNodePass(cpg)(config.schemaValidation).createAndApply()
+      new TypeDeclNodePass(cpg, config).createAndApply()
+      new MethodFullNameUniquenessPass(cpg).createAndApply()
       report.print()
     }
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -7,6 +7,7 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Dispatch
 import org.apache.commons.lang3.StringUtils
 import org.eclipse.cdt.core.dom.ast
 import org.eclipse.cdt.core.dom.ast.*
+import org.eclipse.cdt.core.dom.ast.c.ICArrayType
 import org.eclipse.cdt.core.dom.ast.cpp.*
 import org.eclipse.cdt.core.dom.ast.gnu.IGNUASTCompoundStatementExpression
 import org.eclipse.cdt.internal.core.dom.parser.c.CASTFunctionCallExpression
@@ -18,7 +19,6 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTQualifiedName
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPClosureType
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFunctionCall
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFoldExpression
-import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPMethod
 
 import scala.annotation.tailrec
 import scala.util.Try
@@ -133,9 +133,10 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   private def isConstType(tpe: IType): Boolean = {
     tpe match {
       case t: ICPPFunctionType  => t.isConst
-      case t: ICPPReferenceType => isConstType(t.getType)
-      case t: IPointerType      => isConstType(t.getType)
+      case t: IPointerType      => t.isConst
       case t: IQualifierType    => t.isConst
+      case t: ICArrayType       => t.isConst
+      case t: ICPPReferenceType => isConstType(t.getType)
       case _                    => false
     }
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/Defines.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/Defines.scala
@@ -18,4 +18,5 @@ object Defines {
   val OperatorExpressionList: String         = "<operator>.expressionList"
   val OperatorNew: String                    = "<operator>.new"
   val OperatorBracketedPrimary: String       = "<operator>.bracketedPrimary"
+  val DuplicateSuffix                        = "<duplicate>"
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/Defines.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/Defines.scala
@@ -19,4 +19,5 @@ object Defines {
   val OperatorNew: String                    = "<operator>.new"
   val OperatorBracketedPrimary: String       = "<operator>.bracketedPrimary"
   val DuplicateSuffix                        = "<duplicate>"
+  val ConstSuffix                            = "<const>"
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -16,12 +16,8 @@ class HeaderFileFinder(config: Config) {
       ignoredFilesRegex = Option(config.ignoredFilesRegex),
       ignoredFilesPath = Option(config.ignoredFiles)
     )
-    .map { p =>
-      val file = File(p)
-      (file.name, file.pathAsString)
-    }
-    .groupBy(_._1)
-    .map(x => (x._1, x._2.map(_._2)))
+    .map(p => File(p))
+    .groupMap(_.name)(_.pathAsString)
 
   /** Given an unresolved header file, given as a non-existing absolute path, determine whether a header file with the
     * same name can be found anywhere in the code base.

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FunctionDeclNodePass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FunctionDeclNodePass.scala
@@ -1,6 +1,7 @@
 package io.joern.c2cpg.passes
 
 import io.joern.c2cpg.astcreation.CGlobal
+import io.joern.c2cpg.Config
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.ValidationMode
@@ -21,9 +22,10 @@ import org.apache.commons.lang3.StringUtils
 
 import scala.collection.immutable.Map
 
-class FunctionDeclNodePass(cpg: Cpg, methodDeclarations: Map[String, CGlobal.MethodInfo])(implicit
-  withSchemaValidation: ValidationMode
-) extends CpgPass(cpg) {
+class FunctionDeclNodePass(cpg: Cpg, methodDeclarations: Map[String, CGlobal.MethodInfo], config: Config)
+    extends CpgPass(cpg) {
+
+  private implicit val schemaValidation: ValidationMode = config.schemaValidation
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     methodDeclarations.foreach { case (fullName, methodNodeInfo) =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/MethodFullNameUniquenessPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/MethodFullNameUniquenessPass.scala
@@ -1,0 +1,54 @@
+package io.joern.c2cpg.passes
+
+import io.joern.c2cpg.astcreation.Defines
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.passes.CpgPass
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+/** Ensures that method fullNames are unique across the CPG. In C and C ++ code, function names can appear multiple
+  * times across different translation units, particularly with static functions in different files sharing the same
+  * name. Sometimes we also may fail to resolve proper type names (missing includes, missing macro expanding) and that,
+  * ultimately, leads to the same function fullName being generated.
+  *
+  * The CPG specification requires unique fullNames for all kind of linking and querying operations.
+  *
+  * This unique fullName generation cannot be performed during the initial AST traversal because:
+  *   - The AST is built on a per-file basis where we don't have knowledge of methods defined in other files
+  *   - Name uniqueness must be established across the entire codebase, not just within a single file.
+  *   - Using a global cache during parsing would slow down our parallel processing.
+  *   - Simply prepending the filename to the method name does not work as we can not determine that fullName for the
+  *     call (leads to linking issues later on). Also, the same function fullName may be generated multiple times in on
+  *     file due to missing type information (as mentioned above).
+  *
+  * Instead , this pass runs after all methods have been added to the CPG, identifies duplicates, and appends unique
+  * suffixes to ensure each method can be uniquely identified.
+  */
+class MethodFullNameUniquenessPass(cpg: Cpg) extends CpgPass(cpg) {
+
+  override def run(dstGraph: DiffGraphBuilder): Unit = {
+    val methodFullNameMap = cpg.method
+      .nameNot(NamespaceTraversal.globalNamespaceName)
+      .groupMap(_.fullName)(identity)
+      .filter(_._2.size > 1)
+      // sort for stable output
+      .sortBy(_._1)
+    methodFullNameMap.foreach { case (fullName, methods) =>
+      methods.sortBy(_.code).zipWithIndex.foreach { case (method, index) =>
+        if (index > 0) { // first method found keeps its fullName
+          val signature   = method.signature
+          val isCFunction = !fullName.endsWith(s":$signature")
+          val newFullName = if (isCFunction) {
+            s"$fullName${Defines.DuplicateSuffix}$index"
+          } else {
+            val fullNameWithoutSignature = fullName.stripSuffix(s":$signature")
+            s"$fullNameWithoutSignature${Defines.DuplicateSuffix}$index:$signature"
+          }
+          dstGraph.setNodeProperty(method, PropertyNames.FULL_NAME, newFullName)
+        }
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/MethodFullNameUniquenessPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/MethodFullNameUniquenessPass.scala
@@ -2,6 +2,7 @@ package io.joern.c2cpg.passes
 
 import io.joern.c2cpg.astcreation.Defines
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.*
@@ -24,7 +25,8 @@ import org.slf4j.LoggerFactory
   *     file due to missing type information (as mentioned above).
   *
   * Instead , this pass runs after all methods have been added to the CPG, identifies duplicates, and appends unique
-  * suffixes to ensure each method can be uniquely identified.
+  * suffixes to ensure each method can be uniquely identified. Calls to static methods affected by this are also updated
+  * to reflect the new method fullName.
   */
 class MethodFullNameUniquenessPass(cpg: Cpg) extends CpgPass(cpg) {
 
@@ -33,14 +35,22 @@ class MethodFullNameUniquenessPass(cpg: Cpg) extends CpgPass(cpg) {
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     val methodFullNameMap = cpg.method
       .nameNot(NamespaceTraversal.globalNamespaceName)
-      .groupMap(_.fullName)(identity)
+      .groupBy(_.fullName)
       .filter(_._2.size > 1)
       // sort for stable output
       .sortBy(_._1)
     methodFullNameMap.foreach { case (fullName, methods) =>
       val fromFiles = methods.map(_.filename).mkString("[", ", ", "]")
       logger.debug(s"Found ${methods.size} duplicate method fullNames for '$fullName' in: $fromFiles")
-      methods.sortBy(_.code).tail.zipWithIndex.foreach { case (method, index) =>
+      val sortedMethods = methods.sortBy { method =>
+        val fileName = method.filename
+        val lineNr   = method.lineNumber.getOrElse(-1)
+        val columnNr = method.columnNumber.getOrElse(-1)
+        s"$fileName:$lineNr:$columnNr"
+      }
+      lazy val callsAffected =
+        cpg.call.methodFullNameExact(fullName).filterNot(_.file.exists(_.name == sortedMethods.head.filename)).l
+      sortedMethods.tail.zipWithIndex.foreach { case (method, index) =>
         val signature   = method.signature
         val isCFunction = !fullName.endsWith(s":$signature")
         val newFullName = if (isCFunction) {
@@ -49,7 +59,16 @@ class MethodFullNameUniquenessPass(cpg: Cpg) extends CpgPass(cpg) {
           val fullNameWithoutSignature = fullName.stripSuffix(s":$signature")
           s"$fullNameWithoutSignature${Defines.DuplicateSuffix}$index:$signature"
         }
+        // set the new fullName
         dstGraph.setNodeProperty(method, Method.PropertyNames.FullName, newFullName)
+        // fixup calls to static methods in the same compilation unit via the naive namespace-by-filename approach
+        if (method.isStatic.nonEmpty) {
+          val callCandidates = callsAffected.filter(_.file.exists(_.name == method.filename))
+          // set the new methodFullName
+          callCandidates.foreach { call =>
+            dstGraph.setNodeProperty(call, Call.PropertyNames.MethodFullName, newFullName)
+          }
+        }
       }
     }
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/TypeDeclNodePass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/TypeDeclNodePass.scala
@@ -1,6 +1,7 @@
 package io.joern.c2cpg.passes
 
 import io.joern.c2cpg.astcreation.Defines
+import io.joern.c2cpg.Config
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.NodeTypes
@@ -11,12 +12,13 @@ import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 
-class TypeDeclNodePass(cpg: Cpg)(implicit withSchemaValidation: ValidationMode) extends CpgPass(cpg) {
+class TypeDeclNodePass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
 
-  private val filename: String               = "<includes>"
-  private val globalName: String             = NamespaceTraversal.globalNamespaceName
-  private val fullName: String               = MetaDataPass.getGlobalNamespaceBlockFullName(Option(filename))
-  private val typeDeclFullNames: Set[String] = cpg.typeDecl.fullName.toSetImmutable
+  private val filename: String                          = "<includes>"
+  private val globalName: String                        = NamespaceTraversal.globalNamespaceName
+  private val fullName: String                          = MetaDataPass.getGlobalNamespaceBlockFullName(Option(filename))
+  private val typeDeclFullNames: Set[String]            = cpg.typeDecl.fullName.toSetImmutable
+  private implicit val schemaValidation: ValidationMode = config.schemaValidation
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
     var hadMissingTypeDecl = false

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features20/Cpp20FeaturesTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features20/Cpp20FeaturesTests.scala
@@ -362,10 +362,10 @@ class Cpp20FeaturesTests extends AstC2CpgSuite(fileSuffix = FileDefaults.CppExt)
           |}
           |""".stripMargin)
       cpg.method.nameNot("<global>").fullName.sorted.l shouldBe List(
-        "X1.f:int()",
-        "X2.f:int()",
-        "X3.f:int()",
-        "X4.f:int()",
+        "X1.f<const>:int()",
+        "X2.f<const>:int()",
+        "X3.f<const>:int()",
+        "X4.f<const>:int()",
         "foo:void()"
       )
       cpg.method.nameExact("foo").local.typeFullName.l shouldBe List("X4")

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/MethodFullNameUniquenessPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/MethodFullNameUniquenessPassTests.scala
@@ -1,0 +1,39 @@
+package io.joern.c2cpg.passes
+
+import io.joern.c2cpg.testfixtures.C2CpgSuite
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+class MethodFullNameUniquenessPassTests extends C2CpgSuite {
+
+  "the MethodUniquenessPass" should {
+    val cpg = code(
+      """
+        |void main() {
+        |  foo(1, 2, 3);
+        |}
+    """.stripMargin,
+      "main.c"
+    ).moreCode(
+      """
+        |void foo(float a, float b, float c) {}
+        |""".stripMargin,
+      "h1.h"
+    ).moreCode(
+      """
+        |void foo(int a, int b, int c) {}
+        |""".stripMargin,
+      "h2.h"
+    )
+
+    "create truly unique method fullnames" in {
+      cpg.method.fullName.size shouldBe cpg.method.fullName.toSet.size
+      cpg.method.nameNot(NamespaceTraversal.globalNamespaceName).fullName.sorted.l shouldBe List(
+        "foo",
+        "foo<duplicate>1",
+        "main"
+      )
+    }
+  }
+
+}

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/MethodFullNameUniquenessPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/MethodFullNameUniquenessPassTests.scala
@@ -7,31 +7,51 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 class MethodFullNameUniquenessPassTests extends C2CpgSuite {
 
   "the MethodUniquenessPass" should {
-    val cpg = code(
-      """
-        |void main() {
-        |  foo(1, 2, 3);
-        |}
-    """.stripMargin,
-      "main.c"
-    ).moreCode(
-      """
-        |void foo(float a, float b, float c) {}
-        |""".stripMargin,
-      "h1.h"
-    ).moreCode(
-      """
-        |void foo(int a, int b, int c) {}
-        |""".stripMargin,
-      "h2.h"
-    )
-
-    "create truly unique method fullnames" in {
+    "create truly unique method fullnames for multiple C functions" in {
+      val cpg = code(
+        """
+          |#include "h1.h"
+          |void main() {
+          |  foo(1, 2, 3);
+          |}
+          """.stripMargin,
+        "main.c"
+      ).moreCode(
+        """
+          |void foo(int a, int b, int c) {}
+          |""".stripMargin,
+        "h1.h"
+      ).moreCode(
+        """
+          |void foo(float a, float b, float c) {}
+          |""".stripMargin,
+        "h2.h"
+      )
       cpg.method.fullName.size shouldBe cpg.method.fullName.toSet.size
       cpg.method.nameNot(NamespaceTraversal.globalNamespaceName).fullName.sorted.l shouldBe List(
         "foo",
-        "foo<duplicate>1",
+        "foo<duplicate>0",
         "main"
+      )
+    }
+
+    "create truly unique method fullnames for const C++ functions" in {
+      val cpg = code(
+        """
+          |class Foo {
+          |  public:
+          |    int foo(int a) {}
+          |    int foo(int a) const {}
+          |}
+          |""".stripMargin,
+        "main.cpp"
+      )
+      cpg.method.fullName.size shouldBe cpg.method.fullName.toSet.size
+      cpg.method.nameNot(NamespaceTraversal.globalNamespaceName).fullName.sorted.l shouldBe List(
+        // We can not distinguish between the two methods as they have the same signature.
+        // `const` is not part of the signature.
+        "Foo.foo:int(int)",
+        "Foo.foo<duplicate>0:int(int)"
       )
     }
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -46,9 +46,9 @@ class AstCreationPassTests extends AstC2CpgSuite {
       // We can however manually reconstruct the signature from the params and return type without
       // relying on the resolved function binding signature.
       val List(foo1, foo2) = cpg.method.nameExact("foo").l
-      foo1.fullName shouldBe "tpe<wchar_t>.foo:char(char_type,char)"
+      foo1.fullName shouldBe "tpe<wchar_t>.foo<const>:char(char_type,char)"
       foo1.signature shouldBe "char(char_type,char)"
-      foo2.fullName shouldBe "tpe<wchar_t>.foo:const wchar_t*(char_type*,char_type*,char,char*)"
+      foo2.fullName shouldBe "tpe<wchar_t>.foo<const>:const wchar_t*(char_type*,char_type*,char,char*)"
       foo2.signature shouldBe "const wchar_t*(char_type*,char_type*,char,char*)"
     }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
@@ -220,7 +220,7 @@ class ClassTypeTests extends C2CpgSuite(FileDefaults.CppExt) {
           |""".stripMargin)
       val List(k) = cpg.typeDecl.nameExact("Foo").method.l
       k.name shouldBe "Kind"
-      k.fullName shouldBe "Foo.Kind:Foo.Kind()"
+      k.fullName shouldBe "Foo.Kind<const>:Foo.Kind()"
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
@@ -19,10 +19,10 @@ trait AstC2CpgFrontend extends LanguageFrontend {
       .fold(Config())(_.asInstanceOf[Config])
       .withInputPath(pathAsString)
       .withOutputPath(pathAsString)
+      .withSchemaValidation(ValidationMode.Enabled)
     val astCreationPass = new AstCreationPass(cpg, config)
     astCreationPass.createAndApply()
-    new FunctionDeclNodePass(cpg, astCreationPass.unhandledMethodDeclarations())(ValidationMode.Enabled)
-      .createAndApply()
+    new FunctionDeclNodePass(cpg, astCreationPass.unhandledMethodDeclarations(), config).createAndApply()
     cpg
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -1,15 +1,20 @@
 package io.joern.x2cpg.passes.callgraph
 
 import io.joern.x2cpg.Defines.DynamicCallUnknownFullName
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.PropertyNames
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method, StoredNode, Type, TypeDecl}
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, PropertyNames}
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.nodes.Method
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.*
-import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.*
 
 /** We compute the set of possible call-targets for each dynamic call, and add them as CALL edges to the graph, based on
   * call.methodFullName, method.name and method.signature, the inheritance hierarchy and the AST of typedecls and
@@ -23,7 +28,7 @@ import scala.jdk.CollectionConverters.*
   */
 class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
-  import DynamicCallLinker._
+  import DynamicCallLinker.*
   // Used to track potential method candidates for a given method fullname. Since our method full names contain the type
   // decl we don't need to specify an addition map to wrap this in. LinkedHashSets are used here to preserve order in
   // the best interest of reproducibility during debugging.


### PR DESCRIPTION
This pull request includes several changes to improve the handling of method full names, particularly ensuring their uniqueness and supporting const methods. The changes also include updates to various passes and test cases to incorporate these improvements.

### Improvements to method full name handling:

* Added logic to append a `const` suffix to method full names when applicable.
* Added a utility function to check if a type is const and updated method full name generation to include the `const` suffix.
* Added `ConstSuffix` and `DuplicateSuffix` constants for use in method full name generation.

### Ensuring method full name uniqueness:

* Introduced a new pass to ensure method full names are unique across the CPG by appending unique suffixes with an incrementing counter to duplicates.

### Updates to existing classes:

* Updated the `C2Cpg` class to execute the new `MethodFullNameUniquenessPass`.

### Test case updates:

* Updated test cases to check for the `const` suffix in method full names.
* Added new test cases to verify the uniqueness of method full names and handling of const methods.
* Updated test cases to reflect changes in method full name generation.