### PR TITLE
Move gradle dependency fetching logic into init.gradle

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -4,15 +4,13 @@ import io.joern.x2cpg.utils.FileUtil
 import io.joern.x2cpg.utils.FileUtil.*
 
 import java.nio.charset.Charset
-
 import org.gradle.tooling.{GradleConnector, ProjectConnection}
 import org.gradle.tooling.model.{GradleProject, ProjectIdentifier, Task}
 import org.gradle.tooling.model.build.BuildEnvironment
 import org.slf4j.LoggerFactory
 
-import java.io.ByteArrayOutputStream
+import java.io.{ByteArrayOutputStream, IOException, File as JFile}
 import java.nio.file.{Files, Path, Paths}
-import java.io.File as JFile
 import java.util.stream.Collectors
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
@@ -28,23 +26,7 @@ case class ProjectNameInfo(projectName: String, parentName: Option[String]) {
   }
 }
 
-case class GradleProjectInfo(
-  subprojects: Map[ProjectNameInfo, List[String]],
-  gradleVersion: String,
-  hasAndroidSubproject: Boolean
-) {
-  def gradleVersionMajorMinor(): (Int, Int) = {
-    def isValidPart(part: String) = part.forall(Character.isDigit)
-    val parts                     = gradleVersion.split('.')
-    if (parts.length == 1 && isValidPart(parts(0))) {
-      (parts(0).toInt, 0)
-    } else if (parts.length >= 2 && isValidPart(parts(0)) && isValidPart(parts(1))) {
-      (parts(0).toInt, parts(1).toInt)
-    } else {
-      (-1, -1)
-    }
-  }
-}
+case class GradleVersion(major: Int, minor: Int)
 
 case class GradleDepsInitScript(contents: String, taskName: String, destinationDir: Path)
 
@@ -63,33 +45,24 @@ object GradleDependencies {
 
   // works with Gradle 5.1+ because the script makes use of `task.register`:
   //   https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
-  private def getInitScriptContent(taskName: String, destination: String, projectInfo: GradleProjectInfo): String = {
-    val projectConfigurationString = projectInfo.subprojects
-      .map { case (projectNameInfo, configurationNames) =>
-        val quotedConfigurationNames = configurationNames.map(name => s"\"$name\"").mkString(", ")
-        s"\"${projectNameInfo.projectName}\": [$quotedConfigurationNames]"
-      }
-      .mkString(", ")
-
-    val taskCreationFunction = projectInfo.gradleVersionMajorMinor() match {
-      case (major, minor) if major >= 5 && minor >= 1 => "tasks.register"
-      case _                                          => "tasks.create"
+  private def getInitScriptContent(
+    taskName: String,
+    destinationDir: String,
+    gradleVersion: GradleVersion,
+    projectNameOverride: Option[String],
+    configurationNameOverride: Option[String]
+  ): String = {
+    val taskCreationFunction = gradleVersion match {
+      case GradleVersion(major, minor) if major >= 5 && minor >= 1 => "tasks.register"
+      case _                                                       => "tasks.create"
     }
 
-    val androidTaskDefinition = Option.when(projectInfo.hasAndroidSubproject)(s"""
-           |def androidDepsCopyTaskName = taskName + "_androidDeps"
-           |      $taskCreationFunction(androidDepsCopyTaskName, Copy) {
-           |        def paths = project.configurations.find { it.name.equals("androidApis") }
-           |        if (paths == null) paths = []
-           |        duplicatesStrategy = 'include'
-           |        into destinationDir
-           |        from paths
-           |      }
-           |""".stripMargin)
+    def addSurroundingQuotes(input: String): String = s"\"$input\""
+    val projectNameOverrideString = projectNameOverride.map(addSurroundingQuotes).getOrElse("")
+    val configurationNameOverrideString = configurationNameOverride.map(addSurroundingQuotes).getOrElse("")
 
-    val dependsOnAndroidTask = Option.when(projectInfo.hasAndroidSubproject)("dependsOn androidDepsCopyTaskName")
-
-    s"""import java.nio.file.Path
+    s"""
+       |import java.nio.file.Path
        |import java.nio.file.Files
        |import java.nio.file.StandardCopyOption
        |
@@ -100,44 +73,161 @@ object GradleDependencies {
        |  }
        |
        |  @Input
-       |  abstract ListProperty<String> getSelectedConfigNames()
+       |  abstract SetProperty<String> getConfigurationNameOverrides()
+       |
+       |  @Input
+       |  abstract SetProperty<String> getProjectNameOverrides()
        |
        |  @OutputDirectory
        |  abstract Property<String> getDestinationDirString()
        |
-       |  @TaskAction
-       |  void fetch() {
-       |    def projectString = project.toString()
-       |    def projectFullName = ""
-       |    if (projectString.startsWith("root project")) {
-       |      projectFullName = projectString.substring("root project '".length(), projectString.length() - 1)
-       |    } else {
-       |      projectFullName = projectString.substring("project ':".length(), projectString.length() - 1)
-       |    }
+       |  /**
+       |   * If one project in the build has a different project in the build as a dependency,
+       |   * then fetching jars for all dependencies will include the packaged jar for that
+       |   * subproject. Since the source for that subproject is already used for dependency
+       |   * information, those dependency jars should be excluded. This is done by traversing
+       |   * the dependency graph and only adding dependencies with names/descriptors not starting
+       |   * with `project` or `root project` to the list of dependencies to fetch.
+       |   *
+       |   * This is a modified version of an example from the documentation.
+       |   * See https://docs.gradle.org/current/userguide/dependency_graph_resolution.html
+       |   */
+       |  HashSet<String> getExternalDependencyNames(
+       |    ResolvedComponentResult rootComponent,
+       |    ResolvedVariantResult rootVariant
+       |  ) {
+       |    Set<String> artifactsToFetch = new HashSet<>()
+       |    Set<ResolvedVariantResult> seen = new HashSet<>()
+       |    seen.add(rootVariant)
        |
-       |    def destinationDir = Path.of(destinationDirString.get(), projectFullName.replace(':', '/'))
-       |    Files.createDirectories(destinationDir)
-       |    def selectedConfigs = project.configurations.findAll {
-       |      configuration -> selectedConfigNames.get().contains(configuration.getName())
-       |    }
+       |    def stack = new ArrayDeque<Tuple2<ResolvedVariantResult, ResolvedComponentResult>>()
+       |    stack.addFirst(new Tuple2(rootVariant, rootComponent))
        |
-       |    for (selectedConfig in selectedConfigs) {
-       |      // See https://docs.gradle.org/current/userguide/artifact_resolution.html#artifact-resolution for more information
-       |      for (artifactFiles in selectedConfig.incoming.artifacts.resolvedArtifacts.map{ it.collect { artifact -> artifact.file } }) {
-       |        for (file in artifactFiles.get()) {
-       |          try {
-       |            Files.createSymbolicLink(
-       |              destinationDir.resolve(file.name),
-       |              Path.of(file.getPath())
-       |            )
-       |          } catch (Exception e) {
-       |            Files.copy(
-       |              Path.of(file.getPath()),
-       |              destinationDir.resolve(file.name),
-       |              StandardCopyOption.REPLACE_EXISTING
-       |            )
+       |    while (!stack.isEmpty()) {
+       |      def entry = stack.removeFirst()
+       |      def variant = entry.v1
+       |      def component = entry.v2
+       |      def variantId = variant.owner.displayName
+       |      if (!(variantId.startsWith("project") || variantId.startsWith("root project"))) {
+       |        artifactsToFetch.add(variantId)
+       |      }
+       |
+       |      // Traverse this variant's dependencies
+       |      for (dependency in component.getDependenciesForVariant(variant)) {
+       |        if (dependency instanceof UnresolvedDependencyResult) {
+       |          System.err.println("Unresolved dependency $$dependency")
+       |          continue
+       |        }
+       |        if ((!dependency instanceof ResolvedDependencyResult)) {
+       |          System.err.println("Unknown dependency type: $$dependency")
+       |          continue
+       |        }
+       |
+       |        def resolved = dependency as ResolvedDependencyResult
+       |        if (!dependency.constraint) {
+       |          def toVariant = resolved.resolvedVariant
+       |
+       |          if (seen.add(toVariant)) {
+       |            stack.addFirst(new Tuple2(toVariant, resolved.selected))
        |          }
        |        }
+       |      }
+       |    }
+       |    return artifactsToFetch
+       |  }
+       |
+       |  String getProjectFullName(Project project) {
+       |    def projectString = project.toString()
+       |    if (projectString.startsWith("root project")) {
+       |      return ""
+       |    } else {
+       |      return projectString.substring("project ':".length(), projectString.length() - 1)
+       |    }
+       |  }
+       |
+       |  /**
+       |   * Checking if a configuration is valid:
+       |   *  - If configuration overrides are set, then the configuration name must appear in the overrides list
+       |   *  - If no overrides are set, the configuration name must start with release or runtime
+       |   */
+       |  List<Configuration> getValidConfigurations(Project project) {
+       |    def configurationOverrides = configurationNameOverrides.get()
+       |    def validConfigurations = []
+       |
+       |    for (configuration in project.configurations) {
+       |      if (configuration.canBeResolved) {
+       |        def configurationName = configuration.name
+       |        if (configurationOverrides.isEmpty()) {
+       |          if (configurationName.startsWith("release") || configurationName.startsWith("runtime")) {
+       |            validConfigurations << configuration
+       |          }
+       |        } else if (configurationOverrides.contains(configurationName)) {
+       |          validConfigurations << configuration
+       |        }
+       |      }
+       |    }
+       |
+       |    return validConfigurations
+       |  }
+       |
+       |  void linkOrCopyFileToDestination(File artifactFile, Path destinationDir) {
+       |    try {
+       |      Files.createSymbolicLink(
+       |        destinationDir.resolve(artifactFile.name),
+       |        Path.of(artifactFile.getPath())
+       |      )
+       |    } catch (Exception e) {
+       |      Files.copy(
+       |        Path.of(artifactFile.getPath()),
+       |        destinationDir.resolve(artifactFile.name),
+       |        StandardCopyOption.REPLACE_EXISTING
+       |      )
+       |    }
+       |  }
+       |
+       |  // See https://docs.gradle.org/current/userguide/artifact_views.html
+       |  // See https://docs.gradle.org/current/userguide/artifact_resolution.html#artifact-resolution for more information
+       |  void fetchArtifactsForConfiguration(Configuration configuration, Path destinationDir) {
+       |    for (resolvedArtifacts in configuration.incoming.getResolutionResult()) {
+       |      def artifactsToFetch = getExternalDependencyNames(
+       |        resolvedArtifacts.rootComponent.get(),
+       |        resolvedArtifacts.rootVariant.get()
+       |      )
+       |
+       |      def filteredArtifacts = configuration.incoming.artifactView {
+       |        componentFilter {
+       |          artifactsToFetch.contains(it.toString())
+       |        }
+       |      }
+       |
+       |      for (artifactFile in filteredArtifacts.files) {
+       |        linkOrCopyFileToDestination(artifactFile, destinationDir)
+       |      }
+       |    }
+       |  }
+       |
+       |  boolean shouldFetchDependencies(String projectFullName) {
+       |    return projectNameOverrides.get().isEmpty() ||
+       |      projectFullName.isEmpty() ||
+       |      projectNameOverrides.get().contains(projectFullName)
+       |  }
+       |
+       |  @TaskAction
+       |  void fetch() {
+       |    // TODO Need to update direct project access for gradle 9:
+       |    //      See https://docs.gradle.org/8.12.1/userguide/upgrading_version_7.html#task_project
+       |    def project_ = project
+       |    def projectFullName = getProjectFullName(project_)
+       |
+       |    if (shouldFetchDependencies(projectFullName)) {
+       |      def validConfigurations = getValidConfigurations(project_)
+       |
+       |      if (!validConfigurations.isEmpty()) {
+       |        def destinationDir =
+       |          projectFullName.isEmpty() ? Path.of(destinationDirString.get()) : Path.of(destinationDirString.get(), projectFullName.replace(':', '/'))
+       |        Files.createDirectories(destinationDir)
+       |
+       |        validConfigurations.forEach { fetchArtifactsForConfiguration(it, destinationDir) }
        |      }
        |    }
        |  }
@@ -146,29 +236,76 @@ object GradleDependencies {
        |allprojects { project ->
        |  def taskName = "$taskName"
        |  def compileDepsCopyTaskName = taskName + "_compileDeps"
-       |  def destinationDir = "${destination.replaceAll("\\\\", "/")}"
-       |  def gradleProjectConfigurations = [$projectConfigurationString]
+       |  def androidDepsCopyTaskName = taskName + "_androidDeps"
+       |  def destinationDir = "$destinationDir"
+       |  // If these overrides are non-empty, only fetch dependencies for the given names
+       |  Set<String> projectNameOverrides_ = [$projectNameOverrideString]
+       |  Set<String> configurationNameOverrides_ = [$configurationNameOverrideString]
        |
-       |  if (gradleProjectConfigurations.containsKey(project.name)) {
-       |    $taskCreationFunction(compileDepsCopyTaskName, FetchDependencies) {
-       |      selectedConfigNames = gradleProjectConfigurations.get(project.name)
-       |      destinationDirString = destinationDir
+       |  def hasAndroidProperty = false
+       |  for (property in project.properties.keySet()) {
+       |    if (property.startsWith("android") || property.startsWith(".android")) {
+       |      hasAndroidProperty = true
+       |      break
        |    }
+       |  }
        |
-       |    ${androidTaskDefinition.getOrElse("")}
+       |  if (hasAndroidProperty) {
+       |    $taskCreationFunction(androidDepsCopyTaskName, Copy) {
+       |      def paths = project.configurations.find { it.name.equals("androidApis") }
+       |      if (paths == null) paths = []
+       |      duplicatesStrategy = 'include'
+       |      into destinationDir
+       |      from paths
+       |    }
+       |  }
        |
+       |  $taskCreationFunction(compileDepsCopyTaskName, FetchDependencies) {
+       |    projectNameOverrides = projectNameOverrides_
+       |    configurationNameOverrides = configurationNameOverrides_
+       |    destinationDirString = destinationDir
+       |  }
+       |
+       |  if (project == project.rootProject) {
        |    $taskCreationFunction(taskName) {
-       |      ${dependsOnAndroidTask.getOrElse("")}
-       |      dependsOn compileDepsCopyTaskName
+       |      dependsOn project.getTasksByName(androidDepsCopyTaskName, true)
+       |      dependsOn project.getTasksByName(compileDepsCopyTaskName, true)
        |    }
        |  }
        |}
+       |
        |""".stripMargin
   }
 
-  private def makeInitScript(destinationDir: Path, projectInfo: GradleProjectInfo): GradleDepsInitScript = {
+  private def getGradleVersionMajorMinor(connection: ProjectConnection): GradleVersion = {
+    val buildEnv      = connection.getModel[BuildEnvironment](classOf[BuildEnvironment])
+    val gradleVersion = buildEnv.getGradle.getGradleVersion
+
+    def isValidPart(part: String) = part.forall(Character.isDigit)
+    val parts                     = gradleVersion.split('.')
+    if (parts.length == 1 && isValidPart(parts(0))) {
+      GradleVersion(parts(0).toInt, 0)
+    } else if (parts.length >= 2 && isValidPart(parts(0)) && isValidPart(parts(1))) {
+      GradleVersion(parts(0).toInt, parts(1).toInt)
+    } else {
+      GradleVersion(-1, -1)
+    }
+  }
+
+  private def makeInitScript(
+    destinationDir: Path,
+    gradleVersion: GradleVersion,
+    projectNameOverride: Option[String],
+    configurationNameOverride: Option[String]
+  ): GradleDepsInitScript = {
     val taskName = taskNamePrefix + "_" + (Random.alphanumeric take 8).toList.mkString
-    val content  = getInitScriptContent(taskName, destinationDir.toString, projectInfo)
+    val content = getInitScriptContent(
+      taskName,
+      destinationDir.toString,
+      gradleVersion,
+      projectNameOverride,
+      configurationNameOverride
+    )
     GradleDepsInitScript(content, taskName, destinationDir)
   }
 
@@ -176,205 +313,31 @@ object GradleDependencies {
     GradleConnector.newConnector().forProjectDirectory(projectDir).connect()
   }
 
-  private def getConfigurationsWithDependencies(dependenciesOutput: String): List[String] = {
-    // TODO: this is a heuristic for matching configuration names based on a sample of open source projects.
-    //  either add more options to this or revise the approach completely if this turns out to miss too much.
-    val configurationNameRegex = raw"(\S*([rR]elease|[rR]untime)\S*) -.+$$".r
-    val lines                  = dependenciesOutput.lines.iterator().asScala
-    val results                = mutable.Set[String]()
+  private def dependencyMapFromOutputDir(outputDir: Path): Map[String, List[String]] = {
+    val dependencyMap = mutable.Map.empty[String, List[String]]
 
-    while (lines.hasNext) {
-      val line = lines.next()
-      line match {
-        case configurationNameRegex(configurationName, _) if lines.hasNext =>
-          val next = lines.next()
-          if (next != "No dependencies") {
-            results.addOne(configurationName)
-          }
-          lines.takeWhile(_.nonEmpty)
-
-        case _ =>
-          lines.takeWhile(_.nonEmpty)
-      }
-    }
-
-    results.filterNot(_.toLowerCase.contains("test")).toList
-  }
-
-  private def getSubprojectNames(project: GradleProject, parentName: String): List[ProjectNameInfo] = {
-    project.getChildren.asScala.flatMap { childProject =>
-      val childNameInfo = ProjectNameInfo(childProject.getName, Option(parentName))
-      childNameInfo :: getSubprojectNames(childProject, childNameInfo.toString)
-    }.toList
-  }
-
-  private def getGradleProjectInfo(
-    projectDir: Path,
-    projectNameOverride: Option[String],
-    configurationNameOverride: Option[String]
-  ): Option[GradleProjectInfo] = {
-    Try(makeConnection(projectDir.toFile)) match {
-      case Success(gradleConnection) =>
-        Using.resource(gradleConnection) { connection =>
-          try {
-            val buildEnv = connection.getModel[BuildEnvironment](classOf[BuildEnvironment])
-            val project  = connection.getModel[GradleProject](classOf[GradleProject])
-
-            val availableProjectNames = ProjectNameInfo(project.getName, None) :: getSubprojectNames(project, "")
-
-            val availableProjectNamesString = availableProjectNames.mkString(" ")
-
-            logger.debug(s"Found gradle project names ${availableProjectNames.mkString(" ")}")
-
-            val selectedProjectNames = if (projectNameOverride.isDefined) {
-              val overrideName = projectNameOverride.get
-              availableProjectNames.find(_.projectName == overrideName) match {
-                case Some(projectInfo) =>
-                  logger.debug(s"Only fetching dependencies for overridden project name $overrideName")
-                  projectInfo :: Nil
-
-                case None =>
-                  logger.warn(
-                    s"Project name override was specified for dependency fetching ($overrideName), but no such project found."
+    Try(Files.walk(outputDir)) match {
+      case Success(fileStreamResource) =>
+        Using.resource(fileStreamResource) { fileStream =>
+          fileStream
+            .collect(Collectors.toList)
+            .asScala
+            .groupBy(path => path.getParent.toString)
+            .foreach { case (parentStr, paths) =>
+              paths.collect {
+                case path if !Files.isDirectory(path) =>
+                  dependencyMap.put(
+                    parentStr,
+                    path.toAbsolutePath.toString :: dependencyMap.getOrElseUpdate(parentStr, Nil)
                   )
-                  logger.warn(
-                    s"Falling back to fetching dependencies for all available project names: $availableProjectNamesString"
-                  )
-                  availableProjectNames
-              }
-            } else {
-              availableProjectNames.find(_.projectName == defaultGradleAppName) match {
-                case Some(defaultProjectInfo) =>
-                  // TODO: This is a temporary check to avoid issues that could arise from subprojects using conflicting
-                  //  versions of dependencies. Ideally dependencies for all of these projects will be fetched with
-                  //  any conflicts handled in the consumer.
-                  logger.debug(s"Found project with default name ($defaultGradleAppName)")
-                  logger.debug(s"Fetching dependencies only for default project ($defaultGradleAppName)")
-                  defaultProjectInfo :: Nil
-
-                case None =>
-                  logger.debug(s"No project name override or project with default name ($defaultGradleAppName) found.")
-                  logger.debug(s"Fetching dependencies for all available projects: $availableProjectNamesString")
-                  availableProjectNames
               }
             }
-
-            val selectedConfigurations = selectedProjectNames.flatMap { projectNameInfo =>
-              val dependenciesTaskName = projectNameInfo.makeGradleTaskName("dependencies")
-
-              val availableConfigurations = runGradleTask(connection, dependenciesTaskName) match {
-                case Some(out) =>
-                  getConfigurationsWithDependencies(out) match {
-                    case Nil =>
-                      logger.debug(s"No configurations with dependencies found for project $projectNameInfo")
-                      Nil
-                    case deps =>
-                      logger.debug(
-                        s"Found the following configurations with dependencies for project $projectNameInfo: ${deps.mkString(", ")}"
-                      )
-                      deps
-                  }
-                case None =>
-                  logger.warn(s"Failure executing dependencies task $dependenciesTaskName")
-                  Nil
-              }
-
-              val availableConfigurationsString = availableConfigurations.mkString(", ")
-
-              val selectedConfigurations = if (availableConfigurations.isEmpty) {
-                // Skip logging below, since no available configurations already logged
-                Nil
-              } else if (configurationNameOverride.isDefined) {
-                val overrideName = configurationNameOverride.get
-                availableConfigurations.find(_ == overrideName) match {
-                  case Some(configurationName) =>
-                    logger.debug(s"Only fetching dependencies for overridden configuration $overrideName")
-                    configurationName :: Nil
-
-                  case None =>
-                    logger.warn(
-                      s"Configuration name override was specified for dependency fetching ($overrideName), but no such configuration found for project $projectNameInfo."
-                    )
-                    logger.warn(
-                      s"Falling back to fetching dependencies for all available configurations: $availableConfigurationsString"
-                    )
-                    availableConfigurations
-                }
-              } else {
-                availableConfigurations.find(_ == defaultConfigurationName) match {
-                  case Some(defaultConfigurationName) =>
-                    // TODO: This is a temporary check to avoid issues that could arise from subprojects using conflicting
-                    //  versions of dependencies. Ideally dependencies for all of these configurations will be fetched with
-                    //  any conflicts handled in the consumer.
-                    logger.debug(
-                      s"Found default configuration name ($defaultConfigurationName) for project $projectNameInfo"
-                    )
-                    logger.debug(
-                      s"Fetching dependencies only for default configuration ($defaultConfigurationName) for project $projectNameInfo"
-                    )
-                    defaultConfigurationName :: Nil
-
-                  case None =>
-                    logger.debug(
-                      s"No configuration override or configuration with default name ($defaultConfigurationName) found for project $projectNameInfo."
-                    )
-                    logger.debug(
-                      s"Fetching dependencies for all available configurations for project $projectNameInfo: $availableConfigurationsString"
-                    )
-                    availableConfigurations
-                }
-              }
-
-              Option.when(selectedConfigurations.nonEmpty) {
-                projectNameInfo -> selectedConfigurations
-              }
-            }.toMap
-
-            val includesAndroidProject = selectedProjectNames.exists { projectNameInfo =>
-              val propertiesTaskName = projectNameInfo.makeGradleTaskName(gradlePropertiesTaskName)
-
-              runGradleTask(connection, propertiesTaskName) match {
-                case Some(out) =>
-                  out.lines().iterator().asScala.exists(_.startsWith(gradleAndroidPropertyPrefix))
-                case None => false
-              }
-            }
-
-            val gradleVersion = buildEnv.getGradle.getGradleVersion
-
-            val gradleProjectInfo = GradleProjectInfo(selectedConfigurations, gradleVersion, includesAndroidProject)
-
-            Option(gradleProjectInfo)
-          } catch {
-            case t: Throwable =>
-              logger.warn(s"Caught exception while trying use Gradle connection: ${t.getMessage}")
-              logger.debug(s"Full exception: ", t)
-              None
-          }
         }
-      case Failure(t) =>
-        logger.warn(s"Caught exception while trying fetch Gradle project information: ${t.getMessage}")
-        logger.debug(s"Full exception: ", t)
-        None
+      case Failure(e: Throwable) =>
+        logger.warn(s"Encountered exception while walking dependency fetcher output: ${e.getMessage}")
     }
-  }
 
-  private def runGradleTask(connection: ProjectConnection, taskName: String): Option[String] = {
-    Using.resource(new ByteArrayOutputStream()) { out =>
-      Try(
-        connection
-          .newBuild()
-          .forTasks(taskName)
-          .setStandardOutput(out)
-          .run()
-      ) match {
-        case Success(_) => Some(out.toString)
-        case Failure(ex) =>
-          logger.warn(s"Caught exception while executing Gradle task named `$taskName`:", ex.getMessage)
-          logger.debug(s"Full exception: ", ex)
-          None
-      }
-    }
+    dependencyMap.toMap
   }
 
   private def runGradleTask(
@@ -382,10 +345,9 @@ object GradleDependencies {
     taskName: String,
     destinationDir: Path,
     initScriptPath: String
-  ): Option[collection.Seq[String]] = {
+  ): Map[String, List[String]] = {
     Using.resources(new ByteArrayOutputStream, new ByteArrayOutputStream) { case (stdoutStream, stderrStream) =>
       logger.debug(s"Executing gradle task '${taskName}'...")
-
       Try(
         connection
           .newBuild()
@@ -396,15 +358,10 @@ object GradleDependencies {
           .run()
       ) match {
         case Success(_) =>
-          val result =
-            Files
-              .list(destinationDir)
-              .collect(Collectors.toList[Path])
-              .asScala
-              .filterNot(Files.isDirectory(_))
-              .map(_.toAbsolutePath.toString)
-          logger.info(s"Task $taskName resolved `${result.size}` dependency files.")
-          Some(result)
+          val result          = dependencyMapFromOutputDir(destinationDir)
+          val dependencyCount = result.values.flatten.size
+          logger.info(s"Task $taskName resolved `$dependencyCount` dependency files.")
+          result
         case Failure(ex) =>
           logger.warn(s"Caught exception while executing Gradle task: ${ex.getMessage}")
           val androidSdkError = "Define a valid SDK location with an ANDROID_HOME environment variable"
@@ -422,7 +379,7 @@ object GradleDependencies {
           }
           logger.debug(s"Gradle task execution stdout: \n$stdoutStream")
           logger.debug(s"Gradle task execution stderr: \n$stderrStream")
-          None
+          Map.empty
       }
     }
   }
@@ -463,61 +420,47 @@ object GradleDependencies {
     configurationNameOverride: Option[String]
   ): Map[String, collection.Seq[String]] = {
     logger.info(s"Fetching Gradle project information at path `$projectDir`.")
-    getGradleProjectInfo(projectDir, projectNameOverride, configurationNameOverride) match {
-      case Some(projectInfo) if projectInfo.gradleVersionMajorMinor()._1 < 5 =>
-        logger.warn(s"Unsupported Gradle version `${projectInfo.gradleVersion}`")
-        Map.empty
-      case Some(projectInfo) =>
-        Try(Files.createTempDirectory(tempDirPrefix)) match {
-          case Success(destinationDir) =>
-            FileUtil.deleteOnExit(destinationDir)
-            Try(Files.createTempFile(initScriptPrefix, "")) match {
-              case Success(initScriptFile) =>
-                FileUtil.deleteOnExit(initScriptFile)
-                val initScript = makeInitScript(destinationDir, projectInfo)
-                Files.writeString(initScriptFile, initScript.contents)
-
-                Try(makeConnection(projectDir.toFile)) match {
-                  case Success(connection) =>
-                    Using.resource(connection) { c =>
-                      projectInfo.subprojects.keys.flatMap { projectNameInfo =>
-                        val taskName = projectNameInfo.makeGradleTaskName(initScript.taskName)
-                        val destinationSubdir = projectNameInfo.parentName match {
-                          case None => projectNameInfo.projectName
-                          case _    => projectNameInfo.toString.stripPrefix(":").replace(':', '/')
-                        }
-                        val destinationDir = initScript.destinationDir.resolve(destinationSubdir)
-
-                        runGradleTask(c, taskName, destinationDir, initScriptFile.toString) map { deps =>
-                          val depsOutput = deps.map { d =>
-                            if (!d.endsWith(aarFileExtension)) d
-                            else
-                              extractClassesJarFromAar(Paths.get(d)) match {
-                                case Some(path) => path.toString
-                                case None       => d
-                              }
+    // TODO Get gradle version
+    Try(Files.createTempDirectory(tempDirPrefix)) match {
+      case Success(destinationDir) =>
+        FileUtil.deleteOnExit(destinationDir)
+        Try(Files.createTempFile(initScriptPrefix, "")) match {
+          case Success(initScriptFile) =>
+            FileUtil.deleteOnExit(initScriptFile)
+            Try(makeConnection(projectDir.toFile)) match {
+              case Success(connection) =>
+                Using.resource(connection) { c =>
+                  val gradleVersion = getGradleVersionMajorMinor(connection)
+                  val initScript =
+                    makeInitScript(destinationDir, gradleVersion, projectNameOverride, configurationNameOverride)
+                  Files.writeString(initScriptFile, initScript.contents)
+                  println(s"## INIT SCRIPT ##\n${initScript.contents}\n########")
+                  runGradleTask(c, initScript.taskName, initScript.destinationDir, initScriptFile.toString).map {
+                    case (projectName, dependencies) =>
+                      projectName -> dependencies.map { dependency =>
+                        if (!dependency.endsWith(aarFileExtension))
+                          dependency
+                        else
+                          extractClassesJarFromAar(Paths.get(dependency)) match {
+                            case Some(path) => path.toString
+                            case None       => dependency
                           }
-                          projectNameInfo.projectName -> depsOutput
-                        }
-                      }.toMap
-                    }
-                  case Failure(ex) =>
-                    logger.warn(s"Caught exception while trying to establish a Gradle connection: ${ex.getMessage}")
-                    logger.debug(s"Full exception: ", ex)
-                    Map.empty
+                      }
+                  }
                 }
               case Failure(ex) =>
-                logger.warn(s"Could not create temporary file for Gradle init script: ${ex.getMessage}")
+                logger.warn(s"Caught exception while trying to establish a Gradle connection: ${ex.getMessage}")
                 logger.debug(s"Full exception: ", ex)
                 Map.empty
             }
           case Failure(ex) =>
-            logger.warn(s"Could not create temporary directory for saving dependency files: ${ex.getMessage}")
-            logger.debug("Full exception: ", ex)
+            logger.warn(s"Could not create temporary file for Gradle init script: ${ex.getMessage}")
+            logger.debug(s"Full exception: ", ex)
             Map.empty
         }
-      case None =>
-        logger.warn("Could not fetch Gradle project information")
+      case Failure(ex) =>
+        logger.warn(s"Could not create temporary directory for saving dependency files: ${ex.getMessage}")
+        logger.debug("Full exception: ", ex)
         Map.empty
     }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -446,7 +446,6 @@ object GradleDependencies {
     configurationNameOverride: Option[String]
   ): Map[String, collection.Seq[String]] = {
     logger.info(s"Fetching Gradle project information at path `$projectDir`.")
-    // TODO Get gradle version
     Try(Files.createTempDirectory(tempDirPrefix)) match {
       case Success(destinationDir) =>
         FileUtil.deleteOnExit(destinationDir)
@@ -457,7 +456,6 @@ object GradleDependencies {
               case Success(connection) =>
                 Using.resource(connection) { c =>
                   val gradleVersion = getGradleVersionMajorMinor(connection)
-                  // TODO Filter for only `app` project
                   val initScript =
                     makeInitScript(destinationDir, gradleVersion, projectNameOverride, configurationNameOverride)
                   Files.writeString(initScriptFile, initScript.contents)


### PR DESCRIPTION
Before this PR, a lot of the logic for gradle dependency fetching was happening from Scala code through the gradle connection via the API. This has a lot of overhead as the project needs to be reloaded/initialized/correct verb each time. For example, just listing the available projects with their configurations for the elasticsearch project took ~30 minutes on my machine since there's a configuration step that had to happen for each request. Doing this from a gradle task defined in the build or init file is almost instantaneous.

With this PR, all of that logic is moved into the gradle init script. A separate task to fetch dependencies is created for each subproject and then one task is created in the root project which either depends on all of these, or only on that of the `:app` project if it exists to stay consistent with how we filtered projects before. Only this root project task has to be executed to fetch all of the dependencies, so we avoid the overhead associated with multiple API calls.